### PR TITLE
fix(snowflake): add streaming handler for tool calls

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -303,10 +303,10 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
     ) -> Any:
         """
         Return a Snowflake-specific streaming handler that transforms
-        Snowflake's content_block streaming format to OpenAI-compatible format.
+        Snowflake's streaming format to OpenAI-compatible format.
 
-        Snowflake uses Anthropic-style streaming with content_block_start/delta/stop
-        events for tool calls, which requires custom handling.
+        Snowflake streams tool calls using content_block_start/delta/stop events,
+        which differs from OpenAI's delta.tool_calls format and requires custom handling.
         """
         return SnowflakeStreamingHandler(
             streaming_response=streaming_response,
@@ -319,8 +319,8 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
     """
     Streaming handler for Snowflake Cortex LLM REST API.
 
-    Snowflake uses an Anthropic-style streaming format with content_block events
-    for tool calls. This handler transforms those events to OpenAI-compatible
+    Snowflake streams tool calls using content_block events rather than OpenAI's
+    delta.tool_calls format. This handler transforms those events to OpenAI-compatible
     streaming chunks.
 
     Snowflake streaming format (tool calls):
@@ -359,13 +359,13 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
 
         Handles both:
         1. OpenAI-compatible format (choices with delta) - pass through
-        2. Anthropic-style format (content_block events) - transform to OpenAI format
+        2. Snowflake content_block format - transform to OpenAI format
         """
         # Check if this is OpenAI-compatible format (has choices)
         if "choices" in chunk:
             return self._handle_openai_format_chunk(chunk)
 
-        # Otherwise, handle Anthropic-style content_block format
+        # Otherwise, handle Snowflake's content_block format
         return self._handle_content_block_chunk(chunk)
 
     def _handle_openai_format_chunk(self, chunk: dict) -> ModelResponseStream:
@@ -380,7 +380,7 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
 
     def _handle_content_block_chunk(self, chunk: dict) -> ModelResponseStream:
         """
-        Handle Anthropic-style content_block chunks from Snowflake.
+        Handle Snowflake's content_block streaming chunks.
 
         Event types:
         - message_start: Start of message with usage info

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -345,11 +345,8 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
         )
         # Track tool call index across chunks
         self.tool_index = -1
-        # Track current content block type
+        # Track current content block type (text or tool_use)
         self.current_content_block_type: Optional[str] = None
-        # Track current tool call ID and name for delta chunks
-        self.current_tool_id: Optional[str] = None
-        self.current_tool_name: Optional[str] = None
         # Generate consistent response ID for the stream
         self.response_id = _generate_id()
 
@@ -418,14 +415,14 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
             elif self.current_content_block_type == "tool_use":
                 # Tool use block start - extract id and name
                 self.tool_index += 1
-                self.current_tool_id = content_block.get("id", "")
-                self.current_tool_name = content_block.get("name", "")
+                tool_id = content_block.get("id", "")
+                tool_name = content_block.get("name", "")
 
                 tool_use = ChatCompletionToolCallChunk(
-                    id=self.current_tool_id,
+                    id=tool_id,
                     type="function",
                     function=ChatCompletionToolCallFunctionChunk(
-                        name=self.current_tool_name,
+                        name=tool_name,
                         arguments="",
                     ),
                     index=self.tool_index,
@@ -455,8 +452,6 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
         elif type_chunk == "content_block_stop":
             # Reset current content block tracking
             self.current_content_block_type = None
-            self.current_tool_id = None
-            self.current_tool_name = None
 
         elif type_chunk == "message_delta":
             # End of message - extract finish_reason and final usage
@@ -473,14 +468,15 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
                 else:
                     finish_reason = stop_reason
 
-            # Extract final usage if available
+            # Extract final usage if available.
+            # Note: message_delta only contains output_tokens (completion counts).
+            # Prompt tokens are reported in message_start, not here.
             if "usage" in chunk:
                 usage_data = chunk["usage"]
                 usage = Usage(
-                    prompt_tokens=usage_data.get("input_tokens", 0),
+                    prompt_tokens=0,  # Not available in message_delta
                     completion_tokens=usage_data.get("output_tokens", 0),
-                    total_tokens=usage_data.get("input_tokens", 0)
-                    + usage_data.get("output_tokens", 0),
+                    total_tokens=usage_data.get("output_tokens", 0),
                 )
 
         # Build the response chunk

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -3,12 +3,36 @@ Support for Snowflake REST API
 """
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import httpx
 
-from litellm.types.llms.openai import AllMessageValues
-from litellm.types.utils import ChatCompletionMessageToolCall, Function, ModelResponse
+from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionToolCallChunk,
+    ChatCompletionToolCallFunctionChunk,
+)
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Delta,
+    Function,
+    ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
+    Usage,
+)
+from litellm.types.utils import _generate_id
 
 from ...openai_like.chat.transformation import OpenAIGPTConfig
 
