### PR TITLE
fix: silent metrics race condition

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1492,13 +1492,32 @@ class Router:
     def _get_silent_experiment_kwargs(self, **kwargs) -> dict:
         """
         Prepare kwargs for a silent experiment by ensuring isolation from the primary call.
-        """
-        # Copy kwargs to ensure isolation (use safe_deep_copy to handle non-serializable objects like OTEL spans)
-        from litellm.litellm_core_utils.core_helpers import safe_deep_copy
 
-        silent_kwargs = safe_deep_copy(kwargs)
-        if "metadata" not in silent_kwargs:
-            silent_kwargs["metadata"] = {}
+        IMPORTANT: We avoid calling safe_deep_copy(kwargs) because it temporarily
+        mutates the original dict (pops litellm_parent_otel_span, replaces with
+        "placeholder", then restores). Since this runs in a background thread while
+        the primary request's async callbacks may still be reading the same dict,
+        that mutation causes a race condition that breaks otel/prometheus callbacks
+        for the primary request.
+        """
+        import copy
+
+        # Shallow copy top-level kwargs — does NOT mutate the original
+        silent_kwargs = dict(kwargs)
+
+        # Deep-copy metadata so we don't share state with the primary request.
+        # Remove the OTEL span BEFORE deep-copying (it's not picklable and is
+        # thread-bound anyway).
+        original_metadata = kwargs.get("metadata") or {}
+        metadata_copy = {
+            k: v
+            for k, v in original_metadata.items()
+            if k != "litellm_parent_otel_span"
+        }
+        try:
+            silent_kwargs["metadata"] = copy.deepcopy(metadata_copy)
+        except Exception:
+            silent_kwargs["metadata"] = dict(metadata_copy)
 
         silent_kwargs["metadata"]["is_silent_experiment"] = True
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1518,6 +1518,11 @@ class Router:
         if "metadata" not in silent_kwargs:
             silent_kwargs["metadata"] = {}
 
+        # OTel spans are not safe to use across event loops. The silent
+        # experiment runs in a new event loop, so strip the span to prevent
+        # cross-loop tracing races or span corruption.
+        silent_kwargs["metadata"].pop("litellm_parent_otel_span", None)
+
         silent_kwargs["metadata"]["is_silent_experiment"] = True
 
         # Force stream=False so the response is fully consumed and callbacks fire

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1493,31 +1493,30 @@ class Router:
         """
         Prepare kwargs for a silent experiment by ensuring isolation from the primary call.
 
