### PR TITLE
fix: apply disallowed_tools filter during MCP tool listing

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1074,6 +1074,14 @@ class MCPServerManager:
             else:
                 tools = await self._fetch_tools_with_timeout(client, server.name)
 
+            # Filter tools based on allowed_tools / disallowed_tools config
+            if server.allowed_tools or server.disallowed_tools:
+                tools = [
+                    tool
+                    for tool in tools
+                    if self.check_allowed_or_banned_tools(tool.name, server)
+                ]
+
             prefixed_or_original_tools = self._create_prefixed_tools(
                 tools, server, add_prefix=add_prefix
             )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1075,11 +1075,20 @@ class MCPServerManager:
                 tools = await self._fetch_tools_with_timeout(client, server.name)
 
             # Filter tools based on allowed_tools / disallowed_tools config
+            # For OpenAPI servers (spec_path), tools already have the server
+            # prefix in their name (e.g. "myserver-get_pet"). Strip it before
+            # checking so that unprefixed disallowed_tools entries match.
             if server.allowed_tools or server.disallowed_tools:
+                prefix = f"{server.name}-"
                 tools = [
                     tool
                     for tool in tools
-                    if self.check_allowed_or_banned_tools(tool.name, server)
+                    if self.check_allowed_or_banned_tools(
+                        tool.name.removeprefix(prefix)
+                        if server.spec_path
+                        else tool.name,
+                        server,
+                    )
                 ]
 
             prefixed_or_original_tools = self._create_prefixed_tools(


### PR DESCRIPTION
## Summary
- Fixes #23549
- The MCP `disallowed_tools` config was not working because `_get_tools_from_server()` never filtered tools using the `disallowed_tools` list before returning them to the UI/API
- Added a filtering step that calls the existing `check_allowed_or_banned_tools()` method to exclude disallowed tools during tool listing, not just during tool invocation

## Root Cause
The `check_allowed_or_banned_tools()` method already correctly handled both `allowed_tools` and `disallowed_tools`, but it was only called in `pre_call_tool_check()` (tool invocation time). The tool **listing** path in `_get_tools_from_server()` fetched all tools from upstream and returned them without any filtering, so disallowed tools still appeared in the UI.

## Fix
In `_get_tools_from_server()`, after fetching tools from the upstream MCP server, filter out any tools that don't pass `check_allowed_or_banned_tools()`. This runs before prefix creation so the original tool names are matched against the config, consistent with how `pre_call_tool_check()` works.

## Test plan
- [ ] Configure an MCP server with `disallowed_tools` and verify those tools no longer appear in the UI or `list_tools` API response
- [ ] Configure an MCP server with `allowed_tools` and verify only those tools appear
- [ ] Configure an MCP server with neither setting and verify all tools appear
- [ ] Verify tool invocation still correctly blocked for disallowed tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)