### PR TITLE
fix: EntityUsage only fetches page 1, showing incomplete spend totals

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
@@ -119,69 +119,76 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
   const [topModelsLimit, setTopModelsLimit] = useState<number>(5);
   const [topAgentsLimit, setTopAgentsLimit] = useState<number>(5);
 
+  const fetchAllPages = async (
+    fetcher: (page: number) => Promise<any>,
+  ) => {
+    const firstPageData = await fetcher(1);
+
+    if (!firstPageData.metadata || firstPageData.metadata.total_pages <= 1) {
+      return firstPageData;
+    }
+
+    const allResults = [...firstPageData.results];
+    const aggregatedMetadata = { ...firstPageData.metadata };
+
+    for (let page = 2; page <= firstPageData.metadata.total_pages; page++) {
+      const pageData = await fetcher(page);
+      allResults.push(...pageData.results);
+      if (pageData.metadata) {
+        aggregatedMetadata.total_spend = (aggregatedMetadata.total_spend || 0) + (pageData.metadata.total_spend || 0);
+        aggregatedMetadata.total_api_requests = (aggregatedMetadata.total_api_requests || 0) + (pageData.metadata.total_api_requests || 0);
+        aggregatedMetadata.total_successful_requests = (aggregatedMetadata.total_successful_requests || 0) + (pageData.metadata.total_successful_requests || 0);
+        aggregatedMetadata.total_failed_requests = (aggregatedMetadata.total_failed_requests || 0) + (pageData.metadata.total_failed_requests || 0);
+        aggregatedMetadata.total_tokens = (aggregatedMetadata.total_tokens || 0) + (pageData.metadata.total_tokens || 0);
+        aggregatedMetadata.total_prompt_tokens = (aggregatedMetadata.total_prompt_tokens || 0) + (pageData.metadata.total_prompt_tokens || 0);
+        aggregatedMetadata.total_completion_tokens = (aggregatedMetadata.total_completion_tokens || 0) + (pageData.metadata.total_completion_tokens || 0);
+        aggregatedMetadata.total_cache_read_input_tokens = (aggregatedMetadata.total_cache_read_input_tokens || 0) + (pageData.metadata.total_cache_read_input_tokens || 0);
+        aggregatedMetadata.total_cache_creation_input_tokens = (aggregatedMetadata.total_cache_creation_input_tokens || 0) + (pageData.metadata.total_cache_creation_input_tokens || 0);
+      }
+    }
+
+    return {
+      results: allResults,
+      metadata: aggregatedMetadata,
+    };
+  };
+
   const fetchSpendData = async () => {
     if (!accessToken || !dateValue.from || !dateValue.to) return;
     // Create new Date objects to avoid mutating the original dates
     const startTime = new Date(dateValue.from);
     const endTime = new Date(dateValue.to);
+    const tagsParam = selectedTags.length > 0 ? selectedTags : null;
 
+    let data;
     if (entityType === "tag") {
-      const data = await tagDailyActivityCall(
-        accessToken,
-        startTime,
-        endTime,
-        1,
-        selectedTags.length > 0 ? selectedTags : null,
+      data = await fetchAllPages((page) =>
+        tagDailyActivityCall(accessToken, startTime, endTime, page, tagsParam),
       );
-      setSpendData(data);
     } else if (entityType === "team") {
-      const data = await teamDailyActivityCall(
-        accessToken,
-        startTime,
-        endTime,
-        1,
-        selectedTags.length > 0 ? selectedTags : null,
+      data = await fetchAllPages((page) =>
+        teamDailyActivityCall(accessToken, startTime, endTime, page, tagsParam),
       );
-      setSpendData(data);
     } else if (entityType === "organization") {
-      const data = await organizationDailyActivityCall(
-        accessToken,
-        startTime,
-        endTime,
-        1,
-        selectedTags.length > 0 ? selectedTags : null,
+      data = await fetchAllPages((page) =>
+        organizationDailyActivityCall(accessToken, startTime, endTime, page, tagsParam),
       );
-      setSpendData(data);
     } else if (entityType === "customer") {
-      const data = await customerDailyActivityCall(
-        accessToken,
-        startTime,
-        endTime,
-        1,
-        selectedTags.length > 0 ? selectedTags : null,
+      data = await fetchAllPages((page) =>
+        customerDailyActivityCall(accessToken, startTime, endTime, page, tagsParam),
       );
-      setSpendData(data);
     } else if (entityType === "agent") {
-      const data = await agentDailyActivityCall(
-        accessToken,
-        startTime,
-        endTime,
-        1,
-        selectedTags.length > 0 ? selectedTags : null,
+      data = await fetchAllPages((page) =>
+        agentDailyActivityCall(accessToken, startTime, endTime, page, tagsParam),
       );
-      setSpendData(data);
     } else if (entityType === "user") {
-      const data = await userDailyActivityCall(
-        accessToken,
-        startTime,
-        endTime,
-        1,
-        selectedTags.length > 0 ? selectedTags[0] : null,
+      data = await fetchAllPages((page) =>
+        userDailyActivityCall(accessToken, startTime, endTime, page, selectedTags.length > 0 ? selectedTags[0] : null),
       );
-      setSpendData(data);
     } else {
       throw new Error("Invalid entity type");
     }
+    setSpendData(data);
   };
 
   const fetchAgentSpendData = async () => {

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
@@ -196,7 +196,9 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
     const startTime = new Date(dateValue.from);
     const endTime = new Date(dateValue.to);
     try {
-      const data = await agentDailyActivityCall(accessToken, startTime, endTime, 1, null);
+      const data = await fetchAllPages((page) =>
+        agentDailyActivityCall(accessToken, startTime, endTime, page, null),
+      );
       setAgentSpendData(data);
     } catch (e) {
       console.error("Failed to fetch agent activity data:", e);


### PR DESCRIPTION
## Summary

The `EntityUsage` component (used for tag, team, organization, customer, and agent spend views) only fetches **page 1** from the `/daily/activity` endpoints and computes metadata totals from just that page. When the underlying DailySpend table has more rows than `page_size` (default 1000), the displayed totals (Total Spend, Total Requests, Total Tokens) are incomplete.

The global user usage view (`UsagePageView`) already handles this correctly by iterating through all pages and aggregating metadata. This PR applies the same pattern to `EntityUsage`.

## Root cause

In `EntityUsage.tsx`, every entity type call hardcodes `page=1` and never checks `total_pages`:

```typescript
const data = await tagDailyActivityCall(accessToken, startTime, endTime, 1, ...);
setSpendData(data);
```

The backend computes metadata totals from only the returned page's rows (see `common_daily_activity.py`), so these totals reflect a subset of the data.

## Impact

Any tag/team/org/customer/agent with more than 1000 rows in its DailySpend table shows incorrect (lower) totals in the UI's spend overview cards. This is easy to hit with multiple API keys across multiple models — e.g., 200 keys × 3 models × 2 endpoints = 1200 rows for a single day.

## Fix

Extract a `fetchAllPages` helper that iterates through all pages and aggregates metadata (same approach as `UsagePageView.tsx` L397-411). Use it for all entity types in `fetchSpendData`.
