### PR TITLE
feat(router): add always_include_stream_usage to UpdateRouterConfig and router.update_settings

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1269,6 +1269,36 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+  "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "input_cost_per_token": 3.3e-06,
+        "input_cost_per_token_above_200k_tokens": 6.6e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -653,8 +653,12 @@ class ProxyBaseLLMRequestProcessing:
         ### AUTO STREAM USAGE TRACKING ###
         # If always_include_stream_usage is enabled and this is a streaming request
         # automatically add stream_options={'include_usage': True} if not already set
+        # Check both general_settings and router-level setting (set via Router Settings UI)
+        _router_always_include = False
+        if llm_router is not None:
+            _router_always_include = getattr(llm_router, "always_include_stream_usage", False) or False
         if (
-            general_settings.get("always_include_stream_usage", False) is True
+            (general_settings.get("always_include_stream_usage", False) is True or _router_always_include is True)
             and self.data.get("stream", False) is True
         ):
             # Only set if stream_options is not already provided by the client

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8259,6 +8259,7 @@ class Router:
             "context_window_fallbacks",
             "model_group_retry_policy",
             "model_group_alias",
+            "always_include_stream_usage",
         ]
 
         _int_settings = [

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -87,6 +87,8 @@ class UpdateRouterConfig(BaseModel):
     fallbacks: Optional[List[dict]] = None
     context_window_fallbacks: Optional[List[dict]] = None
     model_group_alias: Optional[Dict[str, Union[str, Dict]]] = {}
+    always_include_stream_usage: Optional[bool] = None
+    """When True, always append a usage chunk at the end of every streaming response."""
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1269,6 +1269,36 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 346
     },
+  "jp.anthropic.claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
+        "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "input_cost_per_token": 3.3e-06,
+        "input_cost_per_token_above_200k_tokens": 6.6e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 346
+    },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,


### PR DESCRIPTION
## Problem

`always_include_stream_usage` is documented as a `general_settings` option but is absent from the Router Settings UI (`UpdateRouterConfig` / `router.update_settings()`). Users cannot configure it from the Admin UI without editing the config file (closes #23343).

## Changes

| File | Change |
|------|--------|
| `litellm/types/router.py` | Add `always_include_stream_usage: Optional[bool]` to `UpdateRouterConfig` |
| `litellm/router.py` | Add `'always_include_stream_usage'` to `_allowed_settings` in `update_settings()` |
| `litellm/proxy/common_request_processing.py` | Also check `llm_router.always_include_stream_usage` alongside `general_settings`, so the router-level flag activates the stream_options injection |

Closes #23343