### PR TITLE
fix: enforce user budget check for team keys

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -481,10 +481,9 @@ async def common_checks(  # noqa: PLR0915
         )
 
         # 4. If user is in budget
-        ## 4.1 check personal budget, if personal key
+        ## 4.1 check user budget (applies to all keys - personal and team)
         if (
-            (team_object is None or team_object.team_id is None)
-            and user_object is not None
+            user_object is not None
             and user_object.max_budget is not None
         ):
             user_budget = user_object.max_budget

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -482,10 +482,7 @@ async def common_checks(  # noqa: PLR0915
 
         # 4. If user is in budget
         ## 4.1 check user budget (applies to all keys - personal and team)
-        if (
-            user_object is not None
-            and user_object.max_budget is not None
-        ):
+        if user_object is not None and user_object.max_budget is not None:
             user_budget = user_object.max_budget
             if user_budget < user_object.spend:
                 raise litellm.BudgetExceededError(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -481,8 +481,16 @@ async def common_checks(  # noqa: PLR0915
         )
 
         # 4. If user is in budget
-        ## 4.1 check user budget (applies to all keys - personal and team)
-        if user_object is not None and user_object.max_budget is not None:
+        ## 4.1 check user budget
+        _enforce_user_budget_on_team_keys = general_settings.get(
+            "enforce_user_budget_on_team_keys", False
+        )
+        _is_personal_key = team_object is None or team_object.team_id is None
+        if (
+            user_object is not None
+            and user_object.max_budget is not None
+            and (_is_personal_key or _enforce_user_budget_on_team_keys)
+        ):
             user_budget = user_object.max_budget
             if user_budget < user_object.spend:
                 raise litellm.BudgetExceededError(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1633,7 +1633,7 @@ async def test_custom_auth_common_checks_opt_in():
 
 @pytest.mark.asyncio
 async def test_user_budget_enforced_with_team_key():
-    """Test that user budget is enforced even when the key belongs to a team."""
+    """Test that user budget is enforced for team keys when enforce_user_budget_on_team_keys is enabled."""
     from fastapi import Request
 
     from litellm.proxy.auth.auth_checks import common_checks
@@ -1659,6 +1659,8 @@ async def test_user_budget_enforced_with_team_key():
         spend=60.0,  # Over user budget
     )
 
+    general_settings = {"enforce_user_budget_on_team_keys": True}
+
     with pytest.raises(litellm.BudgetExceededError):
         await common_checks(
             request_body=request_body,
@@ -1666,7 +1668,7 @@ async def test_user_budget_enforced_with_team_key():
             user_object=user_object,
             end_user_object=None,
             global_proxy_spend=None,
-            general_settings={},
+            general_settings=general_settings,
             route="/chat/completions",
             llm_router=None,
             proxy_logging_obj=MagicMock(),
@@ -1677,7 +1679,7 @@ async def test_user_budget_enforced_with_team_key():
 
 @pytest.mark.asyncio
 async def test_user_budget_not_exceeded_with_team_key():
-    """Test that request passes when user budget is not exceeded with a team key."""
+    """Test that request passes when user budget is not exceeded with a team key and flag enabled."""
     from fastapi import Request
 
     from litellm.proxy.auth.auth_checks import common_checks
@@ -1703,6 +1705,54 @@ async def test_user_budget_not_exceeded_with_team_key():
         spend=30.0,  # Under user budget
     )
 
+    general_settings = {"enforce_user_budget_on_team_keys": True}
+
+    result = await common_checks(
+        request_body=request_body,
+        team_object=team_object,
+        user_object=user_object,
+        end_user_object=None,
+        global_proxy_spend=None,
+        general_settings=general_settings,
+        route="/chat/completions",
+        llm_router=None,
+        proxy_logging_obj=MagicMock(),
+        valid_token=valid_token,
+        request=mock_request,
+    )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_user_budget_skipped_for_team_key_without_flag():
+    """Test that user budget is NOT enforced for team keys when flag is disabled (default)."""
+    from fastapi import Request
+
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    request_body = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+
+    mock_request = MagicMock(spec=Request)
+
+    valid_token = UserAPIKeyAuth(token="test-token", models=["gpt-3.5-turbo"])
+
+    team_object = LiteLLM_TeamTable(
+        team_id="team-123",
+        max_budget=100.0,
+        spend=10.0,
+    )
+
+    user_object = LiteLLM_UserTable(
+        user_id="user-123",
+        max_budget=50.0,
+        spend=60.0,  # Over user budget, but flag is off
+    )
+
+    # Default behavior: flag not set, team key bypasses user budget
     result = await common_checks(
         request_body=request_body,
         team_object=team_object,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1629,3 +1629,92 @@ async def test_custom_auth_common_checks_opt_in():
             parent_otel_span=None,
         )
         mock_common.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_user_budget_enforced_with_team_key():
+    """Test that user budget is enforced even when the key belongs to a team."""
+    from fastapi import Request
+
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    request_body = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+
+    mock_request = MagicMock(spec=Request)
+
+    valid_token = UserAPIKeyAuth(token="test-token", models=["gpt-3.5-turbo"])
+
+    team_object = LiteLLM_TeamTable(
+        team_id="team-123",
+        max_budget=100.0,
+        spend=10.0,
+    )
+
+    user_object = LiteLLM_UserTable(
+        user_id="user-123",
+        max_budget=50.0,
+        spend=60.0,  # Over user budget
+    )
+
+    with pytest.raises(litellm.BudgetExceededError):
+        await common_checks(
+            request_body=request_body,
+            team_object=team_object,
+            user_object=user_object,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings={},
+            route="/chat/completions",
+            llm_router=None,
+            proxy_logging_obj=MagicMock(),
+            valid_token=valid_token,
+            request=mock_request,
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_budget_not_exceeded_with_team_key():
+    """Test that request passes when user budget is not exceeded with a team key."""
+    from fastapi import Request
+
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    request_body = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+
+    mock_request = MagicMock(spec=Request)
+
+    valid_token = UserAPIKeyAuth(token="test-token", models=["gpt-3.5-turbo"])
+
+    team_object = LiteLLM_TeamTable(
+        team_id="team-123",
+        max_budget=100.0,
+        spend=10.0,
+    )
+
+    user_object = LiteLLM_UserTable(
+        user_id="user-123",
+        max_budget=50.0,
+        spend=30.0,  # Under user budget
+    )
+
+    result = await common_checks(
+        request_body=request_body,
+        team_object=team_object,
+        user_object=user_object,
+        end_user_object=None,
+        global_proxy_spend=None,
+        general_settings={},
+        route="/chat/completions",
+        llm_router=None,
+        proxy_logging_obj=MagicMock(),
+        valid_token=valid_token,
+        request=mock_request,
+    )
+
+    assert result is True


### PR DESCRIPTION
## Summary
- User budget (`max_budget` on `LiteLLM_UserTable`) was only checked for personal keys (`team_object is None`), meaning requests through team keys bypassed user budget entirely
- Added a new `general_settings` flag `enforce_user_budget_on_team_keys` (default `False`) that enables user budget enforcement for team keys
- Default behavior is preserved — existing deployments are unaffected

## Usage

```yaml
general_settings:
  enforce_user_budget_on_team_keys: true
```

## Changes
- `litellm/proxy/auth/auth_checks.py`: Added `enforce_user_budget_on_team_keys` flag check in `common_checks()`
- `tests/test_litellm/proxy/auth/test_auth_checks.py`: Added 3 tests:
  - Flag enabled + over budget → BudgetExceededError
  - Flag enabled + under budget → passes
  - Flag disabled (default) + over budget → passes (backward compat)

## Test plan
- [x] `test_user_budget_enforced_with_team_key` — flag on, user over budget with team key → BudgetExceededError
- [x] `test_user_budget_not_exceeded_with_team_key` — flag on, user under budget with team key → passes
- [x] `test_user_budget_skipped_for_team_key_without_flag` — flag off (default), user over budget with team key → passes
- [x] Existing tests unaffected