### PR TITLE
fix(logging): preserve ModelResponse choices format in redacted standard_logging_object + add Charity Engine provider endpoint

### DIFF
--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -73,6 +73,53 @@ def _redact_responses_api_output(output_items):
                         summary_item.text = "redacted-by-litellm"
 
 
+def _redact_standard_logging_object(model_call_details: dict):
+    """Redact messages and response inside standard_logging_object if present."""
+    standard_logging_object = model_call_details.get("standard_logging_object")
+    if standard_logging_object is None:
+        return
+
+    redacted_str = "redacted-by-litellm"
+
+    if standard_logging_object.get("messages") is not None:
+        standard_logging_object["messages"] = [
+            {"role": "user", "content": redacted_str}
+        ]
+
+    response = standard_logging_object.get("response")
+    if response is not None:
+        if isinstance(response, dict) and "output" in response:
+            # ResponsesAPIResponse format - redact content in output items
+            if isinstance(response.get("output"), list):
+                for output_item in response["output"]:
+                    if isinstance(output_item, dict) and "content" in output_item:
+                        if isinstance(output_item["content"], list):
+                            for content_item in output_item["content"]:
+                                if (
+                                    isinstance(content_item, dict)
+                                    and "text" in content_item
+                                ):
+                                    content_item["text"] = redacted_str
+        elif isinstance(response, dict) and "choices" in response:
+            # ModelResponse dict format - redact content in choices
+            if isinstance(response.get("choices"), list):
+                for choice in response["choices"]:
+                    if isinstance(choice, dict):
+                        if "message" in choice and isinstance(choice["message"], dict):
+                            choice["message"]["content"] = redacted_str
+                            if "audio" in choice["message"]:
+                                choice["message"]["audio"] = None
+                        elif "delta" in choice and isinstance(choice["delta"], dict):
+                            choice["delta"]["content"] = redacted_str
+                            if "audio" in choice["delta"]:
+                                choice["delta"]["audio"] = None
+        elif isinstance(response, str):
+            standard_logging_object["response"] = redacted_str
+        else:
+            # For other formats (empty dict, None, etc.), use simple text format
+            standard_logging_object["response"] = {"text": redacted_str}
+
+
 def perform_redaction(model_call_details: dict, result):
     """
     Performs the actual redaction on the logging object and result.
@@ -114,6 +161,29 @@ def perform_redaction(model_call_details: dict, result):
             if hasattr(_result, "choices") and _result.choices is not None:
                 for choice in _result.choices:
                     _redact_choice_content(choice)
+        elif isinstance(_result, dict) and "choices" in _result:
+            # Handle dict representation of ModelResponse (e.g., from model_dump())
+            if _result.get("choices") is not None:
+                for choice in _result["choices"]:
+                    if isinstance(choice, dict):
+                        if "message" in choice and isinstance(choice["message"], dict):
+                            choice["message"]["content"] = "redacted-by-litellm"
+                            if "reasoning_content" in choice["message"]:
+                                choice["message"]["reasoning_content"] = "redacted-by-litellm"
+                            if "thinking_blocks" in choice["message"]:
+                                choice["message"]["thinking_blocks"] = None
+                            if "audio" in choice["message"]:
+                                choice["message"]["audio"] = None
+                        elif "delta" in choice and isinstance(choice["delta"], dict):
+                            choice["delta"]["content"] = "redacted-by-litellm"
+                            if "reasoning_content" in choice["delta"]:
+                                choice["delta"]["reasoning_content"] = "redacted-by-litellm"
+                            if "thinking_blocks" in choice["delta"]:
+                                choice["delta"]["thinking_blocks"] = None
+                            if "audio" in choice["delta"]:
+                                choice["delta"]["audio"] = None
+                    else:
+                        _redact_choice_content(choice)
         elif isinstance(_result, litellm.ResponsesAPIResponse):
             if hasattr(_result, "output"):
                 _redact_responses_api_output(_result.output)

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -458,6 +458,24 @@
         "interactions": true
       }
     },
+    "charity_engine": {
+      "display_name": "Charity Engine (`charity_engine`)",
+      "url": "https://docs.litellm.ai/docs/providers/charity_engine",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "chutes": {
       "display_name": "Chutes (`chutes`)",
       "endpoints": {

--- a/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
+++ b/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
@@ -45,7 +45,8 @@ async def test_global_redaction_on():
     await asyncio.sleep(1)
     standard_logging_payload = test_custom_logger.logged_standard_logging_payload
     assert standard_logging_payload is not None
-    assert standard_logging_payload["response"] == {"text": "redacted-by-litellm"}
+    response = standard_logging_payload["response"]
+    assert response["choices"][0]["message"]["content"] == "redacted-by-litellm"
     assert standard_logging_payload["messages"][0]["content"] == "redacted-by-litellm"
     print(
         "logged standard logging payload",
@@ -75,7 +76,8 @@ async def test_global_redaction_with_dynamic_params(turn_off_message_logging):
     )
 
     if turn_off_message_logging is True:
-        assert standard_logging_payload["response"] == {"text": "redacted-by-litellm"}
+        response = standard_logging_payload["response"]
+        assert response["choices"][0]["message"]["content"] == "redacted-by-litellm"
         assert (
             standard_logging_payload["messages"][0]["content"] == "redacted-by-litellm"
         )
@@ -108,7 +110,8 @@ async def test_global_redaction_off_with_dynamic_params(turn_off_message_logging
         json.dumps(standard_logging_payload, indent=2),
     )
     if turn_off_message_logging is True:
-        assert standard_logging_payload["response"] == {"text": "redacted-by-litellm"}
+        response = standard_logging_payload["response"]
+        assert response["choices"][0]["message"]["content"] == "redacted-by-litellm"
         assert (
             standard_logging_payload["messages"][0]["content"] == "redacted-by-litellm"
         )
@@ -390,7 +393,8 @@ async def test_redaction_with_streaming_response():
     assert standard_logging_payload is not None
     
     # Verify that redaction worked without pickle errors
-    assert standard_logging_payload["response"] == {"text": "redacted-by-litellm"}
+    response = standard_logging_payload["response"]
+    assert response["choices"][0]["message"]["content"] == "redacted-by-litellm"
     assert standard_logging_payload["messages"][0]["content"] == "redacted-by-litellm"
     print(
         "logged standard logging payload for streaming with coroutine handling",
@@ -477,5 +481,6 @@ async def test_redaction_with_metadata_completion_api():
     
     # Verify the helper function works correctly - with get_metadata_variable_name_from_kwargs,
     # the system checks the appropriate field for headers
-    assert standard_logging_payload["response"] == {"text": "redacted-by-litellm"}
+    response = standard_logging_payload["response"]
+    assert response["choices"][0]["message"]["content"] == "redacted-by-litellm"
     assert standard_logging_payload["messages"][0]["content"] == "redacted-by-litellm"


### PR DESCRIPTION
## Summary
Fixes failing redaction tests and adds Charity Engine provider endpoint support.

## Changes

### 1. Redaction fix (`litellm/litellm_core_utils/redact_messages.py`)
- **Fix**: Handle dict representation of ModelResponse (from `model_dump()`) in `perform_redaction`
- When `response_obj` is a dict with `choices`, preserve the full structure and redact content/audio in place
- Add `_redact_standard_logging_object` helper for redacting the `standard_logging_object` field in different formats (ModelResponse, ResponsesAPIResponse, etc.)

### 2. Test updates (`tests/logging_callback_tests/test_logging_redaction_e2e_test.py`)
- Update assertions to expect `choices` format instead of `{"text": "redacted-by-litellm"}`
- Aligns with expected behavior since commit d84e5e381acf

### 3. Provider endpoint (`provider_endpoints_support.json`)
- Add Charity Engine provider endpoint with documentation URL and supported endpoints

## Tests fixed
- `test_standard_logging_payload[True-ft:gpt-3.5-turbo:my-org:custom_suffix:id]`
- `test_standard_logging_payload_audio[True-True]`
- `test_standard_logging_payload_audio[True-False]`
- All `test_logging_redaction_e2e_test` tests

## Motivation
The tests in `test_custom_callback_input.py` were updated (commit a50a84c16c5) to expect the new `choices` format, but the code to support this was reverted. This PR restores the correct redaction behavior.

Made with [Cursor](https://cursor.com)