### PR TITLE
feat(charity_engine): add Charity Engine provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -96,7 +96,7 @@
     "api_key_env": "ASSEMBLYAI_API_KEY"
   },
   "charity_engine": {
-    "base_url": "https://api.charityengine.services/remotejobs/v2/inference/",
+    "base_url": "https://api.charityengine.services/remotejobs/v2/inference",
     "api_key_env": "CHARITY_ENGINE_API_KEY",
     "param_mappings": {
       "max_completion_tokens": "max_tokens"

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -94,5 +94,13 @@
   "assemblyai": {
     "base_url": "https://llm-gateway.assemblyai.com/v1",
     "api_key_env": "ASSEMBLYAI_API_KEY"
+  },
+  "charity_engine": {
+    "base_url": "https://api.charityengine.services/remotejobs/v2/inference/",
+    "api_key_env": "CHARITY_ENGINE_API_KEY",
+    "api_base_env": "CHARITY_ENGINE_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -98,7 +98,6 @@
   "charity_engine": {
     "base_url": "https://api.charityengine.services/remotejobs/v2/inference/",
     "api_key_env": "CHARITY_ENGINE_API_KEY",
-    "api_base_env": "CHARITY_ENGINE_API_BASE",
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3177,6 +3177,7 @@ class LlmProviders(str, Enum):
     TOPAZ = "topaz"
     SAP_GENERATIVE_AI_HUB = "sap"
     ASSEMBLYAI = "assemblyai"
+    CHARITY_ENGINE = "charity_engine"
     GITHUB_COPILOT = "github_copilot"
     SNOWFLAKE = "snowflake"
     GRADIENT_AI = "gradient_ai"

--- a/tests/test_litellm/llms/openai_like/test_charity_engine.py
+++ b/tests/test_litellm/llms/openai_like/test_charity_engine.py
@@ -36,7 +36,7 @@ class TestCharityEngineProviderConfig:
 
         charity_engine = JSONProviderRegistry.get("charity_engine")
         assert charity_engine is not None
-        assert charity_engine.base_url == "https://api.charityengine.services/remotejobs/v2/inference/"
+        assert charity_engine.base_url == "https://api.charityengine.services/remotejobs/v2/inference"
         assert charity_engine.api_key_env == "CHARITY_ENGINE_API_KEY"
         assert charity_engine.param_mappings.get("max_completion_tokens") == "max_tokens"
 
@@ -53,7 +53,7 @@ class TestCharityEngineProviderConfig:
 
         assert model == "gemma3:270m"
         assert provider == "charity_engine"
-        assert api_base == "https://api.charityengine.services/remotejobs/v2/inference/"
+        assert api_base == "https://api.charityengine.services/remotejobs/v2/inference"
 
     def test_charity_engine_router_config(self):
         """Test that charity_engine can be used in Router configuration"""

--- a/tests/test_litellm/llms/openai_like/test_charity_engine.py
+++ b/tests/test_litellm/llms/openai_like/test_charity_engine.py
@@ -38,7 +38,6 @@ class TestCharityEngineProviderConfig:
         assert charity_engine is not None
         assert charity_engine.base_url == "https://api.charityengine.services/remotejobs/v2/inference/"
         assert charity_engine.api_key_env == "CHARITY_ENGINE_API_KEY"
-        assert charity_engine.api_base_env == "CHARITY_ENGINE_API_BASE"
         assert charity_engine.param_mappings.get("max_completion_tokens") == "max_tokens"
 
     def test_charity_engine_provider_resolution(self):

--- a/tests/test_litellm/llms/openai_like/test_charity_engine.py
+++ b/tests/test_litellm/llms/openai_like/test_charity_engine.py
@@ -1,0 +1,102 @@
+"""
+Tests for Charity Engine provider configuration and integration.
+"""
+
+import os
+import sys
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+# Add workspace to path
+workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, workspace_path)
+
+import litellm
+
+
+class TestCharityEngineProviderConfig:
+    """Test Charity Engine provider configuration"""
+
+    def test_charity_engine_in_provider_list(self):
+        """Test that charity_engine is in the provider list"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "CHARITY_ENGINE")
+        assert LlmProviders.CHARITY_ENGINE.value == "charity_engine"
+        assert "charity_engine" in litellm.provider_list
+
+    def test_charity_engine_json_config_exists(self):
+        """Test that charity_engine is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("charity_engine")
+
+        charity_engine = JSONProviderRegistry.get("charity_engine")
+        assert charity_engine is not None
+        assert charity_engine.base_url == "https://api.charityengine.services/remotejobs/v2/inference/"
+        assert charity_engine.api_key_env == "CHARITY_ENGINE_API_KEY"
+        assert charity_engine.api_base_env == "CHARITY_ENGINE_API_BASE"
+        assert charity_engine.param_mappings.get("max_completion_tokens") == "max_tokens"
+
+    def test_charity_engine_provider_resolution(self):
+        """Test that provider resolution finds charity_engine"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="charity_engine/gemma3:270m",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "gemma3:270m"
+        assert provider == "charity_engine"
+        assert api_base == "https://api.charityengine.services/remotejobs/v2/inference/"
+
+    def test_charity_engine_router_config(self):
+        """Test that charity_engine can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gemma3-270m",
+                    "litellm_params": {
+                        "model": "charity_engine/gemma3:270m",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "gemma3-270m"
+
+
+if __name__ == "__main__":
+    print("Testing Charity Engine Provider...")
+
+    test_config = TestCharityEngineProviderConfig()
+
+    print("\n1. Testing provider in list...")
+    test_config.test_charity_engine_in_provider_list()
+    print("   ✓ charity_engine in provider list")
+
+    print("\n2. Testing JSON config...")
+    test_config.test_charity_engine_json_config_exists()
+    print("   ✓ charity_engine JSON config loaded")
+
+    print("\n3. Testing provider resolution...")
+    test_config.test_charity_engine_provider_resolution()
+    print("   ✓ Provider resolution works")
+
+    print("\n4. Testing router configuration...")
+    test_config.test_charity_engine_router_config()
+    print("   ✓ Router configuration works")
+
+    print("\n" + "=" * 50)
+    print("✓ All configuration tests passed!")
+    print("=" * 50)


### PR DESCRIPTION
Charity Engine is a crowdsourced distributed computing platform that donates processing power to charitable causes. Its inference API provides OpenAI-compatible chat, completions, and embeddings endpoints.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Add Charity Engine to the list of openai_like providers.