### PR TITLE
fix: forward service_tier param to Anthropic API

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1069,7 +1069,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
-            elif param == "service_tier" and isinstance(value, str):
+            elif param == "service_tier" and value in ("auto", "standard_only"):
                 optional_params["service_tier"] = value
 
         ## handle thinking tokens

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1069,11 +1069,16 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
-            elif param == "service_tier" and value in ("auto", "standard_only"):
-                # Pass through Anthropic service_tier parameter.
-                # OpenAI-specific values (e.g. "default", "flex") are silently
-                # dropped to avoid hard API errors when routing across providers.
-                optional_params["service_tier"] = value
+            elif param == "service_tier":
+                if value in ("auto", "standard_only"):
+                    optional_params["service_tier"] = value
+                else:
+                    litellm.verbose_logger.warning(
+                        "litellm.AnthropicConfig: dropping unrecognised "
+                        "service_tier='%s'. Anthropic supports 'auto' and "
+                        "'standard_only'.",
+                        value,
+                    )
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1069,14 +1069,17 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
-            elif param == "service_tier":
-                if value in ("auto", "standard_only"):
+            elif param == "service_tier" and isinstance(value, str):
+                # Block known OpenAI-only values to avoid hard Anthropic API
+                # errors when routing across providers. Any other value
+                # (including future Anthropic tiers) is forwarded as-is.
+                _openai_only_tiers = {"default", "flex", "scale"}
+                if value not in _openai_only_tiers:
                     optional_params["service_tier"] = value
                 else:
                     litellm.verbose_logger.warning(
-                        "litellm.AnthropicConfig: dropping unrecognised "
-                        "service_tier='%s'. Anthropic supports 'auto' and "
-                        "'standard_only'.",
+                        "litellm.AnthropicConfig: dropping OpenAI-specific "
+                        "service_tier='%s' — not supported by Anthropic.",
                         value,
                     )
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1072,9 +1072,16 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "service_tier":
                 if value in ("auto", "standard_only"):
                     optional_params["service_tier"] = value
-                # Silently drop unrecognised values (e.g. OpenAI-specific
-                # "default", "flex") to preserve backward-compatibility
-                # when routing across providers.
+                elif not drop_params:
+                    raise litellm.UnsupportedParamsError(
+                        status_code=400,
+                        message=(
+                            f"Anthropic does not support service_tier='{value}'. "
+                            f"Supported values: 'auto', 'standard_only'. "
+                            f"Pass drop_params=True to silently ignore unsupported values."
+                        ),
+                    )
+                # else: silently drop OpenAI-specific values when drop_params=True
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -195,6 +195,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "speed",
             "context_management",
             "cache_control",
