### PR TITLE
feat(mcp): BYOM — non-admin MCP server submission + admin review workflow

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309000000_add_mcp_approval_status/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309000000_add_mcp_approval_status/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable: Add BYOM approval workflow fields to LiteLLM_MCPServerTable
+ALTER TABLE "LiteLLM_MCPServerTable"
+  ADD COLUMN IF NOT EXISTS "approval_status" TEXT DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS "submitted_by"    TEXT,
+  ADD COLUMN IF NOT EXISTS "submitted_at"    TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "reviewed_at"     TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "review_notes"    TEXT;
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "LiteLLM_MCPServerTable_approval_status_idx"
+  ON "LiteLLM_MCPServerTable"("approval_status");

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309000001_add_mcp_source_url/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260309000001_add_mcp_source_url/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: Add source_url field to LiteLLM_MCPServerTable for GitHub/docs link
+ALTER TABLE "LiteLLM_MCPServerTable"
+  ADD COLUMN IF NOT EXISTS "source_url" TEXT;

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
 from litellm._logging import verbose_proxy_logger
@@ -6,6 +7,8 @@ from litellm.proxy._types import (
     LiteLLM_MCPServerTable,
     LiteLLM_ObjectPermissionTable,
     LiteLLM_TeamTable,
+    MCPApprovalStatus,
+    MCPSubmissionsSummary,
     NewMCPServerRequest,
     SpecialMCPServerName,
     UpdateMCPServerRequest,
@@ -102,12 +105,19 @@ def encrypt_credentials(
 
 async def get_all_mcp_servers(
     prisma_client: PrismaClient,
+    approval_status: Optional[str] = "active",
 ) -> List[LiteLLM_MCPServerTable]:
     """
-    Returns all of the mcp servers from the db
+    Returns mcp servers from the db, optionally filtered by approval_status.
+    Pass approval_status=None to return all servers regardless of approval state.
     """
     try:
-        mcp_servers = await prisma_client.db.litellm_mcpservertable.find_many()
+        where: Dict[str, Any] = {}
+        if approval_status is not None:
+            where["approval_status"] = approval_status
+        mcp_servers = await prisma_client.db.litellm_mcpservertable.find_many(
+            where=where if where else {}
+        )
 
         return [
             LiteLLM_MCPServerTable(**mcp_server.model_dump())
@@ -450,4 +460,71 @@ async def delete_user_credential(
     """Delete the user's stored credential for a BYOK MCP server."""
     await prisma_client.db.litellm_mcpusercredentials.delete(
         where={"user_id_server_id": {"user_id": user_id, "server_id": server_id}}
+    )
+
+
+async def approve_mcp_server(
+    prisma_client: PrismaClient,
+    server_id: str,
+    touched_by: str,
+) -> LiteLLM_MCPServerTable:
+    """Set approval_status=active and record reviewed_at."""
+    now = datetime.now(timezone.utc)
+    updated = await prisma_client.db.litellm_mcpservertable.update(
+        where={"server_id": server_id},
+        data={
+            "approval_status": MCPApprovalStatus.active,
+            "reviewed_at": now,
+            "updated_by": touched_by,
+        },
+    )
+    return LiteLLM_MCPServerTable(**updated.model_dump())
+
+
+async def reject_mcp_server(
+    prisma_client: PrismaClient,
+    server_id: str,
+    touched_by: str,
+    review_notes: Optional[str] = None,
+) -> LiteLLM_MCPServerTable:
+    """Set approval_status=rejected, record reviewed_at and review_notes."""
+    now = datetime.now(timezone.utc)
+    data: Dict[str, Any] = {
+        "approval_status": MCPApprovalStatus.rejected,
+        "reviewed_at": now,
+        "updated_by": touched_by,
+    }
+    if review_notes is not None:
+        data["review_notes"] = review_notes
+    updated = await prisma_client.db.litellm_mcpservertable.update(
+        where={"server_id": server_id},
+        data=data,
+    )
+    return LiteLLM_MCPServerTable(**updated.model_dump())
+
+
+async def get_mcp_submissions(
+    prisma_client: PrismaClient,
+) -> MCPSubmissionsSummary:
+    """
+    Returns all MCP servers that were submitted by non-admin users (submitted_at IS NOT NULL),
+    along with a summary count breakdown by approval_status.
+    Mirrors get_guardrail_submissions() from guardrail_endpoints.py.
+    """
+    rows = await prisma_client.db.litellm_mcpservertable.find_many(
+        where={"submitted_at": {"not": None}},
+        order={"submitted_at": "asc"},
+    )
+    items = [LiteLLM_MCPServerTable(**r.model_dump()) for r in rows]
+
+    pending = sum(1 for i in items if i.approval_status == MCPApprovalStatus.pending_review)
+    active = sum(1 for i in items if i.approval_status == MCPApprovalStatus.active)
+    rejected = sum(1 for i in items if i.approval_status == MCPApprovalStatus.rejected)
+
+    return MCPSubmissionsSummary(
+        total=len(items),
+        pending_review=pending,
+        active=active,
+        rejected=rejected,
+        items=items,
     )

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -105,7 +105,7 @@ def encrypt_credentials(
 
 async def get_all_mcp_servers(
     prisma_client: PrismaClient,
-    approval_status: Optional[str] = "active",
+    approval_status: Optional[str] = None,
 ) -> List[LiteLLM_MCPServerTable]:
     """
     Returns mcp servers from the db, optionally filtered by approval_status.

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -514,6 +514,7 @@ async def get_mcp_submissions(
     rows = await prisma_client.db.litellm_mcpservertable.find_many(
         where={"submitted_at": {"not": None}},
         order={"submitted_at": "desc"},
+        take=500,  # safety cap; paginate if needed in a future iteration
     )
     items = [LiteLLM_MCPServerTable(**r.model_dump()) for r in rows]
 

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -513,7 +513,7 @@ async def get_mcp_submissions(
     """
     rows = await prisma_client.db.litellm_mcpservertable.find_many(
         where={"submitted_at": {"not": None}},
-        order={"submitted_at": "asc"},
+        order={"submitted_at": "desc"},
     )
     items = [LiteLLM_MCPServerTable(**r.model_dump()) for r in rows]
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2270,7 +2270,7 @@ class MCPServerManager:
         prisma_client = get_prisma_client_or_throw(
             "Database not connected. Connect a database to your proxy"
         )
-        db_mcp_servers = await get_all_mcp_servers(prisma_client)
+        db_mcp_servers = await get_all_mcp_servers(prisma_client, approval_status="active")
         verbose_logger.info(f"Found {len(db_mcp_servers)} MCP servers in database")
 
         previous_registry = self.registry

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2237,6 +2237,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="If True, forwards client headers (e.g. Authorization) to the LLM API. Required for Claude Code with Max subscription.",
     )
+    mcp_required_fields: Optional[List[str]] = Field(
+        None,
+        description="List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).",
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1087,6 +1087,12 @@ class SpecialMCPServerName(str, enum.Enum):
     all_proxy_servers = "all-proxy-mcpservers"
 
 
+class MCPApprovalStatus(str, enum.Enum):
+    pending_review = "pending_review"
+    active = "active"
+    rejected = "rejected"
+
+
 # MCP Proxy Request Types
 class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     server_id: Optional[str] = None
@@ -1117,6 +1123,10 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     is_byok: bool = False
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
+    # BYOM submission fields (set by endpoint, not by caller)
+    approval_status: Optional[str] = None
+    submitted_by: Optional[str] = None
+    submitted_at: Optional[datetime] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -1239,6 +1249,15 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
     has_user_credential: Optional[bool] = None
+    # BYOM submission fields
+    approval_status: Optional[str] = Field(
+        default="active",
+        description="Approval status: 'pending_review', 'active', 'rejected'",
+    )
+    submitted_by: Optional[str] = None
+    submitted_at: Optional[datetime] = None
+    reviewed_at: Optional[datetime] = None
+    review_notes: Optional[str] = None
 
 
 class MakeMCPServersPublicRequest(LiteLLMPydanticObjectBase):
@@ -1253,6 +1272,18 @@ class MCPUserCredentialRequest(LiteLLMPydanticObjectBase):
 class MCPUserCredentialResponse(LiteLLMPydanticObjectBase):
     server_id: str
     has_credential: bool
+
+
+class RejectMCPServerRequest(LiteLLMPydanticObjectBase):
+    review_notes: Optional[str] = None
+
+
+class MCPSubmissionsSummary(LiteLLMPydanticObjectBase):
+    total: int
+    pending_review: int
+    active: int
+    rejected: int
+    items: List["LiteLLM_MCPServerTable"]
 
 
 ######## Skills API Types ########

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1124,10 +1124,17 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
     source_url: Optional[str] = None
-    # BYOM submission fields (set by endpoint, not by caller)
-    approval_status: Optional[str] = None
-    submitted_by: Optional[str] = None
-    submitted_at: Optional[datetime] = None
+    # BYOM submission fields — set by the endpoint, not by the caller.
+    # Any caller-provided values are silently overridden before persistence.
+    approval_status: Optional[str] = Field(
+        None, description="Server-managed: set by the endpoint; caller values are overridden."
+    )
+    submitted_by: Optional[str] = Field(
+        None, description="Server-managed: set by the endpoint; caller values are overridden."
+    )
+    submitted_at: Optional[datetime] = Field(
+        None, description="Server-managed: set by the endpoint; caller values are overridden."
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1123,6 +1123,7 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     is_byok: bool = False
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
+    source_url: Optional[str] = None
     # BYOM submission fields (set by endpoint, not by caller)
     approval_status: Optional[str] = None
     submitted_by: Optional[str] = None
@@ -1186,6 +1187,7 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     is_byok: bool = False
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
+    source_url: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -1249,6 +1251,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
     has_user_credential: Optional[bool] = None
+    source_url: Optional[str] = None
     # BYOM submission fields
     approval_status: Optional[str] = Field(
         default="active",

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -195,7 +195,10 @@ if MCP_AVAILABLE:
 
         def _field_present(field_name: str) -> bool:
             value = getattr(payload, field_name, None)
-            if not value:
+            if value is None:
+                return False
+            # Treat empty string and empty list as absent (mirrors UI compliance check)
+            if isinstance(value, (str, list)) and not value:
                 return False
             if field_name == "auth_type" and value == _AUTH_TYPE_SENTINEL:
                 return False

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -76,11 +76,14 @@ if MCP_AVAILABLE:
             return _ToolNameValidationResult()
 
     from litellm.proxy._experimental.mcp_server.db import (
+        approve_mcp_server,
         create_mcp_server,
         delete_mcp_server,
         delete_user_credential,
         get_all_mcp_servers_for_user,
         get_mcp_server,
+        get_mcp_submissions,
+        reject_mcp_server,
         store_user_credential,
         update_mcp_server,
     )
@@ -100,9 +103,12 @@ if MCP_AVAILABLE:
         LiteLLM_MCPServerTable,
         LitellmUserRoles,
         MakeMCPServersPublicRequest,
+        MCPApprovalStatus,
+        MCPSubmissionsSummary,
         MCPUserCredentialRequest,
         MCPUserCredentialResponse,
         NewMCPServerRequest,
+        RejectMCPServerRequest,
         SpecialMCPServerName,
         UpdateMCPServerRequest,
         UserAPIKeyAuth,
@@ -688,6 +694,177 @@ if MCP_AVAILABLE:
             {"server_id": server_id, "status": status}
             for server_id, status in server_status_map.items()
         ]
+
+    @router.post(
+        "/server/register",
+        description="Submit a new MCP server for admin review (non-admin users). Mirrors POST /guardrails/register.",
+        dependencies=[Depends(user_api_key_auth)],
+        response_model=LiteLLM_MCPServerTable,
+        status_code=status.HTTP_201_CREATED,
+    )
+    @management_endpoint_wrapper
+    async def register_mcp_server(
+        payload: NewMCPServerRequest,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        """
+        Allow team members to submit an MCP server for admin review.
+        Creates the server with approval_status=pending_review.
+        Requires a team-scoped API key.
+        """
+        from datetime import datetime, timezone
+
+        if not user_api_key_dict.team_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": "Registration requires an API key associated with a team. Use a team-scoped key."
+                },
+            )
+
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+
+        validate_and_normalize_mcp_server_payload(payload)
+
+        payload.approval_status = MCPApprovalStatus.pending_review
+        payload.submitted_by = user_api_key_dict.user_id
+        payload.submitted_at = datetime.now(timezone.utc)
+
+        try:
+            new_mcp_server = await create_mcp_server(
+                prisma_client,
+                payload,
+                touched_by=user_api_key_dict.user_id or user_api_key_dict.team_id,
+            )
+        except Exception as e:
+            verbose_proxy_logger.exception(f"Error registering mcp server: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={"error": f"Error registering mcp server: {str(e)}"},
+            )
+        # Do NOT add to runtime registry — pending servers are not active
+        return _redact_mcp_credentials(new_mcp_server)
+
+    @router.get(
+        "/server/submissions",
+        description="Returns all MCP servers submitted by non-admin users (admin review queue). Mirrors GET /guardrails/submissions.",
+        dependencies=[Depends(user_api_key_auth)],
+        response_model=MCPSubmissionsSummary,
+    )
+    @management_endpoint_wrapper
+    async def get_mcp_server_submissions(
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        """
+        Admin-only endpoint to view all user-submitted MCP servers pending review.
+        """
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "Admin access required to view MCP server submissions."},
+            )
+
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+
+        return await get_mcp_submissions(prisma_client)
+
+    @router.put(
+        "/server/{server_id}/approve",
+        description="Approve a pending MCP server submission (admin only). Mirrors PUT /guardrails/{id}/approve.",
+        dependencies=[Depends(user_api_key_auth)],
+        response_model=LiteLLM_MCPServerTable,
+    )
+    @management_endpoint_wrapper
+    async def approve_mcp_server_submission(
+        server_id: str,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        """
+        Admin approves a pending MCP server — sets approval_status=active and loads it into the runtime registry.
+        """
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "Admin access required to approve MCP server submissions."},
+            )
+
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+
+        existing = await get_mcp_server(prisma_client, server_id)
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": f"MCP server '{server_id}' not found."},
+            )
+        if existing.approval_status != MCPApprovalStatus.pending_review:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": f"MCP server is not pending review (approval_status={existing.approval_status})."
+                },
+            )
+
+        approved = await approve_mcp_server(
+            prisma_client,
+            server_id,
+            touched_by=user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
+        )
+        await global_mcp_server_manager.add_server(approved)
+        await global_mcp_server_manager.reload_servers_from_database()
+
+        return _redact_mcp_credentials(approved)
+
+    @router.put(
+        "/server/{server_id}/reject",
+        description="Reject a pending MCP server submission (admin only). Mirrors PUT /guardrails/{id}/reject.",
+        dependencies=[Depends(user_api_key_auth)],
+    )
+    @management_endpoint_wrapper
+    async def reject_mcp_server_submission(
+        server_id: str,
+        payload: RejectMCPServerRequest,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        """
+        Admin rejects a pending MCP server — sets approval_status=rejected with optional review_notes.
+        """
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "Admin access required to reject MCP server submissions."},
+            )
+
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+
+        existing = await get_mcp_server(prisma_client, server_id)
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": f"MCP server '{server_id}' not found."},
+            )
+        if existing.approval_status != MCPApprovalStatus.pending_review:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": f"MCP server is not pending review (approval_status={existing.approval_status})."
+                },
+            )
+
+        rejected = await reject_mcp_server(
+            prisma_client,
+            server_id,
+            touched_by=user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
+            review_notes=payload.review_notes,
+        )
+        return _redact_mcp_credentials(rejected)
 
     @router.get(
         "/server/{server_id}",

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -736,6 +736,14 @@ if MCP_AVAILABLE:
         Creates the server with approval_status=pending_review.
         Requires a team-scoped API key.
         """
+        if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Admin users should use POST /v1/mcp/server to create servers directly instead of the submission workflow."
+                },
+            )
+
         if not user_api_key_dict.team_id:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -783,7 +791,10 @@ if MCP_AVAILABLE:
         """
         Admin-only endpoint to view all user-submitted MCP servers pending review.
         """
-        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+        if user_api_key_dict.user_role not in (
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"error": "Admin access required to view MCP server submissions."},
@@ -877,13 +888,16 @@ if MCP_AVAILABLE:
                 detail={"error": "MCP server is already rejected."},
             )
 
+        was_active = existing.approval_status == MCPApprovalStatus.active
         rejected = await reject_mcp_server(
             prisma_client,
             server_id,
             touched_by=user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
             review_notes=payload.review_notes,
         )
-        await global_mcp_server_manager.reload_servers_from_database()
+        # Only evict from the runtime registry if the server was previously active
+        if was_active:
+            await global_mcp_server_manager.reload_servers_from_database()
         return _redact_mcp_credentials(rejected)
 
     @router.get(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1026,6 +1026,10 @@ if MCP_AVAILABLE:
 
         # TODO: audit log for create
 
+        # Admin-created servers are always active regardless of any lifecycle fields
+        # in the payload — prevents an admin from accidentally creating a pending server.
+        payload.approval_status = MCPApprovalStatus.active
+
         # Attempt to create the mcp server
         try:
             new_mcp_server = await create_mcp_server(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -18,7 +18,7 @@ import importlib
 import json
 import os
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Literal, Optional
 
 from fastapi import (
@@ -712,8 +712,6 @@ if MCP_AVAILABLE:
         Creates the server with approval_status=pending_review.
         Requires a team-scoped API key.
         """
-        from datetime import datetime, timezone
-
         if not user_api_key_dict.team_id:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -173,9 +173,19 @@ if MCP_AVAILABLE:
         if not required_fields:
             return
 
-        missing = [
-            f for f in required_fields if not getattr(payload, f, None)
-        ]
+        # Mirror the UI's compliance checks (MCPStandardsSettings.tsx FIELD_GROUPS):
+        # auth_type requires a real value — "none" is treated as absent.
+        _AUTH_TYPE_SENTINEL = "none"
+
+        def _field_present(field_name: str) -> bool:
+            value = getattr(payload, field_name, None)
+            if not value:
+                return False
+            if field_name == "auth_type" and value == _AUTH_TYPE_SENTINEL:
+                return False
+            return True
+
+        missing = [f for f in required_fields if not _field_present(f)]
         if missing:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -815,7 +815,6 @@ if MCP_AVAILABLE:
             server_id,
             touched_by=user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
         )
