### PR TITLE
fix(guardrails): log full OpenAI Moderation response in post-call callbacks

### DIFF
--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -111,6 +111,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process A2A output response by applying guardrails to text content.
@@ -166,13 +167,18 @@ class A2AGuardrailHandler(BaseTranslation):
             return response
 
         # Step 2: Apply guardrail to all texts in batch
-        # Create a request_data dict with response info and user API key metadata
-        request_data: dict = {"response": response_dict}
-
-        # Add user API key metadata with prefixed keys
-        user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
-        if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+        # Use the real request_data if provided (proxy path), otherwise
+        # create a throwaway dict (SDK / direct-call path).
+        if request_data is None:
+            request_data = {"response": response_dict}
+            user_metadata = self.transform_user_api_key_dict_to_metadata(
+                user_api_key_dict
+            )
+            if user_metadata:
+                request_data["litellm_metadata"] = user_metadata
+        else:
+            if "response" not in request_data:
+                request_data["response"] = response_dict
 
         inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
 

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -246,12 +246,13 @@ class AnthropicMessagesHandler(BaseTranslation):
                     "text"
                 ] = guardrail_response
 
-    async def process_output_response(
+    async def process_output_response(  # noqa: PLR0915
         self,
         response: "AnthropicMessagesResponse",
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -323,15 +324,18 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
-
-            # Add user API key metadata with prefixed keys
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
-            if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+            # Use the real request_data if provided (proxy path), otherwise
+            # create a throwaway dict (SDK / direct-call path).
+            if request_data is None:
+                request_data = {"response": response}
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
+                if user_metadata:
+                    request_data["litellm_metadata"] = user_metadata
+            else:
+                if "response" not in request_data:
+                    request_data["response"] = response
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -73,6 +73,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response with guardrails.

--- a/litellm/llms/cohere/rerank/guardrail_translation/handler.py
+++ b/litellm/llms/cohere/rerank/guardrail_translation/handler.py
@@ -83,6 +83,7 @@ class CohereRerankHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - not applicable for rerank.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -91,6 +91,7 @@ class OCRHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process OCR output by applying guardrails to extracted page text.

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -260,6 +260,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content.
@@ -308,15 +309,18 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
-
-            # Add user API key metadata with prefixed keys
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
-            if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+            # Use the real request_data if provided (proxy path), otherwise
+            # create a throwaway dict (SDK / direct-call path).
+            if request_data is None:
+                request_data = {"response": response}
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
+                if user_metadata:
+                    request_data["litellm_metadata"] = user_metadata
+            else:
+                if "response" not in request_data:
+                    request_data["response"] = response
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -125,6 +125,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to completion text.
@@ -155,15 +156,18 @@ class OpenAITextCompletionHandler(BaseTranslation):
 
         # Apply guardrails in batch
         if texts_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
-
-            # Add user API key metadata with prefixed keys
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
-            if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+            # Use the real request_data if provided (proxy path), otherwise
+            # create a throwaway dict (SDK / direct-call path).
+            if request_data is None:
+                request_data = {"response": response}
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
+                if user_metadata:
+                    request_data["litellm_metadata"] = user_metadata
+            else:
+                if "response" not in request_data:
+                    request_data["response"] = response
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             # Include model information from the response if available

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -155,6 +155,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - embeddings responses contain vectors, not text.

--- a/litellm/llms/openai/image_generation/guardrail_translation/handler.py
+++ b/litellm/llms/openai/image_generation/guardrail_translation/handler.py
@@ -87,6 +87,7 @@ class OpenAIImageGenerationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - typically not needed for image generation.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -347,6 +347,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -402,15 +403,18 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
-
-            # Add user API key metadata with prefixed keys
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
-            if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+            # Use the real request_data if provided (proxy path), otherwise
+            # create a throwaway dict (SDK / direct-call path).
+            if request_data is None:
+                request_data = {"response": response}
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
+                if user_metadata:
+                    request_data["litellm_metadata"] = user_metadata
+            else:
+                if "response" not in request_data:
+                    request_data["response"] = response
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:

--- a/litellm/llms/openai/speech/guardrail_translation/handler.py
+++ b/litellm/llms/openai/speech/guardrail_translation/handler.py
@@ -85,6 +85,7 @@ class OpenAITextToSpeechHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output - not applicable for text-to-speech.

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -58,6 +58,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output transcription by applying guardrails to transcribed text.
@@ -79,15 +80,18 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
 
         if isinstance(response.text, str):
             original_text = response.text
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
-
-            # Add user API key metadata with prefixed keys
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
-            if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+            # Use the real request_data if provided (proxy path), otherwise
+            # create a throwaway dict (SDK / direct-call path).
+            if request_data is None:
+                request_data = {"response": response}
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
+                if user_metadata:
+                    request_data["litellm_metadata"] = user_metadata
+            else:
+                if "response" not in request_data:
+                    request_data["response"] = response
 
             inputs = GenericGuardrailAPIInputs(texts=[original_text])
             # Include model information from the response if available

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -139,6 +139,7 @@ class PassThroughEndpointHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to targeted fields.

--- a/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
+++ b/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
@@ -92,6 +92,7 @@ class MCPGuardrailTranslationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         verbose_proxy_logger.debug(
             "MCP Guardrail: Output processing not implemented for MCP tools",

--- a/litellm/proxy/guardrails/guardrail_hooks/openai/moderations.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/openai/moderations.py
@@ -5,9 +5,11 @@ OpenAI Moderation Guardrail Integration for LiteLLM
 
 from typing import (
     TYPE_CHECKING,
+    Dict,
     Literal,
     Optional,
     Type,
+    Union,
 )
 
 from fastapi import HTTPException
@@ -22,7 +24,8 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.types.utils import GenericGuardrailAPIInputs
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailStatus
 
 from .base import OpenAIGuardrailBase
 
@@ -223,11 +226,96 @@ class OpenAIModerationGuardrail(OpenAIGuardrailBase, CustomGuardrail):
         # Make moderation request
         moderation_response = await self.async_make_request(input_text=text_to_moderate)
 
+        # Stash full moderation response in request_data for logging
+        # (Model Armor pattern — per-request dict avoids race conditions)
+        if isinstance(request_data, dict):
+            metadata = request_data.setdefault("metadata", {})
+            metadata["_openai_moderation_response"] = moderation_response.model_dump()
+
         # Check if content is flagged and raise exception if needed
         self._check_moderation_result(moderation_response)
 
         # Moderation doesn't modify content, just blocks - return inputs unchanged
         return inputs
+
+    def _process_response(
+        self,
+        response: Optional[Dict],
+        request_data: dict,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        duration: Optional[float] = None,
+        event_type: Optional[GuardrailEventHooks] = None,
+        original_inputs: Optional[Dict] = None,
+    ):
+        """
+        Override to log the full OpenAI Moderation API response instead of
+        the decorator's simplified "allow"/"mask" string.
+
+        Follows the Model Armor pattern (model_armor.py:325-360).
+        """
+        metadata = (
+            request_data.get("metadata") or {}
+            if isinstance(request_data, dict)
+            else {}
+        )
+
+        # .pop() cleans up the internal key so it doesn't leak to downstream
+        # loggers. Falls back to "allow" when no moderation call was made
+        # (e.g. no text to moderate — early return in apply_guardrail).
+        guardrail_response = metadata.pop("_openai_moderation_response", "allow")
+
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response=guardrail_response,
+            request_data=request_data,
+            guardrail_status="success",
+            duration=duration,
+            start_time=start_time,
+            end_time=end_time,
+            event_type=event_type,
+        )
+        return response
+
+    def _process_error(
+        self,
+        e: Exception,
+        request_data: dict,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        duration: Optional[float] = None,
+        event_type: Optional[GuardrailEventHooks] = None,
+    ):
+        """
+        Override to log the full OpenAI Moderation API response on error
+        instead of the stringified exception.
+        """
+        guardrail_status: GuardrailStatus = (
+            "guardrail_intervened"
+            if self._is_guardrail_intervention(e)
+            else "guardrail_failed_to_respond"
+        )
+
+        metadata = (
+            request_data.get("metadata") or {}
+            if isinstance(request_data, dict)
+            else {}
+        )
+
+        # Use the stashed moderation response if available, fall back to exception
+        guardrail_response: Union[dict, Exception, str] = metadata.pop(
+            "_openai_moderation_response", e
+        )
+
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response=guardrail_response,
+            request_data=request_data,
+            guardrail_status=guardrail_status,
+            duration=duration,
+            start_time=start_time,
+            end_time=end_time,
+            event_type=event_type,
+        )
+        raise e
 
     @staticmethod
     def get_config_model() -> Optional[Type["GuardrailConfigModel"]]:

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -247,6 +247,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             guardrail_to_apply=guardrail_to_apply,
             litellm_logging_obj=data.get("litellm_logging_obj"),
             user_api_key_dict=user_api_key_dict,
+            request_data=data,
         )
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
@@ -488,3 +488,242 @@ async def test_openai_moderation_guardrail_streaming_harmful_content():
 
             assert exc_info.value.status_code == 400
             assert "Violated OpenAI moderation policy" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_openai_moderation_guardrail_logs_full_response_safe_content():