+            "service_tier",
         ]
 
         if (
@@ -1068,6 +1069,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
+            elif param == "service_tier" and isinstance(value, str):
+                optional_params["service_tier"] = value
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1069,8 +1069,18 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
-            elif param == "service_tier" and value in ("auto", "standard_only"):
-                optional_params["service_tier"] = value
+            elif param == "service_tier":
+                if value in ("auto", "standard_only"):
+                    optional_params["service_tier"] = value
+                elif not drop_params:
+                    raise litellm.UnsupportedParamsError(
+                        message=(
+                            f"Anthropic does not support service_tier='{value}'. "
+                            "Valid values are 'auto' and 'standard_only'."
+                        ),
+                        model=model,
+                        llm_provider="anthropic",
+                    )
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1072,15 +1072,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "service_tier":
                 if value in ("auto", "standard_only"):
                     optional_params["service_tier"] = value
-                elif not drop_params:
-                    raise litellm.UnsupportedParamsError(
-                        message=(
-                            f"Anthropic does not support service_tier='{value}'. "
-                            "Valid values are 'auto' and 'standard_only'."
-                        ),
-                        model=model,
-                        llm_provider="anthropic",
-                    )
+                # Silently drop unrecognised values (e.g. OpenAI-specific
+                # "default", "flex") to preserve backward-compatibility
+                # when routing across providers.
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1070,18 +1070,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
             elif param == "service_tier" and isinstance(value, str):
-                # Block known OpenAI-only values to avoid hard Anthropic API
-                # errors when routing across providers. Any other value
-                # (including future Anthropic tiers) is forwarded as-is.
-                _openai_only_tiers = {"default", "flex", "scale"}
-                if value not in _openai_only_tiers:
-                    optional_params["service_tier"] = value
-                else:
-                    litellm.verbose_logger.warning(
-                        "litellm.AnthropicConfig: dropping OpenAI-specific "
-                        "service_tier='%s' — not supported by Anthropic.",
-                        value,
-                    )
+                # Pass through service_tier to the Anthropic API.
+                # Anthropic validates the value and returns an error for
+                # unsupported tiers.
+                optional_params["service_tier"] = value
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1069,19 +1069,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
-            elif param == "service_tier":
-                if value in ("auto", "standard_only"):
-                    optional_params["service_tier"] = value
-                elif not drop_params:
-                    raise litellm.UnsupportedParamsError(
-                        status_code=400,
-                        message=(
-                            f"Anthropic does not support service_tier='{value}'. "
-                            f"Supported values: 'auto', 'standard_only'. "
-                            f"Pass drop_params=True to silently ignore unsupported values."
-                        ),
-                    )
-                # else: silently drop OpenAI-specific values when drop_params=True
+            elif param == "service_tier" and value in ("auto", "standard_only"):
+                # Pass through Anthropic service_tier parameter.
+                # OpenAI-specific values (e.g. "default", "flex") are silently
+                # dropped to avoid hard API errors when routing across providers.
+                optional_params["service_tier"] = value
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -364,7 +364,7 @@ class AnthropicMessagesRequestOptionalParams(TypedDict, total=False):
     speed: Optional[str]  # Fast mode support for Opus models
     output_config: Optional[AnthropicOutputConfig]  # Configuration for Claude's output behavior
     cache_control: Optional[Dict[str, Any]]  # Automatic prompt caching
-    service_tier: Optional[Literal["auto", "standard_only"]]  # Service tier for priority capacity
+    service_tier: Optional[str]  # Service tier for priority capacity (e.g. "auto", "standard_only")
 
 
 class AnthropicMessagesRequest(AnthropicMessagesRequestOptionalParams, total=False):

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -364,6 +364,7 @@ class AnthropicMessagesRequestOptionalParams(TypedDict, total=False):
     speed: Optional[str]  # Fast mode support for Opus models
     output_config: Optional[AnthropicOutputConfig]  # Configuration for Claude's output behavior
     cache_control: Optional[Dict[str, Any]]  # Automatic prompt caching
+    service_tier: Optional[str]  # Service tier for priority capacity ("auto", "standard_only")
 
 
 class AnthropicMessagesRequest(AnthropicMessagesRequestOptionalParams, total=False):

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -364,7 +364,7 @@ class AnthropicMessagesRequestOptionalParams(TypedDict, total=False):
     speed: Optional[str]  # Fast mode support for Opus models
     output_config: Optional[AnthropicOutputConfig]  # Configuration for Claude's output behavior
     cache_control: Optional[Dict[str, Any]]  # Automatic prompt caching
-    service_tier: Optional[str]  # Service tier for priority capacity ("auto", "standard_only")
+    service_tier: Optional[Literal["auto", "standard_only"]]  # Service tier for priority capacity
 
 
 class AnthropicMessagesRequest(AnthropicMessagesRequestOptionalParams, total=False):

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3335,35 +3335,10 @@ def test_service_tier_in_supported_params():
 
 
 @pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_invalid_value_raises_when_drop_params_false(
-    service_tier: str,
-):
+def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str):
     """
-    When drop_params=False, an unrecognised service_tier must raise
-    UnsupportedParamsError so the caller knows the value was not forwarded.
-
-    Fixes https://github.com/BerriAI/litellm/issues/23398
-    """
-    import litellm
-
-    config = AnthropicConfig()
-
-    with pytest.raises(litellm.UnsupportedParamsError):
-        config.map_openai_params(
-            non_default_params={"service_tier": service_tier},
-            optional_params={},
-            model="claude-sonnet-4-6",
-            drop_params=False,
-        )
-
-
-@pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_invalid_value_silently_dropped_when_drop_params_true(
-    service_tier: str,
-):
-    """
-    When drop_params=True, an unrecognised service_tier must be silently
-    dropped with no error.
+    OpenAI-specific service_tier values must be silently dropped to avoid
+    hard API errors when routing across providers.
 
     Fixes https://github.com/BerriAI/litellm/issues/23398
     """
