### PR TITLE
fix(azure_ai): add structured output support for Azure AI Foundry provider

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -20,7 +20,11 @@ from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import ModelResponse, ProviderField
-from litellm.utils import _add_path_to_api_base, supports_tool_choice
+from litellm.utils import (
+    _add_path_to_api_base,
+    supports_response_schema,
+    supports_tool_choice,
+)
 
 
 class AzureFoundryErrorStrings(str, enum.Enum):
@@ -56,6 +60,62 @@ class AzureAIStudioConfig(OpenAIConfig):
             return xai_config._supports_stop_reason(model)
         return True
 
+    def _has_json_schema(self, response_format: dict) -> bool:
+        """Check if a response_format dict contains a JSON schema definition."""
+        return "response_schema" in response_format or "json_schema" in response_format
+
+    def _is_response_format_supported(self, model: str) -> bool:
+        """
+        Check if the model supports native response_format with json_schema.
+
+        Uses the supports_response_schema flag from model_prices_and_context_window.json
+        rather than hardcoding model names.
+        """
+        return supports_response_schema(
+            model=f"azure_ai/{model}",
+            custom_llm_provider="azure_ai",
+        )
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map OpenAI params with structured output handling for Azure AI Foundry.
+
+        For response_format with a JSON schema:
+        - If the model supports native structured output, pass through as-is.
+        - If not, convert the schema to a forced tool call (same fallback
+          used by Azure OpenAI).
+
+        For response_format without a schema (e.g. {"type": "json_object"}),
+        always pass through directly.
+        """
+        supported_openai_params = self.get_supported_openai_params(model)
+
+        for param, value in non_default_params.items():
+            if param not in supported_openai_params:
+                continue
+
+            if param == "response_format" and isinstance(value, dict):
+                if self._has_json_schema(value):
+                    is_supported = self._is_response_format_supported(model)
+                    optional_params = self._add_response_format_to_tools(
+                        optional_params=optional_params,
+                        value=value,
+                        is_response_format_supported=is_supported,
+                    )
+                else:
+                    # Plain json_object mode — pass through as-is
+                    optional_params["response_format"] = value
+            else:
+                optional_params[param] = value
+
+        return optional_params
+
     def validate_environment(
         self,
         headers: dict,
@@ -73,12 +133,8 @@ class AzureAIStudioConfig(OpenAIConfig):
                 headers["Authorization"] = f"Bearer {api_key}"
         else:
             # No api_key provided — fall back to Azure AD token-based auth
-            litellm_params_obj = GenericLiteLLMParams(
-                **(litellm_params if isinstance(litellm_params, dict) else {})
-            )
-            headers = BaseAzureLLM._base_validate_azure_environment(
-                headers=headers, litellm_params=litellm_params_obj
-            )
+            litellm_params_obj = GenericLiteLLMParams(**(litellm_params if isinstance(litellm_params, dict) else {}))
+            headers = BaseAzureLLM._base_validate_azure_environment(headers=headers, litellm_params=litellm_params_obj)
 
         headers["Content-Type"] = "application/json"
 

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -81,7 +81,7 @@ class AzureAIStudioConfig(OpenAIConfig):
         non_default_params: dict,
         optional_params: dict,
         model: str,
-        drop_params: bool,
+        drop_params: bool,  # unused: unsupported params are always silently skipped
     ) -> dict:
         """
         Map OpenAI params with structured output handling for Azure AI Foundry.

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -96,23 +96,32 @@ class AzureAIStudioConfig(OpenAIConfig):
         """
         supported_openai_params = self.get_supported_openai_params(model)
 
+        # Defer response_format processing until after all other params
+        # (especially tools) have been set, so that _add_response_format_to_tools
+        # can safely append the schema tool to the caller-supplied tools list
+        # without a later iteration overwriting it.
+        deferred_response_format: Optional[dict] = None
+
         for param, value in non_default_params.items():
             if param not in supported_openai_params:
                 continue
 
             if param == "response_format" and isinstance(value, dict):
-                if self._has_json_schema(value):
-                    is_supported = self._is_response_format_supported(model)
-                    optional_params = self._add_response_format_to_tools(
-                        optional_params=optional_params,
-                        value=value,
-                        is_response_format_supported=is_supported,
-                    )
-                else:
-                    # Plain json_object mode — pass through as-is
-                    optional_params["response_format"] = value
+                deferred_response_format = value
             else:
                 optional_params[param] = value
+
+        if deferred_response_format is not None:
+            if self._has_json_schema(deferred_response_format):
+                is_supported = self._is_response_format_supported(model)
+                optional_params = self._add_response_format_to_tools(
+                    optional_params=optional_params,
+                    value=deferred_response_format,
+                    is_response_format_supported=is_supported,
+                )
+            else:
+                # Plain json_object mode — pass through as-is
+                optional_params["response_format"] = deferred_response_format
 
         return optional_params
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5741,7 +5741,8 @@
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-11b-vision-instruct-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/Llama-3.2-90B-Vision-Instruct": {
         "input_cost_per_token": 2.04e-06,
@@ -5754,7 +5755,8 @@
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-90b-vision-instruct-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/Llama-3.3-70B-Instruct": {
         "input_cost_per_token": 7.1e-07,
@@ -5766,7 +5768,8 @@
         "output_cost_per_token": 7.1e-07,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.llama-3-3-70b-instruct-offer?tab=Overview",
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/Llama-4-Maverick-17B-128E-Instruct-FP8": {
         "input_cost_per_token": 1.41e-06,
@@ -5779,7 +5782,8 @@
         "source": "https://azure.microsoft.com/en-us/blog/introducing-the-llama-4-herd-in-azure-ai-foundry-and-azure-databricks/",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/Llama-4-Scout-17B-16E-Instruct": {
         "input_cost_per_token": 2e-07,
@@ -5792,7 +5796,8 @@
         "source": "https://azure.microsoft.com/en-us/blog/introducing-the-llama-4-herd-in-azure-ai-foundry-and-azure-databricks/",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/Meta-Llama-3-70B-Instruct": {
         "input_cost_per_token": 1.1e-06,
@@ -5802,7 +5807,8 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 3.7e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/Meta-Llama-3.1-405B-Instruct": {
         "input_cost_per_token": 5.33e-06,
@@ -5813,7 +5819,8 @@
         "mode": "chat",
         "output_cost_per_token": 1.6e-05,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-405b-instruct-offer?tab=PlansAndPrice",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/Meta-Llama-3.1-70B-Instruct": {
         "input_cost_per_token": 2.68e-06,
@@ -5824,7 +5831,8 @@
         "mode": "chat",
         "output_cost_per_token": 3.54e-06,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-70b-instruct-offer?tab=PlansAndPrice",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/Meta-Llama-3.1-8B-Instruct": {
         "input_cost_per_token": 3e-07,
@@ -5835,7 +5843,8 @@
         "mode": "chat",
         "output_cost_per_token": 6.1e-07,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-8b-instruct-offer?tab=PlansAndPrice",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3-medium-128k-instruct": {
         "input_cost_per_token": 1.7e-07,
@@ -5847,7 +5856,8 @@
         "output_cost_per_token": 6.8e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3-medium-4k-instruct": {
         "input_cost_per_token": 1.7e-07,
@@ -5859,7 +5869,8 @@
         "output_cost_per_token": 6.8e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3-mini-128k-instruct": {
         "input_cost_per_token": 1.3e-07,
@@ -5871,7 +5882,8 @@
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3-mini-4k-instruct": {
         "input_cost_per_token": 1.3e-07,
@@ -5883,7 +5895,8 @@
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3-small-128k-instruct": {
         "input_cost_per_token": 1.5e-07,
@@ -5895,7 +5908,8 @@
         "output_cost_per_token": 6e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3-small-8k-instruct": {
         "input_cost_per_token": 1.5e-07,
@@ -5907,7 +5921,8 @@
         "output_cost_per_token": 6e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3.5-MoE-instruct": {
         "input_cost_per_token": 1.6e-07,
@@ -5919,7 +5934,8 @@
         "output_cost_per_token": 6.4e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3.5-mini-instruct": {
         "input_cost_per_token": 1.3e-07,
@@ -5931,7 +5947,8 @@
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-3.5-vision-instruct": {
         "input_cost_per_token": 1.3e-07,
@@ -5943,7 +5960,8 @@
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-4": {
         "input_cost_per_token": 1.25e-07,
@@ -5956,7 +5974,8 @@
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/affordable-innovation-unveiling-the-pricing-of-phi-3-slms-on-models-as-a-service/4156495",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": false,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-4-mini-instruct": {
         "input_cost_per_token": 7.5e-08,
@@ -5967,7 +5986,8 @@
         "mode": "chat",
         "output_cost_per_token": 3e-07,
         "source": "https://techcommunity.microsoft.com/blog/Azure-AI-Services-blog/announcing-new-phi-pricing-empowering-your-business-with-small-language-models/4395112",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-4-multimodal-instruct": {
         "input_cost_per_audio_token": 4e-06,
@@ -5981,7 +6001,8 @@
         "source": "https://techcommunity.microsoft.com/blog/Azure-AI-Services-blog/announcing-new-phi-pricing-empowering-your-business-with-small-language-models/4395112",
         "supports_audio_input": true,
         "supports_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-4-mini-reasoning": {
         "input_cost_per_token": 8e-08,
@@ -5992,7 +6013,8 @@
         "mode": "chat",
         "output_cost_per_token": 3.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_response_schema": false
     },
     "azure_ai/Phi-4-reasoning": {
         "input_cost_per_token": 1.25e-07,
@@ -6005,7 +6027,8 @@
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_reasoning": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-document-ai-2505": {
         "litellm_provider": "azure_ai",
@@ -6014,7 +6037,8 @@
         "supported_endpoints": [
             "/v1/ocr"
         ],
-        "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry"
+        "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry",
+        "supports_response_schema": false
     },
     "azure_ai/mistral-document-ai-2512": {
         "litellm_provider": "azure_ai",
@@ -6023,7 +6047,8 @@
         "supported_endpoints": [
             "/v1/ocr"
         ],
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/",
+        "supports_response_schema": false
     },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
@@ -6062,7 +6087,8 @@
         "output_cost_per_token": 5.4e-06,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/cohere-rerank-v3-english": {
         "input_cost_per_query": 0.002,
@@ -6131,7 +6157,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/deepseek-v3.2-speciale": {
         "input_cost_per_token": 5.8e-07,
@@ -6145,7 +6172,8 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/deepseek-r1": {
         "input_cost_per_token": 1.35e-06,
@@ -6157,7 +6185,8 @@
         "output_cost_per_token": 5.4e-06,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/deepseek-r1-improved-performance-higher-limits-and-transparent-pricing/4386367",
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/deepseek-v3": {
         "input_cost_per_token": 1.14e-06,
@@ -6168,7 +6197,8 @@
         "mode": "chat",
         "output_cost_per_token": 4.56e-06,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/deepseek-v3-0324": {
         "input_cost_per_token": 1.14e-06,
@@ -6180,7 +6210,8 @@
         "output_cost_per_token": 4.56e-06,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/embed-v-4-0": {
         "input_cost_per_token": 1.2e-07,
@@ -6350,7 +6381,8 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 0.00971,
-        "source": "https://azure.microsoft.com/en-us/products/ai-services/ai-foundry/models/jais-30b-chat"
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/ai-foundry/models/jais-30b-chat",
+        "supports_response_schema": false
     },
     "azure_ai/jamba-instruct": {
         "input_cost_per_token": 5e-07,
@@ -6360,7 +6392,8 @@
         "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 7e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/kimi-k2.5": {
         "input_cost_per_token": 6e-07,
@@ -6374,7 +6407,8 @@
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/ministral-3b": {
         "input_cost_per_token": 4e-08,
@@ -6386,7 +6420,8 @@
         "output_cost_per_token": 4e-08,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.ministral-3b-2410-offer?tab=Overview",
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-large": {
         "input_cost_per_token": 4e-06,
@@ -6397,7 +6432,8 @@
         "mode": "chat",
         "output_cost_per_token": 1.2e-05,
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-large-2407": {
         "input_cost_per_token": 2e-06,
@@ -6409,7 +6445,8 @@
         "output_cost_per_token": 6e-06,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-large-latest": {
         "input_cost_per_token": 2e-06,
@@ -6421,7 +6458,8 @@
         "output_cost_per_token": 6e-06,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-large-3": {
         "input_cost_per_token": 5e-07,
@@ -6434,7 +6472,8 @@
         "source": "https://azure.microsoft.com/en-us/blog/introducing-mistral-large-3-in-microsoft-foundry-open-capable-and-ready-for-production-workloads/",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-medium-2505": {
         "input_cost_per_token": 4e-07,
@@ -6446,7 +6485,8 @@
         "output_cost_per_token": 2e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-nemo": {
         "input_cost_per_token": 1.5e-07,
@@ -6457,7 +6497,8 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-07,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-nemo-12b-2407?tab=PlansAndPrice",
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-small": {
         "input_cost_per_token": 1e-06,
@@ -6468,7 +6509,8 @@
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "supports_function_calling": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_response_schema": false
     },
     "azure_ai/mistral-small-2503": {
         "input_cost_per_token": 1e-07,
@@ -6480,7 +6522,8 @@
         "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_response_schema": false
     },
     "babbage-002": {
         "input_cost_per_token": 4e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6037,8 +6037,7 @@
         "supported_endpoints": [
             "/v1/ocr"
         ],
-        "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry",
-        "supports_response_schema": false
+        "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry"
     },
     "azure_ai/mistral-document-ai-2512": {
         "litellm_provider": "azure_ai",
@@ -6047,8 +6046,7 @@
         "supported_endpoints": [
             "/v1/ocr"
         ],
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/",
-        "supports_response_schema": false
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
     },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -312,3 +312,48 @@ class TestAzureAIStructuredOutput:
         tool_names = [t["function"]["name"] for t in result["tools"]]
         assert "get_weather" in tool_names
         assert RESPONSE_FORMAT_TOOL_NAME in tool_names
+
+    def test_should_append_to_existing_tools_regardless_of_param_order(self):
+        """
+        When response_format appears before tools in the params dict,
+        the schema tool should still be appended to the caller-supplied
+        tools list. This verifies there is no ordering-dependent bug
+        where tools would overwrite the injected schema tool.
+        """
+        config = AzureAIStudioConfig()
+
+        existing_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            }
+        ]
+
+        # Use a list of tuples to guarantee response_format comes before tools
+        from collections import OrderedDict
+
+        params = OrderedDict(
+            [
+                ("response_format", self.SAMPLE_JSON_SCHEMA),
+                ("tools", existing_tools),
+            ]
+        )
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=False,
+        ):
+            result = config.map_openai_params(
+                non_default_params=params,
+                optional_params={},
+                model="Mistral-7B",
+                drop_params=False,
+            )
+
+        assert len(result["tools"]) == 2, "Should have both the user's tool and the schema tool"
+        tool_names = [t["function"]["name"] for t in result["tools"]]
+        assert "get_weather" in tool_names
+        assert RESPONSE_FORMAT_TOOL_NAME in tool_names

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -5,9 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
+from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
 from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig
 
 
@@ -74,14 +73,17 @@ def test_azure_ai_validate_environment_with_azure_ad_token():
     import litellm
 
     config = AzureAIStudioConfig()
-    with patch(
-        "litellm.llms.azure.common_utils.get_azure_ad_token",
-        return_value="fake-azure-ad-token",
-    ), patch(
-        "litellm.llms.azure.common_utils.get_secret_str",
-        return_value=None,
-    ), patch.object(litellm, "api_key", None), patch.object(
-        litellm, "azure_key", None
+    with (
+        patch(
+            "litellm.llms.azure.common_utils.get_azure_ad_token",
+            return_value="fake-azure-ad-token",
+        ),
+        patch(
+            "litellm.llms.azure.common_utils.get_secret_str",
+            return_value=None,
+        ),
+        patch.object(litellm, "api_key", None),
+        patch.object(litellm, "azure_key", None),
     ):
         headers = config.validate_environment(
             headers={},
@@ -102,18 +104,211 @@ def test_azure_ai_grok_stop_parameter_handling():
     Test that Grok models properly handle stop parameter filtering in Azure AI Studio.
     """
     config = AzureAIStudioConfig()
