### PR TITLE
Fix: OTEL metrics crash on /v1/messages when LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -834,12 +834,16 @@ class OpenTelemetry(CustomLogger):
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
         duration_s = (end_time - start_time).total_seconds()
         params = kwargs.get("litellm_params") or {}
-        provider = params.get("custom_llm_provider", "Unknown")
+        provider = (
+            params.get("custom_llm_provider")
+            or kwargs.get("custom_llm_provider")
+            or "Unknown"
+        )
 
         common_attrs = {
             "gen_ai.operation.name": "chat",
             "gen_ai.system": provider,
-            "gen_ai.request.model": kwargs.get("model"),
+            "gen_ai.request.model": kwargs.get("model") or "Unknown",
             "gen_ai.framework": "litellm",
         }
 
@@ -1087,8 +1091,10 @@ class OpenTelemetry(CustomLogger):
         otel_logger = get_logger(LITELLM_LOGGER_NAME)
 
         parent_ctx = span.get_span_context()
-        provider = (kwargs.get("litellm_params") or {}).get(
-            "custom_llm_provider", "Unknown"
+        provider = (
+            (kwargs.get("litellm_params") or {}).get("custom_llm_provider")
+            or kwargs.get("custom_llm_provider")
+            or "Unknown"
         )
 
         # per-message events
@@ -1611,9 +1617,8 @@ class OpenTelemetry(CustomLogger):
             # the litellm call ID so every call type can be correlated
             # across LiteLLM UI, Phoenix traces, and provider logs (Issue #8).
             response_id = (
-                (response_obj.get("id") if response_obj else None)
-                or standard_logging_payload.get("id")
-            )
+                response_obj.get("id") if response_obj else None
+            ) or standard_logging_payload.get("id")
             if response_id:
                 self.safe_set_attribute(
                     span=span,

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -3,7 +3,7 @@ import os
 import sys
 import time
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from unittest.mock import MagicMock, patch
 
 # Adds the grandparent directory to sys.path to allow importing project modules
@@ -920,6 +920,79 @@ class TestOpenTelemetry(unittest.TestCase):
 
         mock_tracer.start_span.assert_not_called()
 
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True)
+    def test_record_metrics_with_none_custom_llm_provider(self):
+        """Test that _record_metrics does not pass None attributes to OTEL histograms."""
+        metric_reader = InMemoryMetricReader()
+        meter_provider = MeterProvider(metric_readers=[metric_reader])
+ 
+        otel = OpenTelemetry(meter_provider=meter_provider)
+ 
+        # Simulate kwargs as produced by the /v1/messages endpoint:
+        kwargs_with_none_provider = {
+            "litellm_params": {
+                "custom_llm_provider": None,
+                "metadata": {},
+            },
+            "custom_llm_provider": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+            "standard_logging_object": {"metadata": {}},
+        }
+ 
+        start = datetime.now(UTC)
+        end = start + timedelta(seconds=0.5)
+ 
+        # Should not raise
+        otel._record_metrics(
+            kwargs_with_none_provider, {"usage": {"prompt_tokens": 10, "completion_tokens": 5}}, start, end
+        )
+ 
+        # Verify the metric was recorded with the correct provider from kwargs fallback
+        metrics_data = metric_reader.get_metrics_data()
+        found_provider = False
+        for resource_metric in metrics_data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == "gen_ai.client.operation.duration":
+                        for dp in metric.data.data_points:
+                            if dp.attributes.get("gen_ai.system") == "anthropic":
+                                found_provider = True
+        self.assertTrue(found_provider, "Expected gen_ai.system=anthropic from kwargs fallback")
+ 
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True)
+    def test_record_metrics_falls_back_to_unknown_when_provider_missing(self):
+        """Test that _record_metrics uses 'Unknown' when custom_llm_provider is absent everywhere."""
+        metric_reader = InMemoryMetricReader()
+        meter_provider = MeterProvider(metric_readers=[metric_reader])
+ 
+        otel = OpenTelemetry(meter_provider=meter_provider)
+ 
+        kwargs_no_provider = {
+            "litellm_params": {
+                "custom_llm_provider": None,
+                "metadata": {},
+            },
+            "model": None,
+            "standard_logging_object": {"metadata": {}},
+        }
+ 
+        start = datetime.now(UTC)
+        end = start + timedelta(seconds=0.5)
+ 
+        # Should not raise
+        otel._record_metrics(kwargs_no_provider, {"usage": {"prompt_tokens": 1, "completion_tokens": 1}}, start, end)
+ 
+        # Verify fallback to "Unknown"
+        metrics_data = metric_reader.get_metrics_data()
+        found_unknown = False
+        for resource_metric in metrics_data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == "gen_ai.client.operation.duration":
+                        for dp in metric.data.data_points:
+                            if dp.attributes.get("gen_ai.system") == "Unknown" and dp.attributes.get("gen_ai.request.model") == "Unknown":
+                                found_unknown = True
+        self.assertTrue(found_unknown, "Expected gen_ai.system=Unknown and gen_ai.request.model=Unknown as fallback")
 
 class TestOpenTelemetryHeaderSplitting(unittest.TestCase):
     """Test suite for _get_headers_dictionary method"""

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -920,7 +920,7 @@ class TestOpenTelemetry(unittest.TestCase):
 
         mock_tracer.start_span.assert_not_called()
 
