### PR TITLE
Support multiple headers mapped to the customer user role

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -757,7 +757,7 @@ def get_end_user_id_from_request_body(
                     
         elif isinstance(custom_header_name_to_check, str):
             for header_name, header_value in request_headers.items():
-                if header_name.lower() == custom_header_name_to_check:
+                if header_name.lower() == custom_header_name_to_check.lower():
                     user_id_str = (
                         str(header_value)
                         if header_value is not None

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -662,11 +662,12 @@ def _has_user_setup_sso():
     return sso_setup
 
 
-def get_customer_user_header_from_mapping(user_id_mapping) -> Optional[str]:
+def get_customer_user_header_from_mapping(user_id_mapping) -> Optional[list]:
     """Return the header_name mapped to CUSTOMER role, if any (dict-based)."""
     if not user_id_mapping:
         return None
     items = user_id_mapping if isinstance(user_id_mapping, list) else [user_id_mapping]
+    customer_headers_mappings = []
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -675,7 +676,11 @@ def get_customer_user_header_from_mapping(user_id_mapping) -> Optional[str]:
         if role is None or not header_name:
             continue
         if str(role).lower() == str(LitellmUserRoles.CUSTOMER).lower():
-            return header_name
+            customer_headers_mappings.append(header_name.lower())
+
+    if customer_headers_mappings:
+        return customer_headers_mappings
+    
     return None
 
 
@@ -724,7 +729,7 @@ def get_end_user_id_from_request_body(
     # User query: "system not respecting user_header_name property"
     # This implies the key in general_settings is 'user_header_name'.
     if request_headers is not None:
-        custom_header_name_to_check: Optional[str] = None
+        custom_header_name_to_check: Optional[Union[list, str]] = None
 
         # Prefer user mappings (new behavior)
         user_id_mapping = general_settings.get("user_header_mappings", None)
@@ -741,9 +746,9 @@ def get_end_user_id_from_request_body(
                 custom_header_name_to_check = value
 
         # If we have a header name to check, try to read it from request headers
-        if isinstance(custom_header_name_to_check, str):
+        if isinstance(custom_header_name_to_check, list):
             for header_name, header_value in request_headers.items():
-                if header_name.lower() == custom_header_name_to_check.lower():
+                if header_name.lower() in custom_header_name_to_check:
                     user_id_from_header = header_value
                     user_id_str = (
                         str(user_id_from_header)

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -747,21 +747,24 @@ def get_end_user_id_from_request_body(
 
         # If we have a header name to check, try to read it from request headers
         if isinstance(custom_header_name_to_check, list):
+            headers_lower = {k.lower(): v for k, v in request_headers.items()}
+            for expected_header in custom_header_name_to_check:
+                header_value = headers_lower.get(expected_header)
+                if header_value is not None:
+                    user_id_str = str(header_value)
+                    if user_id_str.strip():
+                        return user_id_str
+                    
+        elif isinstance(custom_header_name_to_check, str):
             for header_name, header_value in request_headers.items():
-                if header_name.lower() in custom_header_name_to_check:
-                    user_id_from_header = header_value
+                if header_name.lower() == custom_header_name_to_check:
                     user_id_str = (
-                        str(user_id_from_header)
-                        if user_id_from_header is not None
+                        str(header_value)
+                        if header_value is not None
                         else ""
                     )
                     if user_id_str.strip():
                         return user_id_str
-        elif isinstance(custom_header_name_to_check, str):
-            user_id_from_header = request_headers.get(custom_header_name_to_check)
-            user_id_str = str(user_id_from_header) if user_id_from_header is not None else ""
-            if user_id_str.strip():
-                return user_id_str
 
     # Check 3: 'user' field in request_body (commonly OpenAI)
     if "user" in request_body and request_body["user"] is not None:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -757,6 +757,11 @@ def get_end_user_id_from_request_body(
                     )
                     if user_id_str.strip():
                         return user_id_str
+        elif isinstance(custom_header_name_to_check, str):
+            user_id_from_header = request_headers.get(custom_header_name_to_check)
+            user_id_str = str(user_id_from_header) if user_id_from_header is not None else ""
+            if user_id_str.strip():
+                return user_id_str
 
     # Check 3: 'user' field in request_body (commonly OpenAI)
     if "user" in request_body and request_body["user"] is not None:

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -383,24 +383,3 @@ def test_get_model_from_request_vertex_ai_passthrough(request_data, route, expec
 
     model = get_model_from_request(request_data, route)
     assert model == expected_model
-
-
-# def test_get_end_user_id_from_request_body_no_user_found():
-#     """Test that function returns None when no user ID is found anywhere"""
-#     from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
-#     from fastapi import Request
-#     from unittest.mock import MagicMock, patch
-
-#     # Create a mock Request object with no relevant headers
-#     mock_request = MagicMock(spec=Request)
-#     mock_request.headers = {"X-Other-Header": "some-value"}
-    
-#     # Mock general_settings with user_header_name that doesn't match headers
-#     general_settings_config = {"user_header_name": "X-User-ID"}
-    
-#     # Request body with no user identifiers
-#     request_body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
-    
-#     with patch('litellm.proxy.proxy_server.general_settings', general_settings_config):
-#         end_user_id = get_end_user_id_from_request_body(request_body, dict(mock_request.headers))
-#         assert end_user_id is None

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -295,7 +295,7 @@ def test_get_internal_user_header_from_mapping_returns_internal_header():
     ]
 
     result = LiteLLMProxyRequestSetup.get_internal_user_header_from_mapping(mappings)
-    assert result == "X-OpenWebUI-User-Id"
+    assert result == "X-OpenWebUI-User"
 
 
 def test_get_internal_user_header_from_mapping_no_internal_returns_none():
@@ -383,3 +383,24 @@ def test_get_model_from_request_vertex_ai_passthrough(request_data, route, expec
 
     model = get_model_from_request(request_data, route)
     assert model == expected_model
+
+
+# def test_get_end_user_id_from_request_body_no_user_found():
+#     """Test that function returns None when no user ID is found anywhere"""
+#     from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
+#     from fastapi import Request
+#     from unittest.mock import MagicMock, patch
+
+#     # Create a mock Request object with no relevant headers
+#     mock_request = MagicMock(spec=Request)
+#     mock_request.headers = {"X-Other-Header": "some-value"}
+    
+#     # Mock general_settings with user_header_name that doesn't match headers
+#     general_settings_config = {"user_header_name": "X-User-ID"}
+    
+#     # Request body with no user identifiers
+#     request_body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
+    
+#     with patch('litellm.proxy.proxy_server.general_settings', general_settings_config):
+#         end_user_id = get_end_user_id_from_request_body(request_body, dict(mock_request.headers))
+#         assert end_user_id is None

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -268,7 +268,7 @@ def test_get_customer_user_header_from_mapping_returns_customer_header():
         {"header_name": "X-OpenWebUI-User-Email", "litellm_user_role": "customer"},
     ]
     result = get_customer_user_header_from_mapping(mappings)
-    assert result == "X-OpenWebUI-User-Email"
+    assert result == ["x-openwebui-user-email"]
 
 
 def test_get_customer_user_header_from_mapping_no_customer_returns_none():

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -295,7 +295,7 @@ def test_get_internal_user_header_from_mapping_returns_internal_header():
     ]
 
     result = LiteLLMProxyRequestSetup.get_internal_user_header_from_mapping(mappings)
-    assert result == "X-OpenWebUI-User"
+    assert result == "X-OpenWebUI-User-Id"
 
 
 def test_get_internal_user_header_from_mapping_no_internal_returns_none():

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -239,7 +239,7 @@ def test_get_customer_user_header_from_mapping_returns_customer_header():
     assert result == ["x-openwebui-user-email"]
 
 
-def test_get_customer_user_header_returns_customers_header_when_multiple_exist():
+def test_get_customer_user_header_returns_customers_header_in_config_order_when_multiple_exist():
     from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
 
     mappings = [
@@ -249,17 +249,6 @@ def test_get_customer_user_header_returns_customers_header_when_multiple_exist()
     ]
     result = get_customer_user_header_from_mapping(mappings)
     assert result == ['x-openwebui-user-email', 'x-user-id']
-    
-def test_get_customer_user_header_returns_sorted_customers_header_when_multiple_exist():
-    from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
-
-    mappings = [
-        {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"},
-        {"header_name": "X-User-Id", "litellm_user_role": "customer"},
-        {"header_name": "X-OpenWebUI-User-Email", "litellm_user_role": "customer"},
-    ]
-    result = get_customer_user_header_from_mapping(mappings)
-    assert result == ['x-user-id', 'x-openwebui-user-email']
     
 
 def test_get_end_user_id_returns_id_from_user_header_mappings():
@@ -315,4 +304,14 @@ def test_get_end_user_id_returns_none_when_no_customer_role_in_mappings():
 
     assert result is None
 
+def test_get_end_user_id_falls_back_to_deprecated_user_header_name():
+    from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
 
+    general_settings = {"user_header_name": "x-custom-user-id"}
+    headers = {"x-custom-user-id": "user-legacy"}
+
+    with patch("litellm.proxy.auth.auth_utils._get_customer_id_from_standard_headers", return_value=None), \
+         patch("litellm.proxy.proxy_server.general_settings", general_settings):
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
+
+    assert result == "user-legacy"

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -209,3 +209,113 @@ def test_get_model_from_request_supports_google_model_names_with_slashes():
 def test_get_model_from_request_vertex_passthrough_still_works():
     route = "/vertex_ai/v1/projects/p/locations/l/publishers/google/models/gemini-1.5-pro:generateContent"
     assert get_model_from_request(request_data={}, route=route) == "gemini-1.5-pro"
+
+
+def test_get_customer_user_header_returns_none_when_no_customer_role():
+    from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
+
+    mappings = [
+        {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"}
+    ]
+    result = get_customer_user_header_from_mapping(mappings)
+    assert result is None
+
+
+def test_get_customer_user_header_returns_none_for_single_non_customer_mapping():
+    from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
+
+    mapping = {"header_name": "X-Only-Internal", "litellm_user_role": "internal_user"}
+    result = get_customer_user_header_from_mapping(mapping)
+    assert result is None
+
+def test_get_customer_user_header_from_mapping_returns_customer_header():
+    from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
+
+    mappings = [
+        {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"},
+        {"header_name": "X-OpenWebUI-User-Email", "litellm_user_role": "customer"},
+    ]
+    result = get_customer_user_header_from_mapping(mappings)
+    assert result == ["x-openwebui-user-email"]
+
+
+def test_get_customer_user_header_returns_customers_header_when_multiple_exist():
+    from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
+
+    mappings = [
+        {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"},
+        {"header_name": "X-OpenWebUI-User-Email", "litellm_user_role": "customer"},
+        {"header_name": "X-User-Id", "litellm_user_role": "customer"},
+    ]
+    result = get_customer_user_header_from_mapping(mappings)
+    assert result == ['x-openwebui-user-email', 'x-user-id']
+    
+def test_get_customer_user_header_returns_sorted_customers_header_when_multiple_exist():
+    from litellm.proxy.auth.auth_utils import get_customer_user_header_from_mapping
+
+    mappings = [
+        {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"},
+        {"header_name": "X-User-Id", "litellm_user_role": "customer"},
+        {"header_name": "X-OpenWebUI-User-Email", "litellm_user_role": "customer"},
+    ]
+    result = get_customer_user_header_from_mapping(mappings)
+    assert result == ['x-user-id', 'x-openwebui-user-email']
+
+
+####################################
+
+
+def test_get_end_user_id_returns_id_from_user_header_mappings():
+    from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
+
+    mappings = [
+        {"header_name": "x-openwebui-user-id", "litellm_user_role": "internal_user"},
+        {"header_name": "x-openwebui-user-email", "litellm_user_role": "customer"},
+    ]
+    general_settings = {"user_header_mappings": mappings}
+    headers = {"x-openwebui-user-email": "1234"}
+
+    with patch("litellm.proxy.auth.auth_utils._get_customer_id_from_standard_headers", return_value=None), \
+         patch("litellm.proxy.proxy_server.general_settings", general_settings):
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
+
+    assert result == "1234"
+
+
+def test_get_end_user_id_returns_first_customer_header_when_multiple_mappings_exist():
+    from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
+
+    mappings = [
+        {"header_name": "x-openwebui-user-id", "litellm_user_role": "internal_user"},
+        {"header_name": "x-user-id", "litellm_user_role": "customer"},
+        {"header_name": "x-openwebui-user-email", "litellm_user_role": "customer"},
+    ]
+    general_settings = {"user_header_mappings": mappings}
+    headers = {
+        "x-user-id": "user-456",
+        "x-openwebui-user-email": "user@example.com",
+    }
+
+    with patch("litellm.proxy.auth.auth_utils._get_customer_id_from_standard_headers", return_value=None), \
+         patch("litellm.proxy.proxy_server.general_settings", general_settings):
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
+
+    assert result == "user-456"
+
+
+def test_get_end_user_id_returns_none_when_no_customer_role_in_mappings():
+    from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
+
+    mappings = [
+        {"header_name": "x-openwebui-user-id", "litellm_user_role": "internal_user"},
+    ]
+    general_settings = {"user_header_mappings": mappings}
+    headers = {"x-openwebui-user-id": "user-789"}
+
+    with patch("litellm.proxy.auth.auth_utils._get_customer_id_from_standard_headers", return_value=None), \
+         patch("litellm.proxy.proxy_server.general_settings", general_settings):
+        result = get_end_user_id_from_request_body(request_body={}, request_headers=headers)
+
+    assert result is None
+
+

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -260,10 +260,7 @@ def test_get_customer_user_header_returns_sorted_customers_header_when_multiple_
     ]
     result = get_customer_user_header_from_mapping(mappings)
     assert result == ['x-user-id', 'x-openwebui-user-email']
-
-
-####################################
-
+    
 
 def test_get_end_user_id_returns_id_from_user_header_mappings():
     from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
Added support for mapping multiple request headers to the same LiteLLM user role

<img width="306" height="754" alt="image" src="https://github.com/user-attachments/assets/5aac8861-1793-4399-8ce9-3999c4df6dd6" />


<img width="2248" height="156" alt="image" src="https://github.com/user-attachments/assets/a68e9b16-5eb2-40a9-a7a5-03299937b0bf" />

general_settings: 
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
  user_header_mappings:
    - header_name: X-OpenWebUI-User-Id
      litellm_user_role: internal_user
    - header_name: X-OpenWebUI-User-Email
      litellm_user_role: customer
    - header_name: X-User-Id
      litellm_user_role: customer