### PR TITLE
[Fix] Update Deprecated Model Names in CI Tests

### DIFF
--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -1029,7 +1029,7 @@ def test_completion_claude_stream_bad_key():
             },
         ]
         response = completion(
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5-20251001",
             messages=messages,
             stream=True,
             max_tokens=50,

--- a/tests/local_testing/test_timeout.py
+++ b/tests/local_testing/test_timeout.py
@@ -260,7 +260,7 @@ async def test_anthropic_timeout(streaming, sync_mode):
     try:
         if sync_mode:
             response = litellm.completion(
-                model="claude-3-5-sonnet-20240620",
+                model="claude-sonnet-4-5-20250929",
                 timeout=0.01,
                 messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
                 stream=streaming,
@@ -270,7 +270,7 @@ async def test_anthropic_timeout(streaming, sync_mode):
                     pass
         else:
             response = await litellm.acompletion(
-                model="claude-3-5-sonnet-20240620",
+                model="claude-sonnet-4-5-20250929",
                 timeout=0.01,
                 messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
                 stream=streaming,

--- a/tests/logging_callback_tests/test_alerting.py
+++ b/tests/logging_callback_tests/test_alerting.py
@@ -589,7 +589,7 @@ async def test_webhook_alerting(alerting_type):
             None,
             None,
         ),
-        ("gemini-pro", None, "vertex_ai", "hardy-device-38811", "us-central1"),
+        ("gemini-2.0-flash", None, "vertex_ai", "hardy-device-38811", "us-central1"),
     ],
 )
 @pytest.mark.parametrize("error_code", [500, 408, 400])
@@ -695,7 +695,7 @@ async def test_outage_alerting_called(
             None,
             None,
         ),
-        ("gemini-pro", None, "vertex_ai", "hardy-device-38811", "us-central1"),
+        ("gemini-2.0-flash", None, "vertex_ai", "hardy-device-38811", "us-central1"),
     ],
 )
 @pytest.mark.parametrize("error_code", [500, 408, 400])
@@ -782,7 +782,7 @@ async def test_region_outage_alerting_called(
             await slack_alerting.region_outage_alerts(
                 exception=error_to_raise, deployment_id=deployment_id  # type: ignore
             )
-        if model == "gemini-pro" and (error_code == 500 or error_code == 408):
+        if model == "gemini-2.0-flash" and (error_code == 500 or error_code == 408):
             mock_send_alert.assert_called_once()
         else:
             mock_send_alert.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Fixes CI failures in pipeline #68188 (jobs 1387035 and 1387081).

## Summary

### Failure Path (Before Fix)

The remote model cost map on `main` no longer contains `gemini-pro`, `claude-3-5-sonnet-20240620`, or `claude-3-5-haiku-20241022` (removed in the deprecated model cleanup). CI fetches the remote map, so `get_llm_provider()` fails with "LLM Provider NOT provided" for these models.

### Fix

Replace deprecated model names with current equivalents:
- `gemini-pro` → `gemini-2.0-flash` (vertex_ai)
- `claude-3-5-sonnet-20240620` → `claude-sonnet-4-5-20250929` (anthropic)
- `claude-3-5-haiku-20241022` → `claude-haiku-4-5-20251001` (anthropic)

## Testing

All replacement models verified to resolve correctly via `get_llm_provider()` and Router construction.

## Type

🐛 Bug Fix
✅ Test