### PR TITLE
[Fix] Auth Error Message Typos

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -388,7 +388,7 @@ async def common_checks(  # noqa: PLR0915
     # 1. If team is blocked
     if team_object is not None and team_object.blocked is True:
         raise Exception(
-            f"Team={team_object.team_id} is blocked. Update via `/team/unblock` if your admin."
+            f"Team={team_object.team_id} is blocked. Update via `/team/unblock` if you're an admin."
         )
 
     # 2. If team can call model

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1145,7 +1145,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             ## base case ## key is disabled
             if valid_token.blocked is True:
                 raise Exception(
-                    "Key is blocked. Update via `/key/unblock` if you're admin."
+                    "Key is blocked. Update via `/key/unblock` if you're an admin."
                 )
             config = valid_token.config
 


### PR DESCRIPTION
## Summary

### Problem
- `auth_checks.py`: "if your admin" — wrong word ("your" instead of "you're") and missing article
- `user_api_key_auth.py`: "if you're admin" — missing article "an"

### Fix
Corrected both error messages to say "if you're an admin."

## Type

🐛 Bug Fix