### PR TITLE
feat(proxy): add Prisma DB pool and engine health metrics to Prometheus

### DIFF
--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -574,6 +574,10 @@ Monitor PostgreSQL connection pool utilization and Prisma query engine health. T
 
 The `state` label values come from PostgreSQL's `pg_stat_activity.state` column: `active`, `idle`, `idle in transaction`, `idle in transaction (aborted)`, `fastpath function call`, `disabled`.
 
+**Prerequisites:** Metrics collection requires both:
+- `prometheus_system` in `service_callback` (see [Monitor System Health](#monitor-system-health))
+- `PRISMA_HEALTH_WATCHDOG_ENABLED` not set to `false` (default: `true`). If disabled, a warning is logged and no DB metrics are collected.
+
 The collection interval can be configured via the `PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS` environment variable (default: 30, minimum: 5).
 
 ## 🔥 LiteLLM Maintained Grafana Dashboards

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -565,14 +565,14 @@ Use these metrics to monitor the health of the DB Transaction Queue. Eg. Monitor
 
 Monitor PostgreSQL connection pool utilization and Prisma query engine health. These metrics are collected every 30 seconds by default.
 
-| Metric Name                              | Type    | Description                                                |
-|------------------------------------------|---------|------------------------------------------------------------|
-| `litellm_db_pool_active_connections`     | Gauge   | Number of active (non-idle) connections in the DB pool     |
-| `litellm_db_pool_idle_connections`       | Gauge   | Number of idle connections in the DB pool                  |
-| `litellm_db_pool_total_connections`      | Gauge   | Total number of connections in the DB pool                 |
-| `litellm_db_pool_lock_waiting_connections`    | Gauge   | Number of connections blocked on row/table locks           |
-| `litellm_db_engine_up`                   | Gauge   | Whether the Prisma query engine is alive (1=up, 0=down)   |
-| `litellm_db_engine_restarts_total`       | Counter | Total number of Prisma query engine restarts               |
+| Metric Name                              | Type    | Labels  | Description                                                |
+|------------------------------------------|---------|---------|-----------------------------------------------------------|
+| `litellm_db_pool_connections`            | Gauge   | `state` | Number of DB connections by state (active, idle, etc.)    |
+| `litellm_db_pool_lock_waiting_connections`    | Gauge   |         | Number of connections blocked on row/table locks           |
+| `litellm_db_engine_up`                   | Gauge   |         | Whether the Prisma query engine is alive (1=up, 0=down)   |
+| `litellm_db_engine_restarts_total`       | Counter |         | Total number of Prisma query engine restarts               |
+
+The `state` label values come from PostgreSQL's `pg_stat_activity.state` column: `active`, `idle`, `idle in transaction`, `idle in transaction (aborted)`, `fastpath function call`, `disabled`.
 
 The collection interval can be configured via the `PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS` environment variable (default: 30, minimum: 5).
 

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -570,7 +570,7 @@ Monitor PostgreSQL connection pool utilization and Prisma query engine health. T
 | `litellm_db_pool_active_connections`     | Gauge   | Number of active (non-idle) connections in the DB pool     |
 | `litellm_db_pool_idle_connections`       | Gauge   | Number of idle connections in the DB pool                  |
 | `litellm_db_pool_total_connections`      | Gauge   | Total number of connections in the DB pool                 |
-| `litellm_db_pool_waiting_connections`    | Gauge   | Number of connections waiting on locks in the DB pool      |
+| `litellm_db_pool_lock_waiting_connections`    | Gauge   | Number of connections blocked on row/table locks           |
 | `litellm_db_engine_up`                   | Gauge   | Whether the Prisma query engine is alive (1=up, 0=down)   |
 | `litellm_db_engine_restarts_total`       | Counter | Total number of Prisma query engine restarts               |
 

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -561,9 +561,22 @@ Use these metrics to monitor the health of the DB Transaction Queue. Eg. Monitor
 | `litellm_in_memory_spend_update_queue_size`         | In-memory aggregate spend values for keys, users, teams, team members, etc.| In-Memory    |
 | `litellm_redis_spend_update_queue_size`             | Redis aggregate spend values for keys, users, teams, etc.                  | Redis        |
 
+#### DB Connection Pool and Engine Health Metrics
 
+Monitor PostgreSQL connection pool utilization and Prisma query engine health. These metrics are collected every 30 seconds by default.
 
-## 🔥 LiteLLM Maintained Grafana Dashboards 
+| Metric Name                              | Type    | Description                                                |
+|------------------------------------------|---------|------------------------------------------------------------|
+| `litellm_db_pool_active_connections`     | Gauge   | Number of active (non-idle) connections in the DB pool     |
+| `litellm_db_pool_idle_connections`       | Gauge   | Number of idle connections in the DB pool                  |
+| `litellm_db_pool_total_connections`      | Gauge   | Total number of connections in the DB pool                 |
+| `litellm_db_pool_waiting_connections`    | Gauge   | Number of connections waiting on locks in the DB pool      |
+| `litellm_db_engine_up`                   | Gauge   | Whether the Prisma query engine is alive (1=up, 0=down)   |
+| `litellm_db_engine_restarts_total`       | Counter | Total number of Prisma query engine restarts               |
+
+The collection interval can be configured via the `PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS` environment variable (default: 30, minimum: 5).
+
+## 🔥 LiteLLM Maintained Grafana Dashboards
 
 Link to Grafana Dashboards maintained by LiteLLM
 

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -17,25 +17,29 @@ def _get_or_create_gauge(
     labelnames: Optional[list] = None,
     multiprocess_mode: str = "max",
 ):
-    from prometheus_client import REGISTRY, Gauge
+    from prometheus_client import Gauge
 
-    names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
-    if names_to_collectors is not None and name in names_to_collectors:
-        return names_to_collectors[name]
-    if labelnames:
-        return Gauge(
-            name, description, labelnames=labelnames, multiprocess_mode=multiprocess_mode
-        )
-    return Gauge(name, description, multiprocess_mode=multiprocess_mode)
+    try:
+        if labelnames:
+            return Gauge(
+                name, description, labelnames=labelnames, multiprocess_mode=multiprocess_mode
+            )
+        return Gauge(name, description, multiprocess_mode=multiprocess_mode)
+    except ValueError:
+        from prometheus_client import REGISTRY
+
+        return REGISTRY._names_to_collectors.get(name)
 
 
 def _get_or_create_counter(name: str, description: str):
-    from prometheus_client import REGISTRY, Counter
+    from prometheus_client import Counter
 
-    names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
-    if names_to_collectors is not None and name in names_to_collectors:
-        return names_to_collectors[name]
-    return Counter(name, description)
+    try:
+        return Counter(name, description)
+    except ValueError:
+        from prometheus_client import REGISTRY
+
+        return REGISTRY._names_to_collectors.get(name)
 
 
 _POOL_METRICS_SQL = """

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -32,17 +32,12 @@ def _get_or_create_counter(name: str, description: str) -> Counter:
 
 
 _POOL_METRICS_SQL = """
-SELECT state, count(*) as count
+SELECT state,
+       count(*) as count,
+       count(*) FILTER (WHERE wait_event_type = 'Lock') as lock_waiting
 FROM pg_stat_activity
 WHERE pid != pg_backend_pid() AND datname = current_database() AND usename = current_user
 GROUP BY state
-"""
-
-_LOCK_WAITING_SQL = """
-SELECT count(*) as waiting
-FROM pg_stat_activity
-WHERE pid != pg_backend_pid() AND datname = current_database() AND usename = current_user
-  AND wait_event_type = 'Lock'
 """
 
 # All possible pg_stat_activity states — used to zero out stale labels
@@ -124,9 +119,9 @@ class PrismaMetricsCollector:
     async def _collection_loop(self) -> None:
         while True:
             try:
-                await asyncio.sleep(self._interval)
                 await self._collect_pool_metrics()
                 self._collect_engine_health()
+                await asyncio.sleep(self._interval)
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -136,19 +131,20 @@ class PrismaMetricsCollector:
         try:
             rows = await self.prisma_client.db.query_raw(_POOL_METRICS_SQL)
 
-            # Zero out all known states first to clear stale values
             seen_states: Set[str] = set()
+            total_lock_waiting = 0
             for row in rows:
                 state = row.get("state") or "unknown"
                 self._pool_connections.labels(state=state).set(row.get("count", 0))
+                total_lock_waiting += row.get("lock_waiting", 0)
                 seen_states.add(state)
+
+            # Zero out states absent from this cycle to clear stale values
             for state in _PG_STATES:
                 if state not in seen_states:
                     self._pool_connections.labels(state=state).set(0)
 
-            lock_rows = await self.prisma_client.db.query_raw(_LOCK_WAITING_SQL)
-            if lock_rows:
-                self._pool_waiting.set(lock_rows[0].get("waiting", 0))
+            self._pool_waiting.set(total_lock_waiting)
         except Exception as e:
             verbose_proxy_logger.warning(
                 "PrismaMetricsCollector failed to collect pool metrics: %s", e

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -7,8 +7,6 @@ import asyncio
 import os
 from typing import Optional, Set
 
-from prometheus_client import REGISTRY, Counter, Gauge
-
 import litellm
 from litellm._logging import verbose_proxy_logger
 
@@ -18,7 +16,9 @@ def _get_or_create_gauge(
     description: str,
     labelnames: Optional[list] = None,
     multiprocess_mode: str = "max",
-) -> Gauge:
+):
+    from prometheus_client import REGISTRY, Gauge
+
     names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
     if names_to_collectors is not None and name in names_to_collectors:
         return names_to_collectors[name]
@@ -29,7 +29,9 @@ def _get_or_create_gauge(
     return Gauge(name, description, multiprocess_mode=multiprocess_mode)
 
 
-def _get_or_create_counter(name: str, description: str) -> Counter:
+def _get_or_create_counter(name: str, description: str):
+    from prometheus_client import REGISTRY, Counter
+
     names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
     if names_to_collectors is not None and name in names_to_collectors:
         return names_to_collectors[name]

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -26,15 +26,17 @@ def _is_metric_registered(metric_name: str) -> bool:
 
 def _get_or_create_gauge(name: str, description: str) -> Gauge:
     if _is_metric_registered(name):
-        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", {})
-        return names_to_collectors[name]
+        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
+        if names_to_collectors is not None and name in names_to_collectors:
+            return names_to_collectors[name]
     return Gauge(name, description)
 
 
 def _get_or_create_counter(name: str, description: str) -> Counter:
     if _is_metric_registered(name):
-        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", {})
-        return names_to_collectors[name]
+        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
+        if names_to_collectors is not None and name in names_to_collectors:
+            return names_to_collectors[name]
     return Counter(name, description)
 
 
@@ -86,8 +88,8 @@ class PrismaMetricsCollector:
             "Total number of connections in the DB pool",
         )
         self._pool_waiting = _get_or_create_gauge(
-            "litellm_db_pool_waiting_connections",
-            "Number of connections waiting on locks in the DB pool",
+            "litellm_db_pool_lock_waiting_connections",
+            "Number of connections blocked on row/table locks in the DB pool",
         )
         self._engine_up = _get_or_create_gauge(
             "litellm_db_engine_up",

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -151,8 +151,8 @@ class PrismaMetricsCollector:
             total_lock_waiting = 0
             for row in rows:
                 state = row.get("state") or "unknown"
-                self._pool_connections.labels(state=state).set(row.get("count", 0))
-                total_lock_waiting += row.get("lock_waiting", 0)
+                self._pool_connections.labels(state=state).set(row.get("count") or 0)
+                total_lock_waiting += row.get("lock_waiting") or 0
                 seen_states.add(state)
 
             # Zero out states absent from this cycle to clear stale values

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -77,7 +77,15 @@ class PrismaMetricsCollector:
                 "PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS",
                 str(_DEFAULT_COLLECTION_INTERVAL),
             )
-            self._interval = max(float(raw), _MIN_COLLECTION_INTERVAL)
+            try:
+                self._interval = max(float(raw), _MIN_COLLECTION_INTERVAL)
+            except ValueError:
+                verbose_proxy_logger.warning(
+                    "Invalid PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS=%r; using default %ss",
+                    raw,
+                    _DEFAULT_COLLECTION_INTERVAL,
+                )
+                self._interval = float(_DEFAULT_COLLECTION_INTERVAL)
 
         self._task: Optional[asyncio.Task] = None
 

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -53,6 +53,7 @@ _PG_STATES = [
     "idle in transaction (aborted)",
     "fastpath function call",
     "disabled",
+    "unknown",
 ]
 
 _MIN_COLLECTION_INTERVAL = 5

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -24,11 +24,15 @@ def _is_metric_registered(metric_name: str) -> bool:
     return False
 
 
-def _get_or_create_gauge(name: str, description: str) -> Gauge:
+def _get_or_create_gauge(
+    name: str, description: str, labelnames: Optional[list] = None
+) -> Gauge:
     if _is_metric_registered(name):
         names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
         if names_to_collectors is not None and name in names_to_collectors:
             return names_to_collectors[name]
+    if labelnames:
+        return Gauge(name, description, labelnames=labelnames)
     return Gauge(name, description)
 
 
@@ -41,12 +45,17 @@ def _get_or_create_counter(name: str, description: str) -> Counter:
 
 
 _POOL_METRICS_SQL = """
-SELECT count(*) FILTER (WHERE state = 'active') as active,
-       count(*) FILTER (WHERE state = 'idle') as idle,
-       count(*) as total,
-       count(*) FILTER (WHERE wait_event_type = 'Lock') as waiting
+SELECT state, count(*) as count
 FROM pg_stat_activity
 WHERE pid != pg_backend_pid() AND datname = current_database() AND usename = current_user
+GROUP BY state
+"""
+
+_LOCK_WAITING_SQL = """
+SELECT count(*) as waiting
+FROM pg_stat_activity
+WHERE pid != pg_backend_pid() AND datname = current_database() AND usename = current_user
+  AND wait_event_type = 'Lock'
 """
 
 _MIN_COLLECTION_INTERVAL = 5
@@ -75,17 +84,10 @@ class PrismaMetricsCollector:
         self._task: Optional[asyncio.Task] = None
 
         # Prometheus metrics
-        self._pool_active = _get_or_create_gauge(
-            "litellm_db_pool_active_connections",
-            "Number of active connections in the DB pool",
-        )
-        self._pool_idle = _get_or_create_gauge(
-            "litellm_db_pool_idle_connections",
-            "Number of idle connections in the DB pool",
-        )
-        self._pool_total = _get_or_create_gauge(
-            "litellm_db_pool_total_connections",
-            "Total number of connections in the DB pool",
+        self._pool_connections = _get_or_create_gauge(
+            "litellm_db_pool_connections",
+            "Number of DB connections by state",
+            labelnames=["state"],
         )
         self._pool_waiting = _get_or_create_gauge(
             "litellm_db_pool_lock_waiting_connections",
@@ -135,12 +137,13 @@ class PrismaMetricsCollector:
     async def _collect_pool_metrics(self) -> None:
         try:
             rows = await self.prisma_client.db.query_raw(_POOL_METRICS_SQL)
-            if rows:
-                row = rows[0]
-                self._pool_active.set(row.get("active", 0))
-                self._pool_idle.set(row.get("idle", 0))
-                self._pool_total.set(row.get("total", 0))
-                self._pool_waiting.set(row.get("waiting", 0))
+            for row in rows:
+                state = row.get("state") or "unknown"
+                self._pool_connections.labels(state=state).set(row.get("count", 0))
+
+            lock_rows = await self.prisma_client.db.query_raw(_LOCK_WAITING_SQL)
+            if lock_rows:
+                self._pool_waiting.set(lock_rows[0].get("waiting", 0))
         except Exception as e:
             verbose_proxy_logger.warning(
                 "PrismaMetricsCollector failed to collect pool metrics: %s", e

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -121,11 +121,14 @@ class PrismaMetricsCollector:
             try:
                 await self._collect_pool_metrics()
                 self._collect_engine_health()
-                await asyncio.sleep(self._interval)
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 verbose_proxy_logger.warning("PrismaMetricsCollector loop error: %s", e)
+            try:
+                await asyncio.sleep(self._interval)
+            except asyncio.CancelledError:
+                break
 
     async def _collect_pool_metrics(self) -> None:
         try:

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -5,7 +5,7 @@ and exposes them as Prometheus gauges/counters.
 
 import asyncio
 import os
-from typing import Optional
+from typing import Optional, Set
 
 from prometheus_client import REGISTRY, Counter, Gauge
 
@@ -13,34 +13,21 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 
 
-def _is_metric_registered(metric_name: str) -> bool:
-    """Check if a Prometheus metric is already registered (O(1) lookup)."""
-    names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
-    if names_to_collectors is not None:
-        return metric_name in names_to_collectors
-    for metric in REGISTRY.collect():
-        if metric_name == metric.name:
-            return True
-    return False
-
-
 def _get_or_create_gauge(
     name: str, description: str, labelnames: Optional[list] = None
 ) -> Gauge:
-    if _is_metric_registered(name):
-        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
-        if names_to_collectors is not None and name in names_to_collectors:
-            return names_to_collectors[name]
+    names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
+    if names_to_collectors is not None and name in names_to_collectors:
+        return names_to_collectors[name]
     if labelnames:
         return Gauge(name, description, labelnames=labelnames)
     return Gauge(name, description)
 
 
 def _get_or_create_counter(name: str, description: str) -> Counter:
-    if _is_metric_registered(name):
-        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
-        if names_to_collectors is not None and name in names_to_collectors:
-            return names_to_collectors[name]
+    names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
+    if names_to_collectors is not None and name in names_to_collectors:
+        return names_to_collectors[name]
     return Counter(name, description)
 
 
@@ -57,6 +44,16 @@ FROM pg_stat_activity
 WHERE pid != pg_backend_pid() AND datname = current_database() AND usename = current_user
   AND wait_event_type = 'Lock'
 """
+
+# All possible pg_stat_activity states — used to zero out stale labels
+_PG_STATES = [
+    "active",
+    "idle",
+    "idle in transaction",
+    "idle in transaction (aborted)",
+    "fastpath function call",
+    "disabled",
+]
 
 _MIN_COLLECTION_INTERVAL = 5
 _DEFAULT_COLLECTION_INTERVAL = 30
@@ -137,9 +134,16 @@ class PrismaMetricsCollector:
     async def _collect_pool_metrics(self) -> None:
         try:
             rows = await self.prisma_client.db.query_raw(_POOL_METRICS_SQL)
+
+            # Zero out all known states first to clear stale values
+            seen_states: Set[str] = set()
             for row in rows:
                 state = row.get("state") or "unknown"
                 self._pool_connections.labels(state=state).set(row.get("count", 0))
+                seen_states.add(state)
+            for state in _PG_STATES:
+                if state not in seen_states:
+                    self._pool_connections.labels(state=state).set(0)
 
             lock_rows = await self.prisma_client.db.query_raw(_LOCK_WAITING_SQL)
             if lock_rows:

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -14,14 +14,19 @@ from litellm._logging import verbose_proxy_logger
 
 
 def _get_or_create_gauge(
-    name: str, description: str, labelnames: Optional[list] = None
+    name: str,
+    description: str,
+    labelnames: Optional[list] = None,
+    multiprocess_mode: str = "max",
 ) -> Gauge:
     names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
     if names_to_collectors is not None and name in names_to_collectors:
         return names_to_collectors[name]
     if labelnames:
-        return Gauge(name, description, labelnames=labelnames)
-    return Gauge(name, description)
+        return Gauge(
+            name, description, labelnames=labelnames, multiprocess_mode=multiprocess_mode
+        )
+    return Gauge(name, description, multiprocess_mode=multiprocess_mode)
 
 
 def _get_or_create_counter(name: str, description: str) -> Counter:

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -28,7 +28,8 @@ def _get_or_create_gauge(
     except ValueError:
         from prometheus_client import REGISTRY
 
-        return REGISTRY._names_to_collectors.get(name)
+        names_map = getattr(REGISTRY, "_names_to_collectors", None)
+        return names_map.get(name) if names_map is not None else None
 
 
 def _get_or_create_counter(name: str, description: str):
@@ -39,7 +40,8 @@ def _get_or_create_counter(name: str, description: str):
     except ValueError:
         from prometheus_client import REGISTRY
 
-        return REGISTRY._names_to_collectors.get(name)
+        names_map = getattr(REGISTRY, "_names_to_collectors", None)
+        return names_map.get(name) if names_map is not None else None
 
 
 _POOL_METRICS_SQL = """
@@ -108,6 +110,7 @@ class PrismaMetricsCollector:
         self._engine_up = _get_or_create_gauge(
             "litellm_db_engine_up",
             "Whether the Prisma query engine process is alive (1=up, 0=down)",
+            multiprocess_mode="min",
         )
         self._engine_restarts = _get_or_create_counter(
             "litellm_db_engine_restarts_total",

--- a/litellm/proxy/db/prisma_metrics_collector.py
+++ b/litellm/proxy/db/prisma_metrics_collector.py
@@ -1,0 +1,158 @@
+"""
+Collects Prisma/PostgreSQL connection pool and engine health metrics
+and exposes them as Prometheus gauges/counters.
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+from prometheus_client import REGISTRY, Counter, Gauge
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+
+
+def _is_metric_registered(metric_name: str) -> bool:
+    """Check if a Prometheus metric is already registered (O(1) lookup)."""
+    names_to_collectors = getattr(REGISTRY, "_names_to_collectors", None)
+    if names_to_collectors is not None:
+        return metric_name in names_to_collectors
+    for metric in REGISTRY.collect():
+        if metric_name == metric.name:
+            return True
+    return False
+
+
+def _get_or_create_gauge(name: str, description: str) -> Gauge:
+    if _is_metric_registered(name):
+        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", {})
+        return names_to_collectors[name]
+    return Gauge(name, description)
+
+
+def _get_or_create_counter(name: str, description: str) -> Counter:
+    if _is_metric_registered(name):
+        names_to_collectors = getattr(REGISTRY, "_names_to_collectors", {})
+        return names_to_collectors[name]
+    return Counter(name, description)
+
+
+_POOL_METRICS_SQL = """
+SELECT count(*) FILTER (WHERE state = 'active') as active,
+       count(*) FILTER (WHERE state = 'idle') as idle,
+       count(*) as total,
+       count(*) FILTER (WHERE wait_event_type = 'Lock') as waiting
+FROM pg_stat_activity
+WHERE pid != pg_backend_pid() AND datname = current_database() AND usename = current_user
+"""
+
+_MIN_COLLECTION_INTERVAL = 5
+_DEFAULT_COLLECTION_INTERVAL = 30
+
+
+class PrismaMetricsCollector:
+    """Periodically collects DB pool and engine health metrics for Prometheus."""
+
+    def __init__(
+        self,
+        prisma_client: "litellm.proxy.utils.PrismaClient",  # type: ignore[name-defined]
+        collection_interval: Optional[float] = None,
+    ) -> None:
+        self.prisma_client = prisma_client
+
+        if collection_interval is not None:
+            self._interval = max(collection_interval, _MIN_COLLECTION_INTERVAL)
+        else:
+            raw = os.environ.get(
+                "PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS",
+                str(_DEFAULT_COLLECTION_INTERVAL),
+            )
+            self._interval = max(float(raw), _MIN_COLLECTION_INTERVAL)
+
+        self._task: Optional[asyncio.Task] = None
+
+        # Prometheus metrics
+        self._pool_active = _get_or_create_gauge(
+            "litellm_db_pool_active_connections",
+            "Number of active connections in the DB pool",
+        )
+        self._pool_idle = _get_or_create_gauge(
+            "litellm_db_pool_idle_connections",
+            "Number of idle connections in the DB pool",
+        )
+        self._pool_total = _get_or_create_gauge(
+            "litellm_db_pool_total_connections",
+            "Total number of connections in the DB pool",
+        )
+        self._pool_waiting = _get_or_create_gauge(
+            "litellm_db_pool_waiting_connections",
+            "Number of connections waiting on locks in the DB pool",
+        )
+        self._engine_up = _get_or_create_gauge(
+            "litellm_db_engine_up",
+            "Whether the Prisma query engine process is alive (1=up, 0=down)",
+        )
+        self._engine_restarts = _get_or_create_counter(
+            "litellm_db_engine_restarts_total",
+            "Total number of Prisma query engine restarts",
+        )
+
+    def start(self) -> None:
+        """Start the background collection loop. No-op if already running."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._collection_loop())
+        verbose_proxy_logger.info(
+            "Started PrismaMetricsCollector (interval=%ss)", self._interval
+        )
+
+    async def stop(self) -> None:
+        """Stop the background collection loop."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+        verbose_proxy_logger.info("Stopped PrismaMetricsCollector")
+
+    async def _collection_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._interval)
+                await self._collect_pool_metrics()
+                self._collect_engine_health()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                verbose_proxy_logger.warning("PrismaMetricsCollector loop error: %s", e)
+
+    async def _collect_pool_metrics(self) -> None:
+        try:
+            rows = await self.prisma_client.db.query_raw(_POOL_METRICS_SQL)
+            if rows:
+                row = rows[0]
+                self._pool_active.set(row.get("active", 0))
+                self._pool_idle.set(row.get("idle", 0))
+                self._pool_total.set(row.get("total", 0))
+                self._pool_waiting.set(row.get("waiting", 0))
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "PrismaMetricsCollector failed to collect pool metrics: %s", e
+            )
+
+    def _collect_engine_health(self) -> None:
+        alive = self.prisma_client._is_engine_alive()
+        self._engine_up.set(1 if alive else 0)
+
+    def increment_engine_restarts(self) -> None:
+        """Increment the engine restart counter. Call from attempt_db_reconnect()."""
+        self._engine_restarts.inc()
+
+    @staticmethod
+    def should_enable() -> bool:
+        """Check if Prometheus system metrics are enabled."""
+        return "prometheus_system" in litellm.service_callback

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3942,6 +3942,11 @@ class PrismaClient:
             return False
 
         # Escalate to heavy reconnect after consecutive lightweight failures.
+        # Capture before the escalation block can flip _engine_confirmed_dead
+        engine_was_dead = self._engine_confirmed_dead or (
+            self._engine_pid > 0 and not self._is_engine_alive()
+        )
+
         # When the Prisma engine process is alive but not accepting connections
         # (e.g., startup race condition), lightweight reconnects (disconnect +
         # connect) will never succeed. Force a full Prisma client recreation
@@ -3956,10 +3961,6 @@ class PrismaClient:
 
         verbose_proxy_logger.warning(
             "Attempting Prisma DB reconnect. reason=%s", reason
-        )
-
-        engine_was_dead = self._engine_confirmed_dead or (
-            self._engine_pid > 0 and not self._is_engine_alive()
         )
         reconnect_succeeded = False
         try:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -105,6 +105,7 @@ from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.db.log_db_metrics import log_db_metrics
 from litellm.proxy.db.prisma_client import PrismaWrapper
+from litellm.proxy.db.prisma_metrics_collector import PrismaMetricsCollector
 from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
     UnifiedLLMGuardrails,
 )
