### PR TITLE
fix(snowflake): transform messages for tool calling round trips

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -155,8 +155,8 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         return f"{api_base}/cortex/inference:complete"
 
     def _transform_messages(
-        self, messages: List[AllMessageValues]
-    ) -> List[Dict[str, Any]]:
+        self, messages: List[AllMessageValues], model: str, is_async: bool = False
+    ) -> List[AllMessageValues]:
         """
         Transform OpenAI messages to Snowflake format.
 
@@ -214,7 +214,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                 )
             )
 
-        return transformed
+        return transformed  # type: ignore
 
     def _convert_assistant_tool_message(
         self, message: Dict[str, Any]
@@ -242,6 +242,11 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
         # Add text content if present
         text_content = message.get("content")
+        if isinstance(text_content, list):
+            # Flatten multipart content to a single string
+            text_content = " ".join(
+                part.get("text", "") for part in text_content if isinstance(part, dict)
+            )
         if text_content:
             content_list.append({"type": "text", "text": text_content})
 
@@ -298,10 +303,17 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             function = tool_call.get("function", {})
             function_name = function.get("name", "")
 
-            # Get content - could be string or None
+            # Get content - could be string, list, or None
             content = tool_msg.get("content")
             if content is None:
                 content = "null"
+            elif isinstance(content, list):
+                # Flatten OpenAI multipart tool content to a plain string
+                content = " ".join(
+                    part.get("text", "") for part in content if isinstance(part, dict)
+                )
+            elif not isinstance(content, str):
+                content = str(content)
 
             content_list.append({
                 "type": "tool_results",
@@ -426,7 +438,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         # Transform messages from OpenAI format to Snowflake format
         # This handles role: "tool" -> role: "user" with tool_results content_list
         # and assistant messages with tool_calls -> content_list with tool_use blocks
-        transformed_messages = self._transform_messages(messages)
+        transformed_messages = self._transform_messages(messages, model=model)
 
         return {
             "model": model,

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -329,6 +329,11 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             else:
                 function = tool_call.get("function", {})
                 function_name = function.get("name", "")
+                if not function_name:
+                    litellm.utils.verbose_logger.warning(
+                        f"Snowflake: tool_call_id '{tool_call_id}' found but function name "
+                        "is empty; tool_results block will have name=''."
+                    )
 
             # Get content - could be string, list, or None
             content = tool_msg.get("content")

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -156,7 +156,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
         return f"{api_base}/cortex/inference:complete"
 
-    def _transform_messages(
+    def _transform_messages(  # noqa: ARG002 - model, is_async unused; accepted for interface compatibility
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
     ) -> List[AllMessageValues]:
         """
@@ -335,9 +335,12 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             if content is None:
                 content = "null"
             elif isinstance(content, list):
-                # Flatten OpenAI multipart tool content to a plain string
+                # Flatten OpenAI multipart tool content to a plain string.
+                # Filter out empty strings from non-text parts (e.g., images).
                 content = " ".join(
-                    part.get("text", "") for part in content if isinstance(part, dict)
+                    part.get("text", "")
+                    for part in content
+                    if isinstance(part, dict) and part.get("text")
                 )
             elif not isinstance(content, str):
                 content = str(content)

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -174,13 +174,16 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         Snowflake transformation is synchronous and doesn't require async operations
         like image URL downloads that the parent class handles.
         """
-        # Build a map of tool_call_id -> tool_call for looking up function names
+        # Build a map of tool_call_id -> tool_call for looking up function names.
+        # Must handle both dict and Pydantic BaseModel messages/tool_calls.
         tool_calls_map: Dict[str, Dict[str, Any]] = {}
         for message in messages:
-            if isinstance(message, dict) and message.get("role") == "assistant":
-                for tc in message.get("tool_calls") or []:
-                    if isinstance(tc, dict):
-                        tool_calls_map[tc.get("id", "")] = tc
+            msg = message.model_dump() if isinstance(message, BaseModel) else message
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    tc_dict = tc.model_dump() if isinstance(tc, BaseModel) else tc
+                    if isinstance(tc_dict, dict):
+                        tool_calls_map[tc_dict.get("id", "")] = tc_dict
 
         transformed: List[Dict[str, Any]] = []
         pending_tool_messages: List[Dict[str, Any]] = []
@@ -249,18 +252,23 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         """
         content_list: List[Dict[str, Any]] = []
 