-        IMPORTANT: We avoid calling safe_deep_copy(kwargs) because it temporarily
-        mutates the original dict (pops litellm_parent_otel_span, replaces with
-        "placeholder", then restores). Since this runs in a background thread while
-        the primary request's async callbacks may still be reading the same dict,
-        that mutation causes a race condition that breaks otel/prometheus callbacks
-        for the primary request.
+        Guarantee metadata isolation: safe_deep_copy falls back to the original
+        reference when deepcopy fails (e.g. metadata contains UserAPIKeyAuth with
+        parent_otel_span — an OTel Span that is not deepcopy-able). Force a shallow
+        copy of the metadata dict so mutations (model_group, is_silent_experiment)
+        never corrupt the main call's metadata.
         """
-        import copy
+        from litellm.litellm_core_utils.core_helpers import safe_deep_copy
 
-        # Shallow copy top-level kwargs — does NOT mutate the original
-        silent_kwargs = dict(kwargs)
+        silent_kwargs = safe_deep_copy(kwargs)
 
-        # Deep-copy metadata so we don't share state with the primary request.
-        # Remove the OTEL span BEFORE deep-copying (it's not picklable and is
-        # thread-bound anyway).
-        original_metadata = kwargs.get("metadata") or {}
-        metadata_copy = {
-            k: v
-            for k, v in original_metadata.items()
-            if k != "litellm_parent_otel_span"
-        }
-        try:
-            silent_kwargs["metadata"] = copy.deepcopy(metadata_copy)
-        except Exception:
-            silent_kwargs["metadata"] = dict(metadata_copy)
+        # safe_deep_copy may fall back to the original metadata reference when
+        # deepcopy fails (UserAPIKeyAuth.parent_otel_span is not deepcopy-able).
+        # Detect this via identity check and force a shallow copy so that setting
+        # model_group / is_silent_experiment on the silent dict doesn't corrupt
+        # the primary call's metadata.
+        original_metadata = kwargs.get("metadata")
+        if (
+            original_metadata is not None
+            and silent_kwargs.get("metadata") is original_metadata
+        ):
+            silent_kwargs["metadata"] = dict(original_metadata)
+
+        if "metadata" not in silent_kwargs:
+            silent_kwargs["metadata"] = {}
 
         silent_kwargs["metadata"]["is_silent_experiment"] = True
 

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -20,8 +20,9 @@ def test_get_silent_experiment_kwargs():
         },
     ]
     router = Router(model_list=model_list)
+    mock_span = MagicMock()
     kwargs = {
-        "metadata": {"foo": "bar"},
+        "metadata": {"foo": "bar", "litellm_parent_otel_span": mock_span},
         "litellm_call_id": "call-123",
         "stream": True,
         "proxy_server_request": {"body": {"model": "test"}},
@@ -34,6 +35,11 @@ def test_get_silent_experiment_kwargs():
     assert result["stream"] is False
     # proxy_server_request must be preserved for spend log metadata
     assert "proxy_server_request" in result
+    # parent OTEL span must be removed — it's thread-bound and invalid in the
+    # background thread's new event loop
+    assert "litellm_parent_otel_span" not in result["metadata"]
+    # CRITICAL: original kwargs must NOT be mutated (race condition with primary callbacks)
+    assert kwargs["metadata"]["litellm_parent_otel_span"] is mock_span
 
 
 def test_silent_experiment_completion_direct():

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -8,10 +8,20 @@ import litellm
 from litellm.router import Router
 
 
+class _NonCopyableSpan:
+    """Mimics an OTel Span which raises on deepcopy, forcing safe_deep_copy
+    to fall back to the original reference."""
+
+    def __deepcopy__(self, memo):
+        raise TypeError("OTel spans cannot be deepcopied")
+
+
 def test_get_silent_experiment_kwargs():
     """
     Test _get_silent_experiment_kwargs returns isolated kwargs with silent experiment metadata.
-    Direct call for router code coverage.
+
+    Uses a non-copyable span object so that safe_deep_copy falls back to the
+    original metadata reference — exercising the identity-check fix path.
     """
     model_list = [
         {
@@ -20,7 +30,7 @@ def test_get_silent_experiment_kwargs():
         },
     ]
     router = Router(model_list=model_list)
-    mock_span = MagicMock()
+    mock_span = _NonCopyableSpan()
     kwargs = {
         "metadata": {"foo": "bar", "litellm_parent_otel_span": mock_span},
         "litellm_call_id": "call-123",

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -35,10 +35,12 @@ def test_get_silent_experiment_kwargs():
     assert result["stream"] is False
     # proxy_server_request must be preserved for spend log metadata
     assert "proxy_server_request" in result
-    # parent OTEL span must be removed — it's thread-bound and invalid in the
-    # background thread's new event loop
-    assert "litellm_parent_otel_span" not in result["metadata"]
-    # CRITICAL: original kwargs must NOT be mutated (race condition with primary callbacks)
+    # CRITICAL: metadata must be a DIFFERENT dict object than the original,
+    # so that setting model_group / is_silent_experiment on the silent dict
+    # doesn't corrupt the primary call's metadata.
+    assert result["metadata"] is not kwargs["metadata"]
+    # Original metadata must NOT be mutated
+    assert "is_silent_experiment" not in kwargs["metadata"]
     assert kwargs["metadata"]["litellm_parent_otel_span"] is mock_span
 
 

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -16,12 +16,28 @@ class _NonCopyableSpan:
         raise TypeError("OTel spans cannot be deepcopied")
 
 
+class _FakeUserAPIKeyAuth:
+    """Mimics UserAPIKeyAuth which contains a parent_otel_span that is not
+    deepcopy-able. This is what actually causes safe_deep_copy to fail for
+    the metadata dict in production — safe_deep_copy handles the top-level
+    litellm_parent_otel_span specially (pops it before copying), but does
+    NOT handle user_api_key_auth.parent_otel_span inside it."""
+
+    def __init__(self, key_alias, parent_otel_span):
+        self.key_alias = key_alias
+        self.parent_otel_span = parent_otel_span
+
+    def __deepcopy__(self, memo):
+        raise TypeError("Contains OTel span that cannot be deepcopied")
+
+
 def test_get_silent_experiment_kwargs():
     """
     Test _get_silent_experiment_kwargs returns isolated kwargs with silent experiment metadata.
 
