### PR TITLE
Flaky test analysis

### DIFF
--- a/tests/logging_callback_tests/conftest.py
+++ b/tests/logging_callback_tests/conftest.py
@@ -76,6 +76,26 @@ def isolate_litellm_state():
         if hasattr(litellm, attr):
             setattr(litellm, attr, [])
 
+    # Reset scalar attrs to safe defaults before test.
+    # This prevents module-level assignments (e.g. `litellm.num_retries = 3`
+    # in test_langfuse_e2e_test.py) from leaking into unrelated tests running
+    # in the same xdist worker.  The save/restore above ensures the original
+    # value is put back after the test finishes.
+    _SCALAR_DEFAULTS = {
+        "num_retries": None,
+        "set_verbose": False,
+        "cache": None,
+        "turn_off_message_logging": False,
+        "redact_messages_in_exceptions": False,
+        "redact_user_api_key_info": False,
+        "s3_callback_params": None,
+        "datadog_params": None,
+        "vector_store_registry": None,
+    }
+    for attr, default_val in _SCALAR_DEFAULTS.items():
+        if hasattr(litellm, attr):
+            setattr(litellm, attr, default_val)
+
     yield
 
     # Restore all saved state

--- a/tests/logging_callback_tests/test_alerting.py
+++ b/tests/logging_callback_tests/test_alerting.py
@@ -602,6 +602,9 @@ async def test_outage_alerting_called(
 
     If multiple calls fail, outage alert is sent
     """
+    # Ensure no global retries interfere (defense-in-depth against xdist pollution)
+    litellm.num_retries = None
+
     slack_alerting = SlackAlerting(alerting=["webhook"])
 
     litellm.callbacks = [slack_alerting]
@@ -708,6 +711,9 @@ async def test_region_outage_alerting_called(
 
     If multiple calls fail, outage alert is sent
     """
+    # Ensure no global retries interfere (defense-in-depth against xdist pollution)
+    litellm.num_retries = None
+
     slack_alerting = SlackAlerting(
         alerting=["webhook"], alert_types=[AlertType.region_outage_alerts]
     )

--- a/tests/logging_callback_tests/test_amazing_s3_logs.py
+++ b/tests/logging_callback_tests/test_amazing_s3_logs.py
@@ -9,8 +9,6 @@ sys.path.insert(0, os.path.abspath("../.."))
 from litellm import completion
 import litellm
 
-litellm.num_retries = 3
-
 import time, random
 import pytest
 import boto3

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -424,6 +424,7 @@ async def test_openai_with_knowledge_base_mock_openai(setup_vector_store_registr
                     "T37J8R4WTM"
                 ],
                 client=client,
+                num_retries=0,  # Prevent retry interference from parallel tests
             )
         except Exception as e:
             print(f"Error: {e}")
@@ -497,6 +498,7 @@ async def test_openai_with_vector_store_ids_in_tool_call_mock_openai(setup_vecto
                     "vector_store_ids": ["T37J8R4WTM"]
                 }],
                 client=client,
+                num_retries=0,  # Prevent retry interference from parallel tests
             )
         except Exception as e:
             print(f"Error: {e}")
@@ -569,6 +571,7 @@ async def test_openai_with_mixed_tool_call_mock_openai(setup_vector_store_regist
                     {"type": "file_search", "vector_store_ids": ["unknownVS"]},
                 ],
                 client=client,
+                num_retries=0,  # Prevent retry interference from parallel tests
             )
         except Exception as e:
             print(f"Error: {e}")

--- a/tests/logging_callback_tests/test_custom_callback_router.py
+++ b/tests/logging_callback_tests/test_custom_callback_router.py
@@ -38,8 +38,6 @@ from litellm.integrations.custom_logger import CustomLogger
 ## 1. router.completion() + router.embeddings()
 ## 2. proxy.completions + proxy.embeddings
 
-litellm.num_retries = 0
-
 
 class CompletionCustomHandler(
     CustomLogger

--- a/tests/logging_callback_tests/test_langfuse_e2e_test.py
+++ b/tests/logging_callback_tests/test_langfuse_e2e_test.py
@@ -18,7 +18,6 @@ from litellm import completion
 from litellm.caching import InMemoryCache
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
-litellm.num_retries = 3
 litellm.success_callback = ["langfuse"]
 os.environ["LANGFUSE_DEBUG"] = "True"
 import time

--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -91,6 +91,7 @@ async def call_spend_logs_endpoint():
 LITE_LLM_ENDPOINT = "http://localhost:4000"
 
 
+@pytest.mark.flaky(retries=2, delay=5)
 @pytest.mark.asyncio()
 async def test_basic_vertex_ai_pass_through_with_spendlog():
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

<!-- e.g. "Fixes #000" -->
N/A - Addresses flaky tests identified in CircleCI pipeline `litellm_ci_optimize`.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

This PR addresses several flaky tests identified in the `litellm_ci_optimize` CircleCI pipeline.

**Root Cause:**
The primary cause of flakiness for three tests was global state pollution: module-level assignments of `litellm.num_retries = 3` in `test_langfuse_e2e_test.py` and `test_amazing_s3_logs.py` were persisting across `pytest-xdist` workers. This caused mock-based tests, which expected a single API call, to unexpectedly retry 3 times (resulting in 4 calls). The `conftest` fixture was saving and restoring this polluted value rather than resetting it.

Additionally, one E2E test (`test_basic_vertex_ai_pass_through_with_spendlog`) was inherently flaky due to its reliance on real API calls and asynchronous database flushing, making it susceptible to timing issues.

**Changes Made:**

1.  **`tests/logging_callback_tests/conftest.py`**: Modified the `isolate_litellm_state` fixture to explicitly reset global `litellm` scalar attributes (like `litellm.num_retries`) to `None` or their default safe values *before* each test, preventing state leakage.
2.  **`tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py`**: Added `num_retries=0` to `litellm.acompletion()` calls in the affected mock tests (`test_openai_with_vector_store_ids_in_tool_call_mock_openai`, `test_openai_with_mixed_tool_call_mock_openai`) as a defense-in-depth measure.
3.  **`tests/logging_callback_tests/test_alerting.py`**: Added `litellm.num_retries = None` at the start of the `test_outage_alerting_called` and `test_region_outage_alerting_called` functions for explicit state control.
4.  **`tests/pass_through_tests/test_vertex_ai.py`**: Marked `test_basic_vertex_ai_pass_through_with_spendlog` with `@pytest.mark.flaky(retries=2, delay=5)` to allow retries for this timing-sensitive E2E test.
5.  **`test_langfuse_e2e_test.py`, `test_amazing_s3_logs.py`, `test_custom_callback_router.py`**: Removed module-level `litellm.num_retries` assignments to eliminate the source of global state pollution.

These changes ensure better test isolation and address the root causes of flakiness.

<div><a href="https://cursor.com/agents/bc-fe1539b7-9b3e-4b1c-8aba-b518d272ebf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe1539b7-9b3e-4b1c-8aba-b518d272ebf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->