### PR TITLE
fix(model-pricing): remove audio from gemini-2.5-flash-image input modalities

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13492,7 +13492,6 @@
         "supported_modalities": [
             "text",
             "image",
-            "audio",
             "video"
         ],
         "supported_output_modalities": [
@@ -14803,7 +14802,6 @@
         "supported_modalities": [
             "text",
             "image",
-            "audio",
             "video"
         ],
         "supported_output_modalities": [
@@ -30506,7 +30504,6 @@
         "supported_modalities": [
             "text",
             "image",
-            "audio",
             "video"
         ],
         "supported_output_modalities": [


### PR DESCRIPTION
## Summary

- Remove `"audio"` from `supported_modalities` for all `gemini-2.5-flash-image` model entries
- Affected entries: `gemini-2.5-flash-image`, `gemini/gemini-2.5-flash-image`, `vertex_ai/gemini-2.5-flash-image`
- `gemini-2.5-flash-image` is an image generation model and does not support audio input

## Test plan

- [x] JSON is valid after the change
- [x] Only `supported_modalities` arrays for the 3 `gemini-2.5-flash-image` entries are modified
- [x] No other entries or fields are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)