### PR TITLE
Add return type hint to forward_headers_from_request method

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -40,7 +40,7 @@ class BasePassthroughUtils:
         request_headers: dict,
         headers: dict,
         forward_headers: Optional[bool] = False,
-    ):
+    ) -> dict:
         """
         Helper to forward headers from original request.
 


### PR DESCRIPTION
## Description

This PR adds a missing return type annotation to the `forward_headers_from_request` method in `litellm/passthrough/utils.py`.

## Changes

- Added `-> dict` return type hint to `BasePassthroughUtils.forward_headers_from_request()` method
- Improves type safety and IDE autocomplete support
- No functional changes, purely a type annotation improvement

## Motivation

Type hints improve code maintainability by:
- Enabling better static type checking with tools like mypy
- Providing clearer documentation for API consumers
- Improving IDE autocomplete and type inference

## Testing

No tests needed as this is purely a type annotation change with no functional impact.