-        # Add text content if present
+        # Add text content if present.
+        # Note: Non-text parts (e.g., images) are intentionally dropped because
+        # Snowflake's content_list text blocks only support plain strings.
         text_content = message.get("content")
         if isinstance(text_content, list):
-            # Flatten multipart content to a single string
+            # Flatten to text only; filter out empty strings from non-text parts
             text_content = " ".join(
-                part.get("text", "") for part in text_content if isinstance(part, dict)
+                part.get("text", "")
+                for part in text_content
+                if isinstance(part, dict) and part.get("text")
             )
         if text_content:
             content_list.append({"type": "text", "text": text_content})
 
-        # Add tool_use blocks
-        for tool_call in message.get("tool_calls") or []:
+        # Add tool_use blocks. Handle both dict and Pydantic BaseModel tool_calls.
+        for raw_tc in message.get("tool_calls") or []:
+            tool_call = raw_tc.model_dump() if isinstance(raw_tc, BaseModel) else raw_tc
             if isinstance(tool_call, dict):
                 function = tool_call.get("function", {})
                 # Parse arguments from JSON string to dict
@@ -311,11 +319,13 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             tool_call_id = tool_msg.get("tool_call_id", "")
             tool_call = tool_calls_map.get(tool_call_id)
             if tool_call is None:
-                litellm.utils.verbose_logger.warning(
-                    f"Snowflake: tool_call_id '{tool_call_id}' not found in prior "
-                    "assistant messages; function name will be empty."
-                )
-                function_name = ""
+                # Fall back to 'name' field on the tool message itself (OpenAI format)
+                function_name = tool_msg.get("name", "")
+                if not function_name:
+                    litellm.utils.verbose_logger.warning(
+                        f"Snowflake: tool_call_id '{tool_call_id}' not found in prior "
+                        "assistant messages and no 'name' field; function name will be empty."
+                    )
             else:
                 function = tool_call.get("function", {})
                 function_name = function.get("name", "")

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -154,6 +154,166 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
         return f"{api_base}/cortex/inference:complete"
 
