### PR TITLE
fix: correct wandb model prices (off by 100,000x)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14527,17 +14527,14 @@
         "uses_embed_content": true
     },
     "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_audio_per_second": 0.00016,
-        "input_cost_per_image": 0.00012,
-        "input_cost_per_token": 2e-07,
-        "input_cost_per_video_per_second": 0.00079,
+        "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
         "supports_multimodal": true,
         "uses_embed_content": true
     },
@@ -14552,18 +14549,6 @@
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-        "uses_embed_content": true
-    },
-    "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_token": 1.5e-07,
-        "litellm_provider": "vertex_ai",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0,
-        "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
-        "supports_multimodal": true,
         "uses_embed_content": true
     },
     "gemini/gemini-embedding-001": {
@@ -30938,7 +30923,9 @@
         "mode": "chat",
         "output_cost_per_token": 3.2e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models",
-        "supported_regions": ["global"],
+        "supported_regions": [
+            "global"
+        ],
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -31438,8 +31425,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 0.015,
-        "output_cost_per_token": 0.06,
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 6e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31447,8 +31434,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 0.005,
-        "output_cost_per_token": 0.02,
+        "input_cost_per_token": 5e-08,
+        "output_cost_per_token": 2e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31456,8 +31443,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 0.055,
-        "output_cost_per_token": 0.2,
+        "input_cost_per_token": 5.5e-07,
+        "output_cost_per_token": 2e-06,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31465,8 +31452,8 @@
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
-        "input_cost_per_token": 0.01,
-        "output_cost_per_token": 0.01,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31474,8 +31461,8 @@
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
-        "input_cost_per_token": 0.1,
-        "output_cost_per_token": 0.15,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 1.5e-06,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31483,8 +31470,8 @@
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
-        "input_cost_per_token": 0.01,
-        "output_cost_per_token": 0.01,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31501,8 +31488,8 @@
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.022,
-        "output_cost_per_token": 0.022,
+        "input_cost_per_token": 2.1999999999999998e-07,
+        "output_cost_per_token": 2.1999999999999998e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31510,8 +31497,8 @@
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.055,
-        "output_cost_per_token": 0.165,
+        "input_cost_per_token": 5.5e-07,
+        "output_cost_per_token": 1.65e-06,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31519,8 +31506,8 @@
         "max_tokens": 161000,
         "max_input_tokens": 161000,
         "max_output_tokens": 161000,
-        "input_cost_per_token": 0.135,
-        "output_cost_per_token": 0.54,
+        "input_cost_per_token": 1.35e-06,
+        "output_cost_per_token": 5.4e-06,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31528,8 +31515,8 @@
         "max_tokens": 161000,
         "max_input_tokens": 161000,
         "max_output_tokens": 161000,
-        "input_cost_per_token": 0.114,
-        "output_cost_per_token": 0.275,
+        "input_cost_per_token": 1.14e-06,
+        "output_cost_per_token": 2.7500000000000004e-06,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31537,8 +31524,8 @@
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.071,
-        "output_cost_per_token": 0.071,
+        "input_cost_per_token": 7.1e-07,
+        "output_cost_per_token": 7.1e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31546,8 +31533,8 @@
         "max_tokens": 64000,
         "max_input_tokens": 64000,
         "max_output_tokens": 64000,
-        "input_cost_per_token": 0.017,
-        "output_cost_per_token": 0.066,
+        "input_cost_per_token": 1.7000000000000001e-07,
+        "output_cost_per_token": 6.6e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },
@@ -31555,8 +31542,8 @@
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.008,
-        "output_cost_per_token": 0.035,
+        "input_cost_per_token": 8e-08,
+        "output_cost_per_token": 3.5000000000000004e-07,
         "litellm_provider": "wandb",
         "mode": "chat"
     },


### PR DESCRIPTION
## Summary

Fixes #23503

All 13 wandb model entries in `model_prices_and_context_window_backup.json` had `input_cost_per_token` and `output_cost_per_token` values that were **100,000x too high**. The prices appeared to be in dollars-per-million-tokens rather than dollars-per-token.

For example, `wandb/meta-llama/Llama-3.3-70B-Instruct`:
- **Before:** `input_cost_per_token: 0.071` (= $71,000/1M tokens)
- **After:** `input_cost_per_token: 7.1e-07` (= $0.71/1M tokens, matching [wandb pricing page](https://wandb.ai/site/pricing/inference/))

The one model that already had correct values (`wandb/moonshotai/Kimi-K2-Instruct` at `6e-07`) was left unchanged.

### Models fixed (13 total)
| Model | Input (before → after) | Output (before → after) |
|-------|----------------------|------------------------|
| openai/gpt-oss-120b | 0.015 → 1.5e-07 | 0.06 → 6e-07 |
| openai/gpt-oss-20b | 0.005 → 5e-08 | 0.02 → 2e-07 |
| zai-org/GLM-4.5 | 0.055 → 5.5e-07 | 0.2 → 2e-06 |
| Qwen/Qwen3-235B-A22B-Instruct-2507 | 0.01 → 1e-07 | 0.01 → 1e-07 |
| Qwen/Qwen3-Coder-480B-A35B-Instruct | 0.1 → 1e-06 | 0.15 → 1.5e-06 |
| Qwen/Qwen3-235B-A22B-Thinking-2507 | 0.01 → 1e-07 | 0.01 → 1e-07 |
| meta-llama/Llama-3.1-8B-Instruct | 0.022 → 2.2e-07 | 0.022 → 2.2e-07 |
| deepseek-ai/DeepSeek-V3.1 | 0.055 → 5.5e-07 | 0.165 → 1.65e-06 |
| deepseek-ai/DeepSeek-R1-0528 | 0.135 → 1.35e-06 | 0.54 → 5.4e-06 |
| deepseek-ai/DeepSeek-V3-0324 | 0.114 → 1.14e-06 | 0.275 → 2.75e-06 |
| meta-llama/Llama-3.3-70B-Instruct | 0.071 → 7.1e-07 | 0.071 → 7.1e-07 |
| meta-llama/Llama-4-Scout-17B-16E-Instruct | 0.017 → 1.7e-07 | 0.066 → 6.6e-07 |
| microsoft/Phi-4-mini-instruct | 0.008 → 8e-08 | 0.035 → 3.5e-07 |

## Test plan
- [x] Verified corrected values match [wandb pricing page](https://wandb.ai/site/pricing/inference/)
- [x] Confirmed `wandb/moonshotai/Kimi-K2-Instruct` was already correct and left unchanged
- [x] JSON file parses correctly after changes