### PR TITLE
[Fix] Update test_bad_database_url CI check for new error message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4337,7 +4337,8 @@ jobs:
           name: Check for expected error
           command: |
             if grep -q "Error: P1001: Can't reach database server at" docker_output.log && \
-               grep -q "ERROR:    Application startup failed. Exiting." docker_output.log; then
+               (grep -q "Database setup failed after multiple retries" docker_output.log || \
+                grep -q "ERROR:    Application startup failed. Exiting." docker_output.log); then
               echo "Expected error found. Test passed."
             else
               echo "Expected error not found. Test failed."


### PR DESCRIPTION
## Relevant issues

Caused by PR #23257

## Summary

### Failure Path (Before Fix)

PR #23257 changed proxy startup behavior so that when the database is unreachable, `proxy_cli.py` now exits early with `"Database setup failed after multiple retries"` instead of letting uvicorn emit `"Application startup failed. Exiting."`. The `test_bad_database_url` CI job greps for the old uvicorn message and fails because it's no longer present.

### Fix

Update the CI grep check to accept either error message:
- `"Database setup failed after multiple retries"` (new, from PR #23257's early exit in `proxy_cli.py`)
- `"ERROR:    Application startup failed. Exiting."` (old, from uvicorn lifespan failure)

Both still require the P1001 Prisma connection error to be present.

## Testing

The `test_bad_database_url` CI job should now pass regardless of which error path triggers.

## Type

🐛 Bug Fix
✅ Test