### PR TITLE
fix(model-prices): remove duplicate vertex_ai/gemini-embedding-2-preview entry

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14584,18 +14584,6 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "uses_embed_content": true
     },
-    "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_token": 1.5e-07,
-        "litellm_provider": "vertex_ai",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0,
-        "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
-        "supports_multimodal": true,
-        "uses_embed_content": true
-    },
     "gemini/gemini-embedding-001": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "gemini",


### PR DESCRIPTION
## Relevant issues

Fixes #23578

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) — N/A: JSON-only data change, no code logic affected
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The key `"vertex_ai/gemini-embedding-2-preview"` appeared twice in `model_prices_and_context_window.json` with different pricing values. In JSON, duplicate keys cause the second entry to silently overwrite the first, which led to the more complete multimodal pricing (audio, image, video) being lost.

**Removed:** The second entry (text-only, sourced from Gemini API docs)
**Kept:** The first entry with complete multimodal pricing sourced from [Vertex AI pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing)