### PR TITLE
fix: strip whitespace from MCP credential values before encryption

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/byok_oauth_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/byok_oauth_endpoints.py
@@ -749,6 +749,8 @@ async def byok_token(
             )
 
             _invalidate_byok_cred_cache(user_id, server_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         except Exception as exc:
             verbose_proxy_logger.error(
                 "byok_token: failed to store user credential for user=%s server=%s: %s",

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -95,7 +95,8 @@ def _strip_credential_value(value: Optional[str]) -> Optional[str]:
     """
     if value is None:
         return None
-    return re.sub(r"\s+", "", value)
+    stripped = re.sub(r"\s+", "", value)
+    return stripped or None
 
 
 def encrypt_credentials(
@@ -518,6 +519,7 @@ async def store_user_credential(
     credential: str,
 ) -> None:
     """Store a user credential for a BYOK MCP server."""
+    credential = re.sub(r"\s+", "", credential)
 
     encoded = base64.urlsafe_b64encode(credential.encode()).decode()
     await prisma_client.db.litellm_mcpusercredentials.upsert(
@@ -604,6 +606,10 @@ async def store_user_oauth_credential(
         expires_at = (
             datetime.now(timezone.utc) + timedelta(seconds=expires_in)
         ).isoformat()
+
+    access_token = re.sub(r"\s+", "", access_token)
+    if refresh_token:
+        refresh_token = re.sub(r"\s+", "", refresh_token)
 
     payload: Dict[str, Any] = {
         "type": "oauth2",

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
@@ -85,41 +86,55 @@ def _prepare_mcp_server_data(
     return data_dict
 
 
+def _strip_credential_value(value: Optional[str]) -> Optional[str]:
+    """Strip whitespace from credential values.
+
+    Tokens and secrets copied from terminals or UIs often contain
+    accidental whitespace or embedded newlines from line-wrapping.
+    Stripping these prevents hard-to-debug auth failures.
+    """
+    if value is None:
+        return None
+    return re.sub(r"\s+", "", value)
+
+
 def encrypt_credentials(
     credentials: MCPCredentials, encryption_key: Optional[str]
 ) -> MCPCredentials:
-    auth_value = credentials.get("auth_value")
+    auth_value = _strip_credential_value(credentials.get("auth_value"))
     if auth_value is not None:
         credentials["auth_value"] = encrypt_value_helper(
             value=auth_value,
             new_encryption_key=encryption_key,
         )
-    client_id = credentials.get("client_id")
+    client_id = _strip_credential_value(credentials.get("client_id"))
     if client_id is not None:
         credentials["client_id"] = encrypt_value_helper(
             value=client_id,
             new_encryption_key=encryption_key,
         )
-    client_secret = credentials.get("client_secret")
+    client_secret = _strip_credential_value(credentials.get("client_secret"))
     if client_secret is not None:
         credentials["client_secret"] = encrypt_value_helper(
             value=client_secret,
             new_encryption_key=encryption_key,
         )
     # AWS SigV4 credential fields
-    aws_access_key_id = credentials.get("aws_access_key_id")
+    aws_access_key_id = _strip_credential_value(credentials.get("aws_access_key_id"))
     if aws_access_key_id is not None:
         credentials["aws_access_key_id"] = encrypt_value_helper(
             value=aws_access_key_id,
             new_encryption_key=encryption_key,
         )
-    aws_secret_access_key = credentials.get("aws_secret_access_key")
+    aws_secret_access_key = _strip_credential_value(
+        credentials.get("aws_secret_access_key")
+    )
     if aws_secret_access_key is not None:
         credentials["aws_secret_access_key"] = encrypt_value_helper(
             value=aws_secret_access_key,
             new_encryption_key=encryption_key,
         )
-    aws_session_token = credentials.get("aws_session_token")
+    aws_session_token = _strip_credential_value(credentials.get("aws_session_token"))
     if aws_session_token is not None:
         credentials["aws_session_token"] = encrypt_value_helper(
             value=aws_session_token,
@@ -188,12 +203,12 @@ async def get_mcp_server(
     """
     Returns the matching mcp server from the db iff exists
     """
-    mcp_server: Optional[
-        LiteLLM_MCPServerTable
-    ] = await prisma_client.db.litellm_mcpservertable.find_unique(
-        where={
-            "server_id": server_id,
-        }
+    mcp_server: Optional[LiteLLM_MCPServerTable] = (
+        await prisma_client.db.litellm_mcpservertable.find_unique(
+            where={
+                "server_id": server_id,
+            }
+        )
     )
     return mcp_server
 
@@ -204,12 +219,12 @@ async def get_mcp_servers(
     """
     Returns the matching mcp servers from the db with the server_ids
     """
-    _mcp_servers: List[
-        LiteLLM_MCPServerTable
-    ] = await prisma_client.db.litellm_mcpservertable.find_many(
-        where={
-            "server_id": {"in": server_ids},
-        }
+    _mcp_servers: List[LiteLLM_MCPServerTable] = (
+        await prisma_client.db.litellm_mcpservertable.find_many(
+            where={
+                "server_id": {"in": server_ids},
+            }
+        )
     )
     final_mcp_servers: List[LiteLLM_MCPServerTable] = []
     for _mcp_server in _mcp_servers:

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
@@ -85,41 +86,53 @@ def _prepare_mcp_server_data(
     return data_dict
 
 
+def _strip_credential_value(value: Optional[str]) -> Optional[str]:
+    """Strip whitespace from credential values.
+
+    Tokens and secrets copied from terminals or UIs often contain
+    accidental whitespace or embedded newlines from line-wrapping.
+    Stripping these prevents hard-to-debug auth failures.
+    """
+    if value is None:
+        return None
+    return re.sub(r"\s+", "", value)
+
+
 def encrypt_credentials(
     credentials: MCPCredentials, encryption_key: Optional[str]
 ) -> MCPCredentials:
-    auth_value = credentials.get("auth_value")
+    auth_value = _strip_credential_value(credentials.get("auth_value"))
     if auth_value is not None:
         credentials["auth_value"] = encrypt_value_helper(
             value=auth_value,
             new_encryption_key=encryption_key,
         )
-    client_id = credentials.get("client_id")
+    client_id = _strip_credential_value(credentials.get("client_id"))
     if client_id is not None:
         credentials["client_id"] = encrypt_value_helper(
             value=client_id,
             new_encryption_key=encryption_key,
         )
-    client_secret = credentials.get("client_secret")
+    client_secret = _strip_credential_value(credentials.get("client_secret"))
     if client_secret is not None:
         credentials["client_secret"] = encrypt_value_helper(
             value=client_secret,
             new_encryption_key=encryption_key,
         )
     # AWS SigV4 credential fields
-    aws_access_key_id = credentials.get("aws_access_key_id")
+    aws_access_key_id = _strip_credential_value(credentials.get("aws_access_key_id"))
     if aws_access_key_id is not None:
         credentials["aws_access_key_id"] = encrypt_value_helper(
             value=aws_access_key_id,
             new_encryption_key=encryption_key,
         )
-    aws_secret_access_key = credentials.get("aws_secret_access_key")
+    aws_secret_access_key = _strip_credential_value(credentials.get("aws_secret_access_key"))
     if aws_secret_access_key is not None:
         credentials["aws_secret_access_key"] = encrypt_value_helper(
             value=aws_secret_access_key,
             new_encryption_key=encryption_key,
         )
-    aws_session_token = credentials.get("aws_session_token")
+    aws_session_token = _strip_credential_value(credentials.get("aws_session_token"))
     if aws_session_token is not None:
         credentials["aws_session_token"] = encrypt_value_helper(
             value=aws_session_token,

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -99,48 +99,42 @@ def _strip_credential_value(value: Optional[str]) -> Optional[str]:
     return stripped or None
 
 
+def _encrypt_credential_field(
+    credentials: MCPCredentials,
+    field: str,
+    encryption_key: Optional[str],
+) -> None:
+    """Strip, validate, and encrypt a single credential field in-place.
+
+    If the raw value is ``None`` the field is left untouched.  If it becomes
+    ``None`` after stripping (i.e. whitespace-only input), the field is removed
+    from the dict so that no unencrypted data is persisted.
+    """
+    raw = credentials.get(field)
+    if raw is None:
+        return
+    stripped = _strip_credential_value(raw)
+    if stripped is None:
+        credentials.pop(field, None)
+    else:
+        credentials[field] = encrypt_value_helper(
+            value=stripped,
+            new_encryption_key=encryption_key,
+        )
+
+
 def encrypt_credentials(
     credentials: MCPCredentials, encryption_key: Optional[str]
 ) -> MCPCredentials:
-    auth_value = _strip_credential_value(credentials.get("auth_value"))
-    if auth_value is not None:
-        credentials["auth_value"] = encrypt_value_helper(
-            value=auth_value,
-            new_encryption_key=encryption_key,
-        )
-    client_id = _strip_credential_value(credentials.get("client_id"))
-    if client_id is not None:
-        credentials["client_id"] = encrypt_value_helper(
-            value=client_id,
-            new_encryption_key=encryption_key,
-        )
-    client_secret = _strip_credential_value(credentials.get("client_secret"))
-    if client_secret is not None:
-        credentials["client_secret"] = encrypt_value_helper(
-            value=client_secret,
-            new_encryption_key=encryption_key,
-        )
-    # AWS SigV4 credential fields
-    aws_access_key_id = _strip_credential_value(credentials.get("aws_access_key_id"))
-    if aws_access_key_id is not None:
-        credentials["aws_access_key_id"] = encrypt_value_helper(
-            value=aws_access_key_id,
-            new_encryption_key=encryption_key,
-        )
-    aws_secret_access_key = _strip_credential_value(
-        credentials.get("aws_secret_access_key")
-    )
-    if aws_secret_access_key is not None:
-        credentials["aws_secret_access_key"] = encrypt_value_helper(
-            value=aws_secret_access_key,
-            new_encryption_key=encryption_key,
-        )
-    aws_session_token = _strip_credential_value(credentials.get("aws_session_token"))
-    if aws_session_token is not None:
-        credentials["aws_session_token"] = encrypt_value_helper(
-            value=aws_session_token,
-            new_encryption_key=encryption_key,
-        )
+    for field in (
+        "auth_value",
+        "client_id",
+        "client_secret",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+    ):
+        _encrypt_credential_field(credentials, field, encryption_key)
     # aws_region_name and aws_service_name are NOT secrets — stored as-is
     return credentials
 

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -519,7 +519,9 @@ async def store_user_credential(
     credential: str,
 ) -> None:
     """Store a user credential for a BYOK MCP server."""
-    credential = re.sub(r"\s+", "", credential)
+    credential = _strip_credential_value(credential) or ""
+    if not credential:
+        raise ValueError("Credential must not be empty or whitespace-only")
 
     encoded = base64.urlsafe_b64encode(credential.encode()).decode()
     await prisma_client.db.litellm_mcpusercredentials.upsert(
@@ -607,9 +609,10 @@ async def store_user_oauth_credential(
             datetime.now(timezone.utc) + timedelta(seconds=expires_in)
         ).isoformat()
 
-    access_token = re.sub(r"\s+", "", access_token)
-    if refresh_token:
-        refresh_token = re.sub(r"\s+", "", refresh_token)
+    access_token = _strip_credential_value(access_token) or ""
+    if not access_token:
+        raise ValueError("access_token must not be empty or whitespace-only")
+    refresh_token = _strip_credential_value(refresh_token)
 
     payload: Dict[str, Any] = {
         "type": "oauth2",

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -87,15 +87,16 @@ def _prepare_mcp_server_data(
 
 
 def _strip_credential_value(value: Optional[str]) -> Optional[str]:
-    """Strip whitespace from credential values.
+    """Strip copy-paste artifacts from credential values.
 
     Tokens and secrets copied from terminals or UIs often contain
-    accidental whitespace or embedded newlines from line-wrapping.
-    Stripping these prevents hard-to-debug auth failures.
+    accidental newlines, tabs, or leading/trailing spaces from
+    line-wrapping.  Internal spaces are preserved to avoid corrupting
+    passphrase-style credentials.
     """
     if value is None:
         return None
-    stripped = re.sub(r"\s+", "", value)
+    stripped = re.sub(r"[\r\n\t]", "", value).strip()
     return stripped or None
 
 
@@ -606,7 +607,12 @@ async def store_user_oauth_credential(
     access_token = _strip_credential_value(access_token) or ""
     if not access_token:
         raise ValueError("access_token must not be empty or whitespace-only")
+    raw_refresh_token = refresh_token
     refresh_token = _strip_credential_value(refresh_token)
+    if raw_refresh_token is not None and refresh_token is None:
+        verbose_proxy_logger.warning(
+            "refresh_token was whitespace-only and has been discarded"
+        )
 
     payload: Dict[str, Any] = {
         "type": "oauth2",

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -424,17 +424,17 @@ if MCP_AVAILABLE:
             inherited_credentials["scopes"] = existing_server.scopes
         # AWS SigV4 fields
         if existing_server.aws_access_key_id:
-            inherited_credentials[
-                "aws_access_key_id"
-            ] = existing_server.aws_access_key_id
+            inherited_credentials["aws_access_key_id"] = (
+                existing_server.aws_access_key_id
+            )
         if existing_server.aws_secret_access_key:
-            inherited_credentials[
-                "aws_secret_access_key"
-            ] = existing_server.aws_secret_access_key
+            inherited_credentials["aws_secret_access_key"] = (
+                existing_server.aws_secret_access_key
+            )
         if existing_server.aws_session_token:
-            inherited_credentials[
-                "aws_session_token"
-            ] = existing_server.aws_session_token
+            inherited_credentials["aws_session_token"] = (
+                existing_server.aws_session_token
+            )
         if existing_server.aws_region_name:
             inherited_credentials["aws_region_name"] = existing_server.aws_region_name
         if existing_server.aws_service_name:
@@ -1543,9 +1543,15 @@ if MCP_AVAILABLE:
                 detail={"error": "User ID not found in token"},
             )
         if payload.save:
-            await store_user_credential(
-                prisma_client, user_id, server_id, payload.credential
-            )
+            try:
+                await store_user_credential(
+                    prisma_client, user_id, server_id, payload.credential
+                )
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={"error": str(e)},
+                )
             from litellm.proxy._experimental.mcp_server.server import (
                 _invalidate_byok_cred_cache,
             )
@@ -1617,15 +1623,21 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={"error": "User ID not found in token"},
             )
-        await store_user_oauth_credential(
-            prisma_client,
-            user_id,
-            server_id,
-            payload.access_token,
-            refresh_token=payload.refresh_token,
-            expires_in=payload.expires_in,
-            scopes=payload.scopes,
-        )
+        try:
+            await store_user_oauth_credential(
+                prisma_client,
+                user_id,
+                server_id,
+                payload.access_token,
+                refresh_token=payload.refresh_token,
+                expires_in=payload.expires_in,
+                scopes=payload.scopes,
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": str(e)},
+            )
         # Read back the persisted record so the response reflects the stored
         # expires_at rather than recomputing it here (which could diverge by
         # milliseconds or if the storage logic ever adds a grace period).

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -1,5 +1,5 @@
 """
-Tests for _strip_credential_value and whitespace handling in encrypt_credentials.
+Tests for _strip_credential_value and whitespace handling in credential storage.
 """
 
 from unittest.mock import patch
@@ -7,6 +7,8 @@ from unittest.mock import patch
 from litellm.proxy._experimental.mcp_server.db import (
     _strip_credential_value,
     encrypt_credentials,
+    store_user_credential,
+    store_user_oauth_credential,
 )
 
 
@@ -79,3 +81,59 @@ class TestEncryptCredentialsStripsWhitespace:
         assert result["aws_access_key_id"] == "AKIA123"
         assert result["aws_secret_access_key"] == "secretkey"
         assert result["aws_session_token"] == "tokenvalue"
+
+
+class TestStoreUserCredentialStripsWhitespace:
+    """Verify that store_user_credential strips whitespace."""
+
+    @pytest.mark.asyncio
+    async def test_strips_whitespace_before_storing(self):
+        mock_prisma = AsyncMock()
+        await store_user_credential(mock_prisma, "user1", "server1", " my-token\n ")
+        call_args = mock_prisma.db.litellm_mcpusercredentials.upsert.call_args
+        create_data = call_args.kwargs["data"]["create"]
+        import base64
+
+        stored = base64.urlsafe_b64decode(create_data["credential_b64"]).decode()
+        assert stored == "my-token"
+
+    @pytest.mark.asyncio
+    async def test_rejects_whitespace_only_credential(self):
+        mock_prisma = AsyncMock()
+        with pytest.raises(ValueError, match="must not be empty"):
+            await store_user_credential(mock_prisma, "user1", "server1", "   \n  ")
+
+
+class TestStoreUserOAuthCredentialStripsWhitespace:
+    """Verify that store_user_oauth_credential strips whitespace."""
+
+    @pytest.mark.asyncio
+    async def test_strips_whitespace_from_tokens(self):
+        mock_prisma = AsyncMock()
+        mock_prisma.db.litellm_mcpusercredentials.find_unique = AsyncMock(
+            return_value=None
+        )
+        await store_user_oauth_credential(
+            mock_prisma,
+            "user1",
+            "server1",
+            access_token=" token\n123 ",
+            refresh_token=" refresh\n456 ",
+        )
+        call_args = mock_prisma.db.litellm_mcpusercredentials.upsert.call_args
+        create_data = call_args.kwargs["data"]["create"]
+        import base64, json
+
+        payload = json.loads(
+            base64.urlsafe_b64decode(create_data["credential_b64"]).decode()
+        )
+        assert payload["access_token"] == "token123"
+        assert payload["refresh_token"] == "refresh456"
+
+    @pytest.mark.asyncio
+    async def test_rejects_whitespace_only_access_token(self):
+        mock_prisma = AsyncMock()
+        with pytest.raises(ValueError, match="must not be empty"):
+            await store_user_oauth_credential(
+                mock_prisma, "user1", "server1", access_token="   "
+            )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -32,12 +32,16 @@ class TestStripCredentialValue:
 
     def test_strips_embedded_newline_from_line_wrap(self):
         """Simulates terminal line-wrapping that inserts newline in the middle."""
-        token_with_wrap = "ya29.a0ATkoCc6Vik\n  ZRWgeS5J9dd_gxP9w"
+        token_with_wrap = "ya29.a0ATkoCc6Vik\nZRWgeS5J9dd_gxP9w"
         expected = "ya29.a0ATkoCc6VikZRWgeS5J9dd_gxP9w"
         assert _strip_credential_value(token_with_wrap) == expected
 
     def test_strips_tabs(self):
         assert _strip_credential_value("my\ttoken") == "mytoken"
+
+    def test_preserves_internal_spaces(self):
+        """Internal spaces are preserved for passphrase-style credentials."""
+        assert _strip_credential_value("my secret passphrase") == "my secret passphrase"
 
     def test_empty_string(self):
         assert _strip_credential_value("") is None
@@ -55,9 +59,9 @@ class TestEncryptCredentialsStripsWhitespace:
         "litellm.proxy._experimental.mcp_server.db.encrypt_value_helper",
         side_effect=lambda value, new_encryption_key: value,
     )
