### PR TITLE
feat: add strategy to deployment for helmchart

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
   {{- if and (not .Values.keda.enabled) (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "litellm.selectorLabels" . | nindent 6 }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -35,6 +35,14 @@ deploymentLabels: {}
 podAnnotations: {}
 podLabels: {}
 
+# -- Deployment strategy configuration
+# Example:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+strategy: {}
+
 terminationGracePeriodSeconds: 90
 topologySpreadConstraints:
   []


### PR DESCRIPTION
## Description
This PR adds support for configuring the deployment rollout strategy in the LiteLLM Helm chart.

Currently, the proxy deployment strategy relies on Kubernetes default behavior and cannot be explicitly configured via `values.yaml`. This change allows users to define custom rollout parameters (such as `maxSurge` and `maxUnavailable` for `RollingUpdate`) to better control how proxy updates are deployed with minimal downtime.

## Changes
- Added a `strategy` block under `spec` in `deploy/charts/litellm-helm/templates/deployment.yaml`.
- Added a default empty `strategy: {}` object to `deploy/charts/litellm-helm/values.yaml` to expose the configuration without overriding Kubernetes defaults.

## Example Configuration

Example override in `values.yaml`:

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0
    maxSurge: 1