### PR TITLE
[Feature] Support auto_redirect_ui_login_to_sso in config.yaml

### DIFF
--- a/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -18,8 +18,11 @@ async def get_ui_config():
     from litellm.proxy.auth.auth_utils import _has_user_setup_sso
     from litellm.proxy.utils import get_proxy_base_url, get_server_root_path
 
+    from litellm.proxy.proxy_server import general_settings
+
     auto_redirect_ui_login_to_sso = (
         os.getenv("AUTO_REDIRECT_UI_LOGIN_TO_SSO", "false").lower() == "true"
+        or general_settings.get("auto_redirect_ui_login_to_sso", False) is True
     )
     admin_ui_disabled = os.getenv("DISABLE_ADMIN_UI", "false").lower() == "true"
 

--- a/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
@@ -175,6 +175,46 @@ def test_ui_discovery_endpoints_both_routes_return_same_data():
         assert response1.json() == response2.json()
 
 
+def test_ui_discovery_endpoints_with_auto_redirect_via_general_settings():
+    """When auto_redirect_ui_login_to_sso is set in general_settings (config.yaml), it should be honored."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with patch("litellm.proxy.utils.get_server_root_path", return_value="/"), \
+         patch("litellm.proxy.utils.get_proxy_base_url", return_value=None), \
+         patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=True), \
+         patch("litellm.proxy.proxy_server.general_settings", {"auto_redirect_ui_login_to_sso": True}), \
+         patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False):
+        os.environ.pop("AUTO_REDIRECT_UI_LOGIN_TO_SSO", None)
+
+        response = client.get("/.well-known/litellm-ui-config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["auto_redirect_to_sso"] is True
+        assert data["sso_configured"] is True
+
+
+def test_ui_discovery_endpoints_with_auto_redirect_env_var_overrides_general_settings():
+    """Env var and general_settings should both work — either being true enables the feature."""
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with patch("litellm.proxy.utils.get_server_root_path", return_value="/"), \
+         patch("litellm.proxy.utils.get_proxy_base_url", return_value=None), \
+         patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=True), \
+         patch("litellm.proxy.proxy_server.general_settings", {"auto_redirect_ui_login_to_sso": False}), \
+         patch.dict(os.environ, {"AUTO_REDIRECT_UI_LOGIN_TO_SSO": "true", "DISABLE_ADMIN_UI": "false"}, clear=False):
+
+        response = client.get("/.well-known/litellm-ui-config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["auto_redirect_to_sso"] is True
+
+
 def test_ui_discovery_endpoints_with_admin_ui_disabled():
     app = FastAPI()
     app.include_router(router)


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Problem

`AUTO_REDIRECT_UI_LOGIN_TO_SSO` is only honored as an environment variable. Users cannot set it in config.yaml under `general_settings`, unlike other proxy settings.

### Fix

Read `auto_redirect_ui_login_to_sso` from `general_settings` in addition to the env var. Either source being `true` enables the feature, preserving backward compatibility.

```yaml
general_settings:
  auto_redirect_ui_login_to_sso: true
```

## Testing

- Added test for setting via `general_settings` (config.yaml path)
- Added test confirming env var still works when `general_settings` has it as `false`
- All 12 existing + new tests pass

## Type

🆕 New Feature
✅ Test

## Screenshots

N/A