### PR TITLE
fix(vertex_ai): skip ADC token fetch and auth header overwrite when Authorization is pre-injected

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
@@ -135,11 +135,25 @@ class VertexAIPartnerModels(VertexBase):
         try:
             vertex_httpx_logic = VertexLLM()
 
-            access_token, project_id = vertex_httpx_logic._ensure_access_token(
-                credentials=vertex_credentials,
-                project_id=vertex_project,
-                custom_llm_provider="vertex_ai",
-            )
+            # If the caller already injected a pre-fetched Authorization header
+            # (e.g. via Workload Identity Federation or a custom auth chain),
+            # skip _ensure_access_token so we don't overwrite the supplied token
+            # or fail when ADC is not configured.
+            _pre_fetched_auth = (headers or {}).get("Authorization")
+            if _pre_fetched_auth:
+                # Extract bearer token for paths that pass it as api_key
+                access_token = (
+                    _pre_fetched_auth.removeprefix("Bearer ").strip()
+                    if _pre_fetched_auth.startswith("Bearer ")
+                    else _pre_fetched_auth
+                )
+                project_id = vertex_project or ""
+            else:
+                access_token, project_id = vertex_httpx_logic._ensure_access_token(
+                    credentials=vertex_credentials,
+                    project_id=vertex_project,
+                    custom_llm_provider="vertex_ai",
+                )
 
             openai_like_chat_completions = OpenAILikeChatHandler()
             codestral_fim_completions = CodestralTextCompletion()
@@ -198,7 +212,8 @@ class VertexAIPartnerModels(VertexBase):
             elif "claude" in model:
                 if headers is None:
                     headers = {}
-                headers.update({"Authorization": "Bearer {}".format(access_token)})
+                if "Authorization" not in headers:
+                    headers["Authorization"] = "Bearer {}".format(access_token)
 
                 optional_params.update(
                     {


### PR DESCRIPTION
## Problem

When calling Claude (or other partner models) on Vertex AI with a pre-fetched Bearer token passed via `extra_headers={"Authorization": "Bearer <token>"}`, the token is silently overwritten and the call fails.

Two bugs in `vertex_ai_partner_models/main.py`:

1. `_ensure_access_token()` is called **unconditionally** (line 138) — fails with an ADC error when Application Default Credentials are not configured (e.g. Workload Identity Federation / custom auth chain).
2. `headers.update({"Authorization": "Bearer {}".format(access_token)})` always **overwrites** the user-supplied token (line 201).

## Fix

```python
# 1. Skip ADC fetch if a pre-fetched token is already in headers
_pre_fetched_auth = (headers or {}).get("Authorization")
if _pre_fetched_auth:
    access_token = _pre_fetched_auth.removeprefix("Bearer ").strip()
    project_id = vertex_project or ""
else:
    access_token, project_id = vertex_httpx_logic._ensure_access_token(...)

# 2. Only set Authorization if not already present
if "Authorization" not in headers:
    headers["Authorization"] = "Bearer {}".format(access_token)
```

## Reproducer

```python
import litellm

# Works now even without ADC configured:
response = await litellm.acompletion(
    model="vertex_ai/claude-3-5-sonnet-v2@20241022",
    messages=[{"role": "user", "content": "Hello"}],
    extra_headers={"Authorization": "Bearer <wif-token>"},
    vertex_project="my-project",
    vertex_location="us-east5",
)
```

Fixes #23572