### PR TITLE
[Feature] Allow Admin Viewers to Access Audit Logs

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -684,6 +684,8 @@ class LiteLLMRoutes(enum.Enum):
         "/team/daily/activity",
         "/tag/daily/activity",
         "/tag/list",
+        "/audit",
+        "/audit/{id}",
     ] + info_routes
 
     # All routes accesible by an Org Admin

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -976,6 +976,43 @@ def test_proxy_admin_viewer_can_access_global_spend_tags():
         )
 
 
+@pytest.mark.parametrize("route", ["/audit", "/audit/some-log-id"])
+def test_proxy_admin_viewer_can_access_audit_logs(route):
+    """
+    Test that proxy_admin_viewer can access /audit endpoints.
+
+    Admin viewers should be able to view audit logs since these are read-only.
+    """
+
+    user_obj = LiteLLM_UserTable(
+        user_id="viewer_user",
+        user_email="viewer@example.com",
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+    )
+
+    valid_token = UserAPIKeyAuth(
+        user_id="viewer_user",
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+    )
+
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    try:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+            route=route,
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+    except Exception as e:
+        pytest.fail(
+            f"proxy_admin_viewer should be able to access {route} route. Got error: {str(e)}"
+        )
+
+
 class TestModelsRouteExemptFromDisableLLMEndpoints:
     """
     Test that /models and /v1/models are exempt from DISABLE_LLM_API_ENDPOINTS.


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Summary

### Problem

Users with the `proxy_admin_viewer` role cannot access the `/audit` endpoints, even though audit logs are read-only data that aligns with the admin viewer's purpose.

### Fix

Added `/audit` and `/audit/{id}` to `admin_viewer_routes` in `LiteLLMRoutes`, allowing read-only admin users to view audit logs.

## Testing

- Added parameterized test `test_proxy_admin_viewer_can_access_audit_logs` covering both `/audit` and `/audit/{id}` routes
- `make test-unit` passes

## Type

🆕 New Feature
✅ Test