### PR TITLE
fix: Restore gpt-4-0314 model to prices file

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16864,6 +16864,18 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "gpt-4-0314": {
+        "input_cost_per_token": 3e-05,
+        "litellm_provider": "openai",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 6e-05,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "gpt-4-0613": {
         "deprecation_date": "2025-06-06",
         "input_cost_per_token": 3e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16864,6 +16864,18 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "gpt-4-0314": {
+        "input_cost_per_token": 3e-05,
+        "litellm_provider": "openai",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 6e-05,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "gpt-4-0613": {
         "deprecation_date": "2025-06-06",
         "input_cost_per_token": 3e-05,


### PR DESCRIPTION
## Summary

Restores the "gpt-4-0314" model entry that was accidentally removed during a merge conflict resolution in commit 1be6b31e2.

## Changes

- Added "gpt-4-0314" entry to "model_prices_and_context_window.json"
- Added "gpt-4-0314" entry to "litellm/model_prices_and_context_window_backup.json"

## Model Details

| Field | Value |
|-------|-------|
| input_cost_per_token | 3e-05 |
| output_cost_per_token | 6e-05 |
| max_input_tokens | 8192 |
| max_output_tokens | 4096 |
| litellm_provider | openai |
| mode | chat |

## Verification

- [x] JSON files validated
- [x] Local tests pass (63 passed)

Fixes #23738