@@ -3373,6 +3348,7 @@ def test_service_tier_invalid_value_silently_dropped_when_drop_params_true(
         non_default_params={"service_tier": service_tier},
         optional_params={},
         model="claude-sonnet-4-6",
-        drop_params=True,
+        drop_params=False,
     )
+
     assert "service_tier" not in result

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3332,3 +3332,24 @@ def test_service_tier_in_supported_params():
     assert "service_tier" in config.get_supported_openai_params(
         model="claude-sonnet-4-6"
     )
+
+
+@pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
+def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str):
+    """
+    OpenAI-specific service_tier values must not be forwarded to Anthropic
+    to avoid hard API errors. Only "auto" and "standard_only" are valid on
+    the Anthropic API.
+
+    Fixes https://github.com/BerriAI/litellm/issues/23398
+    """
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"service_tier": service_tier},
+        optional_params={},
+        model="claude-sonnet-4-6",
+        drop_params=False,
+    )
+
+    assert "service_tier" not in result

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3335,21 +3335,44 @@ def test_service_tier_in_supported_params():
 
 
 @pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str):
+def test_service_tier_invalid_value_raises_when_drop_params_false(
+    service_tier: str,
+):
     """
-    OpenAI-specific service_tier values must be silently dropped regardless
-    of drop_params to preserve backward-compatibility when routing across
-    providers.
+    When drop_params=False, an unrecognised service_tier must raise
+    UnsupportedParamsError so the caller knows the value was not forwarded.
+
+    Fixes https://github.com/BerriAI/litellm/issues/23398
+    """
+    import litellm
+
+    config = AnthropicConfig()
+
+    with pytest.raises(litellm.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"service_tier": service_tier},
+            optional_params={},
+            model="claude-sonnet-4-6",
+            drop_params=False,
+        )
+
+
+@pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
+def test_service_tier_invalid_value_silently_dropped_when_drop_params_true(
+    service_tier: str,
+):
+    """
+    When drop_params=True, an unrecognised service_tier must be silently
+    dropped with no error.
 
     Fixes https://github.com/BerriAI/litellm/issues/23398
     """
     config = AnthropicConfig()
 
-    for drop_params in (True, False):
-        result = config.map_openai_params(
-            non_default_params={"service_tier": service_tier},
-            optional_params={},
-            model="claude-sonnet-4-6",
-            drop_params=drop_params,
-        )
-        assert "service_tier" not in result
+    result = config.map_openai_params(
+        non_default_params={"service_tier": service_tier},
+        optional_params={},
+        model="claude-sonnet-4-6",
+        drop_params=True,
+    )
+    assert "service_tier" not in result

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3300,3 +3300,35 @@ def test_map_tool_helper_empty_parameters_get_default():
     assert result is not None
     assert result["input_schema"]["type"] == "object"
     assert result["input_schema"].get("properties") == {}
+
+
+@pytest.mark.parametrize("service_tier", ["auto", "standard_only"])
+def test_service_tier_forwarded_to_anthropic(service_tier: str):
+    """
+    service_tier must be forwarded as-is to the Anthropic API request body.
+
+    Fixes https://github.com/BerriAI/litellm/issues/23398
+    """
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"service_tier": service_tier},
+        optional_params={},
+        model="claude-sonnet-4-6",
+        drop_params=False,
+    )
+
+    assert result.get("service_tier") == service_tier
+
+
+def test_service_tier_in_supported_params():
+    """
+    service_tier must appear in get_supported_openai_params so it is not
+    silently dropped before map_openai_params is called.
+
+    Fixes https://github.com/BerriAI/litellm/issues/23398
+    """
+    config = AnthropicConfig()
+    assert "service_tier" in config.get_supported_openai_params(
+        model="claude-sonnet-4-6"
+    )

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3335,11 +3335,35 @@ def test_service_tier_in_supported_params():
 
 
 @pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str):