-    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True)
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"})
     def test_record_metrics_with_none_custom_llm_provider(self):
         """Test that _record_metrics does not pass None attributes to OTEL histograms."""
         metric_reader = InMemoryMetricReader()
@@ -959,7 +959,7 @@ class TestOpenTelemetry(unittest.TestCase):
                                 found_provider = True
         self.assertTrue(found_provider, "Expected gen_ai.system=anthropic from kwargs fallback")
  
-    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True)
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"})
     def test_record_metrics_falls_back_to_unknown_when_provider_missing(self):
         """Test that _record_metrics uses 'Unknown' when custom_llm_provider is absent everywhere."""
         metric_reader = InMemoryMetricReader()


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type
🐛 Bug Fix

## Changes
### What was happening
 
Enabling `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true` and calling the `/v1/messages` endpoint would log this error on every request:
 
```
Failed to encode key gen_ai.system: Invalid type <class 'NoneType'> of value None
```
 
The same setup worked fine on `/chat/completions`, and disabling metrics made it go away. Took a bit of digging to understand why.
 
### Why it happens
 
The `/v1/messages` path creates the logging object early, before the LLM provider has been resolved. At that point `get_litellm_params()` stores `"custom_llm_provider": None` - the key is there, just set to `None`.
 
Later, the resolved provider (e.g. `"anthropic"`) gets written back onto `model_call_details` as a top-level key, but it never updates the `None` sitting inside `litellm_params`.
 
The metrics code then does:
 
```python
provider = params.get("custom_llm_provider", "Unknown")
```
 
The problem is that `.get()` only falls back to the default when the key is *missing*. Since the key exists, with value `None`, you get `None` back, not `"Unknown"`. That `None` ends up as the `gen_ai.system` attribute on the histogram, and the OTEL SDK encoder blows up.
 
The reason it doesn't happen on `/chat/completions` is that `get_llm_provider()` runs before `get_litellm_params()` there, so `custom_llm_provider` is always a real string by the time the logging object is built.
 
The reason it doesn't affect spans is that `safe_set_attribute()` passes values through `_cast_as_primitive_value_type()` first, which turns `None` into `""`. Metrics skip that safety net and hand attributes straight to the OTEL SDK.
 
## The fix
 
Replace the `.get()` default pattern with `or`-chaining so explicit `None` values are treated as absent, and fall back to the resolved provider on the top-level kwargs:
 
```python
# before
provider = params.get("custom_llm_provider", "Unknown")
 
# after
provider = params.get("custom_llm_provider") or kwargs.get("custom_llm_provider") or "Unknown"
```
 
Same treatment for `gen_ai.request.model`, which had the same potential issue.