-        await global_mcp_server_manager.add_server(approved)
         await global_mcp_server_manager.reload_servers_from_database()
 
         return _redact_mcp_credentials(approved)
@@ -824,6 +823,7 @@ if MCP_AVAILABLE:
         "/server/{server_id}/reject",
         description="Reject a pending MCP server submission (admin only). Mirrors PUT /guardrails/{id}/reject.",
         dependencies=[Depends(user_api_key_auth)],
+        response_model=LiteLLM_MCPServerTable,
     )
     @management_endpoint_wrapper
     async def reject_mcp_server_submission(
@@ -850,12 +850,10 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": f"MCP server '{server_id}' not found."},
             )
-        if existing.approval_status != MCPApprovalStatus.pending_review:
+        if existing.approval_status == MCPApprovalStatus.rejected:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "error": f"MCP server is not pending review (approval_status={existing.approval_status})."
-                },
+                detail={"error": "MCP server is already rejected."},
             )
 
         rejected = await reject_mcp_server(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -161,6 +161,30 @@ if MCP_AVAILABLE:
         _base_validate_and_normalize_mcp_server_payload(payload)
         _validate_mcp_server_name_fields(payload)
 
+    def _validate_mcp_required_fields(payload: Any) -> None:
+        """Validate submission payload against admin-configured mcp_required_fields."""
+        from litellm.proxy.proxy_server import (
+            general_settings as proxy_general_settings,
+        )
+
+        required_fields: Optional[List[str]] = proxy_general_settings.get(
+            "mcp_required_fields"
+        )
+        if not required_fields:
+            return
+
+        missing = [
+            f for f in required_fields if not getattr(payload, f, None)
+        ]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": f"Submission is missing required fields: {missing}. "
+                    "Configure required fields via general_settings.mcp_required_fields."
+                },
+            )
+
     def _is_public_registry_enabled() -> bool:
         from litellm.proxy.proxy_server import (
             general_settings as proxy_general_settings,
@@ -725,6 +749,7 @@ if MCP_AVAILABLE:
         )
 
         validate_and_normalize_mcp_server_payload(payload)
+        _validate_mcp_required_fields(payload)
 
         payload.approval_status = MCPApprovalStatus.pending_review
         payload.submitted_by = user_api_key_dict.user_id
@@ -858,6 +883,7 @@ if MCP_AVAILABLE:
             touched_by=user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
             review_notes=payload.review_notes,
         )
+        await global_mcp_server_manager.reload_servers_from_database()
         return _redact_mcp_credentials(rejected)
 
     @router.get(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1026,9 +1026,12 @@ if MCP_AVAILABLE:
 
         # TODO: audit log for create
 
-        # Admin-created servers are always active regardless of any lifecycle fields
-        # in the payload — prevents an admin from accidentally creating a pending server.
+        # Admin-created servers are always active — clear any submission lifecycle
+        # fields the caller may have provided to prevent fake entries appearing in
+        # the submissions queue.
         payload.approval_status = MCPApprovalStatus.active
+        payload.submitted_by = None
+        payload.submitted_at = None
 
         # Attempt to create the mcp server
         try:

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -161,6 +161,10 @@ if MCP_AVAILABLE:
         _base_validate_and_normalize_mcp_server_payload(payload)
         _validate_mcp_server_name_fields(payload)
 
+    _VALID_MCP_REQUIRED_FIELDS: frozenset = frozenset(
+        NewMCPServerRequest.model_fields
+    )
+
     def _validate_mcp_required_fields(payload: Any) -> None:
         """Validate submission payload against admin-configured mcp_required_fields."""
         from litellm.proxy.proxy_server import (
@@ -172,6 +176,18 @@ if MCP_AVAILABLE:
         )
         if not required_fields:
             return
+
+        # Fail fast on unknown field names — a typo in the config would silently
+        # block every submission with a confusing "missing fields" error.
+        unknown = [f for f in required_fields if f not in _VALID_MCP_REQUIRED_FIELDS]
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "error": f"mcp_required_fields contains unknown field names: {unknown}. "
+                    "Check general_settings.mcp_required_fields in your proxy config."
+                },
+            )
 
         # Mirror the UI's compliance checks (MCPStandardsSettings.tsx FIELD_GROUPS):
         # auth_type requires a real value — "none" is treated as absent.
@@ -750,7 +766,7 @@ if MCP_AVAILABLE:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={
-                    "error": "Admin users should use POST /v1/mcp/server to create servers directly instead of the submission workflow."
+                    "error": "PROXY_ADMIN users should use POST /v1/mcp/server to create servers directly instead of the submission workflow."
                 },
             )
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -782,7 +782,7 @@ if MCP_AVAILABLE:
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ):
         """
-        Admin approves a pending MCP server — sets approval_status=active and loads it into the runtime registry.
+        Admin approves a pending or previously-rejected MCP server — sets approval_status=active and loads it into the runtime registry.
         """
         if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
             raise HTTPException(
@@ -800,12 +800,10 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": f"MCP server '{server_id}' not found."},
             )
