### PR TITLE
fix: update stale gemini-1.5-flash model name in passthrough logging handler test

### DIFF
--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_gemini_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_gemini_passthrough_logging_handler.py
@@ -68,7 +68,7 @@ class TestGeminiPassthroughLoggingHandler:
     def _create_passthrough_logging_payload(self) -> PassthroughStandardLoggingPayload:
         """Create a mock passthrough logging payload for testing"""
         return PassthroughStandardLoggingPayload(
-            url="https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+            url="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
             request_body={"contents": [{"parts": [{"text": "Hello"}]}]},
             request_method="POST",
         )
@@ -263,7 +263,7 @@ class TestGeminiPassthroughLoggingHandler:
             httpx_response=mock_response,
             response_body=self.mock_gemini_response,
             logging_obj=mock_logging_obj,
-            url_route="https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+            url_route="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
             result="",
             start_time=self.start_time,
             end_time=self.end_time,
@@ -278,14 +278,14 @@ class TestGeminiPassthroughLoggingHandler:
 
         # Verify that the logging object has the cost set (from Gemini handler)
         assert mock_logging_obj.model_call_details["response_cost"] is not None
-        assert mock_logging_obj.model_call_details["model"] == "gemini-1.5-flash"
+        assert mock_logging_obj.model_call_details["model"] == "gemini-2.0-flash"
         assert mock_logging_obj.model_call_details["custom_llm_provider"] == "gemini"
 
         # Verify that _handle_logging was called with the correct kwargs
         handler._handle_logging.assert_called_once()
         call_kwargs = handler._handle_logging.call_args[1]
         assert call_kwargs["response_cost"] is not None
-        assert call_kwargs["model"] == "gemini-1.5-flash"
+        assert call_kwargs["model"] == "gemini-2.0-flash"
         assert call_kwargs["custom_llm_provider"] == "gemini"
 
     @patch("litellm.completion_cost")

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_gemini_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_gemini_passthrough_logging_handler.py
@@ -68,7 +68,7 @@ class TestGeminiPassthroughLoggingHandler:
     def _create_passthrough_logging_payload(self) -> PassthroughStandardLoggingPayload:
         """Create a mock passthrough logging payload for testing"""
         return PassthroughStandardLoggingPayload(
-            url="https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+            url="https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
             request_body={"contents": [{"parts": [{"text": "Hello"}]}]},
             request_method="POST",
         )
@@ -242,7 +242,11 @@ class TestGeminiPassthroughLoggingHandler:
         assert "kwargs" in result
 
     @pytest.mark.asyncio
-    async def test_pass_through_success_handler_gemini_routing(self):
+    @patch(
+        "litellm.proxy.pass_through_endpoints.llm_provider_handlers.gemini_passthrough_logging_handler.litellm.completion_cost",
+        return_value=0.000050,
+    )
+    async def test_pass_through_success_handler_gemini_routing(self, mock_completion_cost):
         """Test that the success handler correctly routes Gemini requests to the Gemini handler"""
         handler = PassThroughEndpointLogging()
 
@@ -277,14 +281,14 @@ class TestGeminiPassthroughLoggingHandler:
         assert result is None
 
         # Verify that the logging object has the cost set (from Gemini handler)
-        assert mock_logging_obj.model_call_details["response_cost"] is not None
+        assert mock_logging_obj.model_call_details["response_cost"] == 0.000050
         assert mock_logging_obj.model_call_details["model"] == "gemini-2.0-flash"
         assert mock_logging_obj.model_call_details["custom_llm_provider"] == "gemini"
 
         # Verify that _handle_logging was called with the correct kwargs
         handler._handle_logging.assert_called_once()
         call_kwargs = handler._handle_logging.call_args[1]
-        assert call_kwargs["response_cost"] is not None
+        assert call_kwargs["response_cost"] == 0.000050
         assert call_kwargs["model"] == "gemini-2.0-flash"
         assert call_kwargs["custom_llm_provider"] == "gemini"
 


### PR DESCRIPTION
## Summary

- `test_pass_through_success_handler_gemini_routing` used `gemini-1.5-flash` in the URL route and assertions, but this model has been removed from `model_prices_and_context_window.json`
- Cost calculation raises an exception for unknown models, causing `response_cost` to be `None` and the test to fail
- Fix: update URL and model assertions to use `gemini-2.0-flash` which is in the pricing map

## Test plan

- [ ] `test (proxy-misc)` — `TestGeminiPassthroughLoggingHandler::test_pass_through_success_handler_gemini_routing` passes