### PR TITLE
fix: normalize content_filtered finish_reason

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -96,6 +96,8 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "tool_calls": "tool_calls",
     "function_call": "function_call",
     "content_filter": "content_filter",
+    # Anthropic Sonnet 4
+    "content_filtered": "content_filter",
 }
 
 

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -59,20 +59,19 @@ VALID_OPENAI_FINISH_REASONS = {"stop", "length", "tool_calls", "function_call", 
 
 
 class TestMapFinishReasonAnthropic:
-    def test_stop_sequence(self):
-        assert map_finish_reason("stop_sequence") == "stop"
-
-    def test_end_turn(self):
-        assert map_finish_reason("end_turn") == "stop"
-
-    def test_max_tokens(self):
-        assert map_finish_reason("max_tokens") == "length"
-
-    def test_tool_use(self):
-        assert map_finish_reason("tool_use") == "tool_calls"
-
-    def test_compaction(self):
-        assert map_finish_reason("compaction") == "length"
+    @pytest.mark.parametrize(
+        "provider_reason,expected",
+        [
+            ("stop_sequence", "stop"),
+            ("end_turn", "stop"),
+            ("max_tokens", "length"),
+            ("tool_use", "tool_calls"),
+            ("compaction", "length"),
+            ("content_filtered", "content_filter"),
+        ],
+    )
+    def test_anthropic_finish_reasons(self, provider_reason: str, expected: str) -> None:
+        assert map_finish_reason(provider_reason) == expected
 
 
 class TestMapFinishReasonGemini:


### PR DESCRIPTION
Map provider finish_reason "content_filtered" to the OpenAI-compatible "content_filter" and extend core_helpers tests to cover this case.


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
