### PR TITLE
Fix: allow UI login without database when DATABASE_URL is not set

### DIFF
--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -189,11 +189,14 @@ async def authenticate_user(  # noqa: PLR0915
                 },  # type: ignore
             )
         else:
-            raise ProxyException(
-                message="No Database connected. Set DATABASE_URL in .env. If set, use `--detailed_debug` to debug issue.",
-                type=ProxyErrorTypes.auth_error,
-                param="DATABASE_URL",
-                code=500,
+            key = secrets.token_urlsafe(32)
+
+            return LoginResult(
+                user_id=user_id,
+                key=key,
+                user_email=None,
+                user_role=user_role,
+                login_method="username_password",
             )
 
         key = response["token"]  # type: ignore


### PR DESCRIPTION
## Relevant issues
Fixes #23451
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix
<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->



## Changes
Fixes a bug where LiteLLM UI login fails when `DATABASE_URL` is not configured.
Previously, login using `UI_USERNAME` and `UI_PASSWORD` required a database and raised an error if `DATABASE_URL` was not set.
This change adds a fallback for local deployments by generating a temporary session key when no database is configured, allowing UI login without PostgreSQL.
Testing: Manually tested login with `UI_USERNAME` and `UI_PASSWORD` without `DATABASE_URL`.