+    def _transform_messages(
+        self, messages: List[AllMessageValues]
+    ) -> List[Dict[str, Any]]:
+        """
+        Transform OpenAI messages to Snowflake format.
+
+        Key transformations:
+        1. Assistant messages with tool_calls -> content_list with tool_use blocks
+        2. Tool messages (role: "tool") -> User messages with content_list containing tool_results
+
+        Snowflake uses a format similar to Anthropic/Bedrock where:
+        - tool_use blocks are in assistant message content_list
+        - tool_results are in user message content_list (not role: "tool")
+        """
+        # Build a map of tool_call_id -> tool_call for looking up function names
+        tool_calls_map: Dict[str, Dict[str, Any]] = {}
+        for message in messages:
+            if isinstance(message, dict) and message.get("role") == "assistant":
+                for tc in message.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        tool_calls_map[tc.get("id", "")] = tc
+
+        transformed: List[Dict[str, Any]] = []
+        pending_tool_messages: List[Dict[str, Any]] = []
+
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+
+            role = message.get("role", "")
+
+            # Flush pending tool messages before any non-tool message
+            if role != "tool" and pending_tool_messages:
+                transformed.append(
+                    self._convert_tool_messages_to_user_message(
+                        pending_tool_messages, tool_calls_map
+                    )
+                )
+                pending_tool_messages = []
+
+            if role == "tool":
+                # Collect tool messages to combine into a single user message
+                pending_tool_messages.append(message)
+
+            elif role == "assistant" and message.get("tool_calls"):
+                # Transform assistant message with tool_calls to content_list format
+                transformed.append(self._convert_assistant_tool_message(message))
+
+            else:
+                # Pass through other messages as-is
+                transformed.append(message)
+
+        # Flush any remaining tool messages
+        if pending_tool_messages:
+            transformed.append(
+                self._convert_tool_messages_to_user_message(
+                    pending_tool_messages, tool_calls_map
+                )
+            )
+
+        return transformed
+
+    def _convert_assistant_tool_message(
+        self, message: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Convert assistant message with tool_calls to Snowflake's content_list format.
+
+        OpenAI format:
+        {
+            "role": "assistant",
+            "content": "I'll check that for you.",
+            "tool_calls": [{"id": "...", "function": {"name": "...", "arguments": "..."}}]
+        }
+
+        Snowflake format:
+        {
+            "role": "assistant",
+            "content_list": [
+                {"type": "text", "text": "I'll check that for you."},
+                {"type": "tool_use", "tool_use": {"tool_use_id": "...", "name": "...", "input": {...}}}
+            ]
+        }
+        """
+        content_list: List[Dict[str, Any]] = []
+
+        # Add text content if present
+        text_content = message.get("content")
+        if text_content:
+            content_list.append({"type": "text", "text": text_content})
+
+        # Add tool_use blocks
+        for tool_call in message.get("tool_calls") or []:
+            if isinstance(tool_call, dict):
+                function = tool_call.get("function", {})
+                # Parse arguments from JSON string to dict
+                arguments_str = function.get("arguments", "{}")
+                try:
+                    arguments = json.loads(arguments_str) if arguments_str else {}
+                except json.JSONDecodeError:
+                    arguments = {}
+
+                content_list.append({
+                    "type": "tool_use",
+                    "tool_use": {
+                        "tool_use_id": tool_call.get("id", ""),
+                        "name": function.get("name", ""),
+                        "input": arguments,
+                    },
+                })
+
+        return {"role": "assistant", "content_list": content_list}
+
+    def _convert_tool_messages_to_user_message(
+        self,
+        tool_messages: List[Dict[str, Any]],
+        tool_calls_map: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Convert tool result messages to a single Snowflake user message with tool_results.
+
+        OpenAI format (multiple messages):
+        [
+            {"role": "tool", "tool_call_id": "...", "content": "result1"},
+            {"role": "tool", "tool_call_id": "...", "content": "result2"}
+        ]
+
+        Snowflake format (single user message):
+        {
+            "role": "user",
+            "content_list": [
+                {"type": "tool_results", "tool_results": {"tool_use_id": "...", "name": "...", "content": [{"type": "text", "text": "result1"}]}},
+                {"type": "tool_results", "tool_results": {"tool_use_id": "...", "name": "...", "content": [{"type": "text", "text": "result2"}]}}
+            ]
+        }
+        """
+        content_list: List[Dict[str, Any]] = []
+
+        for tool_msg in tool_messages:
+            tool_call_id = tool_msg.get("tool_call_id", "")
+            tool_call = tool_calls_map.get(tool_call_id, {})
+            function = tool_call.get("function", {})
+            function_name = function.get("name", "")
+
+            # Get content - could be string or None
+            content = tool_msg.get("content")
+            if content is None:
+                content = "null"
+
+            content_list.append({
+                "type": "tool_results",
+                "tool_results": {
+                    "tool_use_id": tool_call_id,
+                    "name": function_name,
+                    "content": [{"type": "text", "text": content}],
+                },
+            })
+
+        return {"role": "user", "content_list": content_list}
+
     def _transform_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Transform OpenAI tool format to Snowflake tool format.
@@ -263,9 +423,14 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         if tool_choice:
             optional_params["tool_choice"] = self._transform_tool_choice(tool_choice)
 
+        # Transform messages from OpenAI format to Snowflake format
+        # This handles role: "tool" -> role: "user" with tool_results content_list
+        # and assistant messages with tool_calls -> content_list with tool_use blocks
+        transformed_messages = self._transform_messages(messages)
+
         return {
             "model": model,
-            "messages": messages,
+            "messages": transformed_messages,
             "stream": stream,
             **optional_params,
             **extra_body,

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -258,8 +258,9 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                 arguments_str = function.get("arguments", "{}")
                 try:
                     arguments = json.loads(arguments_str) if arguments_str else {}
-                except json.JSONDecodeError:
-                    arguments = {}
+                except (json.JSONDecodeError, TypeError):
+                    # TypeError if arguments is not a string (e.g., already a dict)
+                    arguments = arguments_str if isinstance(arguments_str, dict) else {}
 
                 content_list.append({
                     "type": "tool_use",
@@ -435,9 +436,13 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         if tool_choice:
             optional_params["tool_choice"] = self._transform_tool_choice(tool_choice)
 
-        # Transform messages from OpenAI format to Snowflake format
+        # Transform messages from OpenAI format to Snowflake format.
         # This handles role: "tool" -> role: "user" with tool_results content_list
-        # and assistant messages with tool_calls -> content_list with tool_use blocks
+        # and assistant messages with tool_calls -> content_list with tool_use blocks.
+        # Note: We call _transform_messages here directly because Snowflake builds
+        # its own request dict (doesn't delegate to super().transform_request()).
+        # This is intentional - Snowflake routes through base_llm_http_handler,
+        # not openai_like handler, so there's no double-transformation risk.
         transformed_messages = self._transform_messages(messages, model=model)
 
         return {

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -6,7 +6,9 @@ import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx
+from pydantic import BaseModel
 
+import litellm
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ChatCompletionMessageToolCall, Function, ModelResponse
 
@@ -164,9 +166,13 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         1. Assistant messages with tool_calls -> content_list with tool_use blocks
         2. Tool messages (role: "tool") -> User messages with content_list containing tool_results
 
-        Snowflake uses a format similar to Anthropic/Bedrock where:
+        Snowflake uses a format where:
         - tool_use blocks are in assistant message content_list
         - tool_results are in user message content_list (not role: "tool")
+
+        Note: is_async parameter is accepted for interface compatibility but not used.
+        Snowflake transformation is synchronous and doesn't require async operations
+        like image URL downloads that the parent class handles.
         """
         # Build a map of tool_call_id -> tool_call for looking up function names
         tool_calls_map: Dict[str, Dict[str, Any]] = {}
@@ -180,7 +186,10 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         pending_tool_messages: List[Dict[str, Any]] = []
 
         for message in messages:
-            if not isinstance(message, dict):
+            # Handle Pydantic models by converting to dict
+            if isinstance(message, BaseModel):
+                message = message.model_dump()
+            elif not isinstance(message, dict):
                 continue
 
             role = message.get("role", "")
@@ -300,9 +309,16 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
         for tool_msg in tool_messages:
             tool_call_id = tool_msg.get("tool_call_id", "")
-            tool_call = tool_calls_map.get(tool_call_id, {})
-            function = tool_call.get("function", {})
-            function_name = function.get("name", "")
+            tool_call = tool_calls_map.get(tool_call_id)
+            if tool_call is None:
+                litellm.utils.verbose_logger.warning(
+                    f"Snowflake: tool_call_id '{tool_call_id}' not found in prior "
+                    "assistant messages; function name will be empty."
+                )
+                function_name = ""
+            else:
+                function = tool_call.get("function", {})
+                function_name = function.get("name", "")
 
             # Get content - could be string, list, or None
             content = tool_msg.get("content")

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -338,7 +338,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             # Get content - could be string, list, or None
             content = tool_msg.get("content")
             if content is None:
-                content = "null"
+                content = ""
             elif isinstance(content, list):
                 # Flatten OpenAI multipart tool content to a plain string.
                 # Filter out empty strings from non-text parts (e.g., images).

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -439,6 +439,42 @@ class TestSnowflakeToolTransformation:
         assert tool_results[0]["tool_results"]["tool_use_id"] == "call_1"
         assert tool_results[1]["tool_results"]["tool_use_id"] == "call_2"
 
+    def test_transform_request_with_tool_messages(self):
+        """
+        Test that transform_request correctly wires _transform_messages for tool results.
+        """
+        config = SnowflakeConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Paris"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "72°F"},
+        ]
+
+        result = config.transform_request(
+            model="claude-3-5-sonnet",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        transformed = result["messages"]
+        assert len(transformed) == 3
+        assert transformed[2]["role"] == "user"
+        assert "content_list" in transformed[2]
+        assert transformed[2]["content_list"][0]["type"] == "tool_results"
+
 
 class TestSnowFlakeCompletion:
     model_name = "mistral"

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -331,6 +331,114 @@ class TestSnowflakeToolTransformation:
         assert "temperature" in supported_params
         assert "max_tokens" in supported_params
 
+    def test_transform_messages_with_tool_results(self):
+        """
+        Test that OpenAI role: "tool" messages are transformed to Snowflake format.
+
+        OpenAI sends tool results as:
+            {"role": "tool", "tool_call_id": "...", "content": "result"}
+
+        Snowflake expects:
+            {"role": "user", "content_list": [{"type": "tool_results", "tool_results": {...}}]}
+        """
+        config = SnowflakeConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": "I'll check that for you.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "Paris"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": "72°F and sunny",
+            },
+        ]
+
+        transformed = config._transform_messages(messages)
+
+        # Should have 3 messages
+        assert len(transformed) == 3
+
+        # First message unchanged
+        assert transformed[0]["role"] == "user"
+        assert transformed[0]["content"] == "What's the weather in Paris?"
+
+        # Second message (assistant) should have content_list with tool_use
+        assert transformed[1]["role"] == "assistant"
+        assert "content_list" in transformed[1]
+        content_list = transformed[1]["content_list"]
+        assert len(content_list) == 2
+        assert content_list[0]["type"] == "text"
+        assert content_list[0]["text"] == "I'll check that for you."
+        assert content_list[1]["type"] == "tool_use"
+        assert content_list[1]["tool_use"]["tool_use_id"] == "call_123"
+        assert content_list[1]["tool_use"]["name"] == "get_weather"
+        assert content_list[1]["tool_use"]["input"] == {"location": "Paris"}
+
+        # Third message (tool) should become user with tool_results
+        assert transformed[2]["role"] == "user"
+        assert "content_list" in transformed[2]
+        tool_results = transformed[2]["content_list"]
+        assert len(tool_results) == 1
+        assert tool_results[0]["type"] == "tool_results"
+        assert tool_results[0]["tool_results"]["tool_use_id"] == "call_123"
+        assert tool_results[0]["tool_results"]["name"] == "get_weather"
+        assert tool_results[0]["tool_results"]["content"] == [
+            {"type": "text", "text": "72°F and sunny"}
+        ]
+
+    def test_transform_messages_multiple_tool_results(self):
+        """
+        Test that multiple consecutive tool messages are combined into one user message.
+        """
+        config = SnowflakeConfig()
+
+        messages = [
+            {"role": "user", "content": "Get weather for Paris and London"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Paris"}'},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "London"}'},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "72°F"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "55°F"},
+        ]
+
+        transformed = config._transform_messages(messages)
+
+        # Should have 3 messages (user, assistant, combined tool results)
+        assert len(transformed) == 3
+
+        # Third message should have both tool results
+        assert transformed[2]["role"] == "user"
+        tool_results = transformed[2]["content_list"]
+        assert len(tool_results) == 2
+        assert tool_results[0]["tool_results"]["tool_use_id"] == "call_1"
+        assert tool_results[1]["tool_results"]["tool_use_id"] == "call_2"
+
 
 class TestSnowFlakeCompletion:
     model_name = "mistral"

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -437,7 +437,9 @@ class TestSnowflakeToolTransformation:
         tool_results = transformed[2]["content_list"]
         assert len(tool_results) == 2
         assert tool_results[0]["tool_results"]["tool_use_id"] == "call_1"
+        assert tool_results[0]["tool_results"]["name"] == "get_weather"
         assert tool_results[1]["tool_results"]["tool_use_id"] == "call_2"
+        assert tool_results[1]["tool_results"]["name"] == "get_weather"
 
     def test_transform_request_with_tool_messages(self):
         """

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -366,7 +366,7 @@ class TestSnowflakeToolTransformation:
             },
         ]
 
-        transformed = config._transform_messages(messages)
+        transformed = config._transform_messages(messages, model="claude-3-5-sonnet")
 
         # Should have 3 messages
         assert len(transformed) == 3
@@ -427,7 +427,7 @@ class TestSnowflakeToolTransformation:
             {"role": "tool", "tool_call_id": "call_2", "content": "55°F"},
         ]
 
-        transformed = config._transform_messages(messages)
+        transformed = config._transform_messages(messages, model="claude-3-5-sonnet")
 
         # Should have 3 messages (user, assistant, combined tool results)
         assert len(transformed) == 3


### PR DESCRIPTION
Snowflake's requires tool resultsto be in user messages with `content_list` containing `tool_results` blocks (not role: "tool"). Snowflake will throw an error: `unknown role "tool"` when provided with `role: "tool"` messages.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/23285

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

This PR transforms OpenAI message format to Snowflake's expected format:
- `role: "tool"` messages → `role: "user"` with `content_list` containing `tool_results` blocks
- `assistant` messages with `tool_calls` → `content_list` with `tool_use` blocks
- Multiple consecutive tool messages are combined into a single user message

## Test plan

- [x] Unit tests added for message transformation
- [x] Tested against real Snowflake Cortex API