### PR TITLE
fix: add __getattr__ proxy to FallbackStreamWrapper and SyncFallbackStreamWrapper

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1635,7 +1635,8 @@ class Router:
 
         class FallbackStreamWrapper(CustomStreamWrapper):
             def __init__(self, async_generator: AsyncGenerator):
-                # Copy attributes from the original model_response
+                # Keep ref to original stream for __getattr__ proxy
+                self._wrapped_response = model_response
                 super().__init__(
                     completion_stream=async_generator,
                     model=model_response.model,
@@ -1646,6 +1647,10 @@ class Router:
                 # Preserve hidden params (including litellm_overhead_time_ms) from original response
                 if hasattr(model_response, "_hidden_params"):
                     self._hidden_params = model_response._hidden_params.copy()
+
+            def __getattr__(self, name: str):
+                # Proxy unknown attrs to the original stream (e.g. ddtrace .handler)
+                return getattr(self._wrapped_response, name)
 
             def __aiter__(self):
                 return self
@@ -1781,6 +1786,8 @@ class Router:
 
         class SyncFallbackStreamWrapper(CustomStreamWrapper):
             def __init__(self, sync_generator: Generator):
+                # Keep ref to original stream for __getattr__ proxy
+                self._wrapped_response = model_response
                 super().__init__(
                     completion_stream=sync_generator,
                     model=model_response.model,
@@ -1790,6 +1797,10 @@ class Router:
                 self._sync_generator = sync_generator
                 if hasattr(model_response, "_hidden_params"):
                     self._hidden_params = model_response._hidden_params.copy()
+
+            def __getattr__(self, name: str):
+                # Proxy unknown attrs to the original stream (e.g. ddtrace .handler)
+                return getattr(self._wrapped_response, name)
 
             def __iter__(self):
                 return self

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1593,6 +1593,74 @@ def test_completion_streaming_iterator_proxies_unknown_attrs():
 
 
 @pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_getattr_does_not_shadow_own_attrs():
+    """FallbackStreamWrapper.__getattr__ must not shadow CustomStreamWrapper's own attributes."""
+    from unittest.mock import MagicMock
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.model = "original-model-on-wrapped"
+    mock_response.custom_llm_provider = "original-provider-on-wrapped"
+    mock_response.logging_obj = MagicMock()
+    mock_response._hidden_params = {}
+
+    async def _empty():
+        return
+        yield
+
+    mock_response.__aiter__ = lambda self: _empty().__aiter__()
+
+    result = await router._acompletion_streaming_iterator(
+        model_response=mock_response,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    # .model is set by CustomStreamWrapper.__init__, not proxied from _wrapped_response
+    assert result.model == "original-model-on-wrapped"
+    assert result.custom_llm_provider == "original-provider-on-wrapped"
+
+
+def test_completion_streaming_iterator_getattr_does_not_shadow_own_attrs():
+    """SyncFallbackStreamWrapper.__getattr__ must not shadow CustomStreamWrapper's own attributes."""
+    from unittest.mock import MagicMock
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.model = "original-model-on-wrapped"
+    mock_response.custom_llm_provider = "original-provider-on-wrapped"
+    mock_response.logging_obj = MagicMock()
+    mock_response._hidden_params = {}
+    mock_response.__iter__ = MagicMock(return_value=iter([]))
+
+    result = router._completion_streaming_iterator(
+        model_response=mock_response,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    # .model is set by CustomStreamWrapper.__init__, not proxied from _wrapped_response
+    assert result.model == "original-model-on-wrapped"
+    assert result.custom_llm_provider == "original-provider-on-wrapped"
+
+
+@pytest.mark.asyncio
 async def test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation():
     """When MidStreamFallbackError has is_pre_first_chunk=True, use original messages."""
     from unittest.mock import MagicMock

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1624,9 +1624,17 @@ async def test_acompletion_streaming_iterator_getattr_does_not_shadow_own_attrs(
         initial_kwargs={"model": "gpt-4", "stream": True},
     )
 
-    # .model is set by CustomStreamWrapper.__init__, not proxied from _wrapped_response
-    assert result.model == "original-model-on-wrapped"
-    assert result.custom_llm_provider == "original-provider-on-wrapped"
+    # Mutate the wrapped response after construction — if __getattr__ were
+    # wrongly shadowing, result.model would follow the mutation.
+    expected_model = result.model
+    mock_response.model = "SHOULD-NOT-APPEAR"
+    assert result.model == expected_model
+    assert result.model != "SHOULD-NOT-APPEAR"
+
+    expected_provider = result.custom_llm_provider
+    mock_response.custom_llm_provider = "SHOULD-NOT-APPEAR"
+    assert result.custom_llm_provider == expected_provider
+    assert result.custom_llm_provider != "SHOULD-NOT-APPEAR"
 
 
 def test_completion_streaming_iterator_getattr_does_not_shadow_own_attrs():
@@ -1655,9 +1663,17 @@ def test_completion_streaming_iterator_getattr_does_not_shadow_own_attrs():
         initial_kwargs={"model": "gpt-4", "stream": True},
     )
 
-    # .model is set by CustomStreamWrapper.__init__, not proxied from _wrapped_response
-    assert result.model == "original-model-on-wrapped"
-    assert result.custom_llm_provider == "original-provider-on-wrapped"
+    # Mutate the wrapped response after construction — if __getattr__ were
+    # wrongly shadowing, result.model would follow the mutation.
+    expected_model = result.model
+    mock_response.model = "SHOULD-NOT-APPEAR"
+    assert result.model == expected_model
+    assert result.model != "SHOULD-NOT-APPEAR"
+
+    expected_provider = result.custom_llm_provider
+    mock_response.custom_llm_provider = "SHOULD-NOT-APPEAR"
+    assert result.custom_llm_provider == expected_provider
+    assert result.custom_llm_provider != "SHOULD-NOT-APPEAR"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1526,6 +1526,73 @@ def test_completion_streaming_iterator_preserves_hidden_params():
 
 
 @pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_proxies_unknown_attrs():
+    """FallbackStreamWrapper.__getattr__ proxies attrs from the original stream."""
+    from unittest.mock import MagicMock
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.model = "gpt-4"
+    mock_response.custom_llm_provider = "openai"
+    mock_response.logging_obj = MagicMock()
+    mock_response._hidden_params = {}
+    # Simulate an attribute added by a third-party patch (e.g. ddtrace .handler)
+    mock_response.handler = MagicMock(name="ddtrace-handler")
+
+    async def _empty():
+        return
+        yield
+
+    mock_response.__aiter__ = lambda self: _empty().__aiter__()
+
+    result = await router._acompletion_streaming_iterator(
+        model_response=mock_response,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    assert result.handler is mock_response.handler
+
+
+def test_completion_streaming_iterator_proxies_unknown_attrs():
+    """SyncFallbackStreamWrapper.__getattr__ proxies attrs from the original stream."""
+    from unittest.mock import MagicMock
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.model = "gpt-4"
+    mock_response.custom_llm_provider = "openai"
+    mock_response.logging_obj = MagicMock()
+    mock_response._hidden_params = {}
+    mock_response.handler = MagicMock(name="ddtrace-handler")
+    mock_response.__iter__ = MagicMock(return_value=iter([]))
+
+    result = router._completion_streaming_iterator(
+        model_response=mock_response,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    assert result.handler is mock_response.handler
+
+
+@pytest.mark.asyncio
 async def test_acompletion_streaming_iterator_pre_first_chunk_skips_continuation():
     """When MidStreamFallbackError has is_pre_first_chunk=True, use original messages."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

`SyncFallbackStreamWrapper` and `FallbackStreamWrapper` (PR #22375) subclass `CustomStreamWrapper` but hide attributes that third-party instrumentation libraries add to the original stream. This causes `AttributeError` when those libraries access their injected attributes on the returned wrapper.

Concrete case: **ddtrace** wraps the inner `CustomStreamWrapper` in a `TracedStream` (`wrapt.ObjectProxy`) that adds a `.handler` attribute. The Router then wraps this in `SyncFallbackStreamWrapper`, hiding `.handler`:

```
Router.completion()
  → litellm.completion() → CustomStreamWrapper
  → ddtrace wraps in TracedStream (has .handler)
  → Router wraps in SyncFallbackStreamWrapper (hides .handler)
  → ddtrace does resp.handler → AttributeError
```

## Changes

### `litellm/router.py`
- **`FallbackStreamWrapper`**: Store `model_response` as `_wrapped_response` before `super().__init__()`. Add `__getattr__` that proxies to `_wrapped_response`.
- **`SyncFallbackStreamWrapper`**: Same.

`__getattr__` is only called when normal attribute lookup fails, so it doesn't interfere with `CustomStreamWrapper`'s own attributes.

### `tests/test_litellm/test_router.py`
- `test_acompletion_streaming_iterator_proxies_unknown_attrs` — async wrapper proxies `.handler`
- `test_completion_streaming_iterator_proxies_unknown_attrs` — sync wrapper proxies `.handler`

Fixes #23357

