### PR TITLE
feat(mcp): support stateless and stateful clients via session-id routing

### DIFF
--- a/docs/my-website/blog/mcp_progress_notifications/index.md
+++ b/docs/my-website/blog/mcp_progress_notifications/index.md
@@ -46,7 +46,7 @@ LiteLLM now routes requests based on the `mcp-session-id` header and request met
 | Request with `mcp-session-id` | Stateful | Progress notifications work |
 | Other (no session) | Stateless | curl, Inspector work as before |
 
-No configuration required—routing is automatic.
+No configuration required-routing is automatic.
 
 ## Progress Flow
 

--- a/docs/my-website/blog/mcp_progress_notifications/index.md
+++ b/docs/my-website/blog/mcp_progress_notifications/index.md
@@ -1,0 +1,111 @@
+---
+slug: mcp_progress_notifications
+title: "MCP Progress Notifications: Stateless and Stateful Clients on LiteLLM"
+date: 2026-03-13T10:00:00
+authors:
+  - name: Sameer Kankute
+    title: SWE @ LiteLLM (LLM Translation)
+    url: https://www.linkedin.com/in/sameer-kankute/
+    image_url: https://pbs.twimg.com/profile_images/2001352686994907136/ONgNuSk5_400x400.jpg
+  - name: Krrish Dholakia
+    title: "CEO, LiteLLM"
+    url: https://www.linkedin.com/in/krish-d/
+    image_url: https://pbs.twimg.com/profile_images/1298587542745358340/DZv3Oj-h_400x400.jpg
+  - name: Ishaan Jaff
+    title: "CTO, LiteLLM"
+    url: https://www.linkedin.com/in/reffajnaahsi/
+    image_url: https://pbs.twimg.com/profile_images/1613813310264340481/lz54oEiB_400x400.jpg
+description: "LiteLLM now supports both stateless (curl, Inspector) and stateful (Claude Code, Cursor, VSCode) MCP clients on the same endpoint, with progress notifications for long-running tools."
+tags: [mcp, progress, streamable-http, cursor, vscode]
+hide_table_of_contents: false
+---
+
+LiteLLM Proxy's MCP Gateway now supports **both stateless and stateful Streamable HTTP clients** on the same endpoint. curl and MCP Inspector work without changes, while Claude Code, Cursor, and VSCode get session IDs and **progress notifications** for long-running tools.
+
+## Architecture
+
+![MCP Architecture: Stateless and Stateful routing](../../img/litellm_mcp_hybrid_routing_v2.svg)
+
+## The Problem
+
+Previously, LiteLLM used a single stateless session manager. That meant:
+
+- **curl, Inspector, Notion** - No session ID needed
+- **Progress notifications** - Silently failed (no session to push to)
+- **mcp-session-id** - Never returned to clients
+
+Stateful clients (IDEs) need sessions to receive `notifications/progress` during tool execution. Stateless clients don't. We needed both.
+
+## The Solution: Automatic Routing
+
+LiteLLM now routes requests based on the `mcp-session-id` header and request method:
+
+| Scenario | Route | Result |
+|----------|-------|--------|
+| `initialize` (no session) | Stateful | Client gets `mcp-session-id` |
+| Request with `mcp-session-id` | Stateful | Progress notifications work |
+| Other (no session) | Stateless | curl, Inspector work as before |
+
+No configuration required—routing is automatic.
+
+## Progress Flow
+
+![MCP Process flow](../../img/mcp_progress_sequence_v2.svg)
+
+## Quick Test
+
+**1. Initialize** - Get `mcp-session-id` from response headers.
+
+**2. Open GET channel (Terminal A)** - Connect with `Accept: text/event-stream` and `mcp-session-id`.
+
+**3. Call progress tool (Terminal B)** - POST `tools/call` with `_meta.progressToken`.
+
+Progress events stream in Terminal A while Terminal B waits for the final result.
+
+<details>
+<summary>Full code example</summary>
+
+```bash
+# 1. Initialize, get session ID
+SESSION_ID=$(curl -s -D - http://localhost:4000/mcp/progress_test \
+  -H "Content-Type: application/json" \
+  -H "x-litellm-api-key: Bearer sk-1234" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
+  | grep -i mcp-session-id | cut -d' ' -f2 | tr -d '\r')
+
+# 2. Open GET channel (Terminal A)
+curl -N http://localhost:4000/mcp/progress_test \
+  -H "Accept: text/event-stream" \
+  -H "x-litellm-api-key: Bearer sk-1234" \
+  -H "mcp-session-id: $SESSION_ID"
+
+# 3. Call progress tool (Terminal B)
+curl -N http://localhost:4000/mcp/progress_test \
+  -H "Content-Type: application/json" \
+  -H "x-litellm-api-key: Bearer sk-1234" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"progress_test-progress_tool","arguments":{"steps":3},"_meta":{"progressToken":"tok-123"}}}'
+```
+
+</details>
+
+<iframe width="740" height="500" src="https://www.loom.com/embed/8d83322e7b3247818f8b30e431d30049?autoplay=1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
+## Stale Sessions
+
+If LiteLLM restarts, clients may reconnect with an old `mcp-session-id`. LiteLLM strips the stale header and treats the request as a new connection—no 400 errors. For `initialize`, the client gets a fresh session ID.
+
+## FAQ
+
+**Q: When do I need to send `mcp-session-id`?**  
+A: Only if you want progress notifications. Stateless clients (curl, Inspector) can omit it and work as before.
+
+**Q: Do I need to configure stateless vs stateful routing?**  
+A: No. LiteLLM routes automatically based on the `mcp-session-id` header and whether the request is `initialize`.
+
+**Q: I'm not seeing progress events. What's wrong?**  
+A: Ensure you (1) call `initialize` first and capture the `mcp-session-id` from response headers, (2) open a GET connection with `Accept: text/event-stream` and the same session ID, and (3) include `_meta.progressToken` in your `tools/call` params.
+
+**Q: What happens if I use an old session ID after LiteLLM restarts?**  
+A: LiteLLM treats it as a new connection. Send `initialize` again to get a fresh session ID.
+

--- a/docs/my-website/docs/mcp_streamable_http.md
+++ b/docs/my-website/docs/mcp_streamable_http.md
@@ -1,0 +1,100 @@
+# Streamable HTTP: Stateless and Stateful Clients
+
+LiteLLM supports both **stateless** and **stateful** Streamable HTTP clients on the same endpoint. curl and MCP Inspector work without changes, while Claude Code, Cursor, and VSCode get session IDs and **progress notifications** for long-running tools.
+
+## Architecture
+
+![MCP Architecture: Stateless and Stateful routing](/img/litellm_mcp_hybrid_routing_v2.svg)
+
+## The Problem
+
+Previously, LiteLLM used a single stateless session manager. That meant:
+
+- **curl, Inspector, Notion** - No session ID needed
+- **Progress notifications** - Silently failed (no session to push to)
+- **mcp-session-id** - Never returned to clients
+
+Stateful clients (IDEs) need sessions to receive `notifications/progress` during tool execution. Stateless clients don't. We needed both.
+
+## The Solution: Automatic Routing
+
+LiteLLM now routes requests based on the `mcp-session-id` header and request method:
+
+| Scenario | Route | Result |
+|----------|-------|--------|
+| `initialize` (no session) | Stateful | Client gets `mcp-session-id` |
+| Request with `mcp-session-id` | Stateful | Progress notifications work |
+| Other (no session) | Stateless | curl, Inspector work as before |
+
+No configuration required—routing is automatic.
+
+## Progress Flow
+
+![MCP Progress Flow](/img/mcp_progress_sequence_v2.svg)
+
+## Quick Test
+
+**1. Initialize** - Get `mcp-session-id` from response headers.
+
+**2. Open GET channel (Terminal A)** - Connect with `Accept: text/event-stream` and `mcp-session-id`.
+
+**3. Call progress tool (Terminal B)** - POST `tools/call` with `_meta.progressToken`.
+
+Progress events stream in Terminal A while Terminal B waits for the final result.
+
+<details>
+<summary>Full code example</summary>
+
+```bash
+# 1. Initialize, get session ID
+SESSION_ID=$(curl -s -D - http://localhost:4000/mcp/progress_test \
+  -H "Content-Type: application/json" \
+  -H "x-litellm-api-key: Bearer sk-1234" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
+  | grep -i mcp-session-id | cut -d' ' -f2 | tr -d '\r')
+
+# 2. Open GET channel (Terminal A)
+curl -N http://localhost:4000/mcp/progress_test \
+  -H "Accept: text/event-stream" \
+  -H "x-litellm-api-key: Bearer sk-1234" \
+  -H "mcp-session-id: $SESSION_ID"
+
+# 3. Call progress tool (Terminal B)
+curl -N http://localhost:4000/mcp/progress_test \
+  -H "Content-Type: application/json" \
+  -H "x-litellm-api-key: Bearer sk-1234" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"progress_test-progress_tool","arguments":{"steps":3},"_meta":{"progressToken":"tok-123"}}}'
+```
+
+</details>
+
+<iframe width="840" height="500" src="https://www.loom.com/embed/8d83322e7b3247818f8b30e431d30049?autoplay=1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+
+## Stale Sessions
+
+If LiteLLM restarts, clients may reconnect with an old `mcp-session-id`. LiteLLM strips the stale header and treats the request as a new connection—no 400 errors. For `initialize`, the client gets a fresh session ID.
+
+## FAQ
+
+**Q: When do I need to send `mcp-session-id`?**
+
+Only if you want progress notifications. Stateless clients (curl, Inspector) can omit it and work as before.
+
+**Q: Do I need to configure stateless vs stateful routing?**
+
+No. LiteLLM routes automatically based on the `mcp-session-id` header and whether the request is `initialize`.
+
+**Q: I'm not seeing progress events. What's wrong?**
+
+Ensure you (1) call `initialize` first and capture the `mcp-session-id` from response headers, (2) open a GET connection with `Accept: text/event-stream` and the same session ID, and (3) include `_meta.progressToken` in your `tools/call` params.
+
+**Q: What happens if I use an old session ID after LiteLLM restarts?**
+
+LiteLLM treats it as a new connection. Send `initialize` again to get a fresh session ID.
+
+## Learn More
+
+- [MCP Overview](/docs/mcp) — Full MCP docs
+- [MCP Progress Notifications blog post](/blog/mcp_progress_notifications) — Deeper dive with architecture
+- [MCP Troubleshooting](/docs/mcp_troubleshoot) — Debug connectivity issues

--- a/docs/my-website/img/litellm_mcp_hybrid_routing_v2.svg
+++ b/docs/my-website/img/litellm_mcp_hybrid_routing_v2.svg
@@ -1,0 +1,79 @@
+<svg width="100%" viewBox="0 0 680 420" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#888" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arr-dash" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#aaa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    </style>
+  </defs>
+
+  <!-- ── Clients ── -->
+  <rect x="30" y="80" width="140" height="40" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="100" y="105" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">curl / Inspector</text>
+
+  <rect x="30" y="290" width="140" height="40" rx="8" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="100" y="315" text-anchor="middle" font-size="13" font-weight="500" fill="#26215C">VSCode / Cursor</text>
+
+  <!-- ── LiteLLM proxy dashed border ── -->
+  <rect x="235" y="55" width="210" height="310" rx="12" fill="none" stroke="#ccc" stroke-width="1" stroke-dasharray="5 4"/>
+  <text x="340" y="42" text-anchor="middle" font-size="11" fill="#888">LiteLLM proxy</text>
+
+  <!-- ── Router ── -->
+  <rect x="260" y="170" width="160" height="40" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="340" y="195" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Request router</text>
+
+  <!-- ── Stateless manager ── -->
+  <rect x="252" y="255" width="176" height="52" rx="8" fill="#E1F5EE" stroke="#5DCAA5" stroke-width="1"/>
+  <text x="340" y="276" text-anchor="middle" font-size="13" font-weight="500" fill="#085041">Stateless manager</text>
+  <text x="340" y="295" text-anchor="middle" font-size="11" fill="#0F6E56">no session ID</text>
+
+  <!-- ── Stateful manager ── -->
+  <rect x="252" y="330" width="176" height="52" rx="8" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="340" y="351" text-anchor="middle" font-size="13" font-weight="500" fill="#26215C">Stateful manager</text>
+  <text x="340" y="370" text-anchor="middle" font-size="11" fill="#534AB7">issues mcp-session-id</text>
+
+  <!-- ── Backend ── -->
+  <rect x="510" y="275" width="140" height="40" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="580" y="300" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Backend MCP</text>
+
+  <!-- ── Arrows ── -->
+
+  <!-- curl → router -->
+  <path d="M170 100 L215 100 L215 190 L258 190" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- VSCode → router -->
+  <path d="M170 310 L215 310 L215 200 L258 200" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- router → stateless -->
+  <line x1="340" y1="210" x2="340" y2="253" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="355" y="236" font-size="11" fill="#555">no session ID</text>
+
+  <!-- router → stateful (right side detour) -->
+  <path d="M420 190 L455 190 L455 356 L430 356" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="458" y="255" font-size="11" fill="#555">initialize or</text>
+  <text x="458" y="270" font-size="11" fill="#555">has session ID</text>
+
+  <!-- stateless → backend -->
+  <line x1="428" y1="281" x2="508" y2="291" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- stateful → backend -->
+  <path d="M428 356 L468 356 L468 315 L508 305" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- backend → stateful: progress (dashed) -->
+  <path d="M510 310 L468 310 L468 330 L430 348" fill="none" stroke="#aaa" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-dash)"/>
+  <text x="472" y="325" font-size="11" fill="#888">progress</text>
+
+  <!-- stateful → VSCode: session ID (dashed) -->
+  <path d="M252 356 L205 356 L205 330 L170 330" fill="none" stroke="#aaa" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-dash)"/>
+  <text x="100" y="375" text-anchor="middle" font-size="11" fill="#888">mcp-session-id</text>
+
+  <!-- Legend -->
+  <line x1="30" y1="408" x2="55" y2="408" stroke="#888" stroke-width="1.5"/>
+  <text x="60" y="412" font-size="11" fill="#555">request</text>
+  <line x1="130" y1="408" x2="155" y2="408" stroke="#aaa" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="160" y="412" font-size="11" fill="#555">response / notification</text>
+</svg>

