### PR TITLE
QA:  improve gpt-5.4 code/bugs

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -638,9 +638,7 @@ This is useful when you want to use [Responses API](https://platform.openai.com/
 
 :::tip gpt-5.4 + reasoning_effort + function tools
 
-LiteLLM drops `reasoning_effort` from `gpt-5.4` requests to `litellm.completion()` that include tools, since that combination is supported in the Responses API.
-
-If you need reasoning **and** tools together, use the responses bridge instead:
+OpenAI does not support `reasoning_effort` with function tools for `gpt-5.4` in `/v1/chat/completions`. Use the responses bridge instead:
 
 ```python
 response = litellm.completion(

--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -594,9 +594,7 @@ Expected Response
 
 :::tip gpt-5.4: reasoning_effort + function tools
 
-LiteLLM drops `reasoning_effort` from `gpt-5.4` requests to `litellm.completion()` that include tools, since that combination is supported in the Responses API.
-
-If you need reasoning **and** tools together, use `openai/responses/gpt-5.4` to route through the Responses API instead. See [Responses API Bridge](/docs/providers/openai#openai-chat-completion-to-responses-api-bridge) for details.
+OpenAI does not support `reasoning_effort` with function tools for `gpt-5.4` in `/v1/chat/completions`. Use `openai/responses/gpt-5.4` to route through the Responses API instead. See [Responses API Bridge](/docs/providers/openai#openai-chat-completion-to-responses-api-bridge) for details.
 
 :::
 

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -39,6 +39,15 @@ base_llm_http_handler = BaseLLMHTTPHandler()
 #################################################
 
 
+def _get_tool_config_from_kwargs(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Read toolConfig/tool_config without dropping intentionally empty dicts."""
+    if "toolConfig" in kwargs:
+        return kwargs["toolConfig"]
+    if "tool_config" in kwargs:
+        return kwargs["tool_config"]
+    return None
+
+
 class GenerateContentSetupResult(BaseModel):
     """Internal Type - Result of setting up a generate content call"""
 
@@ -171,12 +180,14 @@ class GenerateContentHelper:
         system_instruction = kwargs.get("systemInstruction") or kwargs.get(
             "system_instruction"
         )
+        tool_config = _get_tool_config_from_kwargs(kwargs)
         request_body = (
             generate_content_provider_config.transform_generate_content_request(
                 model=model,
                 contents=contents,
                 tools=tools,
                 generate_content_config_dict=generate_content_config_dict,
+                tool_config=tool_config,
                 system_instruction=system_instruction,
             )
         )
@@ -323,6 +334,7 @@ def generate_content(
         system_instruction = kwargs.get("systemInstruction") or kwargs.get(
             "system_instruction"
         )
+        tool_config = _get_tool_config_from_kwargs(kwargs)
 
         # Check if we should use the adapter (when provider config is None)
         if setup_result.generate_content_provider_config is None:
@@ -354,6 +366,7 @@ def generate_content(
             _is_async=_is_async,
             client=kwargs.get("client"),
             litellm_metadata=kwargs.get("litellm_metadata", {}),
+            tool_config=tool_config,
             system_instruction=system_instruction,
         )
 
@@ -414,6 +427,7 @@ async def agenerate_content_stream(
         system_instruction = kwargs.get("systemInstruction") or kwargs.get(
             "system_instruction"
         )
+        tool_config = _get_tool_config_from_kwargs(kwargs)
 
         # Check if we should use the adapter (when provider config is None)
         if setup_result.generate_content_provider_config is None:
@@ -452,6 +466,7 @@ async def agenerate_content_stream(
             client=kwargs.get("client"),
             stream=True,
             litellm_metadata=kwargs.get("litellm_metadata", {}),
+            tool_config=tool_config,
             system_instruction=system_instruction,
         )
 
@@ -520,6 +535,10 @@ def generate_content_stream(
             )
 
         # Call the handler with streaming enabled (sync version)
+        system_instruction = kwargs.get("systemInstruction") or kwargs.get(
+            "system_instruction"
+        )
+        tool_config = _get_tool_config_from_kwargs(kwargs)
         return base_llm_http_handler.generate_content_handler(
             model=setup_result.model,
             contents=contents,
@@ -536,6 +555,8 @@ def generate_content_stream(
             client=kwargs.get("client"),
             stream=True,
             litellm_metadata=kwargs.get("litellm_metadata", {}),
+            tool_config=tool_config,
+            system_instruction=system_instruction,
         )
 
     except Exception as e:

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -152,6 +152,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         contents: GenerateContentContentListUnionDict,
         tools: Optional[ToolConfigDict],
         generate_content_config_dict: Dict,
+        tool_config: Optional[Dict[str, Any]] = None,
         system_instruction: Optional[Any] = None,
     ) -> dict:
         """
@@ -161,6 +162,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
             model: The model name
             contents: Input contents
             tools: Tools
+            tool_config: Tool configuration
             generate_content_config_dict: Generation config parameters
             system_instruction: Optional system instruction
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -9329,6 +9329,7 @@ class BaseLLMHTTPHandler:
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         stream: bool = False,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        tool_config: Optional[Dict[str, Any]] = None,
         system_instruction: Optional[Any] = None,
     ) -> Any:
         """
@@ -9346,6 +9347,7 @@ class BaseLLMHTTPHandler:
                 generate_content_provider_config=generate_content_provider_config,
                 generate_content_config_dict=generate_content_config_dict,
                 tools=tools,
+                tool_config=tool_config,
                 custom_llm_provider=custom_llm_provider,
                 litellm_params=litellm_params,
                 logging_obj=logging_obj,
@@ -9384,6 +9386,7 @@ class BaseLLMHTTPHandler:
             model=model,
             contents=contents,
             tools=tools,
+            tool_config=tool_config,
             generate_content_config_dict=generate_content_config_dict,
             system_instruction=system_instruction,
         )
@@ -9456,6 +9459,7 @@ class BaseLLMHTTPHandler:
         client: Optional[AsyncHTTPHandler] = None,
         stream: bool = False,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        tool_config: Optional[Dict[str, Any]] = None,
         system_instruction: Optional[Any] = None,
     ) -> Any:
         """
@@ -9493,6 +9497,7 @@ class BaseLLMHTTPHandler:
             model=model,
             contents=contents,
             tools=tools,
+            tool_config=tool_config,
             generate_content_config_dict=generate_content_config_dict,
             system_instruction=system_instruction,
         )

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -308,6 +308,7 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         contents: GenerateContentContentListUnionDict,
         tools: Optional[ToolConfigDict],
         generate_content_config_dict: Dict,
+        tool_config: Optional[Dict[str, Any]] = None,
         system_instruction: Optional[Any] = None,
     ) -> dict:
         from litellm.types.google_genai.main import (
@@ -326,6 +327,8 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
 
         if system_instruction is not None:
             request_dict["systemInstruction"] = system_instruction
+        if tool_config is not None:
+            request_dict["toolConfig"] = tool_config
         return request_dict
 
     def transform_generate_content_response(

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -188,11 +188,9 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         ) or optional_params.get("reasoning_effort")
         effective_effort = _get_effort_level(raw_reasoning_effort)
 
-        # Normalize to string for Chat Completions API when dict has only "effort".
-        # Preserve full dict (e.g. {"effort": "high", "summary": "detailed"}) for Responses API.
-        if isinstance(raw_reasoning_effort, dict) and set(
-            raw_reasoning_effort.keys()
-        ) <= {"effort"}:
+        # Normalize dict reasoning_effort to string for Chat Completions API.
+        # Example: {"effort": "high", "summary": "detailed"} -> "high"
+        if isinstance(raw_reasoning_effort, dict) and "effort" in raw_reasoning_effort:
             normalized = _normalize_reasoning_effort_for_chat_completion(
                 raw_reasoning_effort
             )

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -223,16 +223,6 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                 "max_tokens"
             )
 
-        # gpt-5.4: reasoning_effort + tools is only supported in the Responses API
-        # Drop reasoning_effort when tools are present in chat completions
-        if self.is_model_gpt_5_4_model(model):
-            has_tools = bool(
-                non_default_params.get("tools") or optional_params.get("tools")
-            )
-            if has_tools and effective_effort is not None:
-                non_default_params.pop("reasoning_effort", None)
-                optional_params.pop("reasoning_effort", None)
-
         # gpt-5.1/5.2 support logprobs, top_p, top_logprobs only when reasoning_effort="none"
         supports_none = self._supports_reasoning_effort_level(model, "none")
         if supports_none:

--- a/litellm/llms/vertex_ai/google_genai/transformation.py
+++ b/litellm/llms/vertex_ai/google_genai/transformation.py
@@ -73,6 +73,7 @@ class VertexAIGoogleGenAIConfig(GoogleGenAIConfig):
         contents: Any,
         tools: Optional[Any],
         generate_content_config_dict: Dict,
+        tool_config: Optional[Dict[str, Any]] = None,
         system_instruction: Optional[Any] = None,
     ) -> dict:
         """
@@ -89,8 +90,11 @@ class VertexAIGoogleGenAIConfig(GoogleGenAIConfig):
         if tools:
             result["tools"] = tools
 
+        if tool_config is not None:
+            result["toolConfig"] = tool_config
+
         # Add systemInstruction if provided
-        if system_instruction:
+        if system_instruction is not None:
             result["systemInstruction"] = system_instruction
 
         # Handle generationConfig - Vertex AI expects it in the same format

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -955,7 +955,7 @@ def responses_api_bridge_check(
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
 
-        # OpenAI gpt-5.4 chat-completions calls with both tools + reasoning_effort
+        # OpenAI gpt-5.4+ chat-completions calls with both tools + reasoning_effort
         # must be bridged to Responses API.
         if (
             custom_llm_provider == "openai"
@@ -1616,6 +1616,10 @@ def completion(  # type: ignore # noqa: PLR0915
 
         if model_info.get("mode") == "responses":
             from litellm.completion_extras import responses_api_bridge
+
+            if isinstance(reasoning_effort, dict) and "summary" in reasoning_effort:
+                optional_params = dict(optional_params)
+                optional_params["reasoning_effort"] = reasoning_effort
 
             return responses_api_bridge.completion(
                 model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -99,6 +99,7 @@ from litellm.llms.base_llm.base_model_iterator import (
 from litellm.llms.bedrock.common_utils import BedrockModelInfo
 from litellm.llms.cohere.common_utils import CohereModelInfo
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.llms.vertex_ai.common_utils import (
     VertexAIModelRoute,
@@ -934,6 +935,8 @@ def responses_api_bridge_check(
     model: str,
     custom_llm_provider: str,
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
+    tools: Optional[List[Any]] = None,
+    reasoning_effort: Optional[Any] = None,
 ) -> Tuple[dict, str]:
     model_info: Dict[str, Any] = {}
     try:
@@ -949,6 +952,17 @@ def responses_api_bridge_check(
             model_info["mode"] = mode
 
         if web_search_options is not None and custom_llm_provider == "xai":
+            model_info["mode"] = "responses"
+            model = model.replace("responses/", "")
+
+        # OpenAI gpt-5.4 chat-completions calls with both tools + reasoning_effort
+        # must be bridged to Responses API.
+        if (
+            custom_llm_provider == "openai"
+            and OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
+            and tools
+            and reasoning_effort is not None
+        ):
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
     except Exception as e:
@@ -1596,6 +1610,8 @@ def completion(  # type: ignore # noqa: PLR0915
             model=model,
             custom_llm_provider=custom_llm_provider,
             web_search_options=web_search_options,
+            tools=tools,
+            reasoning_effort=reasoning_effort,
         )
 
         if model_info.get("mode") == "responses":

--- a/tests/proxy_unit_tests/test_google_gemini_proxy_request.py
+++ b/tests/proxy_unit_tests/test_google_gemini_proxy_request.py
@@ -174,6 +174,7 @@ async def test_google_gemini_httpx_request_direct():
             ],
             "role": "user"
         },
+        "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
         "config": {  # Note: already transformed from generationConfig
             "temperature": 0,
             "topP": 1,
@@ -240,6 +241,7 @@ async def test_google_gemini_httpx_request_direct():
                 generate_content_provider_config=provider_config,
                 generate_content_config_dict=sample_payload["config"],
                 tools=None,
+                tool_config=sample_payload["toolConfig"],
                 custom_llm_provider="gemini",
                 litellm_params=litellm_params,
                 logging_obj=logging_obj,
@@ -265,6 +267,7 @@ async def test_google_gemini_httpx_request_direct():
             request_data = call_kwargs.get('json')
             if request_data:
                 assert 'contents' in request_data, "Expected 'contents' in request data"
+                assert request_data["toolConfig"] == sample_payload["toolConfig"]
                 
                 # The config should be included in the request as generationConfig
                 if 'generationConfig' in request_data:

--- a/tests/test_litellm/google_genai/test_google_genai_main.py
+++ b/tests/test_litellm/google_genai/test_google_genai_main.py
@@ -1,24 +1,13 @@
 #!/usr/bin/env python3
-"""
-Test to verify the Google GenAI generate_content adapter functionality
-"""
-import json
+"""Tests for Google GenAI main entrypoints."""
+
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
-
-import json
-import os
-import sys
-
-import pytest
-
-import litellm
+sys.path.insert(0, os.path.abspath("../../.."))
 
 
 @pytest.mark.asyncio
@@ -26,8 +15,6 @@ async def test_agenerate_content_stream():
     """
     Test that the agenerate_content_stream function works
     """
-    from unittest.mock import AsyncMock, patch
-
     from litellm.google_genai.main import (
         agenerate_content_stream,
         base_llm_http_handler,
@@ -36,10 +23,40 @@ async def test_agenerate_content_stream():
     with patch.object(
         base_llm_http_handler, "generate_content_handler", new=AsyncMock()
     ) as mock_post:
-        result = await agenerate_content_stream(
+        await agenerate_content_stream(
             model="gemini/gemini-2.0-flash-001",
             contents="Hello, world!",
             stream=True,
         )
         mock_post.assert_called_once()
-        mock_post.call_args.kwargs["stream"] == True
+        assert mock_post.call_args.kwargs["stream"] is True
+
+
+def test_generate_content_stream_forwards_system_instruction():
+    """Test that generate_content_stream forwards systemInstruction and toolConfig."""
+    from litellm.google_genai.main import (
+        base_llm_http_handler,
+        generate_content_stream,
+    )
+
+    mock_response = MagicMock()
+    tool_config = {"functionCallingConfig": {"mode": "ANY"}}
+
+    with patch.object(
+        base_llm_http_handler, "generate_content_handler", return_value=mock_response
+    ) as mock_post:
+        result = generate_content_stream(
+            model="gemini/gemini-2.0-flash-001",
+            contents="Hello, world!",
+            stream=True,
+            systemInstruction={"parts": [{"text": "You are helpful"}]},
+            toolConfig=tool_config,
+        )
+
+        assert result is mock_response
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs["stream"] is True
+        assert mock_post.call_args.kwargs["tool_config"] == tool_config
+        assert mock_post.call_args.kwargs["system_instruction"] == {
+            "parts": [{"text": "You are helpful"}]
+        }

--- a/tests/test_litellm/google_genai/test_google_genai_transformation.py
+++ b/tests/test_litellm/google_genai/test_google_genai_transformation.py
@@ -12,6 +12,9 @@ sys.path.insert(
 import pytest
 
 from litellm.llms.gemini.google_genai.transformation import GoogleGenAIConfig
+from litellm.llms.vertex_ai.google_genai.transformation import (
+    VertexAIGoogleGenAIConfig,
+)
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
@@ -173,6 +176,26 @@ def test_map_generate_content_optional_params_response_mime_type():
     assert "responseJsonSchema" in result
 
 
+@pytest.mark.parametrize(
+    "config_cls",
+    [GoogleGenAIConfig, VertexAIGoogleGenAIConfig],
+)
+def test_transform_generate_content_request_preserves_tool_config(config_cls):
+    config = config_cls()
+    tool_config = {"functionCallingConfig": {"mode": "ANY"}}
+
+    result = config.transform_generate_content_request(
+        model="gemini-3-flash-preview",
+        contents=[{"role": "user", "parts": [{"text": "hello"}]}],
+        tools=[{"functionDeclarations": [{"name": "execute_command"}]}],
+        tool_config=tool_config,
+        generate_content_config_dict={"temperature": 1},
+        system_instruction={"parts": [{"text": "system"}]},
+    )
+
+    assert result["toolConfig"] == tool_config
+
+
 def test_responses_api_reasoning_dict_format():
     """Test that reasoning parameter with dict format is mapped to reasoning_effort"""
     from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
@@ -274,6 +297,7 @@ def test_transform_generate_content_request_with_system_instruction():
         model="gemini-3-flash-preview",
         contents=contents,
         tools=None,
+        tool_config=None,
         generate_content_config_dict=generate_content_config_dict,
         system_instruction=system_instruction,
     )
@@ -305,6 +329,7 @@ def test_transform_generate_content_request_without_system_instruction():
         model="gemini-3-flash-preview",
         contents=contents,
         tools=None,
+        tool_config=None,
         generate_content_config_dict=generate_content_config_dict,
         system_instruction=None,
     )
@@ -356,6 +381,7 @@ def test_transform_generate_content_request_system_instruction_with_tools():
         model="gemini-3-flash-preview",
         contents=contents,
         tools=tools,
+        tool_config=None,
         generate_content_config_dict=generate_content_config_dict,
         system_instruction=system_instruction,
     )

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -9,11 +9,11 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
+from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
     OpenAIGPTConfig,
 )
-from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 
 
 class TestOpenAIGPTConfig:
@@ -460,8 +460,11 @@ class TestGPT5ReasoningEffortPreservation:
 
         assert "reasoning_effort" not in non_default_params
 
-    def test_reasoning_effort_dict_none_dropped_for_gpt5_4_with_tools(self):
-        """none-dict with tools on gpt-5.4: reasoning_effort is dropped."""
+    def test_reasoning_effort_dict_none_treated_as_none_for_tools(self):
+        """none-dict: {"effort": "none", "summary": "detailed"} is treated as effort=none.
+        
+        Tool-drop guard should NOT fire; reasoning_effort should be kept.
+        """
         tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
         non_default_params = {"reasoning_effort": {"effort": "none", "summary": "detailed"}, "tools": tools}
         optional_params = {}
@@ -473,7 +476,7 @@ class TestGPT5ReasoningEffortPreservation:
             drop_params=False,
         )
 
-        assert "reasoning_effort" not in non_default_params
+        assert non_default_params.get("reasoning_effort") == {"effort": "none", "summary": "detailed"}
         assert non_default_params.get("tools") == tools
 
     def test_reasoning_effort_dict_none_treated_as_none_for_sampling(self):

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -366,10 +366,10 @@ def test_gpt5_xhigh_dict_accepted_for_supported_model(config: OpenAIConfig):
 
 
 def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
-    """Dict with effort='none' and tools: reasoning_effort dropped for gpt-5.4.
+    """Dict with effort='none' and tools: no tool-drop, reasoning_effort preserved.
 
-    gpt-5.4 drops all reasoning_effort when tools are present,
-    since that combination is only supported in the Responses API.
+    Regression: effective_effort='none' must be used for tool-drop guard so
+    {"effort": "none", "summary": "detailed"} is not incorrectly treated as non-none.
     """
     tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
     params = config.map_openai_params(
@@ -378,7 +378,7 @@ def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert "reasoning_effort" not in params
+    assert params["reasoning_effort"] == {"effort": "none", "summary": "detailed"}
     assert params["tools"] == tools
 
 
@@ -412,56 +412,6 @@ def test_gpt5_preserves_reasoning_effort_dict_with_summary_from_optional_params(
         drop_params=False,
     )
     assert params["reasoning_effort"] == {"effort": "medium", "summary": "detailed"}
-
-
-def test_gpt5_4_drops_reasoning_effort_when_user_sends_reasoning_and_tools(config: OpenAIConfig):
-    """gpt-5.4: function calls not supported with reasoning_effort != 'none'. Drop reasoning_effort."""
-    tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
-    params = config.map_openai_params(
-        non_default_params={"reasoning_effort": "high", "tools": tools},
-        optional_params={},
-        model="gpt-5.4",
-        drop_params=False,
-    )
-    assert "reasoning_effort" not in params
-    assert params["tools"] == tools
-
-
-def test_gpt5_4_keeps_reasoning_effort_when_no_tools(config: OpenAIConfig):
-    """reasoning_effort is kept when tools are not present."""
-    params = config.map_openai_params(
-        non_default_params={"reasoning_effort": "high"},
-        optional_params={},
-        model="gpt-5.4",
-        drop_params=False,
-    )
-    assert params["reasoning_effort"] == "high"
-
-
-def test_gpt5_4_drops_reasoning_effort_none_with_tools(config: OpenAIConfig):
-    """reasoning_effort='none' is also dropped when tools are present for gpt-5.4."""
-    tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
-    params = config.map_openai_params(
-        non_default_params={"reasoning_effort": "none", "tools": tools},
-        optional_params={},
-        model="gpt-5.4",
-        drop_params=False,
-    )
-    assert "reasoning_effort" not in params
-    assert params["tools"] == tools
-
-
-def test_gpt5_2_keeps_reasoning_effort_with_tools(config: OpenAIConfig):
-    """gpt-5.2: reasoning_effort drop only applies to gpt-5.4, not gpt-5.2."""
-    tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
-    params = config.map_openai_params(
-        non_default_params={"reasoning_effort": "high", "tools": tools},
-        optional_params={},
-        model="gpt-5.2",
-        drop_params=False,
-    )
-    assert params["reasoning_effort"] == "high"
-    assert params["tools"] == tools
 
 
 def test_gpt5_4_pro_rejects_non_default_temperature(config: OpenAIConfig):

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -324,19 +324,15 @@ def test_gpt5_4_pro_allows_reasoning_effort_xhigh(config: OpenAIConfig):
     assert params["reasoning_effort"] == "xhigh"
 
 
-def test_gpt5_preserves_reasoning_effort_dict_with_summary(config: OpenAIConfig):
-    """Dict with summary/generate_summary is preserved for Responses API.
-
-    Config/deployments may pass Responses API format: {'effort': 'high', 'summary': 'detailed'}.
-    We preserve the full dict so it reaches the Responses API transformation.
-    """
+def test_gpt5_normalizes_reasoning_effort_dict_with_summary(config: OpenAIConfig):
+    """Dict with summary/generate_summary is normalized for chat completions."""
     params = config.map_openai_params(
         non_default_params={"reasoning_effort": {"effort": "high", "summary": "detailed"}},
         optional_params={},
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "high", "summary": "detailed"}
+    assert params["reasoning_effort"] == "high"
 
 
 def test_gpt5_xhigh_dict_triggers_validation(config: OpenAIConfig):
@@ -362,7 +358,7 @@ def test_gpt5_xhigh_dict_accepted_for_supported_model(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "xhigh", "summary": "detailed"}
+    assert params["reasoning_effort"] == "xhigh"
 
 
 def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
@@ -378,7 +374,7 @@ def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "none", "summary": "detailed"}
+    assert params["reasoning_effort"] == "none"
     assert params["tools"] == tools
 
 
@@ -398,20 +394,20 @@ def test_gpt5_none_dict_with_sampling_params_allowed(config: OpenAIConfig):
         model="gpt-5.1",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "none", "summary": "detailed"}
+    assert params["reasoning_effort"] == "none"
     assert params["logprobs"] is True
     assert params["top_p"] == 0.9
 
 
-def test_gpt5_preserves_reasoning_effort_dict_with_summary_from_optional_params(config: OpenAIConfig):
-    """reasoning_effort dict with summary in optional_params is preserved."""
+def test_gpt5_normalizes_reasoning_effort_dict_with_summary_from_optional_params(config: OpenAIConfig):
+    """reasoning_effort dict with summary in optional_params is normalized."""
     params = config.map_openai_params(
         non_default_params={},
         optional_params={"reasoning_effort": {"effort": "medium", "summary": "detailed"}},
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "medium", "summary": "detailed"}
+    assert params["reasoning_effort"] == "medium"
 
 
 def test_gpt5_4_pro_rejects_non_default_temperature(config: OpenAIConfig):

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -627,6 +627,57 @@ def test_responses_api_bridge_check_gpt_5_4_pro():
         )
 
 
+def test_responses_api_bridge_check_gpt_5_4_tools_plus_reasoning_routes_to_responses():
+    """gpt-5.4 with both tools and reasoning_effort should route to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="xhigh",
+        )
+
+    assert model == "gpt-5.4"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_5_tools_plus_reasoning_routes_to_responses():
+    """gpt-5.5+ with both tools and reasoning_effort should route to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.5-pro",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="xhigh",
+        )
+
+    assert model == "gpt-5.5-pro"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_4_tools_without_reasoning_stays_chat():
+    """gpt-5.4 with tools only should not be force-routed to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort=None,
+        )
+
+    assert model == "gpt-5.4"
+    assert model_info.get("mode") != "responses"
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -678,6 +678,43 @@ def test_responses_api_bridge_check_gpt_5_4_tools_without_reasoning_stays_chat()
     assert model_info.get("mode") != "responses"
 
 
+@patch("litellm.completion_extras.responses_api_bridge.completion")
+def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
+    mock_responses_completion,
+):
+    """When routed to Responses, preserve reasoning_effort summary dict."""
+    mock_responses_completion.return_value = MagicMock()
+
+    import litellm
+
+    litellm.completion(
+        model="gpt-5.4",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_capital",
+                    "description": "Get the capital of a country",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"country": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+        reasoning_effort={"effort": "xhigh", "summary": "detailed"},
+        api_key="fake-key",
+    )
+
+    assert mock_responses_completion.called is True
+    optional_params = mock_responses_completion.call_args.kwargs["optional_params"]
+    assert optional_params["reasoning_effort"] == {
+        "effort": "xhigh",
+        "summary": "detailed",
+    }
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix
🧹 Refactoring

## Changes

1. **Revert of drop logic**  
   Reverted the PR that dropped `reasoning_effort` when gpt-5.4 had tools. That behavior was removed so we can route those calls to the Responses API instead.

2. **Routing to Responses API**  
   Added routing so gpt-5.4+ requests with both tools and `reasoning_effort` go to the Responses API. Uses `OpenAIGPT5Config.is_model_gpt_5_4_plus_model()` so it applies to 5.4 and newer.

3. **Dict → string normalization for chat**  
   Chat completions expect `reasoning_effort` as a string, not a dict. We normalize dicts like `{"effort": "high", "summary": "detailed"}` to the string `"high"` for the chat path so gpt-5.2 and other chat models don’t get BadRequestError.

4. **Preserving `summary` on the Responses path**  
   After normalization, `optional_params` lost the `summary` field before the Responses bridge. We restore the original dict (with `summary`) into `optional_params` before calling `responses_api_bridge.completion()` so the Responses API receives the full reasoning config.