### PR TITLE
fix: Ontario driver's licence guardrail not matching plural 'licenses'

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/patterns.json
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/patterns.json
@@ -568,7 +568,7 @@
       "pattern": "\\b[A-Z]\\d{4}[\\-\\s]\\d{5}[\\-\\s]\\d{5}\\b",
       "category": "Canadian PII Patterns",
       "description": "Detects Ontario driver's licence numbers (1 letter + 14 digits, dashed format)",
-      "keyword_pattern": "\\b(?:driver'?s?\\s*licen[cs]e\\s*number|ontario\\s*licen[cs]e\\s*number|driver'?s?\\s*licen[cs]e|licen[cs]e\\s*number|DL\\s*number|ontario\\s*licen[cs]e|permis\\s*de\\s*conduire|numéro\\s*de\\s*permis)\\b",
+      "keyword_pattern": "\\b(?:driver'?s?\\s*licen[cs]es?\\s*number|ontario\\s*licen[cs]es?\\s*number|driver'?s?\\s*licen[cs]es?|licen[cs]es?\\s*number|DL\\s*number|ontario\\s*licen[cs]es?|permis\\s*de\\s*conduire|numéro\\s*de\\s*permis)\\b",
       "allow_word_numbers": false
     },
     {

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_ca_policy_e2e.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_ca_policy_e2e.py
@@ -230,6 +230,22 @@ class TestCanadianPIIPolicyE2E:
         assert "A1234-56789-01234" not in output
 
     @pytest.mark.asyncio
+    async def test_drivers_licences_plural_masked(self):
+        """Ontario driver's licence with plural 'licenses' is detected and masked"""
+        guardrail = self.setup_canadian_guardrail()
+
+        text = "My name is Jose Lujan and my drivers licenses is A1234-56789-01234."
+        result = await guardrail.apply_guardrail(
+            inputs={"texts": [text]},
+            request_data={},
+            input_type="request",
+        )
+        output = result.get("texts", [])[0]
+
+        assert "[CA_ON_DRIVERS_LICENCE_REDACTED]" in output
+        assert "A1234-56789-01234" not in output
+
+    @pytest.mark.asyncio
     async def test_drivers_licence_question_passes(self):
         """Question about driver's licence without actual number passes through"""
         guardrail = self.setup_canadian_guardrail()


### PR DESCRIPTION
The ca_on_drivers_licence keyword pattern only matched singular forms (licen[cs]e). Phrases like 'drivers licenses' failed the contextual keyword check, so the licence number was never redacted.

Updated keyword pattern to licen[cs]es? to support both singular and plural forms.

Made-with: Cursor

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
