### PR TITLE
fix(responses): map chat completions type:'file' to Responses API input_file

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -696,6 +696,16 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             verbose_logger.debug(
                                 f"Chat provider:   image -> {converted}"
                             )
+                        elif item_type == "file":
+                            # Map Chat Completions `{"type": "file", "file": {...}}` to
+                            # Responses API `{"type": "input_file", ...}`.
+                            # The nested "file" dict contains file_data/filename/file_id.
+                            file_payload = item.get("file", {})
+                            converted = {"type": "input_file", **file_payload}
+                            result.append(converted)
+                            verbose_logger.debug(
+                                f"Chat provider:   file -> {converted}"
+                            )
                         elif item_type in [
                             "input_text",
                             "input_image",


### PR DESCRIPTION
## Problem

When bridging `/chat/completions` to the Responses API, content items of `type: "file"` fall through to the default branch in `_convert_chat_message_to_responses_format` and get serialized as `input_text` with `str(item)` — so the model receives the Python dict as plain text instead of the actual file payload.

**Repro:**
```json
{
  "type": "file",
  "file": {"file_data": "base64...", "filename": "doc.pdf"}
}
```
Before fix → translated to `{"type": "input_text", "text": "{'type': 'file', ...}"}`
After fix → translated to `{"type": "input_file", "file_data": "base64...", "filename": "doc.pdf"}`

## Fix

Added an explicit `"file"` → `"input_file"` branch that unpacks the nested `file` dict (containing `file_data`/`filename`/`file_id`) into the flat Responses API `input_file` format, consistent with how `"image"` → `"input_image"` is already handled.

## Testing

Manual verification with an Azure model configured with `mode: "responses"` and a `type: "file"` content block now correctly routes the payload to the model.

Fixes #23588