### PR TITLE
[Fix] Bump PyJWT to ^2.12.0 for Security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt
 # ensure pyjwt is used, not jwt
 RUN pip uninstall jwt -y
 RUN pip uninstall PyJWT -y
-RUN pip install PyJWT==2.9.0 --no-cache-dir
+RUN pip install PyJWT==2.12.0 --no-cache-dir
 
 # Runtime stage
 FROM $LITELLM_RUNTIME_IMAGE AS runtime

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -112,7 +112,7 @@ RUN sed -i 's/\r$//' docker/install_auto_router.sh && chmod +x docker/install_au
 # ensure pyjwt is used, not jwt
 RUN pip uninstall jwt -y
 RUN pip uninstall PyJWT -y
-RUN pip install PyJWT==2.9.0 --no-cache-dir
+RUN pip install PyJWT==2.12.0 --no-cache-dir
 
 # Build Admin UI (runtime stage)
 # Convert Windows line endings to Unix and make executable

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Fix JWT dependency conflicts early
 RUN pip uninstall jwt -y || true && \
     pip uninstall PyJWT -y || true && \
-    pip install PyJWT==2.9.0 --no-cache-dir
+    pip install PyJWT==2.12.0 --no-cache-dir
 
 # Copy only necessary files for build
 COPY pyproject.toml README.md schema.prisma poetry.lock ./

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -198,7 +198,7 @@ RUN sed -i 's/\r$//' docker/entrypoint.sh && \
     chown -R nobody:nogroup /app /var/lib/litellm/ui /var/lib/litellm/assets /nonexistent /.npm && \
     pip uninstall jwt -y || true && \
     pip uninstall PyJWT -y || true && \
-    pip install --no-index --find-links=/wheels/ PyJWT==2.10.1 --no-cache-dir && \
+    pip install --no-index --find-links=/wheels/ PyJWT==2.12.0 --no-cache-dir && \
     rm -rf /wheels && \
     PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
     chown -R nobody:nogroup $PRISMA_PATH && \

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -32,7 +32,7 @@ RUN for i in 1 2 3; do \
 # Cache Python dependencies
 COPY requirements.txt .
 RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt \
-  && pip wheel --no-cache-dir --wheel-dir=/wheels/ "semantic_router==0.1.11" "aurelio-sdk==0.0.19" "PyJWT==2.9.0"
+  && pip wheel --no-cache-dir --wheel-dir=/wheels/ "semantic_router==0.1.11" "aurelio-sdk==0.0.19" "PyJWT==2.12.0"
 
 # Copy source after dependency layers
 COPY . .
@@ -106,7 +106,7 @@ RUN for i in 1 2 3; do \
     apk add --no-cache python3 py3-pip bash openssl tzdata nodejs npm supervisor && break || sleep 5; \
     done \
   && apk upgrade --no-cache nodejs \
-  && npm install -g npm@latest tar@7.5.10 glob@11.1.0 @isaacs/brace-expansion@5.0.1 minimatch@10.2.4 diff@8.0.3 \
+  && npm install -g npm@latest tar@7.5.11 glob@11.1.0 @isaacs/brace-expansion@5.0.1 minimatch@10.2.4 diff@8.0.3 \
   && GLOBAL="$(npm root -g)" \
   && find "$GLOBAL/npm" -type d -name "tar" -path "*/node_modules/tar" | while read d; do \
         rm -rf "$d" && cp -rL "$GLOBAL/tar" "$d"; \

--- a/poetry.lock
+++ b/poetry.lock
@@ -5338,24 +5338,25 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev", "proxy-dev"]
 files = [
-    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
-    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.dependencies]
 cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pynacl"
@@ -7993,4 +7994,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "1ade5dee030fd878c907a20b88a6a52ca26ee4ecbed15ecb045f9ae1d4b8b714"
+content-hash = "1f3bbf967451633fb6290ba88980bdf4fbf83420024b14e862d1da717d903684"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rq = {version = "*", optional = true}
 orjson = {version = "^3.9.7", optional = true}
 apscheduler = {version = "^3.10.4", optional = true}
 fastapi-sso = { version = "^0.16.0", optional = true }
-PyJWT = { version = "^2.10.1", optional = true, python = ">=3.9" }
+PyJWT = { version = "^2.12.0", optional = true, python = ">=3.9" }
 python-multipart = { version = ">=0.0.20", optional = true}
 cryptography = {version = "*", optional = true}
 prisma = {version = "^0.11.0", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ orjson==3.11.7 # fast /embedding responses
 polars==1.31.0 # for data processing
 apscheduler==3.10.4 # for resetting budget in background
 fastapi-sso==0.19.0 # admin UI, SSO
-pyjwt[crypto]==2.10.1 ; python_version >= "3.9"
+pyjwt[crypto]==2.12.0 ; python_version >= "3.9"
 python-multipart>=0.0.20 # admin UI
 jaraco.context>=6.1.0
 azure-ai-contentsafety==1.0.0 # for azure content safety


### PR DESCRIPTION
## Summary

### Issue
Security scans flagged PyJWT `^2.10.1` as vulnerable.

### Fix
Bumped `PyJWT` dependency from `^2.10.1` to `^2.12.0` in `pyproject.toml`.

## Testing
- Dependency resolution verified via `poetry lock`

## Type

🐛 Bug Fix