### PR TITLE
fix: move custom provider dispatch before model-name-based matching

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1618,7 +1618,57 @@ def completion(  # type: ignore # noqa: PLR0915
                 stream=stream,
             )
 
-        if custom_llm_provider == "azure":
+        if (
+            custom_llm_provider in litellm._custom_providers
+        ):  # Explicitly registered custom providers always take priority
+            # over built-in model-name or provider-name matching below.
+            # Get the Custom Handler
+            custom_handler: Optional[CustomLLM] = None
+            for item in litellm.custom_provider_map:
+                if item["provider"] == custom_llm_provider:
+                    custom_handler = item["custom_handler"]
+
+            if custom_handler is None:
+                raise LiteLLMUnknownProvider(
+                    model=model, custom_llm_provider=custom_llm_provider
+                )
+
+            ## ROUTE LLM CALL ##
+            handler_fn = custom_chat_llm_router(
+                async_fn=acompletion, stream=stream, custom_llm=custom_handler
+            )
+
+            headers = headers or litellm.headers or {}
+
+            ## CALL FUNCTION
+            response = handler_fn(
+                model=model,
+                messages=messages,
+                headers=headers,
+                model_response=model_response,
+                print_verbose=print_verbose,
+                api_key=api_key,
+                api_base=api_base,
+                acompletion=acompletion,
+                logging_obj=logging,
+                optional_params=optional_params,
+                litellm_params=litellm_params,
+                logger_fn=logger_fn,
+                timeout=timeout,  # type: ignore
+                custom_prompt_dict=custom_prompt_dict,
+                client=client,  # pass AsyncOpenAI, OpenAI client
+                encoding=_get_encoding(),
+            )
+            if stream is True:
+                return CustomStreamWrapper(
+                    completion_stream=response,
+                    model=model,
+                    custom_llm_provider=custom_llm_provider,
+                    logging_obj=logging,
+                )
+            return response
+
+        elif custom_llm_provider == "azure":
             # azure configs
             ## check dynamic params ##
             dynamic_params = False
@@ -4277,54 +4327,6 @@ def completion(  # type: ignore # noqa: PLR0915
             model_response.created = int(time.time())
             model_response.model = model
             response = model_response
-
-        elif (
-            custom_llm_provider in litellm._custom_providers
-        ):  # Assume custom LLM provider
-            # Get the Custom Handler
-            custom_handler: Optional[CustomLLM] = None
-            for item in litellm.custom_provider_map:
-                if item["provider"] == custom_llm_provider:
-                    custom_handler = item["custom_handler"]
-
-            if custom_handler is None:
-                raise LiteLLMUnknownProvider(
-                    model=model, custom_llm_provider=custom_llm_provider
-                )
-
-            ## ROUTE LLM CALL ##
-            handler_fn = custom_chat_llm_router(
-                async_fn=acompletion, stream=stream, custom_llm=custom_handler
-            )
-
-            headers = headers or litellm.headers or {}
-
-            ## CALL FUNCTION
-            response = handler_fn(
-                model=model,
-                messages=messages,
-                headers=headers,
-                model_response=model_response,
-                print_verbose=print_verbose,
-                api_key=api_key,
-                api_base=api_base,
-                acompletion=acompletion,
-                logging_obj=logging,
-                optional_params=optional_params,
-                litellm_params=litellm_params,
-                logger_fn=logger_fn,
-                timeout=timeout,  # type: ignore
-                custom_prompt_dict=custom_prompt_dict,
-                client=client,  # pass AsyncOpenAI, OpenAI client
-                encoding=_get_encoding(),
-            )
-            if stream is True:
-                return CustomStreamWrapper(
-                    completion_stream=response,
-                    model=model,
-                    custom_llm_provider=custom_llm_provider,
-                    logging_obj=logging,
-                )
 
         elif custom_llm_provider == "langgraph":
             # LangGraph - Agent Runtime Provider


### PR DESCRIPTION
🐛 Bug Fix
## Summary

Fixes: https://github.com/BerriAI/litellm/issues/23352


Custom LLM providers registered via `custom_provider_map` are silently bypassed when the model name (after prefix stripping by `get_llm_provider()`) matches a known built-in model like `gpt-5.4` or `claude-sonnet-4-6`.

## Root Cause

The `if/elif` dispatch chain in `completion()` checks `model in litellm.open_ai_chat_completion_models` **before** `custom_llm_provider in litellm._custom_providers`. Since `get_llm_provider()` strips the provider prefix (`my-provider/gpt-5.4` → `gpt-5.4`), the naked model name matches the OpenAI catch-all branch, and the custom handler is never reached.


## Changes

Move the `_custom_providers` dispatch block to the **top** of the `if/elif` chain in `completion()`, before all built-in provider checks. Explicitly registered custom providers should always take priority over implicit model-name matching.

## Test Plan

- [x] Register a custom provider that proxies `gpt-5.4` via wildcard routing (`mcs/*` → `mcs-provider/*`)
- [x] Verify the custom handler's `acompletion` is called (previously silently bypassed)
- [x] Verify non-custom provider models (e.g. direct `openai/gpt-5.4`) still work
- [ ] Existing unit tests pass (`make test-unit`)

