### PR TITLE
Fixing mcp issue

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -298,6 +298,7 @@ class MCPServerManager:
             resolved_authorization_url = server_config.get("authorization_url") or (
                 mcp_oauth_metadata.authorization_url if mcp_oauth_metadata else None
             )
+            token_url_from_config = bool(server_config.get("token_url"))
             resolved_token_url = server_config.get("token_url") or (
                 mcp_oauth_metadata.token_url if mcp_oauth_metadata else None
             )
@@ -322,6 +323,7 @@ class MCPServerManager:
                 scopes=resolved_scopes,
                 authorization_url=resolved_authorization_url,
                 token_url=resolved_token_url,
+                token_url_from_config=token_url_from_config,
                 registration_url=resolved_registration_url,
                 # TODO: utility fn the default values
                 transport=server_config.get("transport", MCPTransport.http),

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -299,13 +299,21 @@ class MCPServerManager:
                 mcp_oauth_metadata.authorization_url if mcp_oauth_metadata else None
             )
             _explicit_token_url = server_config.get("token_url")
-            _has_pkce_creds = bool(
+            _has_client_creds = bool(
                 server_config.get("client_id") and server_config.get("client_secret")
             )
+            _discovered_token_url = mcp_oauth_metadata.token_url if mcp_oauth_metadata else None
+            if not _explicit_token_url and _has_client_creds and _discovered_token_url:
+                verbose_logger.warning(
+                    "MCP server '%s': auto-discovered token_url '%s' ignored because "
+                    "client_id + client_secret are set without an explicit token_url, "
+                    "which signals a 3LO (authorization_code) flow. "
+                    "Set token_url explicitly in config to use 2LO (client_credentials).",
+                    server_id,
+                    _discovered_token_url,
+                )
             resolved_token_url = _explicit_token_url or (
-                (mcp_oauth_metadata.token_url if mcp_oauth_metadata else None)
-                if not _has_pkce_creds
-                else None
+                _discovered_token_url if not _has_client_creds else None
             )
             resolved_registration_url = server_config.get("registration_url") or (
                 mcp_oauth_metadata.registration_url if mcp_oauth_metadata else None

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -298,9 +298,14 @@ class MCPServerManager:
             resolved_authorization_url = server_config.get("authorization_url") or (
                 mcp_oauth_metadata.authorization_url if mcp_oauth_metadata else None
             )
-            token_url_from_config = bool(server_config.get("token_url"))
-            resolved_token_url = server_config.get("token_url") or (
-                mcp_oauth_metadata.token_url if mcp_oauth_metadata else None
+            _explicit_token_url = server_config.get("token_url")
+            _has_pkce_creds = bool(
+                server_config.get("client_id") and server_config.get("client_secret")
+            )
+            resolved_token_url = _explicit_token_url or (
+                (mcp_oauth_metadata.token_url if mcp_oauth_metadata else None)
+                if not _has_pkce_creds
+                else None
             )
             resolved_registration_url = server_config.get("registration_url") or (
                 mcp_oauth_metadata.registration_url if mcp_oauth_metadata else None
@@ -323,7 +328,6 @@ class MCPServerManager:
                 scopes=resolved_scopes,
                 authorization_url=resolved_authorization_url,
                 token_url=resolved_token_url,
-                token_url_from_config=token_url_from_config,
                 registration_url=resolved_registration_url,
                 # TODO: utility fn the default values
                 transport=server_config.get("transport", MCPTransport.http),

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -312,9 +312,9 @@ class MCPServerManager:
                     server_id,
                     _discovered_token_url,
                 )
-            resolved_token_url = _explicit_token_url or (
-                _discovered_token_url if not _has_client_creds else None
-            )
+                resolved_token_url = None
+            else:
+                resolved_token_url = _explicit_token_url or _discovered_token_url
             resolved_registration_url = server_config.get("registration_url") or (
                 mcp_oauth_metadata.registration_url if mcp_oauth_metadata else None
             )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -299,15 +299,17 @@ class MCPServerManager:
                 mcp_oauth_metadata.authorization_url if mcp_oauth_metadata else None
             )
             _explicit_token_url = server_config.get("token_url")
-            _has_client_creds = bool(
-                server_config.get("client_id") and server_config.get("client_secret")
+            # Use the same signal as MCPServer.has_client_credentials: explicit opt-in
+            # via oauth2_flow="client_credentials".  Presence of client_id/client_secret
+            # alone is ambiguous — both 2LO and 3LO flows use them.
+            _is_client_credentials_flow = (
+                server_config.get("oauth2_flow") == "client_credentials"
             )
             _discovered_token_url = mcp_oauth_metadata.token_url if mcp_oauth_metadata else None
-            if not _explicit_token_url and _has_client_creds and _discovered_token_url:
+            if not _explicit_token_url and _is_client_credentials_flow and _discovered_token_url:
                 verbose_logger.warning(
                     "MCP server '%s': auto-discovered token_url '%s' ignored because "
-                    "client_id + client_secret are set without an explicit token_url, "
-                    "which signals a 3LO (authorization_code) flow. "
+                    "oauth2_flow=client_credentials is set without an explicit token_url. "
                     "Set token_url explicitly in config to use 2LO (client_credentials).",
                     server_id,
                     _discovered_token_url,

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -47,6 +47,7 @@ class MCPServer(BaseModel):
     scopes: Optional[List[str]] = None
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
+    token_url_from_config: bool = False  # True only when token_url was explicitly set in user config (not auto-discovered)
     registration_url: Optional[str] = None
     # AWS SigV4 fields
     aws_access_key_id: Optional[str] = None

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -47,7 +47,6 @@ class MCPServer(BaseModel):
     scopes: Optional[List[str]] = None
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
-    token_url_from_config: bool = False  # True only when token_url was explicitly set in user config (not auto-discovered)
     registration_url: Optional[str] = None
     # AWS SigV4 fields
     aws_access_key_id: Optional[str] = None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1218,7 +1218,7 @@ class TestMCPServerManager:
         When client_id + client_secret are configured but token_url is absent (3LO intent),
         auto-discovered token_url must NOT be stored on the server — otherwise
         has_client_credentials returns True and incorrectly triggers the
-        client_credentials (2LO) grant, leaving the tool set empty.
+        client_credentials (2LO) grant, leaving the tool set empty
         """
         manager = MCPServerManager()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1211,14 +1211,15 @@ class TestMCPServerManager:
         assert server.has_client_credentials is True
 
     @pytest.mark.asyncio
-    async def test_pkce_creds_without_explicit_token_url_stays_3lo(self):
+    async def test_client_creds_without_explicit_token_url_stays_3lo(self):
         """
-        Regression test for: MCP OAuth 3LO fails when token_url is auto-discovered.
+        Regression test: client_id + client_secret without oauth2_flow=client_credentials
+        must stay in the 3LO (authorization_code) path.
 
-        When client_id + client_secret are configured but token_url is absent (3LO intent),
-        auto-discovered token_url must NOT be stored on the server — otherwise
-        has_client_credentials returns True and incorrectly triggers the
-        client_credentials (2LO) grant, leaving the tool set empty
+        - has_client_credentials must be False (no explicit opt-in via oauth2_flow)
+        - token_url MUST be populated from discovery so exchange_token_with_server()
+          can complete the auth-code exchange (raises HTTP 400 if token_url is None)
+        - authorization_url and scopes must also be populated from discovery
         """
         manager = MCPServerManager()
 
@@ -1239,22 +1240,25 @@ class TestMCPServerManager:
                     "auth_type": MCPAuth.oauth2,
                     "client_id": "my-client-id",
                     "client_secret": "my-client-secret",
-                    # Intentionally no token_url — signals 3LO (user-authorised) flow
+                    # No oauth2_flow — signals 3LO (user-authorised) flow
                 }
             }
 
             await manager.load_servers_from_config(config)
 
         server = next(iter(manager.config_mcp_servers.values()))
-        # token_url must NOT be populated from discovery when PKCE creds are present
-        assert server.token_url is None, (
-            "Auto-discovered token_url should not be set when client_id+client_secret "
-            "are configured without an explicit token_url (3LO intent)"
-        )
         assert server.has_client_credentials is False, (
-            "has_client_credentials must be False for 3LO servers so the "
-            "client_credentials grant is not triggered"
+            "has_client_credentials must be False when oauth2_flow is not set to "
+            "client_credentials — presence of client_id/secret alone is ambiguous"
         )
+        # token_url must be populated from discovery so the 3LO auth-code exchange works
+        assert server.token_url == "https://discovered.example.com/token", (
+            "Auto-discovered token_url must be preserved for 3LO servers — "
+            "exchange_token_with_server() raises HTTP 400 if token_url is None"
+        )
+        # authorization_url and scopes must also survive from discovery
+        assert server.authorization_url == "https://discovered.example.com/auth"
+        assert server.scopes == ["read"]
         assert server.needs_user_oauth_token is True
 
     @pytest.mark.asyncio
@@ -1284,7 +1288,8 @@ class TestMCPServerManager:
                     "auth_type": MCPAuth.oauth2,
                     "client_id": "my-client-id",
                     "client_secret": "my-client-secret",
-                    "token_url": "https://explicit.example.com/token",  # 2LO intent
+                    "token_url": "https://explicit.example.com/token",
+                    "oauth2_flow": "client_credentials",  # explicit 2LO opt-in
                 }
             }
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1306,6 +1306,56 @@ class TestMCPServerManager:
         assert server.needs_user_oauth_token is False
 
     @pytest.mark.asyncio
+    async def test_discovered_token_url_suppressed_for_2lo_without_explicit_token_url(self):
+        """
+        Regression guard for the suppression branch (line 309 in mcp_server_manager.py).
+
+        When oauth2_flow=client_credentials is set WITHOUT an explicit token_url, and
+        discovery returns a token_url, the resolved token_url must be suppressed (set to
+        None) to prevent the proxy from silently using a discovered token endpoint the
+        operator never intended to authorise.
+
+        Expected state after load_servers_from_config:
+        - server.token_url is None   (suppressed, not the discovered value)
+        - server.has_client_credentials is True  (explicit opt-in via oauth2_flow)
+        """
+        manager = MCPServerManager()
+
+        discovered_metadata = MCPOAuthMetadata(
+            scopes=["read"],
+            authorization_url="https://discovered.example.com/auth",
+            token_url="https://discovered.example.com/token",
+        )
+
+        async def fake_discovery(server_url: str):
+            return discovered_metadata
+
+        with unittest.mock.patch.object(manager, "_descovery_metadata", side_effect=fake_discovery):
+            config = {
+                "m2m-server": {
+                    "url": "https://m2m.example.com/mcp",
+                    "transport": MCPTransport.http,
+                    "auth_type": MCPAuth.oauth2,
+                    "client_id": "my-client-id",
+                    "client_secret": "my-client-secret",
+                    "oauth2_flow": "client_credentials",  # explicit 2LO opt-in
+                    # Deliberately NO token_url — triggers the suppression branch
+                }
+            }
+
+            await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        assert server.token_url is None, (
+            "Auto-discovered token_url must be suppressed when oauth2_flow=client_credentials "
+            "is set without an explicit token_url — using a discovered endpoint could grant "
+            "unintended M2M access"
+        )
+        assert server.has_client_credentials is True, (
+            "has_client_credentials must be True: oauth2_flow=client_credentials is set"
+        )
+
+    @pytest.mark.asyncio
     async def test_requires_per_user_auth_property_passthrough_auth(self):
         """Test that requires_per_user_auth returns True for passthrough auth (auth_type=none + Authorization header)"""
         # Passthrough auth with Authorization header

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1211,6 +1211,54 @@ class TestMCPServerManager:
         assert server.has_client_credentials is True
 
     @pytest.mark.asyncio
+    async def test_pkce_creds_without_explicit_token_url_stays_3lo(self):
+        """
+        Regression test for: MCP OAuth 3LO fails when token_url is auto-discovered.
+
+        When client_id + client_secret are configured but token_url is absent (3LO intent),
+        auto-discovered token_url must NOT be stored on the server — otherwise
+        has_client_credentials returns True and incorrectly triggers the
+        client_credentials (2LO) grant, leaving the tool set empty.
+        """
+        manager = MCPServerManager()
+
+        discovered_metadata = MCPOAuthMetadata(
+            scopes=["read"],
+            authorization_url="https://discovered.example.com/auth",
+            token_url="https://discovered.example.com/token",
+        )
+
+        async def fake_discovery(server_url: str):
+            return discovered_metadata
+
+        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
+
+        config = {
+            "github": {
+                "url": "https://github.example.com/mcp",
+                "transport": MCPTransport.http,
+                "auth_type": MCPAuth.oauth2,
+                "client_id": "my-client-id",
+                "client_secret": "my-client-secret",
+                # Intentionally no token_url — signals 3LO (user-authorised) flow
+            }
+        }
+
+        await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        # token_url must NOT be populated from discovery when PKCE creds are present
+        assert server.token_url is None, (
+            "Auto-discovered token_url should not be set when client_id+client_secret "
+            "are configured without an explicit token_url (3LO intent)"
+        )
+        assert server.has_client_credentials is False, (
+            "has_client_credentials must be False for 3LO servers so the "
+            "client_credentials grant is not triggered"
+        )
+        assert server.needs_user_oauth_token is True
+
+    @pytest.mark.asyncio
     async def test_requires_per_user_auth_property_passthrough_auth(self):
         """Test that requires_per_user_auth returns True for passthrough auth (auth_type=none + Authorization header)"""
         # Passthrough auth with Authorization header

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -762,8 +762,6 @@ class TestMCPServerManager:
             assert server_url == "https://example.com/mcp"
             return discovered_metadata
 
-        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
-
         config = {
             "example": {
                 "url": "https://example.com/mcp",
@@ -774,7 +772,8 @@ class TestMCPServerManager:
             }
         }
 
-        await manager.load_servers_from_config(config)
+        with unittest.mock.patch.object(manager, "_descovery_metadata", side_effect=fake_discovery):
+            await manager.load_servers_from_config(config)
 
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.scopes == ["config"]  # config overrides discovery

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1259,6 +1259,50 @@ class TestMCPServerManager:
         assert server.needs_user_oauth_token is True
 
     @pytest.mark.asyncio
+    async def test_explicit_token_url_with_client_creds_routes_2lo(self):
+        """
+        Regression test: explicit token_url + client_id + client_secret must route to
+        2LO (client_credentials) even when discovery is active.
+
+        Discovery should NOT override an explicitly configured token_url.
+        """
+        manager = MCPServerManager()
+
+        discovered_metadata = MCPOAuthMetadata(
+            scopes=["read"],
+            authorization_url="https://discovered.example.com/auth",
+            token_url="https://discovered.example.com/token",
+        )
+
+        async def fake_discovery(server_url: str):
+            return discovered_metadata
+
+        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
+
+        config = {
+            "github": {
+                "url": "https://github.example.com/mcp",
+                "transport": MCPTransport.http,
+                "auth_type": MCPAuth.oauth2,
+                "client_id": "my-client-id",
+                "client_secret": "my-client-secret",
+                "token_url": "https://explicit.example.com/token",  # 2LO intent
+            }
+        }
+
+        await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        # Explicit token_url must be preserved, not overridden by discovery
+        assert server.token_url == "https://explicit.example.com/token", (
+            "Explicit token_url should be used as-is when provided in config"
+        )
+        assert server.has_client_credentials is True, (
+            "has_client_credentials must be True when explicit token_url + client creds are set"
+        )
+        assert server.needs_user_oauth_token is False
+
+    @pytest.mark.asyncio
     async def test_requires_per_user_auth_property_passthrough_auth(self):
         """Test that requires_per_user_auth returns True for passthrough auth (auth_type=none + Authorization header)"""
         # Passthrough auth with Authorization header

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+import unittest.mock
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1231,20 +1232,19 @@ class TestMCPServerManager:
         async def fake_discovery(server_url: str):
             return discovered_metadata
 
-        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
-
-        config = {
-            "github": {
-                "url": "https://github.example.com/mcp",
-                "transport": MCPTransport.http,
-                "auth_type": MCPAuth.oauth2,
-                "client_id": "my-client-id",
-                "client_secret": "my-client-secret",
-                # Intentionally no token_url — signals 3LO (user-authorised) flow
+        with unittest.mock.patch.object(manager, "_descovery_metadata", side_effect=fake_discovery):
+            config = {
+                "github": {
+                    "url": "https://github.example.com/mcp",
+                    "transport": MCPTransport.http,
+                    "auth_type": MCPAuth.oauth2,
+                    "client_id": "my-client-id",
+                    "client_secret": "my-client-secret",
+                    # Intentionally no token_url — signals 3LO (user-authorised) flow
+                }
             }
-        }
 
-        await manager.load_servers_from_config(config)
+            await manager.load_servers_from_config(config)
 
         server = next(iter(manager.config_mcp_servers.values()))
         # token_url must NOT be populated from discovery when PKCE creds are present
@@ -1277,20 +1277,19 @@ class TestMCPServerManager:
         async def fake_discovery(server_url: str):
             return discovered_metadata
 
-        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
-
-        config = {
-            "github": {
-                "url": "https://github.example.com/mcp",
-                "transport": MCPTransport.http,
-                "auth_type": MCPAuth.oauth2,
-                "client_id": "my-client-id",
-                "client_secret": "my-client-secret",
-                "token_url": "https://explicit.example.com/token",  # 2LO intent
+        with unittest.mock.patch.object(manager, "_descovery_metadata", side_effect=fake_discovery):
+            config = {
+                "github": {
+                    "url": "https://github.example.com/mcp",
+                    "transport": MCPTransport.http,
+                    "auth_type": MCPAuth.oauth2,
+                    "client_id": "my-client-id",
+                    "client_secret": "my-client-secret",
+                    "token_url": "https://explicit.example.com/token",  # 2LO intent
+                }
             }
-        }
 
-        await manager.load_servers_from_config(config)
+            await manager.load_servers_from_config(config)
 
         server = next(iter(manager.config_mcp_servers.values()))
         # Explicit token_url must be preserved, not overridden by discovery


### PR DESCRIPTION
## Relevant issues

https://github.com/BerriAI/litellm/issues/23221

When client_id + client_secret are configured without an explicit token_url
(the documented 3LO setup), OAuth metadata discovery was populating token_url,
causing has_client_credentials to return True and incorrectly triggering the
client_credentials grant. Tools appeared connected but returned empty.

Fix: skip auto-discovery of token_url when PKCE credentials are present but
token_url is absent from config — the unambiguous signal of 3LO intent.