### PR TITLE
fix(moonshot): preserve reasoning_content for tool-call turns

### DIFF
--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -2,9 +2,10 @@
 Translates from OpenAI's `/v1/chat/completions` to Moonshot AI's `/v1/chat/completions`
 """
 
-from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, cast, overload
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    _extract_reasoning_content,
     handle_messages_with_content_list_to_str_conversion,
 )
 from litellm.secret_managers.main import get_secret_str
@@ -168,6 +169,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 messages=messages,
                 optional_params=optional_params,
             )
+        messages = self._ensure_reasoning_content_for_assistant_tool_calls(messages)
 
         # Call parent transform_request which handles _transform_messages
         return super().transform_request(
@@ -194,3 +196,43 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         )
         optional_params.pop("tool_choice")
         return messages
+
+    def _ensure_reasoning_content_for_assistant_tool_calls(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
+        """
+        Moonshot Kimi models require `reasoning_content` to be present on assistant
+        tool-call messages in multi-turn flows. Preserve existing values and
+        recover from provider_specific_fields when available.
+        """
+        transformed_messages: List[AllMessageValues] = []
+        for message in messages:
+            message_dict = cast(dict, message)
+            if (
+                message_dict.get("role") == "assistant"
+                and isinstance(message_dict.get("tool_calls"), list)
+            ):
+                reasoning_content = message_dict.get("reasoning_content")
+                if reasoning_content in (None, ""):
+                    provider_specific_fields = message_dict.get(
+                        "provider_specific_fields"
+                    )
+                    if isinstance(provider_specific_fields, dict):
+                        provider_reasoning = provider_specific_fields.get(
+                            "reasoning_content"
+                        )
+                        if isinstance(provider_reasoning, str):
+                            reasoning_content = provider_reasoning
+
+                if reasoning_content in (None, ""):
+                    extracted_reasoning, _ = _extract_reasoning_content(message_dict)
+                    if isinstance(extracted_reasoning, str) and extracted_reasoning:
+                        reasoning_content = extracted_reasoning
+
+                if reasoning_content in (None, ""):
+                    # Moonshot validates field presence, so include a minimal placeholder.
+                    reasoning_content = " "
+
+                message_dict["reasoning_content"] = reasoning_content
+            transformed_messages.append(cast(AllMessageValues, message_dict))
+        return transformed_messages

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -10,6 +10,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
+from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -169,7 +170,8 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 messages=messages,
                 optional_params=optional_params,
             )
-        messages = self._ensure_reasoning_content_for_assistant_tool_calls(messages)
+        if supports_reasoning(model=model, custom_llm_provider="moonshot"):
+            messages = self._ensure_reasoning_content_for_assistant_tool_calls(messages)
 
         # Call parent transform_request which handles _transform_messages
         return super().transform_request(
@@ -207,7 +209,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         """
         transformed_messages: List[AllMessageValues] = []
         for message in messages:
