### PR TITLE
feat(openai): route gpt-5.4+ tools+reasoning to Responses API

### DIFF
--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -364,12 +364,11 @@ class TestGPT5ReasoningEffortPreservation:
         # Dict with only 'effort' should be normalized to string
         assert non_default_params.get("reasoning_effort") == "high"
 
-    def test_reasoning_effort_dict_with_summary_preserved(self):
-        """Test that reasoning_effort dict with 'summary' field is preserved for Responses API.
+    def test_reasoning_effort_dict_with_summary_normalized(self):
+        """Test that reasoning_effort dict with 'summary' is normalized for Chat Completions API.
         
-        Regression test for: User reported that summary field was being dropped when
-        routing to Responses API. The dict format with additional fields should be
-        preserved so it can be properly handled by the Responses API transformation.
+        map_openai_params normalizes all dicts to string. Full dict is restored in main.py
+        when routing to Responses API (test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict).
         """
         non_default_params = {"reasoning_effort": {"effort": "high", "summary": "detailed"}}
         optional_params = {}
@@ -381,14 +380,11 @@ class TestGPT5ReasoningEffortPreservation:
             drop_params=False,
         )
         
-        # Dict with additional fields should be preserved
-        assert non_default_params.get("reasoning_effort") == {"effort": "high", "summary": "detailed"}
-        assert isinstance(non_default_params.get("reasoning_effort"), dict)
-        assert non_default_params["reasoning_effort"]["effort"] == "high"
-        assert non_default_params["reasoning_effort"]["summary"] == "detailed"
+        # Dict is normalized to string for Chat Completions API
+        assert non_default_params.get("reasoning_effort") == "high"
 
-    def test_reasoning_effort_dict_with_generate_summary_preserved(self):
-        """Test that reasoning_effort dict with 'generate_summary' field is preserved."""
+    def test_reasoning_effort_dict_with_generate_summary_normalized(self):
+        """Test that reasoning_effort dict with 'generate_summary' is normalized for Chat Completions API."""
         non_default_params = {"reasoning_effort": {"effort": "medium", "generate_summary": "auto"}}
         optional_params = {}
         
@@ -399,12 +395,11 @@ class TestGPT5ReasoningEffortPreservation:
             drop_params=False,
         )
         
-        # Dict with additional fields should be preserved
-        assert non_default_params.get("reasoning_effort") == {"effort": "medium", "generate_summary": "auto"}
-        assert isinstance(non_default_params.get("reasoning_effort"), dict)
+        # Dict is normalized to string for Chat Completions API
+        assert non_default_params.get("reasoning_effort") == "medium"
 
-    def test_reasoning_effort_dict_with_all_fields_preserved(self):
-        """Test that reasoning_effort dict with all fields is preserved."""
+    def test_reasoning_effort_dict_with_all_fields_normalized(self):
+        """Test that reasoning_effort dict with all fields is normalized to effort string."""
         non_default_params = {
             "reasoning_effort": {
                 "effort": "high",
@@ -421,12 +416,8 @@ class TestGPT5ReasoningEffortPreservation:
             drop_params=False,
         )
         
-        # Dict with all fields should be preserved
-        reasoning = non_default_params.get("reasoning_effort")
-        assert isinstance(reasoning, dict)
-        assert reasoning["effort"] == "high"
-        assert reasoning["summary"] == "detailed"
-        assert reasoning["generate_summary"] == "concise"
+        # Dict is normalized to string for Chat Completions API
+        assert non_default_params.get("reasoning_effort") == "high"
 
     def test_reasoning_effort_dict_xhigh_triggers_validation(self):
         """xhigh-dict: effective effort is extracted for model-support validation.
@@ -461,8 +452,8 @@ class TestGPT5ReasoningEffortPreservation:
 
         assert "reasoning_effort" not in non_default_params
 
-    def test_reasoning_effort_dict_none_dropped_for_gpt5_4_with_tools(self):
-        """none-dict with tools on gpt-5.4: reasoning_effort is dropped."""
+    def test_reasoning_effort_dict_none_passed_through_for_gpt5_4_with_tools(self):
+        """none-dict with tools on gpt-5.4: reasoning_effort is passed through (routing to Responses at completion level)."""
         tools = [{"type": "function", "function": {"name": "test", "description": "test"}}]
         non_default_params = {"reasoning_effort": {"effort": "none", "summary": "detailed"}, "tools": tools}
         optional_params = {}
@@ -474,13 +465,15 @@ class TestGPT5ReasoningEffortPreservation:
             drop_params=False,
         )
 
