### PR TITLE
fix(mcp): sync description into mcp_info on update

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -350,8 +350,71 @@ async def update_mcp_server(
     """
     Update a new mcp server record in the db
     """
+    from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
     # Use helper to prepare data with proper JSON serialization
     data_dict = _prepare_mcp_server_data(data)
+
+    # Keep user-editable description consistent across the record.
+    #
+    # The API has a top-level `description` column and a nested `mcp_info.description`
+    # (discovered/metadata). UIs may read either field. Whenever the caller explicitly
+    # sets `description`, sync it into `mcp_info.description` so downstream consumers
+    # reading `mcp_info` do not see stale data.
+    #
+    # NOTE: The branch that reads existing `mcp_info` from the DB is a
+    # read–modify–write sequence (find_unique → mutate → update) and therefore
+    # not atomic. A concurrent update that touches `mcp_info` between the read
+    # and write can be overwritten by the stale snapshot. For the low-traffic
+    # management endpoints that call this helper the practical risk is small,
+    # but callers should be aware this is not a transactional merge.
+    if data.description is not None:
+        if data.mcp_info is not None:
+            # Caller supplied mcp_info — merge description in without a DB round-trip.
+            # Use model_dump() (without exclude_none) to match _prepare_mcp_server_data
+            # / safe_dumps behaviour and preserve explicit nulls.
+            if isinstance(data.mcp_info, dict):
+                merged: Dict[str, Any] = dict(data.mcp_info)
+            else:
+                merged = data.mcp_info.model_dump()  # type: ignore[call-arg]
+            merged["description"] = data.description
+            data_dict["mcp_info"] = safe_dumps(merged)
+        else:
+            existing = await prisma_client.db.litellm_mcpservertable.find_unique(
+                where={"server_id": data.server_id}
+            )
+            existing_mcp_info: Dict[str, Any] = {}
+            if existing is not None and getattr(existing, "mcp_info", None):
+                # Prisma returns JSON fields as dict-like objects
+                existing_mcp_info = cast(Dict[str, Any], existing.mcp_info)
+
+            updated_mcp_info = dict(existing_mcp_info)
+            updated_mcp_info["description"] = data.description
+            data_dict["mcp_info"] = safe_dumps(updated_mcp_info)
+    elif data.mcp_info is not None:
+        # Caller is updating only mcp_info. To keep it consistent with the
+        # authoritative top-level description column, merge the current
+        # description from the DB back into mcp_info.description.
+        #
+        # This ensures that discovery refreshes which send new mcp_info metadata
+        # do not silently overwrite the last user-edited description that was
+        # previously synced into mcp_info.
+        existing = await prisma_client.db.litellm_mcpservertable.find_unique(
+            where={"server_id": data.server_id}
+        )
+        existing_description: Optional[str] = None
+        if existing is not None:
+            existing_description = getattr(existing, "description", None)
+
+        # Only override mcp_info.description when we have an authoritative
+        # top-level description to sync; otherwise preserve caller-supplied value.
+        if existing_description is not None:
+            if isinstance(data.mcp_info, dict):
+                merged_info: Dict[str, Any] = dict(data.mcp_info)
+            else:
+                merged_info = data.mcp_info.model_dump()  # type: ignore[call-arg]
+            merged_info["description"] = existing_description
+            data_dict["mcp_info"] = safe_dumps(merged_info)
 
     # Add audit fields
     data_dict["updated_by"] = touched_by

--- a/tests/store_model_in_db_tests/test_mcp_servers.py
+++ b/tests/store_model_in_db_tests/test_mcp_servers.py
@@ -28,6 +28,112 @@ from litellm.proxy.management_endpoints.mcp_management_endpoints import (
 TEST_MASTER_KEY = os.getenv("LITELLM_MASTER_KEY", "sk-1234")
 
 
+@pytest.mark.asyncio
+async def test_update_mcp_server_syncs_description_into_mcp_info():
+    """
+    Regression test: when updating only top-level description, keep mcp_info.description in sync.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+    import json
+
+    from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+
+    server_id = str(uuid.uuid4())
+
+    existing = LiteLLM_MCPServerTable(
+        server_id=server_id,
+        alias="Existing Server",
+        url="https://example.com/mcp",
+        transport=MCPTransport.sse,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        teams=[],
+    )
+    existing.mcp_info = {
+        "server_name": "github",
+        "description": "old discovery description",
+        "mcp_server_cost_info": {"default_cost_per_query": 0},
+    }
+
+    updated = generate_mcpserver_record(url="https://example.com/mcp", transport=MCPTransport.sse)
+    updated.server_id = server_id
+
+    prisma_client = MagicMock()
+    prisma_client.db = MagicMock()
+    prisma_client.db.litellm_mcpservertable = MagicMock()
+    prisma_client.db.litellm_mcpservertable.find_unique = AsyncMock(return_value=existing)
+    prisma_client.db.litellm_mcpservertable.update = AsyncMock(return_value=updated)
+
+    payload = UpdateMCPServerRequest(
+        server_id=server_id,
+        description="sample description",
+    )
+
+    await update_mcp_server(prisma_client=prisma_client, data=payload, touched_by="test-user")
+
+    # Verify update() was called with mcp_info whose description was synced
+    _kwargs = prisma_client.db.litellm_mcpservertable.update.call_args.kwargs
+    data_dict = _kwargs["data"]
+    assert "mcp_info" in data_dict
+
+    mcp_info_json = data_dict["mcp_info"]
+    mcp_info = json.loads(mcp_info_json)
+    assert mcp_info["description"] == "sample description"
+    assert mcp_info["server_name"] == "github"
+    assert mcp_info["mcp_server_cost_info"] == {"default_cost_per_query": 0}
+
+
+@pytest.mark.asyncio
+async def test_update_mcp_server_merges_description_into_caller_mcp_info():
+    """
+    When callers send both description and mcp_info together, merge description into
+    mcp_info.description without losing other caller-supplied fields (including explicit nulls).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+    import json
+
+    from litellm.proxy._experimental.mcp_server.db import update_mcp_server
+
+    server_id = str(uuid.uuid4())
+
+    # Existing record is not consulted in this branch (mcp_info provided),
+    # but we still need a stub for the update() return value.
+    existing = generate_mcpserver_record(url="https://example.com/mcp", transport=MCPTransport.sse)
+    existing.server_id = server_id
+
+    prisma_client = MagicMock()
+    prisma_client.db = MagicMock()
+    prisma_client.db.litellm_mcpservertable = MagicMock()
+    prisma_client.db.litellm_mcpservertable.find_unique = AsyncMock(return_value=None)
+    prisma_client.db.litellm_mcpservertable.update = AsyncMock(return_value=existing)
+
+    payload = UpdateMCPServerRequest(
+        server_id=server_id,
+        description="user-facing description",
+        mcp_info={
+            "server_name": "github",
+            "description": "caller-supplied discovery description",
+            "mcp_server_cost_info": None,
+        },
+    )
+
+    await update_mcp_server(prisma_client=prisma_client, data=payload, touched_by="test-user")
+
+    _kwargs = prisma_client.db.litellm_mcpservertable.update.call_args.kwargs
+    data_dict = _kwargs["data"]
+    assert "mcp_info" in data_dict
+
+    mcp_info_json = data_dict["mcp_info"]
+    mcp_info = json.loads(mcp_info_json)
+
+    # description is replaced with the authoritative top-level description
+    assert mcp_info["description"] == "user-facing description"
+    # other fields from caller mcp_info are preserved, including explicit nulls
+    assert mcp_info["server_name"] == "github"
+    assert "mcp_server_cost_info" in mcp_info
+    assert mcp_info["mcp_server_cost_info"] is None
+
+
 def generate_mcpserver_record(
     url: Optional[str] = None, transport: Optional[MCPTransportType] = None
 ) -> LiteLLM_MCPServerTable:

--- a/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import PublicModelHub from "./public_model_hub";
 
 vi.mock("next/navigation", () => ({
@@ -63,6 +63,45 @@ describe("PublicModelHub", () => {
   it("renders", () => {
     const { container } = render(<PublicModelHub />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("should prefer server.description over mcp_info.description for MCP hub display", async () => {
+    const networkingModule = await import("./networking");
+
+    vi.mocked(networkingModule.mcpHubPublicServersCall).mockResolvedValue([
+      {
+        server_id: "server-1",
+        server_name: "github",
+        name: "github",
+        description: "sample description",
+        url: "https://api.githubcopilot.com/mcp/",
+        transport: "sse",
+        auth_type: "bearer_token",
+        mcp_info: {
+          server_name: "github",
+          description: "Manage repos, issues, PRs, and workflows through natural language",
+        },
+      } as any,
+    ]);
+
+    render(<PublicModelHub />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "MCP Hub" })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: "MCP Hub" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Available MCP Servers")).toBeInTheDocument();
+    });
+
+    // Table should display the user-edited description (top-level field)
+    await waitFor(() => {
+      expect(screen.getByText("sample description")).toBeInTheDocument();
+    });
   });
 
   it("displays health status correctly for models with health check information", async () => {

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -74,6 +74,7 @@ interface MCPServerData {
   server_id: string;
   name: string;
   alias?: string | null;
+  description?: string | null;
   server_name: string;
   url: string;
   transport: string;
@@ -894,10 +895,13 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     },
     {
       header: "Description",
-      accessorKey: "mcp_info.description",
+      accessorKey: "description",
       enableSorting: false,
       cell: ({ row }) => {
-        const description = row.original.mcp_info?.description || "-";
+        const description =
+          row.original.description ||
+          row.original.mcp_info?.description ||
+          "-";
         const truncated = description.length > 80 ? description.substring(0, 80) + "..." : description;
         return (
           <Tooltip title={description}>
@@ -1879,7 +1883,7 @@ print(response.model_dump(mode='json', exclude_none=True))`;
                   </div>
                   <div className="col-span-2">
                     <Text className="font-medium">Description:</Text>
-                    <Text>{selectedMcpServer.mcp_info?.description || "-"}</Text>
+                    <Text>{selectedMcpServer.description || selectedMcpServer.mcp_info?.description || "-"}</Text>
                   </div>
                   <div className="col-span-2">
                     <Text className="font-medium">URL:</Text>


### PR DESCRIPTION
## Summary
- Sync top-level MCP server `description` into `mcp_info.description` when updating description only, keeping UI views consistent.
- In Public Model Hub, prefer user-set `description` with fallback to `mcp_info.description`.
- Add backend + UI regression tests.

## Test plan
- [x] `poetry run pytest -q tests/store_model_in_db_tests/test_mcp_servers.py::test_update_mcp_server_syncs_description_into_mcp_info`
- [x] `cd ui/litellm-dashboard && npx vitest run src/components/public_model_hub.test.tsx`
