### PR TITLE
fix(mcp): sync description into mcp_info on update

### DIFF
--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -894,10 +894,13 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     },
     {
       header: "Description",
-      accessorKey: "mcp_info.description",
+      accessorKey: "description",
       enableSorting: false,
       cell: ({ row }) => {
-        const description = row.original.mcp_info?.description || "-";
+        const description =
+          row.original.description ||
+          row.original.mcp_info?.description ||
+          "-";
         const truncated = description.length > 80 ? description.substring(0, 80) + "..." : description;
         return (
           <Tooltip title={description}>


### PR DESCRIPTION
## Summary
- Keep top-level MCP server `description` and nested `mcp_info.description` in sync in both directions so user-edited descriptions remain the single source of truth across UI and API consumers.
- When callers update only `description`, merge it into `mcp_info.description` without touching other `mcp_info` fields.
- When callers update only `mcp_info`, preserve the authoritative top-level `description` by merging it back into `mcp_info.description` instead of overwriting it with discovery metadata.
- Add regression tests for all branches of the sync logic and update the Public Model Hub UI to align column accessors with the new behavior.

## Test plan
- [x] poetry run pytest -q tests/store_model_in_db_tests/test_mcp_servers.py::test_update_mcp_server_syncs_description_into_mcp_info
- [x] poetry run pytest -q tests/store_model_in_db_tests/test_mcp_servers.py::test_update_mcp_server_merges_description_into_caller_mcp_info
- [x] poetry run pytest -q tests/store_model_in_db_tests/test_mcp_servers.py::test_update_mcp_server_preserves_user_description_when_only_mcp_info_updated
- [x] poetry run pytest -q tests/store_model_in_db_tests/test_mcp_servers.py::test_create_mcp_server_syncs_description_into_mcp_info_on_create
- [x] cd ui/litellm-dashboard && npx vitest run src/components/public_model_hub.test.tsx