--- a/docs/my-website/img/mcp_progress_sequence_v2.svg
+++ b/docs/my-website/img/mcp_progress_sequence_v2.svg
@@ -1,0 +1,86 @@
+<svg width="100%" viewBox="0 0 680 520" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arr-d" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#7B68EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+
+  <!-- Column headers -->
+  <rect x="20"  y="20" width="120" height="36" rx="8" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="80"  y="43" text-anchor="middle" font-size="13" font-weight="500" fill="#26215C">Client</text>
+
+  <rect x="270" y="20" width="140" height="36" rx="8" fill="#E1F5EE" stroke="#5DCAA5" stroke-width="1"/>
+  <text x="340" y="43" text-anchor="middle" font-size="13" font-weight="500" fill="#085041">LiteLLM proxy</text>
+
+  <rect x="530" y="20" width="130" height="36" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="595" y="43" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Backend MCP</text>
+
+  <!-- Lifelines -->
+  <line x1="80"  y1="56" x2="80"  y2="510" stroke="#ddd" stroke-width="1" stroke-dasharray="4 3"/>
+  <line x1="340" y1="56" x2="340" y2="510" stroke="#ddd" stroke-width="1" stroke-dasharray="4 3"/>
+  <line x1="595" y1="56" x2="595" y2="510" stroke="#ddd" stroke-width="1" stroke-dasharray="4 3"/>
+
+  <!-- 1: initialize -->
+  <line x1="80" y1="95" x2="335" y2="95" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="88" text-anchor="middle" font-size="11" fill="#333">POST initialize</text>
+  <line x1="340" y1="108" x2="85" y2="108" stroke="#aaa" stroke-width="1" stroke-dasharray="3 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="122" text-anchor="middle" font-size="11" fill="#7B68EE">← mcp-session-id: abc123</text>
+
+  <!-- 2: GET SSE channel — shown as thick persistent bar -->
+  <line x1="80" y1="150" x2="335" y2="150" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="143" text-anchor="middle" font-size="11" fill="#333">GET /mcp  (mcp-session-id: abc123)</text>
+
+  <!-- SSE channel open band -->
+  <rect x="68" y="158" width="24" height="230" rx="4" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="80" y="278" text-anchor="middle" font-size="9" fill="#534AB7" transform="rotate(-90,80,278)">SSE channel open</text>
+  <rect x="328" y="158" width="24" height="230" rx="4" fill="#E1F5EE" stroke="#5DCAA5" stroke-width="1"/>
+
+  <!-- 3: tools/call POST -->
+  <line x1="92" y1="200" x2="328" y2="200" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="193" text-anchor="middle" font-size="11" fill="#333">POST tools/call + progressToken</text>
+  <line x1="352" y1="213" x2="528" y2="213" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="440" y="206" text-anchor="middle" font-size="11" fill="#333">forward tools/call</text>
+
+  <!-- backend running -->
+  <text x="595" y="245" text-anchor="middle" font-size="10" fill="#aaa">running...</text>
+
+  <!-- progress 1/3 -->
+  <line x1="528" y1="258" x2="354" y2="258" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="440" y="251" text-anchor="middle" font-size="11" fill="#7B68EE">progress 1/3</text>
+  <line x1="328" y1="268" x2="92" y2="268" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="261" text-anchor="middle" font-size="11" fill="#7B68EE">notifications/progress {1, 3}</text>
+
+  <!-- progress 2/3 -->
+  <line x1="528" y1="300" x2="354" y2="300" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="440" y="293" text-anchor="middle" font-size="11" fill="#7B68EE">progress 2/3</text>
+  <line x1="328" y1="310" x2="92" y2="310" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="303" text-anchor="middle" font-size="11" fill="#7B68EE">notifications/progress {2, 3}</text>
+
+  <!-- progress 3/3 -->
+  <line x1="528" y1="342" x2="354" y2="342" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="440" y="335" text-anchor="middle" font-size="11" fill="#7B68EE">progress 3/3</text>
+  <line x1="328" y1="352" x2="92" y2="352" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="345" text-anchor="middle" font-size="11" fill="#7B68EE">notifications/progress {3, 3}</text>
+
+  <!-- SSE channel close -->
+  <line x1="68" y1="388" x2="92" y2="388" stroke="#AFA9EC" stroke-width="1"/>
+  <line x1="328" y1="388" x2="352" y2="388" stroke="#5DCAA5" stroke-width="1"/>
+
+  <!-- final result -->
+  <line x1="528" y1="410" x2="354" y2="410" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="440" y="403" text-anchor="middle" font-size="11" fill="#333">tool result</text>
+  <line x1="328" y1="423" x2="92" y2="423" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="416" text-anchor="middle" font-size="11" fill="#333">POST response: final result</text>
+
+  <!-- Legend -->
+  <line x1="30" y1="500" x2="52" y2="500" stroke="#555" stroke-width="1.5"/>
+  <text x="57" y="504" font-size="11" fill="#555">request / result</text>
+  <line x1="175" y1="500" x2="197" y2="500" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="202" y="504" font-size="11" fill="#7B68EE">progress notification</text>
+  <rect x="380" y="492" width="12" height="14" rx="2" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="397" y="504" font-size="11" fill="#534AB7">SSE channel</text>
+</svg>

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -613,6 +613,7 @@ const sidebars = {
           label: "/mcp - Model Context Protocol",
           items: [
             "mcp",
+            "mcp_streamable_http",
             "mcp_usage",
             "mcp_openapi",
             "mcp_oauth",

--- a/docs/my-website/static/img/litellm_mcp_hybrid_routing_v2.svg
+++ b/docs/my-website/static/img/litellm_mcp_hybrid_routing_v2.svg
@@ -1,0 +1,79 @@
+<svg width="100%" viewBox="0 0 680 420" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#888" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arr-dash" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#aaa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    </style>
+  </defs>
+
+  <!-- ── Clients ── -->
+  <rect x="30" y="80" width="140" height="40" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="100" y="105" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">curl / Inspector</text>
+
+  <rect x="30" y="290" width="140" height="40" rx="8" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="100" y="315" text-anchor="middle" font-size="13" font-weight="500" fill="#26215C">VSCode / Cursor</text>
+
+  <!-- ── LiteLLM proxy dashed border ── -->
+  <rect x="235" y="55" width="210" height="310" rx="12" fill="none" stroke="#ccc" stroke-width="1" stroke-dasharray="5 4"/>
+  <text x="340" y="42" text-anchor="middle" font-size="11" fill="#888">LiteLLM proxy</text>
+
+  <!-- ── Router ── -->
+  <rect x="260" y="170" width="160" height="40" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="340" y="195" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Request router</text>
+
+  <!-- ── Stateless manager ── -->
+  <rect x="252" y="255" width="176" height="52" rx="8" fill="#E1F5EE" stroke="#5DCAA5" stroke-width="1"/>
+  <text x="340" y="276" text-anchor="middle" font-size="13" font-weight="500" fill="#085041">Stateless manager</text>
+  <text x="340" y="295" text-anchor="middle" font-size="11" fill="#0F6E56">no session ID</text>
+
+  <!-- ── Stateful manager ── -->
+  <rect x="252" y="330" width="176" height="52" rx="8" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="340" y="351" text-anchor="middle" font-size="13" font-weight="500" fill="#26215C">Stateful manager</text>
+  <text x="340" y="370" text-anchor="middle" font-size="11" fill="#534AB7">issues mcp-session-id</text>
+
+  <!-- ── Backend ── -->
+  <rect x="510" y="275" width="140" height="40" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="580" y="300" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Backend MCP</text>
+
+  <!-- ── Arrows ── -->
+
+  <!-- curl → router -->
+  <path d="M170 100 L215 100 L215 190 L258 190" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- VSCode → router -->
+  <path d="M170 310 L215 310 L215 200 L258 200" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- router → stateless -->
+  <line x1="340" y1="210" x2="340" y2="253" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="355" y="236" font-size="11" fill="#555">no session ID</text>
+
+  <!-- router → stateful (right side detour) -->
+  <path d="M420 190 L455 190 L455 356 L430 356" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="458" y="255" font-size="11" fill="#555">initialize or</text>
+  <text x="458" y="270" font-size="11" fill="#555">has session ID</text>
+
+  <!-- stateless → backend -->
+  <line x1="428" y1="281" x2="508" y2="291" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- stateful → backend -->
+  <path d="M428 356 L468 356 L468 315 L508 305" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- backend → stateful: progress (dashed) -->
+  <path d="M510 310 L468 310 L468 330 L430 348" fill="none" stroke="#aaa" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-dash)"/>
+  <text x="472" y="325" font-size="11" fill="#888">progress</text>
+
+  <!-- stateful → VSCode: session ID (dashed) -->
+  <path d="M252 356 L205 356 L205 330 L170 330" fill="none" stroke="#aaa" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-dash)"/>
+  <text x="100" y="375" text-anchor="middle" font-size="11" fill="#888">mcp-session-id</text>
+
+  <!-- Legend -->
+  <line x1="30" y1="408" x2="55" y2="408" stroke="#888" stroke-width="1.5"/>
+  <text x="60" y="412" font-size="11" fill="#555">request</text>
+  <line x1="130" y1="408" x2="155" y2="408" stroke="#aaa" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="160" y="412" font-size="11" fill="#555">response / notification</text>
+</svg>

