### PR TITLE
fix: Remove trailing slash redirect for /mcp route

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2541,6 +2541,10 @@ if MCP_AVAILABLE:
 
     # Mount the MCP handlers
     app.mount("/", handle_streamable_http_mcp)
+    # Add explicit route for /mcp (without trailing slash) to avoid 307 redirect
+    # which disrupts MCP client connections (e.g., Claude Code)
+    # See: https://github.com/BerriAI/litellm/issues/23688
+    app.add_route("/mcp", handle_streamable_http_mcp, methods=["POST", "GET", "PUT", "DELETE", "OPTIONS"])
     app.mount("/mcp", handle_streamable_http_mcp)
     app.mount("/{mcp_server_name}/mcp", handle_streamable_http_mcp)
     app.mount("/sse", handle_sse_mcp)

--- a/tests/mcp_tests/test_mcp_route_redirect_fix.py
+++ b/tests/mcp_tests/test_mcp_route_redirect_fix.py
@@ -1,0 +1,45 @@
+"""
+Test for /mcp route 307 redirect fix
+See: https://github.com/BerriAI/litellm/issues/23688
+"""
+import os
+import re
+
+
+def test_mcp_route_fix_in_source_code():
+    """
+    Verify that the fix is present in the source code by checking
+    that app.add_route("/mcp", ...) is called before app.mount("/mcp", ...)
+    
+    This fixes the issue where clients accessing /mcp (without trailing slash)
+    would receive a 307 redirect to /mcp/, disrupting MCP client connections.
+    
+    See: https://github.com/BerriAI/litellm/issues/23688
+    """
+    # Get the path to the server.py file - use cwd as starting point
+    server_file = "litellm/proxy/_experimental/mcp_server/server.py"
+    
+    assert os.path.exists(server_file), f"Server file not found: {server_file}"
+    
+    with open(server_file, "r") as f:
+        content = f.read()
+    
+    # Check for the explicit route registration for /mcp
+    add_route_pattern = r'app\.add_route\s*\(\s*["\']?/mcp["\']?'
+    assert re.search(add_route_pattern, content), \
+        "Fix not found: app.add_route('/mcp', ...) should be present in server.py"
+    
+    # Check for the issue reference comment
+    assert "23688" in content, \
+        "Issue reference #23688 should be present in the code comments"
+    
+    # Verify the route is added before the mount to ensure it takes precedence
+    add_route_pos = content.find('app.add_route("/mcp"')
+    mount_pos = content.find('app.mount("/mcp"')
+    assert add_route_pos > 0 and mount_pos > 0 and add_route_pos < mount_pos, \
+        "app.add_route('/mcp', ...) should come before app.mount('/mcp', ...)"
+
+
+if __name__ == "__main__":
+    test_mcp_route_fix_in_source_code()
+    print("All tests passed!")


### PR DESCRIPTION
## Issue

When accessing the MCP endpoint at `/mcp` (without trailing slash), FastAPI performs a 307 redirect to `/mcp/`. This trailing slash redirect disrupts MCP client connections, specifically causing problems when accessed by applications like Claude Code.

Fixes #23688

## Root Cause

FastAPI/Starlette's `app.mount()` behavior automatically redirects requests from the mounted path without trailing slash to the path with trailing slash using a 307 Temporary Redirect status code. While this is standard web behavior, MCP clients don't always handle redirects correctly, especially for POST requests.

## Fix

Add an explicit route handler for `/mcp` (without trailing slash) before the mount registration. This ensures requests to `/mcp` are handled directly without the 307 redirect.

### Changes
- Added `app.add_route("/mcp", handle_streamable_http_mcp, methods=[...])` before `app.mount("/mcp", ...)` in `litellm/proxy/_experimental/mcp_server/server.py`

### Testing
- Added test `test_mcp_route_redirect_fix.py` to verify the fix is present in the source code
- Verified that the explicit route registration comes before the mount to ensure correct precedence

## Verification

The fix can be verified by:
1. Sending a POST request to `/mcp` (without trailing slash)
2. Confirming it receives a 200 OK response instead of a 307 redirect

---
*This contribution is submitted by an AI agent operating autonomously.*
