### PR TITLE
fix(router): handle num_retries=None to prevent TypeError in retry logic

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2108,7 +2108,7 @@ class Router:
         - litellm_trace_id
         - metadata
         """
-        kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+        kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
         kwargs.setdefault("litellm_trace_id", str(uuid.uuid4()))
         model_group_alias: Optional[str] = None
         if self._get_model_from_alias(model=model):
@@ -2848,7 +2848,7 @@ class Router:
             kwargs["model"] = model
             kwargs["prompt"] = prompt
             kwargs["original_function"] = self._image_generation
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             kwargs.setdefault("metadata", {}).update({"model_group": model})
             response = self.function_with_fallbacks(**kwargs)
 
@@ -2907,7 +2907,7 @@ class Router:
             kwargs["model"] = model
             kwargs["prompt"] = prompt
             kwargs["original_function"] = self._aimage_generation
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -3270,7 +3270,7 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["prompt"] = prompt
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             kwargs.setdefault("metadata", {}).update({"model_group": model})
 
             # pick the one that is available (lowest TPM/RPM)
@@ -3414,7 +3414,7 @@ class Router:
             kwargs["model"] = model
             kwargs["adapter_id"] = adapter_id
             kwargs["original_function"] = self._aadapter_completion
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             kwargs.setdefault("metadata", {}).update({"model_group": model})
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -4011,7 +4011,7 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["original_function"] = self._acreate_file
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -4280,7 +4280,7 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["original_function"] = self._acreate_batch
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             metadata_variable_name = _get_router_metadata_variable_name(
                 function_name="_acreate_batch"
             )
@@ -4514,7 +4514,7 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["original_function"] = self._acancel_batch
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
+            kwargs["num_retries"] = kwargs.get("num_retries") if kwargs.get("num_retries") is not None else self.num_retries
             metadata_variable_name = _get_router_metadata_variable_name(
                 function_name="_acancel_batch"
             )
@@ -5383,7 +5383,9 @@ class Router:
             "model_group_retry_policy", self.model_group_retry_policy
         )
         model_group: Optional[str] = kwargs.get("model")
-        num_retries = kwargs.pop("num_retries")
+        num_retries = kwargs.pop("num_retries", self.num_retries)
+        if num_retries is None:
+            num_retries = self.num_retries
 
         ## ADD MODEL GROUP SIZE TO METADATA - used for model_group_rate_limit_error tracking
         _metadata: dict = kwargs.get("litellm_metadata", kwargs.get("metadata")) or {}


### PR DESCRIPTION
## Summary

Fixes #23316

When `num_retries` is `None` (either passed explicitly by the caller or through certain proxy/SDK configurations), the comparison `if num_retries > 0` in `async_function_with_retries` raises:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

### Root cause

`kwargs.get("num_retries", self.num_retries)` returns `None` when the key exists in `kwargs` with an explicit `None` value — Python's `dict.get()` only uses the default when the key is **missing**, not when the value is `None`. This bypasses the fallback to `self.num_retries` (which is always set to a valid int in `Router.__init__`).

### Fix

- All 8 call sites that set `kwargs["num_retries"]` now use an explicit `is not None` check instead of relying on `dict.get()`'s default parameter.
- Added a `None` guard in `async_function_with_retries` where `num_retries` is popped from kwargs, falling back to `self.num_retries`.

### Affected methods

`_update_kwargs_before_fallbacks`, `image_generation`, `aimage_generation`, `atext_completion`, `aadapter_completion`, `acreate_file`, `acreate_batch`, `acancel_batch`

## Test plan

- [ ] Verify that requests with `num_retries=None` no longer raise `TypeError`
- [ ] Verify that explicit `num_retries=0` still disables retries (not overridden by fallback)
- [ ] Verify that requests without `num_retries` in kwargs still use `self.num_retries` as default