--- a/docs/my-website/static/img/mcp_progress_sequence_v2.svg
+++ b/docs/my-website/static/img/mcp_progress_sequence_v2.svg
@@ -1,0 +1,86 @@
+<svg width="100%" viewBox="0 0 680 520" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#555" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="arr-d" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="#7B68EE" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+
+  <!-- Column headers -->
+  <rect x="20"  y="20" width="120" height="36" rx="8" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="80"  y="43" text-anchor="middle" font-size="13" font-weight="500" fill="#26215C">Client</text>
+
+  <rect x="270" y="20" width="140" height="36" rx="8" fill="#E1F5EE" stroke="#5DCAA5" stroke-width="1"/>
+  <text x="340" y="43" text-anchor="middle" font-size="13" font-weight="500" fill="#085041">LiteLLM proxy</text>
+
+  <rect x="530" y="20" width="130" height="36" rx="8" fill="#F1EFE8" stroke="#B4B2A9" stroke-width="1"/>
+  <text x="595" y="43" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Backend MCP</text>
+
+  <!-- Lifelines -->
+  <line x1="80"  y1="56" x2="80"  y2="510" stroke="#ddd" stroke-width="1" stroke-dasharray="4 3"/>
+  <line x1="340" y1="56" x2="340" y2="510" stroke="#ddd" stroke-width="1" stroke-dasharray="4 3"/>
+  <line x1="595" y1="56" x2="595" y2="510" stroke="#ddd" stroke-width="1" stroke-dasharray="4 3"/>
+
+  <!-- 1: initialize -->
+  <line x1="80" y1="95" x2="335" y2="95" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="88" text-anchor="middle" font-size="11" fill="#333">POST initialize</text>
+  <line x1="340" y1="108" x2="85" y2="108" stroke="#aaa" stroke-width="1" stroke-dasharray="3 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="122" text-anchor="middle" font-size="11" fill="#7B68EE">← mcp-session-id: abc123</text>
+
+  <!-- 2: GET SSE channel — shown as thick persistent bar -->
+  <line x1="80" y1="150" x2="335" y2="150" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="143" text-anchor="middle" font-size="11" fill="#333">GET /mcp  (mcp-session-id: abc123)</text>
+
+  <!-- SSE channel open band -->
+  <rect x="68" y="158" width="24" height="230" rx="4" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="80" y="278" text-anchor="middle" font-size="9" fill="#534AB7" transform="rotate(-90,80,278)">SSE channel open</text>
+  <rect x="328" y="158" width="24" height="230" rx="4" fill="#E1F5EE" stroke="#5DCAA5" stroke-width="1"/>
+
+  <!-- 3: tools/call POST -->
+  <line x1="92" y1="200" x2="328" y2="200" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="193" text-anchor="middle" font-size="11" fill="#333">POST tools/call + progressToken</text>
+  <line x1="352" y1="213" x2="528" y2="213" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="440" y="206" text-anchor="middle" font-size="11" fill="#333">forward tools/call</text>
+
+  <!-- backend running -->
+  <text x="595" y="245" text-anchor="middle" font-size="10" fill="#aaa">running...</text>
+
+  <!-- progress 1/3 -->
+  <line x1="528" y1="258" x2="354" y2="258" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="440" y="251" text-anchor="middle" font-size="11" fill="#7B68EE">progress 1/3</text>
+  <line x1="328" y1="268" x2="92" y2="268" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="261" text-anchor="middle" font-size="11" fill="#7B68EE">notifications/progress {1, 3}</text>
+
+  <!-- progress 2/3 -->
+  <line x1="528" y1="300" x2="354" y2="300" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="440" y="293" text-anchor="middle" font-size="11" fill="#7B68EE">progress 2/3</text>
+  <line x1="328" y1="310" x2="92" y2="310" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="303" text-anchor="middle" font-size="11" fill="#7B68EE">notifications/progress {2, 3}</text>
+
+  <!-- progress 3/3 -->
+  <line x1="528" y1="342" x2="354" y2="342" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="440" y="335" text-anchor="middle" font-size="11" fill="#7B68EE">progress 3/3</text>
+  <line x1="328" y1="352" x2="92" y2="352" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr-d)"/>
+  <text x="205" y="345" text-anchor="middle" font-size="11" fill="#7B68EE">notifications/progress {3, 3}</text>
+
+  <!-- SSE channel close -->
+  <line x1="68" y1="388" x2="92" y2="388" stroke="#AFA9EC" stroke-width="1"/>
+  <line x1="328" y1="388" x2="352" y2="388" stroke="#5DCAA5" stroke-width="1"/>
+
+  <!-- final result -->
+  <line x1="528" y1="410" x2="354" y2="410" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="440" y="403" text-anchor="middle" font-size="11" fill="#333">tool result</text>
+  <line x1="328" y1="423" x2="92" y2="423" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="205" y="416" text-anchor="middle" font-size="11" fill="#333">POST response: final result</text>
+
+  <!-- Legend -->
+  <line x1="30" y1="500" x2="52" y2="500" stroke="#555" stroke-width="1.5"/>
+  <text x="57" y="504" font-size="11" fill="#555">request / result</text>
+  <line x1="175" y1="500" x2="197" y2="500" stroke="#7B68EE" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="202" y="504" font-size="11" fill="#7B68EE">progress notification</text>
+  <rect x="380" y="492" width="12" height="14" rx="2" fill="#EEEDFE" stroke="#AFA9EC" stroke-width="1"/>
+  <text x="397" y="504" font-size="11" fill="#534AB7">SSE channel</text>
+</svg>

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -5,6 +5,7 @@ LiteLLM MCP Server Routes
 
 import asyncio
 import contextlib
