### PR TITLE
fix(vertex_ai): fix embedding routing for gemini-embedding models

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -263,6 +263,12 @@ def _get_embedding_url(
     except Exception:
         uses_embed_content = False
 
+    # Fallback: models with "gemini-embedding" prefix use embedContent endpoint,
+    # not the legacy :predict endpoint. This ensures correct routing even if
+    # get_model_info fails (e.g., model not yet in model_prices map).
+    if not uses_embed_content and model.startswith("gemini-embedding"):
+        uses_embed_content = True
+
     endpoint = "embedContent" if uses_embed_content else "predict"
 
     base_url = get_vertex_base_url(vertex_location)
@@ -270,7 +276,7 @@ def _get_embedding_url(
     if model.isdigit():
         url = f"{base_url}/{vertex_api_version}/projects/{vertex_project}/locations/{vertex_location}/endpoints/{model}:{endpoint}"
     else:
-        url = f"{base_url}/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:{endpoint}"
+        url = f"{base_url}/{vertex_api_version}/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:{endpoint}"
 
     return url, endpoint
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5204,6 +5204,12 @@ def embedding(  # noqa: PLR0915
             except Exception:
                 uses_embed_content = False
 
+            # Fallback: models with "gemini-embedding" prefix use the
+            # embedContent API, not the legacy :predict endpoint. This
+            # ensures correct routing even when model info lookup fails.
+            if not uses_embed_content and model.startswith("gemini-embedding"):
+                uses_embed_content = True
+
             if uses_embed_content:
                 response = google_batch_embeddings.batch_embeddings(  # type: ignore
                     model=model,


### PR DESCRIPTION
## Summary

Fixes #23508 — `vertex_ai/gemini-embedding-2-preview` routes to `:predict` endpoint and returns `FAILED_PRECONDITION`.

**Two bugs fixed:**

1. **Hardcoded `/v1/` in `_get_embedding_url`** (`common_utils.py` line 273): The non-digit model branch ignored the `vertex_api_version` parameter and always used `/v1/`, while the digit branch correctly used `{vertex_api_version}`. Fixed to use the parameter consistently.

2. **Silent fallthrough when `get_model_info` fails**: Both `_get_embedding_url` and `main.py` routing wrap `get_model_info` in a bare `except Exception` that defaults `uses_embed_content=False`, causing the request to fall through to the legacy `:predict` handler. Added a model-name fallback: any model starting with `gemini-embedding` is routed to the `embedContent` endpoint and `GoogleBatchEmbeddings` handler, matching Google's API design where these models only support `embedContent`, not `:predict`.

## Changes

- `litellm/llms/vertex_ai/common_utils.py`: Fix `_get_embedding_url` to use `vertex_api_version` instead of hardcoded `/v1/`; add `gemini-embedding` prefix fallback for `uses_embed_content`
- `litellm/main.py`: Add `gemini-embedding` prefix fallback in `vertex_ai` embedding routing so models route to `GoogleBatchEmbeddings` even if model info lookup fails

## Test plan

- [ ] Verify `vertex_ai/gemini-embedding-2-preview` text-only embedding calls use `:embedContent` endpoint
- [ ] Verify `vertex_ai/gemini-embedding-001` still uses `:predict` endpoint (no regression)
- [ ] Verify `gemini/gemini-embedding-2-preview` still works via Gemini API path
- [ ] Existing tests in `tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)