### PR TITLE
fix(langsmith): avoid no running event loop during sync init

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -45,7 +45,6 @@ class LangsmithLogger(CustomBatchLogger):
         langsmith_base_url: Optional[str] = None,
         langsmith_sampling_rate: Optional[float] = None,
         langsmith_tenant_id: Optional[str] = None,
-        start_periodic_flush: bool = True,
         **kwargs,
     ):
         self.flush_lock = asyncio.Lock()
@@ -84,9 +83,7 @@ class LangsmithLogger(CustomBatchLogger):
         if _batch_size:
             self.batch_size = int(_batch_size)
         self.log_queue: List[LangsmithQueueObject] = []
-        self._flush_task: Optional[asyncio.Task[Any]] = None
-        if start_periodic_flush:
-            self._flush_task = self._start_periodic_flush_task()
+        self._flush_task: Optional[asyncio.Task[Any]] = self._start_periodic_flush_task()
 
     def _start_periodic_flush_task(self) -> Optional[asyncio.Task[Any]]:
         """Start the periodic flush task only when an event loop is already running."""
@@ -101,6 +98,9 @@ class LangsmithLogger(CustomBatchLogger):
         return loop.create_task(self.periodic_flush())
 
     def _ensure_periodic_flush_task(self) -> None:
+        # This helper is intentionally synchronous. In asyncio's cooperative
+        # execution model, there is no await between the check and assignment,
+        # so one caller cannot interleave here and create a duplicate task.
         if self._flush_task is None or self._flush_task.done():
             self._flush_task = self._start_periodic_flush_task()
 

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -45,6 +45,7 @@ class LangsmithLogger(CustomBatchLogger):
         langsmith_base_url: Optional[str] = None,
         langsmith_sampling_rate: Optional[float] = None,
         langsmith_tenant_id: Optional[str] = None,
+        start_periodic_flush: bool = True,
         **kwargs,
     ):
         self.flush_lock = asyncio.Lock()
@@ -83,7 +84,20 @@ class LangsmithLogger(CustomBatchLogger):
         if _batch_size:
             self.batch_size = int(_batch_size)
         self.log_queue: List[LangsmithQueueObject] = []
