### PR TITLE
fix: tiktoken cache nonroot offline

### DIFF
--- a/litellm/litellm_core_utils/default_encoding.py
+++ b/litellm/litellm_core_utils/default_encoding.py
@@ -15,16 +15,13 @@ except (ImportError, AttributeError):
         __name__, "litellm_core_utils/tokenizers"
     )
 
-# Check if the directory is writable. If not, use /tmp as a fallback.
-# This is especially important for non-root Docker environments where the package directory is read-only.
-is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-if not os.access(filename, os.W_OK) and is_non_root:
-    filename = "/tmp/tiktoken_cache"
-    os.makedirs(filename, exist_ok=True)
-
+# Always default TIKTOKEN_CACHE_DIR to the bundled tokenizers directory
+# unless the user explicitly overrides it via CUSTOM_TIKTOKEN_CACHE_DIR.
+# This keeps tiktoken fully offline-capable by default (see #1071).
 os.environ["TIKTOKEN_CACHE_DIR"] = os.getenv(
     "CUSTOM_TIKTOKEN_CACHE_DIR", filename
 )  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
+
 import tiktoken
 import time
 import random
@@ -45,3 +42,4 @@ for attempt in range(_max_retries):
         # Exponential backoff with jitter to reduce collision probability
         delay = _retry_delay * (2**attempt) + random.uniform(0, 0.1)
         time.sleep(delay)
+

--- a/litellm/litellm_core_utils/default_encoding.py
+++ b/litellm/litellm_core_utils/default_encoding.py
@@ -18,9 +18,15 @@ except (ImportError, AttributeError):
 # Always default TIKTOKEN_CACHE_DIR to the bundled tokenizers directory
 # unless the user explicitly overrides it via CUSTOM_TIKTOKEN_CACHE_DIR.
 # This keeps tiktoken fully offline-capable by default (see #1071).
-os.environ["TIKTOKEN_CACHE_DIR"] = os.getenv(
-    "CUSTOM_TIKTOKEN_CACHE_DIR", filename
-)  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
+custom_cache_dir = os.getenv("CUSTOM_TIKTOKEN_CACHE_DIR")
+if custom_cache_dir:
+    # If the user opts into a custom cache dir, ensure it exists.
+    os.makedirs(custom_cache_dir, exist_ok=True)
+    cache_dir = custom_cache_dir
+else:
+    cache_dir = filename
+
+os.environ["TIKTOKEN_CACHE_DIR"] = cache_dir  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
 
 import tiktoken
 import time

--- a/tests/test_default_encoding_non_root.py
+++ b/tests/test_default_encoding_non_root.py
@@ -29,10 +29,13 @@ def test_default_encoding_uses_bundled_tokenizers_by_default(monkeypatch):
 
 def test_custom_tiktoken_cache_dir_override(monkeypatch, tmp_path):
     """
-    CUSTOM_TIKTOKEN_CACHE_DIR must override the default bundled directory.
+    CUSTOM_TIKTOKEN_CACHE_DIR must override the default bundled directory
+    and the directory should be created if it does not exist.
     """
     custom_dir = tmp_path / "tiktoken_cache"
     monkeypatch.setenv("CUSTOM_TIKTOKEN_CACHE_DIR", str(custom_dir))
     _reload_default_encoding(monkeypatch)
 
-    assert os.environ.get("TIKTOKEN_CACHE_DIR") == str(custom_dir)
+    cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
+    assert cache_dir == str(custom_dir)
+    assert os.path.isdir(cache_dir)

--- a/tests/test_default_encoding_non_root.py
+++ b/tests/test_default_encoding_non_root.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+from unittest.mock import MagicMock, patch
 
 import litellm.litellm_core_utils.default_encoding as default_encoding
 
