### PR TITLE
fix: preserve resolved model name in response instead of returning client alias

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -246,6 +246,40 @@ async def create_response(
     )
 
 
+def _get_provider_prefix_set() -> frozenset:
+    """
+    Return a cached frozenset of known LiteLLM provider prefix strings.
+
+    Built lazily on first call from ``litellm.provider_list`` and cached for the
+    lifetime of the process so that per-chunk lookups in streaming responses are O(1).
+    """
+    cached = getattr(_get_provider_prefix_set, "_cache", None)
+    if cached is not None:
+        return cached
+    result = frozenset(
+        p.value if hasattr(p, "value") else str(p) for p in litellm.provider_list
+    )
+    _get_provider_prefix_set._cache = result  # type: ignore[attr-defined]
+    return result
+
+
+def _response_model_has_provider_prefix(model: Optional[str]) -> bool:
+    """
+    Check if a model string contains a LiteLLM-internal provider prefix (e.g. ``hosted_vllm/...``, ``azure/...``).
+
+    Returns ``True`` when the model value looks like ``<provider>/<actual_model>`` and the
+    provider part is a known LiteLLM provider.  This is used to decide whether the response
+    ``model`` field should be overwritten: we only want to strip internal prefixes, not replace
+    a clean provider-returned model name with the client-requested alias/group name.
+    """
+    if not model or not isinstance(model, str):
+        return False
+    parts = model.split("/", 1)
+    if len(parts) < 2:
+        return False
+    return parts[0] in _get_provider_prefix_set()
+
+
 def _override_openai_response_model(
     *,
     response_obj: Any,
@@ -253,20 +287,16 @@ def _override_openai_response_model(
     log_context: str,
 ) -> None:
     """
-    Force the OpenAI-compatible `model` field in the response to match what the client requested.
+    Override the OpenAI-compatible ``model`` field only when it contains a LiteLLM-internal
+    provider prefix (e.g. ``hosted_vllm/...``, ``azure/...``).
 
-    LiteLLM internally prefixes some provider/deployment model identifiers (e.g. `hosted_vllm/...`).
-    That internal identifier should not be returned to clients in the OpenAI `model` field.
-
-    Note: This is intentionally verbose. A model mismatch is a useful signal that an internal
-    model identifier is being stamped/preserved somewhere in the request/response pipeline.
-    We log mismatches as warnings (and then restamp to the client-requested value) so these
-    paths stay observable for maintainers/operators without breaking client compatibility.
-
-    Errors are reserved for cases where the proxy cannot read/override the response model field.
+    When the downstream provider already returns a clean model name (e.g. ``gpt-4.1-2025-04-14``),
+    it is preserved so that callers can see which actual model served the request.  This matches
+    OpenAI's own behaviour where the response ``model`` is the *resolved* version, not the alias
+    the client sent.
 
     Exception: If a fallback occurred (indicated by x-litellm-attempted-fallbacks header),
-    we should preserve the actual model that was used (the fallback model) rather than
+    we preserve the actual model that was used (the fallback model) rather than
     overriding it with the originally requested model.
     """
     if not requested_model:
@@ -290,13 +320,20 @@ def _override_openai_response_model(
 
     if isinstance(response_obj, dict):
         downstream_model = response_obj.get("model")
-        if downstream_model != requested_model:
+        if not _response_model_has_provider_prefix(downstream_model):
             verbose_proxy_logger.debug(
-                "%s: response model mismatch - requested=%r downstream=%r. Overriding response['model'] to requested model.",
+                "%s: preserving downstream model=%r (no provider prefix). client requested=%r",
                 log_context,
-                requested_model,
                 downstream_model,
+                requested_model,
             )
+            return
+        verbose_proxy_logger.debug(
+            "%s: stripping provider prefix - downstream=%r -> requested=%r",
+            log_context,
+            downstream_model,
+            requested_model,
+        )
         response_obj["model"] = requested_model
         return
 
@@ -309,13 +346,21 @@ def _override_openai_response_model(
         return
 
     downstream_model = getattr(response_obj, "model", None)
-    if downstream_model != requested_model:
+    if not _response_model_has_provider_prefix(downstream_model):
         verbose_proxy_logger.debug(
-            "%s: response model mismatch - requested=%r downstream=%r. Overriding response.model to requested model.",
+            "%s: preserving downstream model=%r (no provider prefix). client requested=%r",
             log_context,
-            requested_model,
             downstream_model,
+            requested_model,
         )
+        return
+
+    verbose_proxy_logger.debug(
+        "%s: stripping provider prefix - downstream=%r -> requested=%r",
+        log_context,
+        downstream_model,
+        requested_model,
+    )
 
     try:
         setattr(response_obj, "model", requested_model)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -289,6 +289,7 @@ from litellm.proxy.batches_endpoints.endpoints import router as batches_router
 from litellm.proxy.caching_routes import router as caching_router
 from litellm.proxy.common_request_processing import (
     ProxyBaseLLMRequestProcessing,
+    _response_model_has_provider_prefix,
     create_response,
 )
 from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
@@ -5417,24 +5418,26 @@ def _restamp_streaming_chunk_model(
     request_data: dict,
     model_mismatch_logged: bool,
 ) -> Tuple[Any, bool]:
-    # Always return the client-requested model name (not provider-prefixed internal identifiers)
-    # on streaming chunks.
-    #
-    # Note: This warning is intentionally verbose. A mismatch is a useful signal that an
-    # internal provider/deployment identifier is leaking into the public API, and helps
-    # maintainers/operators catch regressions while preserving OpenAI-compatible output.
+    # Only override the streaming chunk model when it contains a LiteLLM-internal provider
+    # prefix (e.g. ``hosted_vllm/...``).  When the downstream provider already returns a clean
+    # model name, preserve it so callers can see which actual model served the request.
     if not requested_model_from_client or not isinstance(chunk, (BaseModel, dict)):
         return chunk, model_mismatch_logged
 
     downstream_model = (
         chunk.get("model") if isinstance(chunk, dict) else getattr(chunk, "model", None)
     )
+
+    # If the downstream model does not carry a provider prefix, preserve it as-is.
+    if not _response_model_has_provider_prefix(downstream_model):
+        return chunk, model_mismatch_logged
+
     if not model_mismatch_logged and downstream_model != requested_model_from_client:
         verbose_proxy_logger.debug(
-            "litellm_call_id=%s: streaming chunk model mismatch - requested=%r downstream=%r. Overriding model to requested.",
+            "litellm_call_id=%s: streaming chunk has provider prefix - downstream=%r -> requested=%r",
             request_data.get("litellm_call_id"),
-            requested_model_from_client,
             downstream_model,
+            requested_model_from_client,
         )
         model_mismatch_logged = True
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -17,6 +17,7 @@ from litellm.proxy.common_request_processing import (
     _get_cost_breakdown_from_logging_obj,
     _override_openai_response_model,
     _parse_event_data_for_error,
+    _response_model_has_provider_prefix,
     create_response,
 )
 from litellm.proxy.dd_span_tagger import DDSpanTagger
@@ -1211,127 +1212,150 @@ class TestOverrideOpenAIResponseModel:
         assert response_obj.model == fallback_model
         assert response_obj.model != requested_model
 
-    def test_override_model_overrides_when_no_fallback_dict(self):
+    def test_override_model_strips_provider_prefix_dict(self):
         """
-        Test that when no fallback occurred, the model is overridden
-        to match the requested model (dict response).
+        Test that when the downstream model has a provider prefix (e.g. hosted_vllm/...),
+        it gets overridden to the requested model (dict response).
         """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
+        requested_model = "my-model-alias"
+        downstream_model = "hosted_vllm/meta-llama/Llama-3-8b"
 
-        # Create a dict response without fallback
-        # For dict responses, _hidden_params won't be found via getattr,
-        # so the fallback check won't trigger and model will be overridden
         response_obj = {"model": downstream_model}
 
-        # Call the function - should override to requested model
         _override_openai_response_model(
             response_obj=response_obj,
             requested_model=requested_model,
             log_context="test_context",
         )
 
-        # Verify the model WAS overridden to requested model
         assert response_obj["model"] == requested_model
 
-    def test_override_model_overrides_when_no_fallback_object(self):
+    def test_override_model_strips_provider_prefix_object(self):
         """
-        Test that when no fallback occurred (object response), the model is overridden
-        to match the requested model.
+        Test that when the downstream model has a provider prefix,
+        it gets overridden to the requested model (object response).
         """
-        requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
+        requested_model = "my-model-alias"
+        downstream_model = "azure/gpt-4"
 
-        # Create a mock object response without fallback
         response_obj = MagicMock()
         response_obj.model = downstream_model
         response_obj._hidden_params = {
-            "additional_headers": {}  # No attempted_fallbacks header
+            "additional_headers": {}
         }
 
-        # Call the function - should override to requested model
         _override_openai_response_model(
             response_obj=response_obj,
             requested_model=requested_model,
             log_context="test_context",
         )
 
-        # Verify the model WAS overridden to requested model
         assert response_obj.model == requested_model
+
+    def test_override_model_preserves_clean_downstream_model_dict(self):
+        """
+        Test that when the downstream provider returns a clean model name
+        (no provider prefix), it is preserved — not replaced with the alias.
+        This matches OpenAI behavior where response model is the resolved version.
+        """
+        requested_model = "conversation.voice"
+        downstream_model = "gpt-4.1-2025-04-14"
+
+        response_obj = {"model": downstream_model}
+
+        _override_openai_response_model(
+            response_obj=response_obj,
+            requested_model=requested_model,
+            log_context="test_context",
+        )
+
+        assert response_obj["model"] == downstream_model
+
+    def test_override_model_preserves_clean_downstream_model_object(self):
+        """
+        Test that when the downstream provider returns a clean model name
+        (no provider prefix), it is preserved on object responses.
+        """
+        requested_model = "conversation.voice"
+        downstream_model = "gpt-4.1-2025-04-14"
+
+        response_obj = MagicMock()
+        response_obj.model = downstream_model
+        response_obj._hidden_params = {
+            "additional_headers": {}
+        }
+
+        _override_openai_response_model(
+            response_obj=response_obj,
+            requested_model=requested_model,
+            log_context="test_context",
+        )
+
+        assert response_obj.model == downstream_model
 
     def test_override_model_overrides_when_attempted_fallbacks_is_zero(self):
         """
         Test that when attempted_fallbacks is 0 (no fallback occurred),
-        the model is overridden to match the requested model.
+        the model is overridden if it has a provider prefix.
         """
         requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
+        downstream_model = "azure/gpt-4"
 
-        # Create a mock object response
         response_obj = MagicMock()
         response_obj.model = downstream_model
         response_obj._hidden_params = {
             "additional_headers": {
-                "x-litellm-attempted-fallbacks": 0  # Zero means no fallback occurred
+                "x-litellm-attempted-fallbacks": 0
             }
         }
 
-        # Call the function - should override to requested model
         _override_openai_response_model(
             response_obj=response_obj,
             requested_model=requested_model,
             log_context="test_context",
         )
 
-        # Verify the model WAS overridden to requested model
         assert response_obj.model == requested_model
 
     def test_override_model_overrides_when_attempted_fallbacks_is_none(self):
         """
         Test that when attempted_fallbacks is None (not set),
-        the model is overridden to match the requested model.
+        the model is overridden if it has a provider prefix.
         """
         requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
+        downstream_model = "azure/gpt-4"
 
-        # Create a mock object response
         response_obj = MagicMock()
         response_obj.model = downstream_model
         response_obj._hidden_params = {
             "additional_headers": {"x-litellm-attempted-fallbacks": None}
         }
 
-        # Call the function - should override to requested model
         _override_openai_response_model(
             response_obj=response_obj,
             requested_model=requested_model,
             log_context="test_context",
         )
 
-        # Verify the model WAS overridden to requested model
         assert response_obj.model == requested_model
 
-    def test_override_model_no_hidden_params(self):
+    def test_override_model_no_hidden_params_with_prefix(self):
         """
-        Test that when _hidden_params is not present, the model is overridden
-        to match the requested model.
+        Test that when _hidden_params is not present and model has a provider prefix,
+        the model is overridden.
         """
         requested_model = "gpt-4"
-        downstream_model = "gpt-3.5-turbo"
+        downstream_model = "hosted_vllm/gpt-4"
 
-        # Create a mock object response without _hidden_params
         response_obj = MagicMock()
         response_obj.model = downstream_model
-        # Don't set _hidden_params - getattr will return {}
 
-        # Call the function - should override to requested model
         _override_openai_response_model(
             response_obj=response_obj,
             requested_model=requested_model,
             log_context="test_context",
         )
 
-        # Verify the model WAS overridden to requested model
         assert response_obj.model == requested_model
 
     def test_override_model_no_requested_model(self):
@@ -1341,32 +1365,41 @@ class TestOverrideOpenAIResponseModel:
         """
         fallback_model = "gpt-3.5-turbo"
 
-        # Create a mock object response
         response_obj = MagicMock()
         response_obj.model = fallback_model
         response_obj._hidden_params = {
             "additional_headers": {"x-litellm-attempted-fallbacks": 1}
         }
 
-        # Call the function with None requested_model
         _override_openai_response_model(
             response_obj=response_obj,
             requested_model=None,
             log_context="test_context",
         )
 
-        # Verify the model was not changed
         assert response_obj.model == fallback_model
 
-        # Call with empty string
-        _override_openai_response_model(
-            response_obj=response_obj,
-            requested_model="",
-            log_context="test_context",
-        )
 
-        # Verify the model was not changed
-        assert response_obj.model == fallback_model
+class TestResponseModelHasProviderPrefix:
+    """Tests for _response_model_has_provider_prefix helper"""
+
+    def test_known_provider_prefix(self):
+        assert _response_model_has_provider_prefix("hosted_vllm/meta-llama/Llama-3") is True
+        assert _response_model_has_provider_prefix("azure/gpt-4") is True
+        assert _response_model_has_provider_prefix("openai/gpt-4") is True
+        assert _response_model_has_provider_prefix("bedrock/anthropic.claude-v2") is True
+
+    def test_clean_model_name(self):
+        assert _response_model_has_provider_prefix("gpt-4.1-2025-04-14") is False
+        assert _response_model_has_provider_prefix("claude-haiku-4-5-20251001") is False
+        assert _response_model_has_provider_prefix("meta-llama/Llama-3-8b") is False
+
+    def test_none_and_empty(self):
+        assert _response_model_has_provider_prefix(None) is False
+        assert _response_model_has_provider_prefix("") is False
+
+    def test_no_slash(self):
+        assert _response_model_has_provider_prefix("gpt-4") is False
 
 
 class TestStreamingOverheadHeader:


### PR DESCRIPTION
## Summary

Fixes #22709

- Only override the response `model` field when it contains a LiteLLM-internal provider prefix (e.g. `hosted_vllm/...`, `azure/...`)
- When the downstream provider already returns a clean model name (e.g. `gpt-4.1-2025-04-14`), preserve it instead of replacing it with the client-requested alias/group name
- Applies to both non-streaming (`_override_openai_response_model`) and streaming (`_restamp_streaming_chunk_model`) code paths

**Before (bug):** `{"model": "conversation.voice"}` — returns the alias  
**After (fix):** `{"model": "gpt-4.1-2025-04-14"}` — returns the resolved model from the provider

This matches OpenAI's own behavior where the response `model` is the resolved version, not the alias the client sent.

## Changes

| File | Change |
|---|---|
| `litellm/proxy/common_request_processing.py` | New `_response_model_has_provider_prefix()` helper with cached provider lookup; updated `_override_openai_response_model()` to only override when prefix detected |
| `litellm/proxy/proxy_server.py` | Updated `_restamp_streaming_chunk_model()` with same logic |
| `tests/.../test_common_request_processing.py` | Updated + new tests for prefix detection, clean model preservation, and provider prefix stripping |

## Test plan

- [x] Unit tests pass (`TestOverrideOpenAIResponseModel` — 10 tests, `TestResponseModelHasProviderPrefix` — 4 tests)
- [ ] Verify with a real proxy deployment using model groups/aliases (e.g. `conversation.voice` → `azure/gpt-4.1`)
- [ ] Verify streaming responses also preserve the resolved model name
- [ ] Verify fallback behavior is unchanged (fallback model is still preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)