### PR TITLE
[Fix] Hanging CI Tests in custom_httpx test_http_handler

### DIFF
--- a/tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py
+++ b/tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py
@@ -19,167 +19,67 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent))
 
 
-def count_aiohttp_sessions():
-    """Count unclosed aiohttp ClientSession objects"""
-    import aiohttp
-
-    count = 0
-    for obj in gc.get_objects():
-        if isinstance(obj, aiohttp.ClientSession):
-            if not obj.closed:
-                count += 1
-    return count
-
-
 async def test_aiohttp_handler_cleanup():
-    """Test BaseLLMAIOHTTPHandler session cleanup"""
-    print("\n" + "=" * 70)
-    print("TEST: BaseLLMAIOHTTPHandler Session Cleanup")
-    print("=" * 70)
-
+    """Test BaseLLMAIOHTTPHandler session cleanup via __del__"""
     from litellm.llms.custom_httpx.aiohttp_handler import BaseLLMAIOHTTPHandler
 
-    initial_sessions = count_aiohttp_sessions()
-    print(f"\nInitial unclosed sessions: {initial_sessions}")
-
     # Create handler and trigger session creation
-    print("\nCreating BaseLLMAIOHTTPHandler and triggering session creation...")
     handler = BaseLLMAIOHTTPHandler()
-
-    # This triggers session creation (line 111 of aiohttp_handler.py)
     session = handler._get_async_client_session()
-    print(f"Session created: {session}")
 
-    sessions_after_create = count_aiohttp_sessions()
-    print(f"Sessions after creation: {sessions_after_create}")
+    assert not session.closed, "Session should be open after creation"
 
     # Delete handler - should trigger __del__ cleanup
-    print("\nDeleting handler (should trigger __del__)...")
     del handler
-    del session
     gc.collect()
     await asyncio.sleep(0.1)  # Let async cleanup finish
 
-    final_sessions = count_aiohttp_sessions()
-    print(f"Final unclosed sessions: {final_sessions}")
-
-    session_diff = final_sessions - initial_sessions
-    print(f"\nSession difference: {session_diff:+d}")
-
-    if session_diff == 0:
-        print("\n✅ PASS: __del__ cleanup working correctly")
-        return True
-    else:
-        print(f"\n❌ FAIL: {session_diff} sessions leaked")
-        return False
+    assert session.closed, "Session should be closed after handler deletion"
 
 
 async def test_atexit_cleanup():
     """Test that atexit cleanup works with new event loop approach"""
-    print("\n" + "=" * 70)
-    print("TEST: atexit Cleanup (new event loop approach)")
-    print("=" * 70)
-
     from litellm.llms.custom_httpx.async_client_cleanup import (
         close_litellm_async_clients,
     )
 
-    initial_sessions = count_aiohttp_sessions()
-    print(f"\nInitial unclosed sessions: {initial_sessions}")
-
-    # Use the actual global base_llm_aiohttp_handler from litellm.main
-    print("\nAccessing global base_llm_aiohttp_handler (like Gemini does)...")
     import litellm
 
+    # Use the actual global base_llm_aiohttp_handler from litellm
     handler = litellm.base_llm_aiohttp_handler
     session = handler._get_async_client_session()
 
-    sessions_after_create = count_aiohttp_sessions()
-    print(f"Sessions after creation: {sessions_after_create}")
+    assert not session.closed, "Session should be open after creation"
 
     # Call cleanup function (simulates atexit)
-    print("\nCalling close_litellm_async_clients() (simulates atexit)...")
     await close_litellm_async_clients()
 
-    gc.collect()
-    await asyncio.sleep(0.1)
-
-    final_sessions = count_aiohttp_sessions()
-    print(f"Final unclosed sessions: {final_sessions}")
-
-    session_diff = final_sessions - initial_sessions
-    print(f"\nSession difference: {session_diff:+d}")
-
-    if session_diff == 0:
-        print("\n✅ PASS: atexit cleanup working correctly")
-        return True
-    else:
-        print(f"\n❌ FAIL: {session_diff} sessions leaked")
-        return False
+    assert session.closed, "Session should be closed after atexit cleanup"
 
 
 def test_new_event_loop_atexit():
     """Test that the new atexit handler can create a fresh event loop"""
