### PR TITLE
[Fix] Add litellm-proxy-extras to CI requirements

### DIFF
--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -18,3 +18,4 @@ semantic_router==0.1.10 # for auto-routing with litellm
 fastuuid==0.12.0
 responses==0.25.7  # for proxy client tests
 pytest-retry==1.6.3  # for automatic test retries
+litellm-proxy-extras  # for prisma migrations


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

PR #23257 made proxy startup exit with `sys.exit(1)` if `PrismaManager.setup_database()` returns `False`. Previously the return value was ignored, so the `ImportError` for `litellm_proxy_extras` was silently swallowed. This caused `local_testing_part1` (and other CI jobs) to fail at the "Run prisma ./docker/entrypoint.sh" step.

### Fix

Add `litellm-proxy-extras` (unpinned) to `.circleci/requirements.txt` so the prisma migrate path works in CI. Unpinned to always pull latest from PyPI and avoid version drift with `pyproject.toml` / `requirements.txt`.

## Testing

CI jobs that run `./docker/entrypoint.sh` should now pass the prisma migration step.

## Type

🐛 Bug Fix
🚄 Infrastructure