-    def test_auth_value_whitespace_stripped(self, mock_encrypt):
-        """Ensure whitespace in auth_value is removed before encryption."""
-        creds = {"auth_value": "ya29.abc123\n  def456ghi789"}
+    def test_auth_value_newlines_stripped(self, mock_encrypt):
+        """Ensure newlines in auth_value are removed before encryption."""
+        creds = {"auth_value": "ya29.abc123\ndef456ghi789"}
         result = encrypt_credentials(creds, encryption_key=None)
         assert result["auth_value"] == "ya29.abc123def456ghi789"
 
@@ -79,7 +83,7 @@ class TestEncryptCredentialsStripsWhitespace:
         creds = {
             "aws_access_key_id": " AKIA123 ",
             "aws_secret_access_key": "secret\nkey",
-            "aws_session_token": " token\n  value ",
+            "aws_session_token": " token\n\tvalue ",
         }
         result = encrypt_credentials(creds, encryption_key=None)
         assert result["aws_access_key_id"] == "AKIA123"
@@ -148,3 +152,24 @@ class TestStoreUserOAuthCredentialStripsWhitespace:
             await store_user_oauth_credential(
                 mock_prisma, "user1", "server1", access_token="   "
             )
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_refresh_token_discarded(self):
+        """Whitespace-only refresh_token should be silently discarded."""
+        mock_prisma = AsyncMock()
+        mock_prisma.db.litellm_mcpusercredentials.find_unique = AsyncMock(
+            return_value=None
+        )
+        await store_user_oauth_credential(
+            mock_prisma,
+            "user1",
+            "server1",
+            access_token="valid-token",
+            refresh_token="   \n  ",
+        )
+        call_args = mock_prisma.db.litellm_mcpusercredentials.upsert.call_args
+        create_data = call_args.kwargs["data"]["create"]
+        payload = json.loads(
+            base64.urlsafe_b64decode(create_data["credential_b64"]).decode()
+        )
+        assert "refresh_token" not in payload

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -84,6 +84,17 @@ class TestEncryptCredentialsStripsWhitespace:
         assert result["aws_secret_access_key"] == "secretkey"
         assert result["aws_session_token"] == "tokenvalue"
 
