### PR TITLE
Litellm gpt54 tools reasoning routing

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -188,11 +188,9 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         ) or optional_params.get("reasoning_effort")
         effective_effort = _get_effort_level(raw_reasoning_effort)
 
-        # Normalize to string for Chat Completions API when dict has only "effort".
-        # Preserve full dict (e.g. {"effort": "high", "summary": "detailed"}) for Responses API.
-        if isinstance(raw_reasoning_effort, dict) and set(
-            raw_reasoning_effort.keys()
-        ) <= {"effort"}:
+        # Normalize dict reasoning_effort to string for Chat Completions API.
+        # Example: {"effort": "high", "summary": "detailed"} -> "high"
+        if isinstance(raw_reasoning_effort, dict) and "effort" in raw_reasoning_effort:
             normalized = _normalize_reasoning_effort_for_chat_completion(
                 raw_reasoning_effort
             )

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -223,16 +223,6 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                 "max_tokens"
             )
 
-        # gpt-5.4: reasoning_effort + tools is only supported in the Responses API
-        # Drop reasoning_effort when tools are present in chat completions
-        if self.is_model_gpt_5_4_model(model):
-            has_tools = bool(
-                non_default_params.get("tools") or optional_params.get("tools")
-            )
-            if has_tools and effective_effort is not None:
-                non_default_params.pop("reasoning_effort", None)
-                optional_params.pop("reasoning_effort", None)
-
         # gpt-5.1/5.2 support logprobs, top_p, top_logprobs only when reasoning_effort="none"
         supports_none = self._supports_reasoning_effort_level(model, "none")
         if supports_none:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -955,7 +955,7 @@ def responses_api_bridge_check(
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
 
-        # OpenAI gpt-5.4 chat-completions calls with both tools + reasoning_effort
+        # OpenAI gpt-5.4+ chat-completions calls with both tools + reasoning_effort
         # must be bridged to Responses API.
         if (
             custom_llm_provider == "openai"
@@ -1616,6 +1616,10 @@ def completion(  # type: ignore # noqa: PLR0915
 
         if model_info.get("mode") == "responses":
             from litellm.completion_extras import responses_api_bridge
+
+            if isinstance(reasoning_effort, dict) and "summary" in reasoning_effort:
+                optional_params = dict(optional_params)
+                optional_params["reasoning_effort"] = reasoning_effort
 
             return responses_api_bridge.completion(
                 model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -99,6 +99,7 @@ from litellm.llms.base_llm.base_model_iterator import (
 from litellm.llms.bedrock.common_utils import BedrockModelInfo
 from litellm.llms.cohere.common_utils import CohereModelInfo
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.llms.vertex_ai.common_utils import (
     VertexAIModelRoute,
@@ -934,6 +935,8 @@ def responses_api_bridge_check(
     model: str,
     custom_llm_provider: str,
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
+    tools: Optional[List[Any]] = None,
+    reasoning_effort: Optional[Any] = None,
 ) -> Tuple[dict, str]:
     model_info: Dict[str, Any] = {}
     try:
@@ -949,6 +952,17 @@ def responses_api_bridge_check(
             model_info["mode"] = mode
 
         if web_search_options is not None and custom_llm_provider == "xai":
+            model_info["mode"] = "responses"
+            model = model.replace("responses/", "")
+
+        # OpenAI gpt-5.4 chat-completions calls with both tools + reasoning_effort
+        # must be bridged to Responses API.
+        if (
+            custom_llm_provider == "openai"
+            and OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
+            and tools
+            and reasoning_effort is not None
+        ):
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
     except Exception as e:
@@ -1596,6 +1610,8 @@ def completion(  # type: ignore # noqa: PLR0915
             model=model,
             custom_llm_provider=custom_llm_provider,
             web_search_options=web_search_options,
+            tools=tools,
+            reasoning_effort=reasoning_effort,
         )
 
         if model_info.get("mode") == "responses":

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -9,6 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
+from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
     OpenAIGPTConfig,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -324,11 +324,10 @@ def test_gpt5_4_pro_allows_reasoning_effort_xhigh(config: OpenAIConfig):
     assert params["reasoning_effort"] == "xhigh"
 
 
-def test_gpt5_preserves_reasoning_effort_dict_with_summary(config: OpenAIConfig):
-    """Dict with summary/generate_summary is preserved for Responses API.
+def test_gpt5_normalizes_reasoning_effort_dict_to_string(config: OpenAIConfig):
+    """Chat completion API expects reasoning_effort as a string, not a dict.
 
     Config/deployments may pass Responses API format: {'effort': 'high', 'summary': 'detailed'}.
-    We preserve the full dict so it reaches the Responses API transformation.
     """
     params = config.map_openai_params(
         non_default_params={"reasoning_effort": {"effort": "high", "summary": "detailed"}},
@@ -366,10 +365,10 @@ def test_gpt5_xhigh_dict_accepted_for_supported_model(config: OpenAIConfig):
 
 
 def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
-    """Dict with effort='none' and tools: reasoning_effort dropped for gpt-5.4.
+    """Dict with effort='none' and tools: no tool-drop, reasoning_effort preserved.
 
-    gpt-5.4 drops all reasoning_effort when tools are present,
-    since that combination is only supported in the Responses API.
+    Regression: effective_effort='none' must be used for tool-drop guard so
+    {"effort": "none", "summary": "detailed"} is not incorrectly treated as non-none.
     """
     tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
     params = config.map_openai_params(
@@ -378,7 +377,7 @@ def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert "reasoning_effort" not in params
+    assert params["reasoning_effort"] == {"effort": "none", "summary": "detailed"}
     assert params["tools"] == tools
 
 
@@ -411,10 +410,10 @@ def test_gpt5_preserves_reasoning_effort_dict_with_summary_from_optional_params(
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "medium", "summary": "detailed"}
+    assert params["reasoning_effort"] == "medium"
 
 
-def test_gpt5_4_drops_reasoning_effort_when_user_sends_reasoning_and_tools(config: OpenAIConfig):
+def test_gpt5_4_drops_reasoning_effort_when_tools_present(config: OpenAIConfig):
     """gpt-5.4: function calls not supported with reasoning_effort != 'none'. Drop reasoning_effort."""
     tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
     params = config.map_openai_params(
@@ -438,8 +437,8 @@ def test_gpt5_4_keeps_reasoning_effort_when_no_tools(config: OpenAIConfig):
     assert params["reasoning_effort"] == "high"
 
 
-def test_gpt5_4_drops_reasoning_effort_none_with_tools(config: OpenAIConfig):
-    """reasoning_effort='none' is also dropped when tools are present for gpt-5.4."""
+def test_gpt5_4_keeps_reasoning_effort_none_with_tools(config: OpenAIConfig):
+    """reasoning_effort='none' is kept when tools are present."""
     tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
     params = config.map_openai_params(
         non_default_params={"reasoning_effort": "none", "tools": tools},
@@ -447,7 +446,7 @@ def test_gpt5_4_drops_reasoning_effort_none_with_tools(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert "reasoning_effort" not in params
+    assert params["reasoning_effort"] == "none"
     assert params["tools"] == tools
 
 

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -410,8 +410,12 @@ def test_gpt5_normalizes_reasoning_effort_dict_with_summary_from_optional_params
     assert params["reasoning_effort"] == "medium"
 
 
-def test_gpt5_4_drops_reasoning_effort_when_tools_present(config: OpenAIConfig):
-    """gpt-5.4: function calls not supported with reasoning_effort != 'none'. Drop reasoning_effort."""
+def test_gpt5_4_passes_through_reasoning_effort_with_tools(config: OpenAIConfig):
+    """gpt-5.4 with tools + reasoning_effort: map_openai_params passes through both.
+
+    Routing to Responses API (which supports tools + reasoning) happens at completion()
+    level (responses_api_bridge_check). See test_responses_api_bridge_check_gpt_5_4_tools_plus_reasoning_routes_to_responses.
+    """
     tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
     params = config.map_openai_params(
         non_default_params={"reasoning_effort": "high", "tools": tools},
@@ -419,7 +423,7 @@ def test_gpt5_4_drops_reasoning_effort_when_tools_present(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert "reasoning_effort" not in params
+    assert params["reasoning_effort"] == "high"
     assert params["tools"] == tools
 
 

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -324,18 +324,15 @@ def test_gpt5_4_pro_allows_reasoning_effort_xhigh(config: OpenAIConfig):
     assert params["reasoning_effort"] == "xhigh"
 
 
-def test_gpt5_normalizes_reasoning_effort_dict_to_string(config: OpenAIConfig):
-    """Chat completion API expects reasoning_effort as a string, not a dict.
-
-    Config/deployments may pass Responses API format: {'effort': 'high', 'summary': 'detailed'}.
-    """
+def test_gpt5_normalizes_reasoning_effort_dict_with_summary(config: OpenAIConfig):
+    """Dict with summary/generate_summary is normalized for chat completions."""
     params = config.map_openai_params(
         non_default_params={"reasoning_effort": {"effort": "high", "summary": "detailed"}},
         optional_params={},
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "high", "summary": "detailed"}
+    assert params["reasoning_effort"] == "high"
 
 
 def test_gpt5_xhigh_dict_triggers_validation(config: OpenAIConfig):
@@ -361,7 +358,7 @@ def test_gpt5_xhigh_dict_accepted_for_supported_model(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "xhigh", "summary": "detailed"}
+    assert params["reasoning_effort"] == "xhigh"
 
 
 def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
@@ -377,7 +374,7 @@ def test_gpt5_none_dict_with_tools_no_tool_drop(config: OpenAIConfig):
         model="gpt-5.4",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "none", "summary": "detailed"}
+    assert params["reasoning_effort"] == "none"
     assert params["tools"] == tools
 
 
@@ -397,13 +394,13 @@ def test_gpt5_none_dict_with_sampling_params_allowed(config: OpenAIConfig):
         model="gpt-5.1",
         drop_params=False,
     )
-    assert params["reasoning_effort"] == {"effort": "none", "summary": "detailed"}
+    assert params["reasoning_effort"] == "none"
     assert params["logprobs"] is True
     assert params["top_p"] == 0.9
 
 
-def test_gpt5_preserves_reasoning_effort_dict_with_summary_from_optional_params(config: OpenAIConfig):
-    """reasoning_effort dict with summary in optional_params is preserved."""
+def test_gpt5_normalizes_reasoning_effort_dict_with_summary_from_optional_params(config: OpenAIConfig):
+    """reasoning_effort dict with summary in optional_params is normalized."""
     params = config.map_openai_params(
         non_default_params={},
         optional_params={"reasoning_effort": {"effort": "medium", "summary": "detailed"}},

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -627,6 +627,57 @@ def test_responses_api_bridge_check_gpt_5_4_pro():
         )
 
 
+def test_responses_api_bridge_check_gpt_5_4_tools_plus_reasoning_routes_to_responses():
+    """gpt-5.4 with both tools and reasoning_effort should route to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="xhigh",
+        )
+
+    assert model == "gpt-5.4"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_5_tools_plus_reasoning_routes_to_responses():
+    """gpt-5.5+ with both tools and reasoning_effort should route to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.5-pro",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="xhigh",
+        )
+
+    assert model == "gpt-5.5-pro"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_4_tools_without_reasoning_stays_chat():
+    """gpt-5.4 with tools only should not be force-routed to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort=None,
+        )
+
+    assert model == "gpt-5.4"
+    assert model_info.get("mode") != "responses"
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -678,6 +678,43 @@ def test_responses_api_bridge_check_gpt_5_4_tools_without_reasoning_stays_chat()
     assert model_info.get("mode") != "responses"
 
 
+@patch("litellm.completion_extras.responses_api_bridge.completion")
+def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
+    mock_responses_completion,
+):
+    """When routed to Responses, preserve reasoning_effort summary dict."""
+    mock_responses_completion.return_value = MagicMock()
+
+    import litellm
+
+    litellm.completion(
+        model="gpt-5.4",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_capital",
+                    "description": "Get the capital of a country",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"country": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+        reasoning_effort={"effort": "xhigh", "summary": "detailed"},
+        api_key="fake-key",
+    )
+
+    assert mock_responses_completion.called is True
+    optional_params = mock_responses_completion.call_args.kwargs["optional_params"]
+    assert optional_params["reasoning_effort"] == {
+        "effort": "xhigh",
+        "summary": "detailed",
+    }
+
+
 def test_responses_api_bridge_check_handles_exception():
     """Test that responses_api_bridge_check handles exceptions and still processes responses/ models."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🆕 New Feature
🐛 Bug Fix

## Changes
## Summary

This PR changes how gpt-5.4+ requests with both tools and `reasoning_effort` are handled:

1. **Route instead of drop:** Instead of silently dropping `reasoning_effort` when tools are present, we route these requests to the Responses API, which supports both tools and reasoning.
2. **Dict normalization:** We normalize `reasoning_effort` dicts (e.g. `{"effort": "high", "summary": "detailed"}`) to strings for the Chat Completions API, and restore the full dict when routing to the Responses API.
3. **Summary preservation:** When routing to Responses, we restore the original `reasoning_effort` dict (including `summary`) before calling the Responses API bridge.

---

## Response to Review Comments

**1. Hardcoded model detection in main.py**

The routing decision is driven by an **API constraint**, not a model capability. OpenAI's Chat Completions API rejects `reasoning_effort` when tools are present for gpt-5.4+. The Responses API supports both. This is an API boundary, not a model-specific flag.

`is_model_gpt_5_4_plus_model()` uses version parsing (`gpt-5.4`, `gpt-5.5`, `gpt-5.6`, etc.), so future models like gpt-5.5 and gpt-5.6 are handled without code changes. The only "hardcoded" part is the version threshold (4), which reflects when this API behavior was introduced.

`model_prices_and_context_window.json` is used for pricing and context windows. This routing rule is about which API endpoint to use, not pricing or capabilities. Adding a JSON flag would require updates for every new model; the version-based check keeps behavior consistent and self-documenting.

**2. Provider-specific import in main.py**

`main.py` already imports provider-specific modules for routing (e.g. `OpenAIWebSearchOptions`, `VertexAIModelRoute`). The routing logic needs to know whether the model is an OpenAI gpt-5.4+ model. That check is centralized in `OpenAIGPT5Config`, which is the same pattern used elsewhere for OpenAI-specific behavior.

**3. Fragile summary-field restoration**

Restoration uses `reasoning_effort` from the completion call's kwargs, which is the common path when users pass it directly. Deployment configs that inject `reasoning_effort` into `optional_params` before the call are a separate, less common path. The current change fixes the main case (direct argument) and aligns with how other params are handled. Improving the deployment-config path can be done in a follow-up if needed.

**4. Silent summary drop for non-gpt-5.4+ models**

The Chat Completions API expects `reasoning_effort` as a string (`"none"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`), not a dict. Sending `{"effort": "high", "summary": "detailed"}` would be rejected by OpenAI. Normalizing to a string is **required** for chat completions. The `summary` field is only used by the Responses API. For chat-path models, we must send a string; the normalization is correct and not a "silent drop."

**5. Pre-submission checklist / GitHub issue**

Checklist items will be completed before merge. A related issue can be linked if one exists.
