### PR TITLE
fix(model-prices): add regional Bedrock entries for GLM 4.7 and GLM 4.7 Flash

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37012,5 +37012,126 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
+    },
+    "bedrock/us-east-1/zai.glm-4.7": {
+        "aliases": [
+            "bedrock/us-east-2/zai.glm-4.7",
+            "bedrock/us-west-2/zai.glm-4.7"
+        ],
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/ap-northeast-1/zai.glm-4.7": {
+        "aliases": [
+            "bedrock/ap-south-1/zai.glm-4.7",
+            "bedrock/ap-southeast-3/zai.glm-4.7",
+            "bedrock/eu-north-1/zai.glm-4.7",
+            "bedrock/sa-east-1/zai.glm-4.7"
+        ],
+        "input_cost_per_token": 7.2e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.64e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/ap-southeast-2/zai.glm-4.7": {
+        "input_cost_per_token": 6.18e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2.266e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/us-east-1/zai.glm-4.7-flash": {
+        "aliases": [
+            "bedrock/us-east-2/zai.glm-4.7-flash",
+            "bedrock/us-west-2/zai.glm-4.7-flash"
+        ],
+        "input_cost_per_token": 7e-08,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/ap-northeast-1/zai.glm-4.7-flash": {
+        "aliases": [
+            "bedrock/ap-south-1/zai.glm-4.7-flash",
+            "bedrock/ap-southeast-3/zai.glm-4.7-flash",
+            "bedrock/eu-central-1/zai.glm-4.7-flash",
+            "bedrock/eu-north-1/zai.glm-4.7-flash",
+            "bedrock/eu-south-1/zai.glm-4.7-flash",
+            "bedrock/eu-west-1/zai.glm-4.7-flash",
+            "bedrock/sa-east-1/zai.glm-4.7-flash"
+        ],
+        "input_cost_per_token": 8e-08,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.8e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/eu-west-2/zai.glm-4.7-flash": {
+        "input_cost_per_token": 1.1e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6.2e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/ap-southeast-2/zai.glm-4.7-flash": {
+        "input_cost_per_token": 7.21e-08,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.12e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
     }
 }


### PR DESCRIPTION
## Relevant issues

Fixes #21047

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) — N/A: JSON-only data change, no code logic affected
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Of the 6 models announced in [AWS Bedrock's open weights release](https://aws.amazon.com/about-aws/whats-new/2026/02/amazon-bedrock-adds-support-six-open-weights-models/), 4 already had regional entries but GLM 4.7 and GLM 4.7 Flash only had base entries (`zai.glm-4.7`, `zai.glm-4.7-flash`) without any `bedrock/<region>/` variants.

Added 7 regional entries using the `aliases` feature (expands to 22 at load time) with official AWS Bedrock pricing:

- **GLM 4.7**: 10 regions (US $0.60/$2.20, AP/EU $0.72/$2.64, Sydney $0.618/$2.266)
- **GLM 4.7 Flash**: 12 regions (US $0.07/$0.40, AP/EU $0.08/$0.48, London $0.11/$0.62, Sydney $0.072/$0.412)

Source: https://aws.amazon.com/bedrock/pricing/