### PR TITLE
fix: PANW Prisma AIRS post_call guardrail info missing from spend log

### DIFF
--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -111,6 +111,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process A2A output response by applying guardrails to text content.
@@ -213,6 +214,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        original_request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process A2A streaming output by applying guardrails to accumulated text.

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -244,6 +244,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -367,6 +368,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process output streaming response by applying guardrails to text content.

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -73,6 +73,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response with guardrails.
@@ -82,6 +83,11 @@ class BaseTranslation(ABC):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata (passed separately since response doesn't contain it)
+            original_request_data: The original request data dict from the proxy.
+                When provided, guardrail logging information (e.g. StandardLoggingGuardrailInformation)
+                is written to this dict so it appears in spend logs. Without this, post_call
+                guardrail entries are lost because process_output_response creates a
+                throwaway request_data dict internally.
         """
         pass
 
@@ -91,6 +97,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output streaming response with guardrails.

--- a/litellm/llms/cohere/rerank/guardrail_translation/handler.py
+++ b/litellm/llms/cohere/rerank/guardrail_translation/handler.py
@@ -83,6 +83,7 @@ class CohereRerankHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - not applicable for rerank.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -91,6 +91,7 @@ class OCRHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process OCR output by applying guardrails to extracted page text.

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -320,7 +320,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # Previously, a throwaway dict was created here, causing post_call
             # guardrail entries to be lost (see GitHub issue #23561).
             if original_request_data is not None:
-                request_data: dict = original_request_data
+                request_data: dict = original_request_data.copy()
                 request_data["response"] = response
             else:
                 request_data = {"response": response}
@@ -462,7 +462,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         if texts_to_check:
             # Use original request data as the base when available
             if original_request_data is not None:
-                request_data: dict = original_request_data
+                request_data: dict = original_request_data.copy()
                 request_data["responses"] = responses_so_far
             else:
                 request_data = {"responses": responses_so_far}

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -260,6 +260,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content.
@@ -269,6 +270,11 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata to pass to guardrails
+            original_request_data: The original request data dict from the proxy.
+                When provided, this is used as the base for request_data passed to
+                apply_guardrail, ensuring guardrail logging information (e.g.
+                StandardLoggingGuardrailInformation) is written to the original dict
+                and appears in spend logs.
 
         Returns:
             Modified response with guardrail applied to content
@@ -308,15 +314,30 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Use original request data as the base when available so that
+            # guardrail logging information (StandardLoggingGuardrailInformation)
+            # is written to the original dict and appears in spend logs.
+            # Previously, a throwaway dict was created here, causing post_call
+            # guardrail entries to be lost (see GitHub issue #23561).
+            if original_request_data is not None:
+                request_data: dict = original_request_data
+                request_data["response"] = response
+            else:
+                request_data = {"response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                if "litellm_metadata" not in request_data:
+                    request_data["litellm_metadata"] = user_metadata
+                else:
+                    # Merge without overwriting existing keys
+                    existing = request_data["litellm_metadata"]
+                    if isinstance(existing, dict):
+                        for k, v in user_metadata.items():
+                            existing.setdefault(k, v)
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -364,6 +385,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> List["ModelResponseStream"]:
         """
         Process output streaming responses by applying guardrails to text content.
@@ -373,6 +395,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata to pass to guardrails
+            original_request_data: The original request data dict from the proxy.
 
         Returns:
             Modified list of responses with guardrail applied to content
@@ -402,6 +425,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 guardrail_to_apply=guardrail_to_apply,
                 litellm_logging_obj=litellm_logging_obj,
                 user_api_key_dict=user_api_key_dict,
+                original_request_data=original_request_data,
             )
 
             return responses_so_far
@@ -436,15 +460,25 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"responses": responses_so_far}
+            # Use original request data as the base when available
+            if original_request_data is not None:
+                request_data: dict = original_request_data
+                request_data["responses"] = responses_so_far
+            else:
+                request_data = {"responses": responses_so_far}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                if "litellm_metadata" not in request_data:
+                    request_data["litellm_metadata"] = user_metadata
+                else:
+                    existing = request_data["litellm_metadata"]
+                    if isinstance(existing, dict):
+                        for k, v in user_metadata.items():
+                            existing.setdefault(k, v)
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -125,6 +125,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to completion text.

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -155,6 +155,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - embeddings responses contain vectors, not text.

--- a/litellm/llms/openai/image_generation/guardrail_translation/handler.py
+++ b/litellm/llms/openai/image_generation/guardrail_translation/handler.py
@@ -87,6 +87,7 @@ class OpenAIImageGenerationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - typically not needed for image generation.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -347,6 +347,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -454,6 +455,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process output streaming response by applying guardrails to text content.