@@ -270,3 +294,208 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             **optional_params,
             **extra_body,
         }
+
+    def get_model_response_iterator(
+        self,
+        streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
+        sync_stream: bool,
+        json_mode: Optional[bool] = False,
+    ) -> Any:
+        """
+        Return a Snowflake-specific streaming handler that transforms
+        Snowflake's content_block streaming format to OpenAI-compatible format.
+
+        Snowflake uses Anthropic-style streaming with content_block_start/delta/stop
+        events for tool calls, which requires custom handling.
+        """
+        return SnowflakeStreamingHandler(
+            streaming_response=streaming_response,
+            sync_stream=sync_stream,
+            json_mode=json_mode,
+        )
+
+
+class SnowflakeStreamingHandler(BaseModelResponseIterator):
+    """
+    Streaming handler for Snowflake Cortex LLM REST API.
+
+    Snowflake uses an Anthropic-style streaming format with content_block events
+    for tool calls. This handler transforms those events to OpenAI-compatible
+    streaming chunks.
+
+    Snowflake streaming format (tool calls):
+        - content_block_start: {"type": "content_block_start", "content_block": {"type": "tool_use", "id": "...", "name": "..."}}
+        - content_block_delta: {"type": "content_block_delta", "delta": {"type": "input_json_delta", "partial_json": "..."}}
+        - content_block_stop: {"type": "content_block_stop"}
+
+    OpenAI streaming format (tool calls):
+        - {"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "...", "function": {"name": "...", "arguments": "..."}}]}}]}
+    """
+
+    def __init__(
+        self,
+        streaming_response: Union[Iterator[str], AsyncIterator[str], ModelResponse],
+        sync_stream: bool,
+        json_mode: Optional[bool] = False,
+    ):
+        super().__init__(
+            streaming_response=streaming_response,
+            sync_stream=sync_stream,
+            json_mode=json_mode,
+        )
+        # Track tool call index across chunks
+        self.tool_index = -1
+        # Track current content block type
+        self.current_content_block_type: Optional[str] = None
+        # Track current tool call ID and name for delta chunks
+        self.current_tool_id: Optional[str] = None
+        self.current_tool_name: Optional[str] = None
+        # Generate consistent response ID for the stream
+        self.response_id = _generate_id()
+
+    def chunk_parser(self, chunk: dict) -> ModelResponseStream:
+        """
+        Parse a Snowflake streaming chunk and transform it to OpenAI format.
+
+        Handles both:
+        1. OpenAI-compatible format (choices with delta) - pass through
+        2. Anthropic-style format (content_block events) - transform to OpenAI format
+        """
+        # Check if this is OpenAI-compatible format (has choices)
+        if "choices" in chunk:
+            return self._handle_openai_format_chunk(chunk)
+
+        # Otherwise, handle Anthropic-style content_block format
+        return self._handle_content_block_chunk(chunk)
+
+    def _handle_openai_format_chunk(self, chunk: dict) -> ModelResponseStream:
+        """Handle chunks that are already in OpenAI-compatible format."""
+        return ModelResponseStream(
+            id=chunk.get("id", self.response_id),
+            object="chat.completion.chunk",
+            created=chunk.get("created"),
+            model=chunk.get("model"),
+            choices=chunk.get("choices", []),
+        )
+
+    def _handle_content_block_chunk(self, chunk: dict) -> ModelResponseStream:
+        """
+        Handle Anthropic-style content_block chunks from Snowflake.
+
+        Event types:
+        - message_start: Start of message with usage info
+        - content_block_start: Start of a content block (text or tool_use)
+        - content_block_delta: Delta update for the current block
+        - content_block_stop: End of current content block
+        - message_delta: End of message with finish_reason
+        """
+        type_chunk = chunk.get("type", "")
+        text = ""
+        tool_use: Optional[ChatCompletionToolCallChunk] = None
+        finish_reason: Optional[str] = None
+        usage: Optional[Usage] = None
+
+        if type_chunk == "message_start":
+            # Extract usage from message_start if available
+            message = chunk.get("message", {})
+            if "usage" in message:
+                usage_data = message["usage"]
+                usage = Usage(
+                    prompt_tokens=usage_data.get("input_tokens", 0),
+                    completion_tokens=usage_data.get("output_tokens", 0),
+                    total_tokens=usage_data.get("input_tokens", 0)
+                    + usage_data.get("output_tokens", 0),
+                )
+
+        elif type_chunk == "content_block_start":
+            content_block = chunk.get("content_block", {})
+            self.current_content_block_type = content_block.get("type")
+
+            if self.current_content_block_type == "text":
+                # Text block start - may have initial text
+                text = content_block.get("text", "")
+
+            elif self.current_content_block_type == "tool_use":
+                # Tool use block start - extract id and name
+                self.tool_index += 1
+                self.current_tool_id = content_block.get("id", "")
+                self.current_tool_name = content_block.get("name", "")
+
+                tool_use = ChatCompletionToolCallChunk(
+                    id=self.current_tool_id,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=self.current_tool_name,
+                        arguments="",
+                    ),
+                    index=self.tool_index,
+                )
+
+        elif type_chunk == "content_block_delta":
+            delta = chunk.get("delta", {})
+            delta_type = delta.get("type", "")
+
+            if delta_type == "text_delta":
+                text = delta.get("text", "")
+
+            elif delta_type == "input_json_delta":
+                # Tool argument delta - only emit if in tool_use block
+                if self.current_content_block_type == "tool_use":
+                    partial_json = delta.get("partial_json", "")
+                    tool_use = ChatCompletionToolCallChunk(
+                        id=None,
+                        type="function",
+                        function=ChatCompletionToolCallFunctionChunk(
+                            name=None,
+                            arguments=partial_json,
+                        ),
+                        index=self.tool_index,
+                    )
+
+        elif type_chunk == "content_block_stop":
+            # Reset current content block tracking
+            self.current_content_block_type = None
+            self.current_tool_id = None
+            self.current_tool_name = None
+
+        elif type_chunk == "message_delta":
+            # End of message - extract finish_reason and final usage
+            delta = chunk.get("delta", {})
+            stop_reason = delta.get("stop_reason")
+            if stop_reason:
+                # Map Anthropic stop reasons to OpenAI finish reasons
+                if stop_reason == "end_turn":
+                    finish_reason = "stop"
+                elif stop_reason == "tool_use":
+                    finish_reason = "tool_calls"
+                elif stop_reason == "max_tokens":
+                    finish_reason = "length"
+                else:
+                    finish_reason = stop_reason
+
+            # Extract final usage if available
+            if "usage" in chunk:
+                usage_data = chunk["usage"]
+                usage = Usage(
+                    prompt_tokens=usage_data.get("input_tokens", 0),
+                    completion_tokens=usage_data.get("output_tokens", 0),
+                    total_tokens=usage_data.get("input_tokens", 0)
+                    + usage_data.get("output_tokens", 0),
+                )
+
+        # Build the response chunk
+        return ModelResponseStream(
+            id=self.response_id,
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(
+                        content=text if text else None,
+                        tool_calls=[tool_use] if tool_use is not None else None,
+                    ),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=usage,
+        )

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -17,6 +17,7 @@ from typing import (
 
 import httpx
 
+from litellm.exceptions import APIError
 from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -385,8 +386,22 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
         - content_block_delta: Delta update for the current block
         - content_block_stop: End of current content block
         - message_delta: End of message with finish_reason
+        - error: API error during streaming
         """
         type_chunk = chunk.get("type", "")
+
+        # Handle error events - raise exception rather than silently swallowing
+        if type_chunk == "error":
+            error_info = chunk.get("error", {})
+            error_message = error_info.get("message", str(error_info))
+            error_type = error_info.get("type", "unknown_error")
+            raise APIError(
+                status_code=500,
+                message=f"Snowflake streaming error ({error_type}): {error_message}",
+                llm_provider="snowflake",
+                model=None,
+            )
+
         text = ""
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         finish_reason: Optional[str] = None
@@ -402,6 +417,13 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
                     completion_tokens=usage_data.get("output_tokens", 0),
                     total_tokens=usage_data.get("input_tokens", 0)
                     + usage_data.get("output_tokens", 0),
+                )
+            else:
+                # No usage data - return minimal sentinel to avoid noisy empty chunks
+                return ModelResponseStream(
+                    id=self.response_id,
+                    object="chat.completion.chunk",
+                    choices=[StreamingChoices(index=0, delta=Delta())],
                 )
 
         elif type_chunk == "content_block_start":
@@ -450,8 +472,13 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
                     )
 
         elif type_chunk == "content_block_stop":
-            # Reset current content block tracking
+            # Reset current content block tracking and return minimal sentinel
             self.current_content_block_type = None
+            return ModelResponseStream(
+                id=self.response_id,
+                object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=Delta())],
+            )
 
         elif type_chunk == "message_delta":
             # End of message - extract finish_reason and final usage

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -552,14 +552,16 @@ class TestSnowflakeStreamingHandler:
             json_mode=False,
         )
 
-        # Test end_turn -> stop
+        # Test end_turn -> stop (with usage containing only output_tokens per Snowflake spec)
         chunk = {
             "type": "message_delta",
             "delta": {"stop_reason": "end_turn"},
-            "usage": {"input_tokens": 10, "output_tokens": 20},
+            "usage": {"output_tokens": 20},
         }
         result = handler.chunk_parser(chunk)
         assert result.choices[0].finish_reason == "stop"
+        assert result.usage.completion_tokens == 20
+        assert result.usage.prompt_tokens == 0  # Not available in message_delta
 
         # Test tool_use -> tool_calls
         chunk = {
@@ -630,6 +632,8 @@ class TestSnowflakeStreamingHandler:
         assert isinstance(result, ModelResponseStream)
         assert result.id == "chatcmpl-123"
         assert result.model == "mistral-7b"
+        assert result.choices[0]["delta"]["content"] == "Hello"
+        assert result.choices[0]["finish_reason"] is None
 
     def test_streaming_handler_multiple_tool_calls(self):
         """
@@ -697,8 +701,6 @@ class TestSnowflakeStreamingHandler:
         # Stop the block
         handler.chunk_parser({"type": "content_block_stop"})
         assert handler.current_content_block_type is None
-        assert handler.current_tool_id is None
-        assert handler.current_tool_name is None
 
     def test_get_model_response_iterator_returns_streaming_handler(self):
         """

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -1,6 +1,6 @@
 """
 Unit tests for Snowflake chat transformation
-Tests tool calling request/response transformations
+Tests tool calling request/response transformations and streaming
 """
 
 import os
@@ -13,8 +13,11 @@ from unittest.mock import MagicMock
 import httpx
 
 import litellm
-from litellm.llms.snowflake.chat.transformation import SnowflakeConfig
-from litellm.types.utils import ModelResponse
+from litellm.llms.snowflake.chat.transformation import (
+    SnowflakeConfig,
+    SnowflakeStreamingHandler,
+)
+from litellm.types.utils import ModelResponse, ModelResponseStream
 
 
 class TestSnowflakeToolTransformation:
@@ -425,3 +428,286 @@ class TestSnowFlakeCompletion:
 
         os.environ.pop("SNOWFLAKE_ACCOUNT_ID", None)
         os.environ.pop("SNOWFLAKE_JWT", None)
+
+
+class TestSnowflakeStreamingHandler:
+    """Test suite for Snowflake streaming tool call handling"""
+
+    def test_streaming_handler_text_content_block(self):
+        """
+        Test that text content_block events are correctly parsed.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # Simulate content_block_start for text
+        chunk_start = {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        }
+        result = handler.chunk_parser(chunk_start)
+        assert isinstance(result, ModelResponseStream)
+        assert result.choices[0].delta.content is None  # Empty text
+
+        # Simulate content_block_delta for text
+        chunk_delta = {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello, world!"},
+        }
+        result = handler.chunk_parser(chunk_delta)
+        assert result.choices[0].delta.content == "Hello, world!"
+        assert result.choices[0].delta.tool_calls is None
+
+    def test_streaming_handler_tool_use_content_block(self):
+        """
+        Test that tool_use content_block events are correctly transformed to OpenAI format.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # Simulate content_block_start for tool_use
+        chunk_start = {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "tooluse_abc123",
+                "name": "get_weather",
+            },
+        }
+        result = handler.chunk_parser(chunk_start)
+
+        assert isinstance(result, ModelResponseStream)
+        assert result.choices[0].delta.tool_calls is not None
+        assert len(result.choices[0].delta.tool_calls) == 1
+
+        tool_call = result.choices[0].delta.tool_calls[0]
+        assert tool_call["id"] == "tooluse_abc123"
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "get_weather"
+        assert tool_call["function"]["arguments"] == ""
+        assert tool_call["index"] == 0
+
+    def test_streaming_handler_tool_use_delta(self):
+        """
+        Test that input_json_delta events are correctly parsed for tool arguments.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # First, start a tool_use block to set the context
+        chunk_start = {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "tooluse_abc123",
+                "name": "get_weather",
+            },
+        }
+        handler.chunk_parser(chunk_start)
+
+        # Now simulate input_json_delta
+        chunk_delta = {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": '{"location": "'},
+        }
+        result = handler.chunk_parser(chunk_delta)
+
+        assert result.choices[0].delta.tool_calls is not None
+        tool_call = result.choices[0].delta.tool_calls[0]
+        assert tool_call["function"]["arguments"] == '{"location": "'
+        assert tool_call["index"] == 0
+
+        # Another delta chunk
+        chunk_delta2 = {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": 'Paris"}'},
+        }
+        result = handler.chunk_parser(chunk_delta2)
+
+        tool_call = result.choices[0].delta.tool_calls[0]
+        assert tool_call["function"]["arguments"] == 'Paris"}'
+
+    def test_streaming_handler_message_delta_finish_reason(self):
+        """
+        Test that message_delta events correctly extract finish_reason.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # Test end_turn -> stop
+        chunk = {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+        }
+        result = handler.chunk_parser(chunk)
+        assert result.choices[0].finish_reason == "stop"
+
+        # Test tool_use -> tool_calls
+        chunk = {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use"},
+        }
+        result = handler.chunk_parser(chunk)
+        assert result.choices[0].finish_reason == "tool_calls"
+
+        # Test max_tokens -> length
+        chunk = {
+            "type": "message_delta",
+            "delta": {"stop_reason": "max_tokens"},
+        }
+        result = handler.chunk_parser(chunk)
+        assert result.choices[0].finish_reason == "length"
+
+    def test_streaming_handler_message_start_usage(self):
+        """
+        Test that message_start events correctly extract usage info.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        chunk = {
+            "type": "message_start",
+            "message": {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "usage": {"input_tokens": 50, "output_tokens": 0},
+            },
+        }
+        result = handler.chunk_parser(chunk)
+        assert result.usage is not None
+        assert result.usage.prompt_tokens == 50
+        assert result.usage.completion_tokens == 0
+
+    def test_streaming_handler_openai_format_passthrough(self):
+        """
+        Test that OpenAI-compatible format chunks pass through correctly.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # OpenAI-compatible chunk
+        chunk = {
+            "id": "chatcmpl-123",
+            "object": "chat.completion.chunk",
+            "created": 1700000000,
+            "model": "mistral-7b",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "Hello"},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        result = handler.chunk_parser(chunk)
+
+        assert isinstance(result, ModelResponseStream)
+        assert result.id == "chatcmpl-123"
+        assert result.model == "mistral-7b"
+
+    def test_streaming_handler_multiple_tool_calls(self):
+        """
+        Test that multiple tool calls get sequential indices.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # First tool
+        chunk1 = {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "tooluse_first",
+                "name": "get_weather",
+            },
+        }
+        result1 = handler.chunk_parser(chunk1)
+        assert result1.choices[0].delta.tool_calls[0]["index"] == 0
+
+        # Stop first block
+        handler.chunk_parser({"type": "content_block_stop", "index": 0})
+
+        # Second tool
+        chunk2 = {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "tooluse_second",
+                "name": "get_time",
+            },
+        }
+        result2 = handler.chunk_parser(chunk2)
+        assert result2.choices[0].delta.tool_calls[0]["index"] == 1
+        assert result2.choices[0].delta.tool_calls[0]["id"] == "tooluse_second"
+
+    def test_streaming_handler_content_block_stop_resets_state(self):
+        """
+        Test that content_block_stop resets the current block tracking.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # Start a tool_use block
+        handler.chunk_parser(
+            {
+                "type": "content_block_start",
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "tooluse_123",
+                    "name": "get_weather",
+                },
+            }
+        )
+        assert handler.current_content_block_type == "tool_use"
+
+        # Stop the block
+        handler.chunk_parser({"type": "content_block_stop"})
+        assert handler.current_content_block_type is None
+        assert handler.current_tool_id is None
+        assert handler.current_tool_name is None
+
+    def test_get_model_response_iterator_returns_streaming_handler(self):
+        """
+        Test that SnowflakeConfig.get_model_response_iterator returns SnowflakeStreamingHandler.
+        """
+        config = SnowflakeConfig()
+        iterator = config.get_model_response_iterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+        assert isinstance(iterator, SnowflakeStreamingHandler)

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -713,3 +713,53 @@ class TestSnowflakeStreamingHandler:
             json_mode=False,
         )
         assert isinstance(iterator, SnowflakeStreamingHandler)
+
+    def test_streaming_handler_error_event_raises_exception(self):
+        """
+        Test that error events raise an APIError instead of being silently swallowed.
+        """
+        import pytest
+        from litellm.exceptions import APIError
+
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # Simulate an error event from Snowflake
+        error_chunk = {
+            "type": "error",
+            "error": {
+                "type": "overloaded_error",
+                "message": "Overloaded",
+            },
+        }
+
+        with pytest.raises(APIError) as exc_info:
+            handler.chunk_parser(error_chunk)
+
+        assert "Snowflake streaming error" in str(exc_info.value)
+        assert "overloaded_error" in str(exc_info.value)
+        assert "Overloaded" in str(exc_info.value)
+
+    def test_streaming_handler_content_block_stop_returns_minimal_chunk(self):
+        """
+        Test that content_block_stop returns a minimal sentinel chunk.
+        """
+        handler = SnowflakeStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+            json_mode=False,
+        )
+
+        # Set up state as if we were in a tool_use block
+        handler.current_content_block_type = "tool_use"
+
+        result = handler.chunk_parser({"type": "content_block_stop"})
+
+        # Should return minimal chunk with empty delta
+        assert isinstance(result, ModelResponseStream)
+        assert result.choices[0].delta.content is None
+        assert result.choices[0].delta.tool_calls is None
+        assert handler.current_content_block_type is None


### PR DESCRIPTION
Snowflake uses an Anthropic-style streaming format with content_block events for tool calls, but was inheriting OpenAI's streaming handler which expects a different
format. This caused streaming tool calls to fail.

This commit adds:
- `SnowflakeStreamingHandler` class that transforms content_block events to OpenAI-compatible streaming chunks
- `get_model_response_iterator()` override in SnowflakeConfig to use the custom handler
- Comprehensive unit tests for streaming scenarios

The handler supports:
- content_block_start/delta/stop events for text and tool_use
- message_start/delta events for usage and finish_reason
- Passthrough for already OpenAI-compatible chunks
- Multiple sequential tool calls with proper indexing

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/23286

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a
hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
Link:

- [ ] **CI run for the last commit**
Link:

- [ ] **Merge / cherry-pick CI run**
Links:

## Type

🐛 Bug Fix

## Changes

- Added `SnowflakeStreamingHandler` class in `litellm/llms/snowflake/chat/transformation.py`
- Added `get_model_response_iterator()` method to `SnowflakeConfig`
- Added 10 new unit tests in `tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py`

## Tests

- All 22 Snowflake tests pass (`poetry run pytest tests/test_litellm/llms/snowflake/ -v`)
- Linting passes on changed files (`poetry run black --check` and `poetry run ruff check`)
- MyPy passes on changed files