-    Uses a non-copyable span object so that safe_deep_copy falls back to the
-    original metadata reference — exercising the identity-check fix path.
+    Uses a non-copyable user_api_key_auth (mimicking the real proxy scenario)
+    so that safe_deep_copy falls back to the original metadata reference —
+    exercising the identity-check fix path.
     """
     model_list = [
         {
@@ -31,8 +47,16 @@ def test_get_silent_experiment_kwargs():
     ]
     router = Router(model_list=model_list)
     mock_span = _NonCopyableSpan()
+    mock_auth = _FakeUserAPIKeyAuth(
+        key_alias="HaneefKeyNonTeamProd",
+        parent_otel_span=mock_span,
+    )
     kwargs = {
-        "metadata": {"foo": "bar", "litellm_parent_otel_span": mock_span},
+        "metadata": {
+            "foo": "bar",
+            "litellm_parent_otel_span": mock_span,
+            "user_api_key_auth": mock_auth,
+        },
         "litellm_call_id": "call-123",
         "stream": True,
         "proxy_server_request": {"body": {"model": "test"}},
@@ -52,6 +76,7 @@ def test_get_silent_experiment_kwargs():
     # Original metadata must NOT be mutated
     assert "is_silent_experiment" not in kwargs["metadata"]
     assert kwargs["metadata"]["litellm_parent_otel_span"] is mock_span
+    assert kwargs["metadata"]["user_api_key_auth"] is mock_auth
 
 
 def test_silent_experiment_completion_direct():

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -81,6 +81,9 @@ def test_get_silent_experiment_kwargs():
     assert "is_silent_experiment" not in kwargs["metadata"]
     assert kwargs["metadata"]["litellm_parent_otel_span"] is mock_span
     assert kwargs["metadata"]["user_api_key_auth"] is mock_auth
+    # Shallow copy must preserve user_api_key_auth so the silent experiment
+    # can attribute billing / spend logs to the correct key/team.
+    assert result["metadata"]["user_api_key_auth"] is mock_auth
 
 
 def test_silent_experiment_completion_direct():

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -73,7 +73,11 @@ def test_get_silent_experiment_kwargs():
     # so that setting model_group / is_silent_experiment on the silent dict
     # doesn't corrupt the primary call's metadata.
     assert result["metadata"] is not kwargs["metadata"]
-    # Original metadata must NOT be mutated
+    # OTel span must be stripped from the silent copy — it's not safe to use
+    # across event loops (silent experiment runs in a new event loop).
+    assert "litellm_parent_otel_span" not in result["metadata"]
+    # Original metadata must NOT be mutated — must carry the real span,
+    # not safe_deep_copy's temporary "placeholder" string.
     assert "is_silent_experiment" not in kwargs["metadata"]
     assert kwargs["metadata"]["litellm_parent_otel_span"] is mock_span
     assert kwargs["metadata"]["user_api_key_auth"] is mock_auth


### PR DESCRIPTION
https://github.com/BerriAI/litellm/pull/23209


### 🛠️ Bug Fix: Resolving Metadata Memory Collision in Silent Experiments

#### The Issue
There was a **Pass-by-Reference** bug occurring during the initialization of "Silent/Shadow" experiments. 

1. **The Failure**: `safe_deep_copy` attempts a `copy.deepcopy()` on the `kwargs` dictionary. However, the `metadata` field contains **OpenTelemetry (OTel) Span objects** and Pydantic models that are non-copyable.
2. **The Fallback**: When `deepcopy` fails, the function silently falls back to a basic assignment. This results in `silent_kwargs["metadata"]` pointing to the **exact same memory address** as the original `kwargs["metadata"]`.
3. **The Collision**: Because they shared the same dictionary object, when the silent task updated the model name:
   `silent_kwargs["metadata"]["model_group"] = "shadow-model"`
   It accidentally overwrote the primary request's model name as well. This is why Prometheus metrics showed the "Shadow" model for both the primary and silent calls.

#### The Fix
implemented an **Identity Check** (`is`) to detect if the fallback occurred. If both dictionaries share the same ID, we force a **Shallow Copy** using `dict()`.

```python
# Create a new dictionary container (New Memory ID)
# but keep the internal objects (Spans/Auth) as shared references.
silent_kwargs["metadata"] = dict(original_metadata)
```

**Total Request Metrics (2 separate rows):**

```
litellm_proxy_total_requests_metric_total{api_key_alias="haneef-proxy-test",client_ip="127.0.0.1",end_user="None",hashed_api_key="0352eae332464ce7f2e4e51a6319f252aa7b88f18e3ce91d5730c2f02d5d4aa4",model_id="nvidia-dynamo/openai/chipenmo-gpt-oss-120b",requested_model="nvidia-dynamo/openai/chipenmo-gpt-oss-120b",route="/v1/chat/completions",status_code="200",team="None",team_alias="None",user="None",user_agent="curl/8.7.1",user_email="None"} 1.0
litellm_proxy_total_requests_metric_total{api_key_alias="haneef-proxy-test",client_ip="127.0.0.1",end_user="None",hashed_api_key="0352eae332464ce7f2e4e51a6319f252aa7b88f18e3ce91d5730c2f02d5d4aa4",model_id="shadow-nvidia-dynamo-120b",requested_model="dynamo/openai/gpt-oss-120b-shadow",route="/v1/chat/completions",status_code="200",team="None",team_alias="None",user="None",user_agent="curl/8.7.1",user_email="None"} 1.0
```

**Latency Metrics (both models tracked separately):**

```
litellm_llm_api_latency_metric_count{api_key_alias="haneef-proxy-test",end_user="None",hashed_api_key="0352eae332464ce7f2e4e51a6319f252aa7b88f18e3ce91d5730c2f02d5d4aa4",model="qwen2.5:0.5b",model_id="nvidia-dynamo/openai/chipenmo-gpt-oss-120b",requested_model="nvidia-dynamo/openai/chipenmo-gpt-oss-120b",team="None",team_alias="None",user="None"} 1.0
litellm_llm_api_latency_metric_sum{api_key_alias="haneef-proxy-test",end_user="None",hashed_api_key="0352eae332464ce7f2e4e51a6319f252aa7b88f18e3ce91d5730c2f02d5d4aa4",model="qwen2.5:0.5b",model_id="nvidia-dynamo/openai/chipenmo-gpt-oss-120b",requested_model="nvidia-dynamo/openai/chipenmo-gpt-oss-120b",team="None",team_alias="None",user="None"} 1.044345
litellm_llm_api_latency_metric_count{api_key_alias="haneef-proxy-test",end_user="None",hashed_api_key="0352eae332464ce7f2e4e51a6319f252aa7b88f18e3ce91d5730c2f02d5d4aa4",model="qwen2.5:0.5b",model_id="shadow-nvidia-dynamo-120b",requested_model="dynamo/openai/gpt-oss-120b-shadow",team="None",team_alias="None",user="None"} 1.0
litellm_llm_api_latency_metric_sum{api_key_alias="haneef-proxy-test",end_user="None",hashed_api_key="0352eae332464ce7f2e4e51a6319f252aa7b88f18e3ce91d5730c2f02d5d4aa4",model="qwen2.5:0.5b",model_id="shadow-nvidia-dynamo-120b",requested_model="dynamo/openai/gpt-oss-120b-shadow",team="None",team_alias="None",user="None"} 1.044345
```

**All 3 bugs verified fixed:**
| Bug | Status |
|-----|--------|
| `requested_model` identical for primary & shadow | ✅ Fixed — different values |
| `model_id` identical for primary & shadow | ✅ Fixed — different IDs |
| `api_key_alias="None"` | ✅ Fixed — shows `"haneef-proxy-test"` |

**Config used:** `callbacks: ["prometheus", "otel"]`
