### PR TITLE
fix: strip provider prefix from model name in Ollama health check

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7155,6 +7155,7 @@ async def ahealth_check(
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
+        model_params["model"] = model  # update model to use the provider-stripped name (e.g. "ollama/llama2" -> "llama2")
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 


### PR DESCRIPTION
## Summary

Fixes #17842

The "Test Connect" button for Ollama models is broken in two ways:
- Without the `ollama/` prefix (e.g. `ministral-3:14b`), `get_llm_provider()` cannot determine the provider and throws "LLM Provider NOT provided"
- With the `ollama/` prefix (e.g. `ollama/ministral-3:14b`), the provider is resolved correctly but the prefixed model name is passed through to the Ollama API, which doesn't recognize `ollama/ministral-3:14b` (Ollama expects bare names like `ministral-3:14b`)

### Root cause

In `ahealth_check()` (`litellm/main.py`), `get_llm_provider()` correctly strips the provider prefix and returns the bare model name, but `model_params["model"]` is never updated with this stripped name. When the health check handler subsequently calls `litellm.acompletion(**model_params)`, the original prefixed model name is sent to the Ollama API.

### Fix

Update `model_params["model"]` with the provider-stripped model name returned by `get_llm_provider()`, so downstream health check calls use bare model names (e.g. `llama2` instead of `ollama/llama2`).

This is a one-line change that applies generically to all providers, not just Ollama.

## Test plan

- [ ] Add an Ollama model with `ollama/` prefix and click "Test Connect" — should succeed
- [ ] Add an Ollama model without prefix but with custom_llm_provider=ollama in model config — should succeed
- [ ] Verify existing health checks for other providers (OpenAI, Azure, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)