### PR TITLE
fix: handle reasoning_effort='none' for Claude 4.6 models and add xhigh support

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -764,6 +764,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 type="enabled",
                 budget_tokens=DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET,
             )
+        elif reasoning_effort == "xhigh":
+            # xhigh maps to same as high for Anthropic (max available)
+            return AnthropicThinkingParam(
+                type="enabled",
+                budget_tokens=DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+            )
         else:
             raise ValueError(f"Unmapped reasoning effort: {reasoning_effort}")
 
@@ -1034,6 +1040,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # not thinking budget_tokens. Map reasoning_effort to output_config.
                 if AnthropicConfig._is_claude_4_6_model(model):
                     effort_map = {
+                        "none": None,  # Don't set output_config for "none"
                         "low": "low",
                         "minimal": "low",
                         "medium": "medium",
@@ -1041,7 +1048,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         "max": "max",
                     }
                     mapped_effort = effort_map.get(value, value)
-                    optional_params["output_config"] = {"effort": mapped_effort}
+                    if mapped_effort is not None:
+                        optional_params["output_config"] = {"effort": mapped_effort}
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)


### PR DESCRIPTION
## Summary

Fixes issue #23546 - Infinite retry loop when reasoning_effort="none" falls back to Anthropic models

### Changes

1. **Handle reasoning_effort="none" for Claude 4.6 models**: Add "none" to the effort_map with value `None` to prevent setting invalid output_config when "none" is passed.

2. **Add xhigh support**: Add "xhigh" to `_map_reasoning_effort()` function since it's a valid value in `REASONING_EFFORT` type but was missing from the mapping.

### Root Cause

When using Claude 4.6 models with `reasoning_effort="none"`, the code was passing "none" through to `output_config.effort`, which is invalid and causes the model to fail. The fallback logic then retries infinitely.

---

**Issue**: #23546
**Reported by**: @issue-reporter