-    print("\n" + "=" * 70)
-    print("TEST: atexit with Fresh Event Loop Creation")
-    print("=" * 70)
-
     from litellm.llms.custom_httpx.async_client_cleanup import (
         close_litellm_async_clients,
     )
 
-    print("\nVerifying atexit handler can create fresh loop (no running loop)...")
-    print("Note: At atexit time, there's typically no running event loop")
-
-    # Save current loop to restore later
+    # At atexit time, there's typically no running event loop
     try:
-        current_loop = asyncio.get_running_loop()
-        print("Warning: Found running loop - can't test atexit scenario accurately")
+        asyncio.get_running_loop()
         pytest.skip("Cannot test atexit scenario when event loop is running")
     except RuntimeError:
         pass  # Good - no running loop
 
     # Create a new loop like the fixed atexit handler does
-    print("Creating new event loop (like fixed atexit handler)...")
     new_loop = asyncio.new_event_loop()
     asyncio.set_event_loop(new_loop)
 
     try:
         new_loop.run_until_complete(close_litellm_async_clients())
-        print("✅ Successfully ran cleanup with fresh event loop")
     finally:
         new_loop.close()
 
 
-async def main():
-    """Run all tests"""
-    print("\n" + "=" * 70)
-    print("Gemini aiohttp Session Leak Fix Validation (Issue #12443)")
-    print("=" * 70)
-
-    results = []
-
-    # Test 1: __del__ cleanup
-    results.append(await test_aiohttp_handler_cleanup())
-
-    # Test 2: atexit cleanup function
-    results.append(await test_atexit_cleanup())
-
-    print("\n" + "=" * 70)
-    print("Test Results")
-    print("=" * 70)
-    passed = sum(results)
-    total = len(results)
-    print(f"\nPassed: {passed}/{total}")
-
-    if passed == total:
-        print("\n✅ All tests PASSED - Issue #12443 is FIXED")
-    else:
-        print(f"\n❌ {total - passed} test(s) FAILED")
-
-    return passed == total
-
-
 if __name__ == "__main__":
-    success = asyncio.run(main())
+    success = asyncio.run(test_aiohttp_handler_cleanup())
     sys.exit(0 if success else 1)

--- a/tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py
+++ b/tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py
@@ -81,5 +81,7 @@ def test_new_event_loop_atexit():
 
 
 if __name__ == "__main__":
-    success = asyncio.run(test_aiohttp_handler_cleanup())
-    sys.exit(0 if success else 1)
+    asyncio.run(test_aiohttp_handler_cleanup())
+    # If the assertion inside the test fails, asyncio.run raises;
+    # reaching here means success.
+    sys.exit(0)

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -32,24 +32,25 @@ async def test_ssl_security_level(monkeypatch):
             # Create async client with SSL verification disabled to isolate SSL context testing
             client = AsyncHTTPHandler()
 
-            # Get the transport (should be LiteLLMAiohttpTransport)
-            transport = client.client._transport
-            assert isinstance(transport, LiteLLMAiohttpTransport)
+            try:
+                # Get the transport (should be LiteLLMAiohttpTransport)
+                transport = client.client._transport
+                assert isinstance(transport, LiteLLMAiohttpTransport)
 
-            # Get the aiohttp ClientSession
-            client_session = transport._get_valid_client_session()
+                # Get the aiohttp ClientSession
+                client_session = transport._get_valid_client_session()
 
-            # Get the connector from the session
-            connector = client_session.connector
-            assert isinstance(connector, TCPConnector)
+                # Get the connector from the session
+                connector = client_session.connector
+                assert isinstance(connector, TCPConnector)
 
-            # Get the SSL context from the connector
-            ssl_context = connector._ssl
+                # Get the SSL context from the connector
+                ssl_context = connector._ssl
 
