### PR TITLE
Litellm tests fix usage unit tests

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -800,6 +800,7 @@ describe("UsagePage", () => {
         expect.any(Date),
         expect.any(Date),
         null,
+        expect.any(Number),
       );
     });
   });
@@ -855,6 +856,7 @@ describe("UsagePage", () => {
           expect.any(Date),
           expect.any(Date),
           "user-123",
+          0,
         );
       });
     });
@@ -935,6 +937,7 @@ describe("UsagePage", () => {
         expect.any(Date),
         1,
         null,
+        0,
       );
 
       // Verify second page call
@@ -944,6 +947,7 @@ describe("UsagePage", () => {
         expect.any(Date),
         2,
         null,
+        0,
       );
     });
   });

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -856,7 +856,7 @@ describe("UsagePage", () => {
           expect.any(Date),
           expect.any(Date),
           "user-123",
-          0,
+          expect.any(Number),
         );
       });
     });
@@ -937,7 +937,7 @@ describe("UsagePage", () => {
         expect.any(Date),
         1,
         null,
-        0,
+        expect.any(Number),
       );
 
       // Verify second page call
@@ -947,7 +947,7 @@ describe("UsagePage", () => {
         expect.any(Date),
         2,
         null,
-        0,
+        expect.any(Number),
       );
     });
   });

--- a/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
+++ b/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
@@ -127,6 +127,7 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
 
   const [isOpen, setIsOpen] = useState(false);
   const [tempValue, setTempValue] = useState<DateRangePickerValue>(value);
+  const [tempTimezone, setTempTimezone] = useState<number | undefined>(timezoneOffset);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
   // Custom date inputs only - removed time inputs
@@ -294,6 +295,11 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
 
   const handleApply = () => {
     if (tempValue.from && tempValue.to && validation.isValid) {
+      // Commit timezone change on Apply, not on every dropdown selection
+      if (onTimezoneChange && tempTimezone !== undefined) {
+        onTimezoneChange(tempTimezone);
+      }
+
       // First call with immediate value for UI responsiveness
       onValueChange(tempValue);
 
@@ -313,6 +319,7 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
   const handleCancel = () => {
     // Reset to original value
     setTempValue(value);
+    setTempTimezone(timezoneOffset);
 
     // Reset form inputs
     if (value.from) {
@@ -406,8 +413,8 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
                       <label className="text-sm text-gray-700 mb-1 block">Timezone</label>
                       <Select
                         showSearch
-                        value={timezoneOffset !== undefined ? timezoneOffset : getLocalTimezoneOffset()}
-                        onChange={(val) => onTimezoneChange(val)}
+                        value={tempTimezone !== undefined ? tempTimezone : getLocalTimezoneOffset()}
+                        onChange={(val) => setTempTimezone(val)}
                         options={timezoneOptions}
                         popupMatchSelectWidth={false}
                         listHeight={200}


### PR DESCRIPTION
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

- Fix timezone refetch bug: Changing the timezone dropdown on the Usage page was immediately refetching data on every selection. Now timezone changes are buffered locally and only applied when the user clicks "Apply", matching the existing date range behavior.
- Fix unit tests: Updated 3 test assertions in `UsagePageView.test.tsx` to account for the new `timezoneOffset` parameter added to `userDailyActivityAggregatedCall` and `userDailyActivityCall`.