### PR TITLE
fix: null AWS SigV4 fields on MagicMock in TestTemporaryMCPSessionEndpoints

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1073,6 +1073,11 @@ class TestTemporaryMCPSessionEndpoints:
             client_id="client-id",
             client_secret="client-secret",
             scopes=["scope1"],
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            aws_region_name=None,
+            aws_service_name=None,
         )
         built_server = generate_mock_mcp_server_config_record(server_id="temp-server")
         mock_manager = MagicMock()

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -961,6 +961,11 @@ class TestTemporaryMCPSessionEndpoints:
         existing_server.client_id = "client-123"
         existing_server.client_secret = "secret-xyz"
         existing_server.scopes = ["scope:a", "scope:b"]
+        existing_server.aws_access_key_id = None
+        existing_server.aws_secret_access_key = None
+        existing_server.aws_session_token = None
+        existing_server.aws_region_name = None
+        existing_server.aws_service_name = None
 
         mock_manager = MagicMock()
         mock_manager.get_mcp_server_by_id.return_value = existing_server


### PR DESCRIPTION
## Summary

PR #23282 added AWS SigV4 credential inheritance to `_inherit_credentials_from_existing_server` but did not update the test mocks in `TestTemporaryMCPSessionEndpoints`.

`MagicMock` auto-generates truthy objects for any unset attribute, so all 5 `if existing_server.aws_*:` guards evaluated to `True`. This caused two failures:

- `test_inherit_credentials_from_existing_server` — unexpected AWS fields appeared in the credentials assertion
- `test_add_session_mcp_server_caches_and_redacts_credentials` — MagicMock AWS values flowed into `LiteLLM_MCPServerTable(credentials=...)` where Pydantic rejected them as invalid `Optional[str]`, causing 5 validation errors

Fix: explicitly set the 5 AWS fields to `None` on both mocks so the production `if` guards behave correctly.

## Test plan

- [ ] `test (proxy-guardrails)` — `TestTemporaryMCPSessionEndpoints::test_inherit_credentials_from_existing_server` passes
- [ ] `test (proxy-guardrails)` — `TestTemporaryMCPSessionEndpoints::test_add_session_mcp_server_caches_and_redacts_credentials` passes