-            # Verify that the SSL context exists and has the correct cipher string
-            assert isinstance(ssl_context, ssl.SSLContext)
-            # Optionally, check the ciphers string if needed
-            # assert "DEFAULT@SECLEVEL=1" in ssl_context.get_ciphers()
+                # Verify that the SSL context exists and has the correct cipher string
+                assert isinstance(ssl_context, ssl.SSLContext)
+            finally:
+                await client.close()
     finally:
         # Restore original setting
         litellm.disable_aiohttp_transport = original_disable
@@ -63,15 +64,8 @@ async def test_force_ipv4_transport():
 
     transport = AsyncHTTPHandler._create_async_transport()
 
-    # Should get an AsyncHTTPTransport
+    # Should get an AsyncHTTPTransport (no real HTTP call — avoids CI hangs)
     assert isinstance(transport, httpx.AsyncHTTPTransport)
-    # Verify IPv4 configuration through a request
-    client = httpx.AsyncClient(transport=transport)
-    try:
-        response = await client.get("http://example.com")
-        assert response.status_code == 200
-    finally:
-        await client.aclose()
 
 
 @pytest.mark.asyncio
@@ -83,13 +77,17 @@ async def test_ssl_context_transport():
     transport = AsyncHTTPHandler._create_async_transport(ssl_context=ssl_context)
     assert transport is not None
 
-    if isinstance(transport, LiteLLMAiohttpTransport):
-        # Get the client session and verify SSL context is passed through
-        client_session = transport._get_valid_client_session()
-        assert isinstance(client_session, ClientSession)
-        assert isinstance(client_session.connector, TCPConnector)
-        # Verify the connector has SSL context set by checking if it's using SSL
-        assert client_session.connector._ssl is not None
+    try:
+        if isinstance(transport, LiteLLMAiohttpTransport):
+            # Get the client session and verify SSL context is passed through
+            client_session = transport._get_valid_client_session()
+            assert isinstance(client_session, ClientSession)
+            assert isinstance(client_session.connector, TCPConnector)
+            # Verify the connector has SSL context set by checking if it's using SSL
+            assert client_session.connector._ssl is not None
+    finally:
+        if isinstance(transport, LiteLLMAiohttpTransport):
+            await transport.aclose()
 
 
 @pytest.mark.asyncio
@@ -130,11 +128,14 @@ async def test_ssl_verification_with_aiohttp_transport():
         aiohttp_session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(ssl=False)
         )
-        aiohttp_connector = aiohttp_session.connector
-        assert isinstance(aiohttp_connector, aiohttp.TCPConnector)
+        try:
+            aiohttp_connector = aiohttp_session.connector
+            assert isinstance(aiohttp_connector, aiohttp.TCPConnector)
 
-        # assert both litellm transport and aiohttp session have ssl_verify=False
-        assert transport_connector._ssl == aiohttp_connector._ssl
+            # assert both litellm transport and aiohttp session have ssl_verify=False
+            assert transport_connector._ssl == aiohttp_connector._ssl
+        finally:
+            await aiohttp_session.close()
     finally:
         # Restore original setting
         litellm.disable_aiohttp_transport = original_disable
@@ -220,29 +221,37 @@ async def test_ssl_context_with_shared_session():
 @pytest.mark.asyncio
 async def test_aiohttp_transport_trust_env_setting(monkeypatch):
     """Test that trust_env setting is properly configured in aiohttp transport"""
