### PR TITLE
fix(litellm): drop the mutable default in completion

### DIFF
--- a/litellm/llms/custom_llm.py
+++ b/litellm/llms/custom_llm.py
@@ -63,10 +63,12 @@ class CustomLLM(BaseLLM):
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[HTTPHandler] = None,
     ) -> Union[ModelResponse, "CustomStreamWrapper"]:
+        if headers is None:
+            headers = {}
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
     def streaming(
@@ -84,10 +86,12 @@ class CustomLLM(BaseLLM):
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[HTTPHandler] = None,
     ) -> Iterator[GenericStreamingChunk]:
+        if headers is None:
+            headers = {}
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
     async def acompletion(


### PR DESCRIPTION
Replaces mutable default in completion() within litellm/llms/custom_llm.py to avoid shared state leaks.

Reason: Mutable defaults are shared across calls and usually turn into state leaks.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile litellm/llms/custom_llm.py`.

Context: py-mutable-default at litellm/llms/custom_llm.py:51.