### PR TITLE
Handle response.failed, response.incomplete, and response.cancelled

### DIFF
--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -141,6 +141,12 @@ async def background_streaming_task(  # noqa: PLR0915
                 last_update_time = current_time
 
         # Handle StreamingResponse
+        if not hasattr(response, "body_iterator"):
+            verbose_proxy_logger.warning(
+                f"background_streaming_task: response for {polling_id} has no "
+                "body_iterator; this may indicate a misconfiguration or provider error"
+            )
+
         if hasattr(response, "body_iterator"):
             async for chunk in response.body_iterator:
                 # Parse chunk

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -116,7 +116,6 @@ async def background_streaming_task(  # noqa: PLR0915
         # Track the terminal event from the stream (may not be "completed")
         terminal_status = None  # Will be set by response.completed/failed/incomplete/cancelled
         terminal_error = None
-        terminal_response_data = None
 
         async def flush_state_if_needed(force: bool = False) -> None:
             """Flush accumulated state to Redis if interval elapsed or forced"""
@@ -238,7 +237,6 @@ async def background_streaming_task(  # noqa: PLR0915
                             # Terminal event - extract all ResponsesAPIResponse fields
                             # https://platform.openai.com/docs/api-reference/responses-streaming
                             response_data = event.get("response", {})
-                            terminal_response_data = response_data
                             terminal_status = response_data.get(
                                 "status", "completed"
                             )

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -116,6 +116,12 @@ async def background_streaming_task(  # noqa: PLR0915
         # Track the terminal event from the stream (may not be "completed")
         terminal_status = None  # Will be set by response.completed/failed/incomplete/cancelled
         terminal_error = None
+        _event_to_status = {
+            "response.completed": "completed",
+            "response.failed": "failed",
+            "response.incomplete": "incomplete",
+            "response.cancelled": "cancelled",
+        }
 
         async def flush_state_if_needed(force: bool = False) -> None:
             """Flush accumulated state to Redis if interval elapsed or forced"""
@@ -238,7 +244,8 @@ async def background_streaming_task(  # noqa: PLR0915
                             # https://platform.openai.com/docs/api-reference/responses-streaming
                             response_data = event.get("response", {})
                             terminal_status = response_data.get(
-                                "status", "completed"
+                                "status",
+                                _event_to_status.get(event_type, "completed"),
                             )
 
                             # Extract error for failed responses

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -113,6 +113,11 @@ async def background_streaming_task(  # noqa: PLR0915
         last_update_time = asyncio.get_event_loop().time()
         UPDATE_INTERVAL = 0.150  # 150ms batching interval
 
+        # Track the terminal event from the stream (may not be "completed")
+        terminal_status = None  # Will be set by response.completed/failed/incomplete/cancelled
+        terminal_error = None
+        terminal_response_data = None
+
         async def flush_state_if_needed(force: bool = False) -> None:
             """Flush accumulated state to Redis if interval elapsed or forced"""
             nonlocal state_dirty, last_update_time
@@ -224,10 +229,23 @@ async def background_streaming_task(  # noqa: PLR0915
                                 status="in_progress",
                             )
 
-                        elif event_type == "response.completed":
-                            # Response completed - extract all ResponsesAPIResponse fields
-                            # https://platform.openai.com/docs/api-reference/responses-streaming/response-completed
+                        elif event_type in (
+                            "response.completed",
+                            "response.failed",
+                            "response.incomplete",
+                            "response.cancelled",
+                        ):
+                            # Terminal event - extract all ResponsesAPIResponse fields
+                            # https://platform.openai.com/docs/api-reference/responses-streaming
                             response_data = event.get("response", {})
+                            terminal_response_data = response_data
+                            terminal_status = response_data.get(
+                                "status", "completed"
+                            )
+
+                            # Extract error for failed responses
+                            if event_type == "response.failed":
+                                terminal_error = response_data.get("error")
 
                             # Core response fields
                             usage_data = response_data.get("usage")
@@ -278,11 +296,14 @@ async def background_streaming_task(  # noqa: PLR0915
             # Final flush to ensure all accumulated state is saved
             await flush_state_if_needed(force=True)
 
-        # Mark as completed with all ResponsesAPIResponse fields
+        # Use the terminal status from the stream, default to "completed"
+        final_status = terminal_status or "completed"
+
         await polling_handler.update_state(
             polling_id=polling_id,
-            status="completed",
+            status=final_status,
             usage=usage_data,
+            error=terminal_error,
             reasoning=reasoning_data,
             tool_choice=tool_choice_data,
             tools=tools_data,
@@ -301,7 +322,7 @@ async def background_streaming_task(  # noqa: PLR0915
         )
 
         verbose_proxy_logger.info(
-            f"Completed background streaming for {polling_id}, output_items={len(output_items)}"
+            f"Finished background streaming for {polling_id}, status={final_status}, output_items={len(output_items)}"
         )
 
     except Exception as e:

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -1250,6 +1250,119 @@ class TestStreamingEventParsing:
         assert tools_data == [{"type": "function", "function": {"name": "test"}}]
         assert model_data == "gpt-4o"
 
+    def test_parse_response_failed_event(self):
+        """Test parsing response.failed event extracts error and sets failed status"""
+        event = {
+            "type": "response.failed",
+            "response": {
+                "id": "resp_123",
+                "status": "failed",
+                "error": {
+                    "type": "server_error",
+                    "message": "The model encountered an error",
+                    "code": "model_error",
+                },
+                "model": "gpt-4o",
+                "output": [],
+            },
+        }
+
+        event_type = event.get("type", "")
+        terminal_status = None
+        terminal_error = None
+        model_data = None
+
+        if event_type in (
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+            "response.cancelled",
+        ):
+            response_data = event.get("response", {})
+            terminal_status = response_data.get("status", "completed")
+            model_data = response_data.get("model")
+            if event_type == "response.failed":
+                terminal_error = response_data.get("error")
+
+        assert terminal_status == "failed"
+        assert terminal_error == {
+            "type": "server_error",
+            "message": "The model encountered an error",
+            "code": "model_error",
+        }
+        assert model_data == "gpt-4o"
+
+    def test_parse_response_incomplete_event(self):
+        """Test parsing response.incomplete event extracts incomplete_details"""
+        event = {
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_123",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "usage": {"input_tokens": 10, "output_tokens": 4096},
+                "model": "gpt-4o",
+                "output": [{"id": "item_1", "type": "message"}],
+            },
+        }
+
+        event_type = event.get("type", "")
+        terminal_status = None
+        incomplete_details_data = None
+        usage_data = None
+
+        if event_type in (
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+            "response.cancelled",
+        ):
+            response_data = event.get("response", {})
+            terminal_status = response_data.get("status", "completed")
+            incomplete_details_data = response_data.get("incomplete_details")
+            usage_data = response_data.get("usage")
+
+        assert terminal_status == "incomplete"
+        assert incomplete_details_data == {"reason": "max_output_tokens"}
+        assert usage_data == {"input_tokens": 10, "output_tokens": 4096}
+
+    def test_parse_response_cancelled_event(self):
+        """Test parsing response.cancelled event sets cancelled status"""
+        event = {
+            "type": "response.cancelled",
+            "response": {
+                "id": "resp_123",
+                "status": "cancelled",
+                "model": "gpt-4o",
+                "output": [],
+            },
+        }
+
+        event_type = event.get("type", "")
+        terminal_status = None
+        model_data = None
+
+        if event_type in (
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+            "response.cancelled",
+        ):
+            response_data = event.get("response", {})
+            terminal_status = response_data.get("status", "completed")
+            model_data = response_data.get("model")
+
+        assert terminal_status == "cancelled"
+        assert model_data == "gpt-4o"
+
+    def test_terminal_status_defaults_to_completed_when_missing(self):
+        """Test that terminal_status defaults to completed when no terminal event is received"""
+        terminal_status = None  # No terminal event received
+
+        final_status = terminal_status or "completed"
+
+        assert final_status == "completed"
+
     def test_parse_done_marker(self):
         """Test that [DONE] marker is detected correctly"""
         chunks = [

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -22,11 +22,9 @@ from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from fastapi import Request, Response
 
 sys.path.insert(0, os.path.abspath("../.."))
 
-from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
 from litellm.proxy.response_polling.polling_handler import ResponsePollingHandler
 
 
@@ -1342,9 +1340,9 @@ def _make_background_streaming_kwargs(
         polling_id=polling_id,
         data={"model": "gpt-4o", "stream": False, "background": True},
         polling_handler=polling_handler,
-        request=Mock(spec=Request),
-        fastapi_response=Mock(spec=Response),
-        user_api_key_dict=Mock(spec=UserAPIKeyAuth),
+        request=Mock(),
+        fastapi_response=Mock(),
+        user_api_key_dict=Mock(),
         general_settings={},
         llm_router=None,
         proxy_config=Mock(),

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -22,9 +22,11 @@ from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from fastapi import Request, Response
 
 sys.path.insert(0, os.path.abspath("../.."))
 
+from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
 from litellm.proxy.response_polling.polling_handler import ResponsePollingHandler
 
 
@@ -1250,119 +1252,6 @@ class TestStreamingEventParsing:
         assert tools_data == [{"type": "function", "function": {"name": "test"}}]
         assert model_data == "gpt-4o"
 
-    def test_parse_response_failed_event(self):
-        """Test parsing response.failed event extracts error and sets failed status"""
-        event = {
-            "type": "response.failed",
-            "response": {
-                "id": "resp_123",
-                "status": "failed",
-                "error": {
-                    "type": "server_error",
-                    "message": "The model encountered an error",
-                    "code": "model_error",
-                },
-                "model": "gpt-4o",
-                "output": [],
-            },
-        }
-
-        event_type = event.get("type", "")
-        terminal_status = None
-        terminal_error = None
-        model_data = None
-
-        if event_type in (
-            "response.completed",
-            "response.failed",
-            "response.incomplete",
-            "response.cancelled",
-        ):
-            response_data = event.get("response", {})
-            terminal_status = response_data.get("status", "completed")
-            model_data = response_data.get("model")
-            if event_type == "response.failed":
-                terminal_error = response_data.get("error")
-
-        assert terminal_status == "failed"
-        assert terminal_error == {
-            "type": "server_error",
-            "message": "The model encountered an error",
-            "code": "model_error",
-        }
-        assert model_data == "gpt-4o"
-
-    def test_parse_response_incomplete_event(self):
-        """Test parsing response.incomplete event extracts incomplete_details"""
-        event = {
-            "type": "response.incomplete",
-            "response": {
-                "id": "resp_123",
-                "status": "incomplete",
-                "incomplete_details": {"reason": "max_output_tokens"},
-                "usage": {"input_tokens": 10, "output_tokens": 4096},
-                "model": "gpt-4o",
-                "output": [{"id": "item_1", "type": "message"}],
-            },
-        }
-
-        event_type = event.get("type", "")
-        terminal_status = None
-        incomplete_details_data = None
-        usage_data = None
-
-        if event_type in (
-            "response.completed",
-            "response.failed",
-            "response.incomplete",
-            "response.cancelled",
-        ):
-            response_data = event.get("response", {})
-            terminal_status = response_data.get("status", "completed")
-            incomplete_details_data = response_data.get("incomplete_details")
-            usage_data = response_data.get("usage")
-
-        assert terminal_status == "incomplete"
-        assert incomplete_details_data == {"reason": "max_output_tokens"}
-        assert usage_data == {"input_tokens": 10, "output_tokens": 4096}
-
-    def test_parse_response_cancelled_event(self):
-        """Test parsing response.cancelled event sets cancelled status"""
-        event = {
-            "type": "response.cancelled",
-            "response": {
-                "id": "resp_123",
-                "status": "cancelled",
-                "model": "gpt-4o",
-                "output": [],
-            },
-        }
-
-        event_type = event.get("type", "")
-        terminal_status = None
-        model_data = None
-
-        if event_type in (
-            "response.completed",
-            "response.failed",
-            "response.incomplete",
-            "response.cancelled",
-        ):
-            response_data = event.get("response", {})
-            terminal_status = response_data.get("status", "completed")
-            model_data = response_data.get("model")
-
-        assert terminal_status == "cancelled"
-        assert model_data == "gpt-4o"
-
-    def test_terminal_status_defaults_to_completed_when_missing(self):
-        """Test that terminal_status defaults to completed when no terminal event is received"""
-        terminal_status = None  # No terminal event received
-
-        final_status = terminal_status or "completed"
-
-        assert final_status == "completed"
-
     def test_parse_done_marker(self):
         """Test that [DONE] marker is detected correctly"""
         chunks = [
@@ -1429,6 +1318,271 @@ class TestStreamingEventParsing:
         assert "content" in output_items["item_123"]
         assert len(output_items["item_123"]["content"]) == 1
         assert output_items["item_123"]["content"][0]["type"] == "text"
+
+
+def _make_sse_stream(events: list) -> Mock:
+    """Create a mock StreamingResponse with body_iterator from a list of event dicts."""
+
+    async def _body_iterator():
+        for event in events:
+            yield f"data: {json.dumps(event)}"
+        yield "data: [DONE]"
+
+    mock_response = Mock()
+    mock_response.body_iterator = _body_iterator()
+    return mock_response
+
+
+def _make_background_streaming_kwargs(
+    polling_id: str,
+    polling_handler: ResponsePollingHandler,
+    mock_response: Mock,
+) -> dict:
+    """Build kwargs for background_streaming_task with all required mocks."""
+    mock_processor = AsyncMock()
+    mock_processor.base_process_llm_request = AsyncMock(return_value=mock_response)
+
+    return dict(
+        polling_id=polling_id,
+        data={"model": "gpt-4o", "stream": False, "background": True},
+        polling_handler=polling_handler,
+        request=Mock(spec=Request),
+        fastapi_response=Mock(spec=Response),
+        user_api_key_dict=Mock(spec=UserAPIKeyAuth),
+        general_settings={},
+        llm_router=None,
+        proxy_config=Mock(),
+        proxy_logging_obj=Mock(),
+        select_data_generator=Mock(),
+        user_model=None,
+        user_temperature=None,
+        user_request_timeout=None,
+        user_max_tokens=None,
+        user_api_base=None,
+        version=None,
+    )
+
+
+@pytest.mark.xdist_group("heavy_imports")
+class TestBackgroundStreamingTerminalEvents:
+    """
+    Integration tests that exercise background_streaming_task with mocked
+    streaming responses, verifying the final update_state call for each
+    terminal event type.
+    """
+
+    @pytest.mark.asyncio
+    async def test_response_failed_sets_failed_status_and_error(self):
+        """Test that a response.failed stream event results in failed status with error"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        error_payload = {
+            "type": "server_error",
+            "message": "The model encountered an error",
+            "code": "model_error",
+        }
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": "resp_123",
+                    "status": "failed",
+                    "error": error_payload,
+                    "model": "gpt-4o",
+                    "output": [],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_1", handler, mock_response)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        # Find the final update_state call (last one)
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "failed"
+        assert final_call.kwargs["error"] == error_payload
+
+    @pytest.mark.asyncio
+    async def test_response_incomplete_sets_incomplete_status_and_details(self):
+        """Test that a response.incomplete stream event results in incomplete status"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_123",
+                    "status": "incomplete",
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                    "usage": {"input_tokens": 10, "output_tokens": 4096},
+                    "model": "gpt-4o",
+                    "output": [{"id": "item_1", "type": "message"}],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_2", handler, mock_response)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "incomplete"
+        assert final_call.kwargs["incomplete_details"] == {"reason": "max_output_tokens"}
+        assert final_call.kwargs["usage"] == {"input_tokens": 10, "output_tokens": 4096}
+
+    @pytest.mark.asyncio
+    async def test_response_cancelled_sets_cancelled_status(self):
+        """Test that a response.cancelled stream event results in cancelled status"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.cancelled",
+                "response": {
+                    "id": "resp_123",
+                    "status": "cancelled",
+                    "model": "gpt-4o",
+                    "output": [],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_3", handler, mock_response)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_response_completed_sets_completed_status(self):
+        """Test that a response.completed stream event results in completed status"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "status": "completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 50},
+                    "model": "gpt-4o",
+                    "output": [{"id": "item_1", "type": "message"}],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_4", handler, mock_response)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "completed"
+        assert final_call.kwargs["usage"] == {"input_tokens": 10, "output_tokens": 50}
+
+    @pytest.mark.asyncio
+    async def test_fallback_status_derived_from_event_type_when_status_field_missing(self):
+        """Test that when the response body lacks a status field, the fallback
+        is derived from the event type, not hardcoded to 'completed'."""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        # response.incomplete event with NO status field in the response body
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_123",
+                    # "status" deliberately omitted
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                    "model": "gpt-4o",
+                    "output": [],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_5", handler, mock_response)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "incomplete"
+
+    @pytest.mark.asyncio
+    async def test_no_terminal_event_defaults_to_completed(self):
+        """Test that when no terminal event is received, status defaults to completed"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        # Stream with only in_progress, no terminal event
+        events = [
+            {"type": "response.in_progress"},
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_6", handler, mock_response)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "completed"
 
 
 class TestEdgeCases:

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -1336,12 +1336,8 @@ def _make_sse_stream(events: list) -> Mock:
 def _make_background_streaming_kwargs(
     polling_id: str,
     polling_handler: ResponsePollingHandler,
-    mock_response: Mock,
 ) -> dict:
     """Build kwargs for background_streaming_task with all required mocks."""
-    mock_processor = AsyncMock()
-    mock_processor.base_process_llm_request = AsyncMock(return_value=mock_response)
-
     return dict(
         polling_id=polling_id,
         data={"model": "gpt-4o", "stream": False, "background": True},
@@ -1398,7 +1394,7 @@ class TestBackgroundStreamingTerminalEvents:
         ]
         mock_response = _make_sse_stream(events)
         handler = AsyncMock(spec=ResponsePollingHandler)
-        kwargs = _make_background_streaming_kwargs("poll_1", handler, mock_response)
+        kwargs = _make_background_streaming_kwargs("poll_1", handler)
 
         with patch(
             "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
@@ -1436,7 +1432,7 @@ class TestBackgroundStreamingTerminalEvents:
         ]
         mock_response = _make_sse_stream(events)
         handler = AsyncMock(spec=ResponsePollingHandler)
-        kwargs = _make_background_streaming_kwargs("poll_2", handler, mock_response)
+        kwargs = _make_background_streaming_kwargs("poll_2", handler)
 
         with patch(
             "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
@@ -1472,7 +1468,7 @@ class TestBackgroundStreamingTerminalEvents:
         ]
         mock_response = _make_sse_stream(events)
         handler = AsyncMock(spec=ResponsePollingHandler)
-        kwargs = _make_background_streaming_kwargs("poll_3", handler, mock_response)
+        kwargs = _make_background_streaming_kwargs("poll_3", handler)
 
         with patch(
             "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
@@ -1507,7 +1503,7 @@ class TestBackgroundStreamingTerminalEvents:
         ]
         mock_response = _make_sse_stream(events)
         handler = AsyncMock(spec=ResponsePollingHandler)
-        kwargs = _make_background_streaming_kwargs("poll_4", handler, mock_response)
+        kwargs = _make_background_streaming_kwargs("poll_4", handler)
 
         with patch(
             "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
@@ -1545,7 +1541,7 @@ class TestBackgroundStreamingTerminalEvents:
         ]
         mock_response = _make_sse_stream(events)
         handler = AsyncMock(spec=ResponsePollingHandler)
-        kwargs = _make_background_streaming_kwargs("poll_5", handler, mock_response)
+        kwargs = _make_background_streaming_kwargs("poll_5", handler)
 
         with patch(
             "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
@@ -1571,7 +1567,7 @@ class TestBackgroundStreamingTerminalEvents:
         ]
         mock_response = _make_sse_stream(events)
         handler = AsyncMock(spec=ResponsePollingHandler)
-        kwargs = _make_background_streaming_kwargs("poll_6", handler, mock_response)
+        kwargs = _make_background_streaming_kwargs("poll_6", handler)
 
         with patch(
             "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"


### PR DESCRIPTION
## Relevant issues
This is a follow up PR to https://github.com/BerriAI/litellm/pull/16862. 
Previously the background streaming task only handled response.completed and hardcoded the final status to "completed". This missed three other terminal event types from the OpenAI streaming spec, causing failed/incomplete/cancelled responses to be incorrectly marked as completed.


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