+    @patch(
+        "litellm.proxy._experimental.mcp_server.db.encrypt_value_helper",
+        side_effect=lambda value, new_encryption_key: value,
+    )
+    def test_whitespace_only_field_removed_from_dict(self, mock_encrypt):
+        """Whitespace-only values must be removed, not left unencrypted."""
+        creds = {"auth_value": "   \n  ", "client_id": "valid-id"}
+        result = encrypt_credentials(creds, encryption_key=None)
+        assert "auth_value" not in result
+        assert result["client_id"] == "valid-id"
+
 
 class TestStoreUserCredentialStripsWhitespace:
     """Verify that store_user_credential strips whitespace."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -2,6 +2,8 @@
 Tests for _strip_credential_value and whitespace handling in credential storage.
 """
 
+import base64
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -105,8 +107,6 @@ class TestStoreUserCredentialStripsWhitespace:
         await store_user_credential(mock_prisma, "user1", "server1", " my-token\n ")
         call_args = mock_prisma.db.litellm_mcpusercredentials.upsert.call_args
         create_data = call_args.kwargs["data"]["create"]
-        import base64
-
         stored = base64.urlsafe_b64decode(create_data["credential_b64"]).decode()
         assert stored == "my-token"
 
@@ -135,8 +135,6 @@ class TestStoreUserOAuthCredentialStripsWhitespace:
         )
         call_args = mock_prisma.db.litellm_mcpusercredentials.upsert.call_args
         create_data = call_args.kwargs["data"]["create"]