-    # Test 1: Default trust_env behavior
-    transport = AsyncHTTPHandler._create_aiohttp_transport()
-    client_session = transport._get_valid_client_session()
-    
-    # Default should be False (litellm.aiohttp_trust_env default)
-    default_trust_env = getattr(litellm, 'aiohttp_trust_env', False)
-    assert client_session._trust_env == default_trust_env
-    
-    # Test 2: Environment variable override
-    monkeypatch.setenv("AIOHTTP_TRUST_ENV", "True")
-    transport_with_env = AsyncHTTPHandler._create_aiohttp_transport()
-    client_session_with_env = transport_with_env._get_valid_client_session()
-    
-    # Should be True when environment variable is set
-    assert client_session_with_env._trust_env is True
-    
-    # Test 3: Verify environment variable with False value
-    monkeypatch.setenv("AIOHTTP_TRUST_ENV", "False")
-    transport_with_false_env = AsyncHTTPHandler._create_aiohttp_transport()
-    client_session_with_false_env = transport_with_false_env._get_valid_client_session()
-    
-    # Should respect the litellm.aiohttp_trust_env setting when env var is False
-    assert client_session_with_false_env._trust_env == default_trust_env
+    transports = []
+    try:
+        # Test 1: Default trust_env behavior
+        transport = AsyncHTTPHandler._create_aiohttp_transport()
+        transports.append(transport)
+        client_session = transport._get_valid_client_session()
+
+        # Default should be False (litellm.aiohttp_trust_env default)
+        default_trust_env = getattr(litellm, 'aiohttp_trust_env', False)
+        assert client_session._trust_env == default_trust_env
+
+        # Test 2: Environment variable override
+        monkeypatch.setenv("AIOHTTP_TRUST_ENV", "True")
+        transport_with_env = AsyncHTTPHandler._create_aiohttp_transport()
+        transports.append(transport_with_env)
+        client_session_with_env = transport_with_env._get_valid_client_session()
+
+        # Should be True when environment variable is set
+        assert client_session_with_env._trust_env is True
+
+        # Test 3: Verify environment variable with False value
+        monkeypatch.setenv("AIOHTTP_TRUST_ENV", "False")
+        transport_with_false_env = AsyncHTTPHandler._create_aiohttp_transport()
+        transports.append(transport_with_false_env)
+        client_session_with_false_env = transport_with_false_env._get_valid_client_session()
+
+        # Should respect the litellm.aiohttp_trust_env setting when env var is False
+        assert client_session_with_false_env._trust_env == default_trust_env
+    finally:
+        for t in transports:
+            await t.aclose()
 
 
 def test_get_ssl_configuration():

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -59,13 +59,19 @@ async def test_ssl_security_level(monkeypatch):
 @pytest.mark.asyncio
 async def test_force_ipv4_transport():
     """Test transport creation with force_ipv4 enabled"""
+    original_force_ipv4 = litellm.force_ipv4
+    original_disable = litellm.disable_aiohttp_transport
     litellm.force_ipv4 = True
     litellm.disable_aiohttp_transport = True
 
-    transport = AsyncHTTPHandler._create_async_transport()
+    try:
+        transport = AsyncHTTPHandler._create_async_transport()
 
-    # Should get an AsyncHTTPTransport (no real HTTP call — avoids CI hangs)
-    assert isinstance(transport, httpx.AsyncHTTPTransport)
+        # Should get an AsyncHTTPTransport (no real HTTP call — avoids CI hangs)
+        assert isinstance(transport, httpx.AsyncHTTPTransport)
+    finally:
+        litellm.force_ipv4 = original_force_ipv4
+        litellm.disable_aiohttp_transport = original_disable
 
 
 @pytest.mark.asyncio
@@ -93,13 +99,19 @@ async def test_ssl_context_transport():
 @pytest.mark.asyncio
 async def test_aiohttp_disabled_transport():
     """Test transport creation with aiohttp disabled"""
+    original_disable = litellm.disable_aiohttp_transport
+    original_force_ipv4 = litellm.force_ipv4
     litellm.disable_aiohttp_transport = True
     litellm.force_ipv4 = False
 
-    transport = AsyncHTTPHandler._create_async_transport()
+    try:
+        transport = AsyncHTTPHandler._create_async_transport()
 
-    # Should get None when both aiohttp is disabled and force_ipv4 is False
-    assert transport is None
+        # Should get None when both aiohttp is disabled and force_ipv4 is False
+        assert transport is None
+    finally:
+        litellm.disable_aiohttp_transport = original_disable
+        litellm.force_ipv4 = original_force_ipv4
 
 
 @pytest.mark.asyncio
