### PR TITLE
[Fix] Tag list endpoint 500 from invalid Prisma group_by kwargs

### DIFF
--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -456,11 +456,8 @@ async def list_tags(
         dynamic_tag_rows = await prisma_client.db.litellm_dailytagspend.group_by(
             by=["tag"],
             where={"tag": {"not": None}},
-            # The old find_many(distinct=...) returned arbitrary timestamps from
-            # whichever row Prisma happened to pick. MIN/MAX give more meaningful
-            # values: earliest appearance and most recent activity.
-            _min={"created_at": True},
-            _max={"updated_at": True},
+            min={"created_at": True},
+            max={"updated_at": True},
         )
 
         dynamic_tag_config = [
@@ -468,8 +465,8 @@ async def list_tags(
                 "name": row["tag"],
                 "description": "This is just a spend tag that was passed dynamically in a request. It does not control any LLM models.",
                 "models": None,
-                "created_at": row["_min"]["created_at"].isoformat(),
-                "updated_at": row["_max"]["updated_at"].isoformat(),
+                "created_at": row["_min"]["created_at"],
+                "updated_at": row["_max"]["updated_at"],
             }
             for row in dynamic_tag_rows
             if row["tag"] not in stored_tag_names

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -282,9 +282,9 @@ async def test_list_tags_with_dynamic_tags():
 
             # Setup dynamic tags via group_by — includes one that overlaps with stored
             mock_db.litellm_dailytagspend.group_by = AsyncMock(return_value=[
-                {"tag": "dynamic-tag-1", "_min": {"created_at": datetime(2025, 2, 1)}, "_max": {"updated_at": datetime(2025, 3, 1)}},
-                {"tag": "dynamic-tag-2", "_min": {"created_at": datetime(2025, 2, 2)}, "_max": {"updated_at": datetime(2025, 3, 2)}},
-                {"tag": "stored-tag", "_min": {"created_at": datetime(2025, 1, 1)}, "_max": {"updated_at": datetime(2025, 1, 1)}},  # duplicate, should be excluded
+                {"tag": "dynamic-tag-1", "_min": {"created_at": "2025-02-01T00:00:00Z"}, "_max": {"updated_at": "2025-03-01T00:00:00Z"}},
+                {"tag": "dynamic-tag-2", "_min": {"created_at": "2025-02-02T00:00:00Z"}, "_max": {"updated_at": "2025-03-02T00:00:00Z"}},
+                {"tag": "stored-tag", "_min": {"created_at": "2025-01-01T00:00:00Z"}, "_max": {"updated_at": "2025-01-01T00:00:00Z"}},  # duplicate, should be excluded
             ])
 
             headers = {"Authorization": "Bearer sk-1234"}


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
The `/tag/list` endpoint returned a 500 error: `LiteLLM_DailyTagSpendActions.group_by() got an unexpected keyword argument '_min'`. The `group_by` call used `_min`/`_max` as input kwargs, but those are output keys in the response dict — Prisma's input parameters are `min`/`max` (without underscore). Additionally, the aggregated datetime values are returned as ISO strings, not `datetime` objects, so the `.isoformat()` calls also failed.

### Fix
- Changed `_min={"created_at": True}` → `min={"created_at": True}` and `_max={"updated_at": True}` → `max={"updated_at": True}` in the `group_by` call.
- Removed `.isoformat()` calls since Prisma returns the aggregated values as strings.
- Updated tests to match.

## Testing
- `pytest tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py` — 12/12 pass.

## Type
🐛 Bug Fix
✅ Test