-    
+
     # Test Grok model detection
     assert config._supports_stop_reason("grok-4-fast") == False
     assert config._supports_stop_reason("grok-4") == False
     assert config._supports_stop_reason("grok-3-mini") == False
     assert config._supports_stop_reason("grok-code-fast") == False
     assert config._supports_stop_reason("gpt-4") == True
-    
+
     # Test supported parameters for Grok models
     grok_params = config.get_supported_openai_params("grok-4-fast")
     assert "stop" not in grok_params, "Grok models should not support stop parameter"
-    
+
     # Test supported parameters for non-Grok models
     gpt_params = config.get_supported_openai_params("gpt-4")
     assert "stop" in gpt_params, "GPT models should support stop parameter"
+
+
+class TestAzureAIStructuredOutput:
+    """Tests for structured output (response_format) handling in Azure AI Foundry."""
+
+    SAMPLE_JSON_SCHEMA = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "UserProfile",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "age": {"type": "integer"},
+                },
+                "required": ["name", "age"],
+            },
+        },
+    }
+
+    def test_should_pass_through_response_format_for_supported_model(self):
+        """
+        When a model supports native structured output (supports_response_schema=True),
+        response_format should be passed through as-is without tool conversion.
+        """
+        config = AzureAIStudioConfig()
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=True,
+        ):
+            result = config.map_openai_params(
+                non_default_params={"response_format": self.SAMPLE_JSON_SCHEMA},
+                optional_params={},
+                model="claude-sonnet-4-5",
+                drop_params=False,
+            )
+
+        assert "response_format" in result, "response_format should be passed through for supported models"
+        assert result["response_format"] == self.SAMPLE_JSON_SCHEMA
+        assert "tools" not in result, "No tool conversion should occur for supported models"
+        assert "json_mode" not in result
+
+    def test_should_convert_to_tool_call_for_unsupported_model(self):
+        """
+        When a model does NOT support native structured output (supports_response_schema=False),
+        response_format should be converted to a forced tool call with the JSON schema.
+        """
+        config = AzureAIStudioConfig()
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=False,
+        ):
+            result = config.map_openai_params(
+                non_default_params={"response_format": self.SAMPLE_JSON_SCHEMA},
+                optional_params={},
+                model="Mistral-7B",
+                drop_params=False,
+            )
+
+        assert "response_format" not in result, "response_format should NOT be in params when using tool fallback"
+        assert "tools" in result, "A tool should be injected for schema enforcement"
+        assert len(result["tools"]) == 1
+
+        tool_function = result["tools"][0]["function"]
+        assert tool_function["name"] == RESPONSE_FORMAT_TOOL_NAME
+        assert tool_function["parameters"] == self.SAMPLE_JSON_SCHEMA["json_schema"]["schema"]
+
+        assert "tool_choice" in result, "tool_choice should be forced"
+        assert result["tool_choice"]["function"]["name"] == RESPONSE_FORMAT_TOOL_NAME
+
+        assert result.get("json_mode") is True
+
+    def test_should_pass_through_json_object_format_without_schema(self):
+        """
+        response_format={"type": "json_object"} (no schema) should always pass
+        through directly, regardless of model support for structured output.
+        """
+        config = AzureAIStudioConfig()
+
+        json_object_format = {"type": "json_object"}
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=False,
+        ):
+            result = config.map_openai_params(
+                non_default_params={"response_format": json_object_format},
+                optional_params={},
+                model="Mistral-7B",
+                drop_params=False,
+            )
+
+        assert result["response_format"] == json_object_format
+        assert "tools" not in result, "json_object mode should not trigger tool conversion"
+        assert "json_mode" not in result
+
+    def test_should_preserve_other_params_alongside_response_format(self):
+        """
+        Other params (temperature, max_tokens, etc.) should still be mapped
+        correctly when response_format is also present.
+        """
+        config = AzureAIStudioConfig()
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=True,
+        ):
+            result = config.map_openai_params(
+                non_default_params={
+                    "temperature": 0.7,
+                    "max_tokens": 500,
+                    "response_format": self.SAMPLE_JSON_SCHEMA,
+                },
+                optional_params={},
+                model="claude-sonnet-4-5",
+                drop_params=False,
+            )
+
+        assert result["temperature"] == 0.7
+        assert result["max_tokens"] == 500
+        assert result["response_format"] == self.SAMPLE_JSON_SCHEMA
+
+    def test_should_handle_response_schema_key_variant(self):
+        """
+        Some callers use 'response_schema' instead of 'json_schema' inside
+        the response_format dict. The tool fallback should handle both variants.
+        """
+        config = AzureAIStudioConfig()
+
+        response_format_with_response_schema = {
+            "type": "json_schema",
+            "response_schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        }
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=False,
+        ):
+            result = config.map_openai_params(
+                non_default_params={"response_format": response_format_with_response_schema},
+                optional_params={},
+                model="Phi-4",
+                drop_params=False,
+            )
+
+        assert "tools" in result, "Tool fallback should work with response_schema key"
+        tool_function = result["tools"][0]["function"]
+        assert tool_function["name"] == RESPONSE_FORMAT_TOOL_NAME
+        assert tool_function["parameters"] == response_format_with_response_schema["response_schema"]
+
+    def test_should_append_to_existing_tools(self):
+        """
+        When the user already provides tools and the model does not support
+        structured output, the schema tool should be appended to the existing
+        tools list (not replace it).
+        """
+        config = AzureAIStudioConfig()
+
+        existing_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            }
+        ]
+
+        with patch(
+            "litellm.llms.azure_ai.chat.transformation.supports_response_schema",
+            return_value=False,
+        ):
+            result = config.map_openai_params(
+                non_default_params={
+                    "tools": existing_tools,
+                    "response_format": self.SAMPLE_JSON_SCHEMA,
+                },
+                optional_params={},
+                model="Mistral-7B",
+                drop_params=False,
+            )
+
+        assert len(result["tools"]) == 2, "Should have both the user's tool and the schema tool"
+        tool_names = [t["function"]["name"] for t in result["tools"]]
+        assert "get_weather" in tool_names
+        assert RESPONSE_FORMAT_TOOL_NAME in tool_names


### PR DESCRIPTION
## Summary

Fixes structured output (`response_format` with JSON schema) for the `azure_ai` provider (Azure AI Foundry, `*.services.ai.azure.com` endpoints).

- `AzureAIStudioConfig` inherited a pure passthrough `map_openai_params()` from `OpenAIGPTConfig` with no structured output logic, causing API errors or silent schema-ignoring for most Foundry models
- Added `map_openai_params()` override that mirrors the existing `AzureOpenAIConfig` approach: native passthrough for supported models, tool call fallback via `_add_response_format_to_tools()` for unsupported models
- Added `supports_response_schema` flags for 43 previously-untagged `azure_ai` chat models in `model_prices_and_context_window.json`
- Added 6 unit tests covering all branches of the new logic

## Changes

- `litellm/llms/azure_ai/chat/transformation.py` — added `map_openai_params()` override
- `model_prices_and_context_window.json` — added `supports_response_schema: false` for 43 azure_ai chat models (Llama, Phi, Mistral, DeepSeek, JAIS, Jamba, Kimi, MAI-DS, Ministral)
- `tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py` — 6 new structured output tests, all passing

Closes #23280