### PR TITLE
Add nvidia_nim/z-ai/glm5 model mapping

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -39626,5 +39626,17 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
+    },
+    "nvidia_nim/z-ai/glm5": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "nvidia_nim",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.56e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     }
 }


### PR DESCRIPTION
## Summary
Adds support for the GLM-5 model via NVIDIA NIM API to resolve the model mapping error.

## Changes
- Added `nvidia_nim/z-ai/glm5` to `model_prices_and_context_window.json`

## Model Specifications
- **Context window**: 202,752 input tokens / 128,000 output tokens
- **Mode**: chat
- **Features**: function calling, reasoning, tool choice
- **Pricing**: $0.8/M input tokens, $2.56/M output tokens

## Error Fixed
```
ValueError: This model isn't mapped yet. model=nvidia_nim/z-ai/glm5, custom_llm_provider=nvidia_nim. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)