### PR TITLE
fix: accept custom_body in URL-based create_pass_through_route endpoint_func

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1133,6 +1133,7 @@ def create_pass_through_route(
             fastapi_response: Response,
             user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
             subpath: str = "",  # captures sub-paths when include_subpath=True
+            custom_body: Optional[dict] = None,  # caller-supplied body takes precedence over request-parsed body
         ):
             from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
                 InitPassThroughEndpointHelpers,
@@ -1208,9 +1209,11 @@ def create_pass_through_route(
             )
             if query_params:
                 final_query_params.update(query_params)
-            # Use the body parsed from the raw request
+            # Caller-supplied custom_body takes precedence over the request-parsed body
             final_custom_body: Optional[dict] = None
-            if isinstance(custom_body_data, dict):
+            if custom_body is not None:
+                final_custom_body = custom_body
+            elif isinstance(custom_body_data, dict):
                 final_custom_body = custom_body_data
 
             return await pass_through_request(  # type: ignore


### PR DESCRIPTION
## Summary

- `create_pass_through_route` has two `endpoint_func` implementations: one for adapter-based targets and one for URL-based targets
- The adapter-based `endpoint_func` correctly accepts `custom_body` in its signature
- The URL-based `endpoint_func` (the `except` branch) was missing `custom_body`, causing a `TypeError` when callers like `bedrock_proxy_route` pass `custom_body=data`
- Fix: add `custom_body: Optional[dict] = None` to the URL-based `endpoint_func` signature and give it precedence over the request-parsed body

## Test plan

- [ ] `test (proxy-misc)` — `test_create_pass_through_route_custom_body_url_target` passes