### PR TITLE
[Fix] Generic/OIDC SSO missing groups when provider returns groups only in id_token

### DIFF
--- a/docs/my-website/docs/proxy/admin_ui_sso.md
+++ b/docs/my-website/docs/proxy/admin_ui_sso.md
@@ -55,6 +55,16 @@ GENERIC_USERINFO_ENDPOINT="https://<your-okta-domain>/oauth2/v1/userinfo"
 PROXY_BASE_URL="https://<your-proxy-base-url>"
 ```
 
+:::note
+Some Okta org-level deployments return group claims in the `id_token` but not in `userinfo`.  
+LiteLLM Generic SSO now uses a secure fallback order for group/role resolution:
+1. `userinfo` claims (preferred)
+2. validated `id_token` claims (fallback)
+3. JWT `access_token` claims (last resort)
+
+If you use `role_mappings.group_claim` or `team_ids_jwt_field` (for example `groups`), this fallback helps avoid default-role behavior when `userinfo` omits groups.
+:::
+
 **Custom Authorization Server** (requires the Okta API Access Management SKU):
 ```bash
 GENERIC_CLIENT_ID="<your-client-id>"
@@ -118,6 +128,7 @@ LiteLLM will automatically handle PKCE parameter generation and verification dur
 | `redirect_uri` error | Redirect URI not configured | Add `<proxy_base_url>/sso/callback` to Sign-in redirect URIs in Okta |
 | `access_denied` | User not assigned to app | Assign the user in the Assignments tab |
 | `no_matching_policy` | Missing Access Policy (Custom Authorization Server only) | Create an Access Policy in the Authorization Server (see Step 3a) |
+| User is assigned default role unexpectedly | `userinfo` does not include the configured groups claim | Verify `groups` claim in Okta token preview and use LiteLLM debug endpoints (`/sso/debug/login`, `/sso/debug/callback`) to inspect claim sources |
 
 </TabItem>
 <TabItem value="google" label="Google SSO">

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -14,6 +14,8 @@ import hashlib
 import inspect
 import os
 import secrets
+import time
+from urllib.parse import urlparse
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
@@ -175,6 +177,181 @@ def determine_role_from_groups(
         f"User groups {user_groups} did not match any role mappings, using default_role: {role_mappings.default_role}"
     )
     return role_mappings.default_role
