### PR TITLE
[Fix] Responses Bridge Overwrite on Second Bridge Check

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1613,13 +1613,18 @@ def completion(  # type: ignore # noqa: PLR0915
             )
 
         ## RESPONSES API BRIDGE LOGIC ## - check if model has 'mode: responses' in litellm.model_cost map
-        responses_api_model_info, model = responses_api_bridge_check(
-            model=model,
-            custom_llm_provider=custom_llm_provider,
-            web_search_options=web_search_options,
-            tools=tools,
-            reasoning_effort=reasoning_effort,
-        )
+        # Only run the second bridge check if the first one didn't already
+        # detect responses mode (e.g. via the "responses/" prefix).  The second
+        # check handles cases like gpt-5.4+ with tools+reasoning_effort that
+        # the first (early) check doesn't cover.
+        if responses_api_model_info.get("mode") != "responses":
+            responses_api_model_info, model = responses_api_bridge_check(
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                web_search_options=web_search_options,
+                tools=tools,
+                reasoning_effort=reasoning_effort,
+            )
 
         if responses_api_model_info.get("mode") == "responses":
             from litellm.completion_extras import responses_api_bridge


### PR DESCRIPTION
## Relevant issues

CI failures on `litellm_internal_dev_03_14_2026`: `test_arouter_responses_api_bridge`, `test_azure_openai_responses_bridge`, `test_gpt_5_web_search`, `test_responses_gpt54_with_xhigh_reasoning`

## Summary

### Failure Path (Before Fix)

`litellm.completion()` calls `responses_api_bridge_check` twice — once early (line ~1374) to strip the `responses/` prefix, and once later (line ~1616) to handle gpt-5.4+ with tools+reasoning. The previous fix (6abdf5ad) changed the second call to assign to `responses_api_model_info`, but this unconditionally **overwrites** the result from the first call. For `responses/`-prefixed models (e.g. `azure/responses/<deployment>`), the first check correctly sets `mode: "responses"` and strips the prefix, but the second check returns an empty dict (since the prefix is already stripped), erasing the detection.

### Fix

Skip the second `responses_api_bridge_check` call when the first one already detected `mode: "responses"`. The second call only needs to run for cases the first doesn't cover (e.g. gpt-5.4+ with tools+reasoning_effort).

## Testing

All 4 affected tests pass locally after this change. The fix is a 1-line guard (`if responses_api_model_info.get("mode") != "responses":`) wrapping the existing second call.

## Type

🐛 Bug Fix