### PR TITLE
fix(codeql): remove ruby from language matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,8 +34,6 @@ jobs:
             build-mode: none
           - language: python
             build-mode: none
-          - language: ruby
-            build-mode: none
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Removes Ruby from the CodeQL language matrix
- The only Ruby file in the repo (`tests/pass_through_tests/ruby_passthrough_tests/spec/openai_assistants_passthrough_spec.rb`) is in the `tests/` directory, which is excluded via `paths-ignore` in `codeql-config.yml`
- CodeQL finds no Ruby source to scan and fails with a fatal error every run
- We no longer use comfy-manifests

## Test plan
- [ ] Verify `Analyze (ruby)` job no longer appears in CodeQL workflow
- [ ] Verify remaining CodeQL jobs (actions, javascript-typescript, python) pass