### PR TITLE
fix(anthropic): forward service_tier parameter to Anthropic API (#23398)

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -194,6 +194,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "speed",
             "context_management",
             "cache_control",
+            "service_tier",
         ]
 
         if (
@@ -1065,8 +1066,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # Pass through Anthropic-specific speed parameter for fast mode
                 optional_params["speed"] = value
             elif param == "cache_control" and isinstance(value, dict):
-                # Pass through top-level cache_control for automatic prompt caching
                 optional_params["cache_control"] = value
+            elif param == "service_tier" and isinstance(value, str):
+                optional_params["service_tier"] = value
 
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(
@@ -1789,6 +1791,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         model_response.created = int(time.time())
         model_response.model = completion_response["model"]
+
+        response_service_tier = completion_response.get("service_tier")
+        if isinstance(response_service_tier, str):
+            model_response.service_tier = response_service_tier
 
         model_response._hidden_params = _hidden_params
         return model_response

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3321,3 +3321,118 @@ def test_map_tool_helper_empty_parameters_get_default():
     assert result is not None
     assert result["input_schema"]["type"] == "object"
     assert result["input_schema"].get("properties") == {}
+
+
+# ============ Service Tier Tests ============
+
+
+def test_get_supported_params_includes_service_tier():
+    config = AnthropicConfig()
+    params = config.get_supported_openai_params(model="claude-sonnet-4-20250514")
+    assert "service_tier" in params
+
+
+def test_map_openai_params_forwards_service_tier_auto():
+    config = AnthropicConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"service_tier": "auto"},
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert optional_params["service_tier"] == "auto"
+
+
+def test_map_openai_params_forwards_service_tier_standard_only():
+    config = AnthropicConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"service_tier": "standard_only"},
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    assert optional_params["service_tier"] == "standard_only"
+
+
+def test_service_tier_included_in_request_body():
+    """service_tier should appear as a top-level field in the Anthropic request body."""
+    config = AnthropicConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"service_tier": "auto"},
+        optional_params={},
+        model="claude-sonnet-4-20250514",
+        drop_params=False,
+    )
+    data = config.transform_request(
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert data["service_tier"] == "auto"
+
+
+def test_service_tier_extracted_from_response():
+    """service_tier from the Anthropic response should be set on model_response."""
+    from unittest.mock import MagicMock
+
+    import httpx
+
+    config = AnthropicConfig()
+    mock_raw = MagicMock(spec=httpx.Response)
+    mock_raw.headers = {"request-id": "req-123"}
+    mock_raw.status_code = 200
+
+    completion_response = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello"}],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+        "service_tier": "standard",
+    }
+
+    import litellm
+
+    model_response = litellm.ModelResponse()
+    result = config.transform_parsed_response(
+        completion_response=completion_response,
+        raw_response=mock_raw,
+        model_response=model_response,
+    )
+    assert result.service_tier == "standard"
+
+
+def test_service_tier_absent_from_response():
+    """When service_tier is not in the response, model_response.service_tier stays None."""
+    from unittest.mock import MagicMock
+
+    import httpx
+
+    config = AnthropicConfig()
+    mock_raw = MagicMock(spec=httpx.Response)
+    mock_raw.headers = {"request-id": "req-456"}
+    mock_raw.status_code = 200
+
+    completion_response = {
+        "id": "msg_456",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hi"}],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 2},
+    }
+
+    import litellm
+
+    model_response = litellm.ModelResponse()
+    result = config.transform_parsed_response(
+        completion_response=completion_response,
+        raw_response=mock_raw,
+        model_response=model_response,
+    )
+    assert getattr(result, "service_tier", None) is None


### PR DESCRIPTION
## Summary

Fixes #23398

The `service_tier` parameter (e.g. `"auto"`, `"standard_only"`) was silently dropped when calling Anthropic models via `litellm.completion()` / `acompletion()`. The parameter never reached the Anthropic API request body.

## Root Cause

`service_tier` was absent from `AnthropicConfig.get_supported_openai_params()`, so it was filtered out before reaching `map_openai_params()` and never written into `optional_params`.

## Fix

- Added `"service_tier"` to the supported params list in `get_supported_openai_params()`
- Added passthrough mapping in `map_openai_params()`: `service_tier` is forwarded as-is to `optional_params`, which gets spread into the request body as a top-level field via `**optional_params` in `transform_request()`

This also applies to `VertexAIAnthropicConfig` and `AzureAnthropicConfig` which inherit from `AnthropicConfig`.

## Tests Added

4 tests in `test_anthropic_chat_transformation.py`:
- `test_get_supported_params_includes_service_tier` — verifies param is in supported list
- `test_map_openai_params_forwards_service_tier_auto` — verifies `"auto"` maps through
- `test_map_openai_params_forwards_service_tier_standard_only` — verifies `"standard_only"` maps through
- `test_service_tier_included_in_request_body` — end-to-end: maps params then calls `transform_request()`, asserts `service_tier` is a top-level field in the output dict

All pass. `ruff check` clean (pre-existing `print` warnings in test file are not from this PR).

Made with [Cursor](https://cursor.com)