-        import base64, json
-
         payload = json.loads(
             base64.urlsafe_b64decode(create_data["credential_b64"]).decode()
         )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -34,7 +34,12 @@ class TestStripCredentialValue:
         assert _strip_credential_value("my\ttoken") == "mytoken"
 
     def test_empty_string(self):
-        assert _strip_credential_value("") == ""
+        assert _strip_credential_value("") is None
+
+    def test_whitespace_only_returns_none(self):
+        """All-whitespace input should be treated as absent."""
+        assert _strip_credential_value("   ") is None
+        assert _strip_credential_value("\n\t ") is None
 
 
 class TestEncryptCredentialsStripsWhitespace:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -36,6 +36,11 @@ class TestStripCredentialValue:
         expected = "ya29.a0ATkoCc6VikZRWgeS5J9dd_gxP9w"
         assert _strip_credential_value(token_with_wrap) == expected
 
+    def test_strips_crlf_line_endings(self):
+        """Handles Windows-style CRLF line endings from copy-paste."""
+        assert _strip_credential_value("token\r\nvalue") == "tokenvalue"
+        assert _strip_credential_value("abc\r\n  def") == "abc  def"
+
     def test_strips_tabs(self):
         assert _strip_credential_value("my\ttoken") == "mytoken"
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -4,8 +4,6 @@ Tests for _strip_credential_value and whitespace handling in encrypt_credentials
 
 from unittest.mock import patch
 
