### PR TITLE
fix: preserve deployment custom pricing for /responses and /messages

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -231,9 +231,9 @@ def merge_metadata_preserving_deployment_model_info(
     metadata.model_info, but direct callers may still pass model_info top-level.
     """
     merged_metadata = dict(litellm_metadata or {})
-    deployment_model_info = merged_metadata.pop("model_info", None)
+    deployment_model_info = merged_metadata.pop("model_info", _MISSING_MODEL_INFO)
     merged_metadata.update(user_metadata or {})
-    if deployment_model_info is not None:
+    if deployment_model_info is not _MISSING_MODEL_INFO:
         merged_metadata["model_info"] = deployment_model_info
     elif "model_info" not in merged_metadata and model_info is not None:
         merged_metadata["model_info"] = model_info

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Helper utilities
-from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Union
 
 import httpx
 
@@ -187,6 +187,36 @@ def get_litellm_metadata_from_kwargs(kwargs: dict):
             return metadata
 
     return {}
+
+
+_MISSING_MODEL_INFO = object()
+
+
+def get_model_info_from_litellm_params(
+    litellm_params: Optional[dict],
+) -> Dict[str, Any]:
+    """
+    Read deployment model_info from supported litellm_params locations.
+
+    metadata.model_info takes precedence, including an explicitly empty dict.
+    """
+    if litellm_params is None:
+        return {}
+
+    metadata = litellm_params.get("metadata", {}) or {}
+    metadata_model_info = metadata.get("model_info", _MISSING_MODEL_INFO)
+    if metadata_model_info is not _MISSING_MODEL_INFO:
+        result = metadata_model_info
+    else:
+        litellm_model_info = litellm_params.get("model_info", _MISSING_MODEL_INFO)
+        if litellm_model_info is not _MISSING_MODEL_INFO:
+            result = litellm_model_info
+        else:
+            result = (litellm_params.get("litellm_metadata", {}) or {}).get(
+                "model_info", {}
+            )
+
+    return result if isinstance(result, dict) else {}
 
 
 def merge_metadata_preserving_deployment_model_info(

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -189,6 +189,28 @@ def get_litellm_metadata_from_kwargs(kwargs: dict):
     return {}
 
 
+def merge_metadata_preserving_deployment_model_info(
+    litellm_metadata: Optional[dict],
+    user_metadata: Optional[dict],
+    model_info: Optional[dict] = None,
+) -> dict:
+    """
+    Merge user metadata into LiteLLM metadata while preserving deployment model_info.
+
+    Router-provided deployment model_info should win over any user-supplied
+    metadata.model_info, but direct callers may still pass model_info top-level.
+    """
+    merged_metadata = dict(litellm_metadata or {})
+    deployment_model_info = merged_metadata.pop("model_info", None)
+    merged_metadata.update(user_metadata or {})
+    if deployment_model_info is not None:
+        merged_metadata["model_info"] = deployment_model_info
+    elif "model_info" not in merged_metadata and model_info is not None:
+        merged_metadata["model_info"] = model_info
+
+    return merged_metadata
+
+
 def reconstruct_model_name(
     model_name: str,
     custom_llm_provider: Optional[str],

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1651,6 +1651,7 @@ class Logging(LiteLLMLoggingBaseClass):
             router_model_id = None
             if self.call_type in (
                 "responses",
+                "aresponses",
                 "anthropic_messages",
             ):
                 model_info = _get_model_info_from_litellm_params(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1648,12 +1648,20 @@ class Logging(LiteLLMLoggingBaseClass):
             # handlers like Gemini/Vertex which call completion_cost directly)
             pass
         else:
-            model_info = _get_model_info_from_litellm_params(
-                self.model_call_details.get("litellm_params", {}) or {}
-            )
+            router_model_id = None
+            if self.call_type in (
+                "responses",
+                "aresponses",
+                "_aresponses_websocket",
+                "anthropic_messages",
+            ):
+                model_info = _get_model_info_from_litellm_params(
+                    self.model_call_details.get("litellm_params", {}) or {}
+                )
+                router_model_id = model_info.get("id")
             self.model_call_details["response_cost"] = self._response_cost_calculator(
                 result=logging_result,
-                router_model_id=model_info.get("id"),
+                router_model_id=router_model_id,
             )
 
         self.model_call_details[
@@ -2472,14 +2480,22 @@ class Logging(LiteLLMLoggingBaseClass):
                     _get_base_model_from_metadata(
                         model_call_details=self.model_call_details
                     )
-                    # base_model defaults to None if not set on model_info
-                    model_info = _get_model_info_from_litellm_params(
-                        self.model_call_details.get("litellm_params", {}) or {}
-                    )
+                    router_model_id = None
+                    if self.call_type in (
+                        "responses",
+                        "aresponses",
+                        "_aresponses_websocket",
+                        "anthropic_messages",
+                    ):
+                        # base_model defaults to None if not set on model_info
+                        model_info = _get_model_info_from_litellm_params(
+                            self.model_call_details.get("litellm_params", {}) or {}
+                        )
+                        router_model_id = model_info.get("id")
                     self.model_call_details["response_cost"] = (
                         self._response_cost_calculator(
                             result=complete_streaming_response,
-                            router_model_id=model_info.get("id"),
+                            router_model_id=router_model_id,
                         )
                     )
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1651,8 +1651,6 @@ class Logging(LiteLLMLoggingBaseClass):
             router_model_id = None
             if self.call_type in (
                 "responses",
-                "aresponses",
-                "_aresponses_websocket",
                 "anthropic_messages",
             ):
                 model_info = _get_model_info_from_litellm_params(
@@ -1961,8 +1959,6 @@ class Logging(LiteLLMLoggingBaseClass):
                 router_model_id = None
                 if self.call_type in (
                     "responses",
-                    "aresponses",
-                    "_aresponses_websocket",
                     "anthropic_messages",
                 ):
                     model_info = _get_model_info_from_litellm_params(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1963,6 +1963,8 @@ class Logging(LiteLLMLoggingBaseClass):
                 router_model_id = None
                 if self.call_type in (
                     "responses",
+                    "aresponses",
+                    "_aresponses_websocket",
                     "anthropic_messages",
                 ):
                     model_info = _get_model_info_from_litellm_params(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1651,19 +1651,12 @@ class Logging(LiteLLMLoggingBaseClass):
             # handlers like Gemini/Vertex which call completion_cost directly)
             pass
         else:
-            router_model_id = None
-            if self.call_type in (
-                "responses",
-                "aresponses",
-                "anthropic_messages",
-            ):
-                model_info = get_model_info_from_litellm_params(
-                    self.model_call_details.get("litellm_params", {}) or {}
-                )
-                router_model_id = model_info.get("id")
+            model_info = get_model_info_from_litellm_params(
+                self.model_call_details.get("litellm_params", {}) or {}
+            )
             self.model_call_details["response_cost"] = self._response_cost_calculator(
                 result=logging_result,
-                router_model_id=router_model_id,
+                router_model_id=model_info.get("id"),
             )
 
         self.model_call_details[
@@ -1960,21 +1953,13 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["complete_streaming_response"] = (
                     complete_streaming_response
                 )
-                router_model_id = None
-                if self.call_type in (
-                    "responses",
-                    "aresponses",
-                    "_aresponses_websocket",
-                    "anthropic_messages",
-                ):
-                    model_info = get_model_info_from_litellm_params(
-                        self.model_call_details.get("litellm_params", {}) or {}
-                    )
-                    router_model_id = model_info.get("id")
+                model_info = get_model_info_from_litellm_params(
+                    self.model_call_details.get("litellm_params", {}) or {}
+                )
                 self.model_call_details["response_cost"] = (
                     self._response_cost_calculator(
                         result=complete_streaming_response,
-                        router_model_id=router_model_id,
+                        router_model_id=model_info.get("id"),
                     )
                 )
                 ## STANDARDIZED LOGGING PAYLOAD
@@ -2496,22 +2481,13 @@ class Logging(LiteLLMLoggingBaseClass):
                     _get_base_model_from_metadata(
                         model_call_details=self.model_call_details
                     )
-                    router_model_id = None
-                    if self.call_type in (
-                        "responses",
-                        "aresponses",
-                        "_aresponses_websocket",
-                        "anthropic_messages",
-                    ):
-                        # base_model defaults to None if not set on model_info
-                        model_info = get_model_info_from_litellm_params(
-                            self.model_call_details.get("litellm_params", {}) or {}
-                        )
-                        router_model_id = model_info.get("id")
+                    model_info = get_model_info_from_litellm_params(
+                        self.model_call_details.get("litellm_params", {}) or {}
+                    )
                     self.model_call_details["response_cost"] = (
                         self._response_cost_calculator(
                             result=complete_streaming_response,
-                            router_model_id=router_model_id,
+                            router_model_id=model_info.get("id"),
                         )
                     )
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1955,12 +1955,26 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details[
-                    "complete_streaming_response"
-                ] = complete_streaming_response
-                self.model_call_details[
-                    "response_cost"
-                ] = self._response_cost_calculator(result=complete_streaming_response)
+                self.model_call_details["complete_streaming_response"] = (
+                    complete_streaming_response
+                )
+                router_model_id = None
+                if self.call_type in (
+                    "responses",
+                    "aresponses",
+                    "_aresponses_websocket",
+                    "anthropic_messages",
+                ):
+                    model_info = _get_model_info_from_litellm_params(
+                        self.model_call_details.get("litellm_params", {}) or {}
+                    )
+                    router_model_id = model_info.get("id")
+                self.model_call_details["response_cost"] = (
+                    self._response_cost_calculator(
+                        result=complete_streaming_response,
+                        router_model_id=router_model_id,
+                    )
+                )
                 ## STANDARDIZED LOGGING PAYLOAD
                 self.model_call_details[
                     "standard_logging_object"

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4446,12 +4446,13 @@ def _get_model_info_from_litellm_params(
         return {}
 
     metadata = litellm_params.get("metadata", {}) or {}
-    return (
+    result = (
         metadata.get("model_info")
         or litellm_params.get("model_info")
         or (litellm_params.get("litellm_metadata", {}) or {}).get("model_info")
         or {}
     )
+    return result if isinstance(result, dict) else {}
 
 
 def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4465,6 +4465,9 @@ def _get_custom_logger_settings_from_proxy_server(callback_name: str) -> Dict:
     return {}
 
 
+_MISSING_MODEL_INFO = object()
+
+
 def _get_model_info_from_litellm_params(
     litellm_params: Optional[dict],
 ) -> Dict[str, Any]:
@@ -4472,14 +4475,12 @@ def _get_model_info_from_litellm_params(
         return {}
 
     metadata = litellm_params.get("metadata", {}) or {}
-    _missing = object()
-
-    metadata_model_info = metadata.get("model_info", _missing)
-    if metadata_model_info is not _missing:
+    metadata_model_info = metadata.get("model_info", _MISSING_MODEL_INFO)
+    if metadata_model_info is not _MISSING_MODEL_INFO:
         result = metadata_model_info
     else:
-        litellm_model_info = litellm_params.get("model_info", _missing)
-        if litellm_model_info is not _missing:
+        litellm_model_info = litellm_params.get("model_info", _MISSING_MODEL_INFO)
+        if litellm_model_info is not _MISSING_MODEL_INFO:
             result = litellm_model_info
         else:
             result = (litellm_params.get("litellm_metadata", {}) or {}).get(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -59,7 +59,10 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.deepeval.deepeval import DeepEvalLogger
 from litellm.integrations.mlflow import MlflowLogger
 from litellm.integrations.sqs import SQSLogger
-from litellm.litellm_core_utils.core_helpers import reconstruct_model_name
+from litellm.litellm_core_utils.core_helpers import (
+    get_model_info_from_litellm_params,
+    reconstruct_model_name,
+)
 from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
     StandardBuiltInToolCostTracking,
@@ -4466,29 +4469,10 @@ def _get_custom_logger_settings_from_proxy_server(callback_name: str) -> Dict:
     return {}
 
 
-_MISSING_MODEL_INFO = object()
-
-
 def _get_model_info_from_litellm_params(
     litellm_params: Optional[dict],
 ) -> Dict[str, Any]:
-    if litellm_params is None:
-        return {}
-
-    metadata = litellm_params.get("metadata", {}) or {}
-    metadata_model_info = metadata.get("model_info", _MISSING_MODEL_INFO)
-    if metadata_model_info is not _MISSING_MODEL_INFO:
-        result = metadata_model_info
-    else:
-        litellm_model_info = litellm_params.get("model_info", _MISSING_MODEL_INFO)
-        if litellm_model_info is not _MISSING_MODEL_INFO:
-            result = litellm_model_info
-        else:
-            result = (litellm_params.get("litellm_metadata", {}) or {}).get(
-                "model_info", {}
-            )
-
-    return result if isinstance(result, dict) else {}
+    return get_model_info_from_litellm_params(litellm_params)
 
 
 def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1648,8 +1648,25 @@ class Logging(LiteLLMLoggingBaseClass):
             # handlers like Gemini/Vertex which call completion_cost directly)
             pass
         else:
+            # Extract router_model_id from metadata so that
+            # custom-pricing deployments resolve to the correct cost
+            # even when the result object lacks _hidden_params
+            # (e.g. Anthropic messages API responses).
+            _lp_meta = (
+                self.model_call_details
+                .get("litellm_params", {})
+                .get("metadata", {}) or {}
+            )
+            _lp = self.model_call_details.get("litellm_params", {}) or {}
+            _mi = (
+                _lp_meta.get("model_info")
+                or _lp.get("model_info")
+                or (_lp.get("litellm_metadata", {}) or {}).get("model_info")
+                or {}
+            )
             self.model_call_details["response_cost"] = self._response_cost_calculator(
-                result=logging_result
+                result=logging_result,
+                router_model_id=_mi.get("id"),
             )
 
         self.model_call_details[
@@ -2469,10 +2486,25 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details[
-                        "response_cost"
-                    ] = self._response_cost_calculator(
-                        result=complete_streaming_response
+                    # Extract router_model_id from metadata for
+                    # custom-pricing deployments (e.g. /v1/messages)
+                    _lp_meta_s = (
+                        self.model_call_details
+                        .get("litellm_params", {})
+                        .get("metadata", {}) or {}
+                    )
+                    _lp_s = self.model_call_details.get("litellm_params", {}) or {}
+                    _mi_s = (
+                        _lp_meta_s.get("model_info")
+                        or _lp_s.get("model_info")
+                        or (_lp_s.get("litellm_metadata", {}) or {}).get("model_info")
+                        or {}
+                    )
+                    self.model_call_details["response_cost"] = (
+                        self._response_cost_calculator(
+                            result=complete_streaming_response,
+                            router_model_id=_mi_s.get("id"),
+                        )
                     )
 
                 verbose_logger.debug(
@@ -4446,15 +4478,20 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
         if litellm_params.get(key) is not None:
             return True
 
-    # Check model_info
+    # Check model_info in all supported locations.
     metadata: dict = litellm_params.get("metadata", {}) or {}
-    model_info: dict = metadata.get("model_info", {}) or {}
+    model_info_locations = [
+        metadata.get("model_info", {}) or {},
+        litellm_params.get("model_info", {}) or {},
+        (litellm_params.get("litellm_metadata", {}) or {}).get("model_info", {}) or {},
+    ]
 
-    if model_info:
-        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
-        for key in matching_keys:
-            if model_info.get(key) is not None:
-                return True
+    for model_info in model_info_locations:
+        if model_info:
+            matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+            for key in matching_keys:
+                if model_info.get(key) is not None:
+                    return True
 
     return False
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1657,7 +1657,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 "aresponses",
                 "anthropic_messages",
             ):
-                model_info = _get_model_info_from_litellm_params(
+                model_info = get_model_info_from_litellm_params(
                     self.model_call_details.get("litellm_params", {}) or {}
                 )
                 router_model_id = model_info.get("id")
@@ -1967,7 +1967,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     "_aresponses_websocket",
                     "anthropic_messages",
                 ):
-                    model_info = _get_model_info_from_litellm_params(
+                    model_info = get_model_info_from_litellm_params(
                         self.model_call_details.get("litellm_params", {}) or {}
                     )
                     router_model_id = model_info.get("id")
@@ -2504,7 +2504,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         "anthropic_messages",
                     ):
                         # base_model defaults to None if not set on model_info
-                        model_info = _get_model_info_from_litellm_params(
+                        model_info = get_model_info_from_litellm_params(
                             self.model_call_details.get("litellm_params", {}) or {}
                         )
                         router_model_id = model_info.get("id")
@@ -4471,12 +4471,6 @@ def _get_custom_logger_settings_from_proxy_server(callback_name: str) -> Dict:
     return {}
 
 
-def _get_model_info_from_litellm_params(
-    litellm_params: Optional[dict],
-) -> Dict[str, Any]:
-    return get_model_info_from_litellm_params(litellm_params)
-
-
 def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
     """
     Check if the model uses custom pricing
@@ -4493,7 +4487,7 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
             return True
 
     # Check model_info in all supported locations.
-    model_info = _get_model_info_from_litellm_params(litellm_params)
+    model_info = get_model_info_from_litellm_params(litellm_params)
     if model_info:
         matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
         for key in matching_keys:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1648,25 +1648,12 @@ class Logging(LiteLLMLoggingBaseClass):
             # handlers like Gemini/Vertex which call completion_cost directly)
             pass
         else:
-            # Extract router_model_id from metadata so that
-            # custom-pricing deployments resolve to the correct cost
-            # even when the result object lacks _hidden_params
-            # (e.g. Anthropic messages API responses).
-            _lp_meta = (
-                self.model_call_details
-                .get("litellm_params", {})
-                .get("metadata", {}) or {}
-            )
-            _lp = self.model_call_details.get("litellm_params", {}) or {}
-            _mi = (
-                _lp_meta.get("model_info")
-                or _lp.get("model_info")
-                or (_lp.get("litellm_metadata", {}) or {}).get("model_info")
-                or {}
+            model_info = _get_model_info_from_litellm_params(
+                self.model_call_details.get("litellm_params", {}) or {}
             )
             self.model_call_details["response_cost"] = self._response_cost_calculator(
                 result=logging_result,
-                router_model_id=_mi.get("id"),
+                router_model_id=model_info.get("id"),
             )
 
         self.model_call_details[
@@ -2486,24 +2473,13 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    # Extract router_model_id from metadata for
-                    # custom-pricing deployments (e.g. /v1/messages)
-                    _lp_meta_s = (
-                        self.model_call_details
-                        .get("litellm_params", {})
-                        .get("metadata", {}) or {}
-                    )
-                    _lp_s = self.model_call_details.get("litellm_params", {}) or {}
-                    _mi_s = (
-                        _lp_meta_s.get("model_info")
-                        or _lp_s.get("model_info")
-                        or (_lp_s.get("litellm_metadata", {}) or {}).get("model_info")
-                        or {}
+                    model_info = _get_model_info_from_litellm_params(
+                        self.model_call_details.get("litellm_params", {}) or {}
                     )
                     self.model_call_details["response_cost"] = (
                         self._response_cost_calculator(
                             result=complete_streaming_response,
-                            router_model_id=_mi_s.get("id"),
+                            router_model_id=model_info.get("id"),
                         )
                     )
 
@@ -4463,6 +4439,21 @@ def _get_custom_logger_settings_from_proxy_server(callback_name: str) -> Dict:
     return {}
 
 
+def _get_model_info_from_litellm_params(
+    litellm_params: Optional[dict],
+) -> Dict[str, Any]:
+    if litellm_params is None:
+        return {}
+
+    metadata = litellm_params.get("metadata", {}) or {}
+    return (
+        metadata.get("model_info")
+        or litellm_params.get("model_info")
+        or (litellm_params.get("litellm_metadata", {}) or {}).get("model_info")
+        or {}
+    )
+
+
 def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
     """
     Check if the model uses custom pricing
@@ -4479,19 +4470,12 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
             return True
 
     # Check model_info in all supported locations.
-    metadata: dict = litellm_params.get("metadata", {}) or {}
-    model_info_locations = [
-        metadata.get("model_info", {}) or {},
-        litellm_params.get("model_info", {}) or {},
-        (litellm_params.get("litellm_metadata", {}) or {}).get("model_info", {}) or {},
-    ]
-
-    for model_info in model_info_locations:
-        if model_info:
-            matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
-            for key in matching_keys:
-                if model_info.get(key) is not None:
-                    return True
+    model_info = _get_model_info_from_litellm_params(litellm_params)
+    if model_info:
+        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+        for key in matching_keys:
+            if model_info.get(key) is not None:
+                return True
 
     return False
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4472,12 +4472,20 @@ def _get_model_info_from_litellm_params(
         return {}
 
     metadata = litellm_params.get("metadata", {}) or {}
-    result = (
-        metadata.get("model_info")
-        or litellm_params.get("model_info")
-        or (litellm_params.get("litellm_metadata", {}) or {}).get("model_info")
-        or {}
-    )
+    _missing = object()
+
+    metadata_model_info = metadata.get("model_info", _missing)
+    if metadata_model_info is not _missing:
+        result = metadata_model_info
+    else:
+        litellm_model_info = litellm_params.get("model_info", _missing)
+        if litellm_model_info is not _missing:
+            result = litellm_model_info
+        else:
+            result = (litellm_params.get("litellm_metadata", {}) or {}).get(
+                "model_info", {}
+            )
+
     return result if isinstance(result, dict) else {}
 
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1884,11 +1884,16 @@ class BaseLLMHTTPHandler:
             headers=headers, provider=custom_llm_provider
         )
 
+        merged_metadata = dict(kwargs.get("litellm_metadata") or {})
+        merged_metadata.update(kwargs.get("metadata") or {})
+        if "model_info" not in merged_metadata and kwargs.get("model_info"):
+            merged_metadata["model_info"] = kwargs["model_info"]
+
         logging_obj.update_environment_variables(
             model=model,
             optional_params=dict(anthropic_messages_optional_request_params),
             litellm_params={
-                "metadata": kwargs.get("metadata", {}),
+                "metadata": merged_metadata,
                 "preset_cache_key": None,
                 "stream_response": {},
                 **anthropic_messages_optional_request_params,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1885,7 +1885,12 @@ class BaseLLMHTTPHandler:
         )
 
         merged_metadata = dict(kwargs.get("litellm_metadata") or {})
-        merged_metadata.update(kwargs.get("metadata") or {})
+        user_metadata = dict(kwargs.get("metadata") or {})
+        deployment_model_info = merged_metadata.pop("model_info", None)
+        merged_metadata.update(user_metadata)
+        if deployment_model_info:
+            merged_metadata["model_info"] = deployment_model_info
+        # Direct llm_http_handler callers may pass model_info top-level without Router metadata.
         if "model_info" not in merged_metadata and kwargs.get("model_info"):
             merged_metadata["model_info"] = kwargs["model_info"]
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1898,10 +1898,10 @@ class BaseLLMHTTPHandler:
             model=model,
             optional_params=dict(anthropic_messages_optional_request_params),
             litellm_params={
-                "metadata": merged_metadata,
                 "preset_cache_key": None,
                 "stream_response": {},
                 **anthropic_messages_optional_request_params,
+                "metadata": merged_metadata,
             },
             custom_llm_provider=custom_llm_provider,
         )

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -26,6 +26,9 @@ from litellm.anthropic_beta_headers_manager import (
     update_headers_with_filtered_beta,
 )
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
+from litellm.litellm_core_utils.core_helpers import (
+    merge_metadata_preserving_deployment_model_info,
+)
 from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
@@ -1884,15 +1887,11 @@ class BaseLLMHTTPHandler:
             headers=headers, provider=custom_llm_provider
         )
 
-        merged_metadata = dict(kwargs.get("litellm_metadata") or {})
-        user_metadata = dict(kwargs.get("metadata") or {})
-        deployment_model_info = merged_metadata.pop("model_info", None)
-        merged_metadata.update(user_metadata)
-        if deployment_model_info is not None:
-            merged_metadata["model_info"] = deployment_model_info
-        # Direct llm_http_handler callers may pass model_info top-level without Router metadata.
-        if "model_info" not in merged_metadata and kwargs.get("model_info"):
-            merged_metadata["model_info"] = kwargs["model_info"]
+        merged_metadata = merge_metadata_preserving_deployment_model_info(
+            litellm_metadata=kwargs.get("litellm_metadata"),
+            user_metadata=kwargs.get("metadata"),
+            model_info=kwargs.get("model_info"),
+        )
 
         logging_obj.update_environment_variables(
             model=model,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1888,7 +1888,7 @@ class BaseLLMHTTPHandler:
         user_metadata = dict(kwargs.get("metadata") or {})
         deployment_model_info = merged_metadata.pop("model_info", None)
         merged_metadata.update(user_metadata)
-        if deployment_model_info:
+        if deployment_model_info is not None:
             merged_metadata["model_info"] = deployment_model_info
         # Direct llm_http_handler callers may pass model_info top-level without Router metadata.
         if "model_info" not in merged_metadata and kwargs.get("model_info"):

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -7,6 +7,7 @@ import httpx
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
 from litellm.llms.anthropic import get_anthropic_config
 from litellm.llms.anthropic.chat.handler import (
     ModelResponseIterator as AnthropicModelResponseIterator,
@@ -118,6 +119,14 @@ class AnthropicPassthroughLoggingHandler:
             custom_llm_provider = logging_obj.model_call_details.get(
                 "custom_llm_provider"
             )
+            litellm_params = logging_obj.model_call_details.get("litellm_params", {}) or {}
+            metadata = litellm_params.get("metadata", {}) or {}
+            model_info = (
+                metadata.get("model_info")
+                or litellm_params.get("model_info")
+                or (litellm_params.get("litellm_metadata", {}) or {}).get("model_info")
+                or {}
+            )
 
             # Prepend custom_llm_provider to model if not already present
             model_for_cost = model
@@ -128,10 +137,16 @@ class AnthropicPassthroughLoggingHandler:
                 completion_response=litellm_model_response,
                 model=model_for_cost,
                 custom_llm_provider=custom_llm_provider,
+                custom_pricing=use_custom_pricing_for_model(litellm_params),
+                router_model_id=model_info.get("id"),
+                litellm_logging_obj=logging_obj,
             )
 
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
+            kwargs.setdefault("litellm_params", {})
+            if litellm_params:
+                kwargs["litellm_params"].update(litellm_params)
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")
             )

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -142,8 +142,9 @@ class AnthropicPassthroughLoggingHandler:
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
             kwargs.setdefault("litellm_params", {})
-            if litellm_params.get("metadata") is not None:
-                logging_metadata = litellm_params.get("metadata") or {}
+            raw_logging_metadata = litellm_params.get("metadata")
+            if raw_logging_metadata is not None:
+                logging_metadata = raw_logging_metadata or {}
                 existing_metadata = kwargs["litellm_params"].get("metadata", {}) or {}
                 # Start from logging_obj metadata, let existing pipeline metadata win
                 # for other keys, then restore deployment model_info.

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -143,9 +143,12 @@ class AnthropicPassthroughLoggingHandler:
             kwargs["model"] = model
             kwargs.setdefault("litellm_params", {})
             if litellm_params.get("metadata") is not None:
+                logging_metadata = litellm_params.get("metadata") or {}
                 existing_metadata = kwargs["litellm_params"].get("metadata", {}) or {}
-                merged_metadata = dict(existing_metadata)
-                merged_metadata.update(litellm_params.get("metadata") or {})
+                merged_metadata = dict(logging_metadata)
+                merged_metadata.update(existing_metadata)
+                if logging_metadata.get("model_info") is not None:
+                    merged_metadata["model_info"] = logging_metadata["model_info"]
                 kwargs["litellm_params"]["metadata"] = merged_metadata
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -6,9 +6,12 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.core_helpers import (
+    get_model_info_from_litellm_params,
+    merge_metadata_preserving_deployment_model_info,
+)
 from litellm.litellm_core_utils.litellm_logging import (
     Logging as LiteLLMLoggingObj,
-    _get_model_info_from_litellm_params,
     use_custom_pricing_for_model,
 )
 from litellm.llms.anthropic import get_anthropic_config
@@ -123,7 +126,7 @@ class AnthropicPassthroughLoggingHandler:
                 "custom_llm_provider"
             )
             litellm_params = logging_obj.model_call_details.get("litellm_params", {}) or {}
-            model_info = _get_model_info_from_litellm_params(litellm_params)
+            model_info = get_model_info_from_litellm_params(litellm_params)
 
             # Prepend custom_llm_provider to model if not already present
             model_for_cost = model
@@ -144,15 +147,12 @@ class AnthropicPassthroughLoggingHandler:
             kwargs.setdefault("litellm_params", {})
             raw_logging_metadata = litellm_params.get("metadata")
             if raw_logging_metadata is not None:
-                logging_metadata = raw_logging_metadata or {}
-                existing_metadata = kwargs["litellm_params"].get("metadata", {}) or {}
-                # Start from logging_obj metadata, let existing pipeline metadata win
-                # for other keys, then restore deployment model_info.
-                merged_metadata = dict(logging_metadata)
-                merged_metadata.update(existing_metadata)
-                if logging_metadata.get("model_info") is not None:
-                    merged_metadata["model_info"] = logging_metadata["model_info"]
-                kwargs["litellm_params"]["metadata"] = merged_metadata
+                kwargs["litellm_params"]["metadata"] = (
+                    merge_metadata_preserving_deployment_model_info(
+                        litellm_metadata=raw_logging_metadata,
+                        user_metadata=kwargs["litellm_params"].get("metadata"),
+                    )
+                )
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")
             )

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -145,6 +145,8 @@ class AnthropicPassthroughLoggingHandler:
             if litellm_params.get("metadata") is not None:
                 logging_metadata = litellm_params.get("metadata") or {}
                 existing_metadata = kwargs["litellm_params"].get("metadata", {}) or {}
+                # Start from logging_obj metadata, let existing pipeline metadata win
+                # for other keys, then restore deployment model_info.
                 merged_metadata = dict(logging_metadata)
                 merged_metadata.update(existing_metadata)
                 if logging_metadata.get("model_info") is not None:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -6,8 +6,11 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+from litellm.litellm_core_utils.litellm_logging import (
+    Logging as LiteLLMLoggingObj,
+    _get_model_info_from_litellm_params,
+    use_custom_pricing_for_model,
+)
 from litellm.llms.anthropic import get_anthropic_config
 from litellm.llms.anthropic.chat.handler import (
     ModelResponseIterator as AnthropicModelResponseIterator,
@@ -120,13 +123,7 @@ class AnthropicPassthroughLoggingHandler:
                 "custom_llm_provider"
             )
             litellm_params = logging_obj.model_call_details.get("litellm_params", {}) or {}
-            metadata = litellm_params.get("metadata", {}) or {}
-            model_info = (
-                metadata.get("model_info")
-                or litellm_params.get("model_info")
-                or (litellm_params.get("litellm_metadata", {}) or {}).get("model_info")
-                or {}
-            )
+            model_info = _get_model_info_from_litellm_params(litellm_params)
 
             # Prepend custom_llm_provider to model if not already present
             model_for_cost = model
@@ -145,8 +142,11 @@ class AnthropicPassthroughLoggingHandler:
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
             kwargs.setdefault("litellm_params", {})
-            if litellm_params:
-                kwargs["litellm_params"].update(litellm_params)
+            if litellm_params.get("metadata") is not None:
+                existing_metadata = kwargs["litellm_params"].get("metadata", {}) or {}
+                merged_metadata = dict(existing_metadata)
+                merged_metadata.update(litellm_params.get("metadata") or {})
+                kwargs["litellm_params"]["metadata"] = merged_metadata
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")
             )

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -740,7 +740,10 @@ def responses(
 
         # Pre Call logging - preserve metadata for custom callbacks
         # When called from completion bridge (codex models), metadata is in litellm_metadata
-        metadata_for_callbacks = metadata or kwargs.get("litellm_metadata") or {}
+        metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
+        metadata_for_callbacks.update(metadata or {})
+        if "model_info" not in metadata_for_callbacks and kwargs.get("model_info"):
+            metadata_for_callbacks["model_info"] = kwargs["model_info"]
 
         litellm_logging_obj.update_environment_variables(
             model=model,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -744,7 +744,7 @@ def responses(
         user_metadata = dict(metadata or {})
         deployment_model_info = metadata_for_callbacks.pop("model_info", None)
         metadata_for_callbacks.update(user_metadata)
-        if deployment_model_info:
+        if deployment_model_info is not None:
             metadata_for_callbacks["model_info"] = deployment_model_info
         if "model_info" not in metadata_for_callbacks and kwargs.get("model_info"):
             metadata_for_callbacks["model_info"] = kwargs["model_info"]

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -741,7 +741,11 @@ def responses(
         # Pre Call logging - preserve metadata for custom callbacks
         # When called from completion bridge (codex models), metadata is in litellm_metadata
         metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
-        metadata_for_callbacks.update(metadata or {})
+        user_metadata = dict(metadata or {})
+        deployment_model_info = metadata_for_callbacks.pop("model_info", None)
+        metadata_for_callbacks.update(user_metadata)
+        if deployment_model_info:
+            metadata_for_callbacks["model_info"] = deployment_model_info
         if "model_info" not in metadata_for_callbacks and kwargs.get("model_info"):
             metadata_for_callbacks["model_info"] = kwargs["model_info"]
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -25,6 +25,9 @@ from litellm.completion_extras.litellm_responses_transformation.transformation i
 )
 from litellm.constants import request_timeout
 from litellm.litellm_core_utils.asyncify import run_async_function
+from litellm.litellm_core_utils.core_helpers import (
+    merge_metadata_preserving_deployment_model_info,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     update_responses_input_with_model_file_ids,
@@ -740,14 +743,11 @@ def responses(
 
         # Pre Call logging - preserve metadata for custom callbacks
         # When called from completion bridge (codex models), metadata is in litellm_metadata
-        metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
-        user_metadata = dict(metadata or {})
-        deployment_model_info = metadata_for_callbacks.pop("model_info", None)
-        metadata_for_callbacks.update(user_metadata)
-        if deployment_model_info is not None:
-            metadata_for_callbacks["model_info"] = deployment_model_info
-        if "model_info" not in metadata_for_callbacks and kwargs.get("model_info"):
-            metadata_for_callbacks["model_info"] = kwargs["model_info"]
+        metadata_for_callbacks = merge_metadata_preserving_deployment_model_info(
+            litellm_metadata=kwargs.get("litellm_metadata"),
+            user_metadata=metadata,
+            model_info=kwargs.get("model_info"),
+        )
 
         litellm_logging_obj.update_environment_variables(
             model=model,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -286,6 +286,14 @@ class BaseResponsesAPIStreamingIterator:
             except Exception:
                 request_payload["litellm_params"] = {}
 
+        # Propagate model_info from litellm_metadata so that
+        # set_hidden_params can find the deployment-specific model_id
+        # and _response_cost_calculator uses custom pricing.
+        if "model_info" not in request_payload and self.litellm_metadata:
+            _mi = self.litellm_metadata.get("model_info")
+            if _mi:
+                request_payload["model_info"] = _mi
+
         try:
             update_response_metadata(
                 result=self.completed_response,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -286,14 +286,6 @@ class BaseResponsesAPIStreamingIterator:
             except Exception:
                 request_payload["litellm_params"] = {}
 
-        # Propagate model_info from litellm_metadata so that
-        # set_hidden_params can find the deployment-specific model_id
-        # and _response_cost_calculator uses custom pricing.
-        if "model_info" not in request_payload and self.litellm_metadata:
-            _mi = self.litellm_metadata.get("model_info")
-            if _mi:
-                request_payload["model_info"] = _mi
-
         try:
             update_response_metadata(
                 result=self.completed_response,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -148,6 +148,20 @@ def test_use_custom_pricing_for_model():
     assert use_custom_pricing_for_model(litellm_params) == True
 
 
+def test_get_model_info_from_litellm_params_preserves_explicit_empty_metadata():
+    from litellm.litellm_core_utils.litellm_logging import (
+        _get_model_info_from_litellm_params,
+    )
+
+    litellm_params = {
+        "metadata": {"model_info": {}},
+        "model_info": {"id": "top-level"},
+        "litellm_metadata": {"model_info": {"id": "router"}},
+    }
+
+    assert _get_model_info_from_litellm_params(litellm_params) == {}
+
+
 def test_logging_prevent_double_logging(logging_obj):
     """
     When using a bridge, log only once from the underlying bridge call.

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -163,6 +163,22 @@ def test_get_model_info_from_litellm_params_preserves_explicit_empty_metadata():
     assert _get_model_info_from_litellm_params(litellm_params) == {}
 
 
+def test_merge_metadata_preserving_deployment_model_info_keeps_router_model_info():
+    from litellm.litellm_core_utils.core_helpers import (
+        merge_metadata_preserving_deployment_model_info,
+    )
+
+    merged_metadata = merge_metadata_preserving_deployment_model_info(
+        litellm_metadata={"model_info": {"id": "router"}, "deployment": "test"},
+        user_metadata={"model_info": {"id": "user"}, "user_field": "present"},
+        model_info={"id": "top-level"},
+    )
+
+    assert merged_metadata["model_info"] == {"id": "router"}
+    assert merged_metadata["deployment"] == "test"
+    assert merged_metadata["user_field"] == "present"
+
+
 def test_logging_prevent_double_logging(logging_obj):
     """
     When using a bridge, log only once from the underlying bridge call.

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -179,6 +179,23 @@ def test_merge_metadata_preserving_deployment_model_info_keeps_router_model_info
     assert merged_metadata["user_field"] == "present"
 
 
+def test_merge_metadata_preserving_deployment_model_info_preserves_explicit_none():
+    from litellm.litellm_core_utils.core_helpers import (
+        merge_metadata_preserving_deployment_model_info,
+    )
+
+    merged_metadata = merge_metadata_preserving_deployment_model_info(
+        litellm_metadata={"model_info": None, "deployment": "test"},
+        user_metadata={"model_info": {"id": "user"}, "user_field": "present"},
+        model_info={"id": "top-level"},
+    )
+
+    assert "model_info" in merged_metadata
+    assert merged_metadata["model_info"] is None
+    assert merged_metadata["deployment"] == "test"
+    assert merged_metadata["user_field"] == "present"
+
+
 def test_logging_prevent_double_logging(logging_obj):
     """
     When using a bridge, log only once from the underlying bridge call.
@@ -615,6 +632,63 @@ def test_process_hidden_params_and_response_cost_uses_router_model_id_for_arespo
         logging_result=response,
         start_time=start_time,
         end_time=end_time,
+    )
+
+    logging_obj._response_cost_calculator.assert_called_once()
+    assert logging_obj._response_cost_calculator.call_args.kwargs["router_model_id"] == (
+        "deployment-custom-pricing-test"
+    )
+
+
+def test_streaming_response_cost_uses_router_model_id_for_aresponses_websocket(
+    logging_obj,
+):
+    import datetime
+
+    logging_obj.stream = True
+    logging_obj.call_type = "_aresponses_websocket"
+    logging_obj.model_call_details["litellm_params"] = {
+        "metadata": {"model_info": {"id": "deployment-custom-pricing-test"}}
+    }
+    logging_obj.sync_streaming_chunks = [{"choices": []}]
+
+    response = ResponsesAPIResponse(
+        id="resp_test",
+        object="response",
+        created_at=1741476542,
+        status="completed",
+        model="gpt-4o",
+        output=[],
+        parallel_tool_calls=True,
+        usage={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        text={"format": {"type": "text"}},
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning={"effort": None, "summary": None},
+        truncation="disabled",
+        user=None,
+    )
+
+    logging_obj._get_assembled_streaming_response = MagicMock(return_value=response)
+    logging_obj._response_cost_calculator = MagicMock(return_value=123.0)
+    logging_obj._build_standard_logging_payload = MagicMock(return_value={})
+
+    start_time = datetime.datetime.now()
+    end_time = datetime.datetime.now()
+
+    logging_obj.success_handler(
+        result=response,
+        start_time=start_time,
+        end_time=end_time,
+        cache_hit=False,
     )
 
     logging_obj._response_cost_calculator.assert_called_once()

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -150,8 +150,8 @@ def test_use_custom_pricing_for_model():
 
 
 def test_get_model_info_from_litellm_params_preserves_explicit_empty_metadata():
-    from litellm.litellm_core_utils.litellm_logging import (
-        _get_model_info_from_litellm_params,
+    from litellm.litellm_core_utils.core_helpers import (
+        get_model_info_from_litellm_params,
     )
 
     litellm_params = {
@@ -160,7 +160,7 @@ def test_get_model_info_from_litellm_params_preserves_explicit_empty_metadata():
         "litellm_metadata": {"model_info": {"id": "router"}},
     }
 
-    assert _get_model_info_from_litellm_params(litellm_params) == {}
+    assert get_model_info_from_litellm_params(litellm_params) == {}
 
 
 def test_merge_metadata_preserving_deployment_model_info_keeps_router_model_info():

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -13,6 +13,7 @@ import time
 from litellm.constants import SENTRY_DENYLIST, SENTRY_PII_DENYLIST
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
 from litellm.litellm_core_utils.litellm_logging import set_callbacks
+from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.utils import ModelResponse, TextCompletionResponse
 
 
@@ -552,6 +553,58 @@ def test_success_handler_runs_guardrail_logging_hook_when_enabled(logging_obj):
     guardrail.logging_hook.assert_called_once()
     assert logging_obj.model_call_details.get("guardrail_hook_ran") is True
 
+def test_process_hidden_params_and_response_cost_uses_router_model_id_for_aresponses(
+    logging_obj,
+):
+    logging_obj.stream = False
+    logging_obj.call_type = "aresponses"
+    logging_obj.model_call_details["litellm_params"] = {
+        "metadata": {"model_info": {"id": "deployment-custom-pricing-test"}}
+    }
+
+    response = ResponsesAPIResponse(
+        id="resp_test",
+        object="response",
+        created_at=1741476542,
+        status="completed",
+        model="gpt-4o",
+        output=[],
+        parallel_tool_calls=True,
+        usage={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        text={"format": {"type": "text"}},
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning={"effort": None, "summary": None},
+        truncation="disabled",
+        user=None,
+    )
+
+    logging_obj._response_cost_calculator = MagicMock(return_value=123.0)
+    logging_obj._build_standard_logging_payload = MagicMock(return_value={})
+
+    import datetime
+
+    start_time = datetime.datetime.now()
+    end_time = datetime.datetime.now()
+
+    logging_obj._process_hidden_params_and_response_cost(
+        logging_result=response,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    logging_obj._response_cost_calculator.assert_called_once()
+    assert logging_obj._response_cost_calculator.call_args.kwargs["router_model_id"] == (
+        "deployment-custom-pricing-test"
+    )
 
 def test_get_user_agent_tags():
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -1,10 +1,12 @@
+import asyncio
 import json
 import os
 import sys
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 sys.path.insert(
@@ -12,10 +14,73 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 import litellm
+from litellm import Router
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
 )
+
+CUSTOM_INPUT_COST = 0.50
+CUSTOM_OUTPUT_COST = 1.00
+DEPLOYMENT_MODEL_ID = "deployment-custom-pricing-test"
+
+
+class CostCapturingCallback(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.response_cost: Optional[float] = None
+        self.event = asyncio.Event()
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.response_cost = kwargs.get("response_cost")
+        self.event.set()
+
+
+class MockStreamingHTTPResponse:
+    def __init__(self, lines, status_code=200, headers=None):
+        self.status_code = status_code
+        self._lines = [line.encode("utf-8") for line in lines]
+        self.headers = httpx.Headers(headers or {"content-type": "text/event-stream"})
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line.decode("utf-8")
+
+    async def aiter_bytes(self):
+        for line in self._lines:
+            yield line + b"\n"
+
+    def raise_for_status(self):
+        return None
+
+
+def _make_router_with_custom_pricing(
+    backend_model: str, api_key: str = "fake-key"
+) -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": "test-custom-pricing",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_key": api_key,
+                },
+                "model_info": {
+                    "id": DEPLOYMENT_MODEL_ID,
+                    "input_cost_per_token": CUSTOM_INPUT_COST,
+                    "output_cost_per_token": CUSTOM_OUTPUT_COST,
+                },
+            },
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def cleanup_custom_pricing_state():
+    yield
+    litellm.callbacks = []
+    litellm.model_cost.pop(DEPLOYMENT_MODEL_ID, None)
 
 
 class TestAnthropicLoggingHandlerModelFallback:
@@ -372,6 +437,97 @@ class TestAzureAnthropicCostCalculation:
         call_kwargs = mock_completion_cost.call_args[1]
         assert call_kwargs["model"] == "azure_ai/claude-sonnet-4-5_gb_20250929"
         assert call_kwargs["custom_llm_provider"] == "azure_ai"
+
+
+class TestAnthropicPassthroughLoggingPayload:
+    @staticmethod
+    def _mock_streaming_events() -> List[str]:
+        return [
+            "event: message_start",
+            f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
+            "",
+            "event: content_block_start",
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+            "",
+            "event: content_block_delta",
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
+            "",
+            "event: content_block_stop",
+            'data: {"type":"content_block_stop","index":0}',
+            "",
+            "event: message_delta",
+            'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
+            "",
+            "event: message_stop",
+            'data: {"type":"message_stop"}',
+        ]
+
+    async def _assert_streaming_custom_pricing(self, metadata: Optional[dict] = None):
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing(
+                "anthropic/claude-sonnet-4-20250514"
+            )
+            mock_stream_response = MockStreamingHTTPResponse(
+                self._mock_streaming_events(),
+                headers={
+                    "content-type": "text/event-stream",
+                    "request-id": "req_test",
+                },
+            )
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aanthropic_messages(
+                    model="test-custom-pricing",
+                    messages=[{"role": "user", "content": "Hello!"}],
+                    max_tokens=100,
+                    stream=True,
+                    metadata=metadata,
+                )
+
+                async for _chunk in response:
+                    pass
+
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_messages_uses_custom_pricing(self):
+        await self._assert_streaming_custom_pricing()
+
+    @pytest.mark.asyncio
+    async def test_streaming_messages_with_user_metadata_uses_custom_pricing(self):
+        await self._assert_streaming_custom_pricing(metadata={"user_field": "present"})
+
+    @pytest.mark.asyncio
+    async def test_streaming_messages_with_user_model_info_ignored_for_pricing(self):
+        await self._assert_streaming_custom_pricing(
+            metadata={
+                "user_field": "present",
+                "model_info": {
+                    "id": "user-garbage",
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                },
+            }
+        )
 
 
 class TestAnthropicBatchPassthroughCostTracking:

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -11,6 +11,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
@@ -243,6 +244,61 @@ class TestAzureAnthropicCostCalculation:
         call_kwargs = mock_completion_cost.call_args[1]
         assert call_kwargs["model"] == "azure_ai/claude-sonnet-4-5_gb_20250929"
         assert call_kwargs["custom_llm_provider"] == "azure_ai"
+
+    @patch("litellm.completion_cost")
+    def test_metadata_merge_does_not_overwrite_existing_litellm_params(
+        self, mock_completion_cost
+    ):
+        mock_completion_cost.return_value = 123.0
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "custom_llm_provider": "anthropic",
+            "litellm_params": {
+                "metadata": {
+                    "model_info": {
+                        "id": "deployment-custom-pricing-test",
+                        "input_cost_per_token": 0.5,
+                        "output_cost_per_token": 1.0,
+                    },
+                    "new_field": "from-logging-obj",
+                    "shared_field": "from-logging-obj",
+                },
+                "stream_response": {"should": "not-overwrite"},
+            },
+        }
+        logging_obj.litellm_call_id = "call-test"
+
+        model_response = litellm.ModelResponse()
+        model_response.usage = litellm.Usage(
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
+        )  # type: ignore
+
+        kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=model_response,
+            model="claude-sonnet-4-20250514",
+            kwargs={
+                "litellm_params": {
+                    "metadata": {
+                        "existing_field": "preserved",
+                        "shared_field": "from-existing",
+                    },
+                    "stream_response": {"keep": "existing"},
+                }
+            },
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+        assert kwargs["litellm_params"]["metadata"]["existing_field"] == "preserved"
+        assert kwargs["litellm_params"]["metadata"]["new_field"] == "from-logging-obj"
+        assert kwargs["litellm_params"]["metadata"]["shared_field"] == "from-existing"
+        assert (
+            kwargs["litellm_params"]["metadata"]["model_info"]["id"]
+            == "deployment-custom-pricing-test"
+        )
+        assert kwargs["litellm_params"]["stream_response"] == {"keep": "existing"}
 
     @patch("litellm.completion_cost")
     def test_cost_calculation_without_custom_llm_provider(self, mock_completion_cost):

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -98,8 +98,9 @@ def _make_router_with_custom_pricing(backend_model: str, api_key: str = "fake-ke
 
 @pytest.fixture(autouse=True)
 def cleanup_model_cost():
-    """Remove test deployment entries from litellm.model_cost between tests."""
+    """Remove callback and pricing state between tests."""
     yield
+    litellm.callbacks = []
     litellm.model_cost.pop(DEPLOYMENT_MODEL_ID, None)
 
 

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -31,6 +31,7 @@ import litellm
 from litellm import Router
 from litellm.litellm_core_utils.litellm_logging import (
     Logging as LiteLLMLoggingObj,
+    _get_model_info_from_litellm_params,
     use_custom_pricing_for_model,
 )
 from litellm.litellm_core_utils.litellm_logging import CustomLogger
@@ -103,7 +104,7 @@ def _merge_metadata_preserving_deployment_model_info(
     merged_metadata = dict(litellm_metadata or {})
     deployment_model_info = merged_metadata.pop("model_info", None)
     merged_metadata.update(user_metadata or {})
-    if deployment_model_info:
+    if deployment_model_info is not None:
         merged_metadata["model_info"] = deployment_model_info
     return merged_metadata
 
@@ -384,6 +385,34 @@ class TestRouterMetadataPropagation:
         assert model_info.get("output_cost_per_token") == CUSTOM_OUTPUT_COST
         assert metadata_from_handler["user_field"] == "present"
         assert use_custom_pricing_for_model(litellm_params) is True
+
+    def test_empty_deployment_model_info_still_overrides_user_metadata(self):
+        """
+        An explicitly empty deployment model_info should remain explicit during
+        merge rather than being treated like a missing value.
+        """
+        metadata_for_callbacks = _merge_metadata_preserving_deployment_model_info(
+            {"model_info": {}},
+            {
+                "user_field": "present",
+                "model_info": {"id": "user-supplied", "input_cost_per_token": 0.0},
+            },
+        )
+
+        assert metadata_for_callbacks["model_info"] == {}
+        assert metadata_for_callbacks["user_field"] == "present"
+
+    def test_get_model_info_preserves_explicit_empty_metadata_model_info(self):
+        """Explicit empty metadata.model_info should win over fallback locations."""
+        model_info = _get_model_info_from_litellm_params(
+            {
+                "metadata": {"model_info": {}},
+                "model_info": {"id": "top-level"},
+                "litellm_metadata": {"model_info": {"id": "litellm-metadata"}},
+            }
+        )
+
+        assert model_info == {}
 
     def test_use_custom_pricing_detects_top_level_model_info(self):
         """Custom pricing detection should work when model_info is top-level."""

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -303,7 +303,10 @@ class TestRouterMetadataPropagation:
 
         metadata = {"user_field": "present"}
         metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
+        deployment_model_info = metadata_for_callbacks.pop("model_info", None)
         metadata_for_callbacks.update(metadata)
+        if deployment_model_info:
+            metadata_for_callbacks["model_info"] = deployment_model_info
 
         model_info = metadata_for_callbacks.get("model_info", {})
         assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST, (
@@ -706,6 +709,7 @@ class TestAnthropicPassthroughLoggingPayload:
                         "output_cost_per_token": CUSTOM_OUTPUT_COST,
                     },
                     "new_field": "from-logging-obj",
+                    "shared_field": "from-logging-obj",
                 },
                 "stream_response": {"should": "not-overwrite"},
             },
@@ -721,7 +725,10 @@ class TestAnthropicPassthroughLoggingPayload:
                 model="claude-sonnet-4-20250514",
                 kwargs={
                     "litellm_params": {
-                        "metadata": {"existing_field": "preserved"},
+                        "metadata": {
+                            "existing_field": "preserved",
+                            "shared_field": "from-existing",
+                        },
                         "stream_response": {"keep": "existing"},
                     }
                 },
@@ -732,6 +739,7 @@ class TestAnthropicPassthroughLoggingPayload:
 
         assert kwargs["litellm_params"]["metadata"]["existing_field"] == "preserved"
         assert kwargs["litellm_params"]["metadata"]["new_field"] == "from-logging-obj"
+        assert kwargs["litellm_params"]["metadata"]["shared_field"] == "from-existing"
         assert (
             kwargs["litellm_params"]["metadata"]["model_info"]["id"]
             == DEPLOYMENT_MODEL_ID

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -734,6 +734,57 @@ class TestAnthropicMessagesCustomPricingCost:
         finally:
             litellm.callbacks = []
 
+    @pytest.mark.asyncio
+    async def test_nonstreaming_messages_with_user_metadata_uses_custom_pricing(self):
+        """Non-streaming /v1/messages should preserve custom pricing when metadata is also passed."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing(
+                "anthropic/claude-sonnet-4-20250514"
+            )
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = MockHTTPResponse(
+                    ANTHROPIC_MESSAGES_MOCK,
+                    headers={
+                        "content-type": "application/json",
+                        "request-id": "req_test",
+                    },
+                )
+
+                response = await router.aanthropic_messages(
+                    model="test-custom-pricing",
+                    messages=[{"role": "user", "content": "Hello!"}],
+                    max_tokens=100,
+                    metadata={"user_field": "present"},
+                )
+
+                assert response is not None
+
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None, (
+                "response_cost should be set in the callback"
+            )
+
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            ), (
+                f"Cost should use custom pricing ({expected_custom_cost}), "
+                f"got {cost_callback.response_cost}"
+            )
+        finally:
+            litellm.callbacks = []
+
 
 class TestAnthropicPassthroughLoggingPayload:
     def test_metadata_merge_does_not_overwrite_existing_litellm_params(self):

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -97,6 +97,21 @@ def _make_router_with_custom_pricing(backend_model: str, api_key: str = "fake-ke
     )
 
 
+def _merge_metadata_preserving_deployment_model_info(
+    litellm_metadata: Optional[dict], user_metadata: Optional[dict]
+) -> dict:
+    """
+    Match the fixed merge behavior used by /v1/responses and /v1/messages:
+    user metadata is merged in, but deployment model_info keeps precedence.
+    """
+    merged_metadata = dict(litellm_metadata or {})
+    deployment_model_info = merged_metadata.pop("model_info", None)
+    merged_metadata.update(user_metadata or {})
+    if deployment_model_info:
+        merged_metadata["model_info"] = deployment_model_info
+    return merged_metadata
+
+
 @pytest.fixture(autouse=True)
 def cleanup_model_cost():
     """Remove test deployment entries from litellm.model_cost between tests."""
@@ -302,11 +317,9 @@ class TestRouterMetadataPropagation:
         )
 
         metadata = {"user_field": "present"}
-        metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
-        deployment_model_info = metadata_for_callbacks.pop("model_info", None)
-        metadata_for_callbacks.update(metadata)
-        if deployment_model_info:
-            metadata_for_callbacks["model_info"] = deployment_model_info
+        metadata_for_callbacks = _merge_metadata_preserving_deployment_model_info(
+            kwargs.get("litellm_metadata"), metadata
+        )
 
         model_info = metadata_for_callbacks.get("model_info", {})
         assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST, (
@@ -333,48 +346,23 @@ class TestRouterMetadataPropagation:
             function_name="_ageneric_api_call_with_fallbacks",
         )
 
-        metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
         user_metadata = {
             "user_field": "present",
             "model_info": {"id": "user-supplied", "input_cost_per_token": 0.0},
         }
-        deployment_model_info = metadata_for_callbacks.pop("model_info", None)
-        metadata_for_callbacks.update(user_metadata)
-        if deployment_model_info:
-            metadata_for_callbacks["model_info"] = deployment_model_info
+        metadata_for_callbacks = _merge_metadata_preserving_deployment_model_info(
+            kwargs.get("litellm_metadata"), user_metadata
+        )
 
         model_info = metadata_for_callbacks.get("model_info", {})
         assert model_info.get("id") == DEPLOYMENT_MODEL_ID
         assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST
         assert metadata_for_callbacks["user_field"] == "present"
 
-    def test_messages_api_metadata_resolves_via_litellm_metadata(self):
-        """
-        For /v1/messages, the handler should merge litellm_metadata with explicit
-        metadata so model_info with custom pricing survives.
-        """
-        router = _make_router_with_custom_pricing("anthropic/claude-sonnet-4-20250514")
-        deployment = router.model_list[0]
-
-        kwargs: dict = {}
-        router._update_kwargs_with_deployment(
-            deployment=deployment,
-            kwargs=kwargs,
-            function_name="_ageneric_api_call_with_fallbacks",
-        )
-
-        kwargs["metadata"] = {"user_field": "present"}
-        metadata_from_handler = dict(kwargs.get("litellm_metadata") or {})
-        metadata_from_handler.update(kwargs.get("metadata") or {})
-        litellm_params = {"metadata": metadata_from_handler}
-
-        assert metadata_from_handler["user_field"] == "present"
-        assert use_custom_pricing_for_model(litellm_params) is True
-
     def test_messages_api_user_model_info_does_not_override_deployment(self):
         """
-        User metadata should not overwrite router-provided model_info for
-        anthropic passthrough pricing calculation.
+        For /v1/messages, the handler should preserve router-provided model_info
+        even if the request metadata includes its own model_info payload.
         """
         router = _make_router_with_custom_pricing("anthropic/claude-sonnet-4-20250514")
         deployment = router.model_list[0]
@@ -386,20 +374,20 @@ class TestRouterMetadataPropagation:
             function_name="_ageneric_api_call_with_fallbacks",
         )
 
-        metadata_from_handler = dict(kwargs.get("litellm_metadata") or {})
-        user_metadata = {
+        kwargs["metadata"] = {
             "user_field": "present",
             "model_info": {"id": "user-supplied", "output_cost_per_token": 0.0},
         }
-        deployment_model_info = metadata_from_handler.pop("model_info", None)
-        metadata_from_handler.update(user_metadata)
-        if deployment_model_info:
-            metadata_from_handler["model_info"] = deployment_model_info
+        metadata_from_handler = _merge_metadata_preserving_deployment_model_info(
+            kwargs.get("litellm_metadata"), kwargs.get("metadata")
+        )
+        litellm_params = {"metadata": metadata_from_handler}
 
         model_info = metadata_from_handler.get("model_info", {})
         assert model_info.get("id") == DEPLOYMENT_MODEL_ID
         assert model_info.get("output_cost_per_token") == CUSTOM_OUTPUT_COST
         assert metadata_from_handler["user_field"] == "present"
+        assert use_custom_pricing_for_model(litellm_params) is True
 
     def test_use_custom_pricing_detects_top_level_model_info(self):
         """Custom pricing detection should work when model_info is top-level."""

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -35,6 +35,9 @@ from litellm.litellm_core_utils.litellm_logging import (
     use_custom_pricing_for_model,
 )
 from litellm.litellm_core_utils.litellm_logging import CustomLogger
+from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
+    AnthropicPassthroughLoggingHandler,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -285,10 +288,8 @@ class TestRouterMetadataPropagation:
 
     def test_responses_api_metadata_for_callbacks_gets_model_info(self):
         """
-        In responses/main.py, metadata_for_callbacks should resolve to
-        litellm_metadata (which has model_info) when metadata param is None.
-
-        This simulates: metadata_for_callbacks = metadata or kwargs.get("litellm_metadata") or {}
+        In responses/main.py, metadata_for_callbacks should merge
+        litellm_metadata (which has model_info) with explicit metadata.
         """
         router = _make_router_with_custom_pricing("openai/gpt-4o")
         deployment = router.model_list[0]
@@ -300,28 +301,24 @@ class TestRouterMetadataPropagation:
             function_name="_ageneric_api_call_with_fallbacks",
         )
 
-        # Simulate responses/main.py line 733
-        metadata = None  # responses() call with no explicit metadata
-        metadata_for_callbacks = (
-            metadata or kwargs.get("litellm_metadata") or {}
-        )
+        metadata = {"user_field": "present"}
+        metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
+        metadata_for_callbacks.update(metadata)
 
-        # This should contain model_info with custom pricing
         model_info = metadata_for_callbacks.get("model_info", {})
         assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST, (
             "metadata_for_callbacks should contain model_info with custom pricing "
-            "when metadata param is None"
+            "when explicit metadata is also passed"
         )
+        assert metadata_for_callbacks["user_field"] == "present"
 
-        # use_custom_pricing_for_model should return True
         litellm_params = {"metadata": metadata_for_callbacks}
         assert use_custom_pricing_for_model(litellm_params) is True
 
     def test_messages_api_metadata_resolves_via_litellm_metadata(self):
         """
-        For /v1/messages, the handler resolves metadata from litellm_metadata
-        via the fallthrough pattern: kwargs.get("metadata") or kwargs.get("litellm_metadata").
-        This ensures model_info with custom pricing reaches the logging object.
+        For /v1/messages, the handler should merge litellm_metadata with explicit
+        metadata so model_info with custom pricing survives.
         """
         router = _make_router_with_custom_pricing("anthropic/claude-sonnet-4-20250514")
         deployment = router.model_list[0]
@@ -333,19 +330,13 @@ class TestRouterMetadataPropagation:
             function_name="_ageneric_api_call_with_fallbacks",
         )
 
-        # Simulate the fixed llm_http_handler.py line 1886:
-        # metadata = kwargs.get("metadata") or kwargs.get("litellm_metadata") or {}
-        metadata_from_handler = (
-            kwargs.get("metadata") or kwargs.get("litellm_metadata") or {}
-        )
+        kwargs["metadata"] = {"user_field": "present"}
+        metadata_from_handler = dict(kwargs.get("litellm_metadata") or {})
+        metadata_from_handler.update(kwargs.get("metadata") or {})
         litellm_params = {"metadata": metadata_from_handler}
 
-        # With the fix, model_info with custom pricing is now visible
-        result = use_custom_pricing_for_model(litellm_params)
-        assert result is True, (
-            "After fix: use_custom_pricing_for_model should return True for "
-            "/v1/messages path because metadata falls through to litellm_metadata"
-        )
+        assert metadata_from_handler["user_field"] == "present"
+        assert use_custom_pricing_for_model(litellm_params) is True
 
     def test_use_custom_pricing_detects_top_level_model_info(self):
         """Custom pricing detection should work when model_info is top-level."""
@@ -581,6 +572,52 @@ class TestAnthropicMessagesCustomPricingCost:
             )
         finally:
             litellm.callbacks = []
+
+
+class TestAnthropicPassthroughLoggingPayload:
+    def test_metadata_merge_does_not_overwrite_existing_litellm_params(self):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "custom_llm_provider": "anthropic",
+            "litellm_params": {
+                "metadata": {
+                    "model_info": {
+                        "id": DEPLOYMENT_MODEL_ID,
+                        "input_cost_per_token": CUSTOM_INPUT_COST,
+                        "output_cost_per_token": CUSTOM_OUTPUT_COST,
+                    },
+                    "new_field": "from-logging-obj",
+                },
+                "stream_response": {"should": "not-overwrite"},
+            },
+        }
+        logging_obj.litellm_call_id = "call-test"
+
+        model_response = litellm.ModelResponse()
+        model_response.usage = litellm.Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)  # type: ignore
+
+        with patch("litellm.completion_cost", return_value=123.0):
+            kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+                litellm_model_response=model_response,
+                model="claude-sonnet-4-20250514",
+                kwargs={
+                    "litellm_params": {
+                        "metadata": {"existing_field": "preserved"},
+                        "stream_response": {"keep": "existing"},
+                    }
+                },
+                start_time=time.time(),  # type: ignore[arg-type]
+                end_time=time.time(),  # type: ignore[arg-type]
+                logging_obj=logging_obj,
+            )
+
+        assert kwargs["litellm_params"]["metadata"]["existing_field"] == "preserved"
+        assert kwargs["litellm_params"]["metadata"]["new_field"] == "from-logging-obj"
+        assert (
+            kwargs["litellm_params"]["metadata"]["model_info"]["id"]
+            == DEPLOYMENT_MODEL_ID
+        )
+        assert kwargs["litellm_params"]["stream_response"] == {"keep": "existing"}
 
     @pytest.mark.asyncio
     async def test_streaming_messages_uses_custom_pricing(self):

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -30,11 +30,11 @@ sys.path.insert(0, os.path.abspath("../../.."))
 import litellm
 from litellm import Router
 from litellm.litellm_core_utils.core_helpers import (
+    get_model_info_from_litellm_params,
     merge_metadata_preserving_deployment_model_info,
 )
 from litellm.litellm_core_utils.litellm_logging import (
     Logging as LiteLLMLoggingObj,
-    _get_model_info_from_litellm_params,
     use_custom_pricing_for_model,
 )
 from litellm.litellm_core_utils.litellm_logging import CustomLogger
@@ -391,7 +391,7 @@ class TestRouterMetadataPropagation:
 
     def test_get_model_info_preserves_explicit_empty_metadata_model_info(self):
         """Explicit empty metadata.model_info should win over fallback locations."""
-        model_info = _get_model_info_from_litellm_params(
+        model_info = get_model_info_from_litellm_params(
             {
                 "metadata": {"model_info": {}},
                 "model_info": {"id": "top-level"},
@@ -793,229 +793,6 @@ class TestAnthropicMessagesCustomPricingCost:
             ), (
                 f"Cost should use custom pricing ({expected_custom_cost}), "
                 f"got {cost_callback.response_cost}"
-            )
-        finally:
-            litellm.callbacks = []
-
-class TestAnthropicPassthroughLoggingPayload:
-    @pytest.mark.asyncio
-    async def test_streaming_messages_uses_custom_pricing(self):
-        """Streaming /v1/messages should use custom pricing for cost."""
-        cost_callback = CostCapturingCallback()
-        litellm.callbacks = [cost_callback]
-
-        try:
-            router = _make_router_with_custom_pricing(
-                "anthropic/claude-sonnet-4-20250514"
-            )
-
-            # SSE events for streaming Anthropic messages API
-            sse_events = [
-                'event: message_start',
-                f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
-                '',
-                'event: content_block_start',
-                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
-                '',
-                'event: content_block_delta',
-                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
-                '',
-                'event: content_block_stop',
-                'data: {"type":"content_block_stop","index":0}',
-                '',
-                'event: message_delta',
-                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
-                '',
-                'event: message_stop',
-                'data: {"type":"message_stop"}',
-            ]
-
-            mock_stream_response = MockStreamingHTTPResponse(
-                sse_events,
-                headers={
-                    "content-type": "text/event-stream",
-                    "request-id": "req_test",
-                },
-            )
-
-            with patch(
-                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
-                new_callable=AsyncMock,
-            ) as mock_post:
-                mock_post.return_value = mock_stream_response
-
-                response = await router.aanthropic_messages(
-                    model="test-custom-pricing",
-                    messages=[{"role": "user", "content": "Hello!"}],
-                    max_tokens=100,
-                    stream=True,
-                )
-
-                # Consume the stream
-                async for chunk in response:
-                    pass
-
-                # Wait for async callback
-                try:
-                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
-                except asyncio.TimeoutError:
-                    pass
-
-            assert cost_callback.response_cost is not None, (
-                "response_cost should be set in the callback"
-            )
-
-            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
-            assert cost_callback.response_cost == pytest.approx(
-                expected_custom_cost, rel=0.01
-            ), (
-                f"Streaming cost should use custom pricing ({expected_custom_cost}), "
-                f"got {cost_callback.response_cost}"
-            )
-        finally:
-            litellm.callbacks = []
-
-    @pytest.mark.asyncio
-    async def test_streaming_messages_with_user_metadata_uses_custom_pricing(self):
-        """Streaming /v1/messages should preserve custom pricing when metadata is also passed."""
-        cost_callback = CostCapturingCallback()
-        litellm.callbacks = [cost_callback]
-
-        try:
-            router = _make_router_with_custom_pricing(
-                "anthropic/claude-sonnet-4-20250514"
-            )
-
-            sse_events = [
-                'event: message_start',
-                f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
-                '',
-                'event: content_block_start',
-                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
-                '',
-                'event: content_block_delta',
-                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
-                '',
-                'event: content_block_stop',
-                'data: {"type":"content_block_stop","index":0}',
-                '',
-                'event: message_delta',
-                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
-                '',
-                'event: message_stop',
-                'data: {"type":"message_stop"}',
-            ]
-
-            mock_stream_response = MockStreamingHTTPResponse(
-                sse_events,
-                headers={
-                    "content-type": "text/event-stream",
-                    "request-id": "req_test",
-                },
-            )
-
-            with patch(
-                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
-                new_callable=AsyncMock,
-            ) as mock_post:
-                mock_post.return_value = mock_stream_response
-
-                response = await router.aanthropic_messages(
-                    model="test-custom-pricing",
-                    messages=[{"role": "user", "content": "Hello!"}],
-                    max_tokens=100,
-                    stream=True,
-                    metadata={"user_field": "present"},
-                )
-
-                async for chunk in response:
-                    pass
-
-                try:
-                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
-                except asyncio.TimeoutError:
-                    pass
-
-            assert cost_callback.response_cost is not None
-            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
-            assert cost_callback.response_cost == pytest.approx(
-                expected_custom_cost, rel=0.01
-            )
-        finally:
-            litellm.callbacks = []
-
-    @pytest.mark.asyncio
-    async def test_streaming_messages_with_user_model_info_ignored_for_pricing(self):
-        """Streaming /v1/messages should ignore user-supplied metadata.model_info."""
-        cost_callback = CostCapturingCallback()
-        litellm.callbacks = [cost_callback]
-
-        try:
-            router = _make_router_with_custom_pricing(
-                "anthropic/claude-sonnet-4-20250514"
-            )
-
-            sse_events = [
-                'event: message_start',
-                f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
-                '',
-                'event: content_block_start',
-                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
-                '',
-                'event: content_block_delta',
-                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
-                '',
-                'event: content_block_stop',
-                'data: {"type":"content_block_stop","index":0}',
-                '',
-                'event: message_delta',
-                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
-                '',
-                'event: message_stop',
-                'data: {"type":"message_stop"}',
-            ]
-
-            mock_stream_response = MockStreamingHTTPResponse(
-                sse_events,
-                headers={
-                    "content-type": "text/event-stream",
-                    "request-id": "req_test",
-                },
-            )
-
-            with patch(
-                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
-                new_callable=AsyncMock,
-            ) as mock_post:
-                mock_post.return_value = mock_stream_response
-
-                response = await router.aanthropic_messages(
-                    model="test-custom-pricing",
-                    messages=[{"role": "user", "content": "Hello!"}],
-                    max_tokens=100,
-                    stream=True,
-                    metadata={
-                        "user_field": "present",
-                        "model_info": {
-                            "id": "user-garbage",
-                            "input_cost_per_token": 0.0,
-                            "output_cost_per_token": 0.0,
-                        },
-                    },
-                )
-
-                async for chunk in response:
-                    pass
-
-                try:
-                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
-                except asyncio.TimeoutError:
-                    pass
-
-            assert cost_callback.response_cost is not None
-            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
-            assert cost_callback.response_cost == pytest.approx(
-                expected_custom_cost, rel=0.01
             )
         finally:
             litellm.callbacks = []

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -315,6 +315,36 @@ class TestRouterMetadataPropagation:
         litellm_params = {"metadata": metadata_for_callbacks}
         assert use_custom_pricing_for_model(litellm_params) is True
 
+    def test_responses_api_user_model_info_does_not_override_deployment(self):
+        """
+        User metadata should not overwrite router-provided model_info for
+        responses callback pricing calculation.
+        """
+        router = _make_router_with_custom_pricing("openai/gpt-4o")
+        deployment = router.model_list[0]
+
+        kwargs: dict = {}
+        router._update_kwargs_with_deployment(
+            deployment=deployment,
+            kwargs=kwargs,
+            function_name="_ageneric_api_call_with_fallbacks",
+        )
+
+        metadata_for_callbacks = dict(kwargs.get("litellm_metadata") or {})
+        user_metadata = {
+            "user_field": "present",
+            "model_info": {"id": "user-supplied", "input_cost_per_token": 0.0},
+        }
+        deployment_model_info = metadata_for_callbacks.pop("model_info", None)
+        metadata_for_callbacks.update(user_metadata)
+        if deployment_model_info:
+            metadata_for_callbacks["model_info"] = deployment_model_info
+
+        model_info = metadata_for_callbacks.get("model_info", {})
+        assert model_info.get("id") == DEPLOYMENT_MODEL_ID
+        assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST
+        assert metadata_for_callbacks["user_field"] == "present"
+
     def test_messages_api_metadata_resolves_via_litellm_metadata(self):
         """
         For /v1/messages, the handler should merge litellm_metadata with explicit
@@ -337,6 +367,36 @@ class TestRouterMetadataPropagation:
 
         assert metadata_from_handler["user_field"] == "present"
         assert use_custom_pricing_for_model(litellm_params) is True
+
+    def test_messages_api_user_model_info_does_not_override_deployment(self):
+        """
+        User metadata should not overwrite router-provided model_info for
+        anthropic passthrough pricing calculation.
+        """
+        router = _make_router_with_custom_pricing("anthropic/claude-sonnet-4-20250514")
+        deployment = router.model_list[0]
+
+        kwargs: dict = {}
+        router._update_kwargs_with_deployment(
+            deployment=deployment,
+            kwargs=kwargs,
+            function_name="_ageneric_api_call_with_fallbacks",
+        )
+
+        metadata_from_handler = dict(kwargs.get("litellm_metadata") or {})
+        user_metadata = {
+            "user_field": "present",
+            "model_info": {"id": "user-supplied", "output_cost_per_token": 0.0},
+        }
+        deployment_model_info = metadata_from_handler.pop("model_info", None)
+        metadata_from_handler.update(user_metadata)
+        if deployment_model_info:
+            metadata_from_handler["model_info"] = deployment_model_info
+
+        model_info = metadata_from_handler.get("model_info", {})
+        assert model_info.get("id") == DEPLOYMENT_MODEL_ID
+        assert model_info.get("output_cost_per_token") == CUSTOM_OUTPUT_COST
+        assert metadata_from_handler["user_field"] == "present"
 
     def test_use_custom_pricing_detects_top_level_model_info(self):
         """Custom pricing detection should work when model_info is top-level."""
@@ -499,6 +559,65 @@ class TestResponsesAPICustomPricingCost:
                     input="Hello, how are you?",
                     stream=True,
                     metadata={"user_field": "present"},
+                )
+
+                async for chunk in response:
+                    pass
+
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_responses_with_user_model_info_ignored_for_pricing(self):
+        """Streaming /v1/responses should ignore user-supplied metadata.model_info."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing("openai/gpt-4o")
+
+            sse_events = [
+                'data: {"type":"response.created","response":{"id":"resp_test","object":"response","created_at":1741476542,"status":"in_progress","model":"gpt-4o","output":[],"usage":null}}',
+                'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_test","status":"in_progress","role":"assistant","content":[]}}',
+                'data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}',
+                'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello!"}',
+                'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"Hello!"}',
+                'data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello!","annotations":[]}}',
+                'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}}',
+                f'data: {{"type":"response.completed","response":{json.dumps(RESPONSES_API_MOCK)}}}',
+                "data: [DONE]",
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(sse_events)
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aresponses(
+                    model="test-custom-pricing",
+                    input="Hello, how are you?",
+                    stream=True,
+                    metadata={
+                        "user_field": "present",
+                        "model_info": {
+                            "id": "user-garbage",
+                            "input_cost_per_token": 0.0,
+                            "output_cost_per_token": 0.0,
+                        },
+                    },
                 )
 
                 async for chunk in response:
@@ -747,6 +866,82 @@ class TestAnthropicPassthroughLoggingPayload:
                     max_tokens=100,
                     stream=True,
                     metadata={"user_field": "present"},
+                )
+
+                async for chunk in response:
+                    pass
+
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_messages_with_user_model_info_ignored_for_pricing(self):
+        """Streaming /v1/messages should ignore user-supplied metadata.model_info."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing(
+                "anthropic/claude-sonnet-4-20250514"
+            )
+
+            sse_events = [
+                'event: message_start',
+                f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
+                '',
+                'event: content_block_start',
+                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+                '',
+                'event: content_block_delta',
+                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
+                '',
+                'event: content_block_stop',
+                'data: {"type":"content_block_stop","index":0}',
+                '',
+                'event: message_delta',
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
+                '',
+                'event: message_stop',
+                'data: {"type":"message_stop"}',
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(
+                sse_events,
+                headers={
+                    "content-type": "text/event-stream",
+                    "request-id": "req_test",
+                },
+            )
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aanthropic_messages(
+                    model="test-custom-pricing",
+                    messages=[{"role": "user", "content": "Hello!"}],
+                    max_tokens=100,
+                    stream=True,
+                    metadata={
+                        "user_field": "present",
+                        "model_info": {
+                            "id": "user-garbage",
+                            "input_cost_per_token": 0.0,
+                            "output_cost_per_token": 0.0,
+                        },
+                    },
                 )
 
                 async for chunk in response:

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -1,0 +1,729 @@
+"""
+Test that custom pricing from model_info is correctly propagated through
+the metadata flow for all API endpoints.
+
+Background:
+- PR #20679 correctly strips custom pricing from the shared litellm.model_cost key
+  to prevent cross-deployment pollution.
+- The deployment's model_info retains custom pricing and must reach cost calculation
+  via litellm_params["metadata"]["model_info"].
+- /v1/chat/completions works because it explicitly extracts pricing into litellm_params.
+- /v1/responses and /v1/messages fail because model_info with custom pricing
+  does not reach the logging object's litellm_params["metadata"].
+
+These tests verify that use_custom_pricing_for_model() returns True when called
+with the litellm_params as constructed by each code path.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm import Router
+from litellm.litellm_core_utils.litellm_logging import (
+    Logging as LiteLLMLoggingObj,
+    use_custom_pricing_for_model,
+)
+from litellm.litellm_core_utils.litellm_logging import CustomLogger
+
+
+# ---------------------------------------------------------------------------
+# Custom callback to capture response cost from the logging flow
+# ---------------------------------------------------------------------------
+class CostCapturingCallback(CustomLogger):
+    """Captures response_cost from the async success callback kwargs."""
+
+    def __init__(self):
+        super().__init__()
+        self.response_cost: Optional[float] = None
+        self.custom_pricing: Optional[bool] = None
+        self.event = asyncio.Event()
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.response_cost = kwargs.get("response_cost")
+        # Extract custom_pricing from standard_logging_object if available
+        slo = kwargs.get("standard_logging_object", {})
+        if slo:
+            self.custom_pricing = slo.get("custom_pricing")
+        self.event.set()
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.response_cost = kwargs.get("response_cost")
+        slo = kwargs.get("standard_logging_object", {})
+        if slo:
+            self.custom_pricing = slo.get("custom_pricing")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: Router with custom pricing deployment
+# ---------------------------------------------------------------------------
+CUSTOM_INPUT_COST = 0.50  # $0.50 per token — absurdly high, easy to spot
+CUSTOM_OUTPUT_COST = 1.00
+
+
+DEPLOYMENT_MODEL_ID = "deployment-custom-pricing-test"
+
+
+def _make_router_with_custom_pricing(backend_model: str, api_key: str = "fake-key"):
+    """Create a Router with a single deployment that has custom pricing."""
+    return Router(
+        model_list=[
+            {
+                "model_name": "test-custom-pricing",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_key": api_key,
+                },
+                "model_info": {
+                    "id": DEPLOYMENT_MODEL_ID,
+                    "input_cost_per_token": CUSTOM_INPUT_COST,
+                    "output_cost_per_token": CUSTOM_OUTPUT_COST,
+                },
+            },
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def cleanup_model_cost():
+    """Remove test deployment entries from litellm.model_cost between tests."""
+    yield
+    litellm.model_cost.pop(DEPLOYMENT_MODEL_ID, None)
+
+
+# ---------------------------------------------------------------------------
+# Mock HTTP response helpers
+# ---------------------------------------------------------------------------
+class MockHTTPResponse:
+    """Mimics httpx.Response for non-streaming and streaming."""
+
+    def __init__(self, json_data, status_code=200, headers=None):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.text = json.dumps(json_data)
+        self.headers = httpx.Headers(headers or {"content-type": "application/json"})
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error", request=Mock(), response=self
+            )
+
+    async def aiter_bytes(self):
+        yield self.text.encode("utf-8")
+
+    async def aiter_lines(self):
+        for line in self.text.split("\n"):
+            yield line
+
+    def iter_lines(self):
+        for line in self.text.split("\n"):
+            yield line
+
+
+class MockStreamingHTTPResponse:
+    """Mimics httpx.Response for streaming (SSE)."""
+
+    def __init__(self, sse_lines: list[str], status_code=200, headers=None):
+        self._sse_lines = sse_lines
+        self.status_code = status_code
+        self.headers = httpx.Headers(
+            headers or {"content-type": "text/event-stream"}
+        )
+        self.text = "\n".join(sse_lines)
+
+    def json(self):
+        return json.loads(self.text)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error", request=Mock(), response=self
+            )
+
+    def iter_lines(self):
+        for line in self._sse_lines:
+            yield line
+
+    async def aiter_lines(self):
+        for line in self._sse_lines:
+            yield line
+
+    async def aiter_bytes(self):
+        for line in self._sse_lines:
+            yield (line + "\n").encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Standard mock response payloads
+# ---------------------------------------------------------------------------
+RESPONSES_API_MOCK = {
+    "id": "resp_test_custom_pricing",
+    "object": "response",
+    "created_at": 1741476542,
+    "status": "completed",
+    "model": "gpt-4o",
+    "output": [
+        {
+            "type": "message",
+            "id": "msg_test",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "Hello!", "annotations": []}
+            ],
+        }
+    ],
+    "parallel_tool_calls": True,
+    "usage": {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "total_tokens": 150,
+        "output_tokens_details": {"reasoning_tokens": 0},
+    },
+    "text": {"format": {"type": "text"}},
+    "error": None,
+    "incomplete_details": None,
+    "instructions": None,
+    "metadata": {},
+    "temperature": 1.0,
+    "tool_choice": "auto",
+    "tools": [],
+    "top_p": 1.0,
+    "max_output_tokens": None,
+    "previous_response_id": None,
+    "reasoning": {"effort": None, "summary": None},
+    "truncation": "disabled",
+    "user": None,
+}
+
+ANTHROPIC_MESSAGES_MOCK = {
+    "id": "msg_test_custom_pricing",
+    "type": "message",
+    "role": "assistant",
+    "content": [{"type": "text", "text": "Hello!"}],
+    "model": "claude-sonnet-4-20250514",
+    "stop_reason": "end_turn",
+    "stop_sequence": None,
+    "usage": {
+        "input_tokens": 100,
+        "output_tokens": 50,
+    },
+}
+
+
+# =========================================================================
+# UNIT TESTS: Metadata propagation to use_custom_pricing_for_model
+# =========================================================================
+
+
+class TestRouterMetadataPropagation:
+    """
+    Verify that Router._update_kwargs_with_deployment places model_info
+    with custom pricing into the correct metadata location.
+    """
+
+    def test_chat_completions_puts_model_info_in_metadata(self):
+        """
+        For chat/completions, function_name is None or "acompletion" etc.,
+        so metadata_variable_name = "metadata". model_info should be in
+        kwargs["metadata"]["model_info"].
+        """
+        router = _make_router_with_custom_pricing("openai/gpt-4o")
+        deployment = router.model_list[0]
+
+        kwargs: dict = {}
+        router._update_kwargs_with_deployment(
+            deployment=deployment, kwargs=kwargs, function_name="acompletion"
+        )
+
+        # model_info should be in kwargs["metadata"]["model_info"]
+        assert "metadata" in kwargs
+        model_info = kwargs["metadata"].get("model_info", {})
+        assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST
+        assert model_info.get("output_cost_per_token") == CUSTOM_OUTPUT_COST
+
+        # use_custom_pricing_for_model should return True when litellm_params
+        # includes this metadata
+        litellm_params = {"metadata": kwargs["metadata"]}
+        assert use_custom_pricing_for_model(litellm_params) is True
+
+    def test_generic_api_call_puts_model_info_in_litellm_metadata(self):
+        """
+        For _ageneric_api_call_with_fallbacks (used by /v1/responses and /v1/messages),
+        metadata_variable_name = "litellm_metadata". model_info should be in
+        kwargs["litellm_metadata"]["model_info"].
+        """
+        router = _make_router_with_custom_pricing("openai/gpt-4o")
+        deployment = router.model_list[0]
+
+        kwargs: dict = {}
+        router._update_kwargs_with_deployment(
+            deployment=deployment,
+            kwargs=kwargs,
+            function_name="_ageneric_api_call_with_fallbacks",
+        )
+
+        # model_info should be in kwargs["litellm_metadata"]["model_info"]
+        assert "litellm_metadata" in kwargs
+        model_info = kwargs["litellm_metadata"].get("model_info", {})
+        assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST
+        assert model_info.get("output_cost_per_token") == CUSTOM_OUTPUT_COST
+
+    def test_responses_api_metadata_for_callbacks_gets_model_info(self):
+        """
+        In responses/main.py, metadata_for_callbacks should resolve to
+        litellm_metadata (which has model_info) when metadata param is None.
+
+        This simulates: metadata_for_callbacks = metadata or kwargs.get("litellm_metadata") or {}
+        """
+        router = _make_router_with_custom_pricing("openai/gpt-4o")
+        deployment = router.model_list[0]
+
+        kwargs: dict = {}
+        router._update_kwargs_with_deployment(
+            deployment=deployment,
+            kwargs=kwargs,
+            function_name="_ageneric_api_call_with_fallbacks",
+        )
+
+        # Simulate responses/main.py line 733
+        metadata = None  # responses() call with no explicit metadata
+        metadata_for_callbacks = (
+            metadata or kwargs.get("litellm_metadata") or {}
+        )
+
+        # This should contain model_info with custom pricing
+        model_info = metadata_for_callbacks.get("model_info", {})
+        assert model_info.get("input_cost_per_token") == CUSTOM_INPUT_COST, (
+            "metadata_for_callbacks should contain model_info with custom pricing "
+            "when metadata param is None"
+        )
+
+        # use_custom_pricing_for_model should return True
+        litellm_params = {"metadata": metadata_for_callbacks}
+        assert use_custom_pricing_for_model(litellm_params) is True
+
+    def test_messages_api_metadata_resolves_via_litellm_metadata(self):
+        """
+        For /v1/messages, the handler resolves metadata from litellm_metadata
+        via the fallthrough pattern: kwargs.get("metadata") or kwargs.get("litellm_metadata").
+        This ensures model_info with custom pricing reaches the logging object.
+        """
+        router = _make_router_with_custom_pricing("anthropic/claude-sonnet-4-20250514")
+        deployment = router.model_list[0]
+
+        kwargs: dict = {}
+        router._update_kwargs_with_deployment(
+            deployment=deployment,
+            kwargs=kwargs,
+            function_name="_ageneric_api_call_with_fallbacks",
+        )
+
+        # Simulate the fixed llm_http_handler.py line 1886:
+        # metadata = kwargs.get("metadata") or kwargs.get("litellm_metadata") or {}
+        metadata_from_handler = (
+            kwargs.get("metadata") or kwargs.get("litellm_metadata") or {}
+        )
+        litellm_params = {"metadata": metadata_from_handler}
+
+        # With the fix, model_info with custom pricing is now visible
+        result = use_custom_pricing_for_model(litellm_params)
+        assert result is True, (
+            "After fix: use_custom_pricing_for_model should return True for "
+            "/v1/messages path because metadata falls through to litellm_metadata"
+        )
+
+    def test_use_custom_pricing_detects_top_level_model_info(self):
+        """Custom pricing detection should work when model_info is top-level."""
+        litellm_params = {
+            "metadata": {"user_field": "present"},
+            "model_info": {
+                "id": DEPLOYMENT_MODEL_ID,
+                "input_cost_per_token": CUSTOM_INPUT_COST,
+                "output_cost_per_token": CUSTOM_OUTPUT_COST,
+            },
+        }
+
+        assert use_custom_pricing_for_model(litellm_params) is True
+
+
+# =========================================================================
+# INTEGRATION TESTS: Full Router → cost calculation with HTTP mocking
+# =========================================================================
+
+
+class TestResponsesAPICustomPricingCost:
+    """
+    Test that /v1/responses (via router.aresponses) uses custom pricing
+    for cost calculation when model_info has custom pricing fields.
+    """
+
+    @pytest.mark.asyncio
+    async def test_nonstreaming_responses_uses_custom_pricing(self):
+        """Non-streaming /v1/responses should use custom pricing for cost."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing("openai/gpt-4o")
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = MockHTTPResponse(RESPONSES_API_MOCK)
+
+                response = await router.aresponses(
+                    model="test-custom-pricing",
+                    input="Hello, how are you?",
+                )
+
+                # Wait for async callback
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None, (
+                "response_cost should be set in the callback"
+            )
+
+            # With 100 input + 50 output tokens at custom pricing:
+            # expected = 100 * 0.50 + 50 * 1.00 = 50 + 50 = 100.0
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            ), (
+                f"Cost should use custom pricing ({expected_custom_cost}), "
+                f"got {cost_callback.response_cost}"
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_responses_uses_custom_pricing(self):
+        """Streaming /v1/responses should use custom pricing for cost."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing("openai/gpt-4o")
+
+            # SSE events for streaming responses API
+            sse_events = [
+                'data: {"type":"response.created","response":{"id":"resp_test","object":"response","created_at":1741476542,"status":"in_progress","model":"gpt-4o","output":[],"usage":null}}',
+                'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_test","status":"in_progress","role":"assistant","content":[]}}',
+                'data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}',
+                'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello!"}',
+                'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"Hello!"}',
+                'data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello!","annotations":[]}}',
+                'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}}',
+                f'data: {{"type":"response.completed","response":{json.dumps(RESPONSES_API_MOCK)}}}',
+                "data: [DONE]",
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(sse_events)
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aresponses(
+                    model="test-custom-pricing",
+                    input="Hello, how are you?",
+                    stream=True,
+                )
+
+                # Consume the stream
+                async for chunk in response:
+                    pass
+
+                # Wait for async callback
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None, (
+                "response_cost should be set in the callback"
+            )
+
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            ), (
+                f"Streaming cost should use custom pricing ({expected_custom_cost}), "
+                f"got {cost_callback.response_cost}"
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_responses_with_user_metadata_uses_custom_pricing(self):
+        """Streaming /v1/responses should preserve custom pricing when metadata is also passed."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing("openai/gpt-4o")
+
+            sse_events = [
+                'data: {"type":"response.created","response":{"id":"resp_test","object":"response","created_at":1741476542,"status":"in_progress","model":"gpt-4o","output":[],"usage":null}}',
+                'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_test","status":"in_progress","role":"assistant","content":[]}}',
+                'data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}',
+                'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello!"}',
+                'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"Hello!"}',
+                'data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello!","annotations":[]}}',
+                'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}}',
+                f'data: {{"type":"response.completed","response":{json.dumps(RESPONSES_API_MOCK)}}}',
+                "data: [DONE]",
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(sse_events)
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aresponses(
+                    model="test-custom-pricing",
+                    input="Hello, how are you?",
+                    stream=True,
+                    metadata={"user_field": "present"},
+                )
+
+                async for chunk in response:
+                    pass
+
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            )
+        finally:
+            litellm.callbacks = []
+
+
+class TestAnthropicMessagesCustomPricingCost:
+    """
+    Test that /v1/messages (Anthropic via router) uses custom pricing
+    for cost calculation when model_info has custom pricing fields.
+    """
+
+    @pytest.mark.asyncio
+    async def test_nonstreaming_messages_uses_custom_pricing(self):
+        """Non-streaming /v1/messages should use custom pricing for cost."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing(
+                "anthropic/claude-sonnet-4-20250514"
+            )
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = MockHTTPResponse(
+                    ANTHROPIC_MESSAGES_MOCK,
+                    headers={
+                        "content-type": "application/json",
+                        "request-id": "req_test",
+                    },
+                )
+
+                response = await router.aanthropic_messages(
+                    model="test-custom-pricing",
+                    messages=[{"role": "user", "content": "Hello!"}],
+                    max_tokens=100,
+                )
+
+                # Wait for async callback
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None, (
+                "response_cost should be set in the callback"
+            )
+
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            ), (
+                f"Cost should use custom pricing ({expected_custom_cost}), "
+                f"got {cost_callback.response_cost}"
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_messages_uses_custom_pricing(self):
+        """Streaming /v1/messages should use custom pricing for cost."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing(
+                "anthropic/claude-sonnet-4-20250514"
+            )
+
+            # SSE events for streaming Anthropic messages API
+            sse_events = [
+                'event: message_start',
+                f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
+                '',
+                'event: content_block_start',
+                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+                '',
+                'event: content_block_delta',
+                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
+                '',
+                'event: content_block_stop',
+                'data: {"type":"content_block_stop","index":0}',
+                '',
+                'event: message_delta',
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
+                '',
+                'event: message_stop',
+                'data: {"type":"message_stop"}',
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(
+                sse_events,
+                headers={
+                    "content-type": "text/event-stream",
+                    "request-id": "req_test",
+                },
+            )
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aanthropic_messages(
+                    model="test-custom-pricing",
+                    messages=[{"role": "user", "content": "Hello!"}],
+                    max_tokens=100,
+                    stream=True,
+                )
+
+                # Consume the stream
+                async for chunk in response:
+                    pass
+
+                # Wait for async callback
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None, (
+                "response_cost should be set in the callback"
+            )
+
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            ), (
+                f"Streaming cost should use custom pricing ({expected_custom_cost}), "
+                f"got {cost_callback.response_cost}"
+            )
+        finally:
+            litellm.callbacks = []
+
+    @pytest.mark.asyncio
+    async def test_streaming_messages_with_user_metadata_uses_custom_pricing(self):
+        """Streaming /v1/messages should preserve custom pricing when metadata is also passed."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing(
+                "anthropic/claude-sonnet-4-20250514"
+            )
+
+            sse_events = [
+                'event: message_start',
+                f'data: {{"type":"message_start","message":{{"id":"msg_test","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}',
+                '',
+                'event: content_block_start',
+                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+                '',
+                'event: content_block_delta',
+                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}',
+                '',
+                'event: content_block_stop',
+                'data: {"type":"content_block_stop","index":0}',
+                '',
+                'event: message_delta',
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}',
+                '',
+                'event: message_stop',
+                'data: {"type":"message_stop"}',
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(
+                sse_events,
+                headers={
+                    "content-type": "text/event-stream",
+                    "request-id": "req_test",
+                },
+            )
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+                new_callable=AsyncMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = await router.aanthropic_messages(
+                    model="test-custom-pricing",
+                    messages=[{"role": "user", "content": "Hello!"}],
+                    max_tokens=100,
+                    stream=True,
+                    metadata={"user_field": "present"},
+                )
+
+                async for chunk in response:
+                    pass
+
+                try:
+                    await asyncio.wait_for(cost_callback.event.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            assert cost_callback.response_cost is not None
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            )
+        finally:
+            litellm.callbacks = []

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -29,6 +29,9 @@ sys.path.insert(0, os.path.abspath("../../.."))
 
 import litellm
 from litellm import Router
+from litellm.litellm_core_utils.core_helpers import (
+    merge_metadata_preserving_deployment_model_info,
+)
 from litellm.litellm_core_utils.litellm_logging import (
     Logging as LiteLLMLoggingObj,
     _get_model_info_from_litellm_params,
@@ -92,22 +95,6 @@ def _make_router_with_custom_pricing(backend_model: str, api_key: str = "fake-ke
             },
         ],
     )
-
-
-def _merge_metadata_preserving_deployment_model_info(
-    litellm_metadata: Optional[dict], user_metadata: Optional[dict]
-) -> dict:
-    """
-    Match the fixed merge behavior used by /v1/responses and /v1/messages:
-    user metadata is merged in, but deployment model_info keeps precedence.
-    """
-    merged_metadata = dict(litellm_metadata or {})
-    deployment_model_info = merged_metadata.pop("model_info", None)
-    merged_metadata.update(user_metadata or {})
-    if deployment_model_info is not None:
-        merged_metadata["model_info"] = deployment_model_info
-    return merged_metadata
-
 
 @pytest.fixture(autouse=True)
 def cleanup_model_cost():
@@ -314,7 +301,7 @@ class TestRouterMetadataPropagation:
         )
 
         metadata = {"user_field": "present"}
-        metadata_for_callbacks = _merge_metadata_preserving_deployment_model_info(
+        metadata_for_callbacks = merge_metadata_preserving_deployment_model_info(
             kwargs.get("litellm_metadata"), metadata
         )
 
@@ -347,7 +334,7 @@ class TestRouterMetadataPropagation:
             "user_field": "present",
             "model_info": {"id": "user-supplied", "input_cost_per_token": 0.0},
         }
-        metadata_for_callbacks = _merge_metadata_preserving_deployment_model_info(
+        metadata_for_callbacks = merge_metadata_preserving_deployment_model_info(
             kwargs.get("litellm_metadata"), user_metadata
         )
 
@@ -375,7 +362,7 @@ class TestRouterMetadataPropagation:
             "user_field": "present",
             "model_info": {"id": "user-supplied", "output_cost_per_token": 0.0},
         }
-        metadata_from_handler = _merge_metadata_preserving_deployment_model_info(
+        metadata_from_handler = merge_metadata_preserving_deployment_model_info(
             kwargs.get("litellm_metadata"), kwargs.get("metadata")
         )
         litellm_params = {"metadata": metadata_from_handler}
@@ -391,7 +378,7 @@ class TestRouterMetadataPropagation:
         An explicitly empty deployment model_info should remain explicit during
         merge rather than being treated like a missing value.
         """
-        metadata_for_callbacks = _merge_metadata_preserving_deployment_model_info(
+        metadata_for_callbacks = merge_metadata_preserving_deployment_model_info(
             {"model_info": {}},
             {
                 "user_field": "present",

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -19,7 +19,6 @@ import asyncio
 import json
 import os
 import sys
-import time
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -35,9 +34,6 @@ from litellm.litellm_core_utils.litellm_logging import (
     use_custom_pricing_for_model,
 )
 from litellm.litellm_core_utils.litellm_logging import CustomLogger
-from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
-    AnthropicPassthroughLoggingHandler,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -785,57 +781,7 @@ class TestAnthropicMessagesCustomPricingCost:
         finally:
             litellm.callbacks = []
 
-
 class TestAnthropicPassthroughLoggingPayload:
-    def test_metadata_merge_does_not_overwrite_existing_litellm_params(self):
-        logging_obj = MagicMock()
-        logging_obj.model_call_details = {
-            "custom_llm_provider": "anthropic",
-            "litellm_params": {
-                "metadata": {
-                    "model_info": {
-                        "id": DEPLOYMENT_MODEL_ID,
-                        "input_cost_per_token": CUSTOM_INPUT_COST,
-                        "output_cost_per_token": CUSTOM_OUTPUT_COST,
-                    },
-                    "new_field": "from-logging-obj",
-                    "shared_field": "from-logging-obj",
-                },
-                "stream_response": {"should": "not-overwrite"},
-            },
-        }
-        logging_obj.litellm_call_id = "call-test"
-
-        model_response = litellm.ModelResponse()
-        model_response.usage = litellm.Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)  # type: ignore
-
-        with patch("litellm.completion_cost", return_value=123.0):
-            kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
-                litellm_model_response=model_response,
-                model="claude-sonnet-4-20250514",
-                kwargs={
-                    "litellm_params": {
-                        "metadata": {
-                            "existing_field": "preserved",
-                            "shared_field": "from-existing",
-                        },
-                        "stream_response": {"keep": "existing"},
-                    }
-                },
-                start_time=time.time(),  # type: ignore[arg-type]
-                end_time=time.time(),  # type: ignore[arg-type]
-                logging_obj=logging_obj,
-            )
-
-        assert kwargs["litellm_params"]["metadata"]["existing_field"] == "preserved"
-        assert kwargs["litellm_params"]["metadata"]["new_field"] == "from-logging-obj"
-        assert kwargs["litellm_params"]["metadata"]["shared_field"] == "from-existing"
-        assert (
-            kwargs["litellm_params"]["metadata"]["model_info"]["id"]
-            == DEPLOYMENT_MODEL_ID
-        )
-        assert kwargs["litellm_params"]["stream_response"] == {"keep": "existing"}
-
     @pytest.mark.asyncio
     async def test_streaming_messages_uses_custom_pricing(self):
         """Streaming /v1/messages should use custom pricing for cost."""

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -516,6 +516,61 @@ class TestResponsesAPICustomPricingCost:
         finally:
             litellm.callbacks = []
 
+    def test_sync_streaming_responses_uses_custom_pricing(self):
+        """Sync streaming /v1/responses should use custom pricing for cost."""
+        cost_callback = CostCapturingCallback()
+        litellm.callbacks = [cost_callback]
+
+        try:
+            router = _make_router_with_custom_pricing("openai/gpt-4o")
+
+            sse_events = [
+                'data: {"type":"response.created","response":{"id":"resp_test","object":"response","created_at":1741476542,"status":"in_progress","model":"gpt-4o","output":[],"usage":null}}',
+                'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_test","status":"in_progress","role":"assistant","content":[]}}',
+                'data: {"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}',
+                'data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello!"}',
+                'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"text":"Hello!"}',
+                'data: {"type":"response.content_part.done","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hello!","annotations":[]}}',
+                'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello!","annotations":[]}]}}',
+                f'data: {{"type":"response.completed","response":{json.dumps(RESPONSES_API_MOCK)}}}',
+                "data: [DONE]",
+            ]
+
+            mock_stream_response = MockStreamingHTTPResponse(sse_events)
+
+            with patch(
+                "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+                new_callable=MagicMock,
+            ) as mock_post:
+                mock_post.return_value = mock_stream_response
+
+                response = router.responses(
+                    model="test-custom-pricing",
+                    input="Hello, how are you?",
+                    stream=True,
+                )
+
+                for _chunk in response:
+                    pass
+
+                deadline = time.time() + 2.0
+                while cost_callback.response_cost is None and time.time() < deadline:
+                    time.sleep(0.01)
+
+            assert cost_callback.response_cost is not None, (
+                "response_cost should be set in the callback"
+            )
+
+            expected_custom_cost = 100 * CUSTOM_INPUT_COST + 50 * CUSTOM_OUTPUT_COST
+            assert cost_callback.response_cost == pytest.approx(
+                expected_custom_cost, rel=0.01
+            ), (
+                f"Sync streaming cost should use custom pricing ({expected_custom_cost}), "
+                f"got {cost_callback.response_cost}"
+            )
+        finally:
+            litellm.callbacks = []
+
     @pytest.mark.asyncio
     async def test_streaming_responses_with_user_metadata_uses_custom_pricing(self):
         """Streaming /v1/responses should preserve custom pricing when metadata is also passed."""

--- a/tests/test_litellm/test_custom_pricing_metadata_propagation.py
+++ b/tests/test_litellm/test_custom_pricing_metadata_propagation.py
@@ -553,10 +553,6 @@ class TestResponsesAPICustomPricingCost:
                 for _chunk in response:
                     pass
 
-                deadline = time.time() + 2.0
-                while cost_callback.response_cost is None and time.time() < deadline:
-                    time.sleep(0.01)
-
             assert cost_callback.response_cost is not None, (
                 "response_cost should be set in the callback"
             )


### PR DESCRIPTION
## Relevant issues

https://github.com/BerriAI/litellm/issues/23185

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
All good aside of 7 pre-existing failures due to `responses` package shadowing  `AttributeError: module 'responses' has no attribute 'activate'`, this is a pre-existing issue
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [will request] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Custom pricing from `model_info` config was ignored for `/v1/responses` (streaming) and `/v1/messages` (all modes) endpoints, causing cost calculations to use standard pricing instead. **Regression introduced by:** PR #20679 (commit `1ee43b11de`). See repro steps in the issue linked above.
