### PR TITLE
fix(logging): log ConnectError details before retry

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -467,7 +467,7 @@ class AsyncHTTPHandler:
             response.raise_for_status()
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
-            verbose_logger.warning(f"ConnectError on POST {url}: {e}")
+            verbose_logger.warning(f"{type(e).__name__} on POST {url}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -540,7 +540,7 @@ class AsyncHTTPHandler:
             response.raise_for_status()
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
-            verbose_logger.warning(f"ConnectError on PUT {url}: {e}")
+            verbose_logger.warning(f"{type(e).__name__} on PUT {url}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -606,7 +606,8 @@ class AsyncHTTPHandler:
             response = await self.client.send(req)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
+            verbose_logger.warning(f"{type(e).__name__} on PATCH {url}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -672,7 +673,8 @@ class AsyncHTTPHandler:
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
+            verbose_logger.warning(f"{type(e).__name__} on DELETE {url}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -467,7 +467,7 @@ class AsyncHTTPHandler:
             response.raise_for_status()
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
-            verbose_logger.warning(f"{type(e).__name__} on POST {url}: {e}")
+            verbose_logger.warning(f"{type(e).__name__} on POST {mask_sensitive_info(url)}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -466,7 +466,8 @@ class AsyncHTTPHandler:
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
+            verbose_logger.warning(f"ConnectError on POST {url}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -538,7 +539,8 @@ class AsyncHTTPHandler:
             response = await self.client.send(req)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
+            verbose_logger.warning(f"ConnectError on PUT {url}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -540,7 +540,7 @@ class AsyncHTTPHandler:
             response.raise_for_status()
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError) as e:
-            verbose_logger.warning(f"{type(e).__name__} on PUT {url}: {e}")
+            verbose_logger.warning(f"{type(e).__name__} on PUT {mask_sensitive_info(url)}: {e}")
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks


### PR DESCRIPTION
## Summary
- Add verbose_logger.warning() to ConnectError/RemoteProtocolError catch blocks in AsyncHTTPHandler.apost() and put()
- These exceptions were silently caught and retried, making connection failures invisible in logs
- Enables searching logs for 'ConnectError on POST/PUT' to diagnose network issues

## Test plan
- [ ] Verify warning logs appear when a ConnectError occurs
- [ ] Verify no log noise during normal operation

Made with [Cursor](https://cursor.com)