@@ -2313,6 +2314,7 @@ class PrismaClient:
         self._watching_engine: bool = False
         self._engine_confirmed_dead: bool = False
         self._engine_wait_thread: Optional[threading.Thread] = None
+        self._metrics_collector: Optional[PrismaMetricsCollector] = None
         verbose_proxy_logger.debug("Success - Created Prisma Client")
 
     def get_request_status(
@@ -3946,6 +3948,8 @@ class PrismaClient:
             verbose_proxy_logger.info(
                 "Prisma DB reconnect succeeded. reason=%s", reason
             )
+            if self._metrics_collector is not None:
+                self._metrics_collector.increment_engine_restarts()
         except Exception as reconnect_err:
             self._consecutive_reconnect_failures += 1
             verbose_proxy_logger.error(
@@ -4062,6 +4066,10 @@ class PrismaClient:
         )
         await self._start_engine_watcher()
 
+        if PrismaMetricsCollector.should_enable() and self._metrics_collector is None:
+            self._metrics_collector = PrismaMetricsCollector(self)
+            self._metrics_collector.start()
+
     async def stop_db_health_watchdog_task(self) -> None:
         """Stop DB health watchdog task and engine watcher gracefully."""
         self._stop_engine_watcher()
@@ -4074,6 +4082,10 @@ class PrismaClient:
             pass
         self._db_health_watchdog_task = None
         verbose_proxy_logger.info("Stopped Prisma DB health watchdog")
+
+        if self._metrics_collector is not None:
+            await self._metrics_collector.stop()
+            self._metrics_collector = None
 
     async def _db_health_watchdog_loop(self) -> None:
         while True:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2043,8 +2043,10 @@ class ProxyLogging:
 
                         ## CHECK FOR MODEL-LEVEL GUARDRAILS (cached per-request)
                         if not _guardrail_data_computed:
-                            _cached_guardrail_data = _check_and_merge_model_level_guardrails(
-                                data=data, llm_router=llm_router
+                            _cached_guardrail_data = (
+                                _check_and_merge_model_level_guardrails(
+                                    data=data, llm_router=llm_router
+                                )
                             )
                             _guardrail_data_computed = True
 
@@ -3635,13 +3637,15 @@ class PrismaClient:
             probe_pid, _ = os.waitpid(pid, os.WNOHANG)
         except ChildProcessError:
             verbose_proxy_logger.debug(
-                "PID %s is not a child process; skipping waitpid watch.", pid,
+                "PID %s is not a child process; skipping waitpid watch.",
+                pid,
             )
             return False
 
         if probe_pid == pid:
             verbose_proxy_logger.warning(
-                "prisma-query-engine PID %s already dead at watch start.", pid,
+                "prisma-query-engine PID %s already dead at watch start.",
+                pid,
             )
             self._engine_confirmed_dead = True
             self._reap_all_zombies()
@@ -3818,11 +3822,17 @@ class PrismaClient:
            waitpid thread nor pidfd are available.
 
         """
-        if self._watching_engine or self._engine_pidfd >= 0 or self._engine_wait_thread is not None:
+        if (
+            self._watching_engine
+            or self._engine_pidfd >= 0
+            or self._engine_wait_thread is not None
+        ):
             return
         pid = self._get_engine_pid()
         if pid == 0:
-            verbose_proxy_logger.debug("Could not find prisma-query-engine PID; engine death detection unavailable.")
+            verbose_proxy_logger.debug(
+                "Could not find prisma-query-engine PID; engine death detection unavailable."
+            )
             return
         self._engine_pid = pid
         self._engine_confirmed_dead = False
@@ -3831,15 +3841,18 @@ class PrismaClient:
         pidfd_ok = False if waitpid_ok else self._try_pidfd_watch(pid)
         if waitpid_ok:
             verbose_proxy_logger.info(
-                "Watching engine PID %s via waitpid thread.", pid,
+                "Watching engine PID %s via waitpid thread.",
+                pid,
             )
         elif pidfd_ok:
             verbose_proxy_logger.info(
-                "Watching engine PID %s via pidfd.", pid,
+                "Watching engine PID %s via pidfd.",
+                pid,
             )
         else:
             verbose_proxy_logger.info(
-                "Watching engine PID %s via os.kill polling.", pid,
+                "Watching engine PID %s via os.kill polling.",
+                pid,
             )
             self._watching_engine = True
             asyncio.create_task(self._poll_engine_proc())
@@ -3862,7 +3875,9 @@ class PrismaClient:
         blip -- disconnect, connect, SELECT 1).
         """
         effective_timeout = (
-            timeout_seconds if timeout_seconds is not None else self._db_watchdog_reconnect_timeout_seconds
+            timeout_seconds
+            if timeout_seconds is not None
+            else self._db_watchdog_reconnect_timeout_seconds
         )
 
         engine_is_dead = self._engine_confirmed_dead or (
@@ -3882,14 +3897,18 @@ class PrismaClient:
             async def _do_heavy_reconnect() -> None:
                 db_url = os.getenv("DATABASE_URL", "")
                 if not db_url:
-                    verbose_proxy_logger.error("DATABASE_URL not set; cannot recreate Prisma client.")
+                    verbose_proxy_logger.error(
+                        "DATABASE_URL not set; cannot recreate Prisma client."
+                    )
                     raise RuntimeError("DATABASE_URL not set")
                 await self.db.recreate_prisma_client(db_url)
                 await self._start_engine_watcher()
 
             await asyncio.wait_for(_do_heavy_reconnect(), timeout=effective_timeout)
         else:
-            verbose_proxy_logger.debug("Performing Prisma DB reconnect (engine alive or unknown).")
+            verbose_proxy_logger.debug(
+                "Performing Prisma DB reconnect (engine alive or unknown)."
+            )
 
             async def _do_direct_reconnect() -> None:
                 try:
@@ -3940,6 +3959,9 @@ class PrismaClient:
             "Attempting Prisma DB reconnect. reason=%s", reason
         )
 
+        engine_was_dead = self._engine_confirmed_dead or (
+            self._engine_pid > 0 and not self._is_engine_alive()
+        )
         reconnect_succeeded = False
         try:
             await self._run_reconnect_cycle(timeout_seconds=timeout_seconds)
@@ -3948,7 +3970,7 @@ class PrismaClient:
             verbose_proxy_logger.info(
                 "Prisma DB reconnect succeeded. reason=%s", reason
             )
-            if self._metrics_collector is not None:
+            if self._metrics_collector is not None and engine_was_dead:
                 self._metrics_collector.increment_engine_restarts()
         except Exception as reconnect_err:
             self._consecutive_reconnect_failures += 1
@@ -3990,7 +4012,9 @@ class PrismaClient:
 
         if lock_timeout_seconds is None:
             async with self._db_reconnect_lock:
-                return await self._attempt_reconnect_inside_lock(force, reason, timeout_seconds)
+                return await self._attempt_reconnect_inside_lock(
+                    force, reason, timeout_seconds
+                )
 
         lock_acquired_by_timeout_task = False
 
@@ -4039,14 +4063,17 @@ class PrismaClient:
             return False
 
         try:
-            return await self._attempt_reconnect_inside_lock(force, reason, timeout_seconds)
+            return await self._attempt_reconnect_inside_lock(
+                force, reason, timeout_seconds
+            )
         finally:
             self._db_reconnect_lock.release()
 
     async def start_db_health_watchdog_task(self) -> None:
         """Start background tasks that monitor DB health:
         - A periodic SELECT 1 probe that triggers reconnect on network/connection failure.
-        - A process-level watcher that detects engine death via waitpid thread, pidfd, or os.kill polling."""
+        - A process-level watcher that detects engine death via waitpid thread, pidfd, or os.kill polling.
+        """
         if self._db_health_watchdog_enabled is not True:
             verbose_proxy_logger.debug(
                 "Prisma DB health watchdog disabled via PRISMA_HEALTH_WATCHDOG_ENABLED"
@@ -4514,9 +4541,9 @@ class ProxyUpdateSpend:
                     :MAX_LOGS_PER_INTERVAL
                 ]
                 # Remove the logs we're about to process
-                prisma_client.spend_log_transactions = prisma_client.spend_log_transactions[
-                    len(logs_to_process) :
-                ]
+                prisma_client.spend_log_transactions = (
+                    prisma_client.spend_log_transactions[len(logs_to_process) :]
+                )
             popped_batch = True
         if len(logs_to_process) > 0:
             verbose_proxy_logger.info(
@@ -4670,9 +4697,7 @@ async def update_spend_logs_job(
         return
 
     async with prisma_client._spend_log_transactions_lock:
-        logs_to_process = prisma_client.spend_log_transactions[
-            :MAX_LOGS_PER_INTERVAL
-        ]
+        logs_to_process = prisma_client.spend_log_transactions[:MAX_LOGS_PER_INTERVAL]
         prisma_client.spend_log_transactions = prisma_client.spend_log_transactions[
             len(logs_to_process) :
         ]
@@ -4690,6 +4715,7 @@ async def update_spend_logs_job(
         from litellm.proxy.guardrails.usage_tracking import (
             process_spend_logs_guardrail_usage,
         )
+
         await process_spend_logs_guardrail_usage(
             prisma_client=prisma_client,
             logs_to_process=logs_to_process,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4078,6 +4078,11 @@ class PrismaClient:
             verbose_proxy_logger.debug(
                 "Prisma DB health watchdog disabled via PRISMA_HEALTH_WATCHDOG_ENABLED"
             )
+            if PrismaMetricsCollector.should_enable():
+                verbose_proxy_logger.warning(
+                    "prometheus_system is enabled but PRISMA_HEALTH_WATCHDOG_ENABLED=false — "
+                    "DB pool and engine metrics will not be collected"
+                )
             return
         if self._db_health_watchdog_task is not None:
             return

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -105,7 +105,6 @@ from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.db.log_db_metrics import log_db_metrics
 from litellm.proxy.db.prisma_client import PrismaWrapper
-from litellm.proxy.db.prisma_metrics_collector import PrismaMetricsCollector
 from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
     UnifiedLLMGuardrails,
 )
@@ -2316,7 +2315,7 @@ class PrismaClient:
         self._watching_engine: bool = False
         self._engine_confirmed_dead: bool = False
         self._engine_wait_thread: Optional[threading.Thread] = None
-        self._metrics_collector: Optional[PrismaMetricsCollector] = None
+        self._metrics_collector: Optional["PrismaMetricsCollector"] = None  # type: ignore[name-defined]
         verbose_proxy_logger.debug("Success - Created Prisma Client")
 
     def get_request_status(
@@ -4078,6 +4077,8 @@ class PrismaClient:
             verbose_proxy_logger.debug(
                 "Prisma DB health watchdog disabled via PRISMA_HEALTH_WATCHDOG_ENABLED"
             )
+            from litellm.proxy.db.prisma_metrics_collector import PrismaMetricsCollector
+
             if PrismaMetricsCollector.should_enable():
                 verbose_proxy_logger.warning(
                     "prometheus_system is enabled but PRISMA_HEALTH_WATCHDOG_ENABLED=false — "
@@ -4097,6 +4098,8 @@ class PrismaClient:
             self._db_watchdog_reconnect_timeout_seconds,
         )
         await self._start_engine_watcher()
+
+        from litellm.proxy.db.prisma_metrics_collector import PrismaMetricsCollector
 
         if PrismaMetricsCollector.should_enable() and self._metrics_collector is None:
             self._metrics_collector = PrismaMetricsCollector(self)

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -239,9 +239,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_callback_logging_failures_metric",
     "litellm_in_flight_requests",
     # Database engine / connection pool metrics
-    "litellm_db_pool_active_connections",
-    "litellm_db_pool_idle_connections",
-    "litellm_db_pool_total_connections",
+    "litellm_db_pool_connections",
     "litellm_db_pool_lock_waiting_connections",
     "litellm_db_engine_up",
     "litellm_db_engine_restarts_total",
@@ -625,10 +623,8 @@ class PrometheusMetricLabels:
     litellm_cache_misses_metric = _cache_metric_labels
     litellm_cached_tokens_metric = _cache_metric_labels
 
-    # Database engine / connection pool metrics - global metrics with no labels
-    litellm_db_pool_active_connections: List[str] = []
-    litellm_db_pool_idle_connections: List[str] = []
-    litellm_db_pool_total_connections: List[str] = []
+    # Database engine / connection pool metrics
+    litellm_db_pool_connections: List[str] = ["state"]
     litellm_db_pool_lock_waiting_connections: List[str] = []
     litellm_db_engine_up: List[str] = []
     litellm_db_engine_restarts_total: List[str] = []

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -238,6 +238,13 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_llm_api_failed_requests_metric",
     "litellm_callback_logging_failures_metric",
     "litellm_in_flight_requests",
+    # Database engine / connection pool metrics
+    "litellm_db_pool_active_connections",
+    "litellm_db_pool_idle_connections",
+    "litellm_db_pool_total_connections",
+    "litellm_db_pool_waiting_connections",
+    "litellm_db_engine_up",
+    "litellm_db_engine_restarts_total",
 ]
 
 
@@ -617,6 +624,14 @@ class PrometheusMetricLabels:
     litellm_cache_hits_metric = _cache_metric_labels
     litellm_cache_misses_metric = _cache_metric_labels
     litellm_cached_tokens_metric = _cache_metric_labels
+
+    # Database engine / connection pool metrics - global metrics with no labels
+    litellm_db_pool_active_connections: List[str] = []
+    litellm_db_pool_idle_connections: List[str] = []
+    litellm_db_pool_total_connections: List[str] = []
+    litellm_db_pool_waiting_connections: List[str] = []
+    litellm_db_engine_up: List[str] = []
+    litellm_db_engine_restarts_total: List[str] = []
 
     @staticmethod
     def get_labels(label_name: DEFINED_PROMETHEUS_METRICS) -> List[str]:

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -242,7 +242,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_db_pool_active_connections",
     "litellm_db_pool_idle_connections",
     "litellm_db_pool_total_connections",
-    "litellm_db_pool_waiting_connections",
+    "litellm_db_pool_lock_waiting_connections",
     "litellm_db_engine_up",
     "litellm_db_engine_restarts_total",
 ]
@@ -629,7 +629,7 @@ class PrometheusMetricLabels:
     litellm_db_pool_active_connections: List[str] = []
     litellm_db_pool_idle_connections: List[str] = []
     litellm_db_pool_total_connections: List[str] = []
-    litellm_db_pool_waiting_connections: List[str] = []
+    litellm_db_pool_lock_waiting_connections: List[str] = []
     litellm_db_engine_up: List[str] = []
     litellm_db_engine_restarts_total: List[str] = []
 

--- a/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
+++ b/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
@@ -89,7 +89,7 @@ def test_collector_creates_prometheus_metrics():
         "litellm_db_pool_active_connections",
         "litellm_db_pool_idle_connections",
         "litellm_db_pool_total_connections",
-        "litellm_db_pool_waiting_connections",
+        "litellm_db_pool_lock_waiting_connections",
         "litellm_db_engine_up",
         "litellm_db_engine_restarts",  # counter exposes _total suffix but name is base
     }
@@ -117,7 +117,7 @@ async def test_collect_pool_metrics_sets_gauges():
     assert registry.get_sample_value("litellm_db_pool_active_connections") == 5
     assert registry.get_sample_value("litellm_db_pool_idle_connections") == 10
     assert registry.get_sample_value("litellm_db_pool_total_connections") == 15
-    assert registry.get_sample_value("litellm_db_pool_waiting_connections") == 2
+    assert registry.get_sample_value("litellm_db_pool_lock_waiting_connections") == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
+++ b/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
@@ -46,7 +46,7 @@ def _make_collector(prisma_client=None, collection_interval=None, registry=None)
 
     from prometheus_client import Counter, Gauge
 
-    def _patched_get_or_create_gauge(name, description, labelnames=None):
+    def _patched_get_or_create_gauge(name, description, labelnames=None, **kwargs):
         if labelnames:
             return Gauge(name, description, labelnames=labelnames, registry=registry)
         return Gauge(name, description, registry=registry)
@@ -315,6 +315,17 @@ def test_collection_interval_default():
         with patch.dict(os.environ, env_copy, clear=True):
             collector, _ = _make_collector()
             assert collector._interval == _DEFAULT_COLLECTION_INTERVAL
+
+
+def test_collection_interval_invalid_env_falls_back_to_default():
+    """Non-numeric PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS should fall back to default."""
+    with patch.dict(os.environ, {"PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS": "30s"}):
+        with patch(
+            "litellm.proxy.db.prisma_metrics_collector.verbose_proxy_logger"
+        ) as mock_logger:
+            collector, _ = _make_collector()
+            assert collector._interval == _DEFAULT_COLLECTION_INTERVAL
+            mock_logger.warning.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
+++ b/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
@@ -107,12 +107,11 @@ async def test_collect_pool_metrics_sets_gauges():
     client = _make_prisma_client()
 
     pool_rows = [
-        {"state": "active", "count": 5},
-        {"state": "idle", "count": 10},
-        {"state": "idle in transaction", "count": 3},
+        {"state": "active", "count": 5, "lock_waiting": 1},
+        {"state": "idle", "count": 10, "lock_waiting": 0},
+        {"state": "idle in transaction", "count": 3, "lock_waiting": 1},
     ]
-    lock_rows = [{"waiting": 2}]
-    client.db.query_raw = AsyncMock(side_effect=[pool_rows, lock_rows])
+    client.db.query_raw = AsyncMock(return_value=pool_rows)
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
@@ -136,11 +135,9 @@ async def test_collect_pool_metrics_sets_gauges():
 
 @pytest.mark.asyncio
 async def test_collect_pool_metrics_handles_empty_result():
-    """When query_raw returns empty lists, known states should be zeroed."""
+    """When query_raw returns empty list, known states should be zeroed."""
     client = _make_prisma_client()
-    pool_rows: list = []
-    lock_rows = [{"waiting": 0}]
-    client.db.query_raw = AsyncMock(side_effect=[pool_rows, lock_rows])
+    client.db.query_raw = AsyncMock(return_value=[])
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
@@ -159,9 +156,8 @@ async def test_collect_pool_metrics_handles_empty_result():
 async def test_collect_pool_metrics_handles_null_state():
     """When pg_stat_activity returns a NULL state, it should be mapped to 'unknown'."""
     client = _make_prisma_client()
-    pool_rows = [{"state": None, "count": 1}]
-    lock_rows = [{"waiting": 0}]
-    client.db.query_raw = AsyncMock(side_effect=[pool_rows, lock_rows])
+    pool_rows = [{"state": None, "count": 1, "lock_waiting": 0}]
+    client.db.query_raw = AsyncMock(return_value=pool_rows)
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
@@ -178,9 +174,8 @@ async def test_collect_pool_metrics_clears_stale_states():
     client = _make_prisma_client()
 
     # Cycle 1: active=5
-    pool_rows_1 = [{"state": "active", "count": 5}]
-    lock_rows = [{"waiting": 0}]
-    client.db.query_raw = AsyncMock(side_effect=[pool_rows_1, lock_rows])
+    pool_rows_1 = [{"state": "active", "count": 5, "lock_waiting": 0}]
+    client.db.query_raw = AsyncMock(return_value=pool_rows_1)
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
@@ -190,8 +185,8 @@ async def test_collect_pool_metrics_clears_stale_states():
     )
 
     # Cycle 2: only idle connections, active should be zeroed
-    pool_rows_2 = [{"state": "idle", "count": 3}]
-    client.db.query_raw = AsyncMock(side_effect=[pool_rows_2, lock_rows])
+    pool_rows_2 = [{"state": "idle", "count": 3, "lock_waiting": 0}]
+    client.db.query_raw = AsyncMock(return_value=pool_rows_2)
 
     await collector._collect_pool_metrics()
     assert (

--- a/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
+++ b/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
@@ -136,17 +136,22 @@ async def test_collect_pool_metrics_sets_gauges():
 
 @pytest.mark.asyncio
 async def test_collect_pool_metrics_handles_empty_result():
-    """When query_raw returns empty lists, no crash should occur."""
+    """When query_raw returns empty lists, known states should be zeroed."""
     client = _make_prisma_client()
-    client.db.query_raw = AsyncMock(return_value=[])
+    pool_rows: list = []
+    lock_rows = [{"waiting": 0}]
+    client.db.query_raw = AsyncMock(side_effect=[pool_rows, lock_rows])
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
 
-    # No labeled values should be set — just verify no crash
+    # Known states should be zeroed out
     assert (
         registry.get_sample_value("litellm_db_pool_connections", {"state": "active"})
-        is None
+        == 0
+    )
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "idle"}) == 0
     )
 
 
@@ -164,6 +169,37 @@ async def test_collect_pool_metrics_handles_null_state():
     assert (
         registry.get_sample_value("litellm_db_pool_connections", {"state": "unknown"})
         == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_pool_metrics_clears_stale_states():
+    """States present in cycle 1 but absent in cycle 2 should be zeroed out."""
+    client = _make_prisma_client()
+
+    # Cycle 1: active=5
+    pool_rows_1 = [{"state": "active", "count": 5}]
+    lock_rows = [{"waiting": 0}]
+    client.db.query_raw = AsyncMock(side_effect=[pool_rows_1, lock_rows])
+    collector, registry = _make_collector(prisma_client=client)
+
+    await collector._collect_pool_metrics()
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "active"})
+        == 5
+    )
+
+    # Cycle 2: only idle connections, active should be zeroed
+    pool_rows_2 = [{"state": "idle", "count": 3}]
+    client.db.query_raw = AsyncMock(side_effect=[pool_rows_2, lock_rows])
+
+    await collector._collect_pool_metrics()
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "active"})
+        == 0
+    )
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "idle"}) == 3
     )
 
 

--- a/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
+++ b/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
@@ -1,0 +1,293 @@
+"""
+Unit tests for PrismaMetricsCollector.
+
+All Prometheus metrics are isolated per test using a custom CollectorRegistry
+to avoid cross-test registration conflicts.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm.proxy.db.prisma_metrics_collector import (
+    PrismaMetricsCollector,
+    _DEFAULT_COLLECTION_INTERVAL,
+    _MIN_COLLECTION_INTERVAL,
+)
+
+
+def _make_prisma_client():
+    """Create a mock PrismaClient with the interface PrismaMetricsCollector uses."""
+    client = MagicMock()
+    client.db = MagicMock()
+    client.db.query_raw = AsyncMock(return_value=[])
+    client._is_engine_alive = MagicMock(return_value=True)
+    return client
+
+
+def _make_collector(prisma_client=None, collection_interval=None, registry=None):
+    """Create a PrismaMetricsCollector with an isolated Prometheus registry.
+
+    Patches the module-level helper functions to use the provided registry,
+    so every test gets its own metric instances.
+    """
+    if prisma_client is None:
+        prisma_client = _make_prisma_client()
+    if registry is None:
+        registry = CollectorRegistry()
+
+    from prometheus_client import Counter, Gauge
+
+    def _patched_get_or_create_gauge(name, description):
+        return Gauge(name, description, registry=registry)
+
+    def _patched_get_or_create_counter(name, description):
+        return Counter(name, description, registry=registry)
+
+    with patch(
+        "litellm.proxy.db.prisma_metrics_collector._get_or_create_gauge",
+        side_effect=_patched_get_or_create_gauge,
+    ), patch(
+        "litellm.proxy.db.prisma_metrics_collector._get_or_create_counter",
+        side_effect=_patched_get_or_create_counter,
+    ):
+        collector = PrismaMetricsCollector(
+            prisma_client=prisma_client,
+            collection_interval=collection_interval,
+        )
+
+    return collector, registry
+
+
+# ---------------------------------------------------------------------------
+# Metric creation
+# ---------------------------------------------------------------------------
+
+
+def test_collector_creates_prometheus_metrics():
+    """Verify all 6 metrics (4 pool gauges, engine_up gauge, restarts counter) are created."""
+    collector, registry = _make_collector()
+
+    assert collector._pool_active is not None
+    assert collector._pool_idle is not None
+    assert collector._pool_total is not None
+    assert collector._pool_waiting is not None
+    assert collector._engine_up is not None
+    assert collector._engine_restarts is not None
+
+    # Verify names via the registry
+    metric_names = {m.name for m in registry.collect()}
+    expected = {
+        "litellm_db_pool_active_connections",
+        "litellm_db_pool_idle_connections",
+        "litellm_db_pool_total_connections",
+        "litellm_db_pool_waiting_connections",
+        "litellm_db_engine_up",
+        "litellm_db_engine_restarts",  # counter exposes _total suffix but name is base
+    }
+    assert expected.issubset(
+        metric_names
+    ), f"Missing metrics: {expected - metric_names}"
+
+
+# ---------------------------------------------------------------------------
+# Pool metrics collection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_pool_metrics_sets_gauges():
+    """Mock query_raw to return pool stats and verify each gauge is set correctly."""
+    client = _make_prisma_client()
+    client.db.query_raw = AsyncMock(
+        return_value=[{"active": 5, "idle": 10, "total": 15, "waiting": 2}]
+    )
+    collector, registry = _make_collector(prisma_client=client)
+
+    await collector._collect_pool_metrics()
+
+    assert registry.get_sample_value("litellm_db_pool_active_connections") == 5
+    assert registry.get_sample_value("litellm_db_pool_idle_connections") == 10
+    assert registry.get_sample_value("litellm_db_pool_total_connections") == 15
+    assert registry.get_sample_value("litellm_db_pool_waiting_connections") == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_pool_metrics_handles_empty_result():
+    """When query_raw returns an empty list, no crash should occur."""
+    client = _make_prisma_client()
+    client.db.query_raw = AsyncMock(return_value=[])
+    collector, registry = _make_collector(prisma_client=client)
+
+    await collector._collect_pool_metrics()
+
+    # Gauges should remain at their default (0)
+    assert registry.get_sample_value("litellm_db_pool_active_connections") == 0
+
+
+@pytest.mark.asyncio
+async def test_collect_pool_metrics_handles_query_error():
+    """When query_raw raises an exception, the collector should log a warning and not crash."""
+    client = _make_prisma_client()
+    client.db.query_raw = AsyncMock(side_effect=RuntimeError("connection lost"))
+    collector, _ = _make_collector(prisma_client=client)
+
+    with patch(
+        "litellm.proxy.db.prisma_metrics_collector.verbose_proxy_logger"
+    ) as mock_logger:
+        await collector._collect_pool_metrics()
+        mock_logger.warning.assert_called_once()
+        assert "connection lost" in str(mock_logger.warning.call_args)
+
+
+# ---------------------------------------------------------------------------
+# Engine health
+# ---------------------------------------------------------------------------
+
+
+def test_collect_engine_health_alive():
+    """When engine is alive, engine_up gauge should be 1."""
+    client = _make_prisma_client()
+    client._is_engine_alive = MagicMock(return_value=True)
+    collector, registry = _make_collector(prisma_client=client)
+
+    collector._collect_engine_health()
+
+    assert registry.get_sample_value("litellm_db_engine_up") == 1
+
+
+def test_collect_engine_health_dead():
+    """When engine is dead, engine_up gauge should be 0."""
+    client = _make_prisma_client()
+    client._is_engine_alive = MagicMock(return_value=False)
+    collector, registry = _make_collector(prisma_client=client)
+
+    collector._collect_engine_health()
+
+    assert registry.get_sample_value("litellm_db_engine_up") == 0
+
+
+# ---------------------------------------------------------------------------
+# Engine restart counter
+# ---------------------------------------------------------------------------
+
+
+def test_increment_engine_restarts():
+    """Calling increment_engine_restarts N times should result in counter value N."""
+    collector, registry = _make_collector()
+
+    for _ in range(7):
+        collector.increment_engine_restarts()
+
+    assert registry.get_sample_value("litellm_db_engine_restarts_total") == 7
+
+
+# ---------------------------------------------------------------------------
+# should_enable
+# ---------------------------------------------------------------------------
+
+
+def test_should_enable_true():
+    """should_enable() returns True when prometheus_system is in service_callback."""
+    original = litellm.service_callback
+    try:
+        litellm.service_callback = ["prometheus_system"]
+        assert PrismaMetricsCollector.should_enable() is True
+    finally:
+        litellm.service_callback = original
+
+
+def test_should_enable_false():
+    """should_enable() returns False when service_callback is empty."""
+    original = litellm.service_callback
+    try:
+        litellm.service_callback = []
+        assert PrismaMetricsCollector.should_enable() is False
+    finally:
+        litellm.service_callback = original
+
+
+# ---------------------------------------------------------------------------
+# Collection interval configuration
+# ---------------------------------------------------------------------------
+
+
+def test_collection_interval_from_env():
+    """Interval should be read from PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS env var."""
+    with patch.dict(os.environ, {"PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS": "60"}):
+        collector, _ = _make_collector()
+        assert collector._interval == 60
+
+
+def test_collection_interval_minimum_enforced():
+    """Interval below the minimum should be clamped to _MIN_COLLECTION_INTERVAL."""
+    with patch.dict(os.environ, {"PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS": "1"}):
+        collector, _ = _make_collector()
+        assert collector._interval == _MIN_COLLECTION_INTERVAL
+
+
+def test_collection_interval_constructor_override():
+    """Explicit collection_interval parameter should take precedence over env."""
+    with patch.dict(os.environ, {"PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS": "999"}):
+        collector, _ = _make_collector(collection_interval=45)
+        assert collector._interval == 45
+
+
+def test_collection_interval_default():
+    """Without env var or constructor arg, the default interval is used."""
+    with patch.dict(os.environ, {}, clear=False):
+        # Remove the env var if present
+        env_copy = os.environ.copy()
+        env_copy.pop("PRISMA_METRICS_COLLECTION_INTERVAL_SECONDS", None)
+        with patch.dict(os.environ, env_copy, clear=True):
+            collector, _ = _make_collector()
+            assert collector._interval == _DEFAULT_COLLECTION_INTERVAL
+
+
+# ---------------------------------------------------------------------------
+# Start / Stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_task():
+    """Calling start() should create a background asyncio task."""
+    collector, _ = _make_collector()
+
+    collector.start()
+    assert collector._task is not None
+    # Clean up
+    await collector.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_idempotent():
+    """Calling start() twice should not create a second task."""
+    collector, _ = _make_collector()
+
+    collector.start()
+    first_task = collector._task
+    collector.start()
+    assert collector._task is first_task
+    # Clean up
+    await collector.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_task():
+    """Calling stop() after start() should cancel the task and set it to None."""
+    collector, _ = _make_collector()
+
+    collector.start()
+    assert collector._task is not None
+
+    await collector.stop()
+    assert collector._task is None

--- a/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
+++ b/tests/test_litellm/proxy/db/test_prisma_metrics_collector.py
@@ -46,7 +46,9 @@ def _make_collector(prisma_client=None, collection_interval=None, registry=None)
 
     from prometheus_client import Counter, Gauge
 
-    def _patched_get_or_create_gauge(name, description):
+    def _patched_get_or_create_gauge(name, description, labelnames=None):
+        if labelnames:
+            return Gauge(name, description, labelnames=labelnames, registry=registry)
         return Gauge(name, description, registry=registry)
 
     def _patched_get_or_create_counter(name, description):
@@ -73,12 +75,10 @@ def _make_collector(prisma_client=None, collection_interval=None, registry=None)
 
 
 def test_collector_creates_prometheus_metrics():
-    """Verify all 6 metrics (4 pool gauges, engine_up gauge, restarts counter) are created."""
+    """Verify all 4 metrics (pool connections gauge, lock waiting gauge, engine_up gauge, restarts counter) are created."""
     collector, registry = _make_collector()
 
-    assert collector._pool_active is not None
-    assert collector._pool_idle is not None
-    assert collector._pool_total is not None
+    assert collector._pool_connections is not None
     assert collector._pool_waiting is not None
     assert collector._engine_up is not None
     assert collector._engine_restarts is not None
@@ -86,9 +86,7 @@ def test_collector_creates_prometheus_metrics():
     # Verify names via the registry
     metric_names = {m.name for m in registry.collect()}
     expected = {
-        "litellm_db_pool_active_connections",
-        "litellm_db_pool_idle_connections",
-        "litellm_db_pool_total_connections",
+        "litellm_db_pool_connections",
         "litellm_db_pool_lock_waiting_connections",
         "litellm_db_engine_up",
         "litellm_db_engine_restarts",  # counter exposes _total suffix but name is base
@@ -105,32 +103,68 @@ def test_collector_creates_prometheus_metrics():
 
 @pytest.mark.asyncio
 async def test_collect_pool_metrics_sets_gauges():
-    """Mock query_raw to return pool stats and verify each gauge is set correctly."""
+    """Mock query_raw to return pool stats grouped by state and verify labeled gauge is set."""
     client = _make_prisma_client()
-    client.db.query_raw = AsyncMock(
-        return_value=[{"active": 5, "idle": 10, "total": 15, "waiting": 2}]
-    )
+
+    pool_rows = [
+        {"state": "active", "count": 5},
+        {"state": "idle", "count": 10},
+        {"state": "idle in transaction", "count": 3},
+    ]
+    lock_rows = [{"waiting": 2}]
+    client.db.query_raw = AsyncMock(side_effect=[pool_rows, lock_rows])
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
 
-    assert registry.get_sample_value("litellm_db_pool_active_connections") == 5
-    assert registry.get_sample_value("litellm_db_pool_idle_connections") == 10
-    assert registry.get_sample_value("litellm_db_pool_total_connections") == 15
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "active"})
+        == 5
+    )
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "idle"})
+        == 10
+    )
+    assert (
+        registry.get_sample_value(
+            "litellm_db_pool_connections", {"state": "idle in transaction"}
+        )
+        == 3
+    )
     assert registry.get_sample_value("litellm_db_pool_lock_waiting_connections") == 2
 
 
 @pytest.mark.asyncio
 async def test_collect_pool_metrics_handles_empty_result():
