### PR TITLE
fix: fail proxy startup if prisma migrate fails

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -853,7 +853,14 @@ def run_server(  # noqa: PLR0915
                 ):
                     check_prisma_schema_diff(db_url=None)
                 else:
-                    PrismaManager.setup_database(use_migrate=not use_prisma_db_push)
+                    if not PrismaManager.setup_database(use_migrate=not use_prisma_db_push):
+                        import sys
+
+                        print(  # noqa
+                            "\033[1;31mLiteLLM Proxy: Database setup failed after multiple retries. "
+                            "The proxy cannot start safely. Please check your database connection and migration status.\033[0m"
+                        )
+                        sys.exit(1)
             else:
                 print(  # noqa
                     f"Unable to connect to DB. DATABASE_URL found in environment, but prisma package not found."  # noqa

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -854,8 +854,6 @@ def run_server(  # noqa: PLR0915
                     check_prisma_schema_diff(db_url=None)
                 else:
                     if not PrismaManager.setup_database(use_migrate=not use_prisma_db_push):
-                        import sys
-
                         print(  # noqa
                             "\033[1;31mLiteLLM Proxy: Database setup failed after multiple retries. "
                             "The proxy cannot start safely. Please check your database connection and migration status.\033[0m"

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -664,6 +664,63 @@ class TestHealthAppFactory:
             )
             mock_setup_database.assert_called_with(use_migrate=False)
 
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.check_migration.check_prisma_schema_diff")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema")
+    def test_startup_fails_when_db_setup_fails(
+        self,
+        mock_should_update_schema,
+        mock_check_schema_diff,
+        mock_setup_database,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        """Test that proxy exits with code 1 when PrismaManager.setup_database returns False"""
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+        mock_should_update_schema.return_value = True
+        mock_setup_database.return_value = False
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        clean_env["DATABASE_URL"] = "postgresql://test:test@localhost:5432/test"
+
+        with patch.dict(
+            os.environ, clean_env, clear=True
+        ), patch.dict(
+            "sys.modules",
+            {
+                "proxy_server": mock_proxy_module,
+                "litellm.proxy.proxy_server": mock_proxy_module,
+            },
+        ), patch(
+            "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+        ) as mock_get_args:
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            with pytest.raises(SystemExit) as exc_info:
+                run_server.main(
+                    ["--local", "--skip_server_startup"], standalone_mode=False
+                )
+            assert exc_info.value.code == 1
+
 
 # --- Module-level helpers for worker startup hook tests ---
 

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -720,6 +720,7 @@ class TestHealthAppFactory:
                     ["--local", "--skip_server_startup"], standalone_mode=False
                 )
             assert exc_info.value.code == 1
+            mock_setup_database.assert_called_once_with(use_migrate=True)
 
 
 # --- Module-level helpers for worker startup hook tests ---


### PR DESCRIPTION
## Verification: 

1. Started a fresh Postgres container with your config's credentials
2. Corrupted the latest prisma migration file by appending invalid SQL (ALTER TABLE NONEXISTENT_TABLE...)
3. Ran poetry run litellm --config config.yaml
4. Result: Migration failed → proxy printed the red error message → exited with code 1 (instead of starting with a broken DB schema)

<img width="1093" height="82" alt="image" src="https://github.com/user-attachments/assets/80c91351-e72a-4b2a-acfa-b16d29c9fae6" />

## Changes

Previously, `PrismaManager.setup_database()` returned `False` on failure but the return value was silently ignored in `proxy_cli.py`, allowing the proxy to start with an out-of-sync database schema. This caused runtime `DataError` crashes (e.g. missing columns like `policies`, `router_settings`) in background jobs like `reset_budget_job`.

This fix checks the return value of `setup_database()` and calls `sys.exit(1)` with a clear error message if migrations fail, preventing the proxy from starting in a broken state.


## Edit (Greptile Concerns)

### Greptile's concerns are incorrect:

1. **No opt-out / backwards-incompatible — Incorrect.**  
   Users with externally managed migrations already set `disable_prisma_schema_update: true` (or `DISABLE_SCHEMA_UPDATE=true`).  
   This makes `should_update_prisma_schema()` return `False`, which skips `setup_database` entirely.  
   Therefore, they never reach the `sys.exit(1)` path.

2. **Feature flag needed" — Incorrect.**  
   An opt-out mechanism already exists via the setting above.  
   No additional feature flag is required.

3. **Test relies on non-deterministic environment — Incorrect.**  
   The test uses mocks (`mock_setup_database.return_value = False`), making it fully deterministic.

4. **Clarification on `sys.exit(1)`:**  
   `sys.exit(1)` only triggers when the user has opted into migrations (the default) **and the migrations fail**.  
   In that scenario, blocking startup is the correct behavior.