+def test_service_tier_invalid_value_raises_when_drop_params_false(
+    service_tier: str,
+):
     """
-    OpenAI-specific service_tier values must not be forwarded to Anthropic
-    to avoid hard API errors. Only "auto" and "standard_only" are valid on
-    the Anthropic API.
+    When drop_params=False, passing an unrecognised service_tier must raise
+    UnsupportedParamsError so callers are not silently misled.
+
+    Fixes https://github.com/BerriAI/litellm/issues/23398
+    """
+    import litellm
+
+    config = AnthropicConfig()
+
+    with pytest.raises(litellm.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"service_tier": service_tier},
+            optional_params={},
+            model="claude-sonnet-4-6",
+            drop_params=False,
+        )
+
+
+@pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
+def test_service_tier_invalid_value_silently_dropped_when_drop_params_true(
+    service_tier: str,
+):
+    """
+    When drop_params=True, an unrecognised service_tier must be silently
+    dropped (no error, no key in output).
 
     Fixes https://github.com/BerriAI/litellm/issues/23398
     """
@@ -3349,7 +3373,7 @@ def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str
         non_default_params={"service_tier": service_tier},
         optional_params={},
         model="claude-sonnet-4-6",
-        drop_params=False,
+        drop_params=True,
     )
 
     assert "service_tier" not in result

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3335,10 +3335,11 @@ def test_service_tier_in_supported_params():
 
 
 @pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str):
+def test_service_tier_any_string_forwarded_to_anthropic(service_tier: str):
     """
-    OpenAI-specific service_tier values must be silently dropped to avoid
-    hard API errors when routing across providers.
+    service_tier is forwarded as-is to the Anthropic API for all string
+    values. Anthropic validates the value and returns an error for
+    unsupported tiers.
 
     Fixes https://github.com/BerriAI/litellm/issues/23398
     """
@@ -3351,4 +3352,4 @@ def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str
         drop_params=False,
     )
 
-    assert "service_tier" not in result
+    assert result.get("service_tier") == service_tier

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3335,45 +3335,21 @@ def test_service_tier_in_supported_params():
 
 
 @pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_invalid_value_raises_when_drop_params_false(
-    service_tier: str,
-):
+def test_service_tier_openai_values_not_forwarded_to_anthropic(service_tier: str):
     """
-    When drop_params=False, passing an unrecognised service_tier must raise
-    UnsupportedParamsError so callers are not silently misled.
+    OpenAI-specific service_tier values must be silently dropped regardless
+    of drop_params to preserve backward-compatibility when routing across
+    providers.
 
     Fixes https://github.com/BerriAI/litellm/issues/23398
     """
-    import litellm
-
     config = AnthropicConfig()
 
-    with pytest.raises(litellm.UnsupportedParamsError):
-        config.map_openai_params(
+    for drop_params in (True, False):
+        result = config.map_openai_params(
             non_default_params={"service_tier": service_tier},
             optional_params={},
             model="claude-sonnet-4-6",
-            drop_params=False,
+            drop_params=drop_params,
         )
-
-
-@pytest.mark.parametrize("service_tier", ["default", "flex", "scale"])
-def test_service_tier_invalid_value_silently_dropped_when_drop_params_true(
-    service_tier: str,
-):
-    """
-    When drop_params=True, an unrecognised service_tier must be silently
-    dropped (no error, no key in output).
-
-    Fixes https://github.com/BerriAI/litellm/issues/23398
-    """
-    config = AnthropicConfig()
-
-    result = config.map_openai_params(
-        non_default_params={"service_tier": service_tier},
-        optional_params={},
-        model="claude-sonnet-4-6",
-        drop_params=True,
-    )
-
-    assert "service_tier" not in result
+        assert "service_tier" not in result


### PR DESCRIPTION
service_tier was silently dropped because it was missing from AnthropicConfig.get_supported_openai_params(). Add it to the supported params list and add a passthrough mapping in map_openai_params() so it is forwarded as-is to the request body.

Fixes #23398

## Relevant issues

Fixes #23398

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

  `service_tier` was silently dropped when passed to Anthropic models via `litellm.completion()`.

  Root cause: `service_tier` was missing from `AnthropicConfig.get_supported_openai_params()`,
  so LiteLLM dropped it before `map_openai_params()` was ever called.

  Fix:
  - Added `service_tier` to `get_supported_openai_params()`
  - Added passthrough mapping in `map_openai_params()` to forward it as-is to the Anthropic request body

  Tests added in `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py`:
  - `test_service_tier_forwarded_to_anthropic` — parametrized for `auto` and `standard_only`
  - `test_service_tier_in_supported_params` — verifies the param passes the gatekeeper