-        asyncio.create_task(self.periodic_flush())
+        if start_periodic_flush:
+            self._start_periodic_flush_task()
+
+    def _start_periodic_flush_task(self) -> Optional[asyncio.Task[Any]]:
+        """Start the periodic flush task only when an event loop is already running."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            verbose_logger.debug(
+                "Langsmith logger init: no running event loop, skipping periodic flush task startup"
+            )
+            return None
+
+        return loop.create_task(self.periodic_flush())
 
     def get_credentials_from_env(
         self,

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -84,8 +84,9 @@ class LangsmithLogger(CustomBatchLogger):
         if _batch_size:
             self.batch_size = int(_batch_size)
         self.log_queue: List[LangsmithQueueObject] = []
+        self._flush_task: Optional[asyncio.Task[Any]] = None
         if start_periodic_flush:
-            self._start_periodic_flush_task()
+            self._flush_task = self._start_periodic_flush_task()
 
     def _start_periodic_flush_task(self) -> Optional[asyncio.Task[Any]]:
         """Start the periodic flush task only when an event loop is already running."""
@@ -98,6 +99,10 @@ class LangsmithLogger(CustomBatchLogger):
             return None
 
         return loop.create_task(self.periodic_flush())
+
+    def _ensure_periodic_flush_task(self) -> None:
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = self._start_periodic_flush_task()
 
     def get_credentials_from_env(
         self,
@@ -269,6 +274,7 @@ class LangsmithLogger(CustomBatchLogger):
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
+            self._ensure_periodic_flush_task()
             sampling_rate = self._get_sampling_rate_to_use_for_request(kwargs=kwargs)
             random_sample = random.random()
             if random_sample > sampling_rate:
@@ -310,6 +316,7 @@ class LangsmithLogger(CustomBatchLogger):
             )
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self._ensure_periodic_flush_task()
         sampling_rate = self._get_sampling_rate_to_use_for_request(kwargs=kwargs)
         random_sample = random.random()
         if random_sample > sampling_rate:

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -316,18 +316,18 @@ class LangsmithLogger(CustomBatchLogger):
             )
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
-        self._ensure_periodic_flush_task()
-        sampling_rate = self._get_sampling_rate_to_use_for_request(kwargs=kwargs)
-        random_sample = random.random()
-        if random_sample > sampling_rate:
-            verbose_logger.info(
-                "Skipping Langsmith logging. Sampling rate={}, random_sample={}".format(
-                    sampling_rate, random_sample
-                )
-            )
-            return  # Skip logging
-        verbose_logger.info("Langsmith Failure Event Logging!")
         try:
+            self._ensure_periodic_flush_task()
+            sampling_rate = self._get_sampling_rate_to_use_for_request(kwargs=kwargs)
+            random_sample = random.random()
+            if random_sample > sampling_rate:
+                verbose_logger.info(
+                    "Skipping Langsmith logging. Sampling rate={}, random_sample={}".format(
+                        sampling_rate, random_sample
+                    )
+                )
+                return  # Skip logging
+            verbose_logger.info("Langsmith Failure Event Logging!")
             credentials = self._get_credentials_to_use_for_request(kwargs=kwargs)
             data = self._prepare_log_data(
                 kwargs=kwargs,

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -132,3 +132,17 @@ class TestLangsmithLoggerInit:
         assert (
             logger.sampling_rate >= 0.0
         ), f"sampling_rate should be non-negative, got {logger.sampling_rate}"
+
+    @patch("asyncio.create_task")
+    @patch("asyncio.get_running_loop", side_effect=RuntimeError("no running event loop"))
+    def test_langsmith_init_skips_periodic_flush_without_running_loop(
+        self, mock_get_running_loop, mock_create_task
+    ):
+        """Test that sync initialization does not try to create async tasks without a running loop."""
+        logger = LangsmithLogger(
+            langsmith_api_key="test-key", langsmith_project="test-project"
+        )
+
+        assert logger is not None
+        assert mock_get_running_loop.call_count >= 1
+        mock_create_task.assert_not_called()

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -181,3 +181,23 @@ class TestLangsmithLoggerInit:
 
         logger._start_periodic_flush_task.assert_called_once()
         assert len(logger.log_queue) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_log_failure_event_lazily_starts_periodic_flush(self):
+        """Test that async failure logging lazily starts periodic flush after sync init."""
+        logger = LangsmithLogger(
+            langsmith_api_key="test-key",
+            langsmith_project="test-project",
+            start_periodic_flush=False,
+        )
+        logger._get_sampling_rate_to_use_for_request = MagicMock(return_value=1.0)
+        logger._get_credentials_to_use_for_request = MagicMock(
+            return_value=logger.default_credentials
+        )
+        logger._prepare_log_data = MagicMock(return_value={"id": "run-id"})
+        logger._start_periodic_flush_task = MagicMock(return_value=MagicMock())
+
+        await logger.async_log_failure_event({}, {}, None, None)
+
+        logger._start_periodic_flush_task.assert_called_once()
+        assert len(logger.log_queue) == 1

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -132,11 +132,11 @@ class TestLangsmithLoggerInit:
         self, mock_get_running_loop
     ):
         """Test that helper returns None when no running event loop exists."""
-        logger = LangsmithLogger(
-            langsmith_api_key="test-key",
-            langsmith_project="test-project",
-            start_periodic_flush=False,
-        )
+        with patch.object(LangsmithLogger, "_start_periodic_flush_task", return_value=None):
+            logger = LangsmithLogger(
+                langsmith_api_key="test-key",
+                langsmith_project="test-project",
+            )
 
         mock_get_running_loop.reset_mock()
 
@@ -165,11 +165,11 @@ class TestLangsmithLoggerInit:
     @pytest.mark.asyncio
     async def test_async_log_success_event_lazily_starts_periodic_flush(self):
         """Test that async logging lazily starts periodic flush after sync init."""
-        logger = LangsmithLogger(
-            langsmith_api_key="test-key",
-            langsmith_project="test-project",
-            start_periodic_flush=False,
-        )
+        with patch.object(LangsmithLogger, "_start_periodic_flush_task", return_value=None):
+            logger = LangsmithLogger(
+                langsmith_api_key="test-key",
+                langsmith_project="test-project",
+            )
         logger._get_sampling_rate_to_use_for_request = MagicMock(return_value=1.0)
         logger._get_credentials_to_use_for_request = MagicMock(
             return_value=logger.default_credentials
@@ -185,11 +185,11 @@ class TestLangsmithLoggerInit:
     @pytest.mark.asyncio
     async def test_async_log_failure_event_lazily_starts_periodic_flush(self):
         """Test that async failure logging lazily starts periodic flush after sync init."""
-        logger = LangsmithLogger(
-            langsmith_api_key="test-key",
-            langsmith_project="test-project",
-            start_periodic_flush=False,
-        )
+        with patch.object(LangsmithLogger, "_start_periodic_flush_task", return_value=None):
+            logger = LangsmithLogger(
+                langsmith_api_key="test-key",
+                langsmith_project="test-project",
+            )
         logger._get_sampling_rate_to_use_for_request = MagicMock(return_value=1.0)
         logger._get_credentials_to_use_for_request = MagicMock(
             return_value=logger.default_credentials

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -114,18 +114,34 @@ class TestLangsmithLoggerInit:
             logger.sampling_rate >= 0.0
         ), f"sampling_rate should be non-negative, got {logger.sampling_rate}"
 
-    @patch("asyncio.get_running_loop", side_effect=RuntimeError("no running event loop"))
+    @patch.object(LangsmithLogger, "_start_periodic_flush_task", return_value=None)
     def test_langsmith_init_skips_periodic_flush_without_running_loop(
-        self, mock_get_running_loop
+        self, mock_start_periodic_flush_task
     ):
-        """Test that sync initialization does not try to create async tasks without a running loop."""
+        """Test that sync initialization leaves the periodic flush task unset."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
         )
 
         assert logger is not None
