### PR TITLE
fix: align DefaultInternalUserParams Pydantic default with runtime fallback 

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4262,7 +4262,7 @@ class DefaultInternalUserParams(LiteLLMPydanticObjectBase):
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
         ]
     ] = Field(
-        default=LitellmUserRoles.INTERNAL_USER,
+        default=LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
         description="Default role assigned to new users created",
     )
     max_budget: Optional[float] = Field(

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -111,6 +111,43 @@ class TestProxySettingEndpoints:
         assert "user_role" in data["field_schema"]["properties"]
         assert "description" in data["field_schema"]["properties"]["user_role"]
 
+    def test_get_internal_user_settings_fresh_db_defaults_to_viewer(
+        self, mock_auth, monkeypatch
+    ):
+        """
+        On a fresh DB with no saved settings, the GET endpoint should return
+        INTERNAL_USER_VIEW_ONLY as the default role — matching the runtime
+        fallback in SSO/SCIM/JWT provisioning paths.
+        """
+        # Simulate fresh DB: no default_internal_user_params in config
+        empty_config = {
+            "litellm_settings": {},
+            "general_settings": {},
+            "environment_variables": {},
+        }
+
+        from litellm.proxy.proxy_server import proxy_config
+
+        monkeypatch.setattr(
+            proxy_config, "get_config", lambda: empty_config  # sync, wrapped by endpoint
+        )
+
+        import asyncio
+
+        async def mock_get_config():
+            return empty_config
+
+        monkeypatch.setattr(proxy_config, "get_config", mock_get_config)
+
+        response = client.get("/get/internal_user_settings")
+        assert response.status_code == 200
+
+        values = response.json()["values"]
+        assert values["user_role"] == LitellmUserRoles.INTERNAL_USER_VIEW_ONLY, (
+            f"Fresh DB should default to INTERNAL_USER_VIEW_ONLY, got {values['user_role']}. "
+            "The Pydantic default must match the runtime fallback."
+        )
+
     def test_update_internal_user_settings(
         self, mock_proxy_config, mock_auth, monkeypatch
     ):

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -128,12 +128,6 @@ class TestProxySettingEndpoints:
 
         from litellm.proxy.proxy_server import proxy_config
 
-        monkeypatch.setattr(
-            proxy_config, "get_config", lambda: empty_config  # sync, wrapped by endpoint
-        )
-
-        import asyncio
-
         async def mock_get_config():
             return empty_config
 


### PR DESCRIPTION
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

The Pydantic default for user_role was INTERNAL_USER, but all runtime provisioning paths (SSO, SCIM, JWT) fall back to INTERNAL_USER_VIEW_ONLY when no settings are saved. This caused the UI to show "Internal User" on fresh instances while new users actually got "Internal Viewer".

Changed the default to be INTERNAL_USER_VIEW_ONLY to match what we have and be consistent. 