### PR TITLE
fix(vertex_ai): preserve pre-fetched Authorization header

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
@@ -135,11 +135,17 @@ class VertexAIPartnerModels(VertexBase):
         try:
             vertex_httpx_logic = VertexLLM()
 
-            access_token, project_id = vertex_httpx_logic._ensure_access_token(
-                credentials=vertex_credentials,
-                project_id=vertex_project,
-                custom_llm_provider="vertex_ai",
-            )
+            # Skip _ensure_access_token if Authorization already present in headers
+            # This allows users to pass pre-fetched tokens via extra_headers
+            if headers is None or "Authorization" not in headers:
+                access_token, project_id = vertex_httpx_logic._ensure_access_token(
+                    credentials=vertex_credentials,
+                    project_id=vertex_project,
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                # Use existing project_id if token is pre-provided
+                project_id = vertex_project
 
             openai_like_chat_completions = OpenAILikeChatHandler()
             codestral_fim_completions = CodestralTextCompletion()
@@ -198,7 +204,9 @@ class VertexAIPartnerModels(VertexBase):
             elif "claude" in model:
                 if headers is None:
                     headers = {}
-                headers.update({"Authorization": "Bearer {}".format(access_token)})
+                # Only set Authorization if not already present (allow pre-fetched tokens)
+                if "Authorization" not in headers:
+                    headers["Authorization"] = "Bearer {}".format(access_token)
 
                 optional_params.update(
                     {


### PR DESCRIPTION
Allow users to pass pre-fetched Bearer tokens via extra_headers without being overwritten by ADC tokens.

## Changes
- Skip `_ensure_access_token()` if Authorization already in headers
- Only set Authorization header if not already present

## Fixes
Fixes #23572