### PR TITLE
fix the bug `tool_use` ids must be                   unique

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2733,6 +2733,18 @@ def anthropic_messages_pt(  # noqa: PLR0915
                         # Pass through as-is since these are Anthropic-native content types
                         elif m.get("type", "").endswith("_tool_result"):
                             assistant_content.append(m)  # type: ignore
+                        # handle tool_use blocks - prevent duplicate tool_use ids
+                        # This can happen when message history contains Anthropic-native tool_use blocks
+                        # alongside tool_calls field with the same ids
+                        elif m.get("type", "") == "tool_use":
+                            _tool_use_id = m.get("id")
+                            if _tool_use_id:
+                                if _tool_use_id in unique_tool_ids:
+                                    # Skip duplicate tool_use id to prevent
+                                    # "tool_use ids must be unique" error from Anthropic
+                                    continue
+                                unique_tool_ids.add(_tool_use_id)
+                            assistant_content.append(m)  # type: ignore
                 elif (
                     "content" in assistant_content_block
                     and isinstance(assistant_content_block["content"], str)

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -145,6 +145,48 @@ class OpenrouterConfig(OpenAIGPTConfig):
 
         return transformed_messages
 
+    def _deduplicate_tool_use_in_messages(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
+        """
+        Remove tool_use blocks from assistant message content when tool_calls is present.
+
+        This prevents "tool_use ids must be unique" errors when OpenRouter converts
+        OpenAI format to Anthropic format. If an assistant message has both:
+        1. content list with tool_use blocks (Anthropic style)
+        2. tool_calls field (OpenAI style)
+
+        The tool_use blocks in content will be removed to avoid duplicates after
+        OpenRouter's conversion.
+
+        Returns:
+            List[AllMessageValues]: Cleaned messages with no duplicate tool_use sources.
+        """
+        cleaned_messages: List[AllMessageValues] = []
+        for message in messages:
+            message_dict = dict(message)
+
+            # Only process assistant messages with tool_calls
+            if message_dict.get("role") == "assistant" and message_dict.get("tool_calls"):
+                content = message_dict.get("content")
+
+                if isinstance(content, list):
+                    # Filter out tool_use blocks from content to prevent duplicates
+                    # when OpenRouter converts to Anthropic format
+                    filtered_content = [
+                        block
+                        for block in content
+                        if not (
+                            isinstance(block, dict)
+                            and block.get("type") == "tool_use"
+                        )
+                    ]
+                    message_dict["content"] = filtered_content
+
+            cleaned_messages.append(cast(AllMessageValues, message_dict))
+
+        return cleaned_messages
+
     def transform_request(
         self,
         model: str,
@@ -161,6 +203,10 @@ class OpenrouterConfig(OpenAIGPTConfig):
         """
         if self._supports_cache_control_in_content(model):
             messages = self._move_cache_control_to_content(messages)
+
+        # Deduplicate tool_use blocks to prevent "tool_use ids must be unique" errors
+        # when OpenRouter converts to Anthropic format
+        messages = self._deduplicate_tool_use_in_messages(messages)
 
         extra_body = optional_params.pop("extra_body", {})
         response = super().transform_request(

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,15 +3222,15 @@ files = [
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.54"
+version = "0.4.56"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 optional = true
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-    {file = "litellm_proxy_extras-0.4.54-py3-none-any.whl", hash = "sha256:6621cf529f7f3647eb2dd0d2c417d91db8c7a05c3c592bef251887a122928837"},
-    {file = "litellm_proxy_extras-0.4.54.tar.gz", hash = "sha256:2c777ecdf39901c4007ade4466eb6398985ed4000afe3fc2cac997e1169e8cee"},
+    {file = "litellm_proxy_extras-0.4.56-py3-none-any.whl", hash = "sha256:52dbe3b5358c790e77e12f1ec5ef8e7508b383c2aaf41299750b6fb400908ee7"},
+    {file = "litellm_proxy_extras-0.4.56.tar.gz", hash = "sha256:63ad59baa0defccc5c929cfd933ee7e32a6614b0fc5fa0fc45a12d7608e33f08"},
 ]
 
 [[package]]
@@ -8002,4 +8002,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "5ed0af4e3644bc7b5a02b8bfc8b3eda15c014b43aa6da7a9a97a9b070fba5366"
+content-hash = "1ade5dee030fd878c907a20b88a6a52ca26ee4ecbed15ecb045f9ae1d4b8b714"

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -1944,3 +1944,125 @@ def test_anthropic_messages_pt_list_content_with_thinking_preserves_order():
     # Verify signatures preserved in correct positions
     assert content[0]["signature"] == "sig_1"
     assert content[3]["signature"] == "sig_2"
+
+
+def test_anthropic_messages_pt_tool_use_in_content_list_with_tool_calls():
+    """
+    Test that tool_use blocks in content list are properly deduplicated
+    when the message also has tool_calls field with the same id.
+
+    This prevents "tool_use ids must be unique" errors from Anthropic API.
+    """
+    messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me check the weather."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01ABC123",
+                    "name": "get_weather",
+                    "input": {"location": "SF"},
+                },
+            ],
+            # Also has tool_calls with the SAME id
+            "tool_calls": [
+                {
+                    "id": "toolu_01ABC123",  # Same id as in content!
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "SF"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_01ABC123",
+            "content": "72F and sunny",
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    # Find the assistant message
+    assistant_msg = next(m for m in result if m["role"] == "assistant")
+    content = assistant_msg["content"]
+
+    # Count tool_use blocks with id "toolu_01ABC123"
+    tool_use_count = sum(
+        1
+        for c in content
+        if c.get("type") == "tool_use" and c.get("id") == "toolu_01ABC123"
+    )
+
+    # There should be exactly ONE tool_use block with this id
+    assert (
+        tool_use_count == 1
+    ), f"Expected 1 tool_use block with id 'toolu_01ABC123', got {tool_use_count}"
+
+
+def test_anthropic_messages_pt_tool_use_in_content_list_different_ids():
+    """
+    Test that tool_use blocks in content list are preserved
+    when tool_calls has different ids.
+    """
+    messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me check the weather."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01ABC123",
+                    "name": "get_weather",
+                    "input": {"location": "SF"},
+                },
+            ],
+            # tool_calls with a DIFFERENT id
+            "tool_calls": [
+                {
+                    "id": "toolu_01XYZ789",
+                    "type": "function",
+                    "function": {
+                        "name": "get_time",
+                        "arguments": '{"timezone": "PST"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_01ABC123",
+            "content": "72F and sunny",
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_01XYZ789",
+            "content": "10:30 AM",
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-5", llm_provider="anthropic"
+    )
+
+    # Find the assistant message
+    assistant_msg = next(m for m in result if m["role"] == "assistant")
+    content = assistant_msg["content"]
+
+    # Count all tool_use blocks
+    tool_use_ids = [c.get("id") for c in content if c.get("type") == "tool_use"]
+
+    # Both tool_use blocks should be present
+    assert "toolu_01ABC123" in tool_use_ids
+    assert "toolu_01XYZ789" in tool_use_ids
+
+    # Each id should appear exactly once
+    assert tool_use_ids.count("toolu_01ABC123") == 1
+    assert tool_use_ids.count("toolu_01XYZ789") == 1

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -516,3 +516,146 @@ def test_openrouter_non_reasoning_models_do_not_add_reasoning_effort():
     )
 
     assert "reasoning_effort" not in supported_params
+
+
+def test_openrouter_deduplicate_tool_use_in_messages():
+    """
+    Test that tool_use blocks in content are removed when tool_calls is present.
+
+    This prevents "tool_use ids must be unique" errors when OpenRouter converts
+    OpenAI format to Anthropic format. If an assistant message has both:
+    1. content list with tool_use blocks (Anthropic style)
+    2. tool_calls field (OpenAI style)
+
+    The tool_use blocks in content will be removed to avoid duplicates after
+    OpenRouter's conversion.
+    """
+    config = OpenrouterConfig()
+
+    messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {
+                    "type": "tool_use",  # Should be removed
+                    "id": "toolu_01ABC123",
+                    "name": "get_weather",
+                    "input": {"location": "SF"},
+                },
+            ],
+            "tool_calls": [  # Should be kept
+                {
+                    "id": "toolu_01ABC123",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"location": "SF"}'},
+                }
+            ],
+        },
+    ]
+
+    result = config._deduplicate_tool_use_in_messages(messages)
+
+    # Check that tool_use block was removed from content
+    assistant_msg = result[1]
+    content = assistant_msg["content"]
+    tool_use_blocks = [b for b in content if b.get("type") == "tool_use"]
+
+    assert len(tool_use_blocks) == 0, f"Expected no tool_use blocks, got {len(tool_use_blocks)}"
+    assert assistant_msg.get("tool_calls") is not None, "Expected tool_calls to be preserved"
+
+
+def test_openrouter_deduplicate_preserves_other_content_types():
+    """
+    Test that other content types are preserved when removing tool_use blocks.
+    """
+    config = OpenrouterConfig()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Some text"},
+                {"type": "tool_use", "id": "toolu_01ABC", "name": "tool1", "input": {}},
+                {"type": "thinking", "thinking": "Some thought"},
+            ],
+            "tool_calls": [
+                {"id": "toolu_01ABC", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    result = config._deduplicate_tool_use_in_messages(messages)
+    content = result[0]["content"]
+
+    content_types = [b.get("type") for b in content]
+
+    # Should have text and thinking, but no tool_use
+    assert "text" in content_types
+    assert "thinking" in content_types
+    assert "tool_use" not in content_types
+
+
+def test_openrouter_no_deduplication_when_no_tool_calls():
+    """
+    Test that tool_use blocks are preserved when there are no tool_calls.
+    """
+    config = OpenrouterConfig()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Some text"},
+                {"type": "tool_use", "id": "toolu_01ABC", "name": "tool1", "input": {}},
+            ],
+            # No tool_calls field
+        },
+    ]
+
+    result = config._deduplicate_tool_use_in_messages(messages)
+    content = result[0]["content"]
+
+    tool_use_blocks = [b for b in content if b.get("type") == "tool_use"]
+
+    # Should preserve tool_use blocks when no tool_calls
+    assert len(tool_use_blocks) == 1
+
+
+def test_openrouter_transform_request_deduplicates_tool_use():
+    """
+    Test that transform_request properly deduplicates tool_use blocks.
+    """
+    config = OpenrouterConfig()
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Hi"},
+                {"type": "tool_use", "id": "tool1", "name": "tool", "input": {}},
+            ],
+            "tool_calls": [
+                {"id": "tool1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}
+            ],
+        },
+    ]
+
+    transformed_request = config.transform_request(
+        model="openrouter/anthropic/claude-3-5-sonnet",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    # Check assistant message content
+    assistant_msg = transformed_request["messages"][1]
+    content = assistant_msg["content"]
+    tool_use_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+
+    assert len(tool_use_blocks) == 0, "tool_use blocks should be removed from content"
+    assert assistant_msg.get("tool_calls") is not None, "tool_calls should be preserved"
+


### PR DESCRIPTION

<img width="777" height="325" alt="image" src="https://github.com/user-attachments/assets/e536ff83-9b96-4327-ac0a-4a9ae6447eef" />


Fixed the "tool_use ids must be unique" error that may occur when LiteLLM handles forwarding to OpenRouter and Anthropic.

## Root Cause

When an assistant message contains both:
1. A content list that includes Anthropic-style tool_use blocks
2. A tool_calls field (OpenAI style)

This leads to:
- When calling Anthropic API directly, message conversion may generate duplicate tool_use IDs
- When calling through OpenRouter, format conversion by OpenRouter may generate duplicates

## Fix Details

### 1. Fixed anthropic_messages_pt function

**File:** `litellm/litellm_core_utils/prompt_templates/factory.py`

Added handling for tool_use type content blocks:
- When the content list contains tool_use blocks, check if its ID already exists in unique_tool_ids
- Skip if the ID already exists to prevent duplication
- If the ID doesn't exist, add it to unique_tool_ids and retain the block

### 2. Fixed OpenRouter message preprocessing

**File:** `litellm/llms/openrouter/chat/transformation.py`

Added `_deduplicate_tool_use_in_messages` method:
- When an assistant message has both tool_calls field and tool_use blocks in content list
- Remove tool_use blocks from content list, keeping only tool_calls
- This ensures no duplication occurs when OpenRouter converts to Anthropic format

### 3. Added Test Cases

- `tests/llm_translation/test_prompt_factory.py`: Added tests for anthropic_messages_pt function