+
+
+def _normalize_groups_claim(groups_raw: Any) -> List[str]:
+    """
+    Normalize group claim values into a list of strings.
+    """
+    if isinstance(groups_raw, list):
+        return [str(g) for g in groups_raw]
+    if isinstance(groups_raw, str):
+        return [g.strip() for g in groups_raw.split(",") if g.strip()]
+    if groups_raw is not None:
+        return [str(groups_raw)]
+    return []
+
+
+def _decode_jwt_unverified(token: Optional[str], token_name: str) -> Optional[Dict[str, Any]]:
+    """
+    Decode JWT payload without signature verification.
+
+    This is only called after fastapi_sso.verify_and_process succeeds. We still
+    apply additional claim sanity checks before trusting token-derived auth claims.
+    """
+    if not token:
+        return None
+    import jwt
+
+    try:
+        decoded = jwt.decode(token, options={"verify_signature": False})
+    except jwt.exceptions.DecodeError:
+        verbose_proxy_logger.debug(
+            f"{token_name} is not a valid JWT (possibly opaque); skipping {token_name} claim parsing"
+        )
+        return None
+
+    if not isinstance(decoded, dict):
+        return None
+    return cast(Dict[str, Any], decoded)
+
+
+def _is_valid_generic_id_token_claims(
+    id_token_payload: Dict[str, Any],
+    generic_client_id: str,
+    generic_authorization_endpoint: str,
+    leeway_seconds: int = 60,
+) -> bool:
+    """
+    Minimal claim checks before using id_token-derived auth claims.
+    """
+    exp = id_token_payload.get("exp")
+    if not isinstance(exp, (int, float)):
+        verbose_proxy_logger.warning(
+            "Ignoring id_token claims for Generic SSO: missing/invalid exp claim"
+        )
+        return False
+    now_ts = int(time.time())
+    if int(exp) < (now_ts - leeway_seconds):
+        verbose_proxy_logger.warning(
+            "Ignoring id_token claims for Generic SSO: id_token expired"
+        )
+        return False
+
+    aud = id_token_payload.get("aud")
+    aud_values: List[str] = []
+    if isinstance(aud, str):
+        aud_values = [aud]
+    elif isinstance(aud, list):
+        aud_values = [str(a) for a in aud]
+    if generic_client_id not in aud_values:
+        verbose_proxy_logger.warning(
+            "Ignoring id_token claims for Generic SSO: audience does not include configured client_id"
+        )
+        return False
+
+    iss = id_token_payload.get("iss")
+    if isinstance(iss, str):
+        issuer_host = urlparse(iss).netloc
+        auth_host = urlparse(generic_authorization_endpoint).netloc
+        if issuer_host and auth_host and issuer_host != auth_host:
+            verbose_proxy_logger.warning(
+                "Ignoring id_token claims for Generic SSO: issuer host does not match authorization endpoint host"
+            )
+            return False
+    return True
+
+
+def _apply_id_token_claim_fallback(
+    *,
+    id_token_payload: Dict[str, Any],
+    result: Union[OpenID, dict, None],
+    received_response: Optional[dict],
+    jwt_handler: JWTHandler,
+    sso_jwt_handler: Optional[JWTHandler],
+    role_mappings: Optional["RoleMappings"],
+    team_mappings: Optional["TeamMappings"],
+) -> None:
+    """
+    Apply Generic SSO id_token claim fallback with precedence:
+    userinfo > id_token > access_token.
+
+    - Team IDs: fill only when result.team_ids is empty.
+    - Role mappings: only re-evaluate from id_token when userinfo group claim is missing/empty.
+    """
+    if not result:
+        return
+
+    userinfo_response = (
+        received_response
+        if isinstance(received_response, dict)
+        else (
+            result
+            if isinstance(result, dict)
+            else None
+        )
+    )
+
+    existing_team_ids: List[str]
+    if isinstance(result, dict):
+        existing_team_ids = cast(List[str], result.get("team_ids", []) or [])
+    else:
+        existing_team_ids = cast(List[str], getattr(result, "team_ids", []) or [])
+
+    if not existing_team_ids:
+        team_ids: List[str] = []
+        if team_mappings is not None and team_mappings.team_ids_jwt_field:
+            team_ids = _normalize_groups_claim(
+                get_nested_value(id_token_payload, team_mappings.team_ids_jwt_field)
+            )
+        if not team_ids and sso_jwt_handler is not None:
+            team_ids = sso_jwt_handler.get_team_ids_from_jwt(id_token_payload)
+        if not team_ids:
+            team_ids = jwt_handler.get_team_ids_from_jwt(id_token_payload)
+
+        if team_ids:
+            if isinstance(result, dict):
+                result["team_ids"] = team_ids
+            else:
+                setattr(result, "team_ids", team_ids)
+            verbose_proxy_logger.debug(
+                f"Populated team_ids from Generic SSO id_token claims: {team_ids}"
+            )
+
+    if role_mappings is None or role_mappings.provider.lower() not in ["generic", "okta"]:
+        return
+
+    group_claim = role_mappings.group_claim
+    userinfo_groups = _normalize_groups_claim(
+        get_nested_value(userinfo_response or {}, group_claim)
+    )
+    if userinfo_groups:
+        return
+
+    existing_role = (
+        result.get("user_role")
+        if isinstance(result, dict)
+        else getattr(result, "user_role", None)
+    )
+    if (
+        existing_role is not None
+        and role_mappings.default_role is not None
+        and existing_role != role_mappings.default_role
+    ):
+        # Preserve explicit non-default role values already derived from userinfo.
+        return
+
+    id_token_groups = _normalize_groups_claim(get_nested_value(id_token_payload, group_claim))
+    if id_token_groups:
+        mapped_role = determine_role_from_groups(id_token_groups, role_mappings)
+        if mapped_role is not None:
+            if isinstance(result, dict):
+                result["user_role"] = mapped_role
+            else:
+                setattr(result, "user_role", mapped_role)
+            verbose_proxy_logger.debug(
+                f"Updated user_role from Generic SSO id_token groups '{id_token_groups}' to '{mapped_role}'"
+            )
 
 
 def process_sso_jwt_access_token(
@@ -783,6 +960,35 @@ async def get_generic_sso_response(
             ),
             headers=additional_generic_sso_headers_dict,
         )
