### PR TITLE
fix(security): bump tar to 7.5.11 and tornado to 6.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "overrides": {
     "glob": ">=11.1.0",
-    "tar": ">=7.5.11",
+    "tar": ">=7.5.11",  // enforced via Dockerfile; tar is not a direct transitive dep of this project
     "minimatch": ">=10.2.4",
     "diff": ">=8.0.3",
     "@isaacs/brace-expansion": ">=5.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "overrides": {
     "glob": ">=11.1.0",
-    "tar": ">=7.5.11",  // enforced via Dockerfile; tar is not a direct transitive dep of this project
+    "tar": ">=7.5.11",
     "minimatch": ">=10.2.4",
     "diff": ">=8.0.3",
     "@isaacs/brace-expansion": ">=5.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # LITELLM PROXY DEPENDENCIES #
 # Security: explicit pins for transitive deps (CVE fixes)
 urllib3>=2.6.0  # CVE-2025-66471, CVE-2025-66418, CVE-2026-21441
-tornado>=6.5.3  # CVE-2025-67725, CVE-2025-67726, CVE-2025-67724
+tornado>=6.5.5  # CVE-2025-67725, CVE-2025-67726, CVE-2025-67724, CVE-2026-31958, GHSA-78cv-mqj4-43f7
 filelock>=3.20.1  # CVE-2025-68146
 h11>=0.16.0    # CVE-2025-43859, GHSA-vqfr-h8mv-ghfj — HTTP request smuggling
 wheel>=0.46.2  # CVE-2026-24049 — path traversal

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -88,7 +88,7 @@
     "mermaid": ">=11.10.0",
     "js-yaml": ">=4.1.1",
     "glob": ">=11.1.0",
-    "tar": ">=7.5.10",
+    "tar": ">=7.5.11",
     "minimatch": ">=10.2.4",
     "@isaacs/brace-expansion": ">=5.0.1",
     "node-forge": ">=1.3.2",


### PR DESCRIPTION
## Summary

- `tar >=7.5.11`: fixes **CVE-2026-31802** (HIGH) — node-pkg, 3 locations in image
- `tornado >=6.5.5`: fixes **CVE-2026-31958** (HIGH) and **GHSA-78cv-mqj4-43f7** (MEDIUM) — python-pkg

Addresses all vulnerabilities found in the Trivy scan of `ghcr.io/berriai/litellm:main-v1.82.0-stable`.

## Changes

| File | Change |
|------|--------|
| `requirements.txt` | `tornado>=6.5.3` → `tornado>=6.5.5` |
| `ui/litellm-dashboard/package.json` | `"tar": ">=7.5.10"` → `"tar": ">=7.5.11"` |

Note: `Dockerfile` already pins `tar@7.5.11` in the global npm install and patches all nested copies — no Dockerfile change needed.

## Test plan

- [ ] Rebuild the container image and re-run Trivy scan — expect 0 findings for `tar` and `tornado`
- [ ] Smoke test proxy startup
- [ ] Cherry-pick to `v1.82.0-stable` patch release if needed