### PR TITLE
Refactor: Filtering beta header after transformation

### DIFF
--- a/litellm/anthropic_beta_headers_manager.py
+++ b/litellm/anthropic_beta_headers_manager.py
@@ -367,6 +367,42 @@ def update_headers_with_filtered_beta(
     return headers
 
 
+def update_request_with_filtered_beta(
+    headers: dict,
+    request_data: dict,
+    provider: str,
+) -> tuple[dict, dict]:
+    """
+    Update both headers and request body beta fields based on provider support.
+    Modifies both dicts in place and returns them.
+
+    Args:
+        headers: Request headers dict (will be modified in place)
+        request_data: Request body dict (will be modified in place)
+        provider: Provider name
+
+    Returns:
+        Tuple of (updated headers, updated request_data)
+    """
+    headers = update_headers_with_filtered_beta(headers=headers, provider=provider)
+
+    existing_body_betas = request_data.get("anthropic_beta")
+    if not existing_body_betas:
+        return headers, request_data
+
+    filtered_body_betas = filter_and_transform_beta_headers(
+        beta_headers=existing_body_betas,
+        provider=provider,
+    )
+
+    if filtered_body_betas:
+        request_data["anthropic_beta"] = filtered_body_betas
+    else:
+        request_data.pop("anthropic_beta", None)
+
+    return headers, request_data
+
+
 def get_unsupported_headers(provider: str) -> List[str]:
     """
     Get all beta headers that are unsupported by a provider (have null values in mapping).

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -23,6 +23,9 @@ import litellm
 import litellm.litellm_core_utils
 import litellm.types
 import litellm.types.utils
+from litellm.anthropic_beta_headers_manager import (
+    update_request_with_filtered_beta,
+)
 from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
 from litellm.litellm_core_utils.core_helpers import map_finish_reason
 from litellm.llms.custom_httpx.http_handler import (
@@ -58,9 +61,6 @@ from litellm.types.utils import (
 
 from ...base import BaseLLM
 from ..common_utils import AnthropicError, process_anthropic_headers
-from litellm.anthropic_beta_headers_manager import (
-    update_headers_with_filtered_beta,
-)
 from .transformation import AnthropicConfig
 
 if TYPE_CHECKING:
@@ -339,10 +339,6 @@ class AnthropicChatCompletion(BaseLLM):
             litellm_params=litellm_params,
         )
 
-        headers = update_headers_with_filtered_beta(
-            headers=headers, provider=custom_llm_provider
-        )
-
         config = ProviderConfigManager.get_provider_chat_config(
             model=model,
             provider=LlmProviders(custom_llm_provider),
@@ -358,6 +354,12 @@ class AnthropicChatCompletion(BaseLLM):
             optional_params={**optional_params, "is_vertex_request": is_vertex_request},
             litellm_params=litellm_params,
             headers=headers,
+        )
+
+        headers, data = update_request_with_filtered_beta(
+            headers=headers,
+            request_data=data,
+            provider=custom_llm_provider,
         )
 
         ## LOGGING

--- a/tests/test_litellm/test_anthropic_beta_headers_filtering.py
+++ b/tests/test_litellm/test_anthropic_beta_headers_filtering.py
@@ -17,6 +17,7 @@ import pytest
 import litellm
 from litellm.anthropic_beta_headers_manager import (
     filter_and_transform_beta_headers,
+    update_request_with_filtered_beta,
 )
 
 
@@ -115,6 +116,32 @@ class TestAnthropicBetaHeadersFiltering:
             assert (
                 unknown not in filtered
             ), f"Unknown header '{unknown}' should be filtered out for {provider}"
+
+    def test_update_request_with_filtered_beta_vertex_ai(self):
+        """Test combined filtering for both HTTP headers and request body betas."""
+        headers = {
+            "anthropic-beta": "files-api-2025-04-14,context-management-2025-06-27,code-execution-2025-05-22"
+        }
+        request_data = {
+            "anthropic_beta": [
+                "files-api-2025-04-14",
+                "context-management-2025-06-27",
+                "code-execution-2025-05-22",
+            ]
+        }
+
+        filtered_headers, filtered_request_data = update_request_with_filtered_beta(
+            headers=headers,
+            request_data=request_data,
+            provider="vertex_ai",
+        )
+
+        assert (
+            filtered_headers.get("anthropic-beta") == "context-management-2025-06-27"
+        )
+        assert filtered_request_data.get("anthropic_beta") == [
+            "context-management-2025-06-27"
+        ]
 
     @pytest.mark.asyncio
     async def test_anthropic_messages_http_headers_filtering(self):


### PR DESCRIPTION
## Relevant issues

Unsupported anthropic-beta headers sent to Vertex AI for Anthropic models
Affected versions: At least 1.82.1 (likely earlier)
Symptom:
Requests to Vertex AI Anthropic models (e.g. vertex_ai/claude-sonnet-4-6@default) fail with:
Unexpected value(s) `code-execution-2025-05-22`, `files-api-2025-04-14`
for the `anthropic-beta` header.

This happens when messages contain file IDs ("source": {"type": "file", "file_id": ...}), because LiteLLM auto-detects the feature and adds the corresponding beta headers — headers that Vertex AI does not support.

Root cause:
VertexAIAnthropicConfig.transform_request() (in litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py) builds a beta header set by calling the shared get_anthropic_beta_list() method, which unconditionally adds files-api-2025-04-14 and code-execution-2025-05-22 when file IDs are detected. This set is written directly to both data["anthropic_beta"] (request body) and headers["anthropic-beta"] (HTTP header) without passing through filter_and_transform_beta_headers().

The filtering infrastructure already exists — anthropic_beta_headers_config.json correctly marks files-api-2025-04-14 as null (unsupported) for vertex_ai, and code-execution-2025-05-22 isn't in the mapping at all (so it would also be dropped). The problem is that this filtering is never invoked on the betas generated inside transform_request():
In handler.py, update_headers_with_filtered_beta() runs before transform_request(), so its filtering gets overwritten.

In llm_http_handler.py, filtering only covers the anthropic messages pass-through path, not the standard completion path.
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix

## Changes
Moved beta header filtering to after transform_request() in:

litellm/llms/anthropic/chat/handler.py (lines 362-377) - For the Anthropic-specific handler path (which Vertex AI Claude uses)
Now:
Filter headers["anthropic-beta"] using update_headers_with_filtered_beta()
Filter data["anthropic_beta"] (request body) using filter_and_transform_beta_headers()
This ensures that all beta headers—whether user-provided or auto-detected—are filtered based on the provider's support matrix in anthropic_beta_headers_config.json, where files-api-2025-04-14 is marked as null (unsupported) for vertex_ai, and code-execution-2025-05-22 isn't in the mapping at all (so it gets dropped).


**Before**
<img width="1210" height="215" alt="image" src="https://github.com/user-attachments/assets/57ab022a-5fe2-442d-a44a-789a7c7e46cd" />

**After**
<img width="1210" height="215" alt="image" src="https://github.com/user-attachments/assets/6bd01dab-a290-4298-a32e-ca542dc93ecb" />