+
+        id_token_payload = _decode_jwt_unverified(
+            token=getattr(generic_sso, "id_token", None),
+            token_name="id_token",
+        )
+        if id_token_payload and _is_valid_generic_id_token_claims(
+            id_token_payload=id_token_payload,
+            generic_client_id=generic_client_id,
+            generic_authorization_endpoint=generic_authorization_endpoint,
+        ):
+            _apply_id_token_claim_fallback(
+                id_token_payload=id_token_payload,
+                result=result,
+                received_response=received_response,
+                jwt_handler=jwt_handler,
+                sso_jwt_handler=sso_jwt_handler,
+                role_mappings=role_mappings,
+                team_mappings=team_mappings,
+            )
+            if isinstance(received_response, dict):
+                received_response = {
+                    **received_response,
+                    "__id_token_claim_source__": {
+                        "iss": id_token_payload.get("iss"),
+                        "aud": id_token_payload.get("aud"),
+                        "exp": id_token_payload.get("exp"),
+                        "groups": _normalize_groups_claim(id_token_payload.get("groups")),
+                    },
+                }
 
         access_token_str: Optional[str] = generic_sso.access_token
         process_sso_jwt_access_token(
@@ -1999,8 +2205,16 @@ class SSOAuthenticationHandler:
         if ui_access_mode.get("type") == "restricted_sso_group":
             restricted_sso_group = ui_access_mode.get("restricted_sso_group")
             if restricted_sso_group not in team_ids:
+                claim_source_hint = ""
+                if (
+                    isinstance(received_response, dict)
+                    and received_response.get("__id_token_claim_source__") is not None
+                ):
+                    claim_source_hint = (
+                        " Claim sources inspected: userinfo + validated id_token fallback."
+                    )
                 raise ProxyException(
-                    message=f"User is not in the restricted SSO group: {restricted_sso_group}. User groups: {team_ids}. Received SSO response: {received_response}",
+                    message=f"User is not in the restricted SSO group: {restricted_sso_group}. User groups: {team_ids}. Received SSO response: {received_response}.{claim_source_hint}",
                     type=ProxyErrorTypes.auth_error,
                     param="restricted_sso_group",
                     code=status.HTTP_403_FORBIDDEN,

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1399,6 +1399,250 @@ async def test_get_generic_sso_response_with_empty_headers():
                 assert result == mock_sso_response
 
 
+@pytest.mark.asyncio
+async def test_get_generic_sso_response_uses_id_token_groups_when_userinfo_missing_groups():
+    """
+    Generic SSO fallback test:
+    - userinfo has no groups
+    - id_token has groups
+    Expect id_token fallback to populate team_ids and role mapping.
+    """
+    import time
+
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.management_endpoints.ui_sso import get_generic_sso_response
+
+    mock_request = MagicMock(spec=Request)
+    mock_jwt_handler = MagicMock(spec=JWTHandler)
+    mock_jwt_handler.get_team_ids_from_jwt.side_effect = (
+        lambda payload: payload.get("groups", []) if isinstance(payload, dict) else []
+    )
+
+    generic_client_id = "test_client_id"
+    redirect_url = "http://test.com/callback"
+    userinfo_payload = {
+        "sub": "test_user_123",
+        "email": "test@example.com",
+        "preferred_username": "testuser",
+    }
+
+    id_token_str = pyjwt.encode(
+        {
+            "sub": "test_user_123",
+            "aud": generic_client_id,
+            "iss": "https://auth.example.com",
+            "exp": int(time.time()) + 3600,
+            "groups": ["rita-admins", "open-webui-dev"],
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    test_env_vars = {
+        "GENERIC_CLIENT_SECRET": "test_secret",
+        "GENERIC_AUTHORIZATION_ENDPOINT": "https://auth.example.com/auth",
+        "GENERIC_TOKEN_ENDPOINT": "https://auth.example.com/token",
+        "GENERIC_USERINFO_ENDPOINT": "https://auth.example.com/userinfo",
+        "GENERIC_ROLE_MAPPINGS_GROUP_CLAIM": "groups",
+        "GENERIC_ROLE_MAPPINGS_DEFAULT_ROLE": "internal_user",
+        "GENERIC_ROLE_MAPPINGS_ROLES": "{'proxy_admin': ['rita-admins'], 'internal_user': ['open-webui-dev']}",
+    }
+
+    def fake_create_provider(name, discovery_document, response_convertor):
+        class FakeGenericSSO:
+            def __init__(self, *args, **kwargs):
+                self.id_token = id_token_str
+                self.access_token = None
+
+            async def verify_and_process(self, request, params=None, headers=None):
+                return response_convertor(userinfo_payload, client=None)
+
+        return FakeGenericSSO
+
+    with patch.dict(os.environ, test_env_vars):
+        with patch("fastapi_sso.sso.base.DiscoveryDocument"):
+            with patch(
+                "fastapi_sso.sso.generic.create_provider", side_effect=fake_create_provider
+            ):
+                result, received_response = await get_generic_sso_response(
+                    request=mock_request,
+                    jwt_handler=mock_jwt_handler,
+                    generic_client_id=generic_client_id,
+                    redirect_url=redirect_url,
+                    sso_jwt_handler=None,
+                )
+
+    assert isinstance(result, CustomOpenID)
+    assert result.team_ids == ["rita-admins", "open-webui-dev"]
+    assert result.user_role == LitellmUserRoles.PROXY_ADMIN
+    assert isinstance(received_response, dict)
+    assert received_response.get("__id_token_claim_source__") is not None
+
+
+@pytest.mark.asyncio
+async def test_get_generic_sso_response_userinfo_groups_take_precedence_over_id_token():
+    """
+    Precedence test:
+    - userinfo has groups
+    - id_token has higher-privilege groups
+    Expect userinfo-derived role/team_ids to remain unchanged.
+    """
+    import time
+
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.management_endpoints.ui_sso import get_generic_sso_response
+
+    mock_request = MagicMock(spec=Request)
+    mock_jwt_handler = MagicMock(spec=JWTHandler)
+    mock_jwt_handler.get_team_ids_from_jwt.side_effect = (
+        lambda payload: payload.get("groups", []) if isinstance(payload, dict) else []
+    )
+
+    generic_client_id = "test_client_id"
+    redirect_url = "http://test.com/callback"
+    userinfo_payload = {
+        "sub": "test_user_123",
+        "email": "test@example.com",
+        "preferred_username": "testuser",
+        "groups": ["open-webui-dev"],
+    }
+
+    id_token_str = pyjwt.encode(
+        {
+            "sub": "test_user_123",
+            "aud": generic_client_id,
+            "iss": "https://auth.example.com",
+            "exp": int(time.time()) + 3600,
+            "groups": ["rita-admins"],
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    test_env_vars = {
+        "GENERIC_CLIENT_SECRET": "test_secret",
+        "GENERIC_AUTHORIZATION_ENDPOINT": "https://auth.example.com/auth",
+        "GENERIC_TOKEN_ENDPOINT": "https://auth.example.com/token",
+        "GENERIC_USERINFO_ENDPOINT": "https://auth.example.com/userinfo",
+        "GENERIC_ROLE_MAPPINGS_GROUP_CLAIM": "groups",
+        "GENERIC_ROLE_MAPPINGS_DEFAULT_ROLE": "internal_user",
+        "GENERIC_ROLE_MAPPINGS_ROLES": "{'proxy_admin': ['rita-admins'], 'internal_user': ['open-webui-dev']}",
+    }
+
+    def fake_create_provider(name, discovery_document, response_convertor):
+        class FakeGenericSSO:
+            def __init__(self, *args, **kwargs):
+                self.id_token = id_token_str
+                self.access_token = None
+
+            async def verify_and_process(self, request, params=None, headers=None):
+                return response_convertor(userinfo_payload, client=None)
+
+        return FakeGenericSSO
+
+    with patch.dict(os.environ, test_env_vars):
+        with patch("fastapi_sso.sso.base.DiscoveryDocument"):
+            with patch(
+                "fastapi_sso.sso.generic.create_provider", side_effect=fake_create_provider
+            ):
+                result, _ = await get_generic_sso_response(
+                    request=mock_request,
+                    jwt_handler=mock_jwt_handler,
+                    generic_client_id=generic_client_id,
+                    redirect_url=redirect_url,
+                    sso_jwt_handler=None,
+                )
+
+    assert isinstance(result, CustomOpenID)
+    assert result.team_ids == ["open-webui-dev"]
+    assert result.user_role == LitellmUserRoles.INTERNAL_USER
+
+
+@pytest.mark.asyncio
+async def test_get_generic_sso_response_ignores_invalid_id_token_claims():
+    """
+    Security test:
+    - userinfo has no groups
+    - id_token has groups but invalid audience
+    Expect id_token claims to be ignored.
+    """
+    import time
+
+    import jwt as pyjwt
+
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.management_endpoints.ui_sso import get_generic_sso_response
+
+    mock_request = MagicMock(spec=Request)
+    mock_jwt_handler = MagicMock(spec=JWTHandler)
+    mock_jwt_handler.get_team_ids_from_jwt.return_value = []
+
+    generic_client_id = "test_client_id"
+    redirect_url = "http://test.com/callback"
+    userinfo_payload = {
+        "sub": "test_user_123",
+        "email": "test@example.com",
+        "preferred_username": "testuser",
+    }
+
+    # Invalid because aud does not include generic_client_id
+    id_token_str = pyjwt.encode(
+        {
+            "sub": "test_user_123",
+            "aud": "different_client_id",
+            "iss": "https://auth.example.com",
+            "exp": int(time.time()) + 3600,
+            "groups": ["rita-admins"],
+        },
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    test_env_vars = {
+        "GENERIC_CLIENT_SECRET": "test_secret",
+        "GENERIC_AUTHORIZATION_ENDPOINT": "https://auth.example.com/auth",
+        "GENERIC_TOKEN_ENDPOINT": "https://auth.example.com/token",
+        "GENERIC_USERINFO_ENDPOINT": "https://auth.example.com/userinfo",
+        "GENERIC_ROLE_MAPPINGS_GROUP_CLAIM": "groups",
+        "GENERIC_ROLE_MAPPINGS_DEFAULT_ROLE": "internal_user",
+        "GENERIC_ROLE_MAPPINGS_ROLES": "{'proxy_admin': ['rita-admins'], 'internal_user': ['open-webui-dev']}",
+    }
+
+    def fake_create_provider(name, discovery_document, response_convertor):
+        class FakeGenericSSO:
+            def __init__(self, *args, **kwargs):
+                self.id_token = id_token_str
+                self.access_token = None
+
+            async def verify_and_process(self, request, params=None, headers=None):
+                return response_convertor(userinfo_payload, client=None)
+
+        return FakeGenericSSO
+
+    with patch.dict(os.environ, test_env_vars):
+        with patch("fastapi_sso.sso.base.DiscoveryDocument"):
+            with patch(
+                "fastapi_sso.sso.generic.create_provider", side_effect=fake_create_provider
+            ):
+                result, received_response = await get_generic_sso_response(
+                    request=mock_request,
+                    jwt_handler=mock_jwt_handler,
+                    generic_client_id=generic_client_id,
+                    redirect_url=redirect_url,
+                    sso_jwt_handler=None,
+                )
+
+    assert isinstance(result, CustomOpenID)
+    assert result.team_ids == []
+    assert result.user_role == LitellmUserRoles.INTERNAL_USER
+    assert isinstance(received_response, dict)
+    assert "__id_token_claim_source__" not in received_response
+
+
 class TestCLISSOCallbackFunction:
     """Test the cli_sso_callback function specifically"""
 


### PR DESCRIPTION
## Relevant issues

- Fixes: Generic/OIDC SSO missing groups when provider returns `groups` only in `id_token` (e.g., Okta Org Authorization Server `/oauth2/v1/`).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
      Link:
- [ ] **CI run for the last commit**  
      Link:
- [ ] **Merge / cherry-pick CI run**  
      Links:

## Type

🐛 Bug Fix  
📖 Documentation  
✅ Test

## Changes

### Context
Some OIDC providers (notably **Okta Org Authorization Server** `/oauth2/v1/`) include `groups` in the **ID token** but do **not** include them in the **userinfo** response. Generic SSO previously used `userinfo` only, causing:
- `team_ids` to be empty even when `team_ids_jwt_field: "groups"` is configured
- `role_mappings` to fall back to `default_role` when `group_claim: "groups"` is configured

### What this PR does
- Adds a **Generic/OIDC SSO fallback** to read groups/team IDs from the **ID token** when `userinfo` omits the configured groups claim.
- Uses the following precedence order for group/role/team resolution:
  1. `userinfo` (preferred)
  2. validated `id_token` claims (fallback)
  3. JWT `access_token` claims (last resort; existing path)
- **Team IDs**: populated from `id_token` only when `result.team_ids` is empty.
- **Role mapping**: only re-evaluated from `id_token` groups when the `userinfo` group claim is missing/empty (and preserves explicit non-default roles already derived from `userinfo`).

### Security guardrails
Before using `id_token` claims for authorization mapping, apply minimal sanity checks:
- require valid `exp` (not expired, with small leeway)
- require `aud` includes configured `GENERIC_CLIENT_ID`
- require `iss` host matches `GENERIC_AUTHORIZATION_ENDPOINT` host

If these checks fail, `id_token` claims are ignored (behavior falls back to existing logic).

### Tests
Added regression tests:
- `test_get_generic_sso_response_uses_id_token_groups_when_userinfo_missing_groups`
- `test_get_generic_sso_response_userinfo_groups_take_precedence_over_id_token`
- `test_get_generic_sso_response_ignores_invalid_id_token_claims`

### Docs
- Updated Admin UI SSO docs to note Okta org-level behavior and the new fallback order.