### PR TITLE
fix: route vertex_ai gemini-embedding-2-preview to correct endpoint

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -263,6 +263,11 @@ def _get_embedding_url(
     except Exception:
         uses_embed_content = False
 
+    # Fallback: all gemini-embedding-* models require the
+    # embedContent endpoint, not the legacy :predict endpoint.
+    if not uses_embed_content and model.startswith("gemini-embedding"):
+        uses_embed_content = True
+
     endpoint = "embedContent" if uses_embed_content else "predict"
 
     base_url = get_vertex_base_url(vertex_location)

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5204,6 +5204,11 @@ def embedding(  # noqa: PLR0915
             except Exception:
                 uses_embed_content = False
 
+            # Fallback: all gemini-embedding-* models require the
+            # embedContent endpoint, not the legacy :predict endpoint.
+            if not uses_embed_content and model.startswith("gemini-embedding"):
+                uses_embed_content = True
+
             if uses_embed_content:
                 response = google_batch_embeddings.batch_embeddings(  # type: ignore
                     model=model,


### PR DESCRIPTION
## Summary

- Adds a model-name fallback so that `vertex_ai/gemini-embedding-*` models always route to the `embedContent` endpoint (via `GoogleBatchEmbeddings`) instead of the legacy `:predict` endpoint.
- When `get_model_info()` cannot resolve the `uses_embed_content` flag (e.g. stale or missing model cost map), the code now checks if the model name starts with `gemini-embedding` and sets `uses_embed_content = True` as a fallback.
- Fix applied in both `litellm/main.py` (embedding dispatch) and `litellm/llms/vertex_ai/common_utils.py` (URL construction).

Fixes #23508

## Motivation

`vertex_ai/gemini-embedding-2-preview` returns `400 FAILED_PRECONDITION` because the legacy `:predict` endpoint is not supported for newer `gemini-embedding-*` models. PR #23322 added routing via `uses_embed_content` in the model cost map, but when model info lookup fails (exception path), requests still fall through to `:predict`. This adds a defensive name-based check so routing is correct regardless of model cost map state.

## Test plan

- [ ] Existing test `test_vertex_ai_text_only_embedding_uses_embed_content` continues to pass
- [ ] Verify `litellm.embedding(model="vertex_ai/gemini-embedding-2-preview", ...)` uses `:embedContent` endpoint
- [ ] Verify `vertex_ai/gemini-embedding-001` (older model) still works via its existing path