### PR TITLE
fix: cast ISO timestamp strings to timestamp type in tool_registry_writer SQL

### DIFF
--- a/litellm/proxy/db/tool_registry_writer.py
+++ b/litellm/proxy/db/tool_registry_writer.py
@@ -66,10 +66,10 @@ async def batch_upsert_tools(
             await prisma_client.db.execute_raw(
                 'INSERT INTO "LiteLLM_ToolTable" '
                 "(tool_id, tool_name, origin, call_policy, call_count, created_by, updated_by, key_hash, team_id, key_alias, created_at, updated_at) "
-                "VALUES ($7, $1, $2, 'untrusted', 1, $3, $3, $4, $5, $6, $8, $8) "
+                "VALUES ($7, $1, $2, 'untrusted', 1, $3, $3, $4, $5, $6, $8::timestamp, $8::timestamp) "
                 "ON CONFLICT (tool_name) DO UPDATE SET "
                 "call_count = \"LiteLLM_ToolTable\".call_count + 1, "
-                "updated_at = $8",
+                "updated_at = $8::timestamp",
                 tool_name,
                 origin,
                 created_by,
@@ -143,8 +143,8 @@ async def update_tool_policy(
         now = datetime.now(timezone.utc).isoformat()
         await prisma_client.db.execute_raw(
             'INSERT INTO "LiteLLM_ToolTable" (tool_id, tool_name, call_policy, created_by, updated_by, created_at, updated_at) '
-            "VALUES ($4, $1, $2, $3, $3, $5, $5) "
-            "ON CONFLICT (tool_name) DO UPDATE SET call_policy = $2, updated_by = $3, updated_at = $5",
+            "VALUES ($4, $1, $2, $3, $3, $5::timestamp, $5::timestamp) "
+            "ON CONFLICT (tool_name) DO UPDATE SET call_policy = $2, updated_by = $3, updated_at = $5::timestamp",
             tool_name,
             call_policy,
             _updated_by,


### PR DESCRIPTION
## Summary

Fixes `tool_registry_writer batch_upsert_tools error: ERROR: column "created_at" is of type timestamp without time zone but expression is of type text` by adding explicit `::timestamp` casts to raw SQL parameter references.

## Steps to Reproduce

**1. Deploy LiteLLM v1.82.0-stable with a PostgreSQL database and MCP/tool-calling enabled.**

**2. Send any request that triggers tool discovery** (e.g., a chat completion with tool use).

**3. The `tool_registry_writer` background job fires and fails continuously:**

```
tool_registry_writer batch_upsert_tools error: ERROR: column "created_at" is of type
timestamp without time zone but expression is of type text
HINT: You will need to rewrite or cast the expression.
```

This error fires every ~8 seconds for as long as the proxy is running.

## Production Evidence

Observed on Google Cloud Run deployment (`litellm` service, `trending-threats` project) running v1.82.0-stable with Cloud SQL PostgreSQL. 185 errors in a 1-hour window:

```
2026-03-12T13:34:30  tool_registry_writer batch_upsert_tools error: ERROR: column
  "created_at" is of type timestamp without time zone but expression is of type text
  HINT: You will need to rewrite or cast the expression.
```

## Root Cause

The `batch_upsert_tools()` and `update_tool_policy()` functions in `tool_registry_writer.py` use `execute_raw()` with ISO 8601 timestamp strings (`datetime.now(timezone.utc).isoformat()`):

```python
now = datetime.now(timezone.utc).isoformat()
# Produces: "2026-03-12T13:34:30.123456+00:00"

await prisma_client.db.execute_raw(
    'INSERT INTO "LiteLLM_ToolTable" (..., created_at, updated_at) '
    "VALUES (..., $8, $8) "                    # ← $8 is text type
    "ON CONFLICT (...) DO UPDATE SET "
    "updated_at = $8",                          # ← $8 is text type
    ..., now,
)
```

Prisma's `execute_raw()` passes the `.isoformat()` string as a `text` parameter. PostgreSQL's `created_at` and `updated_at` columns are `timestamp without time zone`, and PostgreSQL does not implicitly cast `text` to `timestamp` in parameterized queries.

## Fix

Added explicit `::timestamp` casts to all timestamp parameter references in the raw SQL:

```sql
-- Before:
VALUES (..., $8, $8)
ON CONFLICT (...) DO UPDATE SET updated_at = $8

-- After:
VALUES (..., $8::timestamp, $8::timestamp)
ON CONFLICT (...) DO UPDATE SET updated_at = $8::timestamp
```

Applied to both `batch_upsert_tools()` and `update_tool_policy()`.

## Test plan

- [x] Verified the SQL syntax is valid with `::timestamp` casts
- [x] Verified ISO 8601 strings with timezone offsets cast correctly to `timestamp without time zone` in PostgreSQL
- [x] Both affected functions (`batch_upsert_tools`, `update_tool_policy`) are fixed
