### PR TITLE
fix: add oauth2_flow="client_credentials" to MCPServer test helper

### DIFF
--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_token_cache.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_token_cache.py
@@ -29,6 +29,7 @@ def _server(**overrides) -> MCPServer:
         client_id="cid",
         client_secret="csec",
         token_url="https://auth.example.com/token",
+        oauth2_flow="client_credentials",
     )
     defaults.update(overrides)
     return MCPServer(**defaults)
@@ -103,6 +104,7 @@ async def test_falls_back_to_static_token():
         client_id=None,
         client_secret=None,
         token_url=None,
+        oauth2_flow=None,
         authentication_token="static-tok-xyz",
     )
     result = await resolve_mcp_auth(server)
@@ -115,7 +117,7 @@ def test_needs_user_oauth_token_property():
     assert _server().needs_user_oauth_token is False
 
     # OAuth2 without credentials → needs per-user token
-    assert _server(client_id=None, client_secret=None, token_url=None).needs_user_oauth_token is True
+    assert _server(client_id=None, client_secret=None, token_url=None, oauth2_flow=None).needs_user_oauth_token is True
 
     # Non-OAuth2 → never needs user OAuth token
     assert _server(auth_type=MCPAuth.bearer_token).needs_user_oauth_token is False


### PR DESCRIPTION
## Summary
- `MCPServer.has_client_credentials` was changed to require `oauth2_flow == "client_credentials"` explicitly (no longer auto-detected from field presence)
- The `_server()` helper in `test_oauth2_token_cache.py` didn't set `oauth2_flow`, so all token-fetching code paths were skipped and 5 tests failed
- Added `oauth2_flow="client_credentials"` to `_server()` defaults
- Added `oauth2_flow=None` to the two test calls that explicitly test the "no client credentials" path

## Test plan
- [ ] `tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_token_cache.py` — all 5 tests pass
- [ ] `make test-unit` passes