### PR TITLE
feat(ui): show MCP tools per server in chat panel

### DIFF
--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Switch, Spin, Input, Button } from "antd";
-import { SearchOutlined, ArrowLeftOutlined, RightOutlined } from "@ant-design/icons";
+import { Spin, Input, Button, Skeleton } from "antd";
+import { SearchOutlined, ArrowLeftOutlined, RightOutlined, ToolOutlined } from "@ant-design/icons";
 import { fetchMCPServers, listMCPTools } from "../networking";
-import { MCPServer } from "../mcp_tools/types";
+import { MCPServer, MCPTool, handleTransport } from "../mcp_tools/types";
 import { message } from "antd";
 
 interface Props {
@@ -33,33 +33,65 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
   const [activeTab, setActiveTab] = useState<TabKey>("all");
   const [togglingOn, setTogglingOn] = useState<Set<string>>(new Set());
   const [detailServer, setDetailServer] = useState<MCPServer | null>(null);
+  const [detailTools, setDetailTools] = useState<MCPTool[]>([]);
+  const [loadingTools, setLoadingTools] = useState(false);
+  // tool counts per server name, preloaded in background
+  const [toolCounts, setToolCounts] = useState<Record<string, number>>({});
+  const [loadingCounts, setLoadingCounts] = useState(false);
+
+  const nameOf = (s: MCPServer) => s.server_name ?? s.alias ?? s.server_id;
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+
+    // 1. Load servers first — show the list immediately
     fetchMCPServers(accessToken)
-      .then((data) => {
+      .then((serverData) => {
         if (cancelled) return;
-        const list: MCPServer[] = Array.isArray(data) ? data : (data?.data ?? []);
+        const list: MCPServer[] = Array.isArray(serverData) ? serverData : (serverData?.data ?? []);
         setServers(list);
+        setLoading(false);
+
+        // 2. Fetch tools per server in parallel — each resolves independently and updates counts one by one
+        setLoadingCounts(true);
+        let remaining = list.length;
+        if (remaining === 0) { setLoadingCounts(false); return; }
+        list.forEach((s) => {
+          listMCPTools(accessToken, s.server_id)
+            .then((toolsData) => {
+              if (cancelled) return;
+              const tools: MCPTool[] = Array.isArray(toolsData?.tools) ? toolsData.tools : [];
+              const sname = nameOf(s);
+              setToolCounts((prev) => ({ ...prev, [sname]: tools.length }));
+            })
+            .catch(() => {})
+            .finally(() => {
+              if (cancelled) return;
+              remaining -= 1;
+              if (remaining === 0) setLoadingCounts(false);
+            });
+        });
       })
       .catch(() => {
-        if (!cancelled) setServers([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setServers([]);
+          setLoading(false);
+        }
       });
     return () => { cancelled = true; };
   }, [accessToken]);
 
-  const handleToggle = async (serverName: string, checked: boolean) => {
+  const handleToggle = async (serverName: string, checked: boolean, serverId?: string) => {
     if (!checked) {
       onChange(selectedServers.filter((s) => s !== serverName));
       return;
     }
     setTogglingOn((prev) => new Set(prev).add(serverName));
     try {
-      const result = await listMCPTools(accessToken, serverName);
+      // Use UUID if available, fall back to name (for connectivity check only)
+      const idToFetch = serverId ?? serverName;
+      const result = await listMCPTools(accessToken, idToFetch);
       if (result?.error) {
         message.warning(`Could not load tools for ${serverName}`);
         return;
@@ -76,7 +108,29 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
     }
   };
 
-  const nameOf = (s: MCPServer) => s.server_name ?? s.alias ?? s.server_id;
+  // Fetch tools for the detail view — server_id must be the UUID
+  useEffect(() => {
+    if (!detailServer) {
+      setDetailTools([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingTools(true);
+    listMCPTools(accessToken, detailServer.server_id)
+      .then((result) => {
+        if (cancelled) return;
+        // API returns { tools: [...], error: null }
+        const tools: MCPTool[] = Array.isArray(result?.tools) ? result.tools : [];
+        setDetailTools(tools);
+      })
+      .catch(() => {
+        if (!cancelled) setDetailTools([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTools(false);
+      });
+    return () => { cancelled = true; };
+  }, [detailServer, accessToken]);
 
   const filtered = servers.filter((s) => {
     const name = nameOf(s);
@@ -88,6 +142,9 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
   });
 
   const connectedCount = servers.filter((s) => selectedServers.includes(nameOf(s))).length;
+
+  // Total tools available across all servers (based on preloaded counts)
+  const totalTools = Object.values(toolCounts).reduce((sum, n) => sum + n, 0);
 
   // ── Detail view ──
   if (detailServer) {
@@ -128,7 +185,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
           <Button
             type={isConnected ? "default" : "primary"}
             loading={isTogglingOn}
-            onClick={() => handleToggle(name, !isConnected)}
+            onClick={() => handleToggle(name, !isConnected, detailServer.server_id)}
             style={{ borderRadius: 8, fontWeight: 600, height: 38, minWidth: 110 }}
           >
             {isConnected ? "Disconnect" : "Connect"}
@@ -137,10 +194,10 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
 
         {/* Info table */}
         <h3 style={{ margin: "0 0 12px", fontSize: 15, fontWeight: 600, color: "#111827" }}>Information</h3>
-        <div style={{ border: "1px solid #e5e7eb", borderRadius: 10, overflow: "hidden" }}>
+        <div style={{ border: "1px solid #e5e7eb", borderRadius: 10, overflow: "hidden", marginBottom: 28 }}>
           {[
             ["Server ID", detailServer.server_id],
-            ["Transport", (detailServer as MCPServer & { mcp_info?: { server_url?: string } }).mcp_info?.server_url ? "HTTP" : "stdio"],
+            ["Transport", handleTransport(detailServer.transport, detailServer.spec_path)],
             ["Status", isConnected ? "Connected" : "Not connected"],
           ].filter(([, v]) => v).map(([label, value], i, arr) => (
             <div key={label} style={{
@@ -154,6 +211,43 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
             </div>
           ))}
         </div>
+
+        {/* Tools section */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: "#111827" }}>Available Tools</h3>
+          {!loadingTools && (
+            <span style={{
+              fontSize: 11, fontWeight: 600, color: "#6b7280",
+              background: "#f3f4f6", borderRadius: 4, padding: "1px 6px",
+            }}>{detailTools.length}</span>
+          )}
+        </div>
+        {loadingTools ? (
+          <div style={{ display: "flex", justifyContent: "center", padding: "24px 0" }}>
+            <Spin size="small" />
+          </div>
+        ) : detailTools.length === 0 ? (
+          <div style={{ color: "#9ca3af", fontSize: 13, padding: "8px 0" }}>
+            No tools available
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {detailTools.map((tool) => (
+              <div key={tool.name} style={{
+                border: "1px solid #e5e7eb", borderRadius: 8,
+                padding: "10px 14px", background: "#fafafa",
+              }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: tool.description ? 4 : 0 }}>
+                  <ToolOutlined style={{ fontSize: 13, color: "#6b7280" }} />
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "#111827", fontFamily: "monospace" }}>{tool.name}</span>
+                </div>
+                {tool.description && (
+                  <p style={{ margin: 0, fontSize: 12, color: "#6b7280", paddingLeft: 21 }}>{tool.description}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }
@@ -165,7 +259,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
       {/* Header row */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20, gap: 16, flexWrap: "wrap" }}>
         <div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 2 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
             <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: "#111827" }}>MCP Servers</h2>
             <span style={{
               fontSize: 10, fontWeight: 600, color: "#1677ff",
@@ -173,9 +267,22 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
               letterSpacing: "0.05em", textTransform: "uppercase",
             }}>Beta</span>
           </div>
-          <p style={{ margin: 0, fontSize: 13, color: "#6b7280" }}>
-            Connect tools to your chat.
-          </p>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <p style={{ margin: 0, fontSize: 13, color: "#6b7280" }}>
+              Connect tools to your chat.
+            </p>
+            {loadingCounts ? (
+              <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 12, color: "#9ca3af" }}>
+                <Spin size="small" style={{ transform: "scale(0.7)" }} />
+                Loading tools...
+              </span>
+            ) : totalTools > 0 ? (
+              <span style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12, color: "#6b7280" }}>
+                <ToolOutlined style={{ fontSize: 11 }} />
+                {totalTools} tool{totalTools !== 1 ? "s" : ""} available
+              </span>
+            ) : null}
+          </div>
         </div>
         <Input
           prefix={<SearchOutlined style={{ color: "#9ca3af", fontSize: 13 }} />}
@@ -227,6 +334,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
             const isConnected = selectedServers.includes(name);
             const color = getAvatarColor(name);
             const isLeftCol = idx % 2 === 0;
+            const count = toolCounts[name];
 
             return (
               <div
@@ -254,8 +362,19 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                   <div style={{ fontSize: 14, fontWeight: 500, color: "#111827", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {name}
                   </div>
-                  <div style={{ fontSize: 12, color: "#9ca3af", marginTop: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {server.description ?? "MCP server"}
+                  <div style={{ fontSize: 12, color: "#9ca3af", marginTop: 1, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {server.description ?? "MCP server"}
+                    </span>
+                    {count !== undefined ? (
+                      count > 0 ? (
+                        <span style={{ flexShrink: 0, display: "flex", alignItems: "center", gap: 3, color: "#9ca3af" }}>
+                          · <ToolOutlined style={{ fontSize: 10 }} /> {count}
+                        </span>
+                      ) : null
+                    ) : loadingCounts ? (
+                      <Skeleton.Input active size="small" style={{ width: 28, height: 12, minWidth: 28, flexShrink: 0 }} />
+                    ) : null}
                   </div>
                 </div>
                 {isConnected && (


### PR DESCRIPTION
## feat(ui): show MCP tools per server in chat panel



<img width="639" height="602" alt="Screenshot 2026-03-10 at 2 38 00 PM" src="https://github.com/user-attachments/assets/df232b04-96d6-499a-9d46-c0741075f9a8" />

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

Two fixes to the MCP panel in the chat (ChatGPT-style) UI:

**Transport display** — was hardcoded as `server_url ? "HTTP" : "stdio"`. Now uses `handleTransport()` so it correctly shows sse/http/stdio/openapi based on the actual `transport` field.

**Tools list** — clicking into an MCP server now shows the tools you have access to on that server. Tool counts also appear on each card in the grid.

The tool counts load in the background after the server list appears — one request per server fired in parallel, so each card's count pops in independently as its server responds. Skeleton placeholder shows on cards still waiting.

Bug fix: `/mcp-rest/tools/list?server_id=` requires the UUID, not the server name. Passing the name was always returning `access_denied`. Fixed to use `server.server_id`.