### PR TITLE
[Fix] Datadog LLM Observability tags format (env, service, version missing)

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -291,7 +291,7 @@ class DataDogLogger(
 
             dd_payload = DatadogPayload(
                 ddsource=get_datadog_source(),
-                ddtags=get_datadog_tags(),
+                ddtags=",".join(get_datadog_tags()),
                 hostname=get_datadog_hostname(),
                 message=safe_dumps(message_payload),
                 service=get_datadog_service(),
@@ -442,7 +442,7 @@ class DataDogLogger(
         verbose_logger.debug("Datadog: Logger - Logging payload = %s", json_payload)
         dd_payload = DatadogPayload(
             ddsource=get_datadog_source(),
-            ddtags=get_datadog_tags(standard_logging_object=standard_logging_object),
+            ddtags=",".join(get_datadog_tags(standard_logging_object=standard_logging_object)),
             hostname=get_datadog_hostname(),
             message=json_payload,
             service=get_datadog_service(),
@@ -545,7 +545,7 @@ class DataDogLogger(
             _dd_message_str = safe_dumps(_payload_dict)
             _dd_payload = DatadogPayload(
                 ddsource=get_datadog_source(),
-                ddtags=get_datadog_tags(),
+                ddtags=",".join(get_datadog_tags()),
                 hostname=get_datadog_hostname(),
                 message=_dd_message_str,
                 service=get_datadog_service(),
@@ -587,7 +587,7 @@ class DataDogLogger(
             _dd_message_str = safe_dumps(_payload_dict)
             _dd_payload = DatadogPayload(
                 ddsource=get_datadog_source(),
-                ddtags=get_datadog_tags(),
+                ddtags=",".join(get_datadog_tags()),
                 hostname=get_datadog_hostname(),
                 message=_dd_message_str,
                 service=get_datadog_service(),
@@ -678,7 +678,7 @@ class DataDogLogger(
 
         dd_payload = DatadogPayload(
             ddsource=get_datadog_source(),
-            ddtags=get_datadog_tags(),
+            ddtags=",".join(get_datadog_tags()),
             hostname=get_datadog_hostname(),
             message=json_payload,
             service=get_datadog_service(),

--- a/litellm/integrations/datadog/datadog_handler.py
+++ b/litellm/integrations/datadog/datadog_handler.py
@@ -38,8 +38,13 @@ def get_datadog_pod_name() -> str:
 
 def get_datadog_tags(
     standard_logging_object: Optional[StandardLoggingPayload] = None,
-) -> str:
-    """Build Datadog tags string used by multiple integrations."""
+) -> List[str]:
+    """Build Datadog tags as a list of individual tag strings.
+
+    Returns a list of "key:value" strings suitable for Datadog LLM Observability
+    (which expects tags as an array). For Datadog Logs API (ddtags), join with
+    comma: ",".join(get_datadog_tags(...)).
+    """
 
     base_tags = {
         "env": get_datadog_env(),
@@ -66,4 +71,4 @@ def get_datadog_tags(
         if team_tag:
             tags.append(f"team:{team_tag}")
 
-    return ",".join(tags)
+    return tags

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -203,7 +203,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
                     type="span",
                     attributes=DDSpanAttributes(
                         ml_app=get_datadog_service(),
-                        tags=[get_datadog_tags()],
+                        tags=get_datadog_tags(),
                         spans=self.log_queue,
                     ),
                 ),
@@ -315,7 +315,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             duration=int((end_time - start_time).total_seconds() * 1e9),
             metrics=metrics,
             status="error" if error_info else "ok",
-            tags=[get_datadog_tags(standard_logging_object=standard_logging_payload)],
+            tags=get_datadog_tags(standard_logging_object=standard_logging_payload),
         )
 
         apm_trace_id = self._get_apm_trace_id()

--- a/tests/logging_callback_tests/test_datadog.py
+++ b/tests/logging_callback_tests/test_datadog.py
@@ -593,7 +593,7 @@ def test_datadog_static_methods():
     # Test tags format with default values
     assert (
         "env:unknown,service:litellm-server,version:unknown,HOSTNAME:"
-        in get_datadog_tags()
+        in ",".join(get_datadog_tags())
     )
 
     # Test with custom environment variables
@@ -631,7 +631,7 @@ def test_datadog_static_methods():
         # Test tags format with custom values
         expected_custom_tags = "env:production,service:custom-service,version:1.0.0,HOSTNAME:test-host,POD_NAME:pod-123"
         print("DataDogLogger._get_datadog_tags()", get_datadog_tags())
-        assert get_datadog_tags() == expected_custom_tags
+        assert ",".join(get_datadog_tags()) == expected_custom_tags
 
 
 @pytest.mark.asyncio
@@ -672,11 +672,11 @@ def test_get_datadog_tags():
     """Test the _get_datadog_tags static method with various inputs"""
     # Test with no standard_logging_object and default env vars
     base_tags = get_datadog_tags()
-    assert "env:" in base_tags
-    assert "service:" in base_tags
-    assert "version:" in base_tags
-    assert "POD_NAME:" in base_tags
-    assert "HOSTNAME:" in base_tags
+    assert any("env:" in t for t in base_tags)
+    assert any("service:" in t for t in base_tags)
+    assert any("version:" in t for t in base_tags)
+    assert any("POD_NAME:" in t for t in base_tags)
+    assert any("HOSTNAME:" in t for t in base_tags)
 
     # Test with custom env vars
     test_env = {
@@ -705,12 +705,12 @@ def test_get_datadog_tags():
     # Test with empty request_tags
     standard_logging_obj["request_tags"] = []
     tags_empty_request = get_datadog_tags(standard_logging_obj)
-    assert "request_tag:" not in tags_empty_request
+    assert not any(t.startswith("request_tag:") for t in tags_empty_request)
 
     # Test with None request_tags
     standard_logging_obj["request_tags"] = None
     tags_none_request = get_datadog_tags(standard_logging_obj)
-    assert "request_tag:" not in tags_none_request
+    assert not any(t.startswith("request_tag:") for t in tags_none_request)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/integrations/datadog/test_datadog_tags_regression.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_tags_regression.py
@@ -44,7 +44,7 @@ class TestDatadogTagsRegression:
         assert "env:test-env" in tags_legacy
         assert "service:test-service" in tags_legacy
         # Verify NO team tag (should not invent one)
-        assert "team:" not in tags_legacy
+        assert not any(t.startswith("team:") for t in tags_legacy)
 
         # Case 2: New feature (team info provided)
         payload_with_team = StandardLoggingPayload(


### PR DESCRIPTION
## Relevant issues
Issue: env, service, version, HOSTNAME, and POD_NAME tags are missing from Datadog LLM Observability metrics; only ml_app, model_name, and model_provider appear.
Cause: get_datadog_tags() returned a comma-separated string, but the Datadog LLM Observability API expects tags as an array of strings. The code wrapped that string in a list, producing ["env:dev,service:llm-gateway,..."] instead of ["env:dev", "service:llm-gateway", ...], so Datadog treated the whole string as one tag.
Fix: Change get_datadog_tags() to return List[str] instead of str. Use the list directly in datadog_llm_obs.py and use ",".join(get_datadog_tags(...)) in datadog.py where the Logs API expects a comma-separated string.

## Pre-Submission checklist
Fix:
LLM_OBSERVABILITY
<img width="391" height="77" alt="Screenshot 2026-03-17 at 6 17 26 PM" src="https://github.com/user-attachments/assets/2f9d0e3a-4691-4267-9f22-7aa8bc10cc73" />
<img width="971" height="179" alt="Screenshot 2026-03-17 at 6 16 38 PM" src="https://github.com/user-attachments/assets/c32bacad-4b2a-4a23-bc17-fdb1ec6e61a9" />
<img width="1016" height="755" alt="Screenshot 2026-03-17 at 6 17 09 PM" src="https://github.com/user-attachments/assets/b0072584-7eb9-432e-a568-836775fb8ffc" />
<img width="725" height="470" alt="Screenshot 2026-03-17 at 6 18 27 PM" src="https://github.com/user-attachments/assets/6a034985-ae79-40b8-b2c4-216f839134f8" />

DD_TRACE
<img width="797" height="627" alt="Screenshot 2026-03-17 at 7 11 25 PM" src="https://github.com/user-attachments/assets/5d20bc46-e581-47d9-932a-f8e2aefe2a67" />

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