-        assert mock_get_running_loop.call_count >= 1
+        mock_start_periodic_flush_task.assert_called_once()
         assert logger._flush_task is None
+
+    @patch("asyncio.get_running_loop", side_effect=RuntimeError("no running event loop"))
+    def test_start_periodic_flush_task_returns_none_without_running_loop(
+        self, mock_get_running_loop
+    ):
+        """Test that helper returns None when no running event loop exists."""
+        logger = LangsmithLogger(
+            langsmith_api_key="test-key",
+            langsmith_project="test-project",
+            start_periodic_flush=False,
+        )
+
+        mock_get_running_loop.reset_mock()
+
+        assert logger._start_periodic_flush_task() is None
+        mock_get_running_loop.assert_called_once()
 
     @patch("asyncio.get_running_loop")
     def test_langsmith_init_starts_periodic_flush_with_running_loop(

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -16,13 +16,9 @@ class TestLangsmithLoggerInit:
     Note: The current implementation has some edge cases in the sampling rate logic.
     """
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {"LANGSMITH_SAMPLING_RATE": "1"}, clear=False)
-    def test_langsmith_sampling_rate_parameter_respected_with_valid_env(
-        self, mock_create_task
-    ):
+    def test_langsmith_sampling_rate_parameter_respected_with_valid_env(self):
         """Test that langsmith_sampling_rate parameter is properly set when env var condition is met."""
-        # When there's a valid integer in env var, the parameter should be used due to 'or' logic
         sampling_rate = 0.5
         logger = LangsmithLogger(
             langsmith_api_key="test-key",
@@ -30,58 +26,47 @@ class TestLangsmithLoggerInit:
             langsmith_sampling_rate=sampling_rate,
         )
 
-        # With the current 'or' logic and valid env var, the parameter should be used
         assert (
             logger.sampling_rate == sampling_rate
         ), f"Expected sampling_rate to be {sampling_rate}, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {"LANGSMITH_SAMPLING_RATE": "1"}, clear=False)
-    def test_langsmith_sampling_rate_zero_parameter_falls_back_to_env(
-        self, mock_create_task
-    ):
+    def test_langsmith_sampling_rate_zero_parameter_falls_back_to_env(self):
         """Test that 0.0 parameter falls back to env var due to falsy value."""
-        # This demonstrates the current behavior where 0.0 is falsy and falls back to env
         logger = LangsmithLogger(
             langsmith_api_key="test-key",
             langsmith_project="test-project",
-            langsmith_sampling_rate=0.0,  # This is falsy!
+            langsmith_sampling_rate=0.0,
         )
 
-        # Due to current 'or' logic, 0.0 falls back to env var
         assert (
             logger.sampling_rate == 1.0
         ), f"Expected sampling_rate to fall back to 1.0 from env, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {"LANGSMITH_SAMPLING_RATE": "1"}, clear=False)
-    def test_langsmith_sampling_rate_from_integer_env_var(self, mock_create_task):
+    def test_langsmith_sampling_rate_from_integer_env_var(self):
         """Test that sampling rate uses environment variable when parameter not provided and env var is integer."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
         )
 
