### PR TITLE
[Docs] Add PKCE_STRICT_CACHE_MISS to env variables reference

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -910,6 +910,7 @@ router_settings:
 | PILLAR_API_BASE | Base URL for Pillar API Guardrails
 | PILLAR_API_KEY | API key for Pillar API Guardrails
 | PILLAR_ON_FLAGGED_ACTION | Action to take when content is flagged ('block' or 'monitor')
+| PKCE_STRICT_CACHE_MISS | When set to `true`, the SSO callback will return a 401 error if the PKCE code_verifier is not found in the cache (e.g. due to a cache miss across pods). When `false` (default), it logs a warning and continues without the code_verifier.
 | POD_NAME | Pod name for the server, this will be [emitted to `datadog` logs](https://docs.litellm.ai/docs/proxy/logging#datadog) as `POD_NAME` 
 | POSTHOG_API_KEY | API key for PostHog analytics integration
 | POSTHOG_API_URL | Base URL for PostHog API (defaults to https://us.i.posthog.com)


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

The `test_env_keys` CI check fails because `PKCE_STRICT_CACHE_MISS` is used in the codebase but not documented in `config_settings.md`.

### Fix

Added `PKCE_STRICT_CACHE_MISS` to the environment variables reference table in alphabetical order.

## Testing

- Ran `python3 tests/documentation_tests/test_env_keys.py` locally — passes.

## Type

📖 Documentation