-    """When query_raw returns an empty list, no crash should occur."""
+    """When query_raw returns empty lists, no crash should occur."""
     client = _make_prisma_client()
     client.db.query_raw = AsyncMock(return_value=[])
     collector, registry = _make_collector(prisma_client=client)
 
     await collector._collect_pool_metrics()
 
-    # Gauges should remain at their default (0)
-    assert registry.get_sample_value("litellm_db_pool_active_connections") == 0
+    # No labeled values should be set — just verify no crash
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "active"})
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_pool_metrics_handles_null_state():
+    """When pg_stat_activity returns a NULL state, it should be mapped to 'unknown'."""
+    client = _make_prisma_client()
+    pool_rows = [{"state": None, "count": 1}]
+    lock_rows = [{"waiting": 0}]
+    client.db.query_raw = AsyncMock(side_effect=[pool_rows, lock_rows])
+    collector, registry = _make_collector(prisma_client=client)
+
+    await collector._collect_pool_metrics()
+
+    assert (
+        registry.get_sample_value("litellm_db_pool_connections", {"state": "unknown"})
+        == 1
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Re-submits #22655 (reverted in #23190) with the import fix applied.

Adds a `PrismaMetricsCollector` that exposes Prometheus metrics for DB connection pool health:
- `litellm_db_pool_connections{state}` — connection count by pg_stat_activity state
- `litellm_db_pool_lock_waiting_connections` — connections blocked on locks
- `litellm_db_engine_up` — Prisma query engine liveness (1=up, 0=down)
- `litellm_db_engine_restarts_total` — engine restart counter

The collector runs as a background asyncio task attached to the existing PrismaClient health watchdog, auto-enabling when `prometheus_system` is in `service_callback`.

## What changed vs #22655
All `prometheus_client` imports are now **lazy** (inside functions, not at module top-level), matching the existing pattern in `litellm/integrations/prometheus.py`. The top-level import in `utils.py` is also moved inline to call sites. This prevents `ModuleNotFoundError` when `prometheus_client` is not installed via `pip install litellm[proxy]`.

## Test plan
- [x] 19 unit tests in `test_prisma_metrics_collector.py` all pass
- [x] `import litellm.proxy.proxy_server` succeeds without `prometheus_client` installed
- [x] `import litellm.proxy.utils` succeeds without `prometheus_client` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)