### PR TITLE
[Fix] Bedrock Nova output_config Rejection via Anthropic Messages Endpoint

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -163,7 +163,10 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 "include_usage": True,
             }
 
-        excluded_keys = {"anthropic_messages"}
+        excluded_keys = {
+            "anthropic_messages",
+            "output_config",  # Anthropic-only param; Bedrock Invoke rejects it as extraneous
+        }
         extra_kwargs = extra_kwargs or {}
         for key, value in extra_kwargs.items():
             if (

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_handler.py
@@ -1,0 +1,57 @@
+"""
+Tests for LiteLLMMessagesToCompletionTransformationHandler
+"""
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
+
+
+def test_prepare_completion_kwargs_excludes_output_config():
+    """
+    Verify that `output_config` (an Anthropic-only parameter) is stripped when
+    translating an Anthropic Messages request into litellm.completion() kwargs.
+
+    The Claude Agent SDK sends `output_config` in its request body. For
+    non-Anthropic providers (e.g. Bedrock Nova), this parameter leaks through
+    **kwargs → extra_kwargs → completion_kwargs, causing Bedrock to reject the
+    request with "extraneous key [output_config] is not permitted".
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/22797
+    """
+    completion_kwargs, _ = (
+        LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hello"}],
+            model="bedrock/us.amazon.nova-pro-v1:0",
+            extra_kwargs={
+                "output_config": {"type": "text"},
+                "custom_llm_provider": "bedrock",
+            },
+        )
+    )
+    assert "output_config" not in completion_kwargs, (
+        "output_config should be excluded from completion kwargs; "
+        "it is an Anthropic-only param that Bedrock rejects."
+    )
+    # custom_llm_provider should still be passed through
+    assert completion_kwargs.get("custom_llm_provider") == "bedrock"
+
+
+def test_prepare_completion_kwargs_excludes_anthropic_messages():
+    """
+    Verify that `anthropic_messages` is also excluded from completion kwargs
+    (pre-existing behavior).
+    """
+    completion_kwargs, _ = (
+        LiteLLMMessagesToCompletionTransformationHandler._prepare_completion_kwargs(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hello"}],
+            model="bedrock/us.amazon.nova-pro-v1:0",
+            extra_kwargs={
+                "anthropic_messages": True,
+                "custom_llm_provider": "bedrock",
+            },
+        )
+    )
+    assert "anthropic_messages" not in completion_kwargs


### PR DESCRIPTION
## Relevant issues

Fixes failing `proxy_e2e_anthropic_messages_tests` CI job — `test_claude_agent_sdk_streaming[bedrock-nova-pro-AWS Nova Pro]`

## Summary

### Failure Path (Before Fix)

The Claude Agent SDK sends `output_config` in the Anthropic Messages request body (`/v1/messages`). For non-Claude Bedrock models like Nova Pro, `get_bedrock_provider_config_for_messages_api()` returns `None` (it only handles Claude models), so the request is routed through `LiteLLMMessagesToCompletionTransformationHandler`. Since `output_config` is not an explicit parameter in the handler's signature, it leaks through `**kwargs` → `extra_kwargs` → `completion_kwargs` → `litellm.acompletion()` → Bedrock, which rejects it with `"extraneous key [output_config] is not permitted"`.

### Fix

Add `output_config` to the `excluded_keys` set in `_prepare_completion_kwargs()` so the Anthropic-only parameter is stripped before reaching `litellm.completion()`. This mirrors how `output_config` is already stripped in the Claude-specific Bedrock Messages transformation (`anthropic_claude3_transformation.py:424`).

## Testing

- Added 2 unit tests in `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_handler.py`
- All 57 existing adapter tests continue to pass

## Type

🐛 Bug Fix
✅ Test