### PR TITLE
fix(anthropic-adapter): exclude output_config from extra_kwargs in Anthropic adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -168,7 +168,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 "include_usage": True,
             }
 
-        excluded_keys = {"anthropic_messages"}
+        excluded_keys = {"anthropic_messages", "output_config"}
         extra_kwargs = extra_kwargs or {}
         for key, value in extra_kwargs.items():
             if (

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_output_config_excluded.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_output_config_excluded.py
@@ -1,0 +1,85 @@
+import os
+import sys
+from typing import Any, Dict
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
+
+
+def test_output_config_excluded_from_completion_kwargs():
+    """
+    Test that `output_config` is excluded when translating Anthropic messages
+    to OpenAI completion format.
+
+    When Claude Code sends requests via the Anthropic Messages API to a
+    non-Anthropic provider (e.g., Azure OpenAI, Fireworks), the adapter
+    translates Anthropic params to OpenAI format. `output_config` is an
+    Anthropic-specific parameter that non-Anthropic providers reject with
+    a 400 error ("Extra inputs are not permitted"). This test verifies
+    that `output_config` is properly stripped during translation.
+
+    Related: https://github.com/BerriAI/litellm/issues/22963
+    """
+    handler = LiteLLMMessagesToCompletionTransformationHandler()
+
+    completion_kwargs, _ = handler._prepare_completion_kwargs(
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello"}],
+        model="azure/my-deployment",
+        extra_kwargs={
+            "output_config": {"effort": "standard"},
+        },
+    )
+
+    # output_config should NOT be present in the completion kwargs
+    assert "output_config" not in completion_kwargs, (
+        "output_config should be excluded from completion kwargs when translating "
+        "Anthropic messages to OpenAI format. Non-Anthropic providers reject this "
+        "Anthropic-specific parameter."
+    )
+
+
+def test_anthropic_messages_excluded_from_completion_kwargs():
+    """
+    Verify that `anthropic_messages` is also excluded (existing behavior).
+    """
+    handler = LiteLLMMessagesToCompletionTransformationHandler()
+
+    completion_kwargs, _ = handler._prepare_completion_kwargs(
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello"}],
+        model="azure/my-deployment",
+        extra_kwargs={
+            "anthropic_messages": [{"role": "user", "content": "test"}],
+        },
+    )
+
+    assert "anthropic_messages" not in completion_kwargs
+
+
+def test_valid_extra_kwargs_still_passed_through():
+    """
+    Verify that legitimate extra kwargs that are NOT in the excluded list
+    are still passed through to completion kwargs.
+    """
+    handler = LiteLLMMessagesToCompletionTransformationHandler()
+
+    completion_kwargs, _ = handler._prepare_completion_kwargs(
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello"}],
+        model="azure/my-deployment",
+        extra_kwargs={
+            "output_config": {"effort": "standard"},  # should be excluded
+            "some_valid_param": "some_value",  # should pass through
+        },
+    )
+
+    assert "output_config" not in completion_kwargs
+    assert completion_kwargs.get("some_valid_param") == "some_value", (
+        "Valid extra kwargs should still be passed through to completion kwargs"
+    )


### PR DESCRIPTION
## Relevant issues

Related to #22963

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai`

## Type

🐛 Bug Fix

## Changes

I ran into this bug while setting up Claude Code CLI with LiteLLM proxy routing to an Azure-hosted Fireworks model (GLM-5). Requests kept failing with:

`400: Extra inputs are not permitted, field: 'output_config'`


PR #22990 fixes this in the Azure transformation layer (`gpt_transformation.py`), but I found that requests coming through the Anthropic adapter path (`POST /v1/messages` → `adapters/handler.py`) bypass that fix entirely.

In `_prepare_completion_kwargs()`, the `excluded_keys` set only contains `"anthropic_messages"`. All other Anthropic-specific params (like [output_config](cci:1://file:///c:/Users/Mujadad%20Computer/.gemini/antigravity/MR%20Azur/test_output_config_excluded.py:13:0-43:5)) pass through [extra_kwargs](cci:1://file:///c:/Users/Mujadad%20Computer/.gemini/antigravity/MR%20Azur/test_output_config_excluded.py:64:0-84:5) to non-Anthropic providers, which reject them.

**Fix:** Added `"output_config"` to `excluded_keys` in `adapters/handler.py` line 171.

**Files changed:**
- `litellm/llms/anthropic/experimental_pass_through/adapters/handler.py` — added [output_config](cci:1://file:///c:/Users/Mujadad%20Computer/.gemini/antigravity/MR%20Azur/test_output_config_excluded.py:13:0-43:5) to `excluded_keys`
- `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_output_config_excluded.py` — 3 unit tests

## Test plan

- [x] 3 unit tests pass — verifying [output_config](cci:1://file:///c:/Users/Mujadad%20Computer/.gemini/antigravity/MR%20Azur/test_output_config_excluded.py:13:0-43:5) exclusion, existing [anthropic_messages](cci:1://file:///c:/Users/Mujadad%20Computer/.gemini/antigravity/MR%20Azur/test_output_config_excluded.py:46:0-61:56) exclusion preserved, and valid kwargs still pass through