-        if existing.approval_status != MCPApprovalStatus.pending_review:
+        if existing.approval_status == MCPApprovalStatus.active:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "error": f"MCP server is not pending review (approval_status={existing.approval_status})."
-                },
+                detail={"error": "MCP server is already active."},
             )
 
         approved = await approve_mcp_server(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -746,7 +746,10 @@ if MCP_AVAILABLE:
         Creates the server with approval_status=pending_review.
         Requires a team-scoped API key.
         """
-        if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+        if user_api_key_dict.user_role in (
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -746,10 +746,7 @@ if MCP_AVAILABLE:
         Creates the server with approval_status=pending_review.
         Requires a team-scoped API key.
         """
-        if user_api_key_dict.user_role in (
-            LitellmUserRoles.PROXY_ADMIN,
-            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-        ):
+        if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -351,15 +351,15 @@ from litellm.proxy.management_endpoints.cache_settings_endpoints import (
 from litellm.proxy.management_endpoints.callback_management_endpoints import (
     router as callback_management_endpoints_router,
 )
-from litellm.proxy.management_endpoints.config_override_endpoints import (
-    router as config_override_router,
-)
 from litellm.proxy.management_endpoints.common_utils import (
     _user_has_admin_privileges,
     admin_can_invite_user,
 )
 from litellm.proxy.management_endpoints.compliance_endpoints import (
     router as compliance_router,
+)
+from litellm.proxy.management_endpoints.config_override_endpoints import (
+    router as config_override_router,
 )
 from litellm.proxy.management_endpoints.cost_tracking_settings import (
     router as cost_tracking_settings_router,
@@ -373,7 +373,9 @@ from litellm.proxy.management_endpoints.fallback_management_endpoints import (
 from litellm.proxy.management_endpoints.internal_user_endpoints import (
     router as internal_user_router,
 )
-from litellm.proxy.management_endpoints.internal_user_endpoints import user_update
+from litellm.proxy.management_endpoints.internal_user_endpoints import (
+    user_update,
+)
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
@@ -442,7 +444,9 @@ from litellm.proxy.openai_evals_endpoints.endpoints import router as evals_route
 from litellm.proxy.openai_files_endpoints.files_endpoints import (
     router as openai_files_router,
 )
-from litellm.proxy.openai_files_endpoints.files_endpoints import set_files_config
+from litellm.proxy.openai_files_endpoints.files_endpoints import (
+    set_files_config,
+)
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     passthrough_endpoint_router,
 )
@@ -541,7 +545,9 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
     LiteLLM_UpperboundKeyGenerateParams,
 )
 from litellm.types.realtime import RealtimeQueryParams
-from litellm.types.router import DeploymentTypedDict
+from litellm.types.router import (
+    DeploymentTypedDict,
+)
 from litellm.types.router import ModelInfo as RouterModelInfo
 from litellm.types.router import (
     RouterGeneralSettings,
@@ -5788,6 +5794,8 @@ class ProxyStartupEvent:
                 _RUNTIME_GENERAL_SETTINGS_FLAGS,
             )
 
+            if prisma_client is None:
+                return
             db_record = await prisma_client.db.litellm_uisettings.find_unique(
                 where={"id": "ui_settings"}
             )
@@ -11983,6 +11991,7 @@ async def get_config_list(
         "mcp_trusted_proxy_ranges": {"type": "List"},
         "always_include_stream_usage": {"type": "Boolean"},
         "forward_client_headers_to_llm_api": {"type": "Boolean"},
+        "mcp_required_fields": {"type": "List"},
     }
 
     return_val = []

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -315,6 +315,7 @@ model LiteLLM_MCPServerTable {
   is_byok               Boolean  @default(false)
   byok_description      String[] @default([])
   byok_api_key_help_url String?
+  source_url            String?
   // BYOM submission lifecycle
   approval_status  String?   @default("active")
   submitted_by     String?

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -315,6 +315,14 @@ model LiteLLM_MCPServerTable {
   is_byok               Boolean  @default(false)
   byok_description      String[] @default([])
   byok_api_key_help_url String?
+  // BYOM submission lifecycle
+  approval_status  String?   @default("active")
+  submitted_by     String?
+  submitted_at     DateTime?
+  reviewed_at      DateTime?
+  review_notes     String?
+
+  @@index([approval_status])
 }
 
 // Per-user BYOK credentials for MCP servers

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1837,3 +1837,20 @@ class TestValidateMCPRequiredFields:
         with patch_proxy_general_settings({}):
             # Should not raise when no required fields are configured
             _validate_mcp_required_fields(payload)
+
+    def test_unknown_field_name_in_config_raises_500(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _validate_mcp_required_fields,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="My Server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+        )
+        # "source_Url" is a typo — not a real field on NewMCPServerRequest
+        with patch_proxy_general_settings({"mcp_required_fields": ["source_Url"]}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_mcp_required_fields(payload)
+        assert exc_info.value.status_code == 500
+        assert "source_Url" in str(exc_info.value.detail)

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1767,3 +1767,73 @@ class TestMCPApprovalWorkflow:
             )
         assert result is not None
         mock_manager.reload_servers_from_database.assert_awaited_once()
+
+
+class TestValidateMCPRequiredFields:
+    """Tests for _validate_mcp_required_fields."""
+
+    def test_missing_required_field_raises_400(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _validate_mcp_required_fields,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="My Server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+            # source_url is absent
+        )
+        with patch_proxy_general_settings({"mcp_required_fields": ["source_url"]}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_mcp_required_fields(payload)
+        assert exc_info.value.status_code == 400
+        assert "source_url" in str(exc_info.value.detail)
+
+    def test_auth_type_sentinel_treated_as_absent(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _validate_mcp_required_fields,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="My Server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+            auth_type=MCPAuth.none,  # sentinel value — treated as absent
+        )
+        with patch_proxy_general_settings({"mcp_required_fields": ["auth_type"]}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_mcp_required_fields(payload)
+        assert exc_info.value.status_code == 400
+        assert "auth_type" in str(exc_info.value.detail)
+
+    def test_all_required_fields_present_passes(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _validate_mcp_required_fields,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="My Server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+            source_url="https://github.com/org/repo",
+            auth_type=MCPAuth.bearer_token,
+        )
+        with patch_proxy_general_settings(
+            {"mcp_required_fields": ["source_url", "auth_type"]}
+        ):
+            # Should not raise
+            _validate_mcp_required_fields(payload)
+
+    def test_no_required_fields_configured_always_passes(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _validate_mcp_required_fields,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="Minimal",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+        )
+        with patch_proxy_general_settings({}):
+            # Should not raise when no required fields are configured
+            _validate_mcp_required_fields(payload)

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1739,6 +1739,9 @@ class TestMCPApprovalWorkflow:
         now_rejected = generate_mock_mcp_server_db_record()
         now_rejected.approval_status = MCPApprovalStatus.rejected
 
+        mock_manager = MagicMock()
+        mock_manager.reload_servers_from_database = AsyncMock()
+
         with (
             patch(
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
@@ -1752,6 +1755,10 @@ class TestMCPApprovalWorkflow:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.reject_mcp_server",
                 AsyncMock(return_value=now_rejected),
             ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
         ):
             result = await reject_mcp_server_submission(
                 server_id=active_server.server_id,
@@ -1759,3 +1766,4 @@ class TestMCPApprovalWorkflow:
                 user_api_key_dict=admin,
             )
         assert result is not None
+        mock_manager.reload_servers_from_database.assert_awaited_once()

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1512,3 +1512,250 @@ class TestManagementPayloadValidation:
             assert len(result) == 1
             assert result[0]["server_id"] == "server-1"
             assert result[0]["status"] == "healthy"
+
+
+class TestMCPApprovalWorkflow:
+    """Tests for BYOM submission: register, list submissions, approve, reject."""
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_requires_team_key(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            register_mcp_server,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="My Server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+        )
+        # No team_id → should raise 400
+        user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            team_id=None,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await register_mcp_server(payload=payload, user_api_key_dict=user_auth)
+        assert exc_info.value.status_code == 400
+        assert "team" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_register_mcp_server_sets_pending_review(self):
+        from litellm.proxy._types import MCPApprovalStatus
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            register_mcp_server,
+        )
+
+        payload = NewMCPServerRequest(
+            alias="My Server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.sse,
+        )
+        user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            team_id="team-123",
+            user_id="user-abc",
+        )
+        created_record = generate_mock_mcp_server_db_record(
+            alias="My Server",
+            url="https://example.com/mcp",
+        )
+        created_record.approval_status = MCPApprovalStatus.pending_review
+        created_record.submitted_by = "user-abc"
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.validate_and_normalize_mcp_server_payload",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.create_mcp_server",
+                AsyncMock(return_value=created_record),
+            ) as mock_create,
+        ):
+            result = await register_mcp_server(
+                payload=payload, user_api_key_dict=user_auth
+            )
+
+        # Endpoint sets pending_review before calling create_mcp_server
+        call_payload = mock_create.call_args[0][1]
+        assert call_payload.approval_status == MCPApprovalStatus.pending_review
+        assert call_payload.submitted_by == "user-abc"
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_get_submissions_non_admin_forbidden(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            get_mcp_server_submissions,
+        )
+
+        non_admin = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_mcp_server_submissions(user_api_key_dict=non_admin)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_get_submissions_admin_returns_summary(self):
+        from litellm.proxy._types import MCPSubmissionsSummary
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            get_mcp_server_submissions,
+        )
+
+        admin = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
+        pending = generate_mock_mcp_server_db_record(alias="Pending")
+        pending.approval_status = "pending_review"
+        summary = MCPSubmissionsSummary(
+            total=1, pending_review=1, active=0, rejected=0, items=[pending]
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_submissions",
+                AsyncMock(return_value=summary),
+            ),
+        ):
+            result = await get_mcp_server_submissions(user_api_key_dict=admin)
+
+        assert result.total == 1
+        assert result.pending_review == 1
+
+    @pytest.mark.asyncio
+    async def test_approve_non_pending_server_raises_400(self):
+        from litellm.proxy._types import MCPApprovalStatus
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            approve_mcp_server_submission,
+        )
+
+        admin = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
+        active_server = generate_mock_mcp_server_db_record()
+        active_server.approval_status = MCPApprovalStatus.active
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=active_server),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await approve_mcp_server_submission(
+                    server_id="server-1", user_api_key_dict=admin
+                )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_approve_pending_server_loads_into_registry(self):
+        from litellm.proxy._types import MCPApprovalStatus
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            approve_mcp_server_submission,
+        )
+
+        admin = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
+        pending_server = generate_mock_mcp_server_db_record()
+        pending_server.approval_status = MCPApprovalStatus.pending_review
+        approved_server = generate_mock_mcp_server_db_record()
+        approved_server.approval_status = MCPApprovalStatus.active
+
+        mock_manager = MagicMock()
+        mock_manager.reload_servers_from_database = AsyncMock()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=pending_server),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.approve_mcp_server",
+                AsyncMock(return_value=approved_server),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            result = await approve_mcp_server_submission(
+                server_id=pending_server.server_id, user_api_key_dict=admin
+            )
+
+        mock_manager.reload_servers_from_database.assert_awaited_once()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_reject_already_rejected_raises_400(self):
+        from litellm.proxy._types import MCPApprovalStatus, RejectMCPServerRequest
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            reject_mcp_server_submission,
+        )
+
+        admin = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
+        rejected_server = generate_mock_mcp_server_db_record()
+        rejected_server.approval_status = MCPApprovalStatus.rejected
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=rejected_server),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await reject_mcp_server_submission(
+                    server_id="server-1",
+                    payload=RejectMCPServerRequest(review_notes="duplicate"),
+                    user_api_key_dict=admin,
+                )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_reject_active_server_allowed(self):
+        """Admin can deactivate an already-approved server via the reject endpoint."""
+        from litellm.proxy._types import MCPApprovalStatus, RejectMCPServerRequest
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            reject_mcp_server_submission,
+        )
+
+        admin = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
+        active_server = generate_mock_mcp_server_db_record()
+        active_server.approval_status = MCPApprovalStatus.active
+        now_rejected = generate_mock_mcp_server_db_record()
+        now_rejected.approval_status = MCPApprovalStatus.rejected
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+                AsyncMock(return_value=active_server),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.reject_mcp_server",
+                AsyncMock(return_value=now_rejected),
+            ),
+        ):
+            result = await reject_mcp_server_submission(
+                server_id=active_server.server_id,
+                payload=RejectMCPServerRequest(review_notes="policy violation"),
+                user_api_key_dict=admin,
+            )
+        assert result is not None