@@ -31,10 +32,17 @@ def test_custom_tiktoken_cache_dir_override(monkeypatch, tmp_path):
     """
     CUSTOM_TIKTOKEN_CACHE_DIR must override the default bundled directory
     and the directory should be created if it does not exist.
+    Reload with an empty custom dir would otherwise trigger tiktoken to
+    download the vocab; we patch get_encoding so the test is offline-safe
+    and does not depend on tiktoken's in-memory cache state.
     """
     custom_dir = tmp_path / "tiktoken_cache"
     monkeypatch.setenv("CUSTOM_TIKTOKEN_CACHE_DIR", str(custom_dir))
-    _reload_default_encoding(monkeypatch)
+    with patch(
+        "litellm.litellm_core_utils.default_encoding.tiktoken.get_encoding",
+        return_value=MagicMock(),
+    ):
+        _reload_default_encoding(monkeypatch)
 
     cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
     assert cache_dir == str(custom_dir)

--- a/tests/test_default_encoding_non_root.py
+++ b/tests/test_default_encoding_non_root.py
@@ -49,3 +49,9 @@ def test_custom_tiktoken_cache_dir_override(monkeypatch, tmp_path):
     cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
     assert cache_dir == str(custom_dir)
     assert os.path.isdir(cache_dir)
+
+    # Restore module to a clean state so default_encoding.encoding is a real
+    # tiktoken Encoding, not the MagicMock, for any test that runs after this.
+    monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
+    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
+    importlib.reload(default_encoding)

--- a/tests/test_default_encoding_non_root.py
+++ b/tests/test_default_encoding_non_root.py
@@ -11,6 +11,7 @@ def _reload_default_encoding(monkeypatch, **env_overrides):
     specific environment overrides.
     """
     monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
+    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
     for key, value in env_overrides.items():
         monkeypatch.setenv(key, value)
     importlib.reload(default_encoding)
@@ -37,12 +38,13 @@ def test_custom_tiktoken_cache_dir_override(monkeypatch, tmp_path):
     and does not depend on tiktoken's in-memory cache state.
     """
     custom_dir = tmp_path / "tiktoken_cache"
-    monkeypatch.setenv("CUSTOM_TIKTOKEN_CACHE_DIR", str(custom_dir))
     with patch(
         "litellm.litellm_core_utils.default_encoding.tiktoken.get_encoding",
         return_value=MagicMock(),
     ):
-        _reload_default_encoding(monkeypatch)
+        _reload_default_encoding(
+            monkeypatch, CUSTOM_TIKTOKEN_CACHE_DIR=str(custom_dir)
+        )
 
     cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
     assert cache_dir == str(custom_dir)

--- a/tests/test_default_encoding_non_root.py
+++ b/tests/test_default_encoding_non_root.py
@@ -1,49 +1,38 @@
+import importlib
 import os
-from unittest.mock import patch
+
+import litellm.litellm_core_utils.default_encoding as default_encoding
 
 
-def test_tiktoken_cache_fallback(monkeypatch):
+def _reload_default_encoding(monkeypatch, **env_overrides):
     """
-    Test that TIKTOKEN_CACHE_DIR falls back to /tmp/tiktoken_cache
-    if the default directory is not writable and LITELLM_NON_ROOT is true.
+    Helper to reload default_encoding with a clean TIKTOKEN_CACHE_DIR and
+    specific environment overrides.
     """
-    # Simulate non-root environment
-    monkeypatch.setenv("LITELLM_NON_ROOT", "true")
-    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
-
-    # Mock os.access to return False (not writable)
-    # and mock os.makedirs to avoid actually creating /tmp/tiktoken_cache on local machine
-    with patch("os.access", return_value=False), patch("os.makedirs"):
-        # We need to reload or re-run the logic in default_encoding.py
-        # But since it's already executed, we'll just test the logic directly
-        # mirroring what we wrote in the file.
-
-        filename = (
-            "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/tokenizers"
-        )
-        is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-
-        if not os.access(filename, os.W_OK) and is_non_root:
-            filename = "/tmp/tiktoken_cache"
-            # mock_makedirs(filename, exist_ok=True)
-
-        assert filename == "/tmp/tiktoken_cache"
+    monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
+    for key, value in env_overrides.items():
+        monkeypatch.setenv(key, value)
+    importlib.reload(default_encoding)
 
 
-def test_tiktoken_cache_no_fallback_if_writable(monkeypatch):
+def test_default_encoding_uses_bundled_tokenizers_by_default(monkeypatch):
     """
-    Test that TIKTOKEN_CACHE_DIR does NOT fall back if writable
+    TIKTOKEN_CACHE_DIR should point at the bundled tokenizers directory
+    when no CUSTOM_TIKTOKEN_CACHE_DIR is set, even in non-root environments.
     """
