### PR TITLE
fix(ui): import MCPEvent type into local scope in chat/types.ts

### DIFF
--- a/ui/litellm-dashboard/src/components/chat/types.ts
+++ b/ui/litellm-dashboard/src/components/chat/types.ts
@@ -1,4 +1,5 @@
-export type { MCPEvent } from "../mcp_tools/types";
+import type { MCPEvent } from "../mcp_tools/types";
+export type { MCPEvent };
 
 export interface ChatMessage {
   id: string;


### PR DESCRIPTION
## Summary

- Fixed TypeScript build error `Cannot find name 'MCPEvent'` in `ui/litellm-dashboard/src/components/chat/types.ts`
- Changed `export type { MCPEvent }` to an explicit import + re-export so the type is in local scope before use

**Root cause:** The file referenced `MCPEvent[]` in the `ChatMessage` interface body, but the type was only re-exported (not imported into scope), causing the TypeScript compiler to fail with `Cannot find name 'MCPEvent'` during `npm run build`.

**Impact:** This was breaking the Docker image build in the `test_bad_database_url` CircleCI job (the build step compiles the Next.js UI).

## Test plan

- [ ] Docker image builds successfully (`npm run build` passes in the UI)
- [ ] `test_bad_database_url` CircleCI job passes