### PR TITLE
fix(codeql): switch to security-extended to fix OOM failures

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,16 @@ name: "LiteLLM CodeQL config"
 queries:
   - uses: security-extended
 
+# These two queries are security queries included in security-extended that
+# individually produce result sets > 2 GiB on this codebase, causing fatal
+# OOM failures. Exclude them as a safety net until CI confirms they no longer
+# OOM; drop these exclusions in a follow-up once verified.
+query-filters:
+  - exclude:
+      id: py/clear-text-logging-sensitive-data  # CWE-312 — > 2 GiB result set
+  - exclude:
+      id: py/polynomial-redos                   # CWE-730 — > 2 GiB result set
+
 paths-ignore:
   - tests
   - docs

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,12 +1,9 @@
 name: "LiteLLM CodeQL config"
 
-# Exclude queries that produce result sets > 2 GiB on this codebase,
-# causing 49+ minute runs that fail and block CI resources.
-query-filters:
-  - exclude:
-      id: py/clear-text-logging-sensitive-data  # CWE-312/CleartextLogging.ql — result set > 2 GiB
-  - exclude:
-      id: py/polynomial-redos                   # CWE-730/PolynomialReDoS.ql — result set > 2 GiB
+# Use security-extended suite instead of security-and-quality to avoid
+# result sets > 2 GiB on this codebase that cause fatal OOM failures.
+queries:
+  - uses: security-extended
 
 paths-ignore:
   - tests


### PR DESCRIPTION
## Summary
- Switches CodeQL config from `security-and-quality` to `security-extended` query suite
- The `security-and-quality` suite produces result sets > 2 GiB on this codebase, causing fatal OOM failures and blocking CI
- Retains `query-filters` exclusions for `py/clear-text-logging-sensitive-data` (CWE-312) and `py/polynomial-redos` (CWE-730) as a safety net — both are security queries present in `security-extended` that individually produce result sets > 2 GiB; exclusions can be dropped in a follow-up once CI confirms they no longer OOM


## Test plan
- [ ] Verify CodeQL `Analyze (python)` job completes without OOM failure
- [ ] Verify CodeQL `Analyze (javascript-typescript)` and `Analyze (actions)` jobs pass
- [ ] Confirm security scanning results are still reported on the PR