### PR TITLE
[Fix] Replace deprecated models in tests

### DIFF
--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -271,7 +271,7 @@ def test_trimming_should_not_change_original_messages():
     assert messages == messages_copy
 
 
-@pytest.mark.parametrize("model", ["gpt-4-0125-preview", "claude-3-opus-20240229"])
+@pytest.mark.parametrize("model", ["gpt-4-0125-preview", "claude-sonnet-4-6"])
 def test_trimming_with_model_cost_max_input_tokens(model):
     messages = [
         {"role": "system", "content": "This is a normal system message"},
@@ -521,7 +521,7 @@ def test_function_to_dict():
         ("gpt-3.5-turbo", True),
         ("azure/gpt-4-1106-preview", True),
         ("groq/gemma-7b-it", True),
-        ("gemini/gemini-1.5-flash", True),
+        ("gemini/gemini-2.5-flash", True),
     ],
 )
 def test_supports_function_calling(model, expected_bool):
@@ -1062,8 +1062,8 @@ def test_parse_content_for_reasoning(content, expected_reasoning, expected_conte
 @pytest.mark.parametrize(
     "model, expected_bool",
     [
-        ("vertex_ai/gemini-1.5-pro", True),
-        ("gemini/gemini-1.5-pro", True),
+        ("vertex_ai/gemini-2.5-pro", True),
+        ("gemini/gemini-2.5-pro", True),
         ("predibase/llama3-8b-instruct", True),
         ("databricks/databricks-meta-llama-3-1-70b-instruct", True),
         ("gpt-3.5-turbo", False),
@@ -1074,7 +1074,7 @@ def test_supports_response_schema(model, expected_bool):
     """
     Unit tests for 'supports_response_schema' helper function.
 
-    Should be true for gemini-1.5-pro on google ai studio / vertex ai AND predibase models
+    Should be true for gemini-2.5-pro on google ai studio / vertex ai AND predibase models
     Should be false otherwise
     """
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
@@ -1093,7 +1093,7 @@ def test_supports_response_schema(model, expected_bool):
         ("gpt-3.5-turbo", True),
         ("gpt-4", True),
         ("command-nightly", False),
-        ("gemini-pro", True),
+        ("gemini-2.5-pro", True),
     ],
 )
 def test_supports_function_calling_v2(model, expected_bool):
@@ -1109,10 +1109,10 @@ def test_supports_function_calling_v2(model, expected_bool):
 @pytest.mark.parametrize(
     "model, expected_bool",
     [
-        ("gpt-4-vision-preview", True),
+        ("gpt-4o", True),
         ("gpt-3.5-turbo", False),
-        ("claude-3-opus-20240229", True),
-        ("gemini-pro-vision", True),
+        ("claude-sonnet-4-6", True),
+        ("gemini-2.5-flash", True),
         ("command-nightly", False),
     ],
 )
@@ -1727,7 +1727,7 @@ def test_supports_vision_gemini():
     litellm.model_cost = litellm.get_model_cost_map(url="")
     from litellm.utils import supports_vision
 
-    assert supports_vision("gemini-1.5-pro") is True
+    assert supports_vision("gemini-2.5-pro") is True
 
 
 def test_pick_cheapest_chat_model_from_llm_provider():

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -1013,7 +1013,7 @@ def test_completion_cost_azure_common_deployment_name():
     "model, custom_llm_provider",
     [
         ("claude-sonnet-4-6", "anthropic"),
-        ("gemini/gemini-2.5-flash", "gemini"),
+        ("claude-haiku-4-5", "anthropic"),
     ],
 )
 def test_completion_cost_prompt_caching(model, custom_llm_provider):

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -1012,8 +1012,8 @@ def test_completion_cost_azure_common_deployment_name():
 @pytest.mark.parametrize(
     "model, custom_llm_provider",
     [
-        ("claude-3-5-sonnet-20240620", "anthropic"),
-        ("gemini/gemini-1.5-flash-001", "gemini"),
+        ("claude-sonnet-4-6", "anthropic"),
+        ("gemini/gemini-2.5-flash", "gemini"),
     ],
 )
 def test_completion_cost_prompt_caching(model, custom_llm_provider):

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1225,14 +1225,14 @@ class TestProxyFunctionCalling:
             ),
             # Anthropic models (Claude supports function calling)
             (
-                "claude-3-5-sonnet-20240620",
-                "litellm_proxy/claude-3-5-sonnet-20240620",
+                "claude-sonnet-4-6",
+                "litellm_proxy/claude-sonnet-4-6",
                 True,
             ),
             # Google models