+import json
 import time
 import traceback
 import uuid
@@ -180,12 +181,22 @@ if MCP_AVAILABLE:
     sse: SseServerTransport = SseServerTransport("/mcp/sse/messages")
 
     # Create session managers
-    session_manager = StreamableHTTPSessionManager(
+    session_manager_stateless = StreamableHTTPSessionManager(
         app=server,
         event_store=None,
         json_response=False,  # enables SSE streaming
         stateless=True,
     )
+
+    session_manager_stateful = StreamableHTTPSessionManager(
+        app=server,
+        event_store=None,  # TODO: Add EventStore for reconnection/event replay if needed
+        json_response=False,  # enables SSE streaming
+        stateless=False,
+    )
+
+    # Keep this alias so existing references to session_manager still work
+    session_manager = session_manager_stateless
 
     # Create SSE session manager
     sse_session_manager = StreamableHTTPSessionManager(
@@ -197,11 +208,12 @@ if MCP_AVAILABLE:
 
     # Context managers for proper lifecycle management
     _session_manager_cm = None
+    _session_manager_stateful_cm = None
     _sse_session_manager_cm = None
 
     async def initialize_session_managers():
         """Initialize the session managers. Can be called from main app lifespan."""
-        global _SESSION_MANAGERS_INITIALIZED, _session_manager_cm, _sse_session_manager_cm
+        global _SESSION_MANAGERS_INITIALIZED, _session_manager_cm, _session_manager_stateful_cm, _sse_session_manager_cm
 
         # Use async lock to prevent concurrent initialization
         async with _INITIALIZATION_LOCK:
@@ -211,11 +223,13 @@ if MCP_AVAILABLE:
             verbose_logger.info("Initializing MCP session managers...")
 
             # Start the session managers with context managers
-            _session_manager_cm = session_manager.run()
+            _session_manager_cm = session_manager_stateless.run()
+            _session_manager_stateful_cm = session_manager_stateful.run()
             _sse_session_manager_cm = sse_session_manager.run()
 
             # Enter the context managers
             await _session_manager_cm.__aenter__()
+            await _session_manager_stateful_cm.__aenter__()
             await _sse_session_manager_cm.__aenter__()
 
             _SESSION_MANAGERS_INITIALIZED = True
@@ -225,7 +239,7 @@ if MCP_AVAILABLE:
 
     async def shutdown_session_managers():
         """Shutdown the session managers."""
-        global _SESSION_MANAGERS_INITIALIZED, _session_manager_cm, _sse_session_manager_cm
+        global _SESSION_MANAGERS_INITIALIZED, _session_manager_cm, _session_manager_stateful_cm, _sse_session_manager_cm
 
         if _SESSION_MANAGERS_INITIALIZED:
             verbose_logger.info("Shutting down MCP session managers...")
@@ -233,12 +247,15 @@ if MCP_AVAILABLE:
             try:
                 if _session_manager_cm:
                     await _session_manager_cm.__aexit__(None, None, None)
+                if _session_manager_stateful_cm:
+                    await _session_manager_stateful_cm.__aexit__(None, None, None)
                 if _sse_session_manager_cm:
                     await _sse_session_manager_cm.__aexit__(None, None, None)
             except Exception as e:
                 verbose_logger.exception(f"Error during session manager shutdown: {e}")
 
             _session_manager_cm = None
+            _session_manager_stateful_cm = None
             _sse_session_manager_cm = None
             _SESSION_MANAGERS_INITIALIZED = False
 
@@ -304,7 +321,7 @@ if MCP_AVAILABLE:
 
     @server.call_tool()
     async def mcp_server_tool_call(
-        name: str, arguments: Dict[str, Any] | None
+        name: str, arguments: Optional[Dict[str, Any]]
     ) -> CallToolResult:
         """
         Call a specific tool with the provided arguments
@@ -347,7 +364,7 @@ if MCP_AVAILABLE:
                 if host_token and hasattr(host_ctx, "session") and host_ctx.session:
                     host_session = host_ctx.session
 
-                    async def forward_progress(progress: float, total: float | None):
+                    async def forward_progress(progress: float, total: Optional[float]):
                         """Forward progress notifications from external MCP to Host"""
                         try:
                             await host_session.send_progress_notification(
@@ -489,7 +506,7 @@ if MCP_AVAILABLE:
 
     @server.get_prompt()
     async def get_prompt(
-        name: str, arguments: dict[str, str] | None
+        name: str, arguments: Optional[Dict[str, str]]
     ) -> GetPromptResult:
         """
         Get a specific prompt with the provided arguments
@@ -2270,6 +2287,33 @@ if MCP_AVAILABLE:
             raw_headers,
         )
 
+    def _get_session_id_from_scope(scope: Scope) -> Optional[str]:
+        """
+        Extract mcp-session-id from ASGI scope headers.
+        Returns None if not present.
+        """
+        for header_name, header_value in scope.get("headers", []):
+            name = header_name if isinstance(header_name, bytes) else header_name.encode()
+            if name.lower() == b"mcp-session-id":
+                return header_value.decode() if isinstance(header_value, bytes) else str(header_value)
+        return None
+
+    def _is_initialize_request(body: bytes) -> bool:
+        """
+        Check if the request body is a JSON-RPC initialize method.
+        Returns True if method is "initialize", False otherwise or on parse error.
+
+        Note: Assumes the body fits in a single ASGI receive() chunk. MCP initialize
+        requests are typically small; large chunked bodies may not be fully parsed.
+        """
+        if not body:
+            return False
+        try:
+            data = json.loads(body)
+            return data.get("method") == "initialize"
+        except (json.JSONDecodeError, TypeError):
+            return False
+
     async def _handle_stale_mcp_session(
         scope: Scope,
         receive: Receive,
@@ -2432,16 +2476,54 @@ if MCP_AVAILABLE:
                 # Give it a moment to start up
                 await asyncio.sleep(0.1)
 
+            # Route based on mcp-session-id and request method:
+            # - Has session ID → stateful (Claude Code, Cursor, VSCode)
+            # - No session ID + initialize → stateful (so client gets mcp-session-id)
+            # - No session ID + other → stateless (curl, Inspector, Notion)
+            session_id = _get_session_id_from_scope(scope)
+            is_initialize = False
+            first_msg = None
+
+            if scope.get("method") == "POST" and not session_id:
+                # Peek at first chunk to detect initialize (assumes body fits in one chunk)
+                first_msg = await receive()
+                body = first_msg.get("body", b"") or b""
+                is_initialize = _is_initialize_request(body)
+
+            use_stateful = bool(session_id or is_initialize)
+            target_manager = (
+                session_manager_stateful if use_stateful else session_manager_stateless
+            )
+
+            verbose_logger.debug(
+                f"MCP routing to {'stateful' if use_stateful else 'stateless'} manager"
+                + (f" (session={session_id[:8]}...)" if session_id else "")
+                + (" (initialize)" if is_initialize else "")
+            )
+
+            # Replay first message if we consumed it for peeking
+            original_receive = receive
+            if first_msg is not None:
+
+                async def wrapped_receive():
+                    nonlocal first_msg
+                    if first_msg is not None:
+                        msg, first_msg = first_msg, None
+                        return msg
+                    return await original_receive()
+
+                receive = wrapped_receive
+
             # Handle stale session IDs - either strip them for reconnection
             # or return success for idempotent DELETE operations
             handled = await _handle_stale_mcp_session(
-                scope, receive, send, session_manager
+                scope, receive, send, target_manager
             )
             if handled:
                 # Request was fully handled (e.g., DELETE on non-existent session)
                 return
 
-            await session_manager.handle_request(scope, receive, send)
+            await target_manager.handle_request(scope, receive, send)
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -720,17 +720,21 @@ async def test_concurrent_initialize_session_managers():
     # Reset state before test
     original_initialized = mcp_server._SESSION_MANAGERS_INITIALIZED
     original_session_cm = mcp_server._session_manager_cm
+    original_session_stateful_cm = mcp_server._session_manager_stateful_cm
     original_sse_session_cm = mcp_server._sse_session_manager_cm
 
     try:
         mcp_server._SESSION_MANAGERS_INITIALIZED = False
         mcp_server._session_manager_cm = None
+        mcp_server._session_manager_stateful_cm = None
         mcp_server._sse_session_manager_cm = None
 
         # Mock the session managers to avoid actual MCP initialization
         with patch(
-            "litellm.proxy._experimental.mcp_server.server.session_manager"
-        ) as mock_session_manager, patch(
+            "litellm.proxy._experimental.mcp_server.server.session_manager_stateless"
+        ) as mock_session_manager_stateless, patch(
+            "litellm.proxy._experimental.mcp_server.server.session_manager_stateful"
+        ) as mock_session_manager_stateful, patch(
             "litellm.proxy._experimental.mcp_server.server.sse_session_manager"
         ) as mock_sse_session_manager, patch(
             "litellm.proxy._experimental.mcp_server.server.verbose_logger"
@@ -740,7 +744,8 @@ async def test_concurrent_initialize_session_managers():
             mock_cm.__aenter__ = AsyncMock()
             mock_cm.__aexit__ = AsyncMock()
 
-            mock_session_manager.run.return_value = mock_cm
+            mock_session_manager_stateless.run.return_value = mock_cm
+            mock_session_manager_stateful.run.return_value = mock_cm
             mock_sse_session_manager.run.return_value = mock_cm
 
             # Create multiple concurrent tasks that call initialize_session_managers
@@ -757,18 +762,21 @@ async def test_concurrent_initialize_session_managers():
                 result == "success" for result in results
             ), f"Some tasks failed: {results}"
 
-            # session_manager.run() should only be called once due to the lock
+            # Each session manager.run() should only be called once due to the lock
             assert (
-                mock_session_manager.run.call_count == 1
-            ), f"Expected 1 call to session_manager.run(), got {mock_session_manager.run.call_count}"
+                mock_session_manager_stateless.run.call_count == 1
+            ), f"Expected 1 call to session_manager_stateless.run(), got {mock_session_manager_stateless.run.call_count}"
+            assert (
+                mock_session_manager_stateful.run.call_count == 1
+            ), f"Expected 1 call to session_manager_stateful.run(), got {mock_session_manager_stateful.run.call_count}"
             assert (
                 mock_sse_session_manager.run.call_count == 1
             ), f"Expected 1 call to sse_session_manager.run(), got {mock_sse_session_manager.run.call_count}"
 
-            # The context managers should only be entered once each
+            # The context managers should only be entered once each (3 managers)
             assert (
-                mock_cm.__aenter__.call_count == 2
-            ), f"Expected 2 calls to __aenter__ (one for each session manager), got {mock_cm.__aenter__.call_count}"
+                mock_cm.__aenter__.call_count == 3
+            ), f"Expected 3 calls to __aenter__ (one per session manager), got {mock_cm.__aenter__.call_count}"
 
             # State should be properly set
             assert mcp_server._SESSION_MANAGERS_INITIALIZED is True