-    monkeypatch.setenv("LITELLM_NON_ROOT", "true")
+    _reload_default_encoding(monkeypatch, LITELLM_NON_ROOT="true")
 
-    filename = "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/tokenizers"
+    assert "TIKTOKEN_CACHE_DIR" in os.environ
+    cache_dir = os.environ["TIKTOKEN_CACHE_DIR"]
+    assert "tokenizers" in cache_dir
 
-    with patch("os.access", return_value=True):
-        is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-        if not os.access(filename, os.W_OK) and is_non_root:
-            filename = "/tmp/tiktoken_cache"
 
-        assert (
-            filename
-            == "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/tokenizers"
-        )
+def test_custom_tiktoken_cache_dir_override(monkeypatch, tmp_path):
+    """
+    CUSTOM_TIKTOKEN_CACHE_DIR must override the default bundled directory.
+    """
+    custom_dir = tmp_path / "tiktoken_cache"
+    monkeypatch.setenv("CUSTOM_TIKTOKEN_CACHE_DIR", str(custom_dir))
+    _reload_default_encoding(monkeypatch)
+
+    assert os.environ.get("TIKTOKEN_CACHE_DIR") == str(custom_dir)


### PR DESCRIPTION
### Summary

This PR fixes a regression in tiktoken cache handling for **non-root + offline** environments and aligns both eager and lazy loading with the same offline-safe behavior.

Today, non-root Docker images with `--network=none` can fail on startup because tiktoken attempts to download the `cl100k_base` vocab into an empty cache directory, instead of using the pre-bundled vocab that LiteLLM ships.

---

### Background

LiteLLM bundles the `cl100k_base` vocab at:

```text
litellm/litellm_core_utils/tokenizers/
```

Historically, `default_encoding.py` set:

```python
TIKTOKEN_CACHE_DIR = <bundled tokenizers dir>
encoding = tiktoken.get_encoding("cl100k_base")
```

This guaranteed:

- **Offline-safe**: tiktoken reads the bundled vocab, no network needed.
- **Non-root-safe**: as long as the directory is readable, no writes are required.

