### PR TITLE
fix(openai): resolve capability lookups for responses/ prefix models

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2538,6 +2538,12 @@ def _supports_factory(model: str, custom_llm_provider: Optional[str], key: str) 
             model=model, custom_llm_provider=custom_llm_provider
         )
 
+        # Strip responses/ prefix so capability lookups resolve to the
+        # base model entry in the cost map (e.g. "gpt-5.4" not
+        # "responses/gpt-5.4").  See #23423.
+        if model.startswith("responses/"):
+            model = model[len("responses/"):]
+
         model_info = _get_model_info_helper(
             model=model, custom_llm_provider=custom_llm_provider
         )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -998,6 +998,10 @@ def test_supports_tool_choice_simple_tests():
 
     assert litellm.utils.supports_tool_choice(model="perplexity/sonar") is False
 
+    # Responses API prefix must resolve to base model. See #23423.
+    assert litellm.utils.supports_tool_choice(model="openai/responses/gpt-5.4") is True
+    assert litellm.utils.supports_tool_choice(model="responses/gpt-5.4", custom_llm_provider="openai") is True
+
 
 def test_check_provider_match():
     """


### PR DESCRIPTION
## Relevant issues

Fixes #23423

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When using the `openai/responses/` prefix (e.g. `openai/responses/gpt-5.4`), `get_llm_provider()` returns `model="responses/gpt-5.4"`. Capability lookup functions like `supports_tool_choice()` then fail to find this in the model cost map (which only has `gpt-5.4`), incorrectly returning `False` and silently dropping `tool_choice` from the request.

**Fix**: Strip the `responses/` prefix in `_supports_factory()` before the model info lookup, so all `supports_*` functions resolve correctly for Responses API models.

**Test**: Added assertions in `test_supports_tool_choice_simple_tests` for both `openai/responses/gpt-5.4` and `responses/gpt-5.4` with explicit provider.