### PR TITLE
test: prevent pytest responses import shadowing

### DIFF
--- a/tests/test_litellm/llms/__init__.py
+++ b/tests/test_litellm/llms/__init__.py
@@ -1,0 +1,1 @@
+"""LLM provider tests package."""

--- a/tests/test_litellm/llms/databricks/__init__.py
+++ b/tests/test_litellm/llms/databricks/__init__.py
@@ -1,0 +1,1 @@
+"""Databricks provider tests package."""

--- a/tests/test_litellm/llms/github_copilot/__init__.py
+++ b/tests/test_litellm/llms/github_copilot/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub Copilot provider tests package."""

--- a/tests/test_litellm/llms/hosted_vllm/__init__.py
+++ b/tests/test_litellm/llms/hosted_vllm/__init__.py
@@ -1,0 +1,1 @@
+"""Hosted vLLM provider tests package."""

--- a/tests/test_litellm/llms/openai/__init__.py
+++ b/tests/test_litellm/llms/openai/__init__.py
@@ -1,0 +1,1 @@
+"""OpenAI provider tests package."""

--- a/tests/test_litellm/llms/openrouter/__init__.py
+++ b/tests/test_litellm/llms/openrouter/__init__.py
@@ -1,0 +1,1 @@
+"""OpenRouter provider tests package."""

--- a/tests/test_litellm/llms/xai/__init__.py
+++ b/tests/test_litellm/llms/xai/__init__.py
@@ -1,0 +1,1 @@
+"""xAI provider tests package."""


### PR DESCRIPTION
## Relevant issues

Fixes pytest import shadowing between the third-party `responses` package and test directories named `responses/` under `tests/test_litellm`.

  ## Pre-Submission checklist

 - [  ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory **Adding at least 1 test is a hard requirement**
 - [  ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
 - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
 - [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

  Notes:
  - This change is test-only and fixes package/import boundaries.
  - I locally verified the original failure mode is resolved:
    - `poetry run pytest tests/test_litellm/proxy/client/test_chat.py -x -vv -n 4`
    - `poetry run pytest tests/test_litellm -x -vv -n 0` now gets past collection instead of failing on `responses.activate`. 
    
Some isolated test failures are pre-existing in the merge-base. Previously, the entire test suite was essentially blocked from even collecting.

  ## Type

  ✅ Test

  ## Changes

This PR fixes a pytest import shadowing issue in the test suite.

When collecting the full `tests/test_litellm` tree (as still run by 'make unit-tests' suggested by https://docs.litellm.ai/docs/extras/contributing_code), pytest resolved `import responses` to local test directories such as `tests/test_litellm/llms/databricks/responses/` instead of the third-party `responses` package. That caused collection failures like:

  ```bash
  AttributeError: module 'responses' has no attribute 'activate'
   ```
   
  
  
   @greptileai