PR [#19449](https://github.com/BerriAI/litellm/pull/19449) changed this for non-root images by introducing:

```python
is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
if not os.access(filename, os.W_OK) and is_non_root:
    filename = "/tmp/tiktoken_cache"
    os.makedirs(filename, exist_ok=True)
TIKTOKEN_CACHE_DIR = CUSTOM_TIKTOKEN_CACHE_DIR or filename
```

This solved “can’t write into read-only site-packages” by redirecting non-root to `/tmp/tiktoken_cache`, but it also introduced a regression:

- `/tmp/tiktoken_cache` starts **empty**.
- In **offline** or `--network=none` environments, tiktoken cannot download the vocab into that empty dir → startup fails.
- This affects all non-root images since v1.81.9 unless `CUSTOM_TIKTOKEN_CACHE_DIR` is manually pointed back at the bundled dir.

Separately, PR [#19774](https://github.com/BerriAI/litellm/pull/19774) fixed **lazy loading** by making `__getattr__` use `_get_default_encoding()`, which assumes that `default_encoding.py` has correctly set `TIKTOKEN_CACHE_DIR` to a local cache. That PR does not address the `/tmp` behavior itself; it just ensures lazy loading respects whatever `default_encoding.py` configured.

---

### Fix

This PR simplifies and hardens the cache selection logic in `default_encoding.py`:

1. **Always resolve the bundled tokenizer directory:**

```python
filename = "<...>/litellm_core_utils/tokenizers"
```

2. **Use it as the default cache dir, unless explicitly overridden:**

```python
custom_cache_dir = os.getenv("CUSTOM_TIKTOKEN_CACHE_DIR")
if custom_cache_dir:
    os.makedirs(custom_cache_dir, exist_ok=True)
    cache_dir = custom_cache_dir
else:
    cache_dir = filename

os.environ["TIKTOKEN_CACHE_DIR"] = cache_dir
```

Key points:

- **Default (no env):**
  - `TIKTOKEN_CACHE_DIR` → bundled `tokenizers` dir.
  - tiktoken reads the pre-bundled vocab (offline-safe, works for root and non-root).

- **When `CUSTOM_TIKTOKEN_CACHE_DIR` is set:**
  - We `os.makedirs(custom_cache_dir, exist_ok=True)` so the directory always exists.
  - `TIKTOKEN_CACHE_DIR` → that custom path.
  - This gives users full control if they want a writable cache (e.g. custom images), without changing the default behavior.

- **Removed logic:**
  - We no longer special-case `LITELLM_NON_ROOT` or redirect to `/tmp/tiktoken_cache` by default.
  - Non-root images now behave the same as root images by default, using the shipped vocab, which is sufficient for read-only filesystems.

---

### Why this approach

- **Restores offline behavior:**  
  - Non-root + `--network=none` uses the bundled vocab again; no network fetch is attempted.
- **Keeps non-root safe:**  
  - Reading from a pre-bundled file does not require write access, even under read-only `site-packages`.
- **Keeps lazy loading correct:**  
  - `_get_default_encoding()` (and PR [#19774](https://github.com/BerriAI/litellm/pull/19774)) already rely on `default_encoding.py` to set `TIKTOKEN_CACHE_DIR` to a local cache.
  - With this change, both eager and lazy paths now share the same offline-safe default and the same override semantics.
- **Minimal surface area:**  
  - All tiktoken cache decisions remain centralized in one place (`default_encoding.py`).
  - No extra copying, no per-env heuristics beyond a single optional override env var.

---

### Tests

Updated tests in `tests/test_default_encoding_non_root.py`:

1. **`test_default_encoding_uses_bundled_tokenizers_by_default`**

   - Sets `LITELLM_NON_ROOT="true"` with **no** `CUSTOM_TIKTOKEN_CACHE_DIR`.
   - Reloads `default_encoding`.
   - Asserts:
     - `TIKTOKEN_CACHE_DIR` is set.
     - Its path contains `"tokenizers"` (i.e., points at the bundled directory).

2. **`test_custom_tiktoken_cache_dir_override`**

   - Creates a temporary path `tmp_path / "tiktoken_cache"`.
   - Sets `CUSTOM_TIKTOKEN_CACHE_DIR` to that path.
   - Reloads `default_encoding`.
   - Asserts:
     - `TIKTOKEN_CACHE_DIR == custom_dir`.
     - `os.path.isdir(TIKTOKEN_CACHE_DIR)` → the directory was created.

These tests verify both:

- The **default offline/non-root behavior** (no more `/tmp` redirect).
- The **override and mkdir semantics** for `CUSTOM_TIKTOKEN_CACHE_DIR`.

---

### Impact

- Fixes the regression where non-root images with no network fail due to tiktoken trying to download into an empty `/tmp` cache.
- Keeps lazy loading behavior from [#19774](https://github.com/BerriAI/litellm/pull/19774) intact, since `TIKTOKEN_CACHE_DIR` is now consistently initialized to a local cache before any `get_encoding` call.
- Maintains an explicit escape hatch (`CUSTOM_TIKTOKEN_CACHE_DIR`) for advanced setups, while keeping the default path simple and offline-safe.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