@@ -777,30 +785,127 @@ async def test_concurrent_initialize_session_managers():
         # Restore original state
         mcp_server._SESSION_MANAGERS_INITIALIZED = original_initialized
         mcp_server._session_manager_cm = original_session_cm
+        mcp_server._session_manager_stateful_cm = original_session_stateful_cm
         mcp_server._sse_session_manager_cm = original_sse_session_cm
 
 
 @pytest.mark.asyncio
 async def test_streamable_http_session_manager_is_stateless():
     """
-    Test that the StreamableHTTPSessionManager is initialized with stateless=True.
+    Test that the StreamableHTTPSessionManager is initialized with both stateless and stateful managers.
 
     Regression test for GitHub issue #20242 / PR #19809.
     When stateless=False, the mcp library rejects non-initialize requests
     that lack an mcp-session-id header, breaking clients like MCP Inspector,
     curl, and any HTTP client without automatic session management.
+    
+    Now we support both:
+    - stateless manager for clients without session IDs (curl, Inspector)
+    - stateful manager for clients with session IDs (Claude Code, Cursor, VSCode)
     """
     try:
-        from litellm.proxy._experimental.mcp_server.server import session_manager
+        from litellm.proxy._experimental.mcp_server.server import (
+            session_manager_stateful,
+            session_manager_stateless,
+        )
     except ImportError:
         pytest.skip("MCP server not available")
 
