### PR TITLE
fix(vertex_ai): pass extra_headers to vertex embedding handler

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5206,6 +5206,7 @@ def embedding(  # noqa: PLR0915
                     api_key=api_key,
                     api_base=api_base,
                     client=client,
+                    extra_headers=headers,
                 )
         elif custom_llm_provider == "oobabooga":
             response = oobabooga.embedding(

--- a/tests/test_litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex.py
@@ -1459,6 +1459,31 @@ def test_aaavertex_embeddings_distances(
         text_embedding = text_response.data[0].embedding
 
 
+def test_vertex_embedding_passes_extra_headers():
+    """
+    Test that extra_headers are forwarded to the vertex embedding handler.
+
+    Relevant issue: https://github.com/BerriAI/litellm/issues/21020
+    """
+    from unittest.mock import MagicMock, patch
+
+    mock_response = MagicMock()
+
+    with patch.object(
+        litellm.main.vertex_embedding, "embedding", return_value=mock_response
+    ) as mock_embedding:
+        litellm.embedding(
+            model="vertex_ai/textembedding-gecko",
+            input=["hello"],
+            extra_headers={"X-Custom-Header": "test-value"},
+        )
+
+        mock_embedding.assert_called_once()
+        call_kwargs = mock_embedding.call_args.kwargs
+        assert "extra_headers" in call_kwargs
+        assert call_kwargs["extra_headers"]["X-Custom-Header"] == "test-value"
+
+
 def test_vertex_parallel_tool_calls_true():
     """
     Test that parallel_tool_calls = True sets the correct tool_config.


### PR DESCRIPTION
## Relevant issues

Fixes #21020

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`extra_headers` were not being forwarded to `vertex_embedding.embedding()` in `litellm/main.py`, even though the handler already accepts and uses them. This caused custom headers (auth tokens, routing headers, tracing headers) to be silently dropped for vertex_ai embedding calls.

The fix adds `extra_headers=headers` to the call, consistent with how bedrock, gemini, and vertex batch embeddings already handle it.