### PR TITLE
fix(anthropic): forward service_tier parameter to Anthropic API

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -195,6 +195,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "speed",
             "context_management",
             "cache_control",
+            "service_tier",
         ]
 
         if (
@@ -1068,6 +1069,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "cache_control" and isinstance(value, dict):
                 # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
+            elif param == "service_tier" and isinstance(value, str):
+                # Pass through Anthropic service_tier for Priority Tier support
+                # Valid values: "auto", "standard_only"
+                optional_params["service_tier"] = value
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(


### PR DESCRIPTION
## Summary
- Add `service_tier` to `AnthropicConfig.get_supported_openai_params()`
- Add mapping in `map_openai_params()` to forward the parameter

## Problem
When calling Anthropic models with `service_tier="auto"`, the parameter is silently dropped and never sent to the Anthropic API. This is because `service_tier` was not listed in the supported params.

## Fix
1. Add `"service_tier"` to the supported params list
2. Add passthrough mapping in `map_openai_params()`

Valid values per [Anthropic service tiers documentation](https://platform.claude.com/docs/en/api/service-tiers):
- `"auto"` — use Priority Tier capacity if available, fall back to standard
- `"standard_only"` — always use standard tier capacity

Closes #23398