### PR TITLE
fix(test): null AWS SigV4 fields on MagicMock in test_add_session_mcp_server_caches_and_redacts_credentials

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1365,6 +1365,11 @@ class TestTemporaryMCPSessionEndpoints:
             client_id="client-id",
             client_secret="client-secret",
             scopes=["scope1"],
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            aws_region_name=None,
+            aws_service_name=None,
         )
         built_server = generate_mock_mcp_server_config_record(server_id="temp-server")
         mock_manager = MagicMock()


### PR DESCRIPTION
## Summary

- PR #23282 added AWS SigV4 credential inheritance to `_inherit_credentials_from_existing_server` but did not update the `inherited_server` mock in `test_add_session_mcp_server_caches_and_redacts_credentials`
- `MagicMock` auto-generates truthy objects for any unset attribute, so all 5 `if existing_server.aws_*:` guards evaluated to `True`, adding MagicMock objects into the credentials dict
- Those MagicMock values then flow into `LiteLLM_MCPServerTable(credentials=...)` where Pydantic rejects them as invalid `Optional[str]` — causing 5 validation errors
- Fix: explicitly set the 5 AWS fields to `None` on the mock so the production guards behave correctly

## Test plan

- [ ] `test (proxy-guardrails)` — `TestTemporaryMCPSessionEndpoints::test_add_session_mcp_server_caches_and_redacts_credentials` passes