### PR TITLE
fix(responses): correctly translate type='file' content to Responses API input_file

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -687,6 +687,15 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         verbose_logger.debug(
                             f"Chat provider:   image_url -> {converted}"
                         )
+                    elif original_type == "file":
+                        # Map chat completions {"type": "file", "file": {"file_data": ..., "filename": ...}}
+                        # to Responses API {"type": "input_file", "file_data": ..., "filename": ...}
+                        file_obj = item.get("file", {})
+                        converted = {"type": "input_file", **file_obj}
+                        result.append(converted)
+                        verbose_logger.debug(
+                            f"Chat provider:   file -> {converted}"
+                        )
                     else:
                         # Try to map other types to responses API format
                         item_type = original_type or "input_text"


### PR DESCRIPTION
## Problem

When bridging `/chat/completions` to the Responses API, content items with `type: "file"` fall through to the default unknown-type handler which stringifies the dict and wraps it as `input_text`. The model receives the Python dict repr as plain text instead of the actual file bytes.

**Broken translation:**
```json
// Input (chat completions format)
{"type": "file", "file": {"file_data": "data:application/pdf;base64,...", "filename": "doc.pdf"}}

// Output (WRONG — sent as input_text containing the string repr of the dict)
{"type": "input_text", "text": "{'type': 'file', 'file': {...}}"}
```

## Fix

Add an explicit handler for `type: "file"` that extracts the nested `file` object and maps it to `input_file`:

```json
// Output (CORRECT)
{"type": "input_file", "file_data": "data:application/pdf;base64,...", "filename": "doc.pdf"}
```

Fixes #23588