+    """Test that safe content logs the full moderation response (categories, scores)
+    in StandardLoggingGuardrailInformation, not just 'allow'."""
+    from litellm.types.utils import GenericGuardrailAPIInputs
+
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+        guardrail = OpenAIModerationGuardrail(
+            guardrail_name="test-openai-moderation",
+        )
+
+        mock_response = OpenAIModerationResponse(
+            id="modr-123",
+            model="omni-moderation-latest",
+            results=[
+                OpenAIModerationResult(
+                    flagged=False,
+                    categories={
+                        "sexual": False,
+                        "hate": False,
+                        "harassment": False,
+                        "self-harm": False,
+                        "violence": False,
+                    },
+                    category_scores={
+                        "sexual": 0.001,
+                        "hate": 0.002,
+                        "harassment": 0.001,
+                        "self-harm": 0.001,
+                        "violence": 0.003,
+                    },
+                    category_applied_input_types={
+                        "sexual": [],
+                        "hate": [],
+                        "harassment": [],
+                        "self-harm": [],
+                        "violence": [],
+                    },
+                )
+            ],
+        )
+
+        with patch.object(guardrail, "async_make_request", return_value=mock_response):
+            inputs = GenericGuardrailAPIInputs(
+                structured_messages=[
+                    {"role": "user", "content": "Hello, how are you?"}
+                ]
+            )
+            request_data = {"metadata": {}}
+
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data=request_data,
+                input_type="request",
+            )
+
+            guardrail_info_list = request_data["metadata"][
+                "standard_logging_guardrail_information"
+            ]
+            assert len(guardrail_info_list) == 1
+
+            info = guardrail_info_list[0]
+            assert info["guardrail_name"] == "test-openai-moderation"
+            assert info["guardrail_status"] == "success"
+
+            # Full moderation response, NOT "allow"
+            guardrail_resp = info["guardrail_response"]
+            assert isinstance(guardrail_resp, dict)
+            assert guardrail_resp["results"][0]["flagged"] is False
+            assert "category_scores" in guardrail_resp["results"][0]
+
+            # Internal key cleaned up (.pop())
+            assert "_openai_moderation_response" not in request_data["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_openai_moderation_guardrail_logs_full_response_harmful_content():
+    """Test that harmful content logs guardrail_intervened status with the full
+    moderation response, not just the exception string."""
+    from litellm.types.utils import GenericGuardrailAPIInputs
+
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+        guardrail = OpenAIModerationGuardrail(
+            guardrail_name="test-openai-moderation",
+        )
+
+        mock_response = OpenAIModerationResponse(
+            id="modr-456",
+            model="omni-moderation-latest",
+            results=[
+                OpenAIModerationResult(
+                    flagged=True,
+                    categories={
+                        "sexual": False,
+                        "hate": True,
+                        "harassment": False,
+                        "self-harm": False,
+                        "violence": False,
+                    },
+                    category_scores={
+                        "sexual": 0.001,
+                        "hate": 0.95,
+                        "harassment": 0.001,
+                        "self-harm": 0.001,
+                        "violence": 0.001,
+                    },
+                    category_applied_input_types={
+                        "sexual": [],
+                        "hate": ["text"],
+                        "harassment": [],
+                        "self-harm": [],
+                        "violence": [],
+                    },
+                )
+            ],
+        )
+
+        with patch.object(guardrail, "async_make_request", return_value=mock_response):
+            inputs = GenericGuardrailAPIInputs(
+                structured_messages=[
+                    {"role": "user", "content": "Hateful content"}
+                ]
+            )
+            request_data = {"metadata": {}}
+
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException):
+                await guardrail.apply_guardrail(
+                    inputs=inputs,
+                    request_data=request_data,
+                    input_type="request",
+                )
+
+            guardrail_info_list = request_data["metadata"][
+                "standard_logging_guardrail_information"
+            ]
+            info = guardrail_info_list[0]
+            assert info["guardrail_status"] == "guardrail_intervened"
+
+            # Full moderation response, NOT stringified exception
+            guardrail_resp = info["guardrail_response"]
+            assert isinstance(guardrail_resp, dict)
+            assert guardrail_resp["results"][0]["flagged"] is True
+            assert guardrail_resp["results"][0]["category_scores"]["hate"] == 0.95
+
+
+@pytest.mark.asyncio
+async def test_openai_moderation_post_call_request_data_passthrough():
+    """Test that post-call guardrail info flows through to the real request_data
+    via the unified guardrail dispatcher (Bug 1 fix)."""
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
+        UnifiedLLMGuardrails,
+    )
+    from litellm.types.utils import ModelResponse
+
+    import litellm
+
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+        guardrail = OpenAIModerationGuardrail(
+            guardrail_name="test-openai-moderation",
+            event_hook="post_call",
+        )
+        unified_guardrail = UnifiedLLMGuardrails()
+
+        mock_mod_response = OpenAIModerationResponse(
+            id="modr-789",
+            model="omni-moderation-latest",
+            results=[
+                OpenAIModerationResult(
+                    flagged=False,
+                    categories={
+                        "sexual": False,
+                        "hate": False,
+                        "harassment": False,
+                        "self-harm": False,
+                        "violence": False,
+                    },
+                    category_scores={
+                        "sexual": 0.001,
+                        "hate": 0.002,
+                        "harassment": 0.001,
+                        "self-harm": 0.001,
+                        "violence": 0.001,
+                    },
+                    category_applied_input_types={
+                        "sexual": [],
+                        "hate": [],
+                        "harassment": [],
+                        "self-harm": [],
+                        "violence": [],
+                    },
+                )
+            ],
+        )
+
+        llm_response = ModelResponse(
+            id="chatcmpl-test",
+            model="gpt-4",
+            choices=[
+                litellm.Choices(
+                    index=0,
+                    message=litellm.Message(
+                        role="assistant", content="Hello world"
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+        )
+
+        request_data = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "guardrail_to_apply": guardrail,
+            "metadata": {"guardrails": ["test-openai-moderation"]},
+        }
+
+        mock_make_request = AsyncMock(return_value=mock_mod_response)
+        with patch.object(guardrail, "async_make_request", mock_make_request):
+            await unified_guardrail.async_post_call_success_hook(
+                data=request_data,
+                user_api_key_dict=UserAPIKeyAuth(
+                    api_key="test", request_route="/chat/completions"
+                ),
+                response=llm_response,
+            )
+
+        mock_make_request.assert_called_once()
+
+        # Guardrail info in the REAL request_data (not a throwaway)
+        guardrail_info_list = request_data["metadata"].get(
+            "standard_logging_guardrail_information"
+        )
+        assert guardrail_info_list is not None
+        assert isinstance(guardrail_info_list[0]["guardrail_response"], dict)
+        assert "results" in guardrail_info_list[0]["guardrail_response"]


### PR DESCRIPTION
Post-call OpenAI Moderation guardrail results were not reaching downstream logging callbacks (Langfuse, Datadog, custom loggers). Two independent bugs:

1. `process_output_response()` created a throwaway `request_data` dict, so guardrail info written by the `@log_guardrail_information` decorator was lost before reaching `StandardLoggingPayload`. Fixed by threading the real `request_data` from the unified guardrail dispatcher through all 13 `BaseTranslation` handlers.

2. The `@log_guardrail_information` decorator reduced the full moderation API response (categories, scores, flagged status) to the string `"allow"`. Fixed by overriding `_process_response` and `_process_error` on `OpenAIModerationGuardrail` to stash and log the full response (following the established Model Armor pattern).

## Relevant issues

Related to #13690 (Bedrock guardrail response logging — same class of issue) and #13321 (Bedrock Guardrail Error Response Incomplete).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### Bug 1: Thread `request_data` through post-call dispatch chain (15 files)

- **`litellm/llms/base_llm/guardrail_translation/base_translation.py`** — Add `request_data: Optional[dict] = None` parameter to abstract `process_output_response()`
- **`litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py`** — Forward `data` as `request_data=data` in `async_post_call_success_hook`
- **13 translation handlers** — Accept `request_data` parameter. The 6 handlers that create a throwaway dict (`openai/chat`, `openai/responses`, `openai/completion`, `openai/transcriptions`, `anthropic/chat`, `a2a/chat`) now use the real dict when provided and inject `response` for CrowdStrike compatibility. The remaining 7 handlers (`pass_through`, `openai/speech`, `openai/embeddings`, `openai/image_generation`, `cohere/rerank`, `mistral/ocr`, `mcp_server`) accept the parameter for signature compatibility.

### Bug 2: Log full moderation response (1 file)

- **`litellm/proxy/guardrails/guardrail_hooks/openai/moderations.py`** — Stash `moderation_response.model_dump()` in `request_data["metadata"]` during `apply_guardrail`, override `_process_response` and `_process_error` to log full moderation API response (categories, category_scores, flagged) instead of `"allow"` string. Uses `.pop()` for cleanup so the internal key doesn't leak to downstream loggers. Follows established Model Armor pattern.

### Tests (1 file)

- **`tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py`** — 3 new tests:
  - `test_openai_moderation_guardrail_logs_full_response_safe_content` — verifies full moderation dict (not `"allow"`) in `guardrail_response`
  - `test_openai_moderation_guardrail_logs_full_response_harmful_content` — verifies `guardrail_intervened` status with full response (not exception string)
  - `test_openai_moderation_post_call_request_data_passthrough` — verifies guardrail info flows through `UnifiedLLMGuardrails` to real `request_data`

### Not in this PR

The timing race between the background logging task and post-call guardrails (Bug 3) will be addressed in a separate PR. This PR ensures that when guardrail info is written, it goes to the right place (Bug 1) with the right content (Bug 2).