### PR TITLE
fix: add guards for empty choices + convert file to input_file

### DIFF
--- a/cookbook/veo_video_generation.py
+++ b/cookbook/veo_video_generation.py
@@ -78,7 +78,7 @@ class VeoVideoGenerator:
                 try:
                     error_data = e.response.json()
                     print(f"Error details: {json.dumps(error_data, indent=2)}")
-                except:
+                except json.JSONDecodeError:
                     print(f"Error response: {e.response.text}")
             return None
     

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -696,6 +696,20 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             verbose_logger.debug(
                                 f"Chat provider:   image -> {converted}"
                             )
+                        elif item_type == "file":
+                            # Convert Chat Completions file format to Responses API input_file format
+                            # Chat Completions: {"type": "file", "file": {"file_data": "...", "filename": "..."}}
+                            # Responses API: {"type": "input_file", "file_data": "...", "filename": "..."}
+                            file_obj = item.get("file", {})
+                            converted = {
+                                "type": "input_file",
+                                "file_data": file_obj.get("file_data", ""),
+                                "filename": file_obj.get("filename", ""),
+                            }
+                            result.append(converted)
+                            verbose_logger.debug(
+                                f"Chat provider:   file -> {converted}"
+                            )
                         elif item_type in [
                             "input_text",
                             "input_image",

--- a/litellm/integrations/braintrust_logging.py
+++ b/litellm/integrations/braintrust_logging.py
@@ -152,13 +152,16 @@ class BraintrustLogger(CustomLogger):
             elif response_obj is not None and isinstance(
                 response_obj, litellm.ModelResponse
             ):
-                output = response_obj["choices"][0]["message"].json()
-                choices = response_obj["choices"]
+                _choices = response_obj.get("choices")
+                if _choices:
+                    output = _choices[0]["message"].json()
+                    choices = _choices
             elif response_obj is not None and isinstance(
                 response_obj, litellm.TextCompletionResponse
             ):
-                output = response_obj.choices[0].text
-                choices = response_obj.choices
+                if response_obj.choices:
+                    output = response_obj.choices[0].text
+                    choices = response_obj.choices
             elif response_obj is not None and isinstance(
                 response_obj, litellm.ImageResponse
             ):
@@ -289,13 +292,16 @@ class BraintrustLogger(CustomLogger):
             elif response_obj is not None and isinstance(
                 response_obj, litellm.ModelResponse
             ):
-                output = response_obj["choices"][0]["message"].json()
-                choices = response_obj["choices"]
+                _choices = response_obj.get("choices")
+                if _choices:
+                    output = _choices[0]["message"].json()
+                    choices = _choices
             elif response_obj is not None and isinstance(
                 response_obj, litellm.TextCompletionResponse
             ):
-                output = response_obj.choices[0].text
-                choices = response_obj.choices
+                if response_obj.choices:
+                    output = response_obj.choices[0].text
+                    choices = response_obj.choices
             elif response_obj is not None and isinstance(
                 response_obj, litellm.ImageResponse
             ):

--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -79,11 +79,14 @@ class GalileoObserve(CustomLogger):
         elif response_obj is not None and isinstance(
             response_obj, litellm.ModelResponse
         ):
-            output = response_obj["choices"][0]["message"].json()
+            choices = response_obj.get("choices")
+            if choices:
+                output = choices[0]["message"].json()
         elif response_obj is not None and isinstance(
             response_obj, litellm.TextCompletionResponse
         ):
-            output = response_obj.choices[0].text
+            if response_obj.choices:
+                output = response_obj.choices[0].text
         elif response_obj is not None and isinstance(
             response_obj, litellm.ImageResponse
         ):

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -131,6 +131,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return None
 
     def _is_reasoning_end(self, chunk):
+        # Guard against empty choices
+        if not chunk.choices:
+            return True
         delta = chunk.choices[0].delta
 
         # if this indicates reasoning content, don't consider reasoning ended
@@ -578,13 +581,18 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if self._cached_item_id is None:
             self._cached_item_id = f"msg_{str(uuid.uuid4())}"
 
+        # Guard against empty choices
+        if not litellm_complete_object.choices:
+            text = ""
+        else:
+            text = getattr(litellm_complete_object.choices[0].message, "content", "") or ""  # type: ignore
+
         return OutputTextDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
             item_id=self._cached_item_id,
             output_index=0,
             content_index=0,
-            text=getattr(litellm_complete_object.choices[0].message, "content", "")  # type: ignore
-            or "",
+            text=text,
         )
 
     def create_output_content_part_done_event(
@@ -593,9 +601,15 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if self._cached_item_id is None:
             self._cached_item_id = f"msg_{str(uuid.uuid4())}"
 
-        text = getattr(litellm_complete_object.choices[0].message, "content", "") or ""  # type: ignore
-        reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""  # type: ignore
-        annotations = getattr(litellm_complete_object.choices[0].message, "annotations", None)  # type: ignore
+        # Guard against empty choices
+        if not litellm_complete_object.choices:
+            text = ""
+            reasoning_content = ""
+            annotations = None
+        else:
+            text = getattr(litellm_complete_object.choices[0].message, "content", "") or ""  # type: ignore
+            reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""  # type: ignore
+            annotations = getattr(litellm_complete_object.choices[0].message, "annotations", None)  # type: ignore
 
         part: Optional[PART_UNION_TYPES] = None
         if reasoning_content:
@@ -629,8 +643,13 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if self._cached_item_id is None:
             self._cached_item_id = f"msg_{str(uuid.uuid4())}"
 
-        text = self.litellm_model_response.choices[0].message.content or ""  # type: ignore
-        annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)  # type: ignore
+        # Guard against empty choices
+        if not self.litellm_model_response.choices:
+            text = ""
+            annotations = None
+        else:
+            text = self.litellm_model_response.choices[0].message.content or ""  # type: ignore
+            annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)  # type: ignore
 
         response_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
             annotations=annotations
@@ -772,6 +791,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
     def _ensure_output_item_for_chunk(self, chunk: ModelResponseStream) -> None:
         # Change: Never return a value, just enqueue output item events
         if self.sent_output_item_added_event:
+            return
+        # Guard against empty choices
+        if not chunk.choices:
             return
         delta = chunk.choices[0].delta
 


### PR DESCRIPTION
## Summary

### Fix 1: Guards for empty choices in streaming iterator
Prevent potential IndexError when accessing `choices[0]` on empty choices list in ModelResponse objects.

Added bounds checking to the following methods in `streaming_iterator.py`:

- `_is_reasoning_end()` - returns `True` early if choices is empty
- `_ensure_output_item_for_chunk()` - returns early if choices is empty  
- `create_output_text_done_event()` - returns empty text if choices is empty
- `create_output_content_part_done_event()` - returns empty values if choices is empty
- `create_output_item_done_event()` - returns empty values if choices is empty

### Fix 2: Convert Chat Completions file type to Responses API input_file format
Convert the `file` field in Chat Completions to the `input_file` format in Responses API.

## Why

Fix 1 prevents crashes when LLM APIs return empty choices arrays, which can happen in edge cases or error scenarios.

Fix 2 ensures compatibility between Chat Completions and Responses API file handling.

## Testing

All modified files pass Python syntax validation.