### PR TITLE
[23462][Feature]: Enable response logging after proxy response hooks fire

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -174,6 +174,18 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         pass
 
+    async def async_post_guardrail_log_success_event(
+        self, kwargs, response_obj, start_time, end_time
+    ):
+        """
+        Called by the proxy after post-call hooks (e.g. guardrails) have run.
+        Use this to log the final response seen by the client when you need
+        post-guardrail content; async_log_success_event runs before post-call
+        hooks and sees the unmodified response.
+        Same signature as async_log_success_event.
+        """
+        pass
+
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         pass
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1073,6 +1073,14 @@ class ProxyBaseLLMRequestProcessing:
             data=self.data, user_api_key_dict=user_api_key_dict, response=response
         )
 
+        # Log success after post-call hooks so callbacks see the final (e.g. guardrail-modified) response
+        await proxy_logging_obj.async_post_guardrail_log_success_event(
+            data=self.data,
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            logging_obj=logging_obj,
+        )
+
         # Always return the client-requested model name (not provider-prefixed internal identifiers)
         # for OpenAI-compatible responses.
         if requested_model_from_client:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5497,7 +5497,33 @@ def _restamp_streaming_chunk_model(
     return chunk, model_mismatch_logged
 
 
-async def async_data_generator(
+async def _async_data_generator_fire_post_guardrail_log(
+    proxy_logging_obj: ProxyLogging,
+    request_data: dict,
+    user_api_key_dict: UserAPIKeyAuth,
+    streaming_chunks: List[Dict[str, Any]],
+) -> None:
+    """Fire async_post_guardrail_log_success_event after stream completes (post-guardrail response)."""
+    if not streaming_chunks:
+        return
+    try:
+        complete_response = litellm.stream_chunk_builder(chunks=streaming_chunks)
+        if complete_response is not None:
+            logging_obj = request_data.get("litellm_logging_obj")
+            await proxy_logging_obj.async_post_guardrail_log_success_event(
+                data=request_data,
+                response=complete_response,
+                user_api_key_dict=user_api_key_dict,
+                logging_obj=logging_obj,
+            )
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            "async_data_generator: async_post_guardrail_log_success_event: %s",
+            e,
+        )
+
+
+async def async_data_generator(  # noqa: PLR0915
     response, user_api_key_dict: UserAPIKeyAuth, request_data: dict
 ):
     verbose_proxy_logger.debug("inside generator")
@@ -5511,6 +5537,8 @@ async def async_data_generator(
         # Previously "".join(str_so_far_parts) was called every chunk, re-joining
         # the entire accumulated response. String += is O(n) amortized total.
         _str_so_far: str = ""
+        # Collect post-guardrail chunks for async_post_guardrail_log_success_event
+        _streaming_chunks_for_log: List[Dict[str, Any]] = []
         async for chunk in proxy_logging_obj.async_post_call_streaming_iterator_hook(
             user_api_key_dict=user_api_key_dict,
             response=response,
@@ -5535,6 +5563,15 @@ async def async_data_generator(
                 model_mismatch_logged=model_mismatch_logged,
             )
 
+            # Collect after restamp so logged response has client-requested model name
+            if isinstance(chunk, BaseModel):
+                try:
+                    _streaming_chunks_for_log.append(
+                        chunk.model_dump(mode="json", exclude_none=True)
+                    )
+                except Exception:
+                    pass
+
             if isinstance(chunk, BaseModel):
                 chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
             elif isinstance(chunk, str) and chunk.startswith("data: "):
@@ -5545,6 +5582,17 @@ async def async_data_generator(
                 yield f"data: {chunk}\n\n"
             except Exception as e:
                 yield f"data: {str(e)}\n\n"
+
+        if error_message is None:
+            # Fire post-guardrail log in background so [DONE] is not delayed
+            asyncio.create_task(
+                _async_data_generator_fire_post_guardrail_log(
+                    proxy_logging_obj=proxy_logging_obj,
+                    request_data=request_data,
+                    user_api_key_dict=user_api_key_dict,
+                    streaming_chunks=_streaming_chunks_for_log,
+                )
+            )
 
         # Streaming is done, yield the [DONE] chunk
         if error_message is not None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1976,6 +1976,70 @@ class ProxyLogging:
             raise e
         return response
 
+    async def async_post_guardrail_log_success_event(
+        self,
+        data: dict,
+        response: LLMResponseTypes,
+        user_api_key_dict: UserAPIKeyAuth,
+        logging_obj: Optional[Any] = None,
+    ) -> None:
+        """
+        Invoke async_post_guardrail_log_success_event on all CustomLogger callbacks.
+        Called by the proxy after post_call_success_hook so loggers see the
+        post-guardrail response (e.g. after tool blocking / response moderation).
+        """
+        try:
+            kwargs = dict(data)
+            if logging_obj is not None and getattr(
+                logging_obj, "model_call_details", None
+            ):
+                kwargs = {**logging_obj.model_call_details, **kwargs}
+            kwargs["user_api_key_dict"] = user_api_key_dict
+            start_time = None
+            end_time = datetime.now(timezone.utc)
+            if logging_obj is not None:
+                start_time = getattr(logging_obj, "completion_start_time", None) or (
+                    kwargs.get("start_time")
+                    if isinstance(kwargs.get("start_time"), datetime)
+                    else None
+                )
+                if getattr(logging_obj, "model_call_details", {}).get("end_time"):
+                    end_time = logging_obj.model_call_details["end_time"]
+
+            for callback in litellm.callbacks:
+                _callback: Optional[CustomLogger] = None
+                if isinstance(callback, str):
+                    _callback = litellm.litellm_core_utils.litellm_logging.get_custom_logger_compatible_class(
+                        cast(_custom_logger_compatible_callbacks_literal, callback)
+                    )
+                else:
+                    _callback = callback  # type: ignore
+
+                if _callback is None or isinstance(_callback, CustomGuardrail):
+                    continue
+                if not isinstance(_callback, CustomLogger):
+                    continue
+                hook = getattr(
+                    _callback, "async_post_guardrail_log_success_event", None
+                )
+                if not callable(hook):
+                    continue
+                try:
+                    await hook(
+                        kwargs=kwargs,
+                        response_obj=response,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                except Exception as e:
+                    verbose_proxy_logger.exception(
+                        "Error in async_post_guardrail_log_success_event: %s", e
+                    )
+        except Exception as e:
+            verbose_proxy_logger.exception(
+                "Error in async_post_guardrail_log_success_event: %s", e
+            )
+
     async def post_call_response_headers_hook(
         self,
         data: dict,
@@ -5233,7 +5297,7 @@ def normalize_route_for_root_path(route: str) -> Optional[str]:
     root_path = get_server_root_path()
     if root_path and root_path != "/":
         if route.startswith(root_path + "/"):
-            return route[len(root_path):]
+            return route[len(root_path) :]
         return None
     return route
 

--- a/tests/test_litellm/proxy/hooks/test_async_post_guardrail_log_success_event.py
+++ b/tests/test_litellm/proxy/hooks/test_async_post_guardrail_log_success_event.py
@@ -1,0 +1,277 @@
+"""
+Integration tests for async_post_guardrail_log_success_event.
+
+Tests verify that the post-guardrail log success hook is invoked after
+post_call_success_hook so callbacks can log the final (e.g. guardrail-modified)
+response. Same patterns as test_post_call_success_hook_integration.py.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import ModelResponse, Choices, Message, Usage
+
+
+class PostGuardrailLogCaptureLogger(CustomLogger):
+    """Logger that implements async_post_guardrail_log_success_event and captures args."""
+
+    def __init__(self):
+        self.called = False
+        self.kwargs = None
+        self.response_obj = None
+        self.start_time = None
+        self.end_time = None
+
+    async def async_post_guardrail_log_success_event(
+        self, kwargs, response_obj, start_time, end_time
+    ):
+        self.called = True
+        self.kwargs = kwargs
+        self.response_obj = response_obj
+        self.start_time = start_time
+        self.end_time = end_time
+
+
+@pytest.mark.asyncio
+async def test_post_guardrail_log_success_event_called_with_response():
+    """
+    Test that async_post_guardrail_log_success_event is called with the given response.
+    """
+    logger = PostGuardrailLogCaptureLogger()
+
+    with patch("litellm.callbacks", [logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        response = ModelResponse(
+            id="post-guardrail-response",
+            choices=[
+                Choices(
+                    message=Message(content="Post-guardrail content", role="assistant"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            model="test-model",
+            usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+        data = {"model": "test-model", "messages": []}
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        await proxy_logging.async_post_guardrail_log_success_event(
+            data=data,
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            logging_obj=None,
+        )
+
+        assert logger.called is True
+        assert logger.response_obj is response
+        assert logger.response_obj.id == "post-guardrail-response"
+        assert logger.kwargs["model"] == "test-model"
+        assert logger.kwargs["user_api_key_dict"] is user_api_key_dict
+
+
+@pytest.mark.asyncio
+async def test_post_guardrail_log_success_event_skips_callbacks_without_hook():
+    """
+    Test that callbacks that do not implement async_post_guardrail_log_success_event
+    are skipped without error (base CustomLogger has no-op pass).
+    """
+    capture_logger = PostGuardrailLogCaptureLogger()
+    # Base CustomLogger does not override the hook (no-op); only capture_logger does
+    no_hook_logger = CustomLogger()
+
+    with patch("litellm.callbacks", [no_hook_logger, capture_logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        response = ModelResponse(
+            id="response",
+            choices=[
+                Choices(
+                    message=Message(content="Content", role="assistant"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            model="test-model",
+            usage=Usage(prompt_tokens=5, completion_tokens=10, total_tokens=15),
+        )
+        data = {"model": "test-model"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="key")
+
+        await proxy_logging.async_post_guardrail_log_success_event(
+            data=data,
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            logging_obj=None,
+        )
+
+        # Only the logger that implements the hook should have been called
+        assert capture_logger.called is True
+        assert capture_logger.response_obj is response
+
+
+@pytest.mark.asyncio
+async def test_post_guardrail_log_success_event_exception_in_callback_does_not_break_others():
+    """
+    Test that when one callback raises in async_post_guardrail_log_success_event,
+    other callbacks are still invoked (exceptions are caught and logged).
+    """
+    failing_logger = PostGuardrailLogCaptureLogger()
+
+    async def raise_in_hook(*args, **kwargs):
+        failing_logger.called = True
+        raise RuntimeError("Intentional failure in post-guardrail log")
+
+    failing_logger.async_post_guardrail_log_success_event = raise_in_hook
+
+    success_logger = PostGuardrailLogCaptureLogger()
+
+    with patch("litellm.callbacks", [failing_logger, success_logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        response = ModelResponse(
+            id="response",
+            choices=[
+                Choices(
+                    message=Message(content="Content", role="assistant"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            model="test-model",
+            usage=Usage(prompt_tokens=5, completion_tokens=10, total_tokens=15),
+        )
+        data = {"model": "test-model"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="key")
+
+        # Should not raise; exception is caught and logged inside ProxyLogging
+        await proxy_logging.async_post_guardrail_log_success_event(
+            data=data,
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            logging_obj=None,
+        )
+
+        assert failing_logger.called is True
+        assert success_logger.called is True
+        assert success_logger.response_obj is response
+
+
+@pytest.mark.asyncio
+async def test_post_guardrail_log_success_event_receives_logging_obj_timing():
+    """
+    Test that when logging_obj is provided with model_call_details / completion_start_time,
+    start_time and end_time are passed to the hook.
+    """
+    logger = PostGuardrailLogCaptureLogger()
+    start = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 15, 12, 0, 5, tzinfo=timezone.utc)
+
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {"start_time": start, "end_time": end}
+    logging_obj.completion_start_time = start
+
+    with patch("litellm.callbacks", [logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        response = ModelResponse(
+            id="response",
+            choices=[
+                Choices(
+                    message=Message(content="Content", role="assistant"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            model="test-model",
+            usage=Usage(prompt_tokens=5, completion_tokens=10, total_tokens=15),
+        )
+        data = {"model": "test-model"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="key")
+
+        await proxy_logging.async_post_guardrail_log_success_event(
+            data=data,
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            logging_obj=logging_obj,
+        )
+
+        assert logger.called is True
+        assert logger.start_time is start
+        assert logger.end_time is end
+        assert logger.kwargs.get("start_time") == start
+        assert logger.kwargs.get("end_time") == end
+
+
+@pytest.mark.asyncio
+async def test_post_guardrail_log_success_event_skips_guardrail_callbacks():
+    """
+    Test that CustomGuardrail callbacks are not invoked for async_post_guardrail_log_success_event
+    (only CustomLogger callbacks are).
+    """
+
+    class GuardrailWithLogHook(CustomGuardrail):
+        def __init__(self):
+            self.called = False
+
+        async def async_post_guardrail_log_success_event(
+            self, kwargs, response_obj, start_time, end_time
+        ):
+            self.called = True
+
+    guardrail = GuardrailWithLogHook()
+    logger = PostGuardrailLogCaptureLogger()
+
+    with patch("litellm.callbacks", [guardrail, logger]):
+        from litellm.proxy.utils import ProxyLogging
+        from litellm.caching.caching import DualCache
+
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        response = ModelResponse(
+            id="response",
+            choices=[
+                Choices(
+                    message=Message(content="Content", role="assistant"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            model="test-model",
+            usage=Usage(prompt_tokens=5, completion_tokens=10, total_tokens=15),
+        )
+        data = {"model": "test-model"}
+        user_api_key_dict = UserAPIKeyAuth(api_key="key")
+
+        await proxy_logging.async_post_guardrail_log_success_event(
+            data=data,
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            logging_obj=None,
+        )
+
+        # Guardrail should be skipped (we only call CustomLogger, not CustomGuardrail)
+        assert guardrail.called is False
+        assert logger.called is True


### PR DESCRIPTION
feat(proxy): add async_post_guardrail_log_success_event hook (issue 23462)
- Add CustomLogger.async_post_guardrail_log_success_event() so callbacks can log the final response after post-call hooks (e.g. guardrails, tool blocking, response moderation). async_log_success_event still runs before post-call hooks and sees the unmodified response.
- ProxyLogging.async_post_guardrail_log_success_event() invokes the hook on all CustomLogger callbacks (skips CustomGuardrails).
- Call the new hook after post_call_success_hook in common_request_processing (non-streaming) and after the stream completes in async_data_generator (streaming), using stream_chunk_builder to assemble the post-guardrail response for streaming.
- Add tests in test_async_post_guardrail_log_success_event.py following test_post_call_success_hook_integration patterns.
## Relevant issues
Fixes #23462
## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
## CI (LiteLLM team)
> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.
- [ ] **Branch creation CI run**  
       Link:
- [ ] **CI run for the last commit**  
       Link:
- [ ] **Merge / cherry-pick CI run**  
       Links:
## Type
🆕 New Feature
<!-- 🐛 Bug Fix -->
<!-- 🧹 Refactoring -->
<!-- 📖 Documentation -->
<!-- 🚄 Infrastructure -->
<!-- ✅ Test -->
## Changes
- **litellm/integrations/custom_logger.py**: Added `async_post_guardrail_log_success_event(kwargs, response_obj, start_time, end_time)` to `CustomLogger` with default no-op and docstring.
- **litellm/proxy/utils.py**: Added `ProxyLogging.async_post_guardrail_log_success_event(data, response, user_api_key_dict, logging_obj)` to invoke the hook on all CustomLogger callbacks (excluding CustomGuardrails), with exception handling per callback.
- **litellm/proxy/common_request_processing.py**: Call `async_post_guardrail_log_success_event` after `post_call_success_hook` for non-streaming chat completions.
- **litellm/proxy/proxy_server.py**: For streaming, collect post-guardrail chunks in `async_data_generator`, assemble with `stream_chunk_builder` after the stream ends, and call `async_post_guardrail_log_success_event`; extracted `_async_data_generator_fire_post_guardrail_log` helper.
- **tests/test_litellm/proxy/hooks/test_async_post_guardrail_log_success_event.py**: New integration tests (hook called with response, callbacks without hook skipped, exception in one callback does not block others, timing from logging_obj, CustomGuardrails skipped).