@@ -117,25 +129,27 @@ async def test_ssl_verification_with_aiohttp_transport():
     litellm.disable_aiohttp_transport = False
     
     try:
-        # Create a test SSL context
         litellm_async_client = AsyncHTTPHandler(ssl_verify=False)
 
-        transport = litellm_async_client.client._transport
-        assert isinstance(transport, LiteLLMAiohttpTransport)
-        transport_connector = transport._get_valid_client_session().connector
-        assert isinstance(transport_connector, TCPConnector)
-
-        aiohttp_session = aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(ssl=False)
-        )
         try:
-            aiohttp_connector = aiohttp_session.connector
-            assert isinstance(aiohttp_connector, aiohttp.TCPConnector)
+            transport = litellm_async_client.client._transport
+            assert isinstance(transport, LiteLLMAiohttpTransport)
+            transport_connector = transport._get_valid_client_session().connector
+            assert isinstance(transport_connector, TCPConnector)
 
-            # assert both litellm transport and aiohttp session have ssl_verify=False
-            assert transport_connector._ssl == aiohttp_connector._ssl
+            aiohttp_session = aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(ssl=False)
+            )
+            try:
+                aiohttp_connector = aiohttp_session.connector
+                assert isinstance(aiohttp_connector, aiohttp.TCPConnector)
+
+                # assert both litellm transport and aiohttp session have ssl_verify=False
+                assert transport_connector._ssl == aiohttp_connector._ssl
+            finally:
+                await aiohttp_session.close()
         finally:
-            await aiohttp_session.close()
+            await litellm_async_client.close()
     finally:
         # Restore original setting
         litellm.disable_aiohttp_transport = original_disable


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
CI unit tests consistently hang at ~98% completion on `test_aiohttp_handler_cleanup`. Two root causes:

1. `count_aiohttp_sessions()` in `test_gemini_session_leak.py` calls `gc.get_objects()`, which traverses **every object** in the Python process. With xdist workers and hundreds of loaded test modules, this means millions of `isinstance()` checks — causing the test to hang in CI.
2. `test_force_ipv4_transport` makes a real HTTP request to `http://example.com` with no timeout, which can also hang when network is slow or restricted.
3. Several tests leak unclosed `aiohttp.ClientSession` and transport objects, causing potential hangs during teardown.
4. Tests mutate `litellm.force_ipv4` and `litellm.disable_aiohttp_transport` without restoring them.

### Fix
**`test_gemini_session_leak.py`:**
- Replace `gc.get_objects()` session-counting with direct `session.closed` assertions. The original tests verified that session count didn't increase after cleanup — the new tests verify the exact same property by checking `session.closed` is `True` after `__del__` / `close_litellm_async_clients()`. This is a stronger assertion (checks the specific session, not a global count) and avoids GC traversal entirely.
- Fix `__main__` block: the refactored test returns `None`, so `0 if success else 1` always exited with code 1.

**`test_http_handler.py`:**
- Remove real HTTP call to `example.com` in `test_force_ipv4_transport`. The test's purpose is to verify `_create_async_transport()` returns an `httpx.AsyncHTTPTransport` when `force_ipv4=True` — the HTTP round-trip added no coverage for that.
- Close `litellm_async_client` (`AsyncHTTPHandler`) in `test_ssl_verification_with_aiohttp_transport` — previously only the manually-created `aiohttp_session` was closed.
- Add `finally` cleanup blocks for transports/handlers in `test_aiohttp_transport_trust_env_setting`, `test_ssl_security_level`, and `test_ssl_context_transport`.
- Save/restore `litellm.force_ipv4` and `litellm.disable_aiohttp_transport` in `test_force_ipv4_transport` and `test_aiohttp_disabled_transport`.

## Testing
All 94 tests in `tests/test_litellm/llms/custom_httpx/` pass locally.

## Type

🐛 Bug Fix
✅ Test