-        # Should use env var since it's a valid integer
         assert (
             logger.sampling_rate == 1.0
         ), f"Expected sampling_rate to be 1.0 from env var, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {"LANGSMITH_SAMPLING_RATE": "0.8"}, clear=False)
-    def test_langsmith_sampling_rate_decimal_env_var_ignored(self, mock_create_task):
+    def test_langsmith_sampling_rate_decimal_env_var_ignored(self):
         """Test that decimal environment variables are ignored due to isdigit() check."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
         )
 
-        # Decimal env vars are ignored due to isdigit() check, falls back to 1.0
         assert (
             logger.sampling_rate == 1.0
         ), f"Expected sampling_rate to default to 1.0 (decimal env ignored), got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {}, clear=True)
-    def test_langsmith_sampling_rate_default_value(self, mock_create_task):
+    def test_langsmith_sampling_rate_default_value(self):
         """Test that sampling rate defaults to 1.0 when no parameter or env var provided."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
@@ -91,9 +76,8 @@ class TestLangsmithLoggerInit:
             logger.sampling_rate == 1.0
         ), f"Expected default sampling_rate to be 1.0, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {"LANGSMITH_SAMPLING_RATE": "invalid"}, clear=False)
-    def test_langsmith_sampling_rate_invalid_env_var_defaults(self, mock_create_task):
+    def test_langsmith_sampling_rate_invalid_env_var_defaults(self):
         """Test that invalid environment variable falls back to default value."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
@@ -103,9 +87,8 @@ class TestLangsmithLoggerInit:
             logger.sampling_rate == 1.0
         ), f"Expected sampling_rate to default to 1.0 with invalid env var, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch.dict(os.environ, {"LANGSMITH_SAMPLING_RATE": ""}, clear=False)
-    def test_langsmith_sampling_rate_empty_env_var_defaults(self, mock_create_task):
+    def test_langsmith_sampling_rate_empty_env_var_defaults(self):
         """Test that empty environment variable falls back to default value."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
@@ -115,14 +98,12 @@ class TestLangsmithLoggerInit:
             logger.sampling_rate == 1.0
         ), f"Expected sampling_rate to default to 1.0 with empty env var, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
-    def test_langsmith_sampling_rate_attribute_exists(self, mock_create_task):
+    def test_langsmith_sampling_rate_attribute_exists(self):
         """Test that the sampling_rate attribute is always set on the logger instance."""
         logger = LangsmithLogger(
             langsmith_api_key="test-key", langsmith_project="test-project"
         )
 
-        # Verify the attribute exists and is a float
         assert hasattr(
             logger, "sampling_rate"
         ), "LangsmithLogger should have sampling_rate attribute"
