### PR TITLE
fix(tool-registry): pass naive UTC datetime to fix PostgreSQL timestamp error on v1.82.0-stable

### DIFF
--- a/litellm/proxy/db/tool_registry_writer.py
+++ b/litellm/proxy/db/tool_registry_writer.py
@@ -62,7 +62,7 @@ async def batch_upsert_tools(
             key_hash = item.get("key_hash")
             team_id = item.get("team_id")
             key_alias = item.get("key_alias")
-            now = datetime.now(timezone.utc).isoformat()
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
             await prisma_client.db.execute_raw(
                 'INSERT INTO "LiteLLM_ToolTable" '
                 "(tool_id, tool_name, origin, call_policy, call_count, created_by, updated_by, key_hash, team_id, key_alias, created_at, updated_at) "
@@ -140,7 +140,7 @@ async def update_tool_policy(
     """Update the call_policy for a tool. Upserts the row if it does not exist yet."""
     try:
         _updated_by = updated_by or "system"
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         await prisma_client.db.execute_raw(
             'INSERT INTO "LiteLLM_ToolTable" (tool_id, tool_name, call_policy, created_by, updated_by, created_at, updated_at) '
             "VALUES ($4, $1, $2, $3, $3, $5, $5) "


### PR DESCRIPTION
## Summary

Fixes continuous `tool_registry_writer batch_upsert_tools error: ERROR: column "created_at" is of type timestamp without time zone but expression is of type text` on v1.82.0-stable with PostgreSQL.

- `datetime.now(timezone.utc).isoformat()` produces a timezone-aware string (`"2026-03-12T13:34:30+00:00"`) that PostgreSQL rejects when binding to a `timestamp without time zone` column via `execute_raw`
- Replace with `.replace(tzinfo=None)` to produce a timezone-naive UTC datetime that Prisma passes natively — no `::timestamp` cast needed, no schema changes required
- Applies to both `batch_upsert_tools` and `update_tool_policy` call sites

## Impact

Reported as ~185 errors/hour on Cloud Run + Cloud SQL PostgreSQL (v1.82.0-stable). Error fires every ~8 seconds for any deployment with tool calling enabled.

## Related

- Contributor PR (closed, not merged): #23449 — same root cause, different fix approach (`::timestamp` cast); closed by author once they confirmed main had a better fix
- Fix on `main` is a full Prisma ORM refactor (#22732) with schema changes (`call_policy` → `input_policy`/`output_policy`) — not backport-safe to stable
- This patch is the minimal safe fix for the stable branch: 2-line change, no schema changes, no new dependencies

## Test plan

- [x] `tests/test_litellm/proxy/db/test_tool_registry_writer.py` — 11/11 passing locally
- [ ] Deploy v1.82.0-stable patch against PostgreSQL and send a chat completion with tool use
- [ ] Confirm `tool_registry_writer batch_upsert_tools error` no longer appears in logs