### PR TITLE
fix: sync model_params after get_llm_provider in ahealth_check

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7155,6 +7155,15 @@ async def ahealth_check(
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
+
+        # Update model_params with the resolved model name (provider prefix
+        # stripped) so that downstream calls like acompletion receive the
+        # correct model identifier.  Without this, providers such as Ollama
+        # receive "ollama/model-name" instead of just "model-name", causing
+        # a 404 from the Ollama server.  See
+        # https://github.com/BerriAI/litellm/issues/17842
+        model_params["model"] = model
+
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 


### PR DESCRIPTION
## Summary

Fixes #17842 — Ollama "Test Connect" button is broken.

**Root cause:** In `ahealth_check()`, after `get_llm_provider()` strips the provider prefix from the model name (e.g., `ollama/ministral-3:14b` → `ministral-3:14b`), the result is stored in a local variable but `model_params["model"]` is never updated. When `acompletion(**model_params)` is subsequently called via `get_mode_handlers`, it receives the original un-stripped model name, which gets sent to the Ollama server as-is, causing a 404 (`model "ollama/ministral-3:14b" not found`).

**Fix:** Add `model_params["model"] = model` after `get_llm_provider()` returns, so downstream health check calls use the correctly resolved model name.

This one-line fix addresses both error cases from the issue:
- **With `ollama/` prefix**: The stripped model name is now propagated correctly, so Ollama receives just `ministral-3:14b`
- **Without prefix**: `get_llm_provider` resolves the provider from `custom_llm_provider` param, strips/re-adds as needed, and the resolved model is written back to `model_params`

## Test plan

- [ ] Add an Ollama model via the UI with model name `ministral-3:14b` (without `ollama/` prefix), click "Test Connect" — should succeed if model is available
- [ ] Add an Ollama model via the UI with model name `ollama/ministral-3:14b` (with prefix), click "Test Connect" — should succeed without 404
- [ ] Verify existing health check tests pass (`pytest tests/ -k "health_check"`)
- [ ] Verify non-Ollama providers (OpenAI, Azure, etc.) still work with Test Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)