@@ -133,10 +114,9 @@ class TestLangsmithLoggerInit:
             logger.sampling_rate >= 0.0
         ), f"sampling_rate should be non-negative, got {logger.sampling_rate}"
 
-    @patch("asyncio.create_task")
     @patch("asyncio.get_running_loop", side_effect=RuntimeError("no running event loop"))
     def test_langsmith_init_skips_periodic_flush_without_running_loop(
-        self, mock_get_running_loop, mock_create_task
+        self, mock_get_running_loop
     ):
         """Test that sync initialization does not try to create async tasks without a running loop."""
         logger = LangsmithLogger(
@@ -145,4 +125,43 @@ class TestLangsmithLoggerInit:
 
         assert logger is not None
         assert mock_get_running_loop.call_count >= 1
-        mock_create_task.assert_not_called()
+        assert logger._flush_task is None
+
+    @patch("asyncio.get_running_loop")
+    def test_langsmith_init_starts_periodic_flush_with_running_loop(
+        self, mock_get_running_loop
+    ):
+        """Test that init schedules periodic flush when a running loop exists."""
+        mock_loop = MagicMock()
+        mock_task = MagicMock()
+        mock_loop.create_task.return_value = mock_task
+        mock_get_running_loop.return_value = mock_loop
+
+        logger = LangsmithLogger(
+            langsmith_api_key="test-key", langsmith_project="test-project"
+        )
+
+        assert logger._flush_task == mock_task
+        mock_loop.create_task.assert_called_once()
+        scheduled_coro = mock_loop.create_task.call_args.args[0]
+        scheduled_coro.close()
+
+    @pytest.mark.asyncio
+    async def test_async_log_success_event_lazily_starts_periodic_flush(self):
+        """Test that async logging lazily starts periodic flush after sync init."""
+        logger = LangsmithLogger(
+            langsmith_api_key="test-key",
+            langsmith_project="test-project",
+            start_periodic_flush=False,
+        )
+        logger._get_sampling_rate_to_use_for_request = MagicMock(return_value=1.0)
+        logger._get_credentials_to_use_for_request = MagicMock(
+            return_value=logger.default_credentials
+        )
+        logger._prepare_log_data = MagicMock(return_value={"id": "run-id"})
+        logger._start_periodic_flush_task = MagicMock(return_value=MagicMock())
+
+        await logger.async_log_success_event({}, {}, None, None)
+
+        logger._start_periodic_flush_task.assert_called_once()
+        assert len(logger.log_queue) == 1


### PR DESCRIPTION
## Summary

Fixes #23733.

Fix the LangSmith logger init path for synchronous callers.

Today `LangsmithLogger.__init__()` always calls `asyncio.create_task(self.periodic_flush())`. When LiteLLM is initialized from a synchronous path, there is no running event loop yet, so logger startup raises `RuntimeError: no running event loop`.

This change starts the periodic flush task only when an event loop is already running. In sync contexts, logger initialization now stays safe and non-blocking instead of raising during setup.

## Root cause

`asyncio.create_task()` requires an active running loop in the current thread. `LangsmithLogger` was calling it unconditionally during object construction.

## Fix

- add a small `_start_periodic_flush_task()` helper
- use `asyncio.get_running_loop()` to detect whether task startup is safe
- lazily start periodic flushing from async logging paths when needed
- keep the behavior unchanged when LiteLLM is initialized inside an async context
- keep the task startup control internal instead of exposing a public test-only constructor flag

## Test plan

- added regression coverage for:
  - init without a running loop
  - init with a running loop
  - lazy startup from `async_log_success_event`
  - lazy startup from `async_log_failure_event`
- `uv run pytest tests/test_litellm/integrations/test_langsmith_init.py -q`
- `uv run pytest tests/logging_callback_tests/test_langsmith_unit_test.py -q`

## Context

This is related to earlier reports around LangSmith sync initialization and event-loop handling:
- #6861
- #14112