-    # The session manager must be stateless to avoid requiring mcp-session-id
+    # The stateless session manager must be stateless to avoid requiring mcp-session-id
     # on every request. This was regressed by PR #19809 (stateless=True -> False).
-    assert session_manager.stateless is True, (
-        "StreamableHTTPSessionManager must be initialized with stateless=True. "
+    assert session_manager_stateless.stateless is True, (
+        "session_manager_stateless must be initialized with stateless=True. "
         "stateless=False breaks MCP clients that don't manage session IDs. "
         "See: https://github.com/BerriAI/litellm/issues/20242"
+    )
+
+    # The stateful session manager must be stateful to support progress notifications
+    assert session_manager_stateful.stateless is False, (
+        "session_manager_stateful must be initialized with stateless=False. "
+        "stateless=True breaks progress notifications for clients that manage session IDs."
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_routing_initialize_to_stateful_no_session_to_stateless():
+    """
+    Test that routing correctly sends:
+    - initialize (no mcp-session-id) → stateful manager (so client gets mcp-session-id)
+    - tools/list (no mcp-session-id) → stateless manager (curl, Inspector)
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+            session_manager_stateful,
+            session_manager_stateless,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    async def make_request(method_body: bytes, path: str = "/mcp/progress_test"):
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"authorization", b"Bearer test-key"),
+            ],
+        }
+        receive = AsyncMock(return_value={"type": "http.request", "body": method_body, "more_body": False})
+        send = AsyncMock()
+
+        stateless_called = []
+        stateful_called = []
+
+        async def stateless_handle(s, r, se):
+            stateless_called.append(1)
+
+        async def stateful_handle(s, r, se):
+            stateful_called.append(1)
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+            new_callable=AsyncMock,
+            return_value=(MagicMock(), None, ["progress_test"], None, None, None),
+        ), patch(
+            "litellm.proxy._experimental.mcp_server.server.set_auth_context",
+        ), patch(
+            "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+            True,
+        ), patch.object(
+            session_manager_stateless,
+            "handle_request",
+            side_effect=stateless_handle,
+        ), patch.object(
+            session_manager_stateful,
+            "handle_request",
+            side_effect=stateful_handle,
+        ), patch.object(
+            session_manager_stateless,
+            "_server_instances",
+            {},
+        ), patch.object(
+            session_manager_stateful,
+            "_server_instances",
+            {},
+        ):
+            await handle_streamable_http_mcp(scope, receive, send)
+
+        return bool(stateless_called), bool(stateful_called)
+
+    # initialize → stateful
+    init_body = b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}'
+    stateless_called, stateful_called = await make_request(init_body)
+    assert stateful_called and not stateless_called, (
+        "initialize (no session) should route to stateful, not stateless"
+    )
+
+    # tools/list → stateless
+    tools_body = b'{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+    stateless_called, stateful_called = await make_request(tools_body)
+    assert stateless_called and not stateful_called, (
+        "tools/list (no session) should route to stateless, not stateful"
     )
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
@@ -7,8 +7,9 @@ they may send a stale `mcp-session-id` header. This test verifies that:
 2. For DELETE requests: idempotent behavior returns success even if session doesn't exist
 """
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 class TestHandleStaleMcpSession:
@@ -326,7 +327,7 @@ async def test_valid_mcp_session_id_is_preserved():
     try:
         from litellm.proxy._experimental.mcp_server.server import (
             handle_streamable_http_mcp,
-            session_manager,
+            session_manager_stateful,
         )
     except ImportError:
         pytest.skip("MCP server not available")
@@ -352,7 +353,7 @@ async def test_valid_mcp_session_id_is_preserved():
     async def mock_handle_request(s, r, se):
         captured_scope.update(s)
 
-    # Session manager HAS this session
+    # Stateful session manager HAS this session (requests with mcp-session-id route there)
     mock_instances = {valid_session_id: MagicMock()}
 
     with patch(
@@ -365,11 +366,11 @@ async def test_valid_mcp_session_id_is_preserved():
         "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
         True,
     ), patch.object(
-        session_manager,
+        session_manager_stateful,
         "handle_request",
         side_effect=mock_handle_request,
     ), patch.object(
-        session_manager,
+        session_manager_stateful,
         "_server_instances",
         mock_instances,
     ):


### PR DESCRIPTION
## Summary
Support both stateless (curl, Inspector) and stateful (Claude Code, Cursor, VSCode) MCP clients simultaneously by routing based on `mcp-session-id` header and request method.

Fixes LIT-2196

## Changes
- Add `session_manager_stateful` (stateless=False) alongside stateless manager
- Route: has session ID → stateful; initialize (no ID) → stateful; else → stateless
- Peek POST body to detect initialize for routing; replay via wrapped receive
- Handle stale session IDs for both managers
- Add `test_mcp_routing_initialize_to_stateful_no_session_to_stateless`
- Update `test_valid_mcp_session_id_is_preserved`, `test_concurrent_initialize_session_managers`

## Why
- stateless=True: curl/Inspector work ✅
- stateless=False: progress notifications + mcp-session-id ✅
- Routing: stateless for clients without session ID, stateful for clients with session ID (or initialize)


Made with [Cursor](https://cursor.com)