### PR TITLE
fix: fallback popup model dropdown z-index issue

### DIFF
--- a/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/FallbackGroupConfig.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/FallbackGroupConfig.tsx
@@ -78,6 +78,7 @@ export function FallbackGroupConfig({
           value={group.primaryModel}
           onChange={handlePrimaryChange}
           showSearch
+          getPopupContainer={(trigger) => trigger.parentElement || document.body}
           filterOption={(input, option) =>
             (option?.label ?? "").toLowerCase().includes(input.toLowerCase())
           }
@@ -125,6 +126,7 @@ export function FallbackGroupConfig({
               value={group.fallbackModels}
               onChange={handleFallbackSelect}
               disabled={!group.primaryModel}
+              getPopupContainer={(trigger) => trigger.parentElement || document.body}
               options={availableFallbackOptions.map((m) => ({
                 label: m,
                 value: m,


### PR DESCRIPTION
## Summary

Fixes #17895 — model dropdowns in the "Add Fallbacks" modal were rendering behind the modal overlay.

- Added `getPopupContainer` prop to both `Select` components in `FallbackGroupConfig.tsx` so Ant Design renders the dropdown popup within the parent element instead of `document.body`, inheriting the modal's stacking context.

## Root Cause

Ant Design's `Select` component portals its dropdown to `document.body` by default. When used inside a `Modal` (which has `z-index: 1000`), the dropdown can appear behind the modal overlay because it doesn't inherit the modal's z-index stacking context.

## Fix

Set `getPopupContainer={(trigger) => trigger.parentElement || document.body}` on both Select components (primary model and fallback chain selectors) in `FallbackGroupConfig.tsx`. This is the standard Ant Design pattern for Select components inside modals.

## Test plan

- [ ] Open the Add Fallbacks modal
- [ ] Click the Primary Model dropdown — it should render above the modal
- [ ] Click the Fallback Chain dropdown — it should render above the modal
- [ ] Verify search/filter still works in both dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)