### PR TITLE
[Fix] Flaky MCP Server and AgentCore Streaming Tests

### DIFF
--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1456,6 +1456,7 @@ async def test_add_update_server_with_alias():
     mock_mcp_server.authorization_url = None
     mock_mcp_server.registration_url = None
     mock_mcp_server.token_url = None
+    mock_mcp_server.oauth2_flow = None
     # Additional fields used by build_mcp_server_from_table
     mock_mcp_server.extra_headers = None
     mock_mcp_server.allow_all_keys = False
@@ -1511,6 +1512,7 @@ async def test_add_update_server_without_alias():
     mock_mcp_server.authorization_url = None
     mock_mcp_server.registration_url = None
     mock_mcp_server.token_url = None
+    mock_mcp_server.oauth2_flow = None
     # Additional fields used by build_mcp_server_from_table
     mock_mcp_server.extra_headers = None
     mock_mcp_server.allow_all_keys = False
@@ -1566,6 +1568,7 @@ async def test_add_update_server_fallback_to_server_id():
     mock_mcp_server.authorization_url = None
     mock_mcp_server.registration_url = None
     mock_mcp_server.token_url = None
+    mock_mcp_server.oauth2_flow = None
     # Additional fields used by build_mcp_server_from_table - set explicitly
     # to avoid MagicMock objects being passed to Pydantic MCPServer constructor
     mock_mcp_server.extra_headers = None

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -219,6 +219,7 @@ class TestAgentCoreStreamingJsonFallback:
                 messages=[{"role": "user", "content": "test"}],
                 stream=True,
                 client=client,
+                api_key="test-jwt-token",
             )
 
             # Collect content across all chunks
@@ -257,6 +258,7 @@ class TestAgentCoreStreamingJsonFallback:
                 messages=[{"role": "user", "content": "test"}],
                 stream=True,
                 client=client,
+                api_key="test-jwt-token",
             )
 
             # Collect content across all chunks
@@ -289,6 +291,7 @@ class TestAgentCoreStreamingJsonFallback:
                     messages=[{"role": "user", "content": "test"}],
                     stream=True,
                     client=client,
+                    api_key="test-jwt-token",
                 )
 
     async def test_async_streaming_malformed_json_raises_error(self):
@@ -316,4 +319,5 @@ class TestAgentCoreStreamingJsonFallback:
                     messages=[{"role": "user", "content": "test"}],
                     stream=True,
                     client=client,
+                    api_key="test-jwt-token",
                 )


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

**MCP tests** (`test_add_update_server_with_alias`, `test_add_update_server_without_alias`, `test_add_update_server_fallback_to_server_id`): `MagicMock` auto-creates attributes on access, so `getattr(mock, "oauth2_flow", None)` returns a `MagicMock` instead of `None`. Pydantic rejects this when validating `MCPServer.oauth2_flow` against `Literal["client_credentials", "authorization_code"]`.

**AgentCore streaming tests** (`TestAgentCoreStreamingJsonFallback`): The 4 tests mock `client.post` but don't pass an `api_key`, so `sign_request()` falls into the SigV4 path which tries to fetch real AWS credentials — failing in CI with `AuthenticationError: Unable to locate credentials`.

### Fix

- MCP tests: explicitly set `mock_mcp_server.oauth2_flow = None` on all 3 mock objects
- AgentCore tests: pass `api_key="test-jwt-token"` to route through JWT/Bearer auth instead of SigV4, matching the pattern used by other passing tests in the same file

## Testing

All 7 fixed tests pass locally:
- `pytest tests/mcp_tests/test_mcp_server.py::test_add_update_server_with_alias tests/mcp_tests/test_mcp_server.py::test_add_update_server_without_alias tests/mcp_tests/test_mcp_server.py::test_add_update_server_fallback_to_server_id -v` — 3 passed
- `pytest tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py::TestAgentCoreStreamingJsonFallback -v` — 4 passed

## Type

🐛 Bug Fix
✅ Test