--- a/ui/litellm-dashboard/src/components/guardrails.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails.tsx
@@ -140,7 +140,7 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
           <Tab>Guardrail Garden</Tab>
           <Tab>Guardrails</Tab>
           <Tab disabled={!accessToken || guardrailsList.length === 0}>Test Playground</Tab>
-          <Tab>Team Guardrails</Tab>
+          <Tab>Submitted Guardrails</Tab>
         </TabList>
 
         <TabPanels>

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -103,7 +103,11 @@ const menuGroups: MenuGroup[] = [
       {
         key: "mcp-servers",
         page: "mcp-servers",
-        label: "MCP Servers",
+        label: (
+          <span className="flex items-center gap-2">
+            Team MCPs <NewBadge />
+          </span>
+        ),
         icon: <ToolOutlined />,
       },
       {

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -103,11 +103,7 @@ const menuGroups: MenuGroup[] = [
       {
         key: "mcp-servers",
         page: "mcp-servers",
-        label: (
-          <span className="flex items-center gap-2">
-            Team MCPs <NewBadge />
-          </span>
-        ),
+        label: "MCP Servers",
         icon: <ToolOutlined />,
       },
       {

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPStandardsSettings.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPStandardsSettings.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
-import { getGeneralSettingsCall, updateConfigFieldSetting } from "../networking";
-import NotificationsManager from "../molecules/notifications_manager";
 import { MCPServer } from "./types";
-
-interface MCPStandardsSettingsProps {
-  accessToken: string | null;
-}
 
 export interface RequiredFieldDef {
   key: string;
@@ -16,146 +9,64 @@ export interface RequiredFieldDef {
   check: (server: MCPServer) => boolean;
 }
 
-export const MCP_REQUIRED_FIELD_DEFS: RequiredFieldDef[] = [
+export interface FieldGroup {
+  label: string;
+  fields: RequiredFieldDef[];
+}
+
+export const FIELD_GROUPS: FieldGroup[] = [
   {
-    key: "description",
-    label: "Description",
-    description: "Server must have a non-empty description.",
-    check: (s) => !!s.description?.trim(),
+    label: "Documentation",
+    fields: [
+      {
+        key: "description",
+        label: "Description",
+        description: "Must have a non-empty description",
+        check: (s) => !!s.description?.trim(),
+      },
+      {
+        key: "alias",
+        label: "Alias",
+        description: "Must have a display alias",
+        check: (s) => !!s.alias?.trim(),
+      },
+    ],
   },
   {
-    key: "source_url",
-    label: "GitHub / Source URL",
-    description: "Server must have a link to the source repository.",
-    check: (s) => !!s.source_url?.trim(),
+    label: "Source",
+    fields: [
+      {
+        key: "source_url",
+        label: "GitHub / Source URL",
+        description: "Must link to a source repository",
+        check: (s) => !!s.source_url?.trim(),
+      },
+    ],
   },
   {
-    key: "alias",
-    label: "Alias",
-    description: "Server must have a human-readable alias.",
-    check: (s) => !!s.alias?.trim(),
+    label: "Connection",
+    fields: [
+      {
+        key: "url",
+        label: "Server URL",
+        description: "Must have a URL configured",
+        check: (s) => !!s.url?.trim(),
+      },
+    ],
   },
   {
-    key: "auth_type",
-    label: "Auth configured",
-    description: "Server must have an auth type set (not 'none').",
-    check: (s) => !!s.auth_type && s.auth_type !== "none",
-  },
-  {
-    key: "url",
-    label: "Server URL",
-    description: "Server must have a URL configured.",
-    check: (s) => !!s.url?.trim(),
+    label: "Security",
+    fields: [
+      {
+        key: "auth_type",
+        label: "Auth configured",
+        description: "Must use authentication (not 'none')",
+        check: (s) => !!s.auth_type && s.auth_type !== "none",
+      },
+    ],
   },
 ];
 
-const SETTINGS_KEY = "mcp_required_fields";
+export const MCP_REQUIRED_FIELD_DEFS: RequiredFieldDef[] = FIELD_GROUPS.flatMap((g) => g.fields);
 
-export default function MCPStandardsSettings({ accessToken }: MCPStandardsSettingsProps) {
-  const [requiredFields, setRequiredFields] = useState<string[]>([]);
-  const [isSaving, setIsSaving] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const loadSettings = useCallback(async () => {
-    if (!accessToken) return;
-    setIsLoading(true);
-    try {
-      const settings = await getGeneralSettingsCall(accessToken);
-      const rows: Array<{ field_name: string; field_value: unknown }> = Array.isArray(settings?.data)
-        ? settings.data
-        : [];
-      const row = rows.find((r) => r.field_name === SETTINGS_KEY);
-      if (row && Array.isArray(row.field_value)) {
-        setRequiredFields(row.field_value as string[]);
-      }
-    } catch {
-      // leave defaults
-    } finally {
-      setIsLoading(false);
-    }
-  }, [accessToken]);
-
-  useEffect(() => {
-    loadSettings();
-  }, [loadSettings]);
-
-  const toggleField = (key: string) => {
-    setRequiredFields((prev) =>
-      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
-    );
-  };
-
-  const handleSave = async () => {
-    if (!accessToken) return;
-    setIsSaving(true);
-    try {
-      await updateConfigFieldSetting(accessToken, SETTINGS_KEY, requiredFields);
-      NotificationsManager.success("Standards saved");
-    } catch {
-      NotificationsManager.fromBackend("Failed to save standards");
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  return (
-    <div className="p-6 max-w-2xl">
-      <div className="mb-6">
-        <h2 className="text-base font-semibold text-gray-900">MCP Submission Standards</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Choose which fields are required for a submission to pass your standards. Each submission
-          card in the Team MCPs tab will show a green ✓ or red ✗ for each requirement.
-        </p>
-      </div>
-
-      {isLoading ? (
-        <div className="text-sm text-gray-400">Loading…</div>
-      ) : (
-        <div className="space-y-3">
-          {MCP_REQUIRED_FIELD_DEFS.map((field) => {
-            const enabled = requiredFields.includes(field.key);
-            return (
-              <div
-                key={field.key}
-                className={`flex items-center justify-between px-4 py-3 rounded-lg border transition-colors ${
-                  enabled ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-white"
-                }`}
-              >
-                <div className="flex-1 min-w-0 mr-4">
-                  <div className="text-sm font-medium text-gray-900">{field.label}</div>
-                  <div className="text-xs text-gray-500 mt-0.5">{field.description}</div>
-                </div>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={enabled}
-                  onClick={() => toggleField(field.key)}
-                  className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
-                    enabled ? "bg-blue-500" : "bg-gray-200"
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                      enabled ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      <div className="mt-6">
-        <button
-          type="button"
-          disabled={isSaving || isLoading}
-          onClick={handleSave}
-          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 rounded-md transition-colors"
-        >
-          {isSaving ? "Saving…" : "Save Standards"}
-        </button>
-      </div>
-    </div>
-  );
-}
+export const SETTINGS_KEY = "mcp_required_fields";

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPStandardsSettings.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPStandardsSettings.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import { getGeneralSettingsCall, updateConfigFieldSetting } from "../networking";
+import NotificationsManager from "../molecules/notifications_manager";
+import { MCPServer } from "./types";
+
+interface MCPStandardsSettingsProps {
+  accessToken: string | null;
+}
+
+export interface RequiredFieldDef {
+  key: string;
+  label: string;
+  description: string;
+  check: (server: MCPServer) => boolean;
+}
+
+export const MCP_REQUIRED_FIELD_DEFS: RequiredFieldDef[] = [
+  {
+    key: "description",
+    label: "Description",
+    description: "Server must have a non-empty description.",
+    check: (s) => !!s.description?.trim(),
+  },
+  {
+    key: "source_url",
+    label: "GitHub / Source URL",
+    description: "Server must have a link to the source repository.",
+    check: (s) => !!s.source_url?.trim(),
+  },
+  {
+    key: "alias",
+    label: "Alias",
+    description: "Server must have a human-readable alias.",
+    check: (s) => !!s.alias?.trim(),
+  },
+  {
+    key: "auth_type",
+    label: "Auth configured",
+    description: "Server must have an auth type set (not 'none').",
+    check: (s) => !!s.auth_type && s.auth_type !== "none",
+  },
+  {
+    key: "url",
+    label: "Server URL",
+    description: "Server must have a URL configured.",
+    check: (s) => !!s.url?.trim(),
+  },
+];
+
+const SETTINGS_KEY = "mcp_required_fields";
+
+export default function MCPStandardsSettings({ accessToken }: MCPStandardsSettingsProps) {
+  const [requiredFields, setRequiredFields] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadSettings = useCallback(async () => {
+    if (!accessToken) return;
+    setIsLoading(true);
+    try {
+      const settings = await getGeneralSettingsCall(accessToken);
+      const rows: Array<{ field_name: string; field_value: unknown }> = Array.isArray(settings?.data)
+        ? settings.data
+        : [];
+      const row = rows.find((r) => r.field_name === SETTINGS_KEY);
+      if (row && Array.isArray(row.field_value)) {
+        setRequiredFields(row.field_value as string[]);
+      }
+    } catch {
+      // leave defaults
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  const toggleField = (key: string) => {
+    setRequiredFields((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    );
+  };
+
+  const handleSave = async () => {
+    if (!accessToken) return;
+    setIsSaving(true);
+    try {
+      await updateConfigFieldSetting(accessToken, SETTINGS_KEY, requiredFields);
+      NotificationsManager.success("Standards saved");
+    } catch {
+      NotificationsManager.fromBackend("Failed to save standards");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <div className="mb-6">
+        <h2 className="text-base font-semibold text-gray-900">MCP Submission Standards</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Choose which fields are required for a submission to pass your standards. Each submission
+          card in the Team MCPs tab will show a green ✓ or red ✗ for each requirement.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="text-sm text-gray-400">Loading…</div>
+      ) : (
+        <div className="space-y-3">
+          {MCP_REQUIRED_FIELD_DEFS.map((field) => {
+            const enabled = requiredFields.includes(field.key);
+            return (
+              <div
+                key={field.key}
+                className={`flex items-center justify-between px-4 py-3 rounded-lg border transition-colors ${
+                  enabled ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-white"
+                }`}
+              >
+                <div className="flex-1 min-w-0 mr-4">
+                  <div className="text-sm font-medium text-gray-900">{field.label}</div>
+                  <div className="text-xs text-gray-500 mt-0.5">{field.description}</div>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={enabled}
+                  onClick={() => toggleField(field.key)}
+                  className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+                    enabled ? "bg-blue-500" : "bg-gray-200"
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      enabled ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-6">
+        <button
+          type="button"
+          disabled={isSaving || isLoading}
+          onClick={handleSave}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 rounded-md transition-colors"
+        >
+          {isSaving ? "Saving…" : "Save Standards"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -542,11 +542,12 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
     if (!accessToken) return;
     try {
       await approveMCPServer(accessToken, serverId);
-      setConfirmAction(null);
       await fetchData();
       NotificationsManager.success(`MCP server "${serverName}" approved`);
     } catch {
       NotificationsManager.fromBackend("Failed to approve MCP server");
+    } finally {
+      setConfirmAction(null);
     }
   }
 
@@ -554,11 +555,12 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
     if (!accessToken) return;
     try {
       await rejectMCPServer(accessToken, serverId, reviewNotes);
-      setConfirmAction(null);
       await fetchData();
       NotificationsManager.success(`MCP server "${serverName}" rejected`);
     } catch {
       NotificationsManager.fromBackend("Failed to reject MCP server");
+    } finally {
+      setConfirmAction(null);
     }
   }
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  SearchIcon,
+  CheckIcon,
+  XIcon,
+  AlertCircleIcon,
+  ServerIcon,
+} from "lucide-react";
+import {
+  fetchMCPSubmissions,
+  approveMCPServer,
+  rejectMCPServer,
+} from "@/components/networking";
+import { MCPServer, MCPSubmissionsSummary } from "./types";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+
+type MCPStatus = "active" | "pending_review" | "rejected";
+
+const STATUS_CONFIG: Record<
+  MCPStatus,
+  { label: string; bg: string; text: string; dot: string }
+> = {
+  active: {
+    label: "Active",
+    bg: "bg-green-50",
+    text: "text-green-700",
+    dot: "bg-green-500",
+  },
+  pending_review: {
+    label: "Pending Review",
+    bg: "bg-yellow-50",
+    text: "text-yellow-700",
+    dot: "bg-yellow-500",
+  },
+  rejected: {
+    label: "Rejected",
+    bg: "bg-red-50",
+    text: "text-red-700",
+    dot: "bg-red-500",
+  },
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  try {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? value : d.toISOString().slice(0, 10);
+  } catch {
+    return value;
+  }
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color: string;
+}) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg px-4 py-3">
+      <div className={`text-2xl font-bold ${color}`}>{value}</div>
+      <div className="text-xs text-gray-500 mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+type ConfirmDialogProps = {
+  action: "approve" | "reject";
+  serverName: string;
+  onConfirm: (reviewNotes?: string) => void;
+  onCancel: () => void;
+};
+
+function ConfirmDialog({ action, serverName, onConfirm, onCancel }: ConfirmDialogProps) {
+  const [reviewNotes, setReviewNotes] = useState("");
+  const isApprove = action === "approve";
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
+        <div
+          className={`w-10 h-10 rounded-full flex items-center justify-center mb-4 ${
+            isApprove ? "bg-green-100" : "bg-red-100"
+          }`}
+        >
+          {isApprove ? (
+            <CheckIcon className="h-5 w-5 text-green-600" />
+          ) : (
+            <AlertCircleIcon className="h-5 w-5 text-red-600" />
+          )}
+        </div>
+        <h3 className="text-base font-semibold text-gray-900 mb-1">
+          {isApprove ? "Approve MCP Server" : "Reject MCP Server"}
+        </h3>
+        <p className="text-sm text-gray-500 mb-4">
+          Are you sure you want to {action}{" "}
+          <span className="font-medium text-gray-700">&quot;{serverName}&quot;</span>?{" "}
+          {isApprove
+            ? "This will make it active and available for use."
+            : "This will mark it as rejected."}
+        </p>
+        {!isApprove && (
+          <textarea
+            placeholder="Reason for rejection (optional)"
+            value={reviewNotes}
+            onChange={(e) => setReviewNotes(e.target.value)}
+            className="w-full border border-gray-200 rounded-md px-3 py-2 text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-500 mb-4 resize-none"
+            rows={3}
+          />
+        )}
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 border border-gray-300 text-gray-700 hover:bg-gray-50 text-sm font-medium py-2 rounded-md transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(isApprove ? undefined : reviewNotes || undefined)}
+            className={`flex-1 text-white text-sm font-medium py-2 rounded-md transition-colors ${
+              isApprove ? "bg-green-500 hover:bg-green-600" : "bg-red-500 hover:bg-red-600"
+            }`}
+          >
+            {isApprove ? "Approve" : "Reject"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type MCPServerCardProps = {
+  server: MCPServer;
+  onApprove: () => void;
+  onReject: () => void;
+};
+
+function MCPServerCard({ server, onApprove, onReject }: MCPServerCardProps) {
+  const approvalStatus = (server.approval_status ?? "active") as MCPStatus;
+  const statusCfg = STATUS_CONFIG[approvalStatus] ?? STATUS_CONFIG["active"];
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <span
+              className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${statusCfg.bg} ${statusCfg.text}`}
+            >
+              <span className={`w-1.5 h-1.5 rounded-full ${statusCfg.dot}`} />
+              {statusCfg.label}
+            </span>
+          </div>
+          <h3 className="text-sm font-semibold text-gray-900 mb-1">
+            {server.alias ?? server.server_name ?? server.server_id}
+          </h3>
+          {server.description && (
+            <p className="text-xs text-gray-500 mb-2 line-clamp-1">{server.description}</p>
+          )}
+          {server.url && (
+            <div className="flex items-center gap-1.5 mb-2">
+              <ServerIcon className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
+              <code className="text-xs text-gray-500 font-mono truncate">{server.url}</code>
+            </div>
+          )}
+          <div className="flex items-center gap-4 text-xs text-gray-500">
+            <span>
+              Transport:{" "}
+              <span className="font-medium text-gray-700">{server.transport ?? "sse"}</span>
+            </span>
+            <span>
+              Submitted by:{" "}
+              <span className="font-medium text-gray-700">{server.submitted_by ?? "—"}</span>
+            </span>
+            <span>
+              Date:{" "}
+              <span className="font-medium text-gray-700">{formatDate(server.submitted_at)}</span>
+            </span>
+          </div>
+          {approvalStatus === "rejected" && server.review_notes && (
+            <p className="text-xs text-red-600 mt-1">
+              Rejection reason: {server.review_notes}
+            </p>
+          )}
+        </div>
+        {approvalStatus === "pending_review" && (
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <button
+              type="button"
+              onClick={onApprove}
+              className="text-xs bg-green-500 hover:bg-green-600 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={onReject}
+              className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
+            >
+              Reject
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface MCPSubmissionsTabProps {
+  accessToken: string | null;
+}
+
+export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
+  const [summary, setSummary] = useState<MCPSubmissionsSummary>({
+    total: 0,
+    pending_review: 0,
+    active: 0,
+    rejected: 0,
+    items: [],
+  });
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | MCPStatus>("all");
+  const [confirmAction, setConfirmAction] = useState<{
+    serverId: string;
+    serverName: string;
+    action: "approve" | "reject";
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!accessToken) {
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res: MCPSubmissionsSummary = await fetchMCPSubmissions(accessToken);
+      setSummary(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load submissions");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const filtered = summary.items.filter((s) => {
+    if (statusFilter !== "all" && s.approval_status !== statusFilter) return false;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      const name = (s.alias ?? s.server_name ?? s.server_id ?? "").toLowerCase();
+      const url = (s.url ?? "").toLowerCase();
+      return name.includes(q) || url.includes(q);
+    }
+    return true;
+  });
+
+  async function handleApprove(serverId: string, serverName: string) {
+    if (!accessToken) return;
+    try {
+      await approveMCPServer(accessToken, serverId);
+      setConfirmAction(null);
+      await fetchData();
+      NotificationsManager.success(`MCP server "${serverName}" approved`);
+    } catch {
+      NotificationsManager.fromBackend("Failed to approve MCP server");
+    }
+  }
+
+  async function handleReject(serverId: string, serverName: string, reviewNotes?: string) {
+    if (!accessToken) return;
+    try {
+      await rejectMCPServer(accessToken, serverId, reviewNotes);
+      setConfirmAction(null);
+      await fetchData();
+      NotificationsManager.success(`MCP server "${serverName}" rejected`);
+    } catch {
+      NotificationsManager.fromBackend("Failed to reject MCP server");
+    }
+  }
+
+  return (
+    <div className="p-6">
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <StatCard label="Total Submitted" value={summary.total} color="text-gray-900" />
+        <StatCard label="Pending Review" value={summary.pending_review} color="text-yellow-600" />
+        <StatCard label="Active" value={summary.active} color="text-green-600" />
+        <StatCard label="Rejected" value={summary.rejected} color="text-red-600" />
+      </div>
+
+      <div className="flex items-center gap-3 mb-5">
+        <div className="relative flex-1 max-w-xs">
+          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search MCP servers..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-4 py-2 border border-gray-200 rounded-md text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as typeof statusFilter)}
+          className="border border-gray-200 rounded-md px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white"
+        >
+          <option value="all">All Status</option>
+          <option value="pending_review">Pending Review</option>
+          <option value="active">Active</option>
+          <option value="rejected">Rejected</option>
+        </select>
+      </div>
+
+      <div className="space-y-3">
+        {isLoading && (
+          <div className="text-center py-12 text-gray-500 text-sm">Loading submissions…</div>
+        )}
+        {error && (
+          <div className="text-center py-12 text-red-600 text-sm">{error}</div>
+        )}
+        {!isLoading && !error && filtered.length === 0 && (
+          <div className="text-center py-12 text-gray-400 text-sm">
+            No MCP server submissions match your filters.
+          </div>
+        )}
+        {!isLoading &&
+          !error &&
+          filtered.map((server) => (
+            <MCPServerCard
+              key={server.server_id}
+              server={server}
+              onApprove={() =>
+                setConfirmAction({
+                  serverId: server.server_id,
+                  serverName: server.alias ?? server.server_name ?? server.server_id,
+                  action: "approve",
+                })
+              }
+              onReject={() =>
+                setConfirmAction({
+                  serverId: server.server_id,
+                  serverName: server.alias ?? server.server_name ?? server.server_id,
+                  action: "reject",
+                })
+              }
+            />
+          ))}
+      </div>
+
+      {confirmAction && (
+        <ConfirmDialog
+          action={confirmAction.action}
+          serverName={confirmAction.serverName}
+          onConfirm={(reviewNotes) =>
+            confirmAction.action === "approve"
+              ? handleApprove(confirmAction.serverId, confirmAction.serverName)
+              : handleReject(confirmAction.serverId, confirmAction.serverName, reviewNotes)
+          }
+          onCancel={() => setConfirmAction(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -7,15 +7,19 @@ import {
   XIcon,
   AlertCircleIcon,
   ServerIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  SettingsIcon,
 } from "lucide-react";
 import {
   fetchMCPSubmissions,
   approveMCPServer,
   rejectMCPServer,
   getGeneralSettingsCall,
+  updateConfigFieldSetting,
 } from "@/components/networking";
 import { MCPServer, MCPSubmissionsSummary } from "./types";
-import { MCP_REQUIRED_FIELD_DEFS } from "./MCPStandardsSettings";
+import { FIELD_GROUPS, MCP_REQUIRED_FIELD_DEFS, SETTINGS_KEY } from "./MCPStandardsSettings";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 
 type MCPStatus = "active" | "pending_review" | "rejected";
@@ -133,6 +137,128 @@ function ConfirmDialog({ action, serverName, onConfirm, onCancel }: ConfirmDialo
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+type SubmissionRulesPanelProps = {
+  requiredFields: string[];
+  onChange: (fields: string[]) => void;
+  onSave: () => Promise<void>;
+  isSaving: boolean;
+};
+
+function SubmissionRulesPanel({ requiredFields, onChange, onSave, isSaving }: SubmissionRulesPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+  const activeLabels = MCP_REQUIRED_FIELD_DEFS.filter((f) => requiredFields.includes(f.key));
+
+  const toggle = (key: string) => {
+    onChange(requiredFields.includes(key) ? requiredFields.filter((k) => k !== key) : [...requiredFields, key]);
+  };
+
+  return (
+    <div className="mb-5 border border-gray-200 rounded-lg bg-white overflow-hidden">
+      {/* Header — always visible */}
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer select-none"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex items-center gap-2">
+          <SettingsIcon className="h-4 w-4 text-gray-400" />
+          <span className="text-sm font-semibold text-gray-800">Submission Rules</span>
+          {activeLabels.length > 0 ? (
+            <span className="text-xs text-gray-500">
+              ({activeLabels.length} required field{activeLabels.length !== 1 ? "s" : ""})
+            </span>
+          ) : (
+            <span className="text-xs text-gray-400 italic">no rules set</span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {/* Active rule chips — collapsed view */}
+          {!expanded && activeLabels.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 max-w-md">
+              {activeLabels.map((f) => (
+                <span
+                  key={f.key}
+                  className="inline-flex items-center gap-1 text-xs bg-blue-50 text-blue-700 border border-blue-200 px-2 py-0.5 rounded-full"
+                >
+                  <CheckIcon className="h-3 w-3" />
+                  {f.label}
+                </span>
+              ))}
+            </div>
+          )}
+          {expanded ? (
+            <ChevronUpIcon className="h-4 w-4 text-gray-400" />
+          ) : (
+            <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+          )}
+        </div>
+      </div>
+
+      {/* Expanded editor */}
+      {expanded && (
+        <div className="border-t border-gray-100 px-4 pt-4 pb-4">
+          <p className="text-xs text-gray-500 mb-4">
+            Select which fields must be filled in before a submission is considered compliant.
+            LiteLLM will show ✓ / ✗ for each rule on every submission card below.
+          </p>
+          <div className="grid grid-cols-2 gap-x-8 gap-y-5">
+            {FIELD_GROUPS.map((group) => (
+              <div key={group.label}>
+                <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                  {group.label}
+                </div>
+                <div className="space-y-2">
+                  {group.fields.map((field) => {
+                    const active = requiredFields.includes(field.key);
+                    return (
+                      <label
+                        key={field.key}
+                        className="flex items-start gap-2.5 cursor-pointer group"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={active}
+                          onChange={() => toggle(field.key)}
+                          className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+                        />
+                        <div>
+                          <div className="text-sm font-medium text-gray-800 group-hover:text-blue-700 transition-colors">
+                            {field.label}
+                          </div>
+                          <div className="text-xs text-gray-400">{field.description}</div>
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5 flex items-center gap-3">
+            <button
+              type="button"
+              disabled={isSaving}
+              onClick={async () => {
+                await onSave();
+                setExpanded(false);
+              }}
+              className="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 rounded-md transition-colors"
+            >
+              {isSaving ? "Saving…" : "Save Rules"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              className="px-4 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -273,6 +399,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [requiredFields, setRequiredFields] = useState<string[]>([]);
+  const [isSavingRules, setIsSavingRules] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (!accessToken) {
@@ -289,7 +416,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
       setSummary(res);
       if (settings?.data && Array.isArray(settings.data)) {
         const row = settings.data.find(
-          (r: { field_name: string; field_value: unknown }) => r.field_name === "mcp_required_fields",
+          (r: { field_name: string; field_value: unknown }) => r.field_name === SETTINGS_KEY,
         );
         if (row && Array.isArray(row.field_value)) {
           setRequiredFields(row.field_value as string[]);
@@ -305,6 +432,19 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  const handleSaveRules = async () => {
+    if (!accessToken) return;
+    setIsSavingRules(true);
+    try {
+      await updateConfigFieldSetting(accessToken, SETTINGS_KEY, requiredFields);
+      NotificationsManager.success("Submission rules saved");
+    } catch {
+      NotificationsManager.fromBackend("Failed to save submission rules");
+    } finally {
+      setIsSavingRules(false);
+    }
+  };
 
   const filtered = summary.items.filter((s) => {
     if (statusFilter !== "all" && s.approval_status !== statusFilter) return false;
@@ -343,6 +483,14 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
 
   return (
     <div className="p-6">
+      {/* Submission Rules panel */}
+      <SubmissionRulesPanel
+        requiredFields={requiredFields}
+        onChange={setRequiredFields}
+        onSave={handleSaveRules}
+        isSaving={isSavingRules}
+      />
+
       <div className="grid grid-cols-4 gap-4 mb-6">
         <StatCard label="Total Submitted" value={summary.total} color="text-gray-900" />
         <StatCard label="Pending Review" value={summary.pending_review} color="text-yellow-600" />

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -12,8 +12,10 @@ import {
   fetchMCPSubmissions,
   approveMCPServer,
   rejectMCPServer,
+  getGeneralSettingsCall,
 } from "@/components/networking";
 import { MCPServer, MCPSubmissionsSummary } from "./types";
+import { MCP_REQUIRED_FIELD_DEFS } from "./MCPStandardsSettings";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 
 type MCPStatus = "active" | "pending_review" | "rejected";
@@ -139,11 +141,20 @@ type MCPServerCardProps = {
   server: MCPServer;
   onApprove: () => void;
   onReject: () => void;
+  requiredFields: string[];
 };
 
-function MCPServerCard({ server, onApprove, onReject }: MCPServerCardProps) {
+function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServerCardProps) {
   const approvalStatus = (server.approval_status ?? "active") as MCPStatus;
   const statusCfg = STATUS_CONFIG[approvalStatus] ?? STATUS_CONFIG["active"];
+
+  const checks = MCP_REQUIRED_FIELD_DEFS.filter((f) => requiredFields.includes(f.key)).map((f) => ({
+    key: f.key,
+    label: f.label,
+    passed: f.check(server),
+  }));
+  const passCount = checks.filter((c) => c.passed).length;
+  const allPassed = checks.length > 0 && passCount === checks.length;
 
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-4">
@@ -156,6 +167,15 @@ function MCPServerCard({ server, onApprove, onReject }: MCPServerCardProps) {
               <span className={`w-1.5 h-1.5 rounded-full ${statusCfg.dot}`} />
               {statusCfg.label}
             </span>
+            {checks.length > 0 && (
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                  allPassed ? "bg-green-50 text-green-700" : "bg-amber-50 text-amber-700"
+                }`}
+              >
+                {passCount}/{checks.length} checks
+              </span>
+            )}
           </div>
           <h3 className="text-sm font-semibold text-gray-900 mb-1">
             {server.alias ?? server.server_name ?? server.server_id}
@@ -187,6 +207,25 @@ function MCPServerCard({ server, onApprove, onReject }: MCPServerCardProps) {
             <p className="text-xs text-red-600 mt-1">
               Rejection reason: {server.review_notes}
             </p>
+          )}
+          {checks.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2 pt-2 border-t border-gray-100">
+              {checks.map((c) => (
+                <span
+                  key={c.key}
+                  className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${
+                    c.passed ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"
+                  }`}
+                >
+                  {c.passed ? (
+                    <CheckIcon className="h-3 w-3" />
+                  ) : (
+                    <XIcon className="h-3 w-3" />
+                  )}
+                  {c.label}
+                </span>
+              ))}
+            </div>
           )}
         </div>
         {approvalStatus === "pending_review" && (
@@ -233,6 +272,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
   } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [requiredFields, setRequiredFields] = useState<string[]>([]);
 
   const fetchData = useCallback(async () => {
     if (!accessToken) {
@@ -242,8 +282,19 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
     setIsLoading(true);
     setError(null);
     try {
-      const res: MCPSubmissionsSummary = await fetchMCPSubmissions(accessToken);
+      const [res, settings] = await Promise.all([
+        fetchMCPSubmissions(accessToken),
+        getGeneralSettingsCall(accessToken).catch(() => null),
+      ]);
       setSummary(res);
+      if (settings?.data && Array.isArray(settings.data)) {
+        const row = settings.data.find(
+          (r: { field_name: string; field_value: unknown }) => r.field_name === "mcp_required_fields",
+        );
+        if (row && Array.isArray(row.field_value)) {
+          setRequiredFields(row.field_value as string[]);
+        }
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load submissions");
     } finally {
@@ -340,6 +391,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
             <MCPServerCard
               key={server.server_id}
               server={server}
+              requiredFields={requiredFields}
               onApprove={() =>
                 setConfirmAction({
                   serverId: server.server_id,

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -322,24 +322,35 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
             )}
           </div>
           {/* Approve/Reject when no checks panel (no rules configured) */}
-          {checks.length === 0 && (approvalStatus === "pending_review" || approvalStatus === "rejected") && (
+          {checks.length === 0 && approvalStatus !== "rejected" && (
+            <div className="flex items-center gap-2 flex-shrink-0">
+              {approvalStatus !== "active" && (
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  className="text-xs bg-green-500 hover:bg-green-600 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
+                >
+                  Approve
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onReject}
+                className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
+              >
+                Reject
+              </button>
+            </div>
+          )}
+          {checks.length === 0 && approvalStatus === "rejected" && (
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 type="button"
                 onClick={onApprove}
                 className="text-xs bg-green-500 hover:bg-green-600 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
               >
-                Approve
+                Re-approve
               </button>
-              {approvalStatus === "pending_review" && (
-                <button
-                  type="button"
-                  onClick={onReject}
-                  className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
-                >
-                  Reject
-                </button>
-              )}
             </div>
           )}
         </div>
@@ -377,8 +388,8 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
               </div>
             </div>
             {/* Approve / Reject in header */}
-            {(approvalStatus === "pending_review" || approvalStatus === "rejected") && (
-              <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 flex-shrink-0">
+              {approvalStatus !== "active" && approvalStatus !== "rejected" && (
                 <button
                   type="button"
                   onClick={onApprove}
@@ -386,17 +397,26 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
                 >
                   Approve
                 </button>
-                {approvalStatus === "pending_review" && (
-                  <button
-                    type="button"
-                    onClick={onReject}
-                    className="text-xs border border-red-300 text-red-600 hover:bg-red-50 bg-white px-3 py-1.5 rounded-md transition-colors font-medium"
-                  >
-                    Reject
-                  </button>
-                )}
-              </div>
-            )}
+              )}
+              {approvalStatus === "rejected" && (
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  className="text-xs bg-green-600 hover:bg-green-700 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
+                >
+                  Re-approve
+                </button>
+              )}
+              {approvalStatus !== "rejected" && (
+                <button
+                  type="button"
+                  onClick={onReject}
+                  className="text-xs border border-red-300 text-red-600 hover:bg-red-50 bg-white px-3 py-1.5 rounded-md transition-colors font-medium"
+                >
+                  Reject
+                </button>
+              )}
+            </div>
           </div>
 
           {/* Individual check rows */}

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -277,102 +277,151 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
   const checks = MCP_REQUIRED_FIELD_DEFS.filter((f) => requiredFields.includes(f.key)).map((f) => ({
     key: f.key,
     label: f.label,
+    description: f.description,
     passed: f.check(server),
   }));
   const passCount = checks.filter((c) => c.passed).length;
-  const allPassed = checks.length > 0 && passCount === checks.length;
+  const failCount = checks.length - passCount;
+  const allPassed = checks.length > 0 && failCount === 0;
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span
-              className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${statusCfg.bg} ${statusCfg.text}`}
-            >
-              <span className={`w-1.5 h-1.5 rounded-full ${statusCfg.dot}`} />
-              {statusCfg.label}
-            </span>
-            {checks.length > 0 && (
+    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      {/* Server info */}
+      <div className="px-4 pt-4 pb-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5">
               <span
-                className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                  allPassed ? "bg-green-50 text-green-700" : "bg-amber-50 text-amber-700"
-                }`}
+                className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${statusCfg.bg} ${statusCfg.text}`}
               >
-                {passCount}/{checks.length} checks
+                <span className={`w-1.5 h-1.5 rounded-full ${statusCfg.dot}`} />
+                {statusCfg.label}
               </span>
+            </div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              {server.alias ?? server.server_name ?? server.server_id}
+            </h3>
+            {server.description && (
+              <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{server.description}</p>
+            )}
+            {server.url && (
+              <div className="flex items-center gap-1.5 mt-1.5">
+                <ServerIcon className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
+                <code className="text-xs text-gray-500 font-mono truncate">{server.url}</code>
+              </div>
+            )}
+            <div className="flex items-center gap-3 mt-1.5 text-xs text-gray-400">
+              <span>Transport: <span className="text-gray-600">{server.transport ?? "sse"}</span></span>
+              <span>·</span>
+              <span>Submitted by: <span className="text-gray-600">{server.submitted_by ?? "—"}</span></span>
+              <span>·</span>
+              <span>{formatDate(server.submitted_at)}</span>
+            </div>
+            {approvalStatus === "rejected" && server.review_notes && (
+              <p className="text-xs text-red-600 mt-1.5">Rejection reason: {server.review_notes}</p>
             )}
           </div>
-          <h3 className="text-sm font-semibold text-gray-900 mb-1">
-            {server.alias ?? server.server_name ?? server.server_id}
-          </h3>
-          {server.description && (
-            <p className="text-xs text-gray-500 mb-2 line-clamp-1">{server.description}</p>
-          )}
-          {server.url && (
-            <div className="flex items-center gap-1.5 mb-2">
-              <ServerIcon className="h-3.5 w-3.5 text-gray-400 flex-shrink-0" />
-              <code className="text-xs text-gray-500 font-mono truncate">{server.url}</code>
-            </div>
-          )}
-          <div className="flex items-center gap-4 text-xs text-gray-500">
-            <span>
-              Transport:{" "}
-              <span className="font-medium text-gray-700">{server.transport ?? "sse"}</span>
-            </span>
-            <span>
-              Submitted by:{" "}
-              <span className="font-medium text-gray-700">{server.submitted_by ?? "—"}</span>
-            </span>
-            <span>
-              Date:{" "}
-              <span className="font-medium text-gray-700">{formatDate(server.submitted_at)}</span>
-            </span>
-          </div>
-          {approvalStatus === "rejected" && server.review_notes && (
-            <p className="text-xs text-red-600 mt-1">
-              Rejection reason: {server.review_notes}
-            </p>
-          )}
-          {checks.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-2 pt-2 border-t border-gray-100">
-              {checks.map((c) => (
-                <span
-                  key={c.key}
-                  className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${
-                    c.passed ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"
-                  }`}
-                >
-                  {c.passed ? (
-                    <CheckIcon className="h-3 w-3" />
-                  ) : (
-                    <XIcon className="h-3 w-3" />
-                  )}
-                  {c.label}
-                </span>
-              ))}
+          {/* Approve/Reject when no checks panel (no rules configured) */}
+          {checks.length === 0 && approvalStatus === "pending_review" && (
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                type="button"
+                onClick={onApprove}
+                className="text-xs bg-green-500 hover:bg-green-600 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
+              >
+                Approve
+              </button>
+              <button
+                type="button"
+                onClick={onReject}
+                className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
+              >
+                Reject
+              </button>
             </div>
           )}
         </div>
-        {approvalStatus === "pending_review" && (
-          <div className="flex items-center gap-2 flex-shrink-0">
-            <button
-              type="button"
-              onClick={onApprove}
-              className="text-xs bg-green-500 hover:bg-green-600 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
-            >
-              Approve
-            </button>
-            <button
-              type="button"
-              onClick={onReject}
-              className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
-            >
-              Reject
-            </button>
-          </div>
-        )}
       </div>
+
+      {/* GitHub-style checks panel */}
+      {checks.length > 0 && (
+        <div className="border-t border-gray-200">
+          {/* Overall status header */}
+          <div
+            className={`flex items-center gap-3 px-4 py-3 ${
+              allPassed ? "bg-green-50 border-b border-green-100" : "bg-red-50 border-b border-red-100"
+            }`}
+          >
+            {/* Large status circle */}
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                allPassed ? "bg-green-500" : "bg-red-500"
+              }`}
+            >
+              {allPassed ? (
+                <CheckIcon className="h-4 w-4 text-white" />
+              ) : (
+                <XIcon className="h-4 w-4 text-white" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className={`text-sm font-semibold leading-tight ${allPassed ? "text-green-800" : "text-red-800"}`}>
+                {allPassed
+                  ? "All checks passed"
+                  : `${failCount} check${failCount !== 1 ? "s" : ""} failed`}
+              </div>
+              <div className="text-xs text-gray-500 mt-0.5">
+                {passCount} passing, {failCount} failing
+              </div>
+            </div>
+            {/* Approve / Reject in header */}
+            {approvalStatus === "pending_review" && (
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  className="text-xs bg-green-600 hover:bg-green-700 text-white px-3 py-1.5 rounded-md transition-colors font-medium"
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  onClick={onReject}
+                  className="text-xs border border-red-300 text-red-600 hover:bg-red-50 bg-white px-3 py-1.5 rounded-md transition-colors font-medium"
+                >
+                  Reject
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Individual check rows */}
+          <div className="divide-y divide-gray-100">
+            {checks.map((c) => (
+              <div key={c.key} className="flex items-center gap-3 px-4 py-2.5">
+                {/* Small circle icon */}
+                <div
+                  className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${
+                    c.passed ? "bg-green-100" : "bg-red-100"
+                  }`}
+                >
+                  {c.passed ? (
+                    <CheckIcon className="h-3 w-3 text-green-600" />
+                  ) : (
+                    <XIcon className="h-3 w-3 text-red-600" />
+                  )}
+                </div>
+                <span className={`text-sm flex-1 ${c.passed ? "text-gray-700" : "text-gray-800"}`}>
+                  {c.label}
+                </span>
+                <span className={`text-xs ${c.passed ? "text-green-600" : "text-red-500"}`}>
+                  {c.passed ? "Passes" : "Missing"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -322,7 +322,7 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
             )}
           </div>
           {/* Approve/Reject when no checks panel (no rules configured) */}
-          {checks.length === 0 && approvalStatus === "pending_review" && (
+          {checks.length === 0 && (approvalStatus === "pending_review" || approvalStatus === "rejected") && (
             <div className="flex items-center gap-2 flex-shrink-0">
               <button
                 type="button"
@@ -331,13 +331,15 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
               >
                 Approve
               </button>
-              <button
-                type="button"
-                onClick={onReject}
-                className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
-              >
-                Reject
-              </button>
+              {approvalStatus === "pending_review" && (
+                <button
+                  type="button"
+                  onClick={onReject}
+                  className="text-xs border border-red-300 text-red-600 hover:bg-red-50 px-3 py-1.5 rounded-md transition-colors font-medium"
+                >
+                  Reject
+                </button>
+              )}
             </div>
           )}
         </div>
@@ -375,7 +377,7 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
               </div>
             </div>
             {/* Approve / Reject in header */}
-            {approvalStatus === "pending_review" && (
+            {(approvalStatus === "pending_review" || approvalStatus === "rejected") && (
               <div className="flex items-center gap-2 flex-shrink-0">
                 <button
                   type="button"
@@ -384,13 +386,15 @@ function MCPServerCard({ server, onApprove, onReject, requiredFields }: MCPServe
                 >
                   Approve
                 </button>
-                <button
-                  type="button"
-                  onClick={onReject}
-                  className="text-xs border border-red-300 text-red-600 hover:bg-red-50 bg-white px-3 py-1.5 rounded-md transition-colors font-medium"
-                >
-                  Reject
-                </button>
+                {approvalStatus === "pending_review" && (
+                  <button
+                    type="button"
+                    onClick={onReject}
+                    className="text-xs border border-red-300 text-red-600 hover:bg-red-50 bg-white px-3 py-1.5 rounded-md transition-colors font-medium"
+                  >
+                    Reject
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPSubmissionsTab.tsx
@@ -78,13 +78,17 @@ function StatCard({
 type ConfirmDialogProps = {
   action: "approve" | "reject";
   serverName: string;
+  isCurrentlyActive?: boolean;
   onConfirm: (reviewNotes?: string) => void;
   onCancel: () => void;
 };
 
-function ConfirmDialog({ action, serverName, onConfirm, onCancel }: ConfirmDialogProps) {
+function ConfirmDialog({ action, serverName, isCurrentlyActive, onConfirm, onCancel }: ConfirmDialogProps) {
   const [reviewNotes, setReviewNotes] = useState("");
   const isApprove = action === "approve";
+  const rejectBody = isCurrentlyActive
+    ? "This server is currently live. Rejecting it will immediately remove it from the proxy runtime."
+    : "This will mark the submission as rejected.";
   return (
     <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
       <div className="bg-white rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
@@ -107,7 +111,7 @@ function ConfirmDialog({ action, serverName, onConfirm, onCancel }: ConfirmDialo
           <span className="font-medium text-gray-700">&quot;{serverName}&quot;</span>?{" "}
           {isApprove
             ? "This will make it active and available for use."
-            : "This will mark it as rejected."}
+            : rejectBody}
         </p>
         {!isApprove && (
           <textarea
@@ -468,6 +472,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
     serverId: string;
     serverName: string;
     action: "approve" | "reject";
+    isCurrentlyActive?: boolean;
   } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -484,7 +489,10 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
     try {
       const [res, settings] = await Promise.all([
         fetchMCPSubmissions(accessToken),
-        getGeneralSettingsCall(accessToken).catch(() => null),
+        getGeneralSettingsCall(accessToken).catch((err) => {
+          console.warn("MCPSubmissionsTab: failed to load general settings, compliance rules will be empty:", err);
+          return null;
+        }),
       ]);
       setSummary(res);
       if (settings?.data && Array.isArray(settings.data)) {
@@ -625,6 +633,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
                   serverId: server.server_id,
                   serverName: server.alias ?? server.server_name ?? server.server_id,
                   action: "reject",
+                  isCurrentlyActive: server.approval_status === "active",
                 })
               }
             />
@@ -635,6 +644,7 @@ export function MCPSubmissionsTab({ accessToken }: MCPSubmissionsTabProps) {
         <ConfirmDialog
           action={confirmAction.action}
           serverName={confirmAction.serverName}
+          isCurrentlyActive={confirmAction.isCurrentlyActive}
           onConfirm={(reviewNotes) =>
             confirmAction.action === "approve"
               ? handleApprove(confirmAction.serverId, confirmAction.serverName)

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Modal, Tooltip, Form, Select, Input, Switch } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
-import { createMCPServer } from "../networking";
+import { createMCPServer, registerMCPServer } from "../networking";
 import { AUTH_TYPE, DiscoverableMCPServer, OAUTH_FLOW, MCPServer, MCPServerCostInfo, TRANSPORT } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import MCPServerCostConfig from "./mcp_server_cost_config";
@@ -373,9 +373,16 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       console.log(`Payload: ${JSON.stringify(payload)}`);
 
       if (accessToken != null) {
-        const response = await createMCPServer(accessToken, payload);
+        const isAdmin = isAdminRole(userRole);
+        const response = isAdmin
+          ? await createMCPServer(accessToken, payload)
+          : await registerMCPServer(accessToken, payload);
 
-        NotificationsManager.success("MCP Server created successfully");
+        NotificationsManager.success(
+          isAdmin
+            ? "MCP Server created successfully"
+            : "MCP Server submitted for admin review"
+        );
         form.resetFields();
         setCostConfig({});
         setTools([]);

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -575,6 +575,16 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
             </Form.Item>
 
             <Form.Item
+              label={<span className="text-sm font-medium text-gray-700">GitHub / Source URL</span>}
+              name="source_url"
+            >
+              <TextInput
+                placeholder="https://github.com/org/mcp-server"
+                className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+              />
+            </Form.Item>
+
+            <Form.Item
               label={<span className="text-sm font-medium text-gray-700">Transport Type</span>}
               name="transport"
               rules={[{ required: true, message: "Please select a transport type" }]}

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -373,7 +373,6 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       console.log(`Payload: ${JSON.stringify(payload)}`);
 
       if (accessToken != null) {
-        const isAdmin = isAdminRole(userRole);
         const response = isAdmin
           ? await createMCPServer(accessToken, payload)
           : await registerMCPServer(accessToken, payload);
@@ -468,11 +467,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     }
   }, [isModalVisible]);
 
-  // rendering
-  if (!isAdminRole(userRole)) {
-    return null;
-  }
+  const isAdmin = isAdminRole(userRole);
 
+  // rendering
   return (
     <Modal
       title={
@@ -496,7 +493,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
               objectFit: "contain",
             }}
           />
-          <h2 className="text-xl font-semibold text-gray-900">Add New MCP Server</h2>
+          <h2 className="text-xl font-semibold text-gray-900">
+            {isAdmin ? "Add New MCP Server" : "Submit MCP Server for Review"}
+          </h2>
         </div>
       }
       open={isModalVisible}
@@ -517,6 +516,12 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
           layout="vertical"
           className="space-y-6"
         >
+          {!isAdmin && (
+            <div className="rounded-md bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-800">
+              Your submission will be sent for admin review before it becomes active.
+              {" "}Note: the request must be made with a team-scoped API key.
+            </div>
+          )}
           <div className="grid grid-cols-1 gap-6">
             <Form.Item
               label={

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -391,7 +391,10 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         onCreateSuccess(response);
       }
     } catch (error) {
-      NotificationsManager.fromBackend("Error creating MCP Server: " + error);
+      const reason = error instanceof Error ? error.message : String(error);
+      NotificationsManager.fromBackend(
+        isAdmin ? `Error creating MCP Server: ${reason}` : `Error submitting MCP Server: ${reason}`
+      );
     } finally {
       setIsLoading(false);
     }

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -6,7 +6,8 @@ import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useMCPServers } from "../../app/(dashboard)/hooks/mcpServers/useMCPServers";
 import { useMCPServerHealth } from "../../app/(dashboard)/hooks/mcpServers/useMCPServerHealth";
 import NotificationsManager from "../molecules/notifications_manager";
-import { deleteMCPServer } from "../networking";
+import { deleteMCPServer, registerMCPServer } from "../networking";
+import { MCPSubmissionsTab } from "./MCPSubmissionsTab";
 import { DataTable } from "../view_logs/table";
 import CreateMCPServer from "./create_mcp_server";
 import MCPConnect from "./mcp_connect";
@@ -299,11 +300,25 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           </div>
           <Text className="text-tremor-content mt-1">Configure and manage your MCP servers</Text>
         </div>
-        {isAdminRole(userRole) && (
-          <Button className="flex-shrink-0" onClick={() => setDiscoveryVisible(true)}>
-            + Add New MCP Server
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          {isAdminRole(userRole) && (
+            <Button className="flex-shrink-0" onClick={() => setDiscoveryVisible(true)}>
+              + Add New MCP Server
+            </Button>
+          )}
+          {!isAdminRole(userRole) && (
+            <Button
+              className="flex-shrink-0"
+              onClick={() => {
+                setPrefillData(null);
+                setModalVisible(true);
+              }}
+              variant="secondary"
+            >
+              + Submit MCP Server
+            </Button>
+          )}
+        </div>
       </div>
       <MCPDiscovery
         isVisible={isDiscoveryVisible}
@@ -327,6 +342,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Connect</Tab>
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
+            {isAdminRole(userRole) && <Tab>Submissions</Tab>}
           </div>
         </TabList>
         <TabPanels>
@@ -410,6 +426,11 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           <TabPanel>
             <MCPNetworkSettings accessToken={accessToken} />
           </TabPanel>
+          {isAdminRole(userRole) && (
+            <TabPanel>
+              <MCPSubmissionsTab accessToken={accessToken} />
+            </TabPanel>
+          )}
         </TabPanels>
       </TabGroup>
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -19,6 +19,7 @@ import MCPSemanticFilterSettings from "../Settings/AdminSettings/MCPSemanticFilt
 import MCPNetworkSettings from "./MCPNetworkSettings";
 import MCPDiscovery from "./mcp_discovery";
 import { ByokCredentialModal } from "./ByokCredentialModal";
+import MCPStandardsSettings from "./MCPStandardsSettings";
 
 const { Text: AntdText, Title: AntdTitle } = Typography;
 const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
@@ -344,6 +345,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
             {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Team MCPs <NewBadge /></span></Tab>}
+            {isAdminRole(userRole) && <Tab>Standards</Tab>}
           </div>
         </TabList>
         <TabPanels>
@@ -430,6 +432,11 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           {isAdminRole(userRole) && (
             <TabPanel>
               <MCPSubmissionsTab accessToken={accessToken} />
+            </TabPanel>
+          )}
+          {isAdminRole(userRole) && (
+            <TabPanel>
+              <MCPStandardsSettings accessToken={accessToken} />
             </TabPanel>
           )}
         </TabPanels>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -1,6 +1,7 @@
 import { isAdminRole } from "@/utils/roles";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { Button, Tab, TabGroup, TabList, TabPanel, TabPanels, Text, Title } from "@tremor/react";
+import NewBadge from "../common_components/NewBadge";
 import { Descriptions, Modal, Select, Tooltip, Typography } from "antd";
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useMCPServers } from "../../app/(dashboard)/hooks/mcpServers/useMCPServers";
@@ -342,7 +343,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Connect</Tab>
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
-            {isAdminRole(userRole) && <Tab>Submissions</Tab>}
+            {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Team MCPs <NewBadge /></span></Tab>}
           </div>
         </TabList>
         <TabPanels>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -343,7 +343,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Connect</Tab>
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
-            {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Team MCPs <NewBadge /></span></Tab>}
+            {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Submitted Tools <NewBadge /></span></Tab>}
           </div>
         </TabList>
         <TabPanels>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useMCPServers } from "../../app/(dashboard)/hooks/mcpServers/useMCPServers";
 import { useMCPServerHealth } from "../../app/(dashboard)/hooks/mcpServers/useMCPServerHealth";
 import NotificationsManager from "../molecules/notifications_manager";
-import { deleteMCPServer, registerMCPServer } from "../networking";
+import { deleteMCPServer } from "../networking";
 import { MCPSubmissionsTab } from "./MCPSubmissionsTab";
 import { DataTable } from "../view_logs/table";
 import CreateMCPServer from "./create_mcp_server";

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -343,7 +343,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Connect</Tab>
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
-            {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Submitted Tools <NewBadge /></span></Tab>}
+            {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Submitted MCPs <NewBadge /></span></Tab>}
           </div>
         </TabList>
         <TabPanels>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -19,7 +19,6 @@ import MCPSemanticFilterSettings from "../Settings/AdminSettings/MCPSemanticFilt
 import MCPNetworkSettings from "./MCPNetworkSettings";
 import MCPDiscovery from "./mcp_discovery";
 import { ByokCredentialModal } from "./ByokCredentialModal";
-import MCPStandardsSettings from "./MCPStandardsSettings";
 
 const { Text: AntdText, Title: AntdTitle } = Typography;
 const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
@@ -345,7 +344,6 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
             {isAdminRole(userRole) && <Tab><span className="flex items-center gap-2">Team MCPs <NewBadge /></span></Tab>}
-            {isAdminRole(userRole) && <Tab>Standards</Tab>}
           </div>
         </TabList>
         <TabPanels>
@@ -432,11 +430,6 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           {isAdminRole(userRole) && (
             <TabPanel>
               <MCPSubmissionsTab accessToken={accessToken} />
-            </TabPanel>
-          )}
-          {isAdminRole(userRole) && (
-            <TabPanel>
-              <MCPStandardsSettings accessToken={accessToken} />
             </TabPanel>
           )}
         </TabPanels>

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -185,6 +185,9 @@ export interface MCPServer {
   byok_api_key_help_url?: string | null;
   has_user_credential?: boolean | null;
 
+  /** GitHub / source repository URL */
+  source_url?: string | null;
+
   /** BYOM (Bring Your Own MCP) submission fields */
   approval_status?: "active" | "pending_review" | "rejected" | null;
   submitted_by?: string | null;

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -184,6 +184,13 @@ export interface MCPServer {
   byok_description?: string[] | null;
   byok_api_key_help_url?: string | null;
   has_user_credential?: boolean | null;
+
+  /** BYOM (Bring Your Own MCP) submission fields */
+  approval_status?: "active" | "pending_review" | "rejected" | null;
+  submitted_by?: string | null;
+  submitted_at?: string | null;
+  reviewed_at?: string | null;
+  review_notes?: string | null;
 }
 
 export interface MCPServerProps {
@@ -210,4 +217,12 @@ export interface DiscoverableMCPServer {
 export interface DiscoverMCPServersResponse {
   servers: DiscoverableMCPServer[];
   categories: string[];
+}
+
+export interface MCPSubmissionsSummary {
+  total: number;
+  pending_review: number;
+  active: number;
+  rejected: number;
+  items: MCPServer[];
 }

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6497,6 +6497,100 @@ export const deleteMCPServer = async (accessToken: string, serverId: string) => 
   }
 };
 
+export const registerMCPServer = async (accessToken: string, formValues: Record<string, any>) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/server/register`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.POST,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(formValues),
+    });
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return response.json();
+  } catch (error) {
+    console.error("Failed to register MCP server:", error);
+    throw error;
+  }
+};
+
+export const fetchMCPSubmissions = async (accessToken: string) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/server/submissions`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.GET,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return response.json();
+  } catch (error) {
+    console.error("Failed to fetch MCP submissions:", error);
+    throw error;
+  }
+};
+
+export const approveMCPServer = async (accessToken: string, serverId: string) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/server/${encodeURIComponent(serverId)}/approve`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.PUT,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return response.json();
+  } catch (error) {
+    console.error("Failed to approve MCP server:", error);
+    throw error;
+  }
+};
+
+export const rejectMCPServer = async (accessToken: string, serverId: string, reviewNotes?: string) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/server/${encodeURIComponent(serverId)}/reject`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.PUT,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ review_notes: reviewNotes ?? null }),
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return response.json();
+  } catch (error) {
+    console.error("Failed to reject MCP server:", error);
+    throw error;
+  }
+};
+
 // Search Tools API calls
 export const fetchSearchTools = async (accessToken: string) => {
   try {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6551,7 +6551,6 @@ export const approveMCPServer = async (accessToken: string, serverId: string) =>
       method: HTTP_REQUEST.PUT,
       headers: {
         [globalLitellmHeaderName]: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
       },
     });
     if (!response.ok) {


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

Mirrors the BYOG (Bring Your Own Guardrails) pattern for MCP servers.

**What it does:**
- Non-admins can submit an MCP server for review via `POST /v1/mcp/server/register` using a team-scoped API key. It lands in `approval_status=pending_review` and does NOT enter the active proxy runtime.
- Admins get a **Submissions** tab in the MCP Servers page showing pending / active / rejected counts + cards with Approve/Reject buttons.
- Approving calls `PUT /v1/mcp/server/{id}/approve` → sets `approval_status=active` and loads the server into the runtime.
- Rejecting calls `PUT /v1/mcp/server/{id}/reject` with optional `review_notes`.
- `reload_servers_from_database()` now filters to `approval_status=active` so pending/rejected submissions never enter the active proxy registry.

**Backend changes:**
- `schema.prisma` + migration: add `approval_status`, `submitted_by`, `submitted_at`, `reviewed_at`, `review_notes` to `LiteLLM_MCPServerTable`
- `_types.py`: `MCPApprovalStatus`, `RejectMCPServerRequest`, `MCPSubmissionsSummary`
- `db.py`: `approve_mcp_server`, `reject_mcp_server`, `get_mcp_submissions` helpers
- `mcp_management_endpoints.py`: `/register`, `/submissions`, `/{id}/approve`, `/{id}/reject` endpoints
- `mcp_server_manager.py`: filter `reload_servers_from_database` to active servers only

**UI changes:**
- New `MCPSubmissionsTab.tsx` — stat cards + card list with confirm dialogs for approve/reject
- `mcp_servers.tsx` — Submissions tab (admin-only), Submit MCP button (non-admin)
- `create_mcp_server.tsx` — routes to `/register` instead of `/v1/mcp/server` for non-admins
- `networking.tsx` — `registerMCPServer`, `fetchMCPSubmissions`, `approveMCPServer`, `rejectMCPServer`
- `types.tsx` — extend `MCPServer` with approval lifecycle fields

**Notable fix:** `get_mcp_submissions` filters by `submitted_at IS NOT NULL` (not `submitted_by IS NOT NULL`), since team-scoped keys without an associated `user_id` produce `submitted_by=null`.