### PR TITLE
[Fix] CI failures: mypy type error, ruff lint, and flaky router test

### DIFF
--- a/litellm/integrations/focus/destinations/vantage_destination.py
+++ b/litellm/integrations/focus/destinations/vantage_destination.py
@@ -6,7 +6,7 @@ import csv
 import io
 from typing import Any, Optional
 
-import httpx
+import httpx  # noqa: F401 - used at runtime (AsyncClient, HTTPStatusError)
 
 from litellm._logging import verbose_logger
 

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -9,7 +9,7 @@ https://platform.openai.com/docs/api-reference/responses-streaming
 """
 import asyncio
 import json
-from typing import Any
+from typing import Any, Optional, cast
 
 from fastapi import Request, Response
 
@@ -17,6 +17,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.response_polling.polling_handler import ResponsePollingHandler
+from litellm.types.llms.openai import ResponsesAPIStatus
 
 
 async def background_streaming_task(  # noqa: PLR0915
@@ -114,7 +115,7 @@ async def background_streaming_task(  # noqa: PLR0915
         UPDATE_INTERVAL = 0.150  # 150ms batching interval
 
         # Track the terminal event from the stream (may not be "completed")
-        terminal_status = None  # Will be set by response.completed/failed/incomplete/cancelled
+        terminal_status: Optional[ResponsesAPIStatus] = None  # Will be set by response.completed/failed/incomplete/cancelled
         terminal_error = None
         _event_to_status = {
             "response.completed": "completed",
@@ -249,9 +250,12 @@ async def background_streaming_task(  # noqa: PLR0915
                             # Terminal event - extract all ResponsesAPIResponse fields
                             # https://platform.openai.com/docs/api-reference/responses-streaming
                             response_data = event.get("response", {})
-                            terminal_status = response_data.get(
-                                "status",
-                                _event_to_status.get(event_type, "completed"),
+                            terminal_status = cast(
+                                ResponsesAPIStatus,
+                                response_data.get(
+                                    "status",
+                                    _event_to_status.get(event_type, "completed"),
+                                ),
                             )
 
                             # Extract error for failed responses

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -643,7 +643,13 @@ def test_arouter_responses_api_bridge():
     ## CONFIRM MODEL NAME IS STRIPPED
     client = HTTPHandler()
 
-    with patch.object(client, "post", return_value=MagicMock()) as mock_post:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"id": "resp_test", "object": "response", "status": "completed", "output": []}
+    mock_response.text = '{"id": "resp_test", "object": "response", "status": "completed", "output": []}'
+
+    with patch.object(client, "post", return_value=mock_response) as mock_post:
         try:
             result = router.completion(
                 model="[IP-approved] o3-pro",


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

Three CI jobs failing on `litellm_internal_dev_03_14_2026`:

1. **mypy_linting**: `background_streaming.py:315` — `terminal_status` from `dict.get()` typed as `Any | str`, but `update_state()` expects `Optional[ResponsesAPIStatus]` (a `Literal` type). Introduced by PR #23492.

2. **check_code_and_doc_quality**: `vantage_destination.py:9` — ruff F401 false positive for `import httpx`. The `from __future__ import annotations` causes older ruff versions to classify runtime uses of `httpx` as type-only.

3. **unit tests**: `test_arouter_responses_api_bridge` — The mock returned a bare `MagicMock()` whose attributes triggered Azure exception mapping when the response was processed, causing an unhandled `APIError`.

### Fix

1. Add `Optional[ResponsesAPIStatus]` annotation to `terminal_status` and `cast()` the value from `response_data.get()`.
2. Add `# noqa: F401` to the `import httpx` line (httpx is used at runtime on lines 135, 165).
3. Provide a properly structured mock response with `status_code=200`, `headers`, `json()`, and `text` so the response processing doesn't error.

## Testing

- `python3 -m mypy litellm/proxy/response_polling/background_streaming.py` — no errors
- `python3 -m pytest tests/test_litellm/test_router.py::test_arouter_responses_api_bridge -xvs` — passes

## Type

🐛 Bug Fix
✅ Test