### PR TITLE
fix: merge annotations from all streaming chunks in stream_chunk_builder

### DIFF
--- a/docs/my-website/docs/proxy/tag_routing.md
+++ b/docs/my-website/docs/proxy/tag_routing.md
@@ -209,6 +209,106 @@ Expect to see the following response header when this works
 x-litellm-model-id: default-model
 ```
 
+## Regex-based tag routing (`tag_regex`)
+
+Use `tag_regex` to route requests based on regex patterns matched against request headers, without requiring clients to pass a tag explicitly. This is useful when clients already send a recognisable header, such as `User-Agent`.
+
+**Use case: route all Claude Code traffic to dedicated AWS accounts**
+
+Claude Code always sends `User-Agent: claude-code/<version>`. With `tag_regex` you can route that traffic to a dedicated deployment automatically — no per-developer configuration needed.
+
+### 1. Config
+
+```yaml
+model_list:
+  # Claude Code traffic → dedicated deployment, matched by User-Agent
+  - model_name: claude-sonnet
+    litellm_params:
+      model: bedrock/converse/anthropic-claude-sonnet-4-6
+      aws_region_name: us-east-1
+      aws_role_name: arn:aws:iam::111122223333:role/LiteLLMClaudeCode
+      tag_regex:
+        - "^User-Agent: claude-code\\/"   # matches claude-code/1.x, 2.x, etc.
+    model_info:
+      id: claude-code-deployment
+
+  # All other traffic falls back to the default deployment
+  - model_name: claude-sonnet
+    litellm_params:
+      model: bedrock/converse/anthropic-claude-sonnet-4-6
+      aws_region_name: us-east-1
+      aws_role_name: arn:aws:iam::444455556666:role/LiteLLMDefault
+      tags:
+        - default
+    model_info:
+      id: regular-deployment
+
+router_settings:
+  enable_tag_filtering: true
+  tag_filtering_match_any: true
+
+general_settings:
+  master_key: sk-1234
+```
+
+### 2. Verify routing
+
+Claude Code sets `User-Agent: claude-code/<version>` automatically — no client config needed:
+
+```shell
+# Claude Code request (User-Agent set automatically by Claude Code)
+curl http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer sk-1234" \
+  -H "User-Agent: claude-code/1.2.3" \
+  -d '{"model": "claude-sonnet", "messages": [{"role": "user", "content": "hi"}]}'
+# → x-litellm-model-id: claude-code-deployment
+
+# Any other client (no matching User-Agent) → default deployment
+curl http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{"model": "claude-sonnet", "messages": [{"role": "user", "content": "hi"}]}'
+# → x-litellm-model-id: regular-deployment
+```
+
+### How matching works
+
+| Priority | Condition | Result |
+|----------|-----------|--------|
+| 1 | Request has `tags` AND deployment has `tags` | Exact tag match (respects `match_any` setting) |
+| 2 | Deployment has `tag_regex` AND request has a `User-Agent` | Regex match (always OR logic — any pattern match suffices) |
+| 3 | Deployment has `tags: [default]` | Default fallback |
+| 4 | No default set | All healthy deployments returned |
+
+`tag_regex` always uses OR semantics — `tag_filtering_match_any=False` applies only to exact tag matching, not to regex patterns.
+
+### Observability
+
+When a regex matches, `tag_routing` is written into request metadata and flows to SpendLogs:
+
+```json
+{
+  "tag_routing": {
+    "matched_via": "tag_regex",
+    "matched_value": "^User-Agent: claude-code\\/",
+    "user_agent": "claude-code/1.2.3",
+    "request_tags": []
+  }
+}
+```
+
+### Security note
+
+:::caution
+
+**`User-Agent` is a client-supplied header and can be set to any value.** Any API consumer can send `User-Agent: claude-code/1.0` regardless of whether they are actually using Claude Code.
+
+Do not rely on `tag_regex` routing to enforce access controls or spend limits — use [team/key-based routing](./users) for that. `tag_regex` is a **traffic classification hint** (useful for billing visibility, capacity planning, and routing convenience), not a security boundary.
+
+:::
+
+
+---
+
 ## ✨ Team based tag routing (Enterprise)
 
 LiteLLM Proxy supports team-based tag routing, allowing you to associate specific tags with teams and route requests accordingly. Example **Team A can access gpt-4 deployment A, Team B can access gpt-4 deployment B** (LLM Access Control For Teams)

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -398,6 +398,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             ResponseOutputMessage,
             ResponseReasoningItem,
         )
+
         try:
             from openai.types.responses.response_output_item import (
                 ResponseApplyPatchToolCall,
@@ -460,7 +461,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 accumulated_tool_calls.append(tool_call_dict)
                 tool_call_index += 1
 
-            elif ResponseApplyPatchToolCall is not None and isinstance(item, ResponseApplyPatchToolCall):
+            elif ResponseApplyPatchToolCall is not None and isinstance(
+                item, ResponseApplyPatchToolCall
+            ):
                 from litellm.responses.litellm_completion_transformation.transformation import (
                     LiteLLMCompletionResponsesConfig,
                 )

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -96,6 +96,8 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "tool_calls": "tool_calls",
     "function_call": "function_call",
     "content_filter": "content_filter",
+    # Anthropic Sonnet 4
+    "content_filtered": "content_filter",
 }
 
 

--- a/litellm/litellm_core_utils/default_encoding.py
+++ b/litellm/litellm_core_utils/default_encoding.py
@@ -15,16 +15,19 @@ except (ImportError, AttributeError):
         __name__, "litellm_core_utils/tokenizers"
     )
 
-# Check if the directory is writable. If not, use /tmp as a fallback.
-# This is especially important for non-root Docker environments where the package directory is read-only.
-is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-if not os.access(filename, os.W_OK) and is_non_root:
-    filename = "/tmp/tiktoken_cache"
-    os.makedirs(filename, exist_ok=True)
+# Always default TIKTOKEN_CACHE_DIR to the bundled tokenizers directory
+# unless the user explicitly overrides it via CUSTOM_TIKTOKEN_CACHE_DIR.
+# This keeps tiktoken fully offline-capable by default (see #1071).
+custom_cache_dir = os.getenv("CUSTOM_TIKTOKEN_CACHE_DIR")
+if custom_cache_dir:
+    # If the user opts into a custom cache dir, ensure it exists.
+    os.makedirs(custom_cache_dir, exist_ok=True)
+    cache_dir = custom_cache_dir
+else:
+    cache_dir = filename
 
-os.environ["TIKTOKEN_CACHE_DIR"] = os.getenv(
-    "CUSTOM_TIKTOKEN_CACHE_DIR", filename
-)  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
+os.environ["TIKTOKEN_CACHE_DIR"] = cache_dir  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
+
 import tiktoken
 import time
 import random
@@ -45,3 +48,4 @@ for attempt in range(_max_retries):
         # Exponential backoff with jitter to reduce collision probability
         delay = _retry_delay * (2**attempt) + random.uniform(0, 0.1)
         time.sleep(delay)
+

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -352,9 +352,9 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
-        self.sync_streaming_chunks: List[
-            Any
-        ] = []  # for generating complete stream response
+        self.sync_streaming_chunks: List[Any] = (
+            []
+        )  # for generating complete stream response
         self.log_raw_request_response = log_raw_request_response
 
         # Initialize dynamic callbacks
@@ -746,9 +746,9 @@ class Logging(LiteLLMLoggingBaseClass):
                         prompt_spec=prompt_spec,
                         dynamic_callback_params=dynamic_callback_params,
                     ):
-                        self.model_call_details[
-                            "prompt_integration"
-                        ] = logger.__class__.__name__
+                        self.model_call_details["prompt_integration"] = (
+                            logger.__class__.__name__
+                        )
                         return logger
                 except Exception:
                     # If check fails, continue to next logger
@@ -816,9 +816,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if anthropic_cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
             non_default_params
         ):
-            self.model_call_details[
-                "prompt_integration"
-            ] = anthropic_cache_control_logger.__class__.__name__
+            self.model_call_details["prompt_integration"] = (
+                anthropic_cache_control_logger.__class__.__name__
+            )
             return anthropic_cache_control_logger
 
         #########################################################
@@ -830,9 +830,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 internal_usage_cache=None,
                 llm_router=None,
             )
-            self.model_call_details[
-                "prompt_integration"
-            ] = vector_store_custom_logger.__class__.__name__
+            self.model_call_details["prompt_integration"] = (
+                vector_store_custom_logger.__class__.__name__
+            )
             # Add to global callbacks so post-call hooks are invoked
             if (
                 vector_store_custom_logger
@@ -892,9 +892,9 @@ class Logging(LiteLLMLoggingBaseClass):
             model
         ):  # if model name was changes pre-call, overwrite the initial model call name with the new one
             self.model_call_details["model"] = model
-        self.model_call_details["litellm_params"][
-            "api_base"
-        ] = self._get_masked_api_base(additional_args.get("api_base", ""))
+        self.model_call_details["litellm_params"]["api_base"] = (
+            self._get_masked_api_base(additional_args.get("api_base", ""))
+        )
 
     def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
         # Log the exact input to the LLM API
@@ -923,10 +923,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:
-                        _metadata[
-                            "raw_request"
-                        ] = "redacted by litellm. \
+                        _metadata["raw_request"] = (
+                            "redacted by litellm. \
                             'litellm.turn_off_message_logging=True'"
+                        )
                     else:
                         curl_command = self._get_request_curl_command(
                             api_base=additional_args.get("api_base", ""),
@@ -937,34 +937,34 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         _metadata["raw_request"] = str(curl_command)
                         # split up, so it's easier to parse in the UI
-                        self.model_call_details[
-                            "raw_request_typed_dict"
-                        ] = RawRequestTypedDict(
-                            raw_request_api_base=str(
-                                additional_args.get("api_base") or ""
-                            ),
-                            raw_request_body=self._get_raw_request_body(
-                                additional_args.get("complete_input_dict", {})
-                            ),
-                            # NOTE: setting ignore_sensitive_headers to True will cause
-                            # the Authorization header to be leaked when calls to the health
-                            # endpoint are made and fail.
-                            raw_request_headers=self._get_masked_headers(
-                                additional_args.get("headers", {}) or {},
-                            ),
-                            error=None,
+                        self.model_call_details["raw_request_typed_dict"] = (
+                            RawRequestTypedDict(
+                                raw_request_api_base=str(
+                                    additional_args.get("api_base") or ""
+                                ),
+                                raw_request_body=self._get_raw_request_body(
+                                    additional_args.get("complete_input_dict", {})
+                                ),
+                                # NOTE: setting ignore_sensitive_headers to True will cause
+                                # the Authorization header to be leaked when calls to the health
+                                # endpoint are made and fail.
+                                raw_request_headers=self._get_masked_headers(
+                                    additional_args.get("headers", {}) or {},
+                                ),
+                                error=None,
+                            )
                         )
                 except Exception as e:
-                    self.model_call_details[
-                        "raw_request_typed_dict"
-                    ] = RawRequestTypedDict(
-                        error=str(e),
+                    self.model_call_details["raw_request_typed_dict"] = (
+                        RawRequestTypedDict(
+                            error=str(e),
+                        )
                     )
-                    _metadata[
-                        "raw_request"
-                    ] = "Unable to Log \
+                    _metadata["raw_request"] = (
+                        "Unable to Log \
                         raw request: {}".format(
-                        str(e)
+                            str(e)
+                        )
                     )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
@@ -1265,13 +1265,13 @@ class Logging(LiteLLMLoggingBaseClass):
         for callback in callbacks:
             try:
                 if isinstance(callback, CustomLogger):
-                    response: Optional[
-                        MCPPostCallResponseObject
-                    ] = await callback.async_post_mcp_tool_call_hook(
-                        kwargs=kwargs,
-                        response_obj=post_mcp_tool_call_response_obj,
-                        start_time=start_time,
-                        end_time=end_time,
+                    response: Optional[MCPPostCallResponseObject] = (
+                        await callback.async_post_mcp_tool_call_hook(
+                            kwargs=kwargs,
+                            response_obj=post_mcp_tool_call_response_obj,
+                            start_time=start_time,
+                            end_time=end_time,
+                        )
                     )
                     ######################################################################
                     # if any of the callbacks modify the response, use the modified response
@@ -1466,9 +1466,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details[
-                "response_cost_failure_debug_information"
-            ] = debug_info
+            self.model_call_details["response_cost_failure_debug_information"] = (
+                debug_info
+            )
             return None
 
         try:
@@ -1494,9 +1494,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details[
-                "response_cost_failure_debug_information"
-            ] = debug_info
+            self.model_call_details["response_cost_failure_debug_information"] = (
+                debug_info
+            )
 
         return None
 
@@ -1652,9 +1652,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 result=logging_result
             )
 
-        self.model_call_details[
-            "standard_logging_object"
-        ] = self._build_standard_logging_payload(logging_result, start_time, end_time)
+        self.model_call_details["standard_logging_object"] = (
+            self._build_standard_logging_payload(logging_result, start_time, end_time)
+        )
 
         if (
             standard_logging_payload := self.model_call_details.get(
@@ -1732,9 +1732,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 end_time = datetime.datetime.now()
             if self.completion_start_time is None:
                 self.completion_start_time = end_time
-                self.model_call_details[
-                    "completion_start_time"
-                ] = self.completion_start_time
+                self.model_call_details["completion_start_time"] = (
+                    self.completion_start_time
+                )
 
             self.model_call_details["log_event_type"] = "successful_api_call"
             self.model_call_details["end_time"] = end_time
@@ -1771,10 +1771,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         end_time=end_time,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
-                    self.model_call_details[
-                        "standard_logging_object"
-                    ] = self._build_standard_logging_payload(
-                        result, start_time, end_time
+                    self.model_call_details["standard_logging_object"] = (
+                        self._build_standard_logging_payload(
+                            result, start_time, end_time
+                        )
                     )
                     if (
                         standard_logging_payload := self.model_call_details.get(
@@ -1783,9 +1783,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     ) is not None:
                         emit_standard_logging_payload(standard_logging_payload)
             elif standard_logging_object is not None:
-                self.model_call_details[
-                    "standard_logging_object"
-                ] = standard_logging_object
+                self.model_call_details["standard_logging_object"] = (
+                    standard_logging_object
+                )
             else:
                 self.model_call_details["response_cost"] = None
 
@@ -1943,17 +1943,17 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details[
-                    "complete_streaming_response"
-                ] = complete_streaming_response
-                self.model_call_details[
-                    "response_cost"
-                ] = self._response_cost_calculator(result=complete_streaming_response)
+                self.model_call_details["complete_streaming_response"] = (
+                    complete_streaming_response
+                )
+                self.model_call_details["response_cost"] = (
+                    self._response_cost_calculator(result=complete_streaming_response)
+                )
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details[
-                    "standard_logging_object"
-                ] = self._build_standard_logging_payload(
-                    complete_streaming_response, start_time, end_time
+                self.model_call_details["standard_logging_object"] = (
+                    self._build_standard_logging_payload(
+                        complete_streaming_response, start_time, end_time
+                    )
                 )
                 if (
                     standard_logging_payload := self.model_call_details.get(
@@ -2287,10 +2287,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details[
-                                    "complete_response"
-                                ] = self.model_call_details.get(
-                                    "complete_streaming_response", {}
+                                self.model_call_details["complete_response"] = (
+                                    self.model_call_details.get(
+                                        "complete_streaming_response", {}
+                                    )
                                 )
                                 result = self.model_call_details["complete_response"]
                             openMeterLogger.log_success_event(
@@ -2314,10 +2314,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details[
-                                    "complete_response"
-                                ] = self.model_call_details.get(
-                                    "complete_streaming_response", {}
+                                self.model_call_details["complete_response"] = (
+                                    self.model_call_details.get(
+                                        "complete_streaming_response", {}
+                                    )
                                 )
                                 result = self.model_call_details["complete_response"]
 
@@ -2456,9 +2456,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if complete_streaming_response is not None:
             print_verbose("Async success callbacks: Got a complete streaming response")
 
-            self.model_call_details[
-                "async_complete_streaming_response"
-            ] = complete_streaming_response
+            self.model_call_details["async_complete_streaming_response"] = (
+                complete_streaming_response
+            )
 
             try:
                 if self.model_call_details.get("cache_hit", False) is True:
@@ -2469,10 +2469,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details[
-                        "response_cost"
-                    ] = self._response_cost_calculator(
-                        result=complete_streaming_response
+                    self.model_call_details["response_cost"] = (
+                        self._response_cost_calculator(
+                            result=complete_streaming_response
+                        )
                     )
 
                 verbose_logger.debug(
@@ -2485,10 +2485,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["response_cost"] = None
 
             ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details[
-                "standard_logging_object"
-            ] = self._build_standard_logging_payload(
-                complete_streaming_response, start_time, end_time
+            self.model_call_details["standard_logging_object"] = (
+                self._build_standard_logging_payload(
+                    complete_streaming_response, start_time, end_time
+                )
             )
 
             # print standard logging payload
@@ -2515,9 +2515,9 @@ class Logging(LiteLLMLoggingBaseClass):
             # _success_handler_helper_fn
             if self.model_call_details.get("standard_logging_object") is None:
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details[
-                    "standard_logging_object"
-                ] = self._build_standard_logging_payload(result, start_time, end_time)
+                self.model_call_details["standard_logging_object"] = (
+                    self._build_standard_logging_payload(result, start_time, end_time)
+                )
 
                 # print standard logging payload
                 if (
@@ -2760,18 +2760,18 @@ class Logging(LiteLLMLoggingBaseClass):
 
         ## STANDARDIZED LOGGING PAYLOAD
 
-        self.model_call_details[
-            "standard_logging_object"
-        ] = get_standard_logging_object_payload(
-            kwargs=self.model_call_details,
-            init_response_obj={},
-            start_time=start_time,
-            end_time=end_time,
-            logging_obj=self,
-            status="failure",
-            error_str=str(exception),
-            original_exception=exception,
-            standard_built_in_tools_params=self.standard_built_in_tools_params,
+        self.model_call_details["standard_logging_object"] = (
+            get_standard_logging_object_payload(
+                kwargs=self.model_call_details,
+                init_response_obj={},
+                start_time=start_time,
+                end_time=end_time,
+                logging_obj=self,
+                status="failure",
+                error_str=str(exception),
+                original_exception=exception,
+                standard_built_in_tools_params=self.standard_built_in_tools_params,
+            )
         )
         return start_time, end_time
 
@@ -3735,9 +3735,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 service_name=arize_config.project_name,
             )
 
-            os.environ[
-                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
-            ] = f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
+            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
+                f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
+            )
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, ArizeLogger)
@@ -3763,13 +3763,13 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
+                    )
                 else:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"openinference.project.name={arize_phoenix_config.project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"openinference.project.name={arize_phoenix_config.project_name}"
+                    )
 
             # Set Phoenix project name from environment variable
             phoenix_project_name = os.environ.get("PHOENIX_PROJECT_NAME", None)
@@ -3777,19 +3777,19 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"{existing_attrs},openinference.project.name={phoenix_project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"{existing_attrs},openinference.project.name={phoenix_project_name}"
+                    )
                 else:
-                    os.environ[
-                        "OTEL_RESOURCE_ATTRIBUTES"
-                    ] = f"openinference.project.name={phoenix_project_name}"
+                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
+                        f"openinference.project.name={phoenix_project_name}"
+                    )
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:
-                os.environ[
-                    "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
-                ] = arize_phoenix_config.otlp_auth_headers
+                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
+                    arize_phoenix_config.otlp_auth_headers
+                )
 
             for callback in _in_memory_loggers:
                 if (
@@ -3965,9 +3965,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 exporter="otlp_http",
                 endpoint="https://langtrace.ai/api/trace",
             )
-            os.environ[
-                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
-            ] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
+            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
+                f"api_key={os.getenv('LANGTRACE_API_KEY')}"
+            )
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, OpenTelemetry)
@@ -4446,15 +4446,17 @@ def use_custom_pricing_for_model(litellm_params: Optional[dict]) -> bool:
         if litellm_params.get(key) is not None:
             return True
 
-    # Check model_info
-    metadata: dict = litellm_params.get("metadata", {}) or {}
-    model_info: dict = metadata.get("model_info", {}) or {}
+    # Check model_info from metadata or litellm_metadata (generic_api_call routes
+    # like /responses and /messages store model_info under litellm_metadata)
+    for metadata_key in ("metadata", "litellm_metadata"):
+        metadata: dict = litellm_params.get(metadata_key, {}) or {}
+        model_info: dict = metadata.get("model_info", {}) or {}
 
-    if model_info:
-        matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
-        for key in matching_keys:
-            if model_info.get(key) is not None:
-                return True
+        if model_info:
+            matching_keys = _CUSTOM_PRICING_KEYS & model_info.keys()
+            for key in matching_keys:
+                if model_info.get(key) is not None:
+                    return True
 
     return False
 
@@ -4881,10 +4883,10 @@ class StandardLoggingPayloadSetup:
             for key in StandardLoggingHiddenParams.__annotations__.keys():
                 if key in hidden_params:
                     if key == "additional_headers":
-                        clean_hidden_params[
-                            "additional_headers"
-                        ] = StandardLoggingPayloadSetup.get_additional_headers(
-                            hidden_params[key]
+                        clean_hidden_params["additional_headers"] = (
+                            StandardLoggingPayloadSetup.get_additional_headers(
+                                hidden_params[key]
+                            )
                         )
                     else:
                         clean_hidden_params[key] = hidden_params[key]  # type: ignore
@@ -5523,9 +5525,9 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
     ):
         for k, v in metadata["user_api_key_metadata"].items():
             if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[
-                    k
-                ] = "scrubbed_by_litellm_for_sensitive_keys"
+                cleaned_user_api_key_metadata[k] = (
+                    "scrubbed_by_litellm_for_sensitive_keys"
+                )
             else:
                 cleaned_user_api_key_metadata[k] = v
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2680,7 +2680,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                 _content_is_list = "content" in assistant_content_block and isinstance(
                     assistant_content_block["content"], list
                 )
-                _content_list = assistant_content_block.get("content") if _content_is_list else None
+                _content_list = (
+                    assistant_content_block.get("content") if _content_is_list else None
+                )
                 _list_has_thinking = False
                 if _content_is_list and _content_list is not None:
                     for _item in _content_list:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -50,6 +50,38 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             # "metadata",
         ]
 
+    def _remove_scope_from_cache_control(
+        self, anthropic_messages_request: Dict
+    ) -> None:
+        """
+        Remove `scope` field from cache_control blocks.
+
+        Some providers (Vertex AI, Azure AI Foundry) do not support the `scope`
+        field in cache_control (e.g. "global" for cross-request caching).
+        Processes both `system` and `messages` content blocks.
+        """
+
+        def _sanitize(cache_control: Any) -> None:
+            if isinstance(cache_control, dict):
+                cache_control.pop("scope", None)
+
+        def _process_content_list(content: list) -> None:
+            for item in content:
+                if isinstance(item, dict) and "cache_control" in item:
+                    _sanitize(item["cache_control"])
+
+        if "system" in anthropic_messages_request:
+            system = anthropic_messages_request["system"]
+            if isinstance(system, list):
+                _process_content_list(system)
+
+        if "messages" in anthropic_messages_request:
+            for message in anthropic_messages_request["messages"]:
+                if isinstance(message, dict) and "content" in message:
+                    content = message["content"]
+                    if isinstance(content, list):
+                        _process_content_list(content)
+
     @staticmethod
     def _filter_billing_headers_from_system(system_param):
         """

--- a/litellm/llms/anthropic/files/transformation.py
+++ b/litellm/llms/anthropic/files/transformation.py
@@ -79,7 +79,9 @@ class AnthropicFilesConfig(BaseFilesConfig):
         return AnthropicError(
             status_code=status_code,
             message=error_message,
-            headers=cast(httpx.Headers, headers) if isinstance(headers, dict) else headers,
+            headers=cast(httpx.Headers, headers)
+            if isinstance(headers, dict)
+            else headers,
         )
 
     def validate_environment(

--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -144,9 +144,7 @@ class BaseModelResponseIterator:
                 # Skip empty lines (common in SSE streams between events).
                 # Only apply to str chunks — non-string objects (e.g. Pydantic
                 # BaseModel events from the Responses API) must pass through.
-                if isinstance(str_line, str) and (
-                    not str_line or not str_line.strip()
-                ):
+                if isinstance(str_line, str) and (not str_line or not str_line.strip()):
                     continue
 
                 # chunk is a str at this point
@@ -184,9 +182,7 @@ class BaseModelResponseIterator:
                 # Skip empty lines (common in SSE streams between events).
                 # Only apply to str chunks — non-string objects (e.g. Pydantic
                 # BaseModel events from the Responses API) must pass through.
-                if isinstance(str_line, str) and (
-                    not str_line or not str_line.strip()
-                ):
+                if isinstance(str_line, str) and (not str_line or not str_line.strip()):
                     continue
 
                 # chunk is a str at this point

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1268,7 +1268,8 @@ class BaseAWSLLM:
 
             # Add back all original headers (including forwarded ones) after signature calculation
             for header_name, header_value in headers.items():
-                request.headers[header_name] = header_value
+                if header_value is not None:
+                    request.headers[header_name] = header_value
 
             if (
                 extra_headers is not None and "Authorization" in extra_headers
@@ -1298,6 +1299,8 @@ class BaseAWSLLM:
         }
 
         for header_name, header_value in headers.items():
+            if header_value is None:
+                continue
             header_lower = header_name.lower()
             if (
                 header_lower in aws_headers
@@ -1393,7 +1396,8 @@ class BaseAWSLLM:
         # Add back original headers after signing. Only headers in SignedHeaders
         # are integrity-protected; forwarded headers (x-forwarded-*) must remain unsigned.
         for header_name, header_value in headers.items():
-            request_headers_dict[header_name] = header_value
+            if header_value is not None:
+                request_headers_dict[header_name] = header_value
         if (
             headers is not None and "Authorization" in headers
         ):  # prevent sigv4 from overwriting the auth header

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -173,7 +173,12 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
                 "S3 bucket_name is required. Set 's3_bucket_name' in litellm_params or AWS_S3_BUCKET_NAME env var"
             )
 
-        aws_region_name = self._get_aws_region_name(optional_params, model)
+        s3_region_name = litellm_params.get("s3_region_name") or optional_params.get(
+            "s3_region_name"
+        )
+        aws_region_name = s3_region_name or self._get_aws_region_name(
+            optional_params, model
+        )
 
         file_data = data.get("file")
         purpose = data.get("purpose")
@@ -397,6 +402,15 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             litellm_params=litellm_params,
             data=create_file_data,
         )
+
+        # s3_region_name always wins for S3 operations (same priority as in
+        # get_complete_file_url above). Overwrite aws_region_name unconditionally
+        # so the SigV4 region matches the URL region, avoiding SignatureDoesNotMatch.
+        s3_region_name = litellm_params.get("s3_region_name") or optional_params.get(
+            "s3_region_name"
+        )
+        if s3_region_name:
+            optional_params = {**optional_params, "aws_region_name": s3_region_name}
 
         # Sign the request and return a pre-signed request object
         signed_headers, signed_body = self._sign_s3_request(

--- a/litellm/llms/black_forest_labs/image_edit/transformation.py
+++ b/litellm/llms/black_forest_labs/image_edit/transformation.py
@@ -201,7 +201,9 @@ class BlackForestLabsImageEditConfig(BaseImageEditConfig):
             return image
         elif isinstance(image, list):
             # If it's a list, take the first image
-            return self._read_image_bytes(image[0], depth=depth + 1, max_depth=max_depth)
+            return self._read_image_bytes(
+                image[0], depth=depth + 1, max_depth=max_depth
+            )
         elif isinstance(image, str):
             if image.startswith(("http://", "https://")):
                 # Download image from URL

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -22,9 +22,7 @@ import litellm.litellm_core_utils
 import litellm.types
 import litellm.types.utils
 from litellm._logging import verbose_logger
-from litellm.anthropic_beta_headers_manager import (
-    update_headers_with_filtered_beta,
-)
+from litellm.anthropic_beta_headers_manager import update_headers_with_filtered_beta
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
 from litellm.llms.base_llm.anthropic_messages.transformation import (
@@ -1889,6 +1887,7 @@ class BaseLLMHTTPHandler:
             optional_params=dict(anthropic_messages_optional_request_params),
             litellm_params={
                 "metadata": kwargs.get("metadata", {}),
+                "litellm_metadata": kwargs.get("litellm_metadata", {}),
                 "preset_cache_key": None,
                 "stream_response": {},
                 **anthropic_messages_optional_request_params,

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -2,13 +2,15 @@
 Translates from OpenAI's `/v1/chat/completions` to Moonshot AI's `/v1/chat/completions`
 """
 
-from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, cast, overload
 
+import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
+from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -17,8 +19,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
-        ...
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
 
     @overload
     def _transform_messages(
@@ -26,8 +27,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         messages: List[AllMessageValues],
         model: str,
         is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]:
-        ...
+    ) -> List[AllMessageValues]: ...
 
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
@@ -53,22 +53,14 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             messages = handle_messages_with_content_list_to_str_conversion(messages)
 
         if is_async:
-            return super()._transform_messages(
-                messages=messages, model=model, is_async=True
-            )
+            return super()._transform_messages(messages=messages, model=model, is_async=True)
         else:
-            return super()._transform_messages(
-                messages=messages, model=model, is_async=False
-            )
+            return super()._transform_messages(messages=messages, model=model, is_async=False)
 
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
-        api_base = (
-            api_base
-            or get_secret_str("MOONSHOT_API_BASE")
-            or "https://api.moonshot.ai/v1"
-        )  # type: ignore
+        api_base = api_base or get_secret_str("MOONSHOT_API_BASE") or "https://api.moonshot.ai/v1"  # type: ignore
         dynamic_api_key = api_key or get_secret_str("MOONSHOT_API_KEY")
         return api_base, dynamic_api_key
 
@@ -149,6 +141,48 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 optional_params["temperature"] = 0.3
         return optional_params
 
+    def fill_reasoning_content(self, messages: List[AllMessageValues]) -> List[AllMessageValues]:
+        """
+        Moonshot reasoning models require `reasoning_content` on every assistant
+        message that contains tool_calls (multi-turn tool-calling flows).
+
+        For each such message that is missing the field:
+          1. Promote provider_specific_fields["reasoning_content"] if present and non-empty
+             (this is where LiteLLM stores it from a previous response)
+          2. Otherwise inject a single space — the minimum value the API accepts
+        Messages that already carry the field, or are not assistant/tool-call messages,
+        are appended as-is (no copy made).
+        """
+        result: List[AllMessageValues] = []
+        for msg in messages:
+            if (
+                msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and "reasoning_content" not in msg
+            ):
+                patched = dict(cast(dict, msg))
+                provider_fields = patched.get("provider_specific_fields") or {}
+                stored = provider_fields.get("reasoning_content")
+                if stored:
+                    patched["reasoning_content"] = stored
+                    # Remove the promoted key from provider_specific_fields to
+                    # avoid sending the value twice in the serialised request body
+                    cleaned_provider_fields = dict(provider_fields)
+                    cleaned_provider_fields.pop("reasoning_content", None)
+                    patched["provider_specific_fields"] = cleaned_provider_fields
+                else:
+                    litellm.verbose_logger.warning(
+                        "Moonshot reasoning model: assistant tool-call message is missing "
+                        "`reasoning_content`. Injecting a placeholder to satisfy API validation. "
+                        "For best results, preserve `reasoning_content` from the original "
+                        "assistant response when building multi-turn conversation history."
+                    )
+                    patched["reasoning_content"] = " "
+                result.append(cast(AllMessageValues, patched))
+            else:
+                result.append(msg)
+        return result
+
     def transform_request(
         self,
         model: str,
@@ -168,6 +202,10 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 messages=messages,
                 optional_params=optional_params,
             )
+
+        # Moonshot reasoning models: fill in reasoning_content before the API call
+        if supports_reasoning(model=model, custom_llm_provider="moonshot"):
+            messages = self.fill_reasoning_content(messages)
 
         # Call parent transform_request which handles _transform_messages
         return super().transform_request(

--- a/litellm/llms/perplexity/responses/transformation.py
+++ b/litellm/llms/perplexity/responses/transformation.py
@@ -71,7 +71,9 @@ class PerplexityResponsesConfig(OpenAIResponsesAPIConfig):
             result: List[Any] = []
             for item in input:
                 if isinstance(item, dict) and "type" not in item:
-                    new_item = dict(item)  # convert to plain dict to avoid TypedDict checking
+                    new_item = dict(
+                        item
+                    )  # convert to plain dict to avoid TypedDict checking
                     new_item["type"] = "message"
                     result.append(new_item)
                 else:

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -150,6 +150,8 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
             headers=headers,
         )
 
+        self._remove_scope_from_cache_control(anthropic_messages_request)
+
         anthropic_messages_request["anthropic_version"] = "vertex-2023-10-16"
 
         anthropic_messages_request.pop(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7514,8 +7514,15 @@ def stream_chunk_builder(  # noqa: PLR0915
         ]
 
         if len(annotation_chunks) > 0:
-            annotations = annotation_chunks[0]["choices"][0]["delta"]["annotations"]
-            response["choices"][0]["message"]["annotations"] = annotations
+            # Merge annotations from ALL chunks — providers may spread
+            # them across multiple streaming chunks or send them only in
+            # the final chunk.
+            all_annotations: list = []
+            for ac in annotation_chunks:
+                all_annotations.extend(
+                    ac["choices"][0]["delta"]["annotations"]
+                )
+            response["choices"][0]["message"]["annotations"] = all_annotations
 
         audio_chunks = [
             chunk

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5122,6 +5122,7 @@ def embedding(  # noqa: PLR0915
                 client=client,
                 aembedding=aembedding,
                 litellm_params=litellm_params_dict,
+                headers=headers,
             )
         elif custom_llm_provider == "bedrock":
             if isinstance(input, str):

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22083,6 +22083,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -22166,6 +22167,7 @@
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -22180,6 +22182,7 @@
         "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -378,9 +378,7 @@ if MCP_AVAILABLE:
         # Resolve a server name to its UUID if needed
         _name_resolved = None
         if server_id not in allowed_server_ids:
-            _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(
-                server_id
-            )
+            _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(server_id)
             if _name_resolved is not None and _name_resolved.server_id in set(
                 allowed_server_ids
             ):
@@ -442,9 +440,7 @@ if MCP_AVAILABLE:
                 extra_headers=user_oauth_extra_headers,
             )
         except Exception as e:
-            verbose_logger.exception(
-                f"Error getting tools from {server.name}: {e}"
-            )
+            verbose_logger.exception(f"Error getting tools from {server.name}: {e}")
             return {
                 "tools": [],
                 "error": "server_error",
@@ -473,7 +469,9 @@ if MCP_AVAILABLE:
         _name_resolved = None
         if server_id not in allowed_server_ids:
             _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(server_id)
-            if _name_resolved is not None and _name_resolved.server_id in set(allowed_server_ids):
+            if _name_resolved is not None and _name_resolved.server_id in set(
+                allowed_server_ids
+            ):
                 server_id = _name_resolved.server_id
 
         if server_id not in allowed_server_ids:
@@ -518,7 +516,9 @@ if MCP_AVAILABLE:
         server_auth_header = _get_server_auth_header(
             server, mcp_server_auth_headers, mcp_auth_header
         )
-        user_oauth_extra_headers = await _get_user_oauth_extra_headers(server, user_api_key_dict)
+        user_oauth_extra_headers = await _get_user_oauth_extra_headers(
+            server, user_api_key_dict
+        )
 
         try:
             list_tools_result = await _get_tools_for_single_server(
@@ -529,9 +529,7 @@ if MCP_AVAILABLE:
                 extra_headers=user_oauth_extra_headers,
             )
         except Exception as e:
-            verbose_logger.exception(
-                f"Error getting tools from {server.name}: {e}"
-            )
+            verbose_logger.exception(f"Error getting tools from {server.name}: {e}")
             return {
                 "tools": [],
                 "error": "server_error",
@@ -905,7 +903,9 @@ if MCP_AVAILABLE:
         try:
             client_id, client_secret, scopes = _extract_credentials(request)
 
-            _oauth2_flow: Optional[Literal["client_credentials", "authorization_code"]] = (
+            _oauth2_flow: Optional[
+                Literal["client_credentials", "authorization_code"]
+            ] = (
                 "client_credentials"
                 if client_id and client_secret and request.token_url
                 else None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -64,7 +64,11 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     populate_request_with_path_params,
 )
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
-from litellm.proxy.utils import PrismaClient, ProxyLogging, normalize_route_for_root_path
+from litellm.proxy.utils import (
+    PrismaClient,
+    ProxyLogging,
+    normalize_route_for_root_path,
+)
 from litellm.secret_managers.main import get_secret_bool
 from litellm.types.services import ServiceTypes
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -106,9 +106,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         if (self.output_parse_pii or self.apply_to_output) and not logging_only:
             current_hook = self.event_hook
             if isinstance(current_hook, str) and current_hook != "post_call":
-                self.event_hook = cast(List[GuardrailEventHooks], [current_hook, "post_call"])
+                self.event_hook = cast(
+                    List[GuardrailEventHooks], [current_hook, "post_call"]
+                )
             elif isinstance(current_hook, list) and "post_call" not in current_hook:
-                self.event_hook = cast(List[GuardrailEventHooks], current_hook + ["post_call"])
+                self.event_hook = cast(
+                    List[GuardrailEventHooks], current_hook + ["post_call"]
+                )
         self.pii_entities_config: Dict[Union[PiiEntityType, str], PiiAction] = (
             pii_entities_config or {}
         )

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1838,9 +1838,7 @@ async def _validate_update_key_data(
 
     # Check team limits if key has a team_id (from request or existing key)
     team_obj: Optional[LiteLLM_TeamTableCachedObj] = None
-    _team_id_to_check = data.team_id or getattr(
-        existing_key_row, "team_id", None
-    )
+    _team_id_to_check = data.team_id or getattr(existing_key_row, "team_id", None)
     if _team_id_to_check is not None:
         team_obj = await get_team_object(
             team_id=_team_id_to_check,
@@ -1910,9 +1908,7 @@ async def _validate_update_key_data(
         if team_obj is None:
             raise HTTPException(
                 status_code=500,
-                detail={
-                    "error": "Team object not found for team change validation"
-                },
+                detail={"error": "Team object not found for team change validation"},
             )
         await validate_key_team_change(
             key=existing_key_row,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -846,12 +846,16 @@ async def get_generic_sso_response(
     verbose_proxy_logger.debug("calling generic_sso.verify_and_process")
     additional_generic_sso_headers_dict = _parse_generic_sso_headers()
 
-    code_verifier: Optional[str] = None  # assigned inside try; initialized for type tracking
+    code_verifier: Optional[
+        str
+    ] = None  # assigned inside try; initialized for type tracking
 
     try:
-        token_exchange_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-            request=request,
-            generic_include_client_id=generic_include_client_id,
+        token_exchange_params = (
+            await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=request,
+                generic_include_client_id=generic_include_client_id,
+            )
         )
 
         # Extract code_verifier (and the cache key for deferred deletion) before calling fastapi-sso
@@ -915,7 +919,9 @@ async def get_generic_sso_response(
             # Assign directly rather than relying on nonlocal mutation so that Pyright
             # can track that received_response is non-None from this point on.
             received_response = {
-                k: v for k, v in combined_response.items() if k not in _OAUTH_TOKEN_FIELDS
+                k: v
+                for k, v in combined_response.items()
+                if k not in _OAUTH_TOKEN_FIELDS
             }
             # In the PKCE path verify_and_process is skipped, so generic_sso.access_token
             # is never set. Read the token directly from the exchange response instead so
@@ -2598,7 +2604,9 @@ class SSOAuthenticationHandler:
                             state,
                         )
                     else:
-                        verbose_proxy_logger.debug("PKCE code_verifier retrieved from cache")
+                        verbose_proxy_logger.debug(
+                            "PKCE code_verifier retrieved from cache"
+                        )
                 elif isinstance(cached_data, str):
                     # Handle legacy format (plain string) for backward compatibility
                     code_verifier = cached_data
@@ -2647,7 +2655,9 @@ class SSOAuthenticationHandler:
         In strict mode (PKCE_STRICT_CACHE_MISS=true) raises ProxyException.
         Otherwise logs a warning and returns (token exchange proceeds without verifier).
         """
-        active_cache = redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
+        active_cache = (
+            redis_usage_cache if redis_usage_cache is not None else user_api_key_cache
+        )
         strict_cache_miss = (
             os.getenv("PKCE_STRICT_CACHE_MISS", "false").lower() == "true"
         )

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -113,6 +113,16 @@ async def background_streaming_task(  # noqa: PLR0915
         last_update_time = asyncio.get_event_loop().time()
         UPDATE_INTERVAL = 0.150  # 150ms batching interval
 
+        # Track the terminal event from the stream (may not be "completed")
+        terminal_status = None  # Will be set by response.completed/failed/incomplete/cancelled
+        terminal_error = None
+        _event_to_status = {
+            "response.completed": "completed",
+            "response.failed": "failed",
+            "response.incomplete": "incomplete",
+            "response.cancelled": "cancelled",
+        }
+
         async def flush_state_if_needed(force: bool = False) -> None:
             """Flush accumulated state to Redis if interval elapsed or forced"""
             nonlocal state_dirty, last_update_time
@@ -131,6 +141,12 @@ async def background_streaming_task(  # noqa: PLR0915
                 last_update_time = current_time
 
         # Handle StreamingResponse
+        if not hasattr(response, "body_iterator"):
+            verbose_proxy_logger.warning(
+                f"background_streaming_task: response for {polling_id} has no "
+                "body_iterator; this may indicate a misconfiguration or provider error"
+            )
+
         if hasattr(response, "body_iterator"):
             async for chunk in response.body_iterator:
                 # Parse chunk
@@ -224,10 +240,23 @@ async def background_streaming_task(  # noqa: PLR0915
                                 status="in_progress",
                             )
 
-                        elif event_type == "response.completed":
-                            # Response completed - extract all ResponsesAPIResponse fields
-                            # https://platform.openai.com/docs/api-reference/responses-streaming/response-completed
+                        elif event_type in (
+                            "response.completed",
+                            "response.failed",
+                            "response.incomplete",
+                            "response.cancelled",
+                        ):
+                            # Terminal event - extract all ResponsesAPIResponse fields
+                            # https://platform.openai.com/docs/api-reference/responses-streaming
                             response_data = event.get("response", {})
+                            terminal_status = response_data.get(
+                                "status",
+                                _event_to_status.get(event_type, "completed"),
+                            )
+
+                            # Extract error for failed responses
+                            if event_type == "response.failed":
+                                terminal_error = response_data.get("error")
 
                             # Core response fields
                             usage_data = response_data.get("usage")
@@ -278,11 +307,14 @@ async def background_streaming_task(  # noqa: PLR0915
             # Final flush to ensure all accumulated state is saved
             await flush_state_if_needed(force=True)
 
-        # Mark as completed with all ResponsesAPIResponse fields
+        # Use the terminal status from the stream, default to "completed"
+        final_status = terminal_status or "completed"
+
         await polling_handler.update_state(
             polling_id=polling_id,
-            status="completed",
+            status=final_status,
             usage=usage_data,
+            error=terminal_error,
             reasoning=reasoning_data,
             tool_choice=tool_choice_data,
             tools=tools_data,
@@ -301,7 +333,7 @@ async def background_streaming_task(  # noqa: PLR0915
         )
 
         verbose_proxy_logger.info(
-            f"Completed background streaming for {polling_id}, output_items={len(output_items)}"
+            f"Finished background streaming for {polling_id}, status={final_status}, output_items={len(output_items)}"
         )
 
     except Exception as e:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5233,7 +5233,7 @@ def normalize_route_for_root_path(route: str) -> Optional[str]:
     root_path = get_server_root_path()
     if root_path and root_path != "/":
         if route.startswith(root_path + "/"):
-            return route[len(root_path):]
+            return route[len(root_path) :]
         return None
     return route
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -415,7 +415,9 @@ class LiteLLMCompletionResponsesConfig:
                                         if isinstance(new_msg, dict)
                                         else getattr(new_msg, "tool_calls", None)
                                     )
-                                    new_tcs: list = _raw_tcs if isinstance(_raw_tcs, list) else []
+                                    new_tcs: list = (
+                                        _raw_tcs if isinstance(_raw_tcs, list) else []
+                                    )
                                     for tc in new_tcs:
                                         LiteLLMCompletionResponsesConfig._add_tool_call_to_assistant(
                                             last_msg, tc

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -14,6 +14,7 @@ import hashlib
 import inspect
 import json
 import logging
+import re
 import threading
 import time
 import traceback
@@ -1551,7 +1552,9 @@ class Router:
                     # Drain any fire-and-forget tasks (e.g. alerting hooks)
                     # scheduled via asyncio.create_task during acompletion.
                     pending = asyncio.all_tasks()
-                    pending.discard(asyncio.current_task())
+                    current = asyncio.current_task()
+                    if current is not None:
+                        pending.discard(current)
                     if pending:
                         await asyncio.gather(*pending, return_exceptions=True)
 
@@ -6541,6 +6544,18 @@ class Router:
                     f"Ignoring deployment {deployment.model_name} as it is not active for environment {deployment.model_info['supported_environments']}"
                 )
                 return None
+
+            # Validate tag_regex patterns BEFORE adding the deployment so we never
+            # have partially-initialised router state if a pattern is invalid.
+            _tag_regex = deployment.litellm_params.get("tag_regex") or []
+            for pattern in _tag_regex:
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    raise ValueError(
+                        f"Invalid regex in tag_regex for model '{deployment.model_name}': "
+                        f"{pattern!r} — {exc}"
+                    ) from exc
 
             deployment = self._add_deployment(deployment=deployment)
 

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -6,6 +6,7 @@ Use this to route requests between Teams
 - If no default_deployments are set, return all deployments
 """
 
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from litellm._logging import verbose_logger
@@ -17,6 +18,29 @@ if TYPE_CHECKING:
     LitellmRouter = _Router
 else:
     LitellmRouter = Any
+
+
+def _is_valid_deployment_tag_regex(
+    tag_regexes: List[str],
+    header_strings: List[str],
+) -> Optional[str]:
+    """
+    Test compiled regex patterns against "Header-Name: value" strings.
+
+    Returns the first matching pattern string, or None if nothing matches.
+    Compiles each pattern once (re's LRU cache) and logs invalid patterns once
+    per pattern, not once per header string.
+    """
+    for pattern in tag_regexes:
+        try:
+            compiled = re.compile(pattern)
+        except re.error:
+            verbose_logger.warning("tag_regex: invalid pattern %r — skipping", pattern)
+            continue
+        for header_str in header_strings:
+            if compiled.search(header_str):
+                return pattern
+    return None
 
 
 def is_valid_deployment_tag(
@@ -45,6 +69,54 @@ def is_valid_deployment_tag(
         )
         return True
     return False
+
+
+def _match_deployment(
+    deployment: Any,
+    request_tags: Optional[List[str]],
+    header_strings: List[str],
+    match_any: bool,
+) -> Optional[Dict[str, str]]:
+    """
+    Determine whether *deployment* matches the current request.
+
+    Returns {"matched_via": ..., "matched_value": ...} if the deployment
+    should be included, or None if it should be excluded.
+
+    Priority:
+      1. Exact tag match (respects match_any semantics).
+      2. Regex match — skipped when match_any=False and the tag check already
+         ran and failed, so the regex cannot override strict-tag policy.
+    """
+    litellm_params = deployment.get("litellm_params", {})
+    deployment_tags: Optional[List[str]] = litellm_params.get("tags")
+    deployment_tag_regex: Optional[List[str]] = litellm_params.get("tag_regex")
+
+    # 1. Exact tag match (existing behaviour).
+    if deployment_tags and request_tags:
+        if is_valid_deployment_tag(deployment_tags, request_tags, match_any):
+            matched_value = next(
+                (t for t in deployment_tags if t in set(request_tags)),
+                deployment_tags[0],
+            )
+            return {"matched_via": "tags", "matched_value": matched_value}
+
+    # 2. Regex match against request headers.
+    # When match_any=False and the deployment has both plain tags and tag_regex,
+    # the strict tag check has already failed (step 1 returned None).  Allow
+    # the regex to fire only when the deployment has NO plain tags, so we never
+    # use regex as a backdoor around the operator's strict-tag policy.
+    strict_tag_check_failed = (
+        not match_any and bool(deployment_tags) and bool(request_tags)
+    )
+    if deployment_tag_regex and header_strings and not strict_tag_check_failed:
+        regex_match = _is_valid_deployment_tag_regex(
+            deployment_tag_regex, header_strings
+        )
+        if regex_match is not None:
+            return {"matched_via": "tag_regex", "matched_value": regex_match}
+
+    return None
 
 
 async def get_deployments_for_tag(
@@ -83,30 +155,63 @@ async def get_deployments_for_tag(
         request_tags = metadata.get("tags")
         match_any = llm_router_instance.tag_filtering_match_any
 
-        new_healthy_deployments = []
-        default_deployments = []
-        if request_tags:
-            verbose_logger.debug(
-                "get_deployments_for_tag routing: router_keys: %s", request_tags
-            )
-            # example this can be router_keys=["free", "custom"]
-            for deployment in healthy_deployments:
-                deployment_litellm_params = deployment.get("litellm_params")
-                deployment_tags = deployment_litellm_params.get("tags")
+        # Build header strings for regex matching from what the proxy already stores.
+        # Currently we match against User-Agent; format matches "^User-Agent: claude-code/..."
+        user_agent = metadata.get("user_agent", "")
+        header_strings: List[str] = [f"User-Agent: {user_agent}"] if user_agent else []
 
-                verbose_logger.debug(
-                    "deployment: %s,  deployment_router_keys: %s",
-                    deployment,
-                    deployment_tags,
+        new_healthy_deployments: List[Any] = []
+        default_deployments: List[Any] = []
+
+        # Only activate header-based regex filtering when at least one deployment in
+        # the candidate set has tag_regex configured.  This preserves existing
+        # behaviour for operators who use plain tags: a request that carries a
+        # User-Agent (all proxy requests do) but targets deployments with no
+        # tag_regex will continue to use the original tag-only code path.
+        has_regex_deployments = any(
+            d.get("litellm_params", {}).get("tag_regex") for d in healthy_deployments
+        )
+        has_tag_filter = bool(request_tags) or (
+            bool(header_strings) and has_regex_deployments
+        )
+        if has_tag_filter:
+            verbose_logger.debug(
+                "get_deployments_for_tag routing: request_tags=%s user_agent=%s",
+                request_tags,
+                user_agent,
+            )
+            for deployment in healthy_deployments:
+                deployment_tags = deployment.get("litellm_params", {}).get("tags")
+
+                match_result = _match_deployment(
+                    deployment=deployment,
+                    request_tags=request_tags,
+                    header_strings=header_strings,
+                    match_any=match_any,
                 )
 
-                if deployment_tags is None:
-                    continue
-
-                if is_valid_deployment_tag(deployment_tags, request_tags, match_any):
+                if match_result is not None:
+                    verbose_logger.debug(
+                        "tag routing match: deployment=%s matched_via=%s matched_value=%s",
+                        deployment.get("model_name"),
+                        match_result["matched_via"],
+                        match_result["matched_value"],
+                    )
+                    # Record provenance in metadata so it flows to SpendLogs.
+                    # Written only for the first match — load balancer selects one
+                    # deployment from new_healthy_deployments, so overwriting on
+                    # subsequent matches would produce misleading observability data.
+                    if "tag_routing" not in metadata:
+                        metadata["tag_routing"] = {
+                            "matched_deployment": deployment.get("model_name"),
+                            "matched_via": match_result["matched_via"],
+                            "matched_value": match_result["matched_value"],
+                            "request_tags": request_tags or [],
+                            "user_agent": user_agent,
+                        }
                     new_healthy_deployments.append(deployment)
 
-                if "default" in deployment_tags:
+                if deployment_tags and "default" in deployment_tags:
                     default_deployments.append(deployment)
 
             if len(new_healthy_deployments) == 0 and len(default_deployments) == 0:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -198,6 +198,11 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     model_info: Optional[Dict] = None
     mock_response: Optional[Union[str, ModelResponse, Exception, Any]] = None
 
+    # tag-based routing
+    tags: Optional[List[str]] = None
+    # regex patterns matched against request headers for tag routing
+    tag_regex: Optional[List[str]] = None
+
     # auto-router params
     auto_router_config_path: Optional[str] = None
     auto_router_config: Optional[str] = None
@@ -334,6 +339,8 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     # routing params
     # use this for tag-based routing
     tags: Optional[List[str]]
+    # regex patterns matched against request headers (e.g. "^User-Agent:\\s*claude-code\\/")
+    tag_regex: Optional[List[str]]
 
     # deployment budgets
     max_budget: Optional[float]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22083,6 +22083,7 @@
         "output_cost_per_token": 3e-06,
         "source": "https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
@@ -22166,6 +22167,7 @@
         "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -22180,6 +22182,7 @@
         "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # LITELLM PROXY DEPENDENCIES #
 # Security: explicit pins for transitive deps (CVE fixes)
 urllib3>=2.6.0  # CVE-2025-66471, CVE-2025-66418, CVE-2026-21441
-tornado>=6.5.3  # CVE-2025-67725, CVE-2025-67726, CVE-2025-67724
+tornado>=6.5.5  # CVE-2025-67725, CVE-2025-67726, CVE-2025-67724, CVE-2026-31958, GHSA-78cv-mqj4-43f7
 filelock>=3.20.1  # CVE-2025-68146
 h11>=0.16.0    # CVE-2025-43859, GHSA-vqfr-h8mv-ghfj — HTTP request smuggling
 wheel>=0.46.2  # CVE-2026-24049 — path traversal

--- a/tests/proxy_unit_tests/test_response_polling_handler.py
+++ b/tests/proxy_unit_tests/test_response_polling_handler.py
@@ -1318,6 +1318,267 @@ class TestStreamingEventParsing:
         assert output_items["item_123"]["content"][0]["type"] == "text"
 
 
+def _make_sse_stream(events: list) -> Mock:
+    """Create a mock StreamingResponse with body_iterator from a list of event dicts."""
+
+    async def _body_iterator():
+        for event in events:
+            yield f"data: {json.dumps(event)}"
+        yield "data: [DONE]"
+
+    mock_response = Mock()
+    mock_response.body_iterator = _body_iterator()
+    return mock_response
+
+
+def _make_background_streaming_kwargs(
+    polling_id: str,
+    polling_handler: ResponsePollingHandler,
+) -> dict:
+    """Build kwargs for background_streaming_task with all required mocks."""
+    return dict(
+        polling_id=polling_id,
+        data={"model": "gpt-4o", "stream": False, "background": True},
+        polling_handler=polling_handler,
+        request=Mock(),
+        fastapi_response=Mock(),
+        user_api_key_dict=Mock(),
+        general_settings={},
+        llm_router=None,
+        proxy_config=Mock(),
+        proxy_logging_obj=Mock(),
+        select_data_generator=Mock(),
+        user_model=None,
+        user_temperature=None,
+        user_request_timeout=None,
+        user_max_tokens=None,
+        user_api_base=None,
+        version=None,
+    )
+
+
+@pytest.mark.xdist_group("heavy_imports")
+class TestBackgroundStreamingTerminalEvents:
+    """
+    Integration tests that exercise background_streaming_task with mocked
+    streaming responses, verifying the final update_state call for each
+    terminal event type.
+    """
+
+    @pytest.mark.asyncio
+    async def test_response_failed_sets_failed_status_and_error(self):
+        """Test that a response.failed stream event results in failed status with error"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        error_payload = {
+            "type": "server_error",
+            "message": "The model encountered an error",
+            "code": "model_error",
+        }
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": "resp_123",
+                    "status": "failed",
+                    "error": error_payload,
+                    "model": "gpt-4o",
+                    "output": [],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_1", handler)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        # Find the final update_state call (last one)
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "failed"
+        assert final_call.kwargs["error"] == error_payload
+
+    @pytest.mark.asyncio
+    async def test_response_incomplete_sets_incomplete_status_and_details(self):
+        """Test that a response.incomplete stream event results in incomplete status"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_123",
+                    "status": "incomplete",
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                    "usage": {"input_tokens": 10, "output_tokens": 4096},
+                    "model": "gpt-4o",
+                    "output": [{"id": "item_1", "type": "message"}],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_2", handler)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "incomplete"
+        assert final_call.kwargs["incomplete_details"] == {"reason": "max_output_tokens"}
+        assert final_call.kwargs["usage"] == {"input_tokens": 10, "output_tokens": 4096}
+
+    @pytest.mark.asyncio
+    async def test_response_cancelled_sets_cancelled_status(self):
+        """Test that a response.cancelled stream event results in cancelled status"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.cancelled",
+                "response": {
+                    "id": "resp_123",
+                    "status": "cancelled",
+                    "model": "gpt-4o",
+                    "output": [],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_3", handler)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_response_completed_sets_completed_status(self):
+        """Test that a response.completed stream event results in completed status"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "status": "completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 50},
+                    "model": "gpt-4o",
+                    "output": [{"id": "item_1", "type": "message"}],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_4", handler)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "completed"
+        assert final_call.kwargs["usage"] == {"input_tokens": 10, "output_tokens": 50}
+
+    @pytest.mark.asyncio
+    async def test_fallback_status_derived_from_event_type_when_status_field_missing(self):
+        """Test that when the response body lacks a status field, the fallback
+        is derived from the event type, not hardcoded to 'completed'."""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        # response.incomplete event with NO status field in the response body
+        events = [
+            {"type": "response.in_progress"},
+            {
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_123",
+                    # "status" deliberately omitted
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                    "model": "gpt-4o",
+                    "output": [],
+                },
+            },
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_5", handler)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "incomplete"
+
+    @pytest.mark.asyncio
+    async def test_no_terminal_event_defaults_to_completed(self):
+        """Test that when no terminal event is received, status defaults to completed"""
+        from litellm.proxy.response_polling.background_streaming import (
+            background_streaming_task,
+        )
+
+        # Stream with only in_progress, no terminal event
+        events = [
+            {"type": "response.in_progress"},
+        ]
+        mock_response = _make_sse_stream(events)
+        handler = AsyncMock(spec=ResponsePollingHandler)
+        kwargs = _make_background_streaming_kwargs("poll_6", handler)
+
+        with patch(
+            "litellm.proxy.response_polling.background_streaming.ProxyBaseLLMRequestProcessing"
+        ) as MockProcessor:
+            MockProcessor.return_value.base_process_llm_request = AsyncMock(
+                return_value=mock_response
+            )
+            await background_streaming_task(**kwargs)
+
+        final_call = handler.update_state.call_args_list[-1]
+        assert final_call.kwargs["status"] == "completed"
+
+
 class TestEdgeCases:
     """Test edge cases and error scenarios"""
 

--- a/tests/test_default_encoding_non_root.py
+++ b/tests/test_default_encoding_non_root.py
@@ -1,49 +1,57 @@
+import importlib
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import litellm.litellm_core_utils.default_encoding as default_encoding
 
 
-def test_tiktoken_cache_fallback(monkeypatch):
+def _reload_default_encoding(monkeypatch, **env_overrides):
     """
-    Test that TIKTOKEN_CACHE_DIR falls back to /tmp/tiktoken_cache
-    if the default directory is not writable and LITELLM_NON_ROOT is true.
+    Helper to reload default_encoding with a clean TIKTOKEN_CACHE_DIR and
+    specific environment overrides.
     """
-    # Simulate non-root environment
-    monkeypatch.setenv("LITELLM_NON_ROOT", "true")
+    monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
     monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
-
-    # Mock os.access to return False (not writable)
-    # and mock os.makedirs to avoid actually creating /tmp/tiktoken_cache on local machine
-    with patch("os.access", return_value=False), patch("os.makedirs"):
-        # We need to reload or re-run the logic in default_encoding.py
-        # But since it's already executed, we'll just test the logic directly
-        # mirroring what we wrote in the file.
-
-        filename = (
-            "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/tokenizers"
-        )
-        is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-
-        if not os.access(filename, os.W_OK) and is_non_root:
-            filename = "/tmp/tiktoken_cache"
-            # mock_makedirs(filename, exist_ok=True)
-
-        assert filename == "/tmp/tiktoken_cache"
+    for key, value in env_overrides.items():
+        monkeypatch.setenv(key, value)
+    importlib.reload(default_encoding)
 
 
-def test_tiktoken_cache_no_fallback_if_writable(monkeypatch):
+def test_default_encoding_uses_bundled_tokenizers_by_default(monkeypatch):
     """
-    Test that TIKTOKEN_CACHE_DIR does NOT fall back if writable
+    TIKTOKEN_CACHE_DIR should point at the bundled tokenizers directory
+    when no CUSTOM_TIKTOKEN_CACHE_DIR is set, even in non-root environments.
     """
-    monkeypatch.setenv("LITELLM_NON_ROOT", "true")
+    _reload_default_encoding(monkeypatch, LITELLM_NON_ROOT="true")
 
-    filename = "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/tokenizers"
+    assert "TIKTOKEN_CACHE_DIR" in os.environ
+    cache_dir = os.environ["TIKTOKEN_CACHE_DIR"]
+    assert "tokenizers" in cache_dir
 
-    with patch("os.access", return_value=True):
-        is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-        if not os.access(filename, os.W_OK) and is_non_root:
-            filename = "/tmp/tiktoken_cache"
 
-        assert (
-            filename
-            == "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/tokenizers"
+def test_custom_tiktoken_cache_dir_override(monkeypatch, tmp_path):
+    """
+    CUSTOM_TIKTOKEN_CACHE_DIR must override the default bundled directory
+    and the directory should be created if it does not exist.
+    Reload with an empty custom dir would otherwise trigger tiktoken to
+    download the vocab; we patch get_encoding so the test is offline-safe
+    and does not depend on tiktoken's in-memory cache state.
+    """
+    custom_dir = tmp_path / "tiktoken_cache"
+    with patch(
+        "litellm.litellm_core_utils.default_encoding.tiktoken.get_encoding",
+        return_value=MagicMock(),
+    ):
+        _reload_default_encoding(
+            monkeypatch, CUSTOM_TIKTOKEN_CACHE_DIR=str(custom_dir)
         )
+
+    cache_dir = os.environ.get("TIKTOKEN_CACHE_DIR")
+    assert cache_dir == str(custom_dir)
+    assert os.path.isdir(cache_dir)
+
+    # Restore module to a clean state so default_encoding.encoding is a real
+    # tiktoken Encoding, not the MagicMock, for any test that runs after this.
+    monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
+    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
+    importlib.reload(default_encoding)

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -59,20 +59,19 @@ VALID_OPENAI_FINISH_REASONS = {"stop", "length", "tool_calls", "function_call", 
 
 
 class TestMapFinishReasonAnthropic:
-    def test_stop_sequence(self):
-        assert map_finish_reason("stop_sequence") == "stop"
-
-    def test_end_turn(self):
-        assert map_finish_reason("end_turn") == "stop"
-
-    def test_max_tokens(self):
-        assert map_finish_reason("max_tokens") == "length"
-
-    def test_tool_use(self):
-        assert map_finish_reason("tool_use") == "tool_calls"
-
-    def test_compaction(self):
-        assert map_finish_reason("compaction") == "length"
+    @pytest.mark.parametrize(
+        "provider_reason,expected",
+        [
+            ("stop_sequence", "stop"),
+            ("end_turn", "stop"),
+            ("max_tokens", "length"),
+            ("tool_use", "tool_calls"),
+            ("compaction", "length"),
+            ("content_filtered", "content_filter"),
+        ],
+    )
+    def test_anthropic_finish_reasons(self, provider_reason: str, expected: str) -> None:
+        assert map_finish_reason(provider_reason) == expected
 
 
 class TestMapFinishReasonGemini:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -148,6 +148,38 @@ def test_use_custom_pricing_for_model():
     assert use_custom_pricing_for_model(litellm_params) == True
 
 
+def test_use_custom_pricing_for_model_via_litellm_metadata():
+    """Pricing in litellm_metadata.model_info must be detected.
+
+    Generic API call routes (/messages, /responses) store model_info
+    under litellm_metadata, not metadata. Regression test for #23185.
+    """
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {
+                "id": "claude-sonnet-4-custom",
+                "input_cost_per_token": 0.0003,
+                "output_cost_per_token": 0.0015,
+            },
+        },
+    }
+    assert use_custom_pricing_for_model(litellm_params) is True
+
+
+def test_use_custom_pricing_not_detected_litellm_metadata_no_pricing():
+    """Should return False when litellm_metadata.model_info has no pricing keys."""
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {"id": "some-id", "db_model": False},
+        },
+    }
+    assert use_custom_pricing_for_model(litellm_params) is False
+
+
 def test_logging_prevent_double_logging(logging_obj):
     """
     When using a bridge, log only once from the underlying bridge call.

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
@@ -272,6 +272,164 @@ class TestBedrockFilesTransformation:
         assert "messages" in model_input
         assert "max_tokens" in model_input
 
+    def test_get_complete_file_url_respects_s3_region_name(self):
+        """
+        s3_region_name in litellm_params must be used when building the S3 URL.
+        Previously the code fell back to us-west-2 even when s3_region_name was set,
+        breaking GovCloud (us-gov-west-1) deployments.
+        """
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        config = BedrockFilesConfig()
+
+        jsonl_content = json.dumps(
+            {
+                "custom_id": "req-1",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model": "bedrock/amazon.nova-pro-v1:0",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 10,
+                },
+            }
+        ).encode()
+
+        create_file_data = {
+            "file": ("batch.jsonl", jsonl_content, "application/jsonl"),
+            "purpose": "batch",
+        }
+
+        litellm_params = {
+            "s3_bucket_name": "litellm-batch-352026",
+            "s3_region_name": "us-gov-west-1",
+        }
+
+        url = config.get_complete_file_url(
+            api_base=None,
+            api_key=None,
+            model="amazon.nova-pro-v1:0",
+            optional_params={},
+            litellm_params=litellm_params,
+            data=create_file_data,
+        )
+
+        assert "us-gov-west-1" in url, (
+            f"Expected us-gov-west-1 in URL but got: {url}"
+        )
+        assert "us-west-2" not in url, (
+            f"us-west-2 must not appear when s3_region_name is set, got: {url}"
+        )
+        assert "litellm-batch-352026" in url
+
+    def test_transform_create_file_request_injects_s3_region_for_signing(self):
+        """
+        When s3_region_name is provided, transform_create_file_request must pass
+        that region to _sign_s3_request so SigV4 signatures use the correct region.
+        """
+        from unittest.mock import patch
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        config = BedrockFilesConfig()
+
+        jsonl_content = json.dumps(
+            {
+                "custom_id": "req-1",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model": "bedrock/amazon.nova-pro-v1:0",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 10,
+                },
+            }
+        ).encode()
+
+        create_file_data = {
+            "file": ("batch.jsonl", jsonl_content, "application/jsonl"),
+            "purpose": "batch",
+        }
+
+        litellm_params = {
+            "s3_bucket_name": "litellm-batch-352026",
+            "s3_region_name": "us-gov-west-1",
+        }
+
+        captured_optional_params: dict = {}
+
+        def fake_sign(content, api_base, optional_params):
+            captured_optional_params.update(optional_params)
+            return {"Authorization": "fake"}, content
+
+        with patch.object(config, "_sign_s3_request", side_effect=fake_sign):
+            config.transform_create_file_request(
+                model="amazon.nova-pro-v1:0",
+                create_file_data=create_file_data,
+                optional_params={},
+                litellm_params=litellm_params,
+            )
+
+        assert captured_optional_params.get("aws_region_name") == "us-gov-west-1", (
+            "s3_region_name must be forwarded as aws_region_name for SigV4 signing"
+        )
+
+    def test_s3_region_name_wins_over_aws_region_name_for_signing(self):
+        """
+        When both s3_region_name and aws_region_name are set to different values,
+        s3_region_name must win for signing (same as for the URL). Otherwise the
+        SigV4 signature would be computed against a different region than the URL,
+        causing SignatureDoesNotMatch from AWS.
+        """
+        from unittest.mock import patch
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        config = BedrockFilesConfig()
+
+        jsonl_content = json.dumps(
+            {
+                "custom_id": "req-1",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model": "bedrock/amazon.nova-pro-v1:0",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 10,
+                },
+            }
+        ).encode()
+
+        create_file_data = {
+            "file": ("batch.jsonl", jsonl_content, "application/jsonl"),
+            "purpose": "batch",
+        }
+
+        litellm_params = {
+            "s3_bucket_name": "litellm-batch-352026",
+            "s3_region_name": "us-gov-west-1",
+        }
+        # aws_region_name set to something different — s3_region_name must still win
+        optional_params = {"aws_region_name": "us-east-1"}
+
+        captured_optional_params: dict = {}
+
+        def fake_sign(content, api_base, optional_params):
+            captured_optional_params.update(optional_params)
+            return {"Authorization": "fake"}, content
+
+        with patch.object(config, "_sign_s3_request", side_effect=fake_sign):
+            config.transform_create_file_request(
+                model="amazon.nova-pro-v1:0",
+                create_file_data=create_file_data,
+                optional_params=optional_params,
+                litellm_params=litellm_params,
+            )
+
+        assert captured_optional_params.get("aws_region_name") == "us-gov-west-1", (
+            "s3_region_name must override aws_region_name for SigV4 signing"
+        )
+
     def test_openai_passthrough_still_works(self):
         """
         Regression test: ensure OpenAI-compatible models (e.g. gpt-oss)

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -14,15 +14,16 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
+from botocore.awsrequest import AWSPreparedRequest, AWSRequest
 from botocore.credentials import Credentials
-from botocore.awsrequest import AWSRequest, AWSPreparedRequest
+
 import litellm
+from litellm.caching.caching import DualCache
 from litellm.llms.bedrock.base_aws_llm import (
     AwsAuthError,
     BaseAWSLLM,
     Boto3CredentialsInfo,
 )
-from litellm.caching.caching import DualCache
 
 # Global variable for the base_aws_llm.py file path
 
@@ -1517,6 +1518,83 @@ def test_is_already_running_as_role_invalid_target_arn():
 
     # Should return False without making any API calls
     assert base_aws_llm._is_already_running_as_role("not-a-valid-arn") is False
+
+
+def test_filter_headers_skips_none_values():
+    """
+    Test that _filter_headers_for_aws_signature skips headers with None values.
+
+    Reproduces the issue where botocore's SigV4Auth crashes with
+    'NoneType' object has no attribute 'split' when a header value is None.
+    """
+    llm = BaseAWSLLM()
+
+    headers = {
+        "Content-Type": "application/json",
+        "x-amz-security-token": None,
+        "x-amzn-bedrock-kb-session-id": None,
+        "host": None,
+        "x-amz-date": "20240101T000000Z",
+        "x-custom-header": None,
+    }
+
+    filtered = llm._filter_headers_for_aws_signature(headers)
+
+    assert filtered["Content-Type"] == "application/json"
+    assert filtered["x-amz-date"] == "20240101T000000Z"
+    assert "x-amz-security-token" not in filtered
+    assert "x-amzn-bedrock-kb-session-id" not in filtered
+    assert "host" not in filtered
+    # Non-AWS headers are excluded regardless
+    assert "x-custom-header" not in filtered
+
+
+def test_sign_request_with_none_header_values():
+    """
+    End-to-end test that _sign_request does not crash when headers contain
+    None values for x-amz-* keys.
+
+    This reproduces the Bedrock KB GovCloud issue where SigV4 signing failed
+    with 'NoneType' object has no attribute 'split'.
+
+    Also verifies that None-valued headers are NOT re-merged into the
+    returned headers dict (which would cause downstream HTTP client failures).
+    """
+    llm = BaseAWSLLM()
+
+    mock_credentials = Credentials("test_key", "test_secret")
+
+    headers_with_nones = {
+        "Content-Type": "application/json",
+        "x-amzn-trace-id": None,
+        "x-forwarded-for": None,
+    }
+
+    with patch.object(
+        llm, "get_credentials", return_value=mock_credentials
+    ), patch.object(
+        llm, "_get_aws_region_name", return_value="us-gov-west-1"
+    ):
+        result_headers, result_body = llm._sign_request(
+            service_name="bedrock",
+            headers=headers_with_nones,
+            optional_params={
+                "aws_access_key_id": "test_key",
+                "aws_secret_access_key": "test_secret",
+                "aws_region_name": "us-gov-west-1",
+            },
+            request_data={"retrievalQuery": {"text": "test query"}},
+            api_base="https://bedrock-agent-runtime.us-gov-west-1.amazonaws.com/knowledgebases/KB123/retrieve",
+        )
+
+        assert "Authorization" in result_headers
+        assert result_body is not None
+
+        # None-valued headers must NOT appear in the returned headers
+        for header_name, header_value in result_headers.items():
+            assert header_value is not None, (
+                f"Header '{header_name}' has None value in returned headers"
+            )
 
 
 def test_is_already_running_as_role_ssl_verify_passed():

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -155,6 +155,80 @@ async def test_async_anthropic_messages_handler_extra_headers():
 
 
 @pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_passes_litellm_metadata():
+    """Ensure litellm_metadata from kwargs is included in litellm_params
+    passed to update_environment_variables.
+
+    Routes like /messages store model_info under kwargs['litellm_metadata'].
+    The handler must forward this into litellm_params so that
+    use_custom_pricing_for_model can detect custom pricing. Regression test for #23185.
+    """
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "test-key"}, "https://api.anthropic.com")
+    )
+    mock_config.transform_anthropic_messages_request = Mock(
+        return_value={"model": "claude-sonnet-4-20250514", "messages": []}
+    )
+
+    mock_client = AsyncMock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello!"}],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+    }
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    mock_logging_obj = Mock()
+    mock_logging_obj.update_environment_variables = Mock()
+    mock_logging_obj.model_call_details = {}
+    mock_logging_obj.stream = False
+
+    custom_model_info = {
+        "id": "claude-sonnet-4-custom-pricing",
+        "input_cost_per_token": 0.0003,
+        "output_cost_per_token": 0.0015,
+    }
+    kwargs = {
+        "litellm_metadata": {
+            "model_info": custom_model_info,
+            "deployment": "anthropic/claude-sonnet-4-20250514",
+        },
+    }
+
+    try:
+        await handler.async_anthropic_messages_handler(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "Hello"}],
+            anthropic_messages_provider_config=mock_config,
+            anthropic_messages_optional_request_params={},
+            custom_llm_provider="anthropic",
+            litellm_params=GenericLiteLLMParams(),
+            logging_obj=mock_logging_obj,
+            client=mock_client,
+            kwargs=kwargs,
+        )
+    except Exception:
+        pass
+
+    mock_logging_obj.update_environment_variables.assert_called_once()
+    call_kwargs = mock_logging_obj.update_environment_variables.call_args
+    litellm_params_arg = call_kwargs.kwargs.get(
+        "litellm_params", call_kwargs[1].get("litellm_params", {})
+    ) if call_kwargs.kwargs else call_kwargs[1].get("litellm_params", {})
+
+    assert "litellm_metadata" in litellm_params_arg
+    assert litellm_params_arg["litellm_metadata"]["model_info"] == custom_model_info
+
+
+@pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_header_priority():
     """
     Test that async_anthropic_messages_handler respects header priority:

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -7,6 +7,7 @@ Moonshot AI is an OpenAI-compatible provider with minor customizations.
 
 import os
 import sys
+from unittest.mock import patch
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
@@ -405,3 +406,148 @@ class TestMoonshotConfig:
         # Content should be flattened to a plain string
         assert isinstance(result["messages"][0]["content"], str)
         assert result["messages"][0]["content"] == "Hello, how are you?"
+
+    # ------------------------------------------------------------------ #
+    # Tests for fill_reasoning_content                                     #
+    # ------------------------------------------------------------------ #
+
+    def test_reasoning_content_space_injected_when_absent(self):
+        """Assistant tool-call message with no reasoning_content gets a space injected."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Sunny, 22°C"},
+        ]
+
+        result = config.fill_reasoning_content(messages)
+
+        assert result[1].get("reasoning_content") == " "
+        # Non-assistant messages are untouched
+        assert "reasoning_content" not in result[0]
+        assert "reasoning_content" not in result[2]
+
+    def test_empty_tool_calls_list_not_injected(self):
+        """Assistant message with tool_calls: [] should not get reasoning_content injected."""
+        config = MoonshotChatConfig()
+
+        original_msg = {
+            "role": "assistant",
+            "content": "Here is the answer.",
+            "tool_calls": [],
+        }
+        messages = [original_msg]
+
+        result = config.fill_reasoning_content(messages)
+
+        assert "reasoning_content" not in result[0]
+        assert result[0] is original_msg
+
+    def test_existing_reasoning_content_not_overwritten(self):
+        """Message that already has reasoning_content is passed through unchanged."""
+        config = MoonshotChatConfig()
+
+        original_msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+            ],
+            "reasoning_content": "<actual thinking>",
+        }
+        messages = [original_msg]
+
+        result = config.fill_reasoning_content(messages)
+
+        assert result[0].get("reasoning_content") == "<actual thinking>"
+        # Same object — no copy was made
+        assert result[0] is original_msg
+
+    def test_provider_specific_fields_reasoning_content_promoted(self):
+        """reasoning_content stored in provider_specific_fields is promoted to top level."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+                ],
+                "provider_specific_fields": {"reasoning_content": "stored thinking"},
+            }
+        ]
+
+        result = config.fill_reasoning_content(messages)
+
+        assert result[0].get("reasoning_content") == "stored thinking"
+        # The promoted key must be removed from provider_specific_fields to
+        # avoid sending the value twice in the serialised request body
+        assert "reasoning_content" not in (result[0].get("provider_specific_fields") or {})
+
+    def test_reasoning_model_fill_called_from_transform_request(self):
+        """transform_request injects reasoning_content end-to-end for reasoning models."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "Call a tool"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+                ],
+            },
+        ]
+
+        with patch(
+            "litellm.llms.moonshot.chat.transformation.supports_reasoning",
+            return_value=True,
+        ):
+            result = config.transform_request(
+                model="kimi-k2-thinking",
+                messages=messages,
+                optional_params={},
+                litellm_params={},
+                headers={},
+            )
+
+        assert result["messages"][1].get("reasoning_content") == " "
+
+    def test_non_reasoning_model_messages_untouched(self):
+        """For non-reasoning models, transform_request leaves messages unchanged."""
+        config = MoonshotChatConfig()
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+                ],
+            },
+        ]
+
+        with patch(
+            "litellm.llms.moonshot.chat.transformation.supports_reasoning",
+            return_value=False,
+        ):
+            result = config.transform_request(
+                model="moonshot-v1-8k",
+                messages=messages,
+                optional_params={},
+                litellm_params={},
+                headers={},
+            )
+
+        # reasoning_content must not have been injected
+        for msg in result["messages"]:
+            assert "reasoning_content" not in msg

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
@@ -5,6 +5,7 @@ import pytest
 from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation import (
     VertexAIPartnerModelsAnthropicMessagesConfig,
 )
+from litellm.types.router import GenericLiteLLMParams
 
 
 def test_validate_environment_uses_vertex_ai_location():
@@ -248,3 +249,47 @@ def test_validate_environment_with_authorization_header_calculates_api_base():
         # Verify Authorization header is still present
         assert "Authorization" in updated_headers, \
             "Authorization header should be preserved"
+
+
+def test_transform_anthropic_messages_request_removes_scope_from_cache_control():
+    """Ensure scope field is removed from cache_control for Vertex AI (not supported)."""
+    config = VertexAIPartnerModelsAnthropicMessagesConfig()
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hello",
+                    "cache_control": {"type": "ephemeral", "scope": "global"},
+                }
+            ],
+        }
+    ]
+    anthropic_messages_optional_request_params = {
+        "max_tokens": 1024,
+        "system": [
+            {
+                "type": "text",
+                "text": "You are an AI assistant.",
+                "cache_control": {"type": "ephemeral", "scope": "global"},
+            }
+        ],
+    }
+
+    result = config.transform_anthropic_messages_request(
+        model="claude-sonnet-4-6",
+        messages=messages,
+        anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    # scope removed from system
+    assert "scope" not in result["system"][0]["cache_control"]
+    assert result["system"][0]["cache_control"]["type"] == "ephemeral"
+
+    # scope removed from message content
+    assert "scope" not in result["messages"][0]["content"][0]["cache_control"]
+    assert result["messages"][0]["content"][0]["cache_control"]["type"] == "ephemeral"

--- a/tests/test_litellm/router_strategy/test_router_tag_regex_routing.py
+++ b/tests/test_litellm/router_strategy/test_router_tag_regex_routing.py
@@ -1,0 +1,375 @@
+"""
+Unit tests for tag_regex routing.
+
+Tests _is_valid_deployment_tag_regex() and get_deployments_for_tag() with tag_regex
+patterns, verifying that regex-based header matching works correctly alongside
+existing tag-based routing.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from unittest.mock import MagicMock
+
+from litellm.router_strategy import tag_based_routing
+from litellm.router_strategy.tag_based_routing import get_deployments_for_tag
+
+_is_valid_deployment_tag_regex = tag_based_routing._is_valid_deployment_tag_regex
+
+
+# ---------------------------------------------------------------------------
+# _is_valid_deployment_tag_regex unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_regex_matches_claude_code_user_agent():
+    """^User-Agent: claude-code/ matches a claude-code UA string."""
+    result = _is_valid_deployment_tag_regex(
+        tag_regexes=[r"^User-Agent: claude-code\/"],
+        header_strings=["User-Agent: claude-code/1.2.3"],
+    )
+    assert result == r"^User-Agent: claude-code\/"
+
+
+def test_regex_no_match_for_other_ua():
+    """Pattern does not match a non-claude-code User-Agent."""
+    result = _is_valid_deployment_tag_regex(
+        tag_regexes=[r"^User-Agent: claude-code\/"],
+        header_strings=["User-Agent: Mozilla/5.0 (browser)"],
+    )
+    assert result is None
+
+
+def test_regex_returns_first_matching_pattern():
+    """When multiple patterns are provided, returns the first match."""
+    result = _is_valid_deployment_tag_regex(
+        tag_regexes=[r"^User-Agent: cursor\/", r"^User-Agent: claude-code\/"],
+        header_strings=["User-Agent: claude-code/2.0.0"],
+    )
+    assert result == r"^User-Agent: claude-code\/"
+
+
+def test_regex_empty_inputs_return_none():
+    """Empty lists return None without errors."""
+    assert _is_valid_deployment_tag_regex([], ["User-Agent: claude-code/1.0"]) is None
+    assert _is_valid_deployment_tag_regex([r"^User-Agent: claude-code\/"], []) is None
+
+
+def test_invalid_regex_skipped_does_not_raise():
+    """An invalid regex pattern is skipped (warning logged) — no exception raised."""
+    result = _is_valid_deployment_tag_regex(
+        tag_regexes=["[invalid(regex"],
+        header_strings=["User-Agent: claude-code/1.0"],
+    )
+    assert result is None
+
+
+def test_regex_matches_version_range():
+    """Semver-aware pattern matches multiple versions."""
+    pattern = r"^User-Agent: claude-code\/\d"
+    for ua in ["claude-code/1.0", "claude-code/2.0.0-beta.1", "claude-code/99.0"]:
+        result = _is_valid_deployment_tag_regex(
+            tag_regexes=[pattern],
+            header_strings=[f"User-Agent: {ua}"],
+        )
+        assert result == pattern, f"Expected match for UA: {ua}"
+
+
+# ---------------------------------------------------------------------------
+# get_deployments_for_tag integration tests
+# ---------------------------------------------------------------------------
+
+CLAUDE_CODE_DEPLOYMENT = {
+    "model_name": "claude-sonnet",
+    "litellm_params": {
+        "model": "openai/claude-code-deployment",
+        "api_key": "fake",
+        "mock_response": "cc",
+        "tag_regex": [r"^User-Agent: claude-code\/"],
+    },
+    "model_info": {"id": "claude-code-deployment"},
+}
+
+REGULAR_DEPLOYMENT = {
+    "model_name": "claude-sonnet",
+    "litellm_params": {
+        "model": "openai/regular-deployment",
+        "api_key": "fake",
+        "mock_response": "regular",
+        "tags": ["default"],
+    },
+    "model_info": {"id": "regular-deployment"},
+}
+
+ALL_DEPLOYMENTS = [CLAUDE_CODE_DEPLOYMENT, REGULAR_DEPLOYMENT]
+
+
+def _make_router_mock(enable_tag_filtering=True, match_any=True):
+    mock = MagicMock()
+    mock.enable_tag_filtering = enable_tag_filtering
+    mock.tag_filtering_match_any = match_any
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_claude_code_ua_routes_to_cc_deployment():
+    """claude-code/x.y.z UA → claude-code-deployment via tag_regex."""
+    router = _make_router_mock()
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=ALL_DEPLOYMENTS,
+        request_kwargs={"metadata": {"user_agent": "claude-code/1.2.3"}},
+    )
+    assert len(result) == 1
+    assert result[0]["model_info"]["id"] == "claude-code-deployment"
+
+
+@pytest.mark.asyncio
+async def test_regular_ua_routes_to_default_deployment():
+    """Mozilla UA → regular-deployment via default tag fallback."""
+    router = _make_router_mock()
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=ALL_DEPLOYMENTS,
+        request_kwargs={"metadata": {"user_agent": "Mozilla/5.0 (browser)"}},
+    )
+    assert len(result) == 1
+    assert result[0]["model_info"]["id"] == "regular-deployment"
+
+
+@pytest.mark.asyncio
+async def test_no_ua_routes_to_default_deployment():
+    """No User-Agent → default deployment."""
+    router = _make_router_mock()
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=ALL_DEPLOYMENTS,
+        request_kwargs={"metadata": {}},
+    )
+    assert len(result) == 1
+    assert result[0]["model_info"]["id"] == "regular-deployment"
+
+
+@pytest.mark.asyncio
+async def test_tag_routing_metadata_written_for_regex_match():
+    """tag_routing metadata block is populated when regex matches."""
+    router = _make_router_mock()
+    metadata: dict = {"user_agent": "claude-code/2.0.0-beta.1"}
+    await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=ALL_DEPLOYMENTS,
+        request_kwargs={"metadata": metadata},
+    )
+    assert "tag_routing" in metadata
+    tr = metadata["tag_routing"]
+    assert tr["matched_via"] == "tag_regex"
+    assert tr["matched_value"] == r"^User-Agent: claude-code\/"
+    assert tr["user_agent"] == "claude-code/2.0.0-beta.1"
+
+
+@pytest.mark.asyncio
+async def test_tag_filtering_disabled_returns_all_deployments():
+    """When enable_tag_filtering is False, all deployments returned regardless of UA."""
+    router = _make_router_mock(enable_tag_filtering=False)
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=ALL_DEPLOYMENTS,
+        request_kwargs={"metadata": {"user_agent": "claude-code/1.0"}},
+    )
+    assert result == ALL_DEPLOYMENTS
+
+
+@pytest.mark.asyncio
+async def test_explicit_tag_match_takes_precedence_over_regex():
+    """A deployment with both tags and tag_regex: exact tag match fires first."""
+    deployment_with_both = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {
+            "model": "openai/both-deployment",
+            "api_key": "fake",
+            "tags": ["premium"],
+            "tag_regex": [r"^User-Agent: claude-code\/"],
+        },
+        "model_info": {"id": "both-deployment"},
+    }
+    router = _make_router_mock()
+    metadata: dict = {
+        "tags": ["premium"],
+        "user_agent": "claude-code/1.0",
+    }
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=[deployment_with_both],
+        request_kwargs={"metadata": metadata},
+    )
+    assert len(result) == 1
+    tr = metadata.get("tag_routing", {})
+    assert tr.get("matched_via") == "tags"
+
+
+@pytest.mark.asyncio
+async def test_user_agent_present_no_tag_regex_deployments_does_not_raise():
+    """
+    Backwards-compat: a request that carries a User-Agent but targets plain-tag
+    deployments (no tag_regex) must NOT raise ValueError — it should fall
+    through to the default/all-deployments path just like before.
+    """
+    plain_tag_only_deployments = [
+        {
+            "model_name": "gpt-4",
+            "litellm_params": {
+                "model": "openai/premium-deployment",
+                "api_key": "fake",
+                "tags": ["premium"],
+            },
+            "model_info": {"id": "premium-deployment"},
+        },
+        {
+            "model_name": "gpt-4",
+            "litellm_params": {
+                "model": "openai/free-deployment",
+                "api_key": "fake",
+                "tags": ["free"],
+            },
+            "model_info": {"id": "free-deployment"},
+        },
+    ]
+    router = _make_router_mock()
+    # The request has a User-Agent (as all proxy requests do) but NO tags and
+    # neither deployment has tag_regex — must not raise, must return all.
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="gpt-4",
+        healthy_deployments=plain_tag_only_deployments,
+        request_kwargs={"metadata": {"user_agent": "Mozilla/5.0 (any-client)"}},
+    )
+    # Falls through to "return healthy_deployments" path unchanged
+    assert result == plain_tag_only_deployments
+
+
+@pytest.mark.asyncio
+async def test_tag_routing_metadata_not_overwritten_for_multiple_matches():
+    """
+    When multiple deployments match, tag_routing records only the first match
+    so the provenance reflects what the load balancer likely selected.
+    """
+    deployment_a = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {
+            "model": "openai/cc-deployment-a",
+            "api_key": "fake",
+            "tag_regex": [r"^User-Agent: claude-code\/"],
+        },
+        "model_info": {"id": "cc-deployment-a"},
+    }
+    deployment_b = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {
+            "model": "openai/cc-deployment-b",
+            "api_key": "fake",
+            "tag_regex": [r"^User-Agent: claude-code\/"],
+        },
+        "model_info": {"id": "cc-deployment-b"},
+    }
+    router = _make_router_mock()
+    metadata: dict = {"user_agent": "claude-code/1.0"}
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=[deployment_a, deployment_b],
+        request_kwargs={"metadata": metadata},
+    )
+    assert len(result) == 2
+    # tag_routing recorded once and reflects the first match
+    tr = metadata.get("tag_routing", {})
+    assert tr.get("matched_deployment") == "claude-sonnet"
+    assert tr.get("matched_via") == "tag_regex"
+
+
+@pytest.mark.asyncio
+async def test_match_any_false_strict_tag_check_blocks_regex_fallback():
+    """
+    When match_any=False and a deployment has both tags and tag_regex:
+    if the strict tag check fails (request has a tag NOT present on the
+    deployment, so req_set is NOT a subset of dep_set), the regex fallback
+    must NOT fire — that would violate the operator's strict-filtering intent.
+
+    Semantics of match_any=False: req_set.issubset(dep_set), i.e. every
+    request tag must appear on the deployment.  A request with tags ["vip"]
+    against a deployment with tags ["premium"] fails because "vip" ∉ dep_set.
+    """
+    deployment_strict = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {
+            "model": "openai/strict-deployment",
+            "api_key": "fake",
+            "tags": ["premium"],
+            "tag_regex": [r"^User-Agent: claude-code\/"],
+        },
+        "model_info": {"id": "strict-deployment"},
+    }
+    default_deployment = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {
+            "model": "openai/default-deployment",
+            "api_key": "fake",
+            "tags": ["default"],
+        },
+        "model_info": {"id": "default-deployment"},
+    }
+    # match_any=False: req_set must be a subset of dep_set.
+    # Request has "vip" which is NOT in ["premium"], so tag check fails.
+    # Even though UA matches tag_regex, the deployment must NOT be selected.
+    router = _make_router_mock(enable_tag_filtering=True, match_any=False)
+    metadata: dict = {
+        "tags": ["vip"],  # "vip" not in deployment tags → strict check fails
+        "user_agent": "claude-code/1.0",
+    }
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=[deployment_strict, default_deployment],
+        request_kwargs={"metadata": metadata},
+    )
+    ids = [d["model_info"]["id"] for d in result]
+    assert "strict-deployment" not in ids, (
+        "strict-deployment should not be selected: strict tag check failed "
+        "and regex must not override the strict policy"
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_any_false_regex_only_deployment_still_matches():
+    """
+    When match_any=False and a deployment has ONLY tag_regex (no plain tags),
+    there is no strict tag policy to violate, so the regex check must still fire.
+    """
+    regex_only_deployment = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {
+            "model": "openai/regex-only-deployment",
+            "api_key": "fake",
+            "tag_regex": [r"^User-Agent: claude-code\/"],
+            # no "tags" key at all
+        },
+        "model_info": {"id": "regex-only-deployment"},
+    }
+    router = _make_router_mock(enable_tag_filtering=True, match_any=False)
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="claude-sonnet",
+        healthy_deployments=[regex_only_deployment],
+        request_kwargs={"metadata": {"user_agent": "claude-code/1.0"}},
+    )
+    assert len(result) == 1
+    assert result[0]["model_info"]["id"] == "regex-only-deployment"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -332,6 +332,62 @@ def test_custom_pricing_with_router_model_id():
     assert model_info["cache_read_input_token_cost"] == 0.0000006
 
 
+def test_custom_pricing_cost_calc_uses_router_model_id_from_litellm_metadata():
+    """When custom pricing is in litellm_metadata.model_info,
+    use_custom_pricing_for_model should return True and
+    _select_model_name_for_cost_calc should use router_model_id.
+
+    This tests the full chain that was broken for /messages and /responses
+    endpoints. Regression test for #23185.
+    """
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    custom_model_id = "claude-sonnet-4-custom-pricing-test"
+    custom_pricing_info = {
+        "input_cost_per_token": 0.0003,
+        "output_cost_per_token": 0.0015,
+        "max_tokens": 8192,
+        "litellm_provider": "anthropic",
+    }
+    litellm.register_model(model_cost={custom_model_id: custom_pricing_info})
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {
+                "id": custom_model_id,
+                "input_cost_per_token": 0.0003,
+                "output_cost_per_token": 0.0015,
+            },
+        },
+    }
+
+    custom_pricing = use_custom_pricing_for_model(litellm_params)
+    assert custom_pricing is True
+
+    # _select_model_name_for_cost_calc appends provider prefix to the
+    # selected router_model_id, so the result is "anthropic/<model_id>"
+    selected_model = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=None,
+        custom_pricing=custom_pricing,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert selected_model is not None
+    assert custom_model_id in selected_model
+
+    # Without custom_pricing, the router_model_id is NOT selected
+    selected_model_no_custom = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=None,
+        custom_pricing=False,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert custom_model_id not in (selected_model_no_custom or "")
+
+
 def test_azure_realtime_cost_calculator():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -365,11 +421,7 @@ def test_azure_audio_output_cost_calculation():
     Audio tokens should be charged at output_cost_per_audio_token rate,
     not at the text token rate (output_cost_per_token).
     """
-    from litellm.types.utils import (
-        Choices,
-        CompletionTokensDetailsWrapper,
-        Message,
-    )
+    from litellm.types.utils import Choices, CompletionTokensDetailsWrapper, Message
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -471,11 +523,7 @@ def test_default_image_cost_calculator(monkeypatch):
 
 def test_cost_calculator_with_cache_creation():
     from litellm import completion_cost
-    from litellm.types.utils import (
-        Choices,
-        Message,
-        Usage,
-    )
+    from litellm.types.utils import Choices, Message, Usage
 
     litellm_model_response = ModelResponse(
         id="chatcmpl-cc5638bc-fdfe-48e4-8884-57c8f4fb7c63",
@@ -896,10 +944,7 @@ def test_azure_ai_cache_cost_calculation():
     applied correctly.
     """
     from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-    from litellm.types.utils import (
-        PromptTokensDetailsWrapper,
-        Usage,
-    )
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")

--- a/tests/test_litellm/test_model_cost_aliases.py
+++ b/tests/test_litellm/test_model_cost_aliases.py
@@ -5,8 +5,9 @@ The ``_expand_model_aliases`` function processes ``aliases`` lists from model
 entries, creating shared dict references for alias entries at load time.
 """
 
-import logging
+from unittest.mock import patch
 
+from litellm import verbose_logger
 from litellm.litellm_core_utils.get_model_cost_map import _expand_model_aliases
 
 
@@ -118,7 +119,7 @@ class TestExpandModelAliases:
 class TestAliasConflicts:
     """Tests for alias conflict detection and handling."""
 
-    def test_alias_conflicts_with_canonical_entry(self, caplog):
+    def test_alias_conflicts_with_canonical_entry(self):
         """Alias that matches an existing canonical entry is skipped with a warning."""
         model_cost = {
             "model-latest": {
@@ -133,14 +134,17 @@ class TestAliasConflicts:
                 "mode": "chat",
             },
         }
-        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        with patch.object(verbose_logger, "warning") as mock_warn:
             result = _expand_model_aliases(model_cost)
 
         # The canonical "model-dated" entry is preserved, not overwritten
         assert "model-dated" in result
-        assert "alias conflict" in caplog.text.lower()
+        # Verify a warning about the alias conflict was logged
+        mock_warn.assert_called()
+        warning_messages = " ".join(str(c) for c in mock_warn.call_args_list)
+        assert "alias conflict" in warning_messages.lower()
 
-    def test_duplicate_alias_across_entries(self, caplog):
+    def test_duplicate_alias_across_entries(self):
         """Same alias claimed by two different entries: second one is skipped."""
         model_cost = {
             "model-a": {
@@ -156,13 +160,16 @@ class TestAliasConflicts:
                 "mode": "chat",
             },
         }
-        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        with patch.object(verbose_logger, "warning") as mock_warn:
             result = _expand_model_aliases(model_cost)
 
         # "shared-alias" should point to model-a (first one wins)
         assert "shared-alias" in result
         assert result["shared-alias"]["input_cost_per_token"] == 1e-06
-        assert "alias conflict" in caplog.text.lower()
+        # Verify a warning about the alias conflict was logged
+        mock_warn.assert_called()
+        warning_messages = " ".join(str(c) for c in mock_warn.call_args_list)
+        assert "alias conflict" in warning_messages.lower()
 
     def test_canonical_entry_not_overwritten_by_alias(self):
         """An alias must never overwrite an existing canonical entry's data."""

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2735,6 +2735,81 @@ def test_credential_name_not_injected_when_absent():
     assert kwargs["metadata"]["tags"] == ["A.101"]
 
 
+def test_update_kwargs_with_deployment_model_info_in_litellm_metadata():
+    """For generic_api_call, model_info with pricing must go to litellm_metadata.
+
+    Routes like /messages and /responses use generic_api_call which stores
+    model_info under litellm_metadata. Regression test for #23185.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet-4",
+                "litellm_params": {
+                    "model": "anthropic/claude-sonnet-4-20250514",
+                    "api_key": "fake-key",
+                },
+                "model_info": {
+                    "id": "custom-pricing-id",
+                    "input_cost_per_token": 0.0003,
+                    "output_cost_per_token": 0.0015,
+                },
+            },
+        ],
+    )
+
+    kwargs: dict = {}
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="claude-sonnet-4"
+    )
+    router._update_kwargs_with_deployment(
+        deployment=deployment, kwargs=kwargs, function_name="generic_api_call"
+    )
+
+    assert "litellm_metadata" in kwargs
+    model_info = kwargs["litellm_metadata"]["model_info"]
+    assert model_info["id"] == "custom-pricing-id"
+    assert model_info["input_cost_per_token"] == 0.0003
+    assert model_info["output_cost_per_token"] == 0.0015
+
+
+def test_update_kwargs_with_deployment_model_info_in_metadata():
+    """For acompletion (function_name=None), model_info goes to metadata.
+
+    /chat/completions uses acompletion which stores model_info under metadata.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet-4",
+                "litellm_params": {
+                    "model": "anthropic/claude-sonnet-4-20250514",
+                    "api_key": "fake-key",
+                },
+                "model_info": {
+                    "id": "custom-pricing-id",
+                    "input_cost_per_token": 0.0003,
+                    "output_cost_per_token": 0.0015,
+                },
+            },
+        ],
+    )
+
+    kwargs: dict = {}
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="claude-sonnet-4"
+    )
+    router._update_kwargs_with_deployment(
+        deployment=deployment, kwargs=kwargs, function_name=None
+    )
+
+    assert "metadata" in kwargs
+    model_info = kwargs["metadata"]["model_info"]
+    assert model_info["id"] == "custom-pricing-id"
+    assert model_info["input_cost_per_token"] == 0.0003
+    assert model_info["output_cost_per_token"] == 0.0015
+
+
 def test_combine_fallback_usage():
     """Test that _combine_fallback_usage merges partial and fallback usage."""
     from litellm.router import Router

--- a/tests/test_litellm/test_stream_chunk_builder_annotations.py
+++ b/tests/test_litellm/test_stream_chunk_builder_annotations.py
@@ -1,0 +1,191 @@
+"""
+Tests for stream_chunk_builder annotation merging.
+
+Previously, stream_chunk_builder only took annotations from the FIRST
+annotation chunk, losing any annotations that arrived in later chunks.
+This fix merges annotations from ALL chunks.
+"""
+
+from litellm import stream_chunk_builder
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+
+def test_stream_chunk_builder_merges_annotations_from_multiple_chunks():
+    """
+    stream_chunk_builder must merge annotations from ALL streaming chunks,
+    not just take them from the first annotation chunk.
+
+    Providers may spread annotations across multiple chunks (e.g. Gemini
+    sends grounding metadata in the final chunk, while intermediate chunks
+    may carry different annotations).
+    """
+    annotation_a = {
+        "type": "url_citation",
+        "url_citation": {
+            "url": "https://example.com/a",
+            "title": "Source A",
+            "start_index": 0,
+            "end_index": 10,
+        },
+    }
+    annotation_b = {
+        "type": "url_citation",
+        "url_citation": {
+            "url": "https://example.com/b",
+            "title": "Source B",
+            "start_index": 20,
+            "end_index": 30,
+        },
+    }
+
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(
+                        content="Part one. ",
+                        role="assistant",
+                        annotations=[annotation_a],
+                    ),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(content="Part two."),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(
+                        content=None,
+                        annotations=[annotation_b],
+                    ),
+                )
+            ],
+        ),
+    ]
+
+    response = stream_chunk_builder(chunks=chunks)
+    assert response is not None
+
+    message = response["choices"][0]["message"]
+    assert message.annotations is not None
+    assert len(message.annotations) == 2
+    assert message.annotations[0] == annotation_a
+    assert message.annotations[1] == annotation_b
+
+
+def test_stream_chunk_builder_single_annotation_chunk_still_works():
+    """
+    When annotations come from a single chunk (most common case),
+    stream_chunk_builder must still work correctly (no regression).
+    """
+    annotation = {
+        "type": "url_citation",
+        "url_citation": {
+            "url": "https://example.com/only",
+            "title": "Only Source",
+            "start_index": 0,
+            "end_index": 5,
+        },
+    }
+
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(content="Hello", role="assistant"),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(content=None, annotations=[annotation]),
+                )
+            ],
+        ),
+    ]
+
+    response = stream_chunk_builder(chunks=chunks)
+    assert response is not None
+
+    message = response["choices"][0]["message"]
+    assert message.annotations is not None
+    assert len(message.annotations) == 1
+    assert message.annotations[0] == annotation
+
+
+def test_stream_chunk_builder_no_annotations():
+    """
+    When no chunks contain annotations, the message should not have
+    an annotations key (no regression).
+    """
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(content="Hello", role="assistant"),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-test",
+            created=1700000000,
+            model="test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(content=None),
+                )
+            ],
+        ),
+    ]
+
+    response = stream_chunk_builder(chunks=chunks)
+    assert response is not None
+
+    message = response["choices"][0]["message"]
+    assert not hasattr(message, "annotations") or message.annotations is None

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -88,7 +88,7 @@
     "mermaid": ">=11.10.0",
     "js-yaml": ">=4.1.1",
     "glob": ">=11.1.0",
-    "tar": ">=7.5.10",
+    "tar": ">=7.5.11",
     "minimatch": ">=10.2.4",
     "@isaacs/brace-expansion": ">=5.0.1",
     "node-forge": ">=1.3.2",

--- a/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/FallbackGroupConfig.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/RouterSettings/Fallbacks/FallbackGroupConfig.tsx
@@ -78,6 +78,7 @@ export function FallbackGroupConfig({
           value={group.primaryModel}
           onChange={handlePrimaryChange}
           showSearch
+          getPopupContainer={(trigger) => trigger.parentElement || document.body}
           filterOption={(input, option) =>
             (option?.label ?? "").toLowerCase().includes(input.toLowerCase())
           }
@@ -125,6 +126,7 @@ export function FallbackGroupConfig({
               value={group.fallbackModels}
               onChange={handleFallbackSelect}
               disabled={!group.primaryModel}
+              getPopupContainer={(trigger) => trigger.parentElement || document.body}
               options={availableFallbackOptions.map((m) => ({
                 label: m,
                 value: m,


### PR DESCRIPTION
## Relevant issues

Fixes `stream_chunk_builder` losing annotations from all but the first annotation-bearing streaming chunk.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

Bug Fix

## Changes

### Problem

In `litellm/main.py`, `stream_chunk_builder()` collects all streaming chunks that contain annotations, but then only uses annotations from the **first** chunk:

```python
annotations = annotation_chunks[0]["choices"][0]["delta"]["annotations"]
```

This means if annotations arrive across multiple streaming chunks (e.g. Gemini sends grounding metadata in the final chunk while other providers may include citations in intermediate chunks), all but the first set of annotations are silently lost.

### Fix

Merge annotations from ALL annotation-bearing chunks by extending a list:

```python
all_annotations: list = []
for ac in annotation_chunks:
    all_annotations.extend(ac["choices"][0]["delta"]["annotations"])
response["choices"][0]["message"]["annotations"] = all_annotations
```

### Tests added

`tests/test_litellm/test_stream_chunk_builder_annotations.py`:

- `test_stream_chunk_builder_merges_annotations_from_multiple_chunks` — verifies annotations from chunk 1 and chunk 3 are both present in the assembled response
- `test_stream_chunk_builder_single_annotation_chunk_still_works` — verifies existing single-chunk behavior (no regression)
- `test_stream_chunk_builder_no_annotations` — verifies no annotations attribute when none are present (no regression)