### PR TITLE
fix: support MCP tools in Generic Guardrail API

### DIFF
--- a/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
-from typing_extensions import TYPE_CHECKING, TypedDict
+from typing_extensions import TypedDict
 
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionToolCallChunk,
     ChatCompletionToolParam,
+    OpenAIMcpServerTool,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 from litellm.types.utils import ChatCompletionMessageToolCall
@@ -65,7 +66,7 @@ class GenericGuardrailAPIRequest(BaseModel):
     ] = None  # the trace id of the LLM call - useful if there are multiple LLM calls for the same conversation
     structured_messages: Optional[List[AllMessageValues]] = None
     images: Optional[List[str]] = None
-    tools: Optional[List[ChatCompletionToolParam]] = None
+    tools: Optional[List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]] = None
     texts: Optional[List[str]] = None
     request_data: GenericGuardrailAPIMetadata
     request_headers: Optional[Dict[str, str]] = Field(
@@ -88,7 +89,7 @@ class GenericGuardrailAPIResponse:
 
     texts: Optional[List[str]]
     images: Optional[List[str]]
-    tools: Optional[List[ChatCompletionToolParam]]
+    tools: Optional[List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]]
     action: str
     blocked_reason: Optional[str]
 
@@ -98,7 +99,7 @@ class GenericGuardrailAPIResponse:
         texts: Optional[List[str]] = None,
         blocked_reason: Optional[str] = None,
         images: Optional[List[str]] = None,
-        tools: Optional[List[ChatCompletionToolParam]] = None,
+        tools: Optional[List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]] = None,
     ):
         self.action = action
         self.blocked_reason = blocked_reason

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -69,6 +69,7 @@ from .llms.openai import (
     OpenAIChatCompletionChunk,
     OpenAIChatCompletionFinishReason,
     OpenAIFileObject,
+    OpenAIMcpServerTool,
     OpenAIRealtimeStreamList,
     ResponsesAPIResponse,
     WebSearchOptions,
@@ -3564,7 +3565,7 @@ class PriorityReservationSettings(BaseModel):
 class GenericGuardrailAPIInputs(TypedDict, total=False):
     texts: List[str]  # extracted text from the LLM response - for basic text guardrails
     images: List[str]  # extracted images from the LLM response - for image guardrails
-    tools: List[ChatCompletionToolParam]  # tools sent to the LLM
+    tools: List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]  # tools sent to the LLM
     tool_calls: Union[
         List[ChatCompletionToolCallChunk], List[ChatCompletionMessageToolCall]
     ]  # tool calls sent from the LLM


### PR DESCRIPTION
## Summary

- Changed `tools` field from `List[ChatCompletionToolParam]` to `List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]` in `GenericGuardrailAPIRequest`, `GenericGuardrailAPIResponse`, and `GenericGuardrailAPIInputs`
- MCP tools (`type: "mcp"`) don't have a `function` field, so `ChatCompletionToolParam` validation rejects them with: `tools.0.function - Field required`
- Aligned with the Responses API pattern (`transformation.py:1150-1152`) which already uses `Union[ChatCompletionToolParam, OpenAIMcpServerTool]` for mixed tool types

Fixes #23695

## Test plan

- [x] Send a chat completion with `tools=[{"type": "mcp", "server_label": "test", "server_url": "https://example.com", "allowed_tools": ["hello"]}]` through LiteLLM proxy with a generic guardrail configured — should no longer return 500
- [x] Verify function tools (`type: "function"`) still work as before