### PR TITLE
feat(chat-ui): add MCP OAuth2 value prop and server auth badges

### DIFF
--- a/ui/litellm-dashboard/src/components/chat/ChatPage.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ChatPage.tsx
@@ -944,9 +944,19 @@ const ChatPage: React.FC<ChatPageProps> = ({ accessToken, userRole, userId, user
                   : greeting}
               </h1>
 
-              {isComparisonMode && (
+              {isComparisonMode ? (
                 <p style={{ margin: "-16px 0 24px", fontSize: 14, color: "#6b7280", textAlign: "center" }}>
                   Send a message to see responses side-by-side
+                </p>
+              ) : (
+                <p style={{ margin: "-16px 0 28px", fontSize: 14, color: "#6b7280", textAlign: "center", maxWidth: 520, lineHeight: 1.6 }}>
+                  Chat with 100+ LLMs + MCP tools — authenticate once, use them here.{" "}
+                  <button
+                    onClick={() => setSidebarView("apps")}
+                    style={{ background: "none", border: "none", cursor: "pointer", color: "#1677ff", fontSize: 14, padding: 0, fontWeight: 500 }}
+                  >
+                    Open Apps →
+                  </button>
                 </p>
               )}
 

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Switch, Spin, Input, Button } from "antd";
 import { SearchOutlined, ArrowLeftOutlined, RightOutlined } from "@ant-design/icons";
 import { fetchMCPServers, listMCPTools } from "../networking";
-import { MCPServer } from "../mcp_tools/types";
+import { AUTH_TYPE, MCPServer } from "../mcp_tools/types";
 import { message } from "antd";
 
 interface Props {
@@ -261,7 +261,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                 {isConnected && (
                   <span style={{ width: 7, height: 7, borderRadius: "50%", background: "#1677ff", flexShrink: 0 }} />
                 )}
-                {server.auth_type === "oauth2" && (
+                {server.auth_type === AUTH_TYPE.OAUTH2 && (
                   <span style={{
                     fontSize: 10, fontWeight: 600, color: "#7c3aed",
                     background: "#f3e8ff", borderRadius: 4, padding: "1px 5px",

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -174,7 +174,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
             }}>Beta</span>
           </div>
           <p style={{ margin: 0, fontSize: 13, color: "#6b7280" }}>
-            Connect tools to your chat.
+            Browse tools, authenticate once, use in chat — no setup needed.
           </p>
         </div>
         <Input
@@ -260,6 +260,15 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                 </div>
                 {isConnected && (
                   <span style={{ width: 7, height: 7, borderRadius: "50%", background: "#1677ff", flexShrink: 0 }} />
+                )}
+                {server.auth_type === "oauth2" && (
+                  <span style={{
+                    fontSize: 10, fontWeight: 600, color: "#7c3aed",
+                    background: "#f3e8ff", borderRadius: 4, padding: "1px 5px",
+                    letterSpacing: "0.03em", flexShrink: 0, whiteSpace: "nowrap",
+                  }}>
+                    OAuth2
+                  </span>
                 )}
                 <RightOutlined style={{ fontSize: 11, color: "#d1d5db", flexShrink: 0 }} />
               </div>


### PR DESCRIPTION
## Relevant issues
<img width="761" height="910" alt="Screenshot 2026-03-10 at 2 37 19 PM" src="https://github.com/user-attachments/assets/612dee93-85c1-4bf2-9dbe-c17b8acd2951" />

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

The chat UI exists so users don't have to build their own ChatGPT-style interface with MCP OAuth 2 — but that wasn't obvious from the UI. This makes it clearer.

- **Empty state**: adds a subtitle below the greeting explaining the value prop ("Chat with 100+ LLMs + MCP tools — authenticate once, use them here") with an "Open Apps →" link that switches the sidebar to the Apps view
- **MCPAppsPanel header**: updates the copy from "Connect tools to your chat." to "Browse tools, authenticate once, use in chat — no setup needed."
- **Server cards**: shows a purple `OAuth2` pill badge on cards where `auth_type === "oauth2"` so users know upfront that auth is required