-            ("gemini-pro", "litellm_proxy/gemini-pro", True),
-            ("gemini/gemini-1.5-pro", "litellm_proxy/gemini/gemini-1.5-pro", True),
-            ("gemini/gemini-1.5-flash", "litellm_proxy/gemini/gemini-1.5-flash", True),
+            ("gemini-2.5-pro", "litellm_proxy/gemini-2.5-pro", True),
+            ("gemini/gemini-2.5-pro", "litellm_proxy/gemini/gemini-2.5-pro", True),
+            ("gemini/gemini-2.5-flash", "litellm_proxy/gemini/gemini-2.5-flash", True),
             # Groq models (mixed support)
             ("groq/gemma-7b-it", "litellm_proxy/groq/gemma-7b-it", True),
             (

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -384,14 +384,14 @@ def test_all_model_configs():
     assert (
         "max_completion_tokens"
         in VertexAIAnthropicConfig().get_supported_openai_params(
-            model="claude-3-5-sonnet-20240620"
+            model="claude-sonnet-4-6"
         )
     )
 
     assert VertexAIAnthropicConfig().map_openai_params(
         non_default_params={"max_completion_tokens": 10},
         optional_params={},
-        model="claude-3-5-sonnet-20240620",
+        model="claude-sonnet-4-6",
         drop_params=False,
     ) == {"max_tokens": 10}
 
@@ -1136,7 +1136,7 @@ def test_get_model_info_shows_supports_computer_use():
     [
         ("gpt-3.5-turbo", "openai"),
         ("anthropic.claude-3-7-sonnet-20250219-v1:0", "bedrock"),
-        ("gemini-1.5-pro", "vertex_ai"),
+        ("gemini-2.5-pro", "vertex_ai"),
     ],
 )
 def test_pre_process_non_default_params(model, custom_llm_provider):
@@ -1437,8 +1437,8 @@ class TestProxyFunctionCalling:
             ("litellm_proxy/gpt-3.5-turbo", True),
             ("litellm_proxy/gpt-4", True),
             ("litellm_proxy/gpt-4o", True),
-            ("litellm_proxy/claude-3-5-sonnet-20240620", True),
-            ("litellm_proxy/gemini/gemini-1.5-pro", True),
+            ("litellm_proxy/claude-sonnet-4-6", True),
+            ("litellm_proxy/gemini/gemini-2.5-pro", True),
             # Test proxy models that should not support function calling
             ("litellm_proxy/command-nightly", False),
             ("litellm_proxy/anthropic.claude-instant-v1", False),
@@ -1483,8 +1483,8 @@ class TestProxyFunctionCalling:
         [
             "litellm_proxy/gpt-3.5-turbo",
             "litellm_proxy/gpt-4",
-            "litellm_proxy/claude-3-5-sonnet-20240620",
-            "litellm_proxy/gemini/gemini-1.5-pro",
+            "litellm_proxy/claude-sonnet-4-6",
+            "litellm_proxy/gemini/gemini-2.5-pro",
         ],
     )
     def test_proxy_model_with_custom_llm_provider_none(self, model_name):


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

Multiple tests fail because deprecated models (`gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-1.5-flash-001`, `gemini-pro`, `gemini-pro-vision`, `gpt-4-vision-preview`, `claude-3-5-sonnet-20240620`, `claude-3-opus-20240229`) have been removed from the model cost map. Tests that call `supports_function_calling()`, `supports_vision()`, `supports_response_schema()`, or do model cost lookups return incorrect results or raise errors.

### Fix

Replace deprecated model references with current equivalents across 3 test files:
- `claude-3-5-sonnet-20240620` / `claude-3-opus-20240229` → `claude-sonnet-4-6`
- `gemini-pro` / `gemini-1.5-pro` → `gemini-2.5-pro`
- `gemini-1.5-flash` → `gemini-2.5-flash`
- `gemini-pro-vision` → `gemini-2.5-flash`
- `gpt-4-vision-preview` → `gpt-4o`
- `gemini/gemini-1.5-flash-001` → `claude-haiku-4-5` (prompt caching cost test requires `cache_creation_input_token_cost`, which no gemini model has)

## Testing

All affected tests pass locally:
- `tests/test_litellm/test_utils.py::TestProxyFunctionCalling` (80 passed)
- `tests/litellm_utils_tests/test_utils.py` — `test_supports_function_calling`, `test_supports_function_calling_v2`, `test_supports_response_schema`, `test_supports_vision`, `test_supports_vision_gemini`, `test_trimming_with_model_cost_max_input_tokens` (22 passed)
- `tests/test_litellm/test_utils.py` — `test_all_model_configs`, `test_pre_process_non_default_params` (4 passed)
- `tests/local_testing/test_completion_cost.py::test_completion_cost_prompt_caching` (2 passed)

## Type

🐛 Bug Fix
✅ Test