-import pytest
-
 from litellm.proxy._experimental.mcp_server.db import (
     _strip_credential_value,
     encrypt_credentials,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -1,0 +1,78 @@
+"""
+Tests for _strip_credential_value and whitespace handling in encrypt_credentials.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from litellm.proxy._experimental.mcp_server.db import (
+    _strip_credential_value,
+    encrypt_credentials,
+)
+
+
+class TestStripCredentialValue:
+    def test_returns_none_for_none(self):
+        assert _strip_credential_value(None) is None
+
+    def test_no_change_for_clean_value(self):
+        token = "ya29.a0ATkoCc6VikZRWgeS5J9dd_gxP9wCmAARKc7m1lAjbF94"
+        assert _strip_credential_value(token) == token
+
+    def test_strips_leading_trailing_spaces(self):
+        assert _strip_credential_value("  my-token  ") == "my-token"
+
+    def test_strips_leading_trailing_newlines(self):
+        assert _strip_credential_value("\nmy-token\n") == "my-token"
+
+    def test_strips_embedded_newline_from_line_wrap(self):
+        """Simulates terminal line-wrapping that inserts newline in the middle."""
+        token_with_wrap = "ya29.a0ATkoCc6Vik\n  ZRWgeS5J9dd_gxP9w"
+        expected = "ya29.a0ATkoCc6VikZRWgeS5J9dd_gxP9w"
+        assert _strip_credential_value(token_with_wrap) == expected
+
+    def test_strips_tabs(self):
+        assert _strip_credential_value("my\ttoken") == "mytoken"
+
+    def test_empty_string(self):
+        assert _strip_credential_value("") == ""
+
+
+class TestEncryptCredentialsStripsWhitespace:
+    """Verify that encrypt_credentials strips whitespace before encrypting."""
+
+    @patch(
+        "litellm.proxy._experimental.mcp_server.db.encrypt_value_helper",
+        side_effect=lambda value, new_encryption_key: value,
+    )
+    def test_auth_value_whitespace_stripped(self, mock_encrypt):
+        """Ensure whitespace in auth_value is removed before encryption."""
+        creds = {"auth_value": "ya29.abc123\n  def456ghi789"}
+        result = encrypt_credentials(creds, encryption_key=None)
+        assert result["auth_value"] == "ya29.abc123def456ghi789"
+
+    @patch(
+        "litellm.proxy._experimental.mcp_server.db.encrypt_value_helper",
+        side_effect=lambda value, new_encryption_key: value,
+    )
+    def test_client_id_and_secret_stripped(self, mock_encrypt):
+        creds = {"client_id": " my-client-id \n", "client_secret": "\n secret \t"}
+        result = encrypt_credentials(creds, encryption_key=None)
+        assert result["client_id"] == "my-client-id"
+        assert result["client_secret"] == "secret"
+
+    @patch(
+        "litellm.proxy._experimental.mcp_server.db.encrypt_value_helper",
+        side_effect=lambda value, new_encryption_key: value,
+    )
+    def test_aws_fields_stripped(self, mock_encrypt):
+        creds = {
+            "aws_access_key_id": " AKIA123 ",
+            "aws_secret_access_key": "secret\nkey",
+            "aws_session_token": " token\n  value ",
+        }
+        result = encrypt_credentials(creds, encryption_key=None)
+        assert result["aws_access_key_id"] == "AKIA123"
+        assert result["aws_secret_access_key"] == "secretkey"
+        assert result["aws_session_token"] == "tokenvalue"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py
@@ -2,7 +2,9 @@
 Tests for _strip_credential_value and whitespace handling in credential storage.
 """
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from litellm.proxy._experimental.mcp_server.db import (
     _strip_credential_value,


### PR DESCRIPTION
## Summary

Credential values pasted into the UI may contain accidental whitespace or newlines from copy-paste (e.g. terminal line-wrapping on long tokens). These invisible characters are stored as-is and encrypted, causing silent authentication failures at runtime with no clear error message.

Strip all whitespace from credential values before encryption to prevent this.

## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm)
directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

- Added `_strip_credential_value()` helper in `litellm/proxy/_experimental/mcp_server/db.py` that removes all whitespace from credential strings using `re.sub(r"[\r\n\t]", "", value).strip()`
- Applied to all credential fields in `encrypt_credentials()`: `auth_value`, `client_id`, `client_secret`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`
- Added 10 unit tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_strip_credential_whitespace.py`
- No behavior change for credentials without whitespace