-        assert "reasoning_effort" not in non_default_params
+        # Normalized to "none", passed through; routing to Responses API happens at completion()
+        assert non_default_params.get("reasoning_effort") == "none"
         assert non_default_params.get("tools") == tools
 
     def test_reasoning_effort_dict_none_treated_as_none_for_sampling(self):
         """none-dict: {"effort": "none", "summary": "detailed"} allows logprobs/top_p.
         
-        Sampling-param guard should NOT fire; logprobs should be kept.
+        effective_effort='none' is used for sampling guard; logprobs should be kept.
+        Dict is normalized to "none" for Chat Completions API.
         """
         non_default_params = {
             "reasoning_effort": {"effort": "none", "summary": "detailed"},
@@ -495,11 +488,14 @@ class TestGPT5ReasoningEffortPreservation:
             drop_params=False,
         )
 
-        assert non_default_params.get("reasoning_effort") == {"effort": "none", "summary": "detailed"}
+        assert non_default_params.get("reasoning_effort") == "none"
         assert non_default_params.get("logprobs") is True
 
     def test_reasoning_effort_dict_none_allows_temperature(self):
-        """none-dict: {"effort": "none", "summary": "detailed"} allows non-default temperature."""
+        """none-dict: {"effort": "none", "summary": "detailed"} allows non-default temperature.
+        
+        effective_effort='none' is used for temperature guard. Dict is normalized to "none".
+        """
         non_default_params = {
             "reasoning_effort": {"effort": "none", "summary": "detailed"},
             "temperature": 0.5,
@@ -514,4 +510,4 @@ class TestGPT5ReasoningEffortPreservation:
         )
 
         assert optional_params.get("temperature") == 0.5
-        assert non_default_params.get("reasoning_effort") == {"effort": "none", "summary": "detailed"}
+        assert non_default_params.get("reasoning_effort") == "none"


### PR DESCRIPTION
## Summary

This PR changes how gpt-5.4+ requests with both tools and `reasoning_effort` are handled:

1. **Route instead of drop:** Instead of silently dropping `reasoning_effort` when tools are present, we route these requests to the Responses API, which supports both tools and reasoning.
2. **Dict normalization:** We normalize `reasoning_effort` dicts (e.g. `{"effort": "high", "summary": "detailed"}`) to strings for the Chat Completions API, and restore the full dict when routing to the Responses API.
3. **Summary preservation:** When routing to Responses, we restore the original `reasoning_effort` dict (including `summary`) before calling the Responses API bridge.

---

## Response to Review Comments

**1. Hardcoded model detection in main.py**

The routing decision is driven by an **API constraint**, not a model capability. OpenAI's Chat Completions API rejects `reasoning_effort` when tools are present for gpt-5.4+. The Responses API supports both. This is an API boundary, not a model-specific flag.

`is_model_gpt_5_4_plus_model()` uses version parsing (`gpt-5.4`, `gpt-5.5`, `gpt-5.6`, etc.), so future models like gpt-5.5 and gpt-5.6 are handled without code changes. The only "hardcoded" part is the version threshold (4), which reflects when this API behavior was introduced.

`model_prices_and_context_window.json` is used for pricing and context windows. This routing rule is about which API endpoint to use, not pricing or capabilities. Adding a JSON flag would require updates for every new model; the version-based check keeps behavior consistent and self-documenting.

**2. Provider-specific import in main.py**

`main.py` already imports provider-specific modules for routing (e.g. `OpenAIWebSearchOptions`, `VertexAIModelRoute`). The routing logic needs to know whether the model is an OpenAI gpt-5.4+ model. That check is centralized in `OpenAIGPT5Config`, which is the same pattern used elsewhere for OpenAI-specific behavior.

**3. Fragile summary-field restoration**

Restoration uses `reasoning_effort` from the completion call's kwargs, which is the common path when users pass it directly. Deployment configs that inject `reasoning_effort` into `optional_params` before the call are a separate, less common path. The current change fixes the main case (direct argument) and aligns with how other params are handled. Improving the deployment-config path can be done in a follow-up if needed.

**4. Silent summary drop for non-gpt-5.4+ models**

The Chat Completions API expects `reasoning_effort` as a string (`"none"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`), not a dict. Sending `{"effort": "high", "summary": "detailed"}` would be rejected by OpenAI. Normalizing to a string is **required** for chat completions. The `summary` field is only used by the Responses API. For chat-path models, we must send a string; the normalization is correct and not a "silent drop."

**5. Pre-submission checklist / GitHub issue**

Checklist items will be completed before merge. A related issue can be linked if one exists.
