### PR TITLE
fix(anthropic): strip vector_store_ids from request payload to prevent 400 error

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1419,6 +1419,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         # Remove internal LiteLLM parameters that should not be sent to Anthropic API
         optional_params.pop("is_vertex_request", None)
+        optional_params.pop("vector_store_ids", None)
+        optional_params.pop("vector_store_id", None)
 
         data = {
             "model": model,

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3233,91 +3233,44 @@ def test_map_tool_helper_enforces_object_type_when_missing():
     result, _ = config._map_tool_helper(tool)
     assert result is not None
     assert result["input_schema"]["type"] == "object"
-    assert "properties" in result["input_schema"]
-    assert "query" in result["input_schema"]["properties"]
-    # Original parameters dict must not be modified in place
-    assert tool["function"]["parameters"] == original_params, (
-        "parameters dict was mutated; _map_tool_helper should not modify caller data"
-    )
-
-
-def test_map_tool_helper_enforces_object_type_when_wrong_type():
-    """
-    If a tool schema has type:"string" or type:"array" at the root level,
-    LiteLLM should normalize it to type:"object" for Anthropic compatibility.
-    """
-    config = AnthropicConfig()
-
-    tool = {
-        "type": "function",
-        "function": {
-            "name": "echo",
-            "description": "Echo input",
-            "parameters": {
-                "type": "string",
-                "description": "The input to echo",
-            },
-        },
-    }
-
-    original_params = tool["function"]["parameters"].copy()
-    result, _ = config._map_tool_helper(tool)
-    assert result is not None
-    assert result["input_schema"]["type"] == "object"
-    assert result["input_schema"].get("properties") == {}, (
-        "properties should be injected as {} when schema has non-object type and no properties key"
-    )
-    # Original parameters dict must not be modified in place
-    assert tool["function"]["parameters"] == original_params, (
-        "parameters dict was mutated; _map_tool_helper should not modify caller data"
-    )
-
-
-def test_map_tool_helper_preserves_valid_object_schema():
-    """
-    When a tool schema already has type:"object", it should be preserved
-    without modification.
-    """
-    config = AnthropicConfig()
-
-    tool = {
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "city": {"type": "string"},
-                },
-                "required": ["city"],
-            },
-        },
-    }
-
-    result, _ = config._map_tool_helper(tool)
-    assert result is not None
-    assert result["input_schema"]["type"] == "object"
-    assert "city" in result["input_schema"]["properties"]
-    assert result["input_schema"]["required"] == ["city"]
-
-
-def test_map_tool_helper_empty_parameters_get_default():
-    """
-    When parameters is entirely missing, the existing default should still
-    produce a valid {type:"object", properties:{}} schema.
-    """
-    config = AnthropicConfig()
-
-    tool = {
-        "type": "function",
-        "function": {
-            "name": "no_params_tool",
-            "description": "Tool with no parameters",
-        },
-    }
-
-    result, _ = config._map_tool_helper(tool)
-    assert result is not None
-    assert result["input_schema"]["type"] == "object"
     assert result["input_schema"].get("properties") == {}
+
+
+def test_transform_request_strips_vector_store_ids():
+    config = AnthropicConfig()
+    messages = [{"role": "user", "content": "Hello"}]
+    optional_params = {
+        "vector_store_ids": ["vs_abc123", "vs_def456"],
+        "vector_store_id": "vs_abc123",
+        "max_tokens": 100,
+    }
+
+    data = config.transform_request(
+        model="claude-3-5-sonnet-20240620",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "vector_store_ids" not in data
+    assert "vector_store_id" not in data
+    assert data["max_tokens"] == 100
+
+
+def test_transform_request_strips_vector_store_ids_when_absent():
+    config = AnthropicConfig()
+    messages = [{"role": "user", "content": "Hello"}]
+    optional_params = {"max_tokens": 50}
+
+    data = config.transform_request(
+        model="claude-3-5-sonnet-20240620",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "vector_store_ids" not in data
+    assert "vector_store_id" not in data
+    assert data["max_tokens"] == 50

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3233,6 +3233,93 @@ def test_map_tool_helper_enforces_object_type_when_missing():
     result, _ = config._map_tool_helper(tool)
     assert result is not None
     assert result["input_schema"]["type"] == "object"
+    assert "properties" in result["input_schema"]
+    assert "query" in result["input_schema"]["properties"]
+    # Original parameters dict must not be modified in place
+    assert tool["function"]["parameters"] == original_params, (
+        "parameters dict was mutated; _map_tool_helper should not modify caller data"
+    )
+
+
+def test_map_tool_helper_enforces_object_type_when_wrong_type():
+    """
+    If a tool schema has type:"string" or type:"array" at the root level,
+    LiteLLM should normalize it to type:"object" for Anthropic compatibility.
+    """
+    config = AnthropicConfig()
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Echo input",
+            "parameters": {
+                "type": "string",
+                "description": "The input to echo",
+            },
+        },
+    }
+
+    original_params = tool["function"]["parameters"].copy()
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
+    assert result["input_schema"].get("properties") == {}, (
+        "properties should be injected as {} when schema has non-object type and no properties key"
+    )
+    # Original parameters dict must not be modified in place
+    assert tool["function"]["parameters"] == original_params, (
+        "parameters dict was mutated; _map_tool_helper should not modify caller data"
+    )
+
+
+def test_map_tool_helper_preserves_valid_object_schema():
+    """
+    When a tool schema already has type:"object", it should be preserved
+    without modification.
+    """
+    config = AnthropicConfig()
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+                "required": ["city"],
+            },
+        },
+    }
+
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
+    assert "city" in result["input_schema"]["properties"]
+    assert result["input_schema"]["required"] == ["city"]
+
+
+def test_map_tool_helper_empty_parameters_get_default():
+    """
+    When parameters is entirely missing, the existing default should still
+    produce a valid {type:"object", properties:{}} schema.
+    """
+    config = AnthropicConfig()
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "no_params_tool",
+            "description": "Tool with no parameters",
+        },
+    }
+
+    result, _ = config._map_tool_helper(tool)
+    assert result is not None
+    assert result["input_schema"]["type"] == "object"
     assert result["input_schema"].get("properties") == {}
 
 


### PR DESCRIPTION
## Summary

- Strip `vector_store_ids` and `vector_store_id` from `optional_params` in `AnthropicConfig.transform_request()` before building the final request payload
- These are OpenAI Assistants API parameters injected by LiteLLM proxy for internal RBAC/vector-store hooks — Anthropic rejects them with `400: Extra inputs are not permitted`
- Adds 2 unit tests covering both the stripping behavior and the no-op case

## Problem

`AnthropicConfig.transform_request()` builds the Anthropic payload via `**optional_params`. LiteLLM proxy injects `vector_store_ids` into the request body for internal pre-call hooks (`proxy/auth/auth_checks.py`, `http_parsing_utils.py`). This parameter leaks through to Anthropic, causing:

```
AnthropicException - {"type":"error","error":{"type":"invalid_request_error","message":"vector_store_ids: Extra inputs are not permitted"}}
```

`is_vertex_request` was already being stripped at this same location — this PR extends that pattern to cover `vector_store_ids` and `vector_store_id`.

## Changes

- `litellm/llms/anthropic/chat/transformation.py`: pop `vector_store_ids` and `vector_store_id` before `data = {..., **optional_params}`
- `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py`: 2 new mock-only tests

## Related

Fixes #23741

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem