### PR TITLE
docs(openai): document gpt-5.4 reasoning_effort + tools limitation

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -628,7 +628,22 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 
 ## OpenAI Chat Completion to Responses API Bridge
 
-Call any Responses API model from OpenAI's `/chat/completions` endpoint. 
+Call any Responses API model from OpenAI's `/chat/completions` endpoint.
+
+:::tip gpt-5.4 + reasoning_effort + function tools
+
+OpenAI does not support `reasoning_effort` with function tools for `gpt-5.4` in `/v1/chat/completions`. Use the responses bridge instead:
+
+```python
+response = litellm.completion(
+    model="openai/responses/gpt-5.4",  # routes to /v1/responses
+    messages=[{"role": "user", "content": "What's the weather?"}],
+    tools=[...],
+    reasoning_effort="low",
+)
+```
+
+:::
 
 <Tabs>
 <TabItem value="sdk" label="SDK">

--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -592,6 +592,12 @@ Expected Response
 </TabItem>
 </Tabs>
 
+:::tip gpt-5.4: reasoning_effort + function tools
+
+OpenAI does not support `reasoning_effort` with function tools for `gpt-5.4` in `/v1/chat/completions`. Use `openai/responses/gpt-5.4` to route through the Responses API instead. See [Responses API Bridge](/docs/providers/openai#openai-chat-completion-to-responses-api-bridge) for details.
+
+:::
+
 ## OpenAI Responses API - Auto-Summary Control
 
 When using OpenAI Responses API models (like `gpt-5`) via `/chat/completions` with `reasoning_effort`, you can control whether `summary="detailed"` is automatically added to the reasoning parameter.


### PR DESCRIPTION
## Relevant issues

Relates to #23156

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## Type

📖 Documentation

## Changes

Document that OpenAI does not support `reasoning_effort` + function tools for `gpt-5.4` in `/v1/chat/completions`, and that the responses bridge (`openai/responses/gpt-5.4`) should be used instead.

- `docs/providers/openai.md` — tip box in the Responses API Bridge section
- `docs/reasoning_content.md` — tip box with link to the bridge docs