### PR TITLE
fix: convert datetime to ISO string for PostgreSQL timestamp compatibility

### DIFF
--- a/litellm/proxy/db/tool_registry_writer.py
+++ b/litellm/proxy/db/tool_registry_writer.py
@@ -83,7 +83,7 @@ async def batch_upsert_tools(
         data = [item for item in items if item.get("tool_name")]
         if not data:
             return
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).isoformat()
         table = prisma_client.db.litellm_tooltable
         for item in data:
             tool_name = item.get("tool_name", "")


### PR DESCRIPTION
Fixes timestamp type mismatch error in `tool_registry_writer.py` when inserting into `LiteLLM_ToolTable`. PostgreSQL expects timestamp format, not timezone-aware datetime objects.

Closes #23585