-            message_dict = cast(dict, message)
+            message_dict = dict(cast(dict, message))
             if (
                 message_dict.get("role") == "assistant"
                 and isinstance(message_dict.get("tool_calls"), list)
@@ -224,13 +226,12 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                         if isinstance(provider_reasoning, str):
                             reasoning_content = provider_reasoning
 
-                if reasoning_content in (None, ""):
+                if reasoning_content in (None, "") and "reasoning_content" not in message_dict:
                     extracted_reasoning, _ = _extract_reasoning_content(message_dict)
                     if isinstance(extracted_reasoning, str) and extracted_reasoning:
                         reasoning_content = extracted_reasoning
 
                 if reasoning_content in (None, ""):
-                    # Moonshot validates field presence, so include a minimal placeholder.
                     reasoning_content = " "
 
                 message_dict["reasoning_content"] = reasoning_content

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22083,6 +22083,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -22153,6 +22154,7 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "moonshot/kimi-k2-thinking": {
@@ -22166,6 +22168,7 @@
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -22180,6 +22183,7 @@
         "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22083,6 +22083,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -22153,6 +22154,7 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "moonshot/kimi-k2-thinking": {
@@ -22166,6 +22168,7 @@
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -22180,6 +22183,7 @@
         "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -405,3 +405,105 @@ class TestMoonshotConfig:
         # Content should be flattened to a plain string
         assert isinstance(result["messages"][0]["content"], str)
         assert result["messages"][0]["content"] == "Hello, how are you?"
+
+    def test_transform_request_injects_reasoning_content_for_tool_calls(self):
+        """Moonshot requires reasoning_content on assistant tool-call messages."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\": \"SF\"}",
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"temp\":72}"},
+        ]
+
+        result = config.transform_request(
+            model="kimi-k2.5",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert result["messages"][1]["reasoning_content"] == " "
+
+    def test_transform_request_preserves_existing_reasoning_content_for_tool_calls(self):
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "Need to fetch weather via tool.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\": \"SF\"}",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        result = config.transform_request(
+            model="kimi-k2.5",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert (
+            result["messages"][1]["reasoning_content"]
+            == "Need to fetch weather via tool."
+        )
+
+    def test_transform_request_uses_provider_specific_reasoning_content(self):
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "provider_specific_fields": {
+                    "reasoning_content": "Provider reasoning details."
+                },
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\": \"SF\"}",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        result = config.transform_request(
+            model="kimi-k2.5",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert result["messages"][1]["reasoning_content"] == "Provider reasoning details."

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -7,6 +7,7 @@ Moonshot AI is an OpenAI-compatible provider with minor customizations.
 
 import os
 import sys
+from unittest.mock import patch
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
@@ -406,7 +407,10 @@ class TestMoonshotConfig:
         assert isinstance(result["messages"][0]["content"], str)
         assert result["messages"][0]["content"] == "Hello, how are you?"
 
-    def test_transform_request_injects_reasoning_content_for_tool_calls(self):
+    @patch("litellm.llms.moonshot.chat.transformation.supports_reasoning", return_value=True)
+    def test_transform_request_injects_reasoning_content_for_tool_calls(
+        self, _mock_supports_reasoning
+    ):
         """Moonshot requires reasoning_content on assistant tool-call messages."""
         config = MoonshotChatConfig()
 
@@ -439,7 +443,10 @@ class TestMoonshotConfig:
 
         assert result["messages"][1]["reasoning_content"] == " "
 
-    def test_transform_request_preserves_existing_reasoning_content_for_tool_calls(self):
+    @patch("litellm.llms.moonshot.chat.transformation.supports_reasoning", return_value=True)
+    def test_transform_request_preserves_existing_reasoning_content_for_tool_calls(
+        self, _mock_supports_reasoning
+    ):
         config = MoonshotChatConfig()
 
         messages = [
@@ -474,7 +481,10 @@ class TestMoonshotConfig:
             == "Need to fetch weather via tool."
         )
 
-    def test_transform_request_uses_provider_specific_reasoning_content(self):
+    @patch("litellm.llms.moonshot.chat.transformation.supports_reasoning", return_value=True)
+    def test_transform_request_uses_provider_specific_reasoning_content(
+        self, _mock_supports_reasoning
+    ):
         config = MoonshotChatConfig()
 
         messages = [
@@ -507,3 +517,38 @@ class TestMoonshotConfig:
         )
 
         assert result["messages"][1]["reasoning_content"] == "Provider reasoning details."
+
+    @patch("litellm.llms.moonshot.chat.transformation.supports_reasoning", return_value=False)
+    def test_transform_request_skips_reasoning_content_for_non_reasoning_models(
+        self, _mock_supports_reasoning
+    ):
+        """Non-reasoning Moonshot models (e.g. moonshot-v1-8k) must not get reasoning_content."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\": \"SF\"}",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        result = config.transform_request(
+            model="moonshot-v1-8k",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert "reasoning_content" not in result["messages"][1]


### PR DESCRIPTION
## Summary
- ensure Moonshot request transformation preserves/injects `reasoning_content` on assistant messages that contain `tool_calls`
- recover `reasoning_content` from `provider_specific_fields` when available, with a minimal fallback to satisfy Moonshot API validation
- add Moonshot regression tests for inject/preserve/provider-specific reasoning behavior in multi-turn tool-calling payloads

FIxes #21672

## Test plan
- [x] `poetry run pytest tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py::TestMoonshotConfig::test_transform_request_injects_reasoning_content_for_tool_calls -v`
- [x] `poetry run pytest tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py -q`

Made with [Cursor](https://cursor.com)