### PR TITLE
feat(ui): Add send_invite_email toggle to Invite User modal

### DIFF
--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -20,6 +20,13 @@ vi.mock("./networking", () => ({
   getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost"),
 }));
 
+vi.mock("./onboarding_link", () => ({
+  __esModule: true,
+  default: ({ isInvitationLinkModalVisible }: { isInvitationLinkModalVisible: boolean }) =>
+    isInvitationLinkModalVisible ? <div data-testid="onboarding-modal">Onboarding Modal</div> : null,
+  InvitationLink: {},
+}));
+
 vi.mock("./bulk_create_users_button", () => ({
   default: () => <div data-testid="bulk-create-users">Bulk Create Users</div>,
 }));
@@ -86,6 +93,92 @@ describe("CreateUserButton", { timeout: 20000 }, () => {
     const dialog = screen.getByRole("dialog", { name: /invite user/i });
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: /invite user/i })).toBeInTheDocument();
+  });
+
+  it("should render send invite email toggle in modal with default off", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateUserButton {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /invite user/i });
+    expect(within(dialog).getByText("Send Invite Email")).toBeInTheDocument();
+
+    const switchToggle = within(dialog).getByRole("switch");
+    expect(switchToggle).toBeInTheDocument();
+    expect(switchToggle).not.toBeChecked();
+  });
+
+  it("should pass send_invite_email true to API when toggle is on", async () => {
+    const user = userEvent.setup();
+    mockUserCreateCall.mockResolvedValue({ data: { user_id: "email-user" } });
+    mockInvitationCreateCall.mockResolvedValue({
+      id: "inv-email",
+      user_id: "email-user",
+      has_user_setup_sso: false,
+    } as any);
+
+    renderWithProviders(
+      <CreateUserButton {...defaultProps} possibleUIRoles={{ proxy_user: { ui_label: "User", description: "" } }} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /invite user/i });
+    await user.type(within(dialog).getByLabelText(/user email/i), "invite@example.com");
+
+    // Toggle the switch ON
+    const switchToggle = within(dialog).getByRole("switch");
+    await user.click(switchToggle);
+
+    await user.click(within(dialog).getByRole("combobox", { name: /global proxy role/i }));
+    await user.click(screen.getByText("User"));
+    await user.click(within(dialog).getByRole("button", { name: /invite user/i }));
+
+    await waitFor(() => {
+      expect(mockUserCreateCall).toHaveBeenCalledWith("token", null, expect.objectContaining({
+        user_email: "invite@example.com",
+        send_invite_email: true,
+      }));
+    });
+  });
+
+  it("should pass send_invite_email false to API when toggle is off", async () => {
+    const user = userEvent.setup();
+    mockUserCreateCall.mockResolvedValue({ data: { user_id: "no-email-user" } });
+    mockInvitationCreateCall.mockResolvedValue({
+      id: "inv-no-email",
+      user_id: "no-email-user",
+      has_user_setup_sso: false,
+    } as any);
+
+    renderWithProviders(
+      <CreateUserButton {...defaultProps} possibleUIRoles={{ proxy_user: { ui_label: "User", description: "" } }} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /invite user/i });
+    await user.type(within(dialog).getByLabelText(/user email/i), "noemail@example.com");
+    await user.click(within(dialog).getByRole("combobox", { name: /global proxy role/i }));
+    await user.click(screen.getByText("User"));
+    await user.click(within(dialog).getByRole("button", { name: /invite user/i }));
+
+    await waitFor(() => {
+      expect(mockUserCreateCall).toHaveBeenCalledWith("token", null, expect.objectContaining({
+        user_email: "noemail@example.com",
+        send_invite_email: false,
+      }));
+    });
   });
 
   it("should display email invitations info message in embedded mode", () => {

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -2,7 +2,7 @@ import { InfoCircleOutlined, UserAddOutlined } from "@ant-design/icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { Accordion, AccordionBody, AccordionHeader, SelectItem, TextInput } from "@tremor/react";
-import { Alert, Button, Form, Input, Modal, Select, Select as Select2, Space, Tooltip, Typography } from "antd";
+import { Alert, Button, Form, Input, Modal, Select, Select as Select2, Space, Switch, Tooltip, Typography } from "antd";
 import React, { useEffect, useMemo, useState } from "react";
 import BulkCreateUsers from "./bulk_create_users_button";
 import TeamDropdown from "./common_components/team_dropdown";
@@ -113,6 +113,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
     user_role: string;
     organization_ids?: string[];
     organizations?: string[];
+    send_invite_email?: boolean;
   }) => {
     try {
       NotificationsManager.info("Making API Call");
@@ -262,6 +263,21 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
         <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
           <Form.Item label="User Email" name="user_email">
             <Input />
+          </Form.Item>
+          <Form.Item
+            label={
+              <span>
+                Send Invite Email{" "}
+                <Tooltip title="Send an invitation email to the user with login instructions. Requires email settings to be configured.">
+                  <InfoCircleOutlined />
+                </Tooltip>
+              </span>
+            }
+            name="send_invite_email"
+            valuePropName="checked"
+            initialValue={false}
+          >
+            <Switch />
           </Form.Item>
           <Form.Item
             label={


### PR DESCRIPTION
The Invite User modal in the Admin UI was not passing send_invite_email to the /user/new API, so SMTP invitation emails were never triggered from the UI. Users had to call the API directly with send_invite_email: true as a workaround.

This adds a Switch toggle between the User Email and Global Proxy Role fields in the standalone Invite User modal. The toggle defaults to OFF and includes a tooltip explaining the email configuration requirement.

Tests added:
- Toggle renders in modal with default OFF
- send_invite_email: true passed to API when toggle is ON
- send_invite_email: false passed to API when toggle is OFF

## Relevant issues

Related to #19611 (same feature — this PR is rebased on latest main with additional test coverage)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

- **`ui/litellm-dashboard/src/components/CreateUserButton.tsx`**:
  - Added `Switch` import from antd
  - Added `send_invite_email?: boolean` to `handleCreate` form values type
  - Added `Switch` toggle (`Form.Item` with `valuePropName="checked"`, `initialValue={false}`) between "User Email" and "Global Proxy Role" fields in the standalone Invite User modal
  - Tooltip: "Send an invitation email to the user with login instructions. Requires email settings to be configured."

- **`ui/litellm-dashboard/src/components/CreateUserButton.test.tsx`**:
  - Added `onboarding_link` module mock for test isolation
  - Added test: toggle renders in modal with default OFF
  - Added test: `send_invite_email: true` passed in API call when toggle is ON
  - Added test: `send_invite_email: false` passed in API call when toggle is OFF (negative case)