--- a/litellm/llms/openai/speech/guardrail_translation/handler.py
+++ b/litellm/llms/openai/speech/guardrail_translation/handler.py
@@ -85,6 +85,7 @@ class OpenAITextToSpeechHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output - not applicable for text-to-speech.

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -58,6 +58,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output transcription by applying guardrails to transcribed text.

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -139,6 +139,7 @@ class PassThroughEndpointHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to targeted fields.

--- a/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
+++ b/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
@@ -92,6 +92,7 @@ class MCPGuardrailTranslationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        original_request_data: Optional[dict] = None,
     ) -> Any:
         verbose_proxy_logger.debug(
             "MCP Guardrail: Output processing not implemented for MCP tools",

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -398,7 +398,8 @@ class UnifiedLLMGuardrails(CustomLogger):
                         guardrail_to_apply=guardrail_to_apply,
                         litellm_logging_obj=request_data.get("litellm_logging_obj"),
                         user_api_key_dict=user_api_key_dict,
-                        original_request_data=request_data,
+                        # Only pass original_request_data at end-of-stream to avoid
+                        # recording guardrail log entries at every sampling interval
                     )
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -247,6 +247,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             guardrail_to_apply=guardrail_to_apply,
             litellm_logging_obj=data.get("litellm_logging_obj"),
             user_api_key_dict=user_api_key_dict,
+            original_request_data=data,
         )
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(
@@ -397,6 +398,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                         guardrail_to_apply=guardrail_to_apply,
                         litellm_logging_obj=request_data.get("litellm_logging_obj"),
                         user_api_key_dict=user_api_key_dict,
+                        original_request_data=request_data,
                     )
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.
@@ -457,6 +459,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     guardrail_to_apply=guardrail_to_apply,
                     litellm_logging_obj=request_data.get("litellm_logging_obj"),
                     user_api_key_dict=user_api_key_dict,
+                    original_request_data=request_data,
                 )
             except HTTPException as e:
                 if call_type is not None and CallTypes(call_type) in A2A_CALL_TYPES:


### PR DESCRIPTION
## Summary

Fixes #23561

When the PANW Prisma AIRS guardrail is configured with `post_call` mode, the LLM response **is scanned** by AIRS (via the `apply_guardrail` unified path), but the guardrail logging information (`StandardLoggingGuardrailInformation`) is written to a throwaway `request_data` dict created inside `process_output_response`. As a result:

- The spend log shows **no `post_call` guardrail entries** — only `pre_call` entries appear
- Users cannot verify that response scanning occurred
- The second "phantom" entry in the spend log (with `guardrail_provider: null` and empty `guardrail_response: {}`) comes from the `@log_guardrail_information` decorator duplicating the `pre_call` entry

### Root cause

In `OpenAIChatCompletionsHandler.process_output_response()` ([handler.py L312](https://github.com/BerriAI/litellm/blob/main/litellm/llms/openai/chat/guardrail_translation/handler.py#L312)):

```python
request_data: dict = {"response": response}  # throwaway dict
```

This new dict has no connection to the original request data, so when `apply_guardrail` writes guardrail info to it via `add_standard_logging_guardrail_information_to_request_data`, that info is lost.

### Fix

- Add `original_request_data: Optional[dict] = None` parameter to `BaseTranslation.process_output_response()` and `process_output_streaming_response()`
- Pass the original `data` dict from `UnifiedLLMGuardrails.async_post_call_success_hook()` and `async_post_call_streaming_iterator_hook()`
- In `OpenAIChatCompletionsHandler`, use the original request data as the base when available, so guardrail logging entries are written to the correct dict and appear in spend logs

The parameter is optional with a default of `None`, so **no existing guardrail translation handlers break** (Anthropic, MCP, Mistral OCR, OpenAI responses/transcriptions, pass-through).

## Files changed

| File | Change |
|------|--------|
| `litellm/llms/base_llm/guardrail_translation/base_translation.py` | Add `original_request_data` param to abstract methods |
| `litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py` | Pass `data`/`request_data` as `original_request_data` |
| `litellm/llms/openai/chat/guardrail_translation/handler.py` | Use original request data dict instead of creating throwaway |

## Test plan

- [ ] Existing PANW Prisma AIRS tests pass (`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py`)
- [ ] Existing unified guardrail tests pass (`tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py`)
- [ ] Configure PANW guardrail with `mode: ["pre_call", "post_call"]` and verify spend log shows both `pre_call` and `post_call` entries with correct `guardrail_provider` and `guardrail_response`
- [ ] Configure with `mode: ["post_call"]` only and verify `post_call` entry appears
- [ ] Verify streaming responses also produce `post_call` guardrail entries
- [ ] Other guardrail handlers (Anthropic, MCP, etc.) still work correctly (new param is optional)