### PR TITLE
[Fix] Ruff Lint Errors: Unused Imports, Undefined Names, Statement Counts

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Helper utilities
-from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Union
 
 import httpx
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -63,6 +63,7 @@ from litellm.utils import exception_type, get_litellm_params, get_optional_param
 # Logging is imported lazily when needed to avoid loading litellm_logging at import time
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.types.utils import TokenCountResponse
 
 from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1228,13 +1228,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
             # --- PRESERVE USAGE METADATA ---
             # stream_chunk_builder might miss usage if it's only in the last chunk
-            if (
-                not getattr(assembled_model_response, "usage", None)
-            ) and remaining_chunks:
-                last_chunk = remaining_chunks[-1]
-                last_chunk_usage = getattr(last_chunk, "usage", None)
-                if last_chunk_usage:
-                    setattr(assembled_model_response, "usage", last_chunk_usage)
+            self._preserve_usage_from_last_chunk(
+                assembled_model_response, remaining_chunks
+            )
 
             # Apply PII unmasking to assembled content (unmasking tokens back to original text)
             await self._process_response_for_pii(
@@ -1252,6 +1248,17 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
             for chunk in remaining_chunks:
                 yield chunk
+
+    @staticmethod
+    def _preserve_usage_from_last_chunk(
+        assembled_model_response: Any,
+        chunks: List[Any],
+    ) -> None:
+        """Copy usage metadata from the last chunk when stream_chunk_builder misses it."""
+        if not getattr(assembled_model_response, "usage", None) and chunks:
+            last_chunk_usage = getattr(chunks[-1], "usage", None)
+            if last_chunk_usage:
+                setattr(assembled_model_response, "usage", last_chunk_usage)
 
     def get_presidio_settings_from_request_data(
         self, data: dict

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1756,6 +1756,34 @@ async def _process_single_key_update(
     return updated_key_info
 
 
+async def _validate_mcp_servers_for_key_update(
+    data: "UpdateKeyRequest",
+    team_obj: Optional["LiteLLM_TeamTableCachedObj"],
+    existing_key_row: Any,
+    prisma_client: Any,
+    user_api_key_cache: Any,
+) -> None:
+    """Validate MCP servers in object_permission against the effective team."""
+    effective_team_obj = team_obj
+    # If team_id isn't being changed, resolve the existing key's team
+    if effective_team_obj is None and existing_key_row.team_id:
+        effective_team_obj = await get_team_object(
+            team_id=existing_key_row.team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            check_db_only=True,
+        )
+    object_permission_dict = (
+        data.object_permission.model_dump()
+        if hasattr(data.object_permission, "model_dump")
+        else data.object_permission
+    )
+    await validate_key_mcp_servers_against_team(
+        object_permission=object_permission_dict,
+        team_obj=effective_team_obj,
+    )
+
+
 @router.post(
     "/key/update", tags=["key management"], dependencies=[Depends(user_api_key_auth)]
 )
@@ -1956,23 +1984,12 @@ async def update_key_fn(
 
         # Validate MCP servers in object_permission against the effective team
         if data.object_permission is not None:
-            effective_team_obj = team_obj
-            # If team_id isn't being changed, resolve the existing key's team
-            if effective_team_obj is None and existing_key_row.team_id:
-                effective_team_obj = await get_team_object(
-                    team_id=existing_key_row.team_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    check_db_only=True,
-                )
-            object_permission_dict = (
-                data.object_permission.model_dump()
-                if hasattr(data.object_permission, "model_dump")
-                else data.object_permission
-            )
-            await validate_key_mcp_servers_against_team(
-                object_permission=object_permission_dict,
-                team_obj=effective_team_obj,
+            await _validate_mcp_servers_for_key_update(
+                data=data,
+                team_obj=team_obj,
+                existing_key_row=existing_key_row,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
             )
 
         non_default_values = await prepare_key_update_data(

--- a/litellm/proxy/management_endpoints/tool_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tool_management_endpoints.py
@@ -26,7 +26,6 @@ from litellm.types.tool_management import (
     ToolDetailResponse,
     ToolInputPolicy,
     ToolListResponse,
-    ToolOutputPolicy,
     ToolPolicyOption,
     ToolPolicyOptionsResponse,
     ToolPolicyUpdateRequest,

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -4,7 +4,7 @@ organizations, teams, and keys.
 """
 
 import json
-from typing import Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
 from fastapi import HTTPException, status
 
@@ -12,6 +12,12 @@ from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy.utils import PrismaClient
+
+if TYPE_CHECKING:
+    from litellm.proxy._types import (
+        LiteLLM_ObjectPermissionTable,
+        LiteLLM_TeamTableCachedObj,
+    )
         
 
 


### PR DESCRIPTION
## Relevant issues

Fixes CI `check_code_and_doc_quality` failures on main (pipeline #67841).

## Summary

### Failure Path (Before Fix)

8 ruff errors on main causing `check_code_and_doc_quality` CI job to fail:
- 2x F401: unused imports (`get_args`, `ToolOutputPolicy`)
- 4x F821: undefined names in string annotations (`TokenCountResponse`, `LiteLLM_ObjectPermissionTable`, `LiteLLM_TeamTableCachedObj`)
- 2x PLR0915: functions exceeding the 50-statement limit (presidio.py at 51, key_management_endpoints.py at 53)

### Fix

- Removed unused imports
- Added `TYPE_CHECKING` imports for forward-referenced types
- Extracted `_preserve_usage_from_last_chunk()` helper in presidio.py
- Extracted `_validate_mcp_servers_for_key_update()` helper in key_management_endpoints.py

## Testing

`ruff check ./litellm` passes with zero errors.

## Type

🐛 Bug Fix
🧹 Refactoring