### PR TITLE
fix: update stale model name in vertex AI batch cost calculation test

### DIFF
--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_ai_batch_passthrough.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_ai_batch_passthrough.py
@@ -243,7 +243,7 @@ class TestVertexAIBatchPassthroughHandler:
         ]
 
         total_cost, usage = calculate_vertex_ai_batch_cost_and_usage(
-            vertex_ai_batch_responses, model_name="gemini-1.5-flash-001"
+            vertex_ai_batch_responses, model_name="gemini-2.0-flash-001"
         )
 
         assert usage.total_tokens == 15


### PR DESCRIPTION
## Summary

- `test_batch_cost_calculation_integration` used `gemini-1.5-flash-001` which has been removed from `model_prices_and_context_window.json`
- `batch_cost_calculator` throws an exception for unknown models, which is silently swallowed, leaving `total_cost = 0.0`
- Fix: update to `gemini-2.0-flash-001` which is in the pricing map with non-zero input/output token costs

## Test plan

- [ ] `test (proxy-misc)` — `TestVertexAIBatchPassthroughHandler::test_batch_cost_calculation_integration` passes