### PR TITLE
fix: forward extra_headers to HuggingFace embedding API

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5098,6 +5098,7 @@ def embedding(  # noqa: PLR0915
                 client=client,
                 aembedding=aembedding,
                 litellm_params=litellm_params_dict,
+                headers=headers,
             )
         elif custom_llm_provider == "bedrock":
             if isinstance(input, str):


### PR DESCRIPTION
When calling `litellm.embedding()` with `custom_llm_provider="huggingface"`, the `headers` parameter was not being passed to `huggingface_embed.embedding()`. This caused `extra_headers` (e.g. `X-HF-Bill-To` for HuggingFace organization billing) to be silently dropped.

This fix adds `headers=headers` to the HuggingFace embedding call, matching the behavior of other providers like openrouter and bedrock.

Fixes #23502