### PR TITLE
fix: add 'block' to guardrail on_violation Literal type

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -658,7 +658,7 @@ class BaseLitellmParams(
     )
     on_violation: Optional[Literal["warn", "end_session", "block"]] = Field(
         default=None,
-        description="For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
+        description="For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection. 'block' blocks the request (used by guardrails such as MCP Security).",
     )
     realtime_violation_message: Optional[str] = Field(
         default=None,

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -656,7 +656,7 @@ class BaseLitellmParams(
         default=None,
         description="For /v1/realtime sessions: automatically close the session after this many guardrail violations.",
     )
-    on_violation: Optional[Literal["warn", "end_session"]] = Field(
+    on_violation: Optional[Literal["warn", "end_session", "block"]] = Field(
         default=None,
         description="For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
     )


### PR DESCRIPTION
## Summary

Fixes #23624

The `on_violation` field in `BaseLitellmParams` only allowed `'warn'` and `'end_session'` as valid values, but `'block'` is a valid and commonly used value for guardrail configurations. This caused a pydantic `ValidationError` when loading guardrails from the database that had `on_violation` set to `'block'`:

```
Input should be 'warn' or 'end_session' [type=literal_error, input_value='block', input_type=str]
```

## Changes

- Added `'block'` to the `Literal` type for `on_violation` in `BaseLitellmParams` (`litellm/types/guardrails.py` line 659)

## Test plan

- Verify that guardrails with `on_violation='block'` no longer cause a pydantic validation error
- Verify that existing `'warn'` and `'end_session'` values continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)