### PR TITLE
Fix: reasoning_content lost for custom providers in streaming

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -981,6 +981,9 @@ class CustomStreamWrapper:
                         completion_obj["provider_specific_fields"] = response_obj[
                             "provider_specific_fields"
                         ]
+                        # Extract reasoning_content so Delta() receives it as a named argument
+                        if "reasoning_content" in response_obj["provider_specific_fields"]:
+                            completion_obj["reasoning_content"] = response_obj["provider_specific_fields"]["reasoning_content"]
                     model_response.choices[0].delta = Delta(**completion_obj)
                     _index: Optional[int] = completion_obj.get("index")
                     if _index is not None:

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1491,3 +1491,54 @@ def test_tool_use_not_dropped_when_finish_reason_already_set(
     )
     assert tool_calls[0].id == "call_1"
     assert tool_calls[0].function.name == "get_weather"
+
+
+def test_reasoning_content_from_provider_specific_fields_in_generic_chunk(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    When a custom provider returns reasoning_content in
+    GenericStreamingChunk.provider_specific_fields, it must appear as
+    delta.reasoning_content on the final ModelResponseStream — not just
+    inside delta.provider_specific_fields.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/9197
+    """
+    completion_obj = {"content": ""}
+    response_obj = {
+        "text": "",
+        "is_finished": False,
+        "finish_reason": None,
+        "usage": None,
+        "tool_use": None,
+        "provider_specific_fields": {
+            "reasoning_content": "thinking hard",
+        },
+    }
+    model_response = ModelResponseStream(
+        id="test-chunk",
+        created=1000,
+        model="custom-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content=None),
+                finish_reason=None,
+            )
+        ],
+    )
+
+    initialized_custom_stream_wrapper.sent_first_chunk = True
+    result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
+        completion_obj=completion_obj,
+        model_response=model_response,
+        response_obj=response_obj,
+    )
+
+    assert result is not None
+    delta = result.choices[0].delta
+    assert hasattr(delta, "reasoning_content"), (
+        "reasoning_content should be a top-level Delta attribute"
+    )
+    assert delta.reasoning_content == "thinking hard"


### PR DESCRIPTION
## Relevant issues
`CustomLLM` handlers return reasoning tokens via `GenericStreamingChunk.provider_specific_fields["reasoning_content"]`. The streaming handler copies this dict into `completion_obj` and passes it to `Delta(**completion_obj)`, but `reasoning_content` stays nested in the dict because it's never passed as a named argument.

The fix is to simply extract the reasoning content from `provider_specific_fields` into `completion_obj`.

Relates to #9197 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)
- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
* Copy `reasoning_content` from `provider_specific_fields` into `completion_obj` in: `litellm/litellm_core_utils/streaming_handler.py`
* Added test in `tests/test_litellm/litellm_core_utils/test_streaming_handler.py`

@greptileai