### PR TITLE
fix(bedrock): strip output_config from Converse requests; fix spend tracking redaction test

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1206,6 +1206,7 @@ class AmazonConverseConfig(BaseConfig):
             self._validate_request_metadata(request_metadata)
 
         output_config: Optional[OutputConfigBlock] = inference_params.pop("outputConfig", None)
+        inference_params.pop("output_config", None)  # Bedrock Converse doesn't support it
 
         # keep supported params in 'inference_params', and set all model-specific params in 'additional_request_params'
         additional_request_params = {

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3170,6 +3170,33 @@ def test_transform_request_with_output_config():
     assert result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["name"] == "TestSchema"
 
 
+def test_output_config_snake_case_stripped_from_bedrock_converse_request():
+    """Test that output_config (snake_case) is stripped from Bedrock Converse requests.
+
+    Bedrock Converse API doesn't support the output_config parameter (Anthropic-only).
+    Nova and other Converse models reject requests with extraneous output_config.
+    """
+    config = AmazonConverseConfig()
+    messages = [{"role": "user", "content": "test"}]
+    optional_params = {
+        "output_config": {"effort": "high"},
+    }
+
+    result = config._transform_request(
+        model="us.amazon.nova-pro-v1:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    # output_config must not appear in additionalModelRequestFields
+    additional = result.get("additionalModelRequestFields", {})
+    assert "output_config" not in additional, (
+        f"output_config should be stripped for Bedrock Converse, got: {list(additional.keys())}"
+    )
+
+
 def test_transform_response_native_structured_output():
     """Test response handling when model returns JSON as text content (native structured output)."""
     response_json = {

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1071,9 +1071,10 @@ def test_spend_logs_redacts_request_and_response_when_turn_off_message_logging_e
     response_result = _get_response_for_spend_logs_payload(payload=payload, kwargs=kwargs)
 
     # When redaction is enabled and response is a dict (not ModelResponse),
-    # perform_redaction returns {"text": "redacted-by-litellm"}
+    # perform_redaction redacts content in-place within the choices structure
     parsed_response = json.loads(response_result)
-    assert parsed_response == {"text": "redacted-by-litellm"}
+    assert parsed_response["choices"][0]["message"]["content"] == "redacted-by-litellm"
+    assert parsed_response["choices"][0]["message"]["role"] == "assistant"
 
 
 @patch("litellm.secret_managers.main.get_secret_bool")


### PR DESCRIPTION
## Summary
- Strip `output_config` (snake_case) from Bedrock Converse requests — Nova and other Converse models reject this Anthropic-only param
- Fix `test_spend_logs_redacts_request_and_response_when_turn_off_message_logging_enabled` to match actual `perform_redaction` behavior (in-place content redaction)

## Changes
- `converse_transformation.py`: pop `output_config` before building request
- `test_converse_transformation.py`: add `test_output_config_snake_case_stripped_from_bedrock_converse_request`
- `test_spend_tracking_utils.py`: update assertion for dict response redaction

Made with [Cursor](https://cursor.com)