### PR TITLE
fix(guardrails): add 'block' as valid on_violation value in BaseLitellmParams

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -656,9 +656,9 @@ class BaseLitellmParams(
         default=None,
         description="For /v1/realtime sessions: automatically close the session after this many guardrail violations.",
     )
-    on_violation: Optional[Literal["warn", "end_session"]] = Field(
+    on_violation: Optional[Literal["warn", "end_session", "block"]] = Field(
         default=None,
-        description="For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
+        description="For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection. 'block' rejects the request (same as the default guardrail behaviour).",
     )
     realtime_violation_message: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
## Problem

The LiteLLM proxy crashes on startup when a guardrail stored in the database has `on_violation='block'`:

```
ERROR: guardrail_endpoints.py:247 - Error getting guardrails from db: 1 validation error for BaseLitellmParams
on_violation
  Input should be 'warn' or 'end_session' [type=literal_error, input_value='block', input_type=str]
```

## Root cause

In `litellm/types/guardrails.py`, `BaseLitellmParams.on_violation` is typed as `Literal["warn", "end_session"]`, which excludes `"block"` — a natural and commonly-used action value (e.g. to block a request, consistent with `on_flagged: Literal["block", "monitor"]` elsewhere in the same file).

## Fix

Add `"block"` to the Literal:

```python
# Before
on_violation: Optional[Literal["warn", "end_session"]] = Field(...)

# After  
on_violation: Optional[Literal["warn", "end_session", "block"]] = Field(...)
```

Fixes #23624