### PR TITLE
Proxy fails to start on Windows with AttributeError: module 'os' has no attribute 'WNOHANG'.

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import os
 import smtplib
+import sys
 import threading
 import time
 import traceback
@@ -3663,7 +3664,11 @@ class PrismaClient:
         Returns a set of reaped PIDs.  As PID 1 in Docker (or any
         process that spawns children), we must reap ALL terminated
         children to prevent zombie accumulation.
+
+        No-op on Windows: os.waitpid and os.WNOHANG are Unix-only.
         """
+        if sys.platform == "win32":
+            return set()
         reaped: set = set()
         while True:
             try:
@@ -3684,7 +3689,11 @@ class PrismaClient:
         via call_soon_threadsafe.
 
         Returns True if the thread was started, False on failure.
+        On Windows, returns False immediately (os.waitpid/WNOHANG are Unix-only);
+        caller falls back to os.kill polling.
         """
+        if sys.platform == "win32":
+            return False
         try:
             probe_pid, _ = os.waitpid(pid, os.WNOHANG)
         except ChildProcessError:

--- a/tests/litellm/proxy/test_prisma_engine_watchdog.py
+++ b/tests/litellm/proxy/test_prisma_engine_watchdog.py
@@ -342,8 +342,23 @@ async def test_stop_watchdog_task_also_stops_engine_watcher(
 
 
 # ---------------------------------------------------------------------------
-# waitpid thread (cross-platform)
+# waitpid thread (Unix only; Windows falls back to os.kill polling)
 # ---------------------------------------------------------------------------
+
+
+def test_try_waitpid_watch_returns_false_on_windows(engine_client):
+    """_try_waitpid_watch returns False on Windows (os.waitpid/WNOHANG unavailable)."""
+    with patch("sys.platform", "win32"):
+        result = engine_client._try_waitpid_watch(1234)
+    assert result is False
+    assert engine_client._engine_wait_thread is None
+
+
+def test_reap_all_zombies_returns_empty_on_windows(engine_client):
+    """_reap_all_zombies returns empty set on Windows (waitpid unavailable)."""
+    with patch("sys.platform", "win32"):
+        reaped = PrismaClient._reap_all_zombies()
+    assert reaped == set()
 
 
 def test_try_waitpid_watch_returns_false_when_not_child(engine_client):


### PR DESCRIPTION
Cause: PR #21899 added a Prisma engine watchdog that uses os.waitpid() and os.WNOHANG, which are Unix-only. On Windows these are missing and cause the crash.
Fix: Add sys.platform == "win32" checks so that on Windows _try_waitpid_watch returns False (falling back to os.kill polling) and _reap_all_zombies returns an empty set.
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
