### PR TITLE
fix: Register DynamoAI guardrail initializer and enum entry

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/dynamoai/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/dynamoai/__init__.py
@@ -1,3 +1,34 @@
+from typing import TYPE_CHECKING
+
+from litellm.types.guardrails import SupportedGuardrailIntegrations
+
 from .dynamoai import DynamoAIGuardrails
 
-__all__ = ["DynamoAIGuardrails"]
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
+    import litellm
+    from litellm.proxy.guardrails.guardrail_hooks.dynamoai import DynamoAIGuardrails
+
+    _dynamoai_callback = DynamoAIGuardrails(
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+        guardrail_name=guardrail.get("guardrail_name", ""),
+        event_hook=litellm_params.mode,
+        default_on=litellm_params.default_on,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(_dynamoai_callback)
+
+    return _dynamoai_callback
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.DYNAMOAI.value: initialize_guardrail,
+}
+
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.DYNAMOAI.value: DynamoAIGuardrails,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/dynamoai/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/dynamoai/__init__.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 
 def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
     import litellm
-    _dynamoai_callback = DynamoAIGuardrails(
 
     _dynamoai_callback = DynamoAIGuardrails(
         api_base=litellm_params.api_base,

--- a/litellm/proxy/guardrails/guardrail_hooks/dynamoai/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/dynamoai/__init__.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
     import litellm
-    from litellm.proxy.guardrails.guardrail_hooks.dynamoai import DynamoAIGuardrails
+    _dynamoai_callback = DynamoAIGuardrails(
 
     _dynamoai_callback = DynamoAIGuardrails(
         api_base=litellm_params.api_base,

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -44,6 +44,7 @@ guardrails:
 class SupportedGuardrailIntegrations(Enum):
     APORIA = "aporia"
     BEDROCK = "bedrock"
+    DYNAMOAI = "dynamoai"
     GUARDRAILS_AI = "guardrails_ai"
     LAKERA = "lakera"
     LAKERA_V2 = "lakera_v2"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_dynamoai.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_dynamoai.py
@@ -1,0 +1,81 @@
+"""
+Tests for DynamoAI guardrail registration and initialization.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestDynamoAIGuardrailRegistration:
+    """Tests for DynamoAI guardrail registration in the guardrail system."""
+
+    def test_supported_guardrail_enum_entry(self):
+        """Test that DYNAMOAI is in SupportedGuardrailIntegrations enum."""
+        from litellm.types.guardrails import SupportedGuardrailIntegrations
+
+        assert hasattr(SupportedGuardrailIntegrations, "DYNAMOAI")
+        assert SupportedGuardrailIntegrations.DYNAMOAI.value == "dynamoai"
+
+    def test_initialize_guardrail_function_exists(self):
+        """Test that initialize_guardrail function is properly exported."""
+        from litellm.proxy.guardrails.guardrail_hooks.dynamoai import (
+            guardrail_initializer_registry,
+            initialize_guardrail,
+        )
+
+        assert initialize_guardrail is not None
+        assert "dynamoai" in guardrail_initializer_registry
+
+    def test_guardrail_class_registry_exists(self):
+        """Test that guardrail_class_registry is properly exported."""
+        from litellm.proxy.guardrails.guardrail_hooks.dynamoai import (
+            guardrail_class_registry,
+        )
+        from litellm.proxy.guardrails.guardrail_hooks.dynamoai.dynamoai import (
+            DynamoAIGuardrails,
+        )
+
+        assert "dynamoai" in guardrail_class_registry
+        assert guardrail_class_registry["dynamoai"] == DynamoAIGuardrails
+
+    def test_initialize_guardrail_creates_instance(self):
+        """Test that initialize_guardrail creates a DynamoAIGuardrails instance."""
+        from litellm.proxy.guardrails.guardrail_hooks.dynamoai import (
+            initialize_guardrail,
+        )
+        from litellm.proxy.guardrails.guardrail_hooks.dynamoai.dynamoai import (
+            DynamoAIGuardrails,
+        )
+        from litellm.types.guardrails import LitellmParams
+
+        litellm_params = LitellmParams(
+            guardrail="dynamoai",
+            mode="pre_call",
+            api_key="test-key",
+            api_base="https://test.dynamo.ai",
+        )
+
+        guardrail = {
+            "guardrail_name": "test-dynamoai-guard",
+        }
+
+        with patch(
+            "litellm.logging_callback_manager.add_litellm_callback"
+        ) as mock_add:
+            result = initialize_guardrail(litellm_params, guardrail)
+
+            assert isinstance(result, DynamoAIGuardrails)
+            assert result.api_key == "test-key"
+            assert result.api_base == "https://test.dynamo.ai"
+            assert result.guardrail_name == "test-dynamoai-guard"
+            mock_add.assert_called_once_with(result)
+
+    def test_dynamoai_in_global_registry(self):
+        """Test that dynamoai is discoverable in the global guardrail registry."""
+        from litellm.proxy.guardrails.guardrail_registry import (
+            guardrail_initializer_registry,
+        )
+
+        assert "dynamoai" in guardrail_initializer_registry


### PR DESCRIPTION
## Summary

Fixes #22773 — DynamoAI guardrail now properly registers with the initialization system, resolving the "Unsupported guardrail: dynamoai" error.

## Changes

1. Added `DYNAMOAI = "dynamoai"` to `SupportedGuardrailIntegrations` enum
2. Implemented `initialize_guardrail()` function in `dynamoai/__init__.py`
3. Added `guardrail_initializer_registry` and `guardrail_class_registry` for proper registration

The DynamoAI guardrail was added in PR #15920 but was never wired into the registration system. The dynamic discovery mechanism at module load time looks for `guardrail_initializer_registry` in each guardrail hook's `__init__.py` — DynamoAI was missing this, causing lookups to fail.

🐛 Bug Fix