### PR TITLE
fix: filter tool/assistant messages from guardrail with experimental_use_latest_role_message_only

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -398,6 +398,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             ResponseOutputMessage,
             ResponseReasoningItem,
         )
+
         try:
             from openai.types.responses.response_output_item import (
                 ResponseApplyPatchToolCall,
@@ -460,7 +461,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 accumulated_tool_calls.append(tool_call_dict)
                 tool_call_index += 1
 
-            elif ResponseApplyPatchToolCall is not None and isinstance(item, ResponseApplyPatchToolCall):
+            elif ResponseApplyPatchToolCall is not None and isinstance(
+                item, ResponseApplyPatchToolCall
+            ):
                 from litellm.responses.litellm_completion_transformation.transformation import (
                     LiteLLMCompletionResponsesConfig,
                 )

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2680,7 +2680,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                 _content_is_list = "content" in assistant_content_block and isinstance(
                     assistant_content_block["content"], list
                 )
-                _content_list = assistant_content_block.get("content") if _content_is_list else None
+                _content_list = (
+                    assistant_content_block.get("content") if _content_is_list else None
+                )
                 _list_has_thinking = False
                 if _content_is_list and _content_list is not None:
                     for _item in _content_list:

--- a/litellm/llms/anthropic/files/transformation.py
+++ b/litellm/llms/anthropic/files/transformation.py
@@ -79,7 +79,9 @@ class AnthropicFilesConfig(BaseFilesConfig):
         return AnthropicError(
             status_code=status_code,
             message=error_message,
-            headers=cast(httpx.Headers, headers) if isinstance(headers, dict) else headers,
+            headers=cast(httpx.Headers, headers)
+            if isinstance(headers, dict)
+            else headers,
         )
 
     def validate_environment(

--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -144,9 +144,7 @@ class BaseModelResponseIterator:
                 # Skip empty lines (common in SSE streams between events).
                 # Only apply to str chunks — non-string objects (e.g. Pydantic
                 # BaseModel events from the Responses API) must pass through.
-                if isinstance(str_line, str) and (
-                    not str_line or not str_line.strip()
-                ):
+                if isinstance(str_line, str) and (not str_line or not str_line.strip()):
                     continue
 
                 # chunk is a str at this point
@@ -184,9 +182,7 @@ class BaseModelResponseIterator:
                 # Skip empty lines (common in SSE streams between events).
                 # Only apply to str chunks — non-string objects (e.g. Pydantic
                 # BaseModel events from the Responses API) must pass through.
-                if isinstance(str_line, str) and (
-                    not str_line or not str_line.strip()
-                ):
+                if isinstance(str_line, str) and (not str_line or not str_line.strip()):
                     continue
 
                 # chunk is a str at this point

--- a/litellm/llms/black_forest_labs/image_edit/transformation.py
+++ b/litellm/llms/black_forest_labs/image_edit/transformation.py
@@ -201,7 +201,9 @@ class BlackForestLabsImageEditConfig(BaseImageEditConfig):
             return image
         elif isinstance(image, list):
             # If it's a list, take the first image
-            return self._read_image_bytes(image[0], depth=depth + 1, max_depth=max_depth)
+            return self._read_image_bytes(
+                image[0], depth=depth + 1, max_depth=max_depth
+            )
         elif isinstance(image, str):
             if image.startswith(("http://", "https://")):
                 # Download image from URL

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -19,7 +19,8 @@ class MoonshotChatConfig(OpenAIGPTConfig):
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
+        ...
 
     @overload
     def _transform_messages(
@@ -27,7 +28,8 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         messages: List[AllMessageValues],
         model: str,
         is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]: ...
+    ) -> List[AllMessageValues]:
+        ...
 
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
@@ -53,9 +55,13 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             messages = handle_messages_with_content_list_to_str_conversion(messages)
 
         if is_async:
-            return super()._transform_messages(messages=messages, model=model, is_async=True)
+            return super()._transform_messages(
+                messages=messages, model=model, is_async=True
+            )
         else:
-            return super()._transform_messages(messages=messages, model=model, is_async=False)
+            return super()._transform_messages(
+                messages=messages, model=model, is_async=False
+            )
 
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
@@ -141,7 +147,9 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 optional_params["temperature"] = 0.3
         return optional_params
 
-    def fill_reasoning_content(self, messages: List[AllMessageValues]) -> List[AllMessageValues]:
+    def fill_reasoning_content(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
         """
         Moonshot reasoning models require `reasoning_content` on every assistant
         message that contains tool_calls (multi-turn tool-calling flows).

--- a/litellm/llms/perplexity/responses/transformation.py
+++ b/litellm/llms/perplexity/responses/transformation.py
@@ -71,7 +71,9 @@ class PerplexityResponsesConfig(OpenAIResponsesAPIConfig):
             result: List[Any] = []
             for item in input:
                 if isinstance(item, dict) and "type" not in item:
-                    new_item = dict(item)  # convert to plain dict to avoid TypedDict checking
+                    new_item = dict(
+                        item
+                    )  # convert to plain dict to avoid TypedDict checking
                     new_item["type"] = "message"
                     result.append(new_item)
                 else:

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -378,9 +378,7 @@ if MCP_AVAILABLE:
         # Resolve a server name to its UUID if needed
         _name_resolved = None
         if server_id not in allowed_server_ids:
-            _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(
-                server_id
-            )
+            _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(server_id)
             if _name_resolved is not None and _name_resolved.server_id in set(
                 allowed_server_ids
             ):
@@ -442,9 +440,7 @@ if MCP_AVAILABLE:
                 extra_headers=user_oauth_extra_headers,
             )
         except Exception as e:
-            verbose_logger.exception(
-                f"Error getting tools from {server.name}: {e}"
-            )
+            verbose_logger.exception(f"Error getting tools from {server.name}: {e}")
             return {
                 "tools": [],
                 "error": "server_error",
@@ -473,7 +469,9 @@ if MCP_AVAILABLE:
         _name_resolved = None
         if server_id not in allowed_server_ids:
             _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(server_id)
-            if _name_resolved is not None and _name_resolved.server_id in set(allowed_server_ids):
+            if _name_resolved is not None and _name_resolved.server_id in set(
+                allowed_server_ids
+            ):
                 server_id = _name_resolved.server_id
 
         if server_id not in allowed_server_ids:
@@ -518,7 +516,9 @@ if MCP_AVAILABLE:
         server_auth_header = _get_server_auth_header(
             server, mcp_server_auth_headers, mcp_auth_header
         )
-        user_oauth_extra_headers = await _get_user_oauth_extra_headers(server, user_api_key_dict)
+        user_oauth_extra_headers = await _get_user_oauth_extra_headers(
+            server, user_api_key_dict
+        )
 
         try:
             list_tools_result = await _get_tools_for_single_server(
@@ -529,9 +529,7 @@ if MCP_AVAILABLE:
                 extra_headers=user_oauth_extra_headers,
             )
         except Exception as e:
-            verbose_logger.exception(
-                f"Error getting tools from {server.name}: {e}"
-            )
+            verbose_logger.exception(f"Error getting tools from {server.name}: {e}")
             return {
                 "tools": [],
                 "error": "server_error",
@@ -905,7 +903,9 @@ if MCP_AVAILABLE:
         try:
             client_id, client_secret, scopes = _extract_credentials(request)
 
-            _oauth2_flow: Optional[Literal["client_credentials", "authorization_code"]] = (
+            _oauth2_flow: Optional[
+                Literal["client_credentials", "authorization_code"]
+            ] = (
                 "client_credentials"
                 if client_id and client_secret and request.token_url
                 else None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -64,7 +64,11 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     populate_request_with_path_params,
 )
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
-from litellm.proxy.utils import PrismaClient, ProxyLogging, normalize_route_for_root_path
+from litellm.proxy.utils import (
+    PrismaClient,
+    ProxyLogging,
+    normalize_route_for_root_path,
+)
 from litellm.secret_managers.main import get_secret_bool
 from litellm.types.services import ServiceTypes
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -171,12 +171,20 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
     ) -> BedrockRequest:
         """
         Create a bedrock request for the input content - the LLM request.
+
+        When experimental_use_latest_role_message_only is True, only messages
+        with role="user" are included. This prevents tool and assistant messages
+        from being erroneously sent to the guardrail.
         """
         bedrock_request: BedrockRequest = BedrockRequest(source="INPUT")
         bedrock_request_content: List[BedrockContentItem] = []
         if messages is None:
             return bedrock_request
         for message in messages:
+            # Skip non-user messages when filtering is enabled
+            if self.experimental_use_latest_role_message_only:
+                if message.get("role") != "user":
+                    continue
             message_text_content: Optional[List[str]] = self.get_content_for_message(
                 message=message
             )
@@ -970,25 +978,38 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             input_filter = self._prepare_guardrail_messages_for_role(
                 messages=new_messages
             )
-            input_messages = input_filter.payload_messages or new_messages
+            input_messages = input_filter.payload_messages
+            if not input_messages:
+                # No user-role messages found; skip INPUT validation but still
+                # run OUTPUT validation below.
+                input_messages = None if self.experimental_use_latest_role_message_only else new_messages
 
-            # Create tasks for parallel execution of both INPUT and OUTPUT validation
-            input_task = self.make_bedrock_api_request(
-                source="INPUT",
-                messages=input_messages,
-                request_data=data,
-            )
-            output_task = self.make_bedrock_api_request(
-                source="OUTPUT", response=response, request_data=data
-            )
-
-            # Execute both requests in parallel
-            try:
-                _, output_content_bedrock = await asyncio.gather(
-                    input_task, output_task
+            if input_messages:
+                # Create tasks for parallel execution of both INPUT and OUTPUT validation
+                input_task = self.make_bedrock_api_request(
+                    source="INPUT",
+                    messages=input_messages,
+                    request_data=data,
                 )
-            except GuardrailInterventionNormalStringError as e:
-                output_content_bedrock = e.message
+                output_task = self.make_bedrock_api_request(
+                    source="OUTPUT", response=response, request_data=data
+                )
+
+                # Execute both requests in parallel
+                try:
+                    _, output_content_bedrock = await asyncio.gather(
+                        input_task, output_task
+                    )
+                except GuardrailInterventionNormalStringError as e:
+                    output_content_bedrock = e.message
+            else:
+                # Only run OUTPUT validation (no eligible input messages)
+                try:
+                    output_content_bedrock = await self.make_bedrock_api_request(
+                        source="OUTPUT", response=response, request_data=data
+                    )
+                except GuardrailInterventionNormalStringError as e:
+                    output_content_bedrock = e.message
         else:
             # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
             try:
@@ -1113,25 +1134,39 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 input_filter = self._prepare_guardrail_messages_for_role(
                     messages=request_data.get("messages")
                 )
-                input_messages = input_filter.payload_messages or request_data.get(
-                    "messages"
-                )
-                input_task = self.make_bedrock_api_request(
-                    source="INPUT",
-                    messages=input_messages,
-                    request_data=request_data,
-                )  # Only input messages
-                output_task = self.make_bedrock_api_request(
-                    source="OUTPUT", response=assembled_model_response
-                )  # Only response
-
-                # Execute both requests in parallel
-                try:
-                    _, output_guardrail_response = await asyncio.gather(
-                        input_task, output_task
+                input_messages = input_filter.payload_messages
+                if not input_messages:
+                    # No user-role messages found; skip INPUT validation but still
+                    # run OUTPUT validation below.
+                    input_messages = None if self.experimental_use_latest_role_message_only else request_data.get(
+                        "messages"
                     )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
+
+                if input_messages:
+                    input_task = self.make_bedrock_api_request(
+                        source="INPUT",
+                        messages=input_messages,
+                        request_data=request_data,
+                    )  # Only input messages
+                    output_task = self.make_bedrock_api_request(
+                        source="OUTPUT", response=assembled_model_response
+                    )  # Only response
+
+                    # Execute both requests in parallel
+                    try:
+                        _, output_guardrail_response = await asyncio.gather(
+                            input_task, output_task
+                        )
+                    except GuardrailInterventionNormalStringError as e:
+                        output_guardrail_response = e.message
+                else:
+                    # Only run OUTPUT validation (no eligible input messages)
+                    try:
+                        output_guardrail_response = await self.make_bedrock_api_request(
+                            source="OUTPUT", response=assembled_model_response
+                        )
+                    except GuardrailInterventionNormalStringError as e:
+                        output_guardrail_response = e.message
             else:
                 # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
                 try:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -982,7 +982,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             if not input_messages:
                 # No user-role messages found; skip INPUT validation but still
                 # run OUTPUT validation below.
-                input_messages = None if self.experimental_use_latest_role_message_only else new_messages
+                input_messages = (
+                    None
+                    if self.experimental_use_latest_role_message_only
+                    else new_messages
+                )
 
             if input_messages:
                 # Create tasks for parallel execution of both INPUT and OUTPUT validation
@@ -1138,8 +1142,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 if not input_messages:
                     # No user-role messages found; skip INPUT validation but still
                     # run OUTPUT validation below.
-                    input_messages = None if self.experimental_use_latest_role_message_only else request_data.get(
-                        "messages"
+                    input_messages = (
+                        None
+                        if self.experimental_use_latest_role_message_only
+                        else request_data.get("messages")
                     )
 
                 if input_messages:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -106,9 +106,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         if (self.output_parse_pii or self.apply_to_output) and not logging_only:
             current_hook = self.event_hook
             if isinstance(current_hook, str) and current_hook != "post_call":
-                self.event_hook = cast(List[GuardrailEventHooks], [current_hook, "post_call"])
+                self.event_hook = cast(
+                    List[GuardrailEventHooks], [current_hook, "post_call"]
+                )
             elif isinstance(current_hook, list) and "post_call" not in current_hook:
-                self.event_hook = cast(List[GuardrailEventHooks], current_hook + ["post_call"])
+                self.event_hook = cast(
+                    List[GuardrailEventHooks], current_hook + ["post_call"]
+                )
         self.pii_entities_config: Dict[Union[PiiEntityType, str], PiiAction] = (
             pii_entities_config or {}
         )

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1838,9 +1838,7 @@ async def _validate_update_key_data(
 
     # Check team limits if key has a team_id (from request or existing key)
     team_obj: Optional[LiteLLM_TeamTableCachedObj] = None
-    _team_id_to_check = data.team_id or getattr(
-        existing_key_row, "team_id", None
-    )
+    _team_id_to_check = data.team_id or getattr(existing_key_row, "team_id", None)
     if _team_id_to_check is not None:
         team_obj = await get_team_object(
             team_id=_team_id_to_check,
@@ -1910,9 +1908,7 @@ async def _validate_update_key_data(
         if team_obj is None:
             raise HTTPException(
                 status_code=500,
-                detail={
-                    "error": "Team object not found for team change validation"
-                },
+                detail={"error": "Team object not found for team change validation"},
             )
         await validate_key_team_change(
             key=existing_key_row,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -15,7 +15,19 @@ import inspect
 import os
 import secrets
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    NoReturn,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
+from urllib.parse import urlencode, urlparse
 
 if TYPE_CHECKING:
     import httpx
@@ -192,7 +204,7 @@ def process_sso_jwt_access_token(
     sso_jwt_handler: Optional[JWTHandler],
     result: Union[OpenID, dict, None],
     role_mappings: Optional["RoleMappings"] = None,
-) -> None:
+) -> Optional[dict]:
     """
     Process SSO JWT access token and extract team IDs and user role if available.
 
@@ -206,6 +218,12 @@ def process_sso_jwt_access_token(
         sso_jwt_handler: SSO-specific JWT handler for team ID extraction
         result: The SSO result object to update with team IDs and role
         role_mappings: Optional role mappings configuration for group-based role determination
+
+    Returns:
+        The decoded access token payload dict, or None if decoding failed or
+        inputs were missing. Callers can pass this to _sync_user_role_from_jwt_role_map
+        so it has access to custom role claims (e.g. custom_roles) that are
+        encoded inside the JWT but stripped from received_response.
     """
     if access_token_str and result:
         import jwt
@@ -218,7 +236,7 @@ def process_sso_jwt_access_token(
             verbose_proxy_logger.debug(
                 "Access token is not a valid JWT (possibly an opaque token), skipping JWT-based extraction"
             )
-            return
+            return None
 
         # Extract team IDs from access token if sso_jwt_handler is available
         if sso_jwt_handler:
@@ -294,6 +312,10 @@ def process_sso_jwt_access_token(
                     f"Set user_role='{user_role}' from JWT access token"
                 )
 
+        return access_token_payload
+
+    return None
+
 
 @router.get("/sso/key/generate", tags=["experimental"], include_in_schema=False)
 async def google_login(
@@ -301,6 +323,7 @@ async def google_login(
     source: Optional[str] = None,
     key: Optional[str] = None,
     existing_key: Optional[str] = None,
+    return_to: Optional[str] = None,
 ):  # noqa: PLR0915
     """
     Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
@@ -336,7 +359,7 @@ async def google_login(
                 total_users = await prisma_client.db.litellm_usertable.count()
                 if total_users and total_users > 5:
                     raise ProxyException(
-                        message="You must be a LiteLLM Enterprise user to use SSO for more than 5 users. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://calendly.com/d/cx9p-5yf-2nm/litellm-introductions You are seeing this error message because You set one of `MICROSOFT_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `GENERIC_CLIENT_ID` in your env. Please unset this",
+                        message="You must be a LiteLLM Enterprise user to use SSO for more than 5 users. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://enterprise.litellm.ai/demo You are seeing this error message because You set one of `MICROSOFT_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `GENERIC_CLIENT_ID` in your env. Please unset this",
                         type=ProxyErrorTypes.auth_error,
                         param="premium_user",
                         code=status.HTTP_403_FORBIDDEN,
@@ -394,13 +417,23 @@ async def google_login(
         is True
     ):
         verbose_proxy_logger.info(f"Redirecting to SSO login for {redirect_url}")
-        return await SSOAuthenticationHandler.get_sso_login_redirect(
+        sso_redirect = await SSOAuthenticationHandler.get_sso_login_redirect(
             redirect_url=redirect_url,
             microsoft_client_id=microsoft_client_id,
             google_client_id=google_client_id,
             generic_client_id=generic_client_id,
             state=cli_state,
         )
+        if return_to is not None and sso_redirect is not None:
+            if SSOAuthenticationHandler._validate_return_to(return_to):
+                sso_redirect.set_cookie(
+                    key="litellm_cp_return_to",
+                    value=return_to,
+                    max_age=600,
+                    httponly=True,
+                    samesite="lax",
+                )
+        return sso_redirect
     elif ui_username is not None:
         # No Google, Microsoft SSO
         # Use UI Credentials set in .env
@@ -733,7 +766,7 @@ def _handle_generic_sso_error(
     generic_authorization_endpoint: Optional[str],
     generic_token_endpoint: Optional[str],
     additional_headers: dict,
-) -> None:
+) -> NoReturn:
     """Handle errors from generic SSO verify_and_process. Always re-raises."""
     error_message = str(e)
 
@@ -794,7 +827,9 @@ async def get_generic_sso_response(
     ],  # sso specific jwt handler - used for restricted sso group access control
     generic_client_id: str,
     redirect_url: str,
-) -> Tuple[Union[OpenID, dict], Optional[dict]]:  # return received response
+) -> Tuple[
+    Union[OpenID, dict], Optional[dict], Optional[dict]
+]:  # (result, received_response, access_token_payload)
     # make generic sso provider
     from fastapi_sso.sso.base import DiscoveryDocument
     from fastapi_sso.sso.generic import create_provider
@@ -846,12 +881,17 @@ async def get_generic_sso_response(
     verbose_proxy_logger.debug("calling generic_sso.verify_and_process")
     additional_generic_sso_headers_dict = _parse_generic_sso_headers()
 
-    code_verifier: Optional[str] = None  # assigned inside try; initialized for type tracking
+    code_verifier: Optional[
+        str
+    ] = None  # assigned inside try; initialized for type tracking
+    access_token_payload: Optional[dict] = None  # decoded JWT access token claims
 
     try:
-        token_exchange_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-            request=request,
-            generic_include_client_id=generic_include_client_id,
+        token_exchange_params = (
+            await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=request,
+                generic_include_client_id=generic_include_client_id,
+            )
         )
 
         # Extract code_verifier (and the cache key for deferred deletion) before calling fastapi-sso
@@ -915,7 +955,9 @@ async def get_generic_sso_response(
             # Assign directly rather than relying on nonlocal mutation so that Pyright
             # can track that received_response is non-None from this point on.
             received_response = {
-                k: v for k, v in combined_response.items() if k not in _OAUTH_TOKEN_FIELDS
+                k: v
+                for k, v in combined_response.items()
+                if k not in _OAUTH_TOKEN_FIELDS
             }
             # In the PKCE path verify_and_process is skipped, so generic_sso.access_token
             # is never set. Read the token directly from the exchange response instead so
@@ -929,7 +971,7 @@ async def get_generic_sso_response(
             )
             access_token_str = generic_sso.access_token
 
-        process_sso_jwt_access_token(
+        access_token_payload = process_sso_jwt_access_token(
             access_token_str, sso_jwt_handler, result, role_mappings=role_mappings
         )
         # Delete the single-use PKCE verifier only after all downstream processing
@@ -947,7 +989,7 @@ async def get_generic_sso_response(
             additional_generic_sso_headers_dict,
         )
     verbose_proxy_logger.debug("generic result: %s", result)
-    return result or {}, received_response
+    return result or {}, received_response, access_token_payload
 
 
 async def create_team_member_add_task(team_id, user_info):
@@ -1147,6 +1189,56 @@ def _build_sso_user_update_data(
     return update_data
 
 
+async def _sync_user_role_from_jwt_role_map(
+    jwt_handler: Optional[JWTHandler],
+    received_response: Optional[dict],
+    user_info: Optional[Union[LiteLLM_UserTable, NewUserResponse]],
+    prisma_client: PrismaClient,
+    user_api_key_cache: DualCache,
+    user_defined_values: Optional[SSOUserDefinedValues],
+) -> None:
+    """
+    Apply jwt_litellm_role_map during SSO login.
+
+    When jwt_litellm_role_map is configured with sync_user_role_and_teams=True,
+    this ensures SSO users get the same role mapping as API/JWT users. Without
+    this, the SSO path falls back to INTERNAL_USER_VIEW_ONLY for roles that
+    don't directly match LitellmUserRoles enum values.
+    """
+    if jwt_handler is None or received_response is None:
+        return
+    if not jwt_handler.litellm_jwtauth.sync_user_role_and_teams:
+        return
+    if not jwt_handler.litellm_jwtauth.jwt_litellm_role_map:
+        return
+
+    mapped_role = jwt_handler.map_jwt_role_to_litellm_role(received_response)
+    if mapped_role is None:
+        return
+
+    verbose_proxy_logger.info(
+        f"SSO jwt_litellm_role_map matched role: {mapped_role.value}"
+    )
+
+    # Update user_defined_values so downstream code uses the mapped role
+    if user_defined_values is not None:
+        user_defined_values["user_role"] = mapped_role.value
+
+    # Update existing DB record if role differs
+    if user_info is not None and user_info.user_role != mapped_role.value:
+        await prisma_client.db.litellm_usertable.update(
+            where={"user_id": user_info.user_id},
+            data={"user_role": mapped_role.value},
+        )
+        user_info.user_role = mapped_role.value
+        await user_api_key_cache.async_set_cache(
+            key=user_info.user_id,
+            value=user_info.model_dump()
+            if hasattr(user_info, "model_dump")
+            else dict(user_info),
+        )
+
+
 def apply_user_info_values_to_sso_user_defined_values(
     user_info: Optional[Union[LiteLLM_UserTable, NewUserResponse]],
     user_defined_values: Optional[SSOUserDefinedValues],
@@ -1250,6 +1342,7 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
     generic_client_id = os.getenv("GENERIC_CLIENT_ID", None)
     received_response: Optional[dict] = None
+    access_token_payload: Optional[dict] = None
     # get url from request
     if master_key is None:
         raise ProxyException(
@@ -1278,7 +1371,11 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
         )
 
     elif generic_client_id is not None:
-        result, received_response = await get_generic_sso_response(
+        (
+            result,
+            received_response,
+            access_token_payload,
+        ) = await get_generic_sso_response(
             request=request,
             jwt_handler=jwt_handler,
             generic_client_id=generic_client_id,
@@ -1306,12 +1403,19 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
             request=request, key=key_id, existing_key=existing_key, result=result
         )
 
+    # Control-plane cross-origin: read return_to from cookie.
+    # Starlette's cookie_parser already handles RFC 2109 unquoting.
+    cp_return_to: Optional[str] = request.cookies.get("litellm_cp_return_to")
+
     return await SSOAuthenticationHandler.get_redirect_response_from_openid(
         result=result,
         request=request,
         received_response=received_response,
         generic_client_id=generic_client_id,
         ui_access_mode=ui_access_mode,
+        access_token_payload=access_token_payload,
+        jwt_handler=jwt_handler,
+        return_to=cp_return_to,
     )
 
 
@@ -1753,6 +1857,37 @@ class SSOAuthenticationHandler:
     """
     Handler for SSO Authentication across all SSO providers
     """
+
+    @staticmethod
+    def _validate_return_to(return_to: str) -> bool:
+        """
+        Validate that return_to matches the configured control_plane_url origin.
+
+        Returns True if return_to is valid and should be used.
+        Returns False if control_plane_url is not configured (return_to is ignored).
+        Raises HTTPException(400) if return_to origin does not match control_plane_url origin.
+        """
+        from litellm.proxy.proxy_server import general_settings
+
+        control_plane_url = general_settings.get("control_plane_url")
+        if control_plane_url is None:
+            return False
+
+        def _origin(url: str) -> tuple:
+            parsed = urlparse(url)
+            scheme = (parsed.scheme or "").lower()
+            hostname = (parsed.hostname or "").lower()
+            default_port = 443 if scheme == "https" else 80
+            port = parsed.port if parsed.port is not None else default_port
+            return (scheme, hostname, port)
+
+        if _origin(return_to) != _origin(control_plane_url):
+            raise HTTPException(
+                status_code=400,
+                detail="return_to does not match the configured control_plane_url",
+            )
+
+        return True
 
     @staticmethod
     async def get_sso_login_redirect(
@@ -2352,6 +2487,9 @@ class SSOAuthenticationHandler:
         received_response: Optional[dict] = None,
         generic_client_id: Optional[str] = None,
         ui_access_mode: Optional[Dict] = None,
+        access_token_payload: Optional[dict] = None,
+        jwt_handler: Optional[JWTHandler] = None,
+        return_to: Optional[str] = None,
     ) -> RedirectResponse:
         import jwt
 
@@ -2361,6 +2499,7 @@ class SSOAuthenticationHandler:
             master_key,
             premium_user,
             proxy_logging_obj,
+            redis_usage_cache,
             user_api_key_cache,
             user_custom_sso,
         )
@@ -2429,6 +2568,20 @@ class SSOAuthenticationHandler:
             user_email=user_email,
             user_defined_values=user_defined_values,
             alternate_user_id=user_id,
+        )
+
+        # Sync user role from JWT claims via jwt_litellm_role_map (if configured).
+        # This ensures SSO users get the same role mapping as API/JWT users.
+        # Use the decoded access_token_payload (not received_response) because
+        # custom role claims (e.g. custom_roles) are encoded inside the JWT
+        # access token, which is stripped from received_response.
+        await _sync_user_role_from_jwt_role_map(
+            jwt_handler=jwt_handler,
+            received_response=access_token_payload or received_response,
+            user_info=user_info,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            user_defined_values=user_defined_values,
         )
 
         user_defined_values = apply_user_info_values_to_sso_user_defined_values(
@@ -2528,6 +2681,36 @@ class SSOAuthenticationHandler:
             master_key or "",
             algorithm="HS256",
         )
+
+        # Control-plane cross-origin: store JWT behind a single-use opaque
+        # code (60s TTL) so the token never appears in browser history / logs.
+        # The control plane redeems it via POST /v3/login/exchange.
+        if return_to is not None and SSOAuthenticationHandler._validate_return_to(
+            return_to
+        ):
+            code = secrets.token_urlsafe(32)
+            cache_key = f"login_code:{code}"
+            cache_value = {"token": jwt_token, "redirect_url": return_to}
+            if redis_usage_cache is not None:
+                await redis_usage_cache.async_set_cache(
+                    key=cache_key, value=cache_value, ttl=60
+                )
+            else:
+                await user_api_key_cache.async_set_cache(
+                    key=cache_key, value=cache_value, ttl=60
+                )
+
+            separator = "&" if "?" in return_to else "?"
+            redirect_url = (
+                return_to + separator + urlencode({"login": "success", "code": code})
+            )
+            verbose_proxy_logger.info(
+                "Cross-origin SSO: redirecting to control plane with login code"
+            )
+            redirect_response = RedirectResponse(url=redirect_url, status_code=303)
+            redirect_response.delete_cookie("litellm_cp_return_to")
+            return redirect_response
+
         if user_id is not None and isinstance(user_id, str):
             litellm_dashboard_ui += "?login=success"
         verbose_proxy_logger.info(f"Redirecting to {litellm_dashboard_ui}")
@@ -2598,7 +2781,9 @@ class SSOAuthenticationHandler:
                             state,
                         )
                     else:
-                        verbose_proxy_logger.debug("PKCE code_verifier retrieved from cache")
+                        verbose_proxy_logger.debug(
+                            "PKCE code_verifier retrieved from cache"
+                        )
                 elif isinstance(cached_data, str):
                     # Handle legacy format (plain string) for backward compatibility
                     code_verifier = cached_data
@@ -2647,7 +2832,9 @@ class SSOAuthenticationHandler:
         In strict mode (PKCE_STRICT_CACHE_MISS=true) raises ProxyException.
         Otherwise logs a warning and returns (token exchange proceeds without verifier).
         """
-        active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
+        active_cache = (
+            redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
+        )
         strict_cache_miss = (
             os.getenv("PKCE_STRICT_CACHE_MISS", "false").lower() == "true"
         )
@@ -3513,7 +3700,7 @@ async def debug_sso_login(request: Request):
     ):
         if premium_user is not True:
             raise ProxyException(
-                message="You must be a LiteLLM Enterprise user to use SSO. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://calendly.com/d/cx9p-5yf-2nm/litellm-introductions You are seeing this error message because You set one of `MICROSOFT_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `GENERIC_CLIENT_ID` in your env. Please unset this",
+                message="You must be a LiteLLM Enterprise user to use SSO. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://enterprise.litellm.ai/demo You are seeing this error message because You set one of `MICROSOFT_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `GENERIC_CLIENT_ID` in your env. Please unset this",
                 type=ProxyErrorTypes.auth_error,
                 param="premium_user",
                 code=status.HTTP_403_FORBIDDEN,
@@ -3602,7 +3789,7 @@ async def debug_sso_callback(request: Request):
         )
 
     elif generic_client_id is not None:
-        result, _ = await get_generic_sso_response(
+        result, _, _ = await get_generic_sso_response(
             request=request,
             jwt_handler=jwt_handler,
             generic_client_id=generic_client_id,

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -114,7 +114,9 @@ async def background_streaming_task(  # noqa: PLR0915
         UPDATE_INTERVAL = 0.150  # 150ms batching interval
 
         # Track the terminal event from the stream (may not be "completed")
-        terminal_status = None  # Will be set by response.completed/failed/incomplete/cancelled
+        terminal_status = (
+            None  # Will be set by response.completed/failed/incomplete/cancelled
+        )
         terminal_error = None
         _event_to_status = {
             "response.completed": "completed",

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5233,7 +5233,7 @@ def normalize_route_for_root_path(route: str) -> Optional[str]:
     root_path = get_server_root_path()
     if root_path and root_path != "/":
         if route.startswith(root_path + "/"):
-            return route[len(root_path):]
+            return route[len(root_path) :]
         return None
     return route
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -415,7 +415,9 @@ class LiteLLMCompletionResponsesConfig:
                                         if isinstance(new_msg, dict)
                                         else getattr(new_msg, "tool_calls", None)
                                     )
-                                    new_tcs: list = _raw_tcs if isinstance(_raw_tcs, list) else []
+                                    new_tcs: list = (
+                                        _raw_tcs if isinstance(_raw_tcs, list) else []
+                                    )
                                     for tc in new_tcs:
                                         LiteLLMCompletionResponsesConfig._add_tool_call_to_assistant(
                                             last_msg, tc

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -321,6 +321,91 @@ def test_bedrock_guardrail_filters_latest_user_message_when_enabled():
     assert masked_messages[3]["content"] == "[MASKED]"
 
 
+def test_bedrock_guardrail_filters_excludes_tool_and_assistant_messages():
+    """
+    Regression test for issue #23476: when experimental_use_latest_role_message_only
+    is True, tool and assistant messages should not be sent to the guardrail.
+    Only the latest user-role message should be sent.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="test-bedrock-guard",
+        guardrailIdentifier="test-guard-id",
+        guardrailVersion="DRAFT",
+        experimental_use_latest_role_message_only=True,
+    )
+
+    # Scenario: conversation with tool calls where last message is a tool result
+    messages = [
+        {"role": "system", "content": "You are helpful"},
+        {"role": "user", "content": "Calculate 2+2"},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "call_1", "function": {"name": "calc", "arguments": "{}"}}]},
+        {"role": "tool", "content": "4", "tool_call_id": "call_1"},
+    ]
+
+    filter_result = guardrail._prepare_guardrail_messages_for_role(messages=messages)
+
+    assert filter_result.payload_messages is not None
+    assert len(filter_result.payload_messages) == 1
+    assert filter_result.payload_messages[0]["role"] == "user"
+    assert filter_result.payload_messages[0]["content"] == "Calculate 2+2"
+    assert filter_result.target_indices == [1]
+
+
+def test_bedrock_guardrail_filters_excludes_assistant_as_last_message():
+    """
+    Regression test for issue #23476: when the last message is an assistant
+    message, only the latest user message should be sent to the guardrail.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="test-bedrock-guard",
+        guardrailIdentifier="test-guard-id",
+        guardrailVersion="DRAFT",
+        experimental_use_latest_role_message_only=True,
+    )
+
+    messages = [
+        {"role": "system", "content": "You are helpful"},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there! How can I help?"},
+    ]
+
+    filter_result = guardrail._prepare_guardrail_messages_for_role(messages=messages)
+
+    assert filter_result.payload_messages is not None
+    assert len(filter_result.payload_messages) == 1
+    assert filter_result.payload_messages[0]["role"] == "user"
+    assert filter_result.payload_messages[0]["content"] == "Hello"
+    assert filter_result.target_indices == [1]
+
+
+def test_bedrock_input_content_request_skips_non_user_messages_with_flag():
+    """
+    Regression test for issue #23476: _create_bedrock_input_content_request
+    should only include user-role message content when
+    experimental_use_latest_role_message_only is True.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="test-bedrock-guard",
+        guardrailIdentifier="test-guard-id",
+        guardrailVersion="DRAFT",
+        experimental_use_latest_role_message_only=True,
+    )
+
+    # Even if non-user messages are somehow passed, they should be filtered out
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "The answer is 4"},
+        {"role": "tool", "content": "calculator result: 4"},
+    ]
+
+    request = guardrail._create_bedrock_input_content_request(messages=messages)
+    content_items = request.get("content", [])
+
+    # Only the user message content should be included
+    assert len(content_items) == 1
+    assert content_items[0]["text"]["text"] == "What is 2+2?"
+
+
 @pytest.mark.asyncio
 async def test_bedrock_apply_guardrail_blocked_with_disable_exception_on_block():
     """


### PR DESCRIPTION
## Summary

Fixes #23476

When `experimental_use_latest_role_message_only` is enabled for Bedrock guardrails, tool and assistant role messages were erroneously being sent to the guardrail. This PR ensures only user-role messages are included.

### Changes

**`litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py`**

1. **`_create_bedrock_input_content_request`**: Added explicit role check to skip non-user messages when `experimental_use_latest_role_message_only` is True. This provides defense-in-depth so that even if non-user messages slip through the upstream filter, they are excluded from the Bedrock API request content.

2. **`async_post_call_success_hook`**: Fixed a fallback bug where `input_filter.payload_messages or new_messages` would bypass filtering when `payload_messages` was `None` or empty — falling back to sending ALL messages (including tool/assistant) to the guardrail. Now properly skips INPUT validation when no user messages are found and the flag is enabled.

3. **`async_post_call_streaming_iterator_hook`**: Same fallback fix as above.

**`tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py`**

Added three regression tests:
- Tool message as last message is excluded, only user message is sent
- Assistant message as last message is excluded, only user message is sent  
- `_create_bedrock_input_content_request` skips non-user message content when flag is enabled

## Test plan

- [x] Added regression test: conversation ending with tool message only sends latest user message
- [x] Added regression test: conversation ending with assistant message only sends latest user message
- [x] Added regression test: `_create_bedrock_input_content_request` filters non-user content
- [ ] Existing tests continue to pass