### PR TITLE
fix: reserve estimated tokens at pre-call to prevent concurrent TPM bypass

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1465,9 +1465,15 @@ if TYPE_CHECKING:
     from .llms.petals.completion.transformation import PetalsConfig as PetalsConfig
     from .llms.ollama.chat.transformation import OllamaChatConfig as OllamaChatConfig
     from .llms.ollama.completion.transformation import OllamaConfig as OllamaConfig
-    from .llms.sagemaker.completion.transformation import SagemakerConfig as SagemakerConfig
-    from .llms.sagemaker.chat.transformation import SagemakerChatConfig as SagemakerChatConfig
-    from .llms.sagemaker.nova.transformation import SagemakerNovaConfig as SagemakerNovaConfig
+    from .llms.sagemaker.completion.transformation import (
+        SagemakerConfig as SagemakerConfig,
+    )
+    from .llms.sagemaker.chat.transformation import (
+        SagemakerChatConfig as SagemakerChatConfig,
+    )
+    from .llms.sagemaker.nova.transformation import (
+        SagemakerNovaConfig as SagemakerNovaConfig,
+    )
     from .llms.cohere.chat.transformation import CohereChatConfig as CohereChatConfig
     from .llms.anthropic.experimental_pass_through.messages.transformation import (
         AnthropicMessagesConfig as AnthropicMessagesConfig,

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -17,7 +17,9 @@ if set_verbose is True:
         "`litellm.set_verbose` is deprecated. Please set `os.environ['LITELLM_LOG'] = 'DEBUG'` for debug logs."
     )
 
-_ENABLE_SECRET_REDACTION = os.getenv("LITELLM_DISABLE_REDACT_SECRETS", "").lower() != "true"
+_ENABLE_SECRET_REDACTION = (
+    os.getenv("LITELLM_DISABLE_REDACT_SECRETS", "").lower() != "true"
+)
 
 _REDACTED = "REDACTED"
 
@@ -199,7 +201,9 @@ class JsonFormatter(Formatter):
                 json_record[key] = value
 
         if record.exc_info:
-            json_record["stacktrace"] = record.exc_text or self.formatException(record.exc_info)
+            json_record["stacktrace"] = record.exc_text or self.formatException(
+                record.exc_info
+            )
 
         return safe_dumps(json_record)
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1182,7 +1182,9 @@ def completion_cost(  # noqa: PLR0915
                         and _usage["prompt_tokens_details"] != {}
                         and _usage["prompt_tokens_details"]
                     ):
-                        prompt_tokens_details = _usage.get("prompt_tokens_details") or {}
+                        prompt_tokens_details = (
+                            _usage.get("prompt_tokens_details") or {}
+                        )
                         cache_read_input_tokens = prompt_tokens_details.get(
                             "cached_tokens", 0
                         )
@@ -1508,7 +1510,9 @@ def completion_cost(  # noqa: PLR0915
                 if custom_llm_provider == "azure_ai":
                     model_for_additional_costs = request_model_for_cost
                     if completion_response is not None:
-                        hidden_params = getattr(completion_response, "_hidden_params", None) or {}
+                        hidden_params = (
+                            getattr(completion_response, "_hidden_params", None) or {}
+                        )
                         hidden_model = hidden_params.get("model") or hidden_params.get(
                             "litellm_model_name"
                         )

--- a/litellm/integrations/focus/destinations/factory.py
+++ b/litellm/integrations/focus/destinations/factory.py
@@ -59,17 +59,14 @@ class FocusDestinationFactory:
             return {k: v for k, v in resolved.items() if v is not None}
         if provider == "vantage":
             resolved = {
-                "api_key": overrides.get("api_key")
-                or os.getenv("VANTAGE_API_KEY"),
+                "api_key": overrides.get("api_key") or os.getenv("VANTAGE_API_KEY"),
                 "integration_token": overrides.get("integration_token")
                 or os.getenv("VANTAGE_INTEGRATION_TOKEN"),
                 "base_url": overrides.get("base_url")
                 or os.getenv("VANTAGE_BASE_URL", "https://api.vantage.sh"),
             }
             if not resolved.get("api_key"):
-                raise ValueError(
-                    "VANTAGE_API_KEY must be provided for Vantage exports"
-                )
+                raise ValueError("VANTAGE_API_KEY must be provided for Vantage exports")
             if not resolved.get("integration_token"):
                 raise ValueError(
                     "VANTAGE_INTEGRATION_TOKEN must be provided for Vantage exports"

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -340,9 +340,9 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
             )
             status_message = str(kwargs.get("exception", "Unknown error"))
             if standard_logging_object is not None:
-                status_message = standard_logging_object.get(
-                    "error_str", None
-                ) or status_message
+                status_message = (
+                    standard_logging_object.get("error_str", None) or status_message
+                )
             langfuse_logger_to_use.log_event_on_langfuse(
                 start_time=start_time,
                 end_time=end_time,

--- a/litellm/integrations/vantage/vantage_logger.py
+++ b/litellm/integrations/vantage/vantage_logger.py
@@ -83,7 +83,9 @@ class VantageLogger(FocusLogger):
 
         verbose_logger.debug(
             "VantageLogger initialized (integration_token=%s)",
-            resolved_token[:4] + "***" if resolved_token and len(resolved_token) > 4 else "***",
+            resolved_token[:4] + "***"
+            if resolved_token and len(resolved_token) > 4
+            else "***",
         )
 
     async def initialize_focus_export_job(self) -> None:
@@ -128,9 +130,7 @@ class VantageLogger(FocusLogger):
             callback_type=VantageLogger
         )
         if not vantage_loggers:
-            verbose_logger.debug(
-                "No Vantage logger registered; skipping scheduler"
-            )
+            verbose_logger.debug("No Vantage logger registered; skipping scheduler")
             return
 
         vantage_logger = cast(VantageLogger, vantage_loggers[0])

--- a/litellm/litellm_core_utils/default_encoding.py
+++ b/litellm/litellm_core_utils/default_encoding.py
@@ -26,7 +26,9 @@ if custom_cache_dir:
 else:
     cache_dir = filename
 
-os.environ["TIKTOKEN_CACHE_DIR"] = cache_dir  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
+os.environ[
+    "TIKTOKEN_CACHE_DIR"
+] = cache_dir  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071
 
 import tiktoken
 import time
@@ -48,4 +50,3 @@ for attempt in range(_max_retries):
         # Exponential backoff with jitter to reduce collision probability
         delay = _retry_delay * (2**attempt) + random.uniform(0, 0.1)
         time.sleep(delay)
-

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -352,9 +352,9 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
-        self.sync_streaming_chunks: List[Any] = (
-            []
-        )  # for generating complete stream response
+        self.sync_streaming_chunks: List[
+            Any
+        ] = []  # for generating complete stream response
         self.log_raw_request_response = log_raw_request_response
 
         # Initialize dynamic callbacks
@@ -782,9 +782,9 @@ class Logging(LiteLLMLoggingBaseClass):
                         prompt_spec=prompt_spec,
                         dynamic_callback_params=dynamic_callback_params,
                     ):
-                        self.model_call_details["prompt_integration"] = (
-                            logger.__class__.__name__
-                        )
+                        self.model_call_details[
+                            "prompt_integration"
+                        ] = logger.__class__.__name__
                         return logger
                 except Exception:
                     # If check fails, continue to next logger
@@ -852,9 +852,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if anthropic_cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
             non_default_params
         ):
-            self.model_call_details["prompt_integration"] = (
-                anthropic_cache_control_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = anthropic_cache_control_logger.__class__.__name__
             return anthropic_cache_control_logger
 
         #########################################################
@@ -866,9 +866,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 internal_usage_cache=None,
                 llm_router=None,
             )
-            self.model_call_details["prompt_integration"] = (
-                vector_store_custom_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = vector_store_custom_logger.__class__.__name__
             # Add to global callbacks so post-call hooks are invoked
             if (
                 vector_store_custom_logger
@@ -928,9 +928,9 @@ class Logging(LiteLLMLoggingBaseClass):
             model
         ):  # if model name was changes pre-call, overwrite the initial model call name with the new one
             self.model_call_details["model"] = model
-        self.model_call_details["litellm_params"]["api_base"] = (
-            self._get_masked_api_base(additional_args.get("api_base", ""))
-        )
+        self.model_call_details["litellm_params"][
+            "api_base"
+        ] = self._get_masked_api_base(additional_args.get("api_base", ""))
 
     def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
         # Log the exact input to the LLM API
@@ -959,10 +959,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:
-                        _metadata["raw_request"] = (
-                            "redacted by litellm. \
+                        _metadata[
+                            "raw_request"
+                        ] = "redacted by litellm. \
                             'litellm.turn_off_message_logging=True'"
-                        )
                     else:
                         curl_command = self._get_request_curl_command(
                             api_base=additional_args.get("api_base", ""),
@@ -973,34 +973,34 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         _metadata["raw_request"] = str(curl_command)
                         # split up, so it's easier to parse in the UI
-                        self.model_call_details["raw_request_typed_dict"] = (
-                            RawRequestTypedDict(
-                                raw_request_api_base=str(
-                                    additional_args.get("api_base") or ""
-                                ),
-                                raw_request_body=self._get_raw_request_body(
-                                    additional_args.get("complete_input_dict", {})
-                                ),
-                                # NOTE: setting ignore_sensitive_headers to True will cause
-                                # the Authorization header to be leaked when calls to the health
-                                # endpoint are made and fail.
-                                raw_request_headers=self._get_masked_headers(
-                                    additional_args.get("headers", {}) or {},
-                                ),
-                                error=None,
-                            )
+                        self.model_call_details[
+                            "raw_request_typed_dict"
+                        ] = RawRequestTypedDict(
+                            raw_request_api_base=str(
+                                additional_args.get("api_base") or ""
+                            ),
+                            raw_request_body=self._get_raw_request_body(
+                                additional_args.get("complete_input_dict", {})
+                            ),
+                            # NOTE: setting ignore_sensitive_headers to True will cause
+                            # the Authorization header to be leaked when calls to the health
+                            # endpoint are made and fail.
+                            raw_request_headers=self._get_masked_headers(
+                                additional_args.get("headers", {}) or {},
+                            ),
+                            error=None,
                         )
                 except Exception as e:
-                    self.model_call_details["raw_request_typed_dict"] = (
-                        RawRequestTypedDict(
-                            error=str(e),
-                        )
+                    self.model_call_details[
+                        "raw_request_typed_dict"
+                    ] = RawRequestTypedDict(
+                        error=str(e),
                     )
-                    _metadata["raw_request"] = (
-                        "Unable to Log \
+                    _metadata[
+                        "raw_request"
+                    ] = "Unable to Log \
                         raw request: {}".format(
-                            str(e)
-                        )
+                        str(e)
                     )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
@@ -1301,13 +1301,13 @@ class Logging(LiteLLMLoggingBaseClass):
         for callback in callbacks:
             try:
                 if isinstance(callback, CustomLogger):
-                    response: Optional[MCPPostCallResponseObject] = (
-                        await callback.async_post_mcp_tool_call_hook(
-                            kwargs=kwargs,
-                            response_obj=post_mcp_tool_call_response_obj,
-                            start_time=start_time,
-                            end_time=end_time,
-                        )
+                    response: Optional[
+                        MCPPostCallResponseObject
+                    ] = await callback.async_post_mcp_tool_call_hook(
+                        kwargs=kwargs,
+                        response_obj=post_mcp_tool_call_response_obj,
+                        start_time=start_time,
+                        end_time=end_time,
                     )
                     ######################################################################
                     # if any of the callbacks modify the response, use the modified response
@@ -1502,9 +1502,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
             return None
 
         try:
@@ -1530,9 +1530,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
 
         return None
 
@@ -1688,9 +1688,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 result=logging_result
             )
 
-        self.model_call_details["standard_logging_object"] = (
-            self._build_standard_logging_payload(logging_result, start_time, end_time)
-        )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = self._build_standard_logging_payload(logging_result, start_time, end_time)
 
         if (
             standard_logging_payload := self.model_call_details.get(
@@ -1768,9 +1768,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 end_time = datetime.datetime.now()
             if self.completion_start_time is None:
                 self.completion_start_time = end_time
-                self.model_call_details["completion_start_time"] = (
-                    self.completion_start_time
-                )
+                self.model_call_details[
+                    "completion_start_time"
+                ] = self.completion_start_time
 
             self.model_call_details["log_event_type"] = "successful_api_call"
             self.model_call_details["end_time"] = end_time
@@ -1807,10 +1807,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         end_time=end_time,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
-                    self.model_call_details["standard_logging_object"] = (
-                        self._build_standard_logging_payload(
-                            result, start_time, end_time
-                        )
+                    self.model_call_details[
+                        "standard_logging_object"
+                    ] = self._build_standard_logging_payload(
+                        result, start_time, end_time
                     )
                     if (
                         standard_logging_payload := self.model_call_details.get(
@@ -1819,9 +1819,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     ) is not None:
                         emit_standard_logging_payload(standard_logging_payload)
             elif standard_logging_object is not None:
-                self.model_call_details["standard_logging_object"] = (
-                    standard_logging_object
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = standard_logging_object
             else:
                 self.model_call_details["response_cost"] = None
 
@@ -1979,17 +1979,17 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details["complete_streaming_response"] = (
-                    complete_streaming_response
-                )
-                self.model_call_details["response_cost"] = (
-                    self._response_cost_calculator(result=complete_streaming_response)
-                )
+                self.model_call_details[
+                    "complete_streaming_response"
+                ] = complete_streaming_response
+                self.model_call_details[
+                    "response_cost"
+                ] = self._response_cost_calculator(result=complete_streaming_response)
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(
-                        complete_streaming_response, start_time, end_time
-                    )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = self._build_standard_logging_payload(
+                    complete_streaming_response, start_time, end_time
                 )
                 if (
                     standard_logging_payload := self.model_call_details.get(
@@ -2323,10 +2323,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
                             openMeterLogger.log_success_event(
@@ -2350,10 +2350,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
 
@@ -2492,9 +2492,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if complete_streaming_response is not None:
             print_verbose("Async success callbacks: Got a complete streaming response")
 
-            self.model_call_details["async_complete_streaming_response"] = (
-                complete_streaming_response
-            )
+            self.model_call_details[
+                "async_complete_streaming_response"
+            ] = complete_streaming_response
 
             try:
                 if self.model_call_details.get("cache_hit", False) is True:
@@ -2505,10 +2505,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details["response_cost"] = (
-                        self._response_cost_calculator(
-                            result=complete_streaming_response
-                        )
+                    self.model_call_details[
+                        "response_cost"
+                    ] = self._response_cost_calculator(
+                        result=complete_streaming_response
                     )
 
                 verbose_logger.debug(
@@ -2521,10 +2521,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["response_cost"] = None
 
             ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details["standard_logging_object"] = (
-                self._build_standard_logging_payload(
-                    complete_streaming_response, start_time, end_time
-                )
+            self.model_call_details[
+                "standard_logging_object"
+            ] = self._build_standard_logging_payload(
+                complete_streaming_response, start_time, end_time
             )
 
             # print standard logging payload
@@ -2551,9 +2551,9 @@ class Logging(LiteLLMLoggingBaseClass):
             # _success_handler_helper_fn
             if self.model_call_details.get("standard_logging_object") is None:
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(result, start_time, end_time)
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = self._build_standard_logging_payload(result, start_time, end_time)
 
                 # print standard logging payload
                 if (
@@ -2796,18 +2796,18 @@ class Logging(LiteLLMLoggingBaseClass):
 
         ## STANDARDIZED LOGGING PAYLOAD
 
-        self.model_call_details["standard_logging_object"] = (
-            get_standard_logging_object_payload(
-                kwargs=self.model_call_details,
-                init_response_obj={},
-                start_time=start_time,
-                end_time=end_time,
-                logging_obj=self,
-                status="failure",
-                error_str=str(exception),
-                original_exception=exception,
-                standard_built_in_tools_params=self.standard_built_in_tools_params,
-            )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = get_standard_logging_object_payload(
+            kwargs=self.model_call_details,
+            init_response_obj={},
+            start_time=start_time,
+            end_time=end_time,
+            logging_obj=self,
+            status="failure",
+            error_str=str(exception),
+            original_exception=exception,
+            standard_built_in_tools_params=self.standard_built_in_tools_params,
         )
         return start_time, end_time
 
@@ -3771,9 +3771,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 service_name=arize_config.project_name,
             )
 
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, ArizeLogger)
@@ -3799,13 +3799,13 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
                 else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={arize_phoenix_config.project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"openinference.project.name={arize_phoenix_config.project_name}"
 
             # Set Phoenix project name from environment variable
             phoenix_project_name = os.environ.get("PHOENIX_PROJECT_NAME", None)
@@ -3813,19 +3813,19 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={phoenix_project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"{existing_attrs},openinference.project.name={phoenix_project_name}"
                 else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={phoenix_project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"openinference.project.name={phoenix_project_name}"
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:
-                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                    arize_phoenix_config.otlp_auth_headers
-                )
+                os.environ[
+                    "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+                ] = arize_phoenix_config.otlp_auth_headers
 
             for callback in _in_memory_loggers:
                 if (
@@ -3904,7 +3904,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             from litellm.integrations.focus.focus_logger import FocusLogger
 
             for callback in _in_memory_loggers:
-                if type(callback) is FocusLogger:  # exact match; exclude subclasses like VantageLogger
+                if (
+                    type(callback) is FocusLogger
+                ):  # exact match; exclude subclasses like VantageLogger
                     return callback  # type: ignore
             focus_logger = FocusLogger()
             _in_memory_loggers.append(focus_logger)
@@ -4010,9 +4012,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 exporter="otlp_http",
                 endpoint="https://langtrace.ai/api/trace",
             )
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"api_key={os.getenv('LANGTRACE_API_KEY')}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, OpenTelemetry)
@@ -4286,7 +4288,9 @@ def get_custom_logger_compatible_class(  # noqa: PLR0915
             from litellm.integrations.focus.focus_logger import FocusLogger
 
             for callback in _in_memory_loggers:
-                if type(callback) is FocusLogger:  # exact match; exclude subclasses like VantageLogger
+                if (
+                    type(callback) is FocusLogger
+                ):  # exact match; exclude subclasses like VantageLogger
                     return callback
         elif logging_integration == "vantage":
             from litellm.integrations.vantage.vantage_logger import VantageLogger
@@ -4934,10 +4938,10 @@ class StandardLoggingPayloadSetup:
             for key in StandardLoggingHiddenParams.__annotations__.keys():
                 if key in hidden_params:
                     if key == "additional_headers":
-                        clean_hidden_params["additional_headers"] = (
-                            StandardLoggingPayloadSetup.get_additional_headers(
-                                hidden_params[key]
-                            )
+                        clean_hidden_params[
+                            "additional_headers"
+                        ] = StandardLoggingPayloadSetup.get_additional_headers(
+                            hidden_params[key]
                         )
                     else:
                         clean_hidden_params[key] = hidden_params[key]  # type: ignore
@@ -5576,9 +5580,9 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
     ):
         for k, v in metadata["user_api_key_metadata"].items():
             if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[k] = (
-                    "scrubbed_by_litellm_for_sensitive_keys"
-                )
+                cleaned_user_api_key_metadata[
+                    k
+                ] = "scrubbed_by_litellm_for_sensitive_keys"
             else:
                 cleaned_user_api_key_metadata[k] = v
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -780,7 +780,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 # Keep Anthropic-native tools in their original format
                 new_tools.append(tool)  # type: ignore[arg-type]
                 continue
-            
+
             original_name = tool["name"]
             truncated_name = truncate_tool_name(original_name)
 

--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -336,9 +336,7 @@ class BaseVideoConfig(ABC):
         Returns:
             Tuple[str, Dict]: (url, data) for the POST request
         """
-        raise NotImplementedError(
-            "video edit is not supported for this provider"
-        )
+        raise NotImplementedError("video edit is not supported for this provider")
 
     def transform_video_edit_response(
         self,
@@ -346,9 +344,7 @@ class BaseVideoConfig(ABC):
         logging_obj: LiteLLMLoggingObj,
         custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
-        raise NotImplementedError(
-            "video edit is not supported for this provider"
-        )
+        raise NotImplementedError("video edit is not supported for this provider")
 
     def transform_video_extension_request(
         self,
@@ -366,9 +362,7 @@ class BaseVideoConfig(ABC):
         Returns:
             Tuple[str, Dict]: (url, data) for the POST request
         """
-        raise NotImplementedError(
-            "video extension is not supported for this provider"
-        )
+        raise NotImplementedError("video extension is not supported for this provider")
 
     def transform_video_extension_response(
         self,
@@ -376,9 +370,7 @@ class BaseVideoConfig(ABC):
         logging_obj: LiteLLMLoggingObj,
         custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
-        raise NotImplementedError(
-            "video extension is not supported for this provider"
-        )
+        raise NotImplementedError("video extension is not supported for this provider")
 
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -6162,7 +6162,10 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
-        url, files_list = video_provider_config.transform_video_create_character_request(
+        (
+            url,
+            files_list,
+        ) = video_provider_config.transform_video_create_character_request(
             name=name,
             video=video,
             api_base=api_base,
@@ -6230,7 +6233,10 @@ class BaseLLMHTTPHandler:
             litellm_params=dict(litellm_params),
         )
 
-        url, files_list = video_provider_config.transform_video_create_character_request(
+        (
+            url,
+            files_list,
+        ) = video_provider_config.transform_video_create_character_request(
             name=name,
             video=video,
             api_base=api_base,
@@ -6324,11 +6330,7 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            response = sync_httpx_client.get(
-                url=url,
-                headers=headers,
-                params=params
-            )
+            response = sync_httpx_client.get(url=url, headers=headers, params=params)
             response.raise_for_status()
             return video_provider_config.transform_video_get_character_response(
                 raw_response=response,
@@ -6386,9 +6388,7 @@ class BaseLLMHTTPHandler:
 
         try:
             response = await async_httpx_client.get(
-                url=url,
-                headers=headers,
-                params=params
+                url=url, headers=headers, params=params
             )
             response.raise_for_status()
             return video_provider_config.transform_video_get_character_response(

--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -525,28 +525,47 @@ class GeminiVideoConfig(BaseVideoConfig):
         """Video delete is not supported."""
         raise NotImplementedError("Video delete is not supported by Google Veo.")
 
-    def transform_video_create_character_request(self, name, video, api_base, litellm_params, headers):
+    def transform_video_create_character_request(
+        self, name, video, api_base, litellm_params, headers
+    ):
         raise NotImplementedError("video create character is not supported for Gemini")
 
     def transform_video_create_character_response(self, raw_response, logging_obj):
         raise NotImplementedError("video create character is not supported for Gemini")
 
-    def transform_video_get_character_request(self, character_id, api_base, litellm_params, headers):
+    def transform_video_get_character_request(
+        self, character_id, api_base, litellm_params, headers
+    ):
         raise NotImplementedError("video get character is not supported for Gemini")
 
     def transform_video_get_character_response(self, raw_response, logging_obj):
         raise NotImplementedError("video get character is not supported for Gemini")
 
-    def transform_video_edit_request(self, prompt, video_id, api_base, litellm_params, headers, extra_body=None):
+    def transform_video_edit_request(
+        self, prompt, video_id, api_base, litellm_params, headers, extra_body=None
+    ):
         raise NotImplementedError("video edit is not supported for Gemini")
 
-    def transform_video_edit_response(self, raw_response, logging_obj, custom_llm_provider=None):
+    def transform_video_edit_response(
+        self, raw_response, logging_obj, custom_llm_provider=None
+    ):
         raise NotImplementedError("video edit is not supported for Gemini")
 
-    def transform_video_extension_request(self, prompt, video_id, seconds, api_base, litellm_params, headers, extra_body=None):
+    def transform_video_extension_request(
+        self,
+        prompt,
+        video_id,
+        seconds,
+        api_base,
+        litellm_params,
+        headers,
+        extra_body=None,
+    ):
         raise NotImplementedError("video extension is not supported for Gemini")
 
-    def transform_video_extension_response(self, raw_response, logging_obj, custom_llm_provider=None):
+    def transform_video_extension_response(
+        self, raw_response, logging_obj, custom_llm_provider=None
+    ):
         raise NotImplementedError("video extension is not supported for Gemini")
 
     def get_error_class(

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -19,7 +19,8 @@ class MoonshotChatConfig(OpenAIGPTConfig):
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
+        ...
 
     @overload
     def _transform_messages(
@@ -27,7 +28,8 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         messages: List[AllMessageValues],
         model: str,
         is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]: ...
+    ) -> List[AllMessageValues]:
+        ...
 
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
@@ -53,9 +55,13 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             messages = handle_messages_with_content_list_to_str_conversion(messages)
 
         if is_async:
-            return super()._transform_messages(messages=messages, model=model, is_async=True)
+            return super()._transform_messages(
+                messages=messages, model=model, is_async=True
+            )
         else:
-            return super()._transform_messages(messages=messages, model=model, is_async=False)
+            return super()._transform_messages(
+                messages=messages, model=model, is_async=False
+            )
 
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
@@ -141,7 +147,9 @@ class MoonshotChatConfig(OpenAIGPTConfig):
                 optional_params["temperature"] = 0.3
         return optional_params
 
-    def fill_reasoning_content(self, messages: List[AllMessageValues]) -> List[AllMessageValues]:
+    def fill_reasoning_content(
+        self, messages: List[AllMessageValues]
+    ) -> List[AllMessageValues]:
         """
         Moonshot reasoning models require `reasoning_content` on every assistant
         message that contains tool_calls (multi-turn tool-calling flows).

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -592,28 +592,51 @@ class RunwayMLVideoConfig(BaseVideoConfig):
 
         return video_obj
 
-    def transform_video_create_character_request(self, name, video, api_base, litellm_params, headers):
-        raise NotImplementedError("video create character is not supported for RunwayML")
+    def transform_video_create_character_request(
+        self, name, video, api_base, litellm_params, headers
+    ):
+        raise NotImplementedError(
+            "video create character is not supported for RunwayML"
+        )
 
     def transform_video_create_character_response(self, raw_response, logging_obj):
-        raise NotImplementedError("video create character is not supported for RunwayML")
+        raise NotImplementedError(
+            "video create character is not supported for RunwayML"
+        )
 
-    def transform_video_get_character_request(self, character_id, api_base, litellm_params, headers):
+    def transform_video_get_character_request(
+        self, character_id, api_base, litellm_params, headers
+    ):
         raise NotImplementedError("video get character is not supported for RunwayML")
 
     def transform_video_get_character_response(self, raw_response, logging_obj):
         raise NotImplementedError("video get character is not supported for RunwayML")
 
-    def transform_video_edit_request(self, prompt, video_id, api_base, litellm_params, headers, extra_body=None):
+    def transform_video_edit_request(
+        self, prompt, video_id, api_base, litellm_params, headers, extra_body=None
+    ):
         raise NotImplementedError("video edit is not supported for RunwayML")
 
-    def transform_video_edit_response(self, raw_response, logging_obj, custom_llm_provider=None):
+    def transform_video_edit_response(
+        self, raw_response, logging_obj, custom_llm_provider=None
+    ):
         raise NotImplementedError("video edit is not supported for RunwayML")
 
-    def transform_video_extension_request(self, prompt, video_id, seconds, api_base, litellm_params, headers, extra_body=None):
+    def transform_video_extension_request(
+        self,
+        prompt,
+        video_id,
+        seconds,
+        api_base,
+        litellm_params,
+        headers,
+        extra_body=None,
+    ):
         raise NotImplementedError("video extension is not supported for RunwayML")
 
-    def transform_video_extension_response(self, raw_response, logging_obj, custom_llm_provider=None):
+    def transform_video_extension_response(
+        self, raw_response, logging_obj, custom_llm_provider=None
+    ):
         raise NotImplementedError("video extension is not supported for RunwayML")
 
     def get_error_class(

--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -184,9 +184,7 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
                 llm_provider = LlmProviders(custom_llm_provider)
             except ValueError:
                 llm_provider = LlmProviders.SAGEMAKER_CHAT
-            client = get_async_httpx_client(
-                llm_provider=llm_provider, params={}
-            )
+            client = get_async_httpx_client(llm_provider=llm_provider, params={})
 
         try:
             response = await client.post(

--- a/litellm/llms/vertex_ai/batches/transformation.py
+++ b/litellm/llms/vertex_ai/batches/transformation.py
@@ -142,8 +142,8 @@ class VertexAIBatchTransformation:
         Gets the output file id from the Vertex AI Batch response
         """
 
-        output_file_id: str = (
-            response.get("outputInfo", OutputInfo()).get("gcsOutputDirectory", "")
+        output_file_id: str = response.get("outputInfo", OutputInfo()).get(
+            "gcsOutputDirectory", ""
         )
         if output_file_id:
             output_file_id = output_file_id.rstrip("/") + "/predictions.jsonl"

--- a/litellm/llms/vertex_ai/videos/transformation.py
+++ b/litellm/llms/vertex_ai/videos/transformation.py
@@ -624,28 +624,51 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
         """Video delete is not supported."""
         raise NotImplementedError("Video delete is not supported by Vertex AI Veo.")
 
-    def transform_video_create_character_request(self, name, video, api_base, litellm_params, headers):
-        raise NotImplementedError("video create character is not supported for Vertex AI")
+    def transform_video_create_character_request(
+        self, name, video, api_base, litellm_params, headers
+    ):
+        raise NotImplementedError(
+            "video create character is not supported for Vertex AI"
+        )
 
     def transform_video_create_character_response(self, raw_response, logging_obj):
-        raise NotImplementedError("video create character is not supported for Vertex AI")
+        raise NotImplementedError(
+            "video create character is not supported for Vertex AI"
+        )
 
-    def transform_video_get_character_request(self, character_id, api_base, litellm_params, headers):
+    def transform_video_get_character_request(
+        self, character_id, api_base, litellm_params, headers
+    ):
         raise NotImplementedError("video get character is not supported for Vertex AI")
 
     def transform_video_get_character_response(self, raw_response, logging_obj):
         raise NotImplementedError("video get character is not supported for Vertex AI")
 
-    def transform_video_edit_request(self, prompt, video_id, api_base, litellm_params, headers, extra_body=None):
+    def transform_video_edit_request(
+        self, prompt, video_id, api_base, litellm_params, headers, extra_body=None
+    ):
         raise NotImplementedError("video edit is not supported for Vertex AI")
 
-    def transform_video_edit_response(self, raw_response, logging_obj, custom_llm_provider=None):
+    def transform_video_edit_response(
+        self, raw_response, logging_obj, custom_llm_provider=None
+    ):
         raise NotImplementedError("video edit is not supported for Vertex AI")
 
-    def transform_video_extension_request(self, prompt, video_id, seconds, api_base, litellm_params, headers, extra_body=None):
+    def transform_video_extension_request(
+        self,
+        prompt,
+        video_id,
+        seconds,
+        api_base,
+        litellm_params,
+        headers,
+        extra_body=None,
+    ):
         raise NotImplementedError("video extension is not supported for Vertex AI")
 
-    def transform_video_extension_response(self, raw_response, logging_obj, custom_llm_provider=None):
+    def transform_video_extension_response(
+        self, raw_response, logging_obj, custom_llm_provider=None
+    ):
         raise NotImplementedError("video extension is not supported for Vertex AI")
 
     def get_error_class(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7533,9 +7533,7 @@ def stream_chunk_builder(  # noqa: PLR0915
             # the final chunk.
             all_annotations: list = []
             for ac in annotation_chunks:
-                all_annotations.extend(
-                    ac["choices"][0]["delta"]["annotations"]
-                )
+                all_annotations.extend(ac["choices"][0]["delta"]["annotations"])
             response["choices"][0]["message"]["annotations"] = all_annotations
 
         audio_chunks = [

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -680,7 +680,7 @@ def get_customer_user_header_from_mapping(user_id_mapping) -> Optional[list]:
 
     if customer_headers_mappings:
         return customer_headers_mappings
-    
+
     return None
 
 
@@ -754,15 +754,11 @@ def get_end_user_id_from_request_body(
                     user_id_str = str(header_value)
                     if user_id_str.strip():
                         return user_id_str
-                    
+
         elif isinstance(custom_header_name_to_check, str):
             for header_name, header_value in request_headers.items():
                 if header_name.lower() == custom_header_name_to_check.lower():
-                    user_id_str = (
-                        str(header_value)
-                        if header_value is not None
-                        else ""
-                    )
+                    user_id_str = str(header_value) if header_value is not None else ""
                     if user_id_str.strip():
                         return user_id_str
 

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -732,6 +732,29 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         except Exception as e:
             self.print_verbose(e)  # noqa
 
+    async def _append_failure_release_entry(
+        self,
+        entity_key: str,
+        precise_minute: str,
+        reserved_tokens: int,
+        values_to_update_in_cache: list,
+        litellm_parent_otel_span,
+        label: str = "",
+    ) -> None:
+        """Read-modify-append one cache bucket for async_log_failure_event."""
+        request_count_key = f"{entity_key}::{precise_minute}::request_count"
+        current = await self.internal_usage_cache.async_get_cache(
+            key=request_count_key,
+            litellm_parent_otel_span=litellm_parent_otel_span,
+        ) or {"current_requests": 1, "current_tpm": 0, "current_rpm": 0}
+        new_val = {
+            "current_requests": max(current["current_requests"] - 1, 0),
+            "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
+            "current_rpm": current["current_rpm"],
+        }
+        self.print_verbose(f"updated_value in failure call{label}: {new_val}")
+        values_to_update_in_cache.append((request_count_key, new_val))
+
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
             self.print_verbose("Inside Max Parallel Request Failure Hook")
@@ -799,27 +822,13 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Release reservation - API Key
                 # ------------
                 if user_api_key is not None:
-                    request_count_api_key = (
-                        f"{user_api_key}::{precise_minute}::request_count"
-                    )
-
-                    current = await self.internal_usage_cache.async_get_cache(
-                        key=request_count_api_key,
+                    await self._append_failure_release_entry(
+                        entity_key=user_api_key,
+                        precise_minute=precise_minute,
+                        reserved_tokens=reserved_tokens,
+                        values_to_update_in_cache=values_to_update_in_cache,
                         litellm_parent_otel_span=litellm_parent_otel_span,
-                    ) or {
-                        "current_requests": 1,
-                        "current_tpm": 0,
-                        "current_rpm": 0,
-                    }
-
-                    new_val = {
-                        "current_requests": max(current["current_requests"] - 1, 0),
-                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
-                        "current_rpm": current["current_rpm"],
-                    }
-
-                    self.print_verbose(f"updated_value in failure call: {new_val}")
-                    values_to_update_in_cache.append((request_count_api_key, new_val))
+                    )
 
                 # ------------
                 # Release reservation - model group + API Key
@@ -834,111 +843,53 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                         or user_api_key_model_max_budget is not None
                     )
                 ):
-                    request_count_api_key = f"{user_api_key}::{model_group}::{precise_minute}::request_count"
-
-                    current = await self.internal_usage_cache.async_get_cache(
-                        key=request_count_api_key,
+                    await self._append_failure_release_entry(
+                        entity_key=f"{user_api_key}::{model_group}",
+                        precise_minute=precise_minute,
+                        reserved_tokens=reserved_tokens,
+                        values_to_update_in_cache=values_to_update_in_cache,
                         litellm_parent_otel_span=litellm_parent_otel_span,
-                    ) or {
-                        "current_requests": 1,
-                        "current_tpm": 0,
-                        "current_rpm": 0,
-                    }
-
-                    new_val = {
-                        "current_requests": max(current["current_requests"] - 1, 0),
-                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
-                        "current_rpm": current["current_rpm"],
-                    }
-
-                    self.print_verbose(
-                        f"updated_value in failure call (model_per_key): {new_val}"
+                        label=" (model_per_key)",
                     )
-                    values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 # ------------
                 # Release reservation - User
                 # ------------
                 if user_api_key_user_id is not None:
-                    request_count_api_key = (
-                        f"{user_api_key_user_id}::{precise_minute}::request_count"
-                    )
-
-                    current = await self.internal_usage_cache.async_get_cache(
-                        key=request_count_api_key,
+                    await self._append_failure_release_entry(
+                        entity_key=user_api_key_user_id,
+                        precise_minute=precise_minute,
+                        reserved_tokens=reserved_tokens,
+                        values_to_update_in_cache=values_to_update_in_cache,
                         litellm_parent_otel_span=litellm_parent_otel_span,
-                    ) or {
-                        "current_requests": 1,
-                        "current_tpm": 0,
-                        "current_rpm": 0,
-                    }
-
-                    new_val = {
-                        "current_requests": max(current["current_requests"] - 1, 0),
-                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
-                        "current_rpm": current["current_rpm"],
-                    }
-
-                    self.print_verbose(
-                        f"updated_value in failure call (user): {new_val}"
+                        label=" (user)",
                     )
-                    values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 # ------------
                 # Release reservation - Team
                 # ------------
                 if user_api_key_team_id is not None:
-                    request_count_api_key = (
-                        f"{user_api_key_team_id}::{precise_minute}::request_count"
-                    )
-
-                    current = await self.internal_usage_cache.async_get_cache(
-                        key=request_count_api_key,
+                    await self._append_failure_release_entry(
+                        entity_key=user_api_key_team_id,
+                        precise_minute=precise_minute,
+                        reserved_tokens=reserved_tokens,
+                        values_to_update_in_cache=values_to_update_in_cache,
                         litellm_parent_otel_span=litellm_parent_otel_span,
-                    ) or {
-                        "current_requests": 1,
-                        "current_tpm": 0,
-                        "current_rpm": 0,
-                    }
-
-                    new_val = {
-                        "current_requests": max(current["current_requests"] - 1, 0),
-                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
-                        "current_rpm": current["current_rpm"],
-                    }
-
-                    self.print_verbose(
-                        f"updated_value in failure call (team): {new_val}"
+                        label=" (team)",
                     )
-                    values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 # ------------
                 # Release reservation - End User
                 # ------------
                 if user_api_key_end_user_id is not None:
-                    request_count_api_key = (
-                        f"{user_api_key_end_user_id}::{precise_minute}::request_count"
-                    )
-
-                    current = await self.internal_usage_cache.async_get_cache(
-                        key=request_count_api_key,
+                    await self._append_failure_release_entry(
+                        entity_key=user_api_key_end_user_id,
+                        precise_minute=precise_minute,
+                        reserved_tokens=reserved_tokens,
+                        values_to_update_in_cache=values_to_update_in_cache,
                         litellm_parent_otel_span=litellm_parent_otel_span,
-                    ) or {
-                        "current_requests": 1,
-                        "current_tpm": 0,
-                        "current_rpm": 0,
-                    }
-
-                    new_val = {
-                        "current_requests": max(current["current_requests"] - 1, 0),
-                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
-                        "current_rpm": current["current_rpm"],
-                    }
-
-                    self.print_verbose(
-                        f"updated_value in failure call (end_user): {new_val}"
+                        label=" (end_user)",
                     )
-                    values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 await self.internal_usage_cache.async_batch_set_cache(
                     cache_list=values_to_update_in_cache,

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -65,8 +65,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         is released).
         """
         estimated = data.get("max_tokens") or data.get("max_completion_tokens") or 0
-        if isinstance(estimated, int) and estimated > 0:
-            return estimated
+        if isinstance(estimated, (int, float)) and estimated > 0:
+            return int(estimated)
         return 0
 
     async def check_key_in_limits(
@@ -95,6 +95,14 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # base case
                 raise self.raise_rate_limit_error(
                     additional_details=f"{CommonProxyErrors.max_parallel_request_limit_reached.value}. Hit limit for {rate_limit_type}. Current limits: max_parallel_requests: {max_parallel_requests}, tpm_limit: {tpm_limit}, rpm_limit: {rpm_limit}"
+                )
+            # Check that the estimated tokens for this single request
+            # don't already exceed the TPM limit
+            if estimated_tokens > tpm_limit:
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"LiteLLM Rate Limit Handler for rate limit type = {rate_limit_type}. {CommonProxyErrors.max_parallel_request_limit_reached.value}. Estimated tokens {estimated_tokens} exceed tpm limit: {tpm_limit}",
+                    headers={"retry-after": str(self.time_to_next_minute())},
                 )
             new_val = {
                 "current_requests": 1,
@@ -732,6 +740,13 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Get the reserved token estimate for release
             reserved_tokens = _metadata.get("_reserved_estimated_tokens", 0)
             user_api_key = _metadata.get("user_api_key", None)
+            user_api_key_user_id = _metadata.get("user_api_key_user_id", None)
+            user_api_key_team_id = _metadata.get("user_api_key_team_id", None)
+            user_api_key_end_user_id = kwargs.get("user")
+            user_api_key_metadata = _metadata.get("user_api_key_metadata", {}) or {}
+            user_api_key_model_max_budget = _metadata.get(
+                "user_api_key_model_max_budget", None
+            )
             self.print_verbose(f"user_api_key: {user_api_key}")
             if user_api_key is None:
                 return
@@ -742,6 +757,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             ):
                 pass  # ignore failed calls due to max limit being reached
             else:
+                from litellm.proxy.common_utils.callback_utils import (
+                    get_model_group_from_litellm_kwargs,
+                )
+
                 # ------------
                 # Setup values
                 # ------------
@@ -769,36 +788,152 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 current_minute = datetime.now().strftime("%M")
                 precise_minute = f"{current_date}-{current_hour}-{current_minute}"
 
-                request_count_api_key = (
-                    f"{user_api_key}::{precise_minute}::request_count"
-                )
+                values_to_update_in_cache = []
 
                 # ------------
-                # Update usage
+                # Release reservation - API Key
                 # ------------
-                current = await self.internal_usage_cache.async_get_cache(
-                    key=request_count_api_key,
-                    litellm_parent_otel_span=litellm_parent_otel_span,
-                ) or {
-                    "current_requests": 1,
-                    "current_tpm": 0,
-                    "current_rpm": 0,
-                }
+                if user_api_key is not None:
+                    request_count_api_key = (
+                        f"{user_api_key}::{precise_minute}::request_count"
+                    )
 
-                # Release the reserved tokens on failure
-                new_val = {
-                    "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
-                    "current_rpm": current["current_rpm"],
-                }
+                    current = await self.internal_usage_cache.async_get_cache(
+                        key=request_count_api_key,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    ) or {
+                        "current_requests": 1,
+                        "current_tpm": 0,
+                        "current_rpm": 0,
+                    }
 
-                self.print_verbose(f"updated_value in failure call: {new_val}")
-                await self.internal_usage_cache.async_set_cache(
-                    request_count_api_key,
-                    new_val,
+                    new_val = {
+                        "current_requests": max(current["current_requests"] - 1, 0),
+                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
+                        "current_rpm": current["current_rpm"],
+                    }
+
+                    self.print_verbose(f"updated_value in failure call: {new_val}")
+                    values_to_update_in_cache.append((request_count_api_key, new_val))
+
+                # ------------
+                # Release reservation - model group + API Key
+                # ------------
+                model_group = get_model_group_from_litellm_kwargs(kwargs)
+                if (
+                    user_api_key is not None
+                    and model_group is not None
+                    and (
+                        "model_rpm_limit" in user_api_key_metadata
+                        or "model_tpm_limit" in user_api_key_metadata
+                        or user_api_key_model_max_budget is not None
+                    )
+                ):
+                    request_count_api_key = (
+                        f"{user_api_key}::{model_group}::{precise_minute}::request_count"
+                    )
+
+                    current = await self.internal_usage_cache.async_get_cache(
+                        key=request_count_api_key,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    ) or {
+                        "current_requests": 1,
+                        "current_tpm": 0,
+                        "current_rpm": 0,
+                    }
+
+                    new_val = {
+                        "current_requests": max(current["current_requests"] - 1, 0),
+                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
+                        "current_rpm": current["current_rpm"],
+                    }
+
+                    self.print_verbose(f"updated_value in failure call (model_per_key): {new_val}")
+                    values_to_update_in_cache.append((request_count_api_key, new_val))
+
+                # ------------
+                # Release reservation - User
+                # ------------
+                if user_api_key_user_id is not None:
+                    request_count_api_key = (
+                        f"{user_api_key_user_id}::{precise_minute}::request_count"
+                    )
+
+                    current = await self.internal_usage_cache.async_get_cache(
+                        key=request_count_api_key,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    ) or {
+                        "current_requests": 1,
+                        "current_tpm": 0,
+                        "current_rpm": 0,
+                    }
+
+                    new_val = {
+                        "current_requests": max(current["current_requests"] - 1, 0),
+                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
+                        "current_rpm": current["current_rpm"],
+                    }
+
+                    self.print_verbose(f"updated_value in failure call (user): {new_val}")
+                    values_to_update_in_cache.append((request_count_api_key, new_val))
+
+                # ------------
+                # Release reservation - Team
+                # ------------
+                if user_api_key_team_id is not None:
+                    request_count_api_key = (
+                        f"{user_api_key_team_id}::{precise_minute}::request_count"
+                    )
+
+                    current = await self.internal_usage_cache.async_get_cache(
+                        key=request_count_api_key,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    ) or {
+                        "current_requests": 1,
+                        "current_tpm": 0,
+                        "current_rpm": 0,
+                    }
+
+                    new_val = {
+                        "current_requests": max(current["current_requests"] - 1, 0),
+                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
+                        "current_rpm": current["current_rpm"],
+                    }
+
+                    self.print_verbose(f"updated_value in failure call (team): {new_val}")
+                    values_to_update_in_cache.append((request_count_api_key, new_val))
+
+                # ------------
+                # Release reservation - End User
+                # ------------
+                if user_api_key_end_user_id is not None:
+                    request_count_api_key = (
+                        f"{user_api_key_end_user_id}::{precise_minute}::request_count"
+                    )
+
+                    current = await self.internal_usage_cache.async_get_cache(
+                        key=request_count_api_key,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    ) or {
+                        "current_requests": 1,
+                        "current_tpm": 0,
+                        "current_rpm": 0,
+                    }
+
+                    new_val = {
+                        "current_requests": max(current["current_requests"] - 1, 0),
+                        "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
+                        "current_rpm": current["current_rpm"],
+                    }
+
+                    self.print_verbose(f"updated_value in failure call (end_user): {new_val}")
+                    values_to_update_in_cache.append((request_count_api_key, new_val))
+
+                await self.internal_usage_cache.async_batch_set_cache(
+                    cache_list=values_to_update_in_cache,
                     ttl=60,
                     litellm_parent_otel_span=litellm_parent_otel_span,
-                )  # save in cache for up to 1 min.
+                )
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Inside Parallel Request Limiter: An exception occurred - {}".format(

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -231,7 +231,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         if rpm_limit is None:
             rpm_limit = sys.maxsize
 
-        values_to_update_in_cache: List[Tuple[Any, Any]] = (
+        values_to_update_in_cache: List[
+            Tuple[Any, Any]
+        ] = (
             []
         )  # values that need to get updated in cache, will run a batch_set_cache after this function
 
@@ -733,9 +735,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
             self.print_verbose("Inside Max Parallel Request Failure Hook")
-            litellm_parent_otel_span: Union[Span, None] = (
-                _get_parent_otel_span_from_kwargs(kwargs=kwargs)
-            )
+            litellm_parent_otel_span: Union[
+                Span, None
+            ] = _get_parent_otel_span_from_kwargs(kwargs=kwargs)
             _metadata = kwargs["litellm_params"].get("metadata", {}) or {}
             global_max_parallel_requests = _metadata.get(
                 "global_max_parallel_requests", None
@@ -998,11 +1000,11 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         current_minute = datetime.now().strftime("%M")
         precise_minute = f"{current_date}-{current_hour}-{current_minute}"
         request_count_api_key = f"{api_key}::{precise_minute}::request_count"
-        current: Optional[CurrentItemRateLimit] = (
-            await self.internal_usage_cache.async_get_cache(
-                key=request_count_api_key,
-                litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
-            )
+        current: Optional[
+            CurrentItemRateLimit
+        ] = await self.internal_usage_cache.async_get_cache(
+            key=request_count_api_key,
+            litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
         )
 
         key_remaining_rpm_limit: Optional[int] = None
@@ -1034,15 +1036,15 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             _additional_headers = _hidden_params.get("additional_headers", {}) or {}
 
             if key_remaining_rpm_limit is not None:
-                _additional_headers["x-ratelimit-remaining-requests"] = (
-                    key_remaining_rpm_limit
-                )
+                _additional_headers[
+                    "x-ratelimit-remaining-requests"
+                ] = key_remaining_rpm_limit
             if key_rpm_limit is not None:
                 _additional_headers["x-ratelimit-limit-requests"] = key_rpm_limit
             if key_remaining_tpm_limit is not None:
-                _additional_headers["x-ratelimit-remaining-tokens"] = (
-                    key_remaining_tpm_limit
-                )
+                _additional_headers[
+                    "x-ratelimit-remaining-tokens"
+                ] = key_remaining_tpm_limit
             if key_tpm_limit is not None:
                 _additional_headers["x-ratelimit-limit-tokens"] = key_tpm_limit
 

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -52,6 +52,23 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         except Exception:
             pass
 
+    @staticmethod
+    def _estimate_request_tokens(data: dict) -> int:
+        """Estimate tokens for a request to reserve at pre-call time.
+
+        Uses max_tokens/max_completion_tokens as the reservation amount.
+        This prevents concurrent requests from bypassing TPM limits by
+        ensuring tokens are accounted for before the request completes.
+
+        The reservation is reconciled in async_log_success_event (actual
+        tokens replace the estimate) and async_log_failure_event (estimate
+        is released).
+        """
+        estimated = data.get("max_tokens") or data.get("max_completion_tokens") or 0
+        if isinstance(estimated, int) and estimated > 0:
+            return estimated
+        return 0
+
     async def check_key_in_limits(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -69,6 +86,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         verbose_proxy_logger.info(
             f"Current Usage of {rate_limit_type} in this minute: {current}"
         )
+        # Estimate tokens to reserve at pre-call time to prevent concurrent
+        # requests from bypassing TPM limits (fixes TOCTOU race condition).
+        estimated_tokens = self._estimate_request_tokens(data)
+
         if current is None:
             if max_parallel_requests == 0 or tpm_limit == 0 or rpm_limit == 0:
                 # base case
@@ -77,19 +98,19 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 )
             new_val = {
                 "current_requests": 1,
-                "current_tpm": 0,
+                "current_tpm": estimated_tokens,
                 "current_rpm": 1,
             }
             values_to_update_in_cache.append((request_count_api_key, new_val))
         elif (
             int(current["current_requests"]) < max_parallel_requests
-            and current["current_tpm"] < tpm_limit
+            and current["current_tpm"] + estimated_tokens <= tpm_limit
             and current["current_rpm"] < rpm_limit
         ):
-            # Increase count for this token
+            # Increase count for this token and reserve estimated TPM
             new_val = {
                 "current_requests": current["current_requests"] + 1,
-                "current_tpm": current["current_tpm"],
+                "current_tpm": current["current_tpm"] + estimated_tokens,
                 "current_rpm": current["current_rpm"] + 1,
             }
             values_to_update_in_cache.append((request_count_api_key, new_val))
@@ -443,6 +464,14 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             )  # don't block execution for cache updates
         )
 
+        # Store reserved token estimate in metadata for reconciliation
+        # in async_log_success_event / async_log_failure_event
+        estimated_tokens = self._estimate_request_tokens(data)
+        if estimated_tokens > 0:
+            if "metadata" not in data:
+                data["metadata"] = {}
+            data["metadata"]["_reserved_estimated_tokens"] = estimated_tokens
+
         return
 
     async def async_log_success_event(  # noqa: PLR0915
@@ -503,6 +532,13 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             if isinstance(response_obj, ModelResponse):
                 total_tokens = response_obj.usage.total_tokens  # type: ignore
 
+            # Get the reserved token estimate from pre-call for reconciliation
+            reserved_tokens = (
+                kwargs.get("litellm_params", {})
+                .get("metadata", {})
+                .get("_reserved_estimated_tokens", 0)
+            )
+
             # ------------
             # Update usage - API Key
             # ------------
@@ -523,9 +559,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     "current_rpm": 0,
                 }
 
+                # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"] + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -560,9 +597,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     "current_rpm": 0,
                 }
 
+                # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"] + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -593,9 +631,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     "current_rpm": 1,
                 }
 
+                # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"] + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -626,9 +665,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     "current_rpm": 1,
                 }
 
+                # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"] + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -659,9 +699,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     "current_rpm": 1,
                 }
 
+                # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"] + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -688,6 +729,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             global_max_parallel_requests = _metadata.get(
                 "global_max_parallel_requests", None
             )
+            # Get the reserved token estimate for release
+            reserved_tokens = _metadata.get("_reserved_estimated_tokens", 0)
             user_api_key = _metadata.get("user_api_key", None)
             self.print_verbose(f"user_api_key: {user_api_key}")
             if user_api_key is None:
@@ -742,9 +785,10 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     "current_rpm": 0,
                 }
 
+                # Release the reserved tokens on failure
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"],
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0),
                     "current_rpm": current["current_rpm"],
                 }
 

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -231,9 +231,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         if rpm_limit is None:
             rpm_limit = sys.maxsize
 
-        values_to_update_in_cache: List[
-            Tuple[Any, Any]
-        ] = (
+        values_to_update_in_cache: List[Tuple[Any, Any]] = (
             []
         )  # values that need to get updated in cache, will run a batch_set_cache after this function
 
@@ -570,7 +568,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0)
+                    + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -608,7 +607,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0)
+                    + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -642,7 +642,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0)
+                    + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -676,7 +677,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0)
+                    + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -710,7 +712,8 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Reconcile: subtract the pre-call reservation, add actual tokens
                 new_val = {
                     "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0) + total_tokens,
+                    "current_tpm": max(current["current_tpm"] - reserved_tokens, 0)
+                    + total_tokens,
                     "current_rpm": current["current_rpm"],
                 }
 
@@ -730,9 +733,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
             self.print_verbose("Inside Max Parallel Request Failure Hook")
-            litellm_parent_otel_span: Union[
-                Span, None
-            ] = _get_parent_otel_span_from_kwargs(kwargs=kwargs)
+            litellm_parent_otel_span: Union[Span, None] = (
+                _get_parent_otel_span_from_kwargs(kwargs=kwargs)
+            )
             _metadata = kwargs["litellm_params"].get("metadata", {}) or {}
             global_max_parallel_requests = _metadata.get(
                 "global_max_parallel_requests", None
@@ -829,9 +832,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                         or user_api_key_model_max_budget is not None
                     )
                 ):
-                    request_count_api_key = (
-                        f"{user_api_key}::{model_group}::{precise_minute}::request_count"
-                    )
+                    request_count_api_key = f"{user_api_key}::{model_group}::{precise_minute}::request_count"
 
                     current = await self.internal_usage_cache.async_get_cache(
                         key=request_count_api_key,
@@ -848,7 +849,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                         "current_rpm": current["current_rpm"],
                     }
 
-                    self.print_verbose(f"updated_value in failure call (model_per_key): {new_val}")
+                    self.print_verbose(
+                        f"updated_value in failure call (model_per_key): {new_val}"
+                    )
                     values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 # ------------
@@ -874,7 +877,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                         "current_rpm": current["current_rpm"],
                     }
 
-                    self.print_verbose(f"updated_value in failure call (user): {new_val}")
+                    self.print_verbose(
+                        f"updated_value in failure call (user): {new_val}"
+                    )
                     values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 # ------------
@@ -900,7 +905,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                         "current_rpm": current["current_rpm"],
                     }
 
-                    self.print_verbose(f"updated_value in failure call (team): {new_val}")
+                    self.print_verbose(
+                        f"updated_value in failure call (team): {new_val}"
+                    )
                     values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 # ------------
@@ -926,7 +933,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                         "current_rpm": current["current_rpm"],
                     }
 
-                    self.print_verbose(f"updated_value in failure call (end_user): {new_val}")
+                    self.print_verbose(
+                        f"updated_value in failure call (end_user): {new_val}"
+                    )
                     values_to_update_in_cache.append((request_count_api_key, new_val))
 
                 await self.internal_usage_cache.async_batch_set_cache(
@@ -989,11 +998,11 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         current_minute = datetime.now().strftime("%M")
         precise_minute = f"{current_date}-{current_hour}-{current_minute}"
         request_count_api_key = f"{api_key}::{precise_minute}::request_count"
-        current: Optional[
-            CurrentItemRateLimit
-        ] = await self.internal_usage_cache.async_get_cache(
-            key=request_count_api_key,
-            litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
+        current: Optional[CurrentItemRateLimit] = (
+            await self.internal_usage_cache.async_get_cache(
+                key=request_count_api_key,
+                litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
+            )
         )
 
         key_remaining_rpm_limit: Optional[int] = None
@@ -1025,15 +1034,15 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             _additional_headers = _hidden_params.get("additional_headers", {}) or {}
 
             if key_remaining_rpm_limit is not None:
-                _additional_headers[
-                    "x-ratelimit-remaining-requests"
-                ] = key_remaining_rpm_limit
+                _additional_headers["x-ratelimit-remaining-requests"] = (
+                    key_remaining_rpm_limit
+                )
             if key_rpm_limit is not None:
                 _additional_headers["x-ratelimit-limit-requests"] = key_rpm_limit
             if key_remaining_tpm_limit is not None:
-                _additional_headers[
-                    "x-ratelimit-remaining-tokens"
-                ] = key_remaining_tpm_limit
+                _additional_headers["x-ratelimit-remaining-tokens"] = (
+                    key_remaining_tpm_limit
+                )
             if key_tpm_limit is not None:
                 _additional_headers["x-ratelimit-limit-tokens"] = key_tpm_limit
 

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -2142,8 +2142,7 @@ async def _resolve_org_filter_for_user_search(
     member_org_ids: List[str] = []
     if caller_user is not None:
         member_org_ids = [
-            m.organization_id
-            for m in (caller_user.organization_memberships or [])
+            m.organization_id for m in (caller_user.organization_memberships or [])
         ]
 
     if member_org_ids:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -857,7 +857,13 @@ async def new_team(  # noqa: PLR0915
 
         # Apply defaults from litellm.default_team_params for any fields
         # not explicitly provided in the request.
-        for field in ("max_budget", "budget_duration", "tpm_limit", "rpm_limit", "team_member_permissions"):
+        for field in (
+            "max_budget",
+            "budget_duration",
+            "tpm_limit",
+            "rpm_limit",
+            "team_member_permissions",
+        ):
             if getattr(data, field, None) is None:
                 default_value = _get_default_team_param(field)
                 if default_value is not None:

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -857,7 +857,10 @@ async def update_batch_in_database(
             # If the batch_processed column doesn't exist (old schema),
             # retry without it so the status update still succeeds.
             err_str = str(col_err).lower()
-            if "batch_processed" in err_str and update_data.get("batch_processed") is not None:
+            if (
+                "batch_processed" in err_str
+                and update_data.get("batch_processed") is not None
+            ):
                 verbose_proxy_logger.warning(
                     f"batch_processed column not found, retrying update without it: {col_err}"
                 )

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -115,7 +115,9 @@ async def background_streaming_task(  # noqa: PLR0915
         UPDATE_INTERVAL = 0.150  # 150ms batching interval
 
         # Track the terminal event from the stream (may not be "completed")
-        terminal_status: Optional[ResponsesAPIStatus] = None  # Will be set by response.completed/failed/incomplete/cancelled
+        terminal_status: Optional[
+            ResponsesAPIStatus
+        ] = None  # Will be set by response.completed/failed/incomplete/cancelled
         terminal_error = None
         _event_to_status = {
             "response.completed": "completed",

--- a/litellm/proxy/spend_tracking/vantage_endpoints.py
+++ b/litellm/proxy/spend_tracking/vantage_endpoints.py
@@ -40,9 +40,7 @@ def _get_registered_vantage_logger():
     return None
 
 
-async def _set_vantage_settings(
-    api_key: str, integration_token: str, base_url: str
-):
+async def _set_vantage_settings(api_key: str, integration_token: str, base_url: str):
     """Store Vantage settings in the database with encrypted API key."""
     from litellm.proxy.proxy_server import prisma_client
 
@@ -341,9 +339,7 @@ async def init_vantage_settings(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(
-            f"Error initializing Vantage settings: {str(e)}"
-        )
+        verbose_proxy_logger.error(f"Error initializing Vantage settings: {str(e)}")
         raise HTTPException(
             status_code=500,
             detail={"error": f"Failed to initialize Vantage settings: {str(e)}"},
@@ -395,7 +391,8 @@ async def vantage_dry_run_export(
             """Cast Decimal columns to Float64 so .to_dicts() produces
             JSON-serializable float values instead of decimal.Decimal."""
             decimal_cols = [
-                col for col, dtype in zip(frame.columns, frame.dtypes)
+                col
+                for col, dtype in zip(frame.columns, frame.dtypes)
                 if isinstance(dtype, pl.Decimal)
             ]
             if decimal_cols:
@@ -404,8 +401,16 @@ async def vantage_dry_run_export(
                 )
             return frame.to_dicts()
 
-        usage_sample = _to_json_safe_dicts(data.head(min(50, len(data)))) if not data.is_empty() else []
-        normalized_sample = _to_json_safe_dicts(normalized.head(min(50, len(normalized)))) if not normalized.is_empty() else []
+        usage_sample = (
+            _to_json_safe_dicts(data.head(min(50, len(data))))
+            if not data.is_empty()
+            else []
+        )
+        normalized_sample = (
+            _to_json_safe_dicts(normalized.head(min(50, len(normalized))))
+            if not normalized.is_empty()
+            else []
+        )
 
         # Use the same pre-transform column names as
         # FocusExportEngine.dry_run_export_usage_data for consistency.
@@ -437,14 +442,10 @@ async def vantage_dry_run_export(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(
-            f"Error performing Vantage dry run export: {str(e)}"
-        )
+        verbose_proxy_logger.error(f"Error performing Vantage dry run export: {str(e)}")
         raise HTTPException(
             status_code=500,
-            detail={
-                "error": f"Failed to perform Vantage dry run export: {str(e)}"
-            },
+            detail={"error": f"Failed to perform Vantage dry run export: {str(e)}"},
         )
 
 

--- a/litellm/proxy/video_endpoints/utils.py
+++ b/litellm/proxy/video_endpoints/utils.py
@@ -7,7 +7,9 @@ from litellm.types.videos.utils import encode_character_id_with_provider
 
 def extract_model_from_target_model_names(target_model_names: Any) -> Optional[str]:
     if isinstance(target_model_names, str):
-        target_model_names = [m.strip() for m in target_model_names.split(",") if m.strip()]
+        target_model_names = [
+            m.strip() for m in target_model_names.split(",") if m.strip()
+        ]
     elif not isinstance(target_model_names, list):
         return None
     return target_model_names[0] if target_model_names else None

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -692,11 +692,11 @@ def responses(
             return run_async_function(aresponses_api_with_mcp, **mcp_call_kwargs)
 
         # get provider config
-        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
-            ProviderConfigManager.get_provider_responses_api_config(
-                model=model,
-                provider=custom_llm_provider,
-            )
+        responses_api_provider_config: Optional[
+            BaseResponsesAPIConfig
+        ] = ProviderConfigManager.get_provider_responses_api_config(
+            model=model,
+            provider=custom_llm_provider,
         )
 
         local_vars.update(kwargs)
@@ -908,11 +908,11 @@ def delete_responses(
             raise ValueError("custom_llm_provider is required but passed as None")
 
         # get provider config
-        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
-            ProviderConfigManager.get_provider_responses_api_config(
-                model=None,
-                provider=custom_llm_provider,
-            )
+        responses_api_provider_config: Optional[
+            BaseResponsesAPIConfig
+        ] = ProviderConfigManager.get_provider_responses_api_config(
+            model=None,
+            provider=custom_llm_provider,
         )
 
         if responses_api_provider_config is None:
@@ -1089,11 +1089,11 @@ def get_responses(
             raise ValueError("custom_llm_provider is required but passed as None")
 
         # get provider config
-        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
-            ProviderConfigManager.get_provider_responses_api_config(
-                model=None,
-                provider=custom_llm_provider,
-            )
+        responses_api_provider_config: Optional[
+            BaseResponsesAPIConfig
+        ] = ProviderConfigManager.get_provider_responses_api_config(
+            model=None,
+            provider=custom_llm_provider,
         )
 
         if responses_api_provider_config is None:
@@ -1247,11 +1247,11 @@ def list_input_items(
         if custom_llm_provider is None:
             raise ValueError("custom_llm_provider is required but passed as None")
 
-        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
-            ProviderConfigManager.get_provider_responses_api_config(
-                model=None,
-                provider=custom_llm_provider,
-            )
+        responses_api_provider_config: Optional[
+            BaseResponsesAPIConfig
+        ] = ProviderConfigManager.get_provider_responses_api_config(
+            model=None,
+            provider=custom_llm_provider,
         )
 
         if responses_api_provider_config is None:
@@ -1406,11 +1406,11 @@ def cancel_responses(
             raise ValueError("custom_llm_provider is required but passed as None")
 
         # get provider config
-        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
-            ProviderConfigManager.get_provider_responses_api_config(
-                model=None,
-                provider=custom_llm_provider,
-            )
+        responses_api_provider_config: Optional[
+            BaseResponsesAPIConfig
+        ] = ProviderConfigManager.get_provider_responses_api_config(
+            model=None,
+            provider=custom_llm_provider,
         )
 
         if responses_api_provider_config is None:
@@ -1594,11 +1594,11 @@ def compact_responses(
             raise ValueError("custom_llm_provider is required but passed as None")
 
         # get provider config
-        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
-            ProviderConfigManager.get_provider_responses_api_config(
-                model=model,
-                provider=custom_llm_provider,
-            )
+        responses_api_provider_config: Optional[
+            BaseResponsesAPIConfig
+        ] = ProviderConfigManager.get_provider_responses_api_config(
+            model=model,
+            provider=custom_llm_provider,
         )
 
         if responses_api_provider_config is None:

--- a/litellm/types/proxy/vantage_endpoints.py
+++ b/litellm/types/proxy/vantage_endpoints.py
@@ -39,7 +39,8 @@ class VantageExportRequest(BaseModel):
     """Request model for Vantage export operations (actual export, no default limit)"""
 
     limit: Optional[int] = Field(
-        None, description="Optional limit on number of records to export (default: no limit)"
+        None,
+        description="Optional limit on number of records to export (default: no limit)",
     )
     start_time_utc: Optional[datetime] = Field(
         None, description="Start time for data export in UTC"

--- a/litellm/types/videos/utils.py
+++ b/litellm/types/videos/utils.py
@@ -195,7 +195,9 @@ def decode_character_id_with_provider(encoded_character_id: str) -> DecodedChara
             character_id=decoded_character_id,
         )
     except Exception as e:
-        verbose_logger.debug(f"Error decoding character_id '{encoded_character_id}': {e}")
+        verbose_logger.debug(
+            f"Error decoding character_id '{encoded_character_id}': {e}"
+        )
         return DecodedCharacterId(
             custom_llm_provider=None,
             model_id=None,

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -1186,13 +1186,17 @@ def video_create_character(
 
         litellm_params = GenericLiteLLMParams(**kwargs)
 
-        provider_config: Optional[BaseVideoConfig] = ProviderConfigManager.get_provider_video_config(
+        provider_config: Optional[
+            BaseVideoConfig
+        ] = ProviderConfigManager.get_provider_video_config(
             model=None,
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
         if provider_config is None:
-            raise ValueError(f"video create character is not supported for {custom_llm_provider}")
+            raise ValueError(
+                f"video create character is not supported for {custom_llm_provider}"
+            )
 
         local_vars.update(kwargs)
         request_params: Dict = {"name": name}
@@ -1311,13 +1315,17 @@ def video_get_character(
 
         litellm_params = GenericLiteLLMParams(**kwargs)
 
-        provider_config: Optional[BaseVideoConfig] = ProviderConfigManager.get_provider_video_config(
+        provider_config: Optional[
+            BaseVideoConfig
+        ] = ProviderConfigManager.get_provider_video_config(
             model=None,
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
         if provider_config is None:
-            raise ValueError(f"video get character is not supported for {custom_llm_provider}")
+            raise ValueError(
+                f"video get character is not supported for {custom_llm_provider}"
+            )
 
         local_vars.update(kwargs)
         request_params: Dict = {"character_id": character_id}
@@ -1439,7 +1447,9 @@ def video_edit(
 
         litellm_params = GenericLiteLLMParams(**kwargs)
 
-        provider_config: Optional[BaseVideoConfig] = ProviderConfigManager.get_provider_video_config(
+        provider_config: Optional[
+            BaseVideoConfig
+        ] = ProviderConfigManager.get_provider_video_config(
             model=None,
             provider=litellm.LlmProviders(custom_llm_provider),
         )
@@ -1572,16 +1582,24 @@ def video_extension(
 
         litellm_params = GenericLiteLLMParams(**kwargs)
 
-        provider_config: Optional[BaseVideoConfig] = ProviderConfigManager.get_provider_video_config(
+        provider_config: Optional[
+            BaseVideoConfig
+        ] = ProviderConfigManager.get_provider_video_config(
             model=None,
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
         if provider_config is None:
-            raise ValueError(f"video extension is not supported for {custom_llm_provider}")
+            raise ValueError(
+                f"video extension is not supported for {custom_llm_provider}"
+            )
 
         local_vars.update(kwargs)
-        request_params: Dict = {"video_id": video_id, "prompt": prompt, "seconds": seconds}
+        request_params: Dict = {
+            "video_id": video_id,
+            "prompt": prompt,
+            "seconds": seconds,
+        }
 
         litellm_logging_obj.update_environment_variables(
             model="",

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py
@@ -165,7 +165,9 @@ async def test_reservation_cleared_after_success(handler, user_api_key_dict):
     except Exception:
         second_allowed = False
 
-    assert second_allowed, "Second request should be allowed after first completed with lower actual usage"
+    assert (
+        second_allowed
+    ), "Second request should be allowed after first completed with lower actual usage"
 
 
 @pytest.mark.asyncio
@@ -212,7 +214,9 @@ async def test_reservation_released_on_failure(handler, user_api_key_dict):
     except Exception:
         allowed = False
 
-    assert allowed, "Request should be allowed after failed request released its reservation"
+    assert (
+        allowed
+    ), "Request should be allowed after failed request released its reservation"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py
@@ -76,6 +76,9 @@ def test_estimate_request_tokens():
     assert handler_cls._estimate_request_tokens({}) == 0
     assert handler_cls._estimate_request_tokens({"max_tokens": 0}) == 0
     assert handler_cls._estimate_request_tokens({"max_tokens": -1}) == 0
+    # Bug 4: float values from JSON parsing should be handled
+    assert handler_cls._estimate_request_tokens({"max_tokens": 100.0}) == 100
+    assert handler_cls._estimate_request_tokens({"max_tokens": 99.9}) == 99
 
 
 @pytest.mark.asyncio
@@ -86,10 +89,8 @@ async def test_concurrent_requests_respect_tpm_limit(handler, user_api_key_dict)
     With the fix, only 2 should pass (100 tokens reserved).
     """
     cache = MagicMock()
-    allowed_count = 0
-    rejected_count = 0
 
-    for i in range(5):
+    async def try_request():
         data = {"model": "gpt-4", "max_tokens": 50, "metadata": {}}
         try:
             await handler.async_pre_call_hook(
@@ -98,9 +99,13 @@ async def test_concurrent_requests_respect_tpm_limit(handler, user_api_key_dict)
                 data=data,
                 call_type="completion",
             )
-            allowed_count += 1
+            return "allowed"
         except Exception:
-            rejected_count += 1
+            return "rejected"
+
+    results = await asyncio.gather(*[try_request() for _ in range(5)])
+    allowed_count = results.count("allowed")
+    rejected_count = results.count("rejected")
 
     # With TPM limit of 100 and max_tokens=50 per request,
     # only 2 requests should be allowed (2 * 50 = 100 <= TPM limit)
@@ -208,3 +213,21 @@ async def test_reservation_released_on_failure(handler, user_api_key_dict):
         allowed = False
 
     assert allowed, "Request should be allowed after failed request released its reservation"
+
+
+@pytest.mark.asyncio
+async def test_first_request_exceeding_tpm_limit_rejected(handler, user_api_key_dict):
+    """Bug 1: A single first request with max_tokens > tpm_limit should be
+    rejected even when the cache has no prior entry."""
+    cache = MagicMock()
+
+    # tpm_limit is 100, but request wants 200 tokens
+    data = {"model": "gpt-4", "max_tokens": 200, "metadata": {}}
+    with pytest.raises(Exception) as exc_info:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=cache,
+            data=data,
+            call_type="completion",
+        )
+    assert exc_info.value.status_code == 429

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py
@@ -1,0 +1,210 @@
+"""
+Test that concurrent requests don't bypass TPM limits.
+
+Fixes: https://github.com/BerriAI/litellm/issues/18730
+
+The root cause was a TOCTOU race condition: TPM was only updated
+after requests completed (in async_log_success_event), so concurrent
+requests all saw current_tpm=0 and passed the check.
+
+The fix reserves estimated tokens (max_tokens) at pre-call time and
+reconciles with actual usage on completion.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm import ModelResponse
+from litellm.proxy.hooks.parallel_request_limiter import (
+    _PROXY_MaxParallelRequestsHandler,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class FakeInternalUsageCache:
+    """In-memory cache for testing (mimics InternalUsageCache interface)."""
+
+    def __init__(self):
+        self._cache = {}
+
+    async def async_get_cache(self, key=None, **kwargs):
+        return self._cache.get(key)
+
+    async def async_set_cache(self, key, value, **kwargs):
+        self._cache[key] = value
+
+    async def async_batch_get_cache(self, keys=None, **kwargs):
+        if keys is None:
+            return None
+        return [self._cache.get(k) for k in keys]
+
+    async def async_batch_set_cache(self, cache_list=None, **kwargs):
+        if cache_list:
+            for key, value in cache_list:
+                self._cache[key] = value
+
+    async def async_increment_cache(self, key=None, value=1, **kwargs):
+        current = self._cache.get(key, 0)
+        self._cache[key] = current + value
+
+
+@pytest.fixture
+def handler():
+    cache = FakeInternalUsageCache()
+    return _PROXY_MaxParallelRequestsHandler(internal_usage_cache=cache)
+
+
+@pytest.fixture
+def user_api_key_dict():
+    return UserAPIKeyAuth(
+        api_key="test-key-123",
+        max_parallel_requests=100,
+        tpm_limit=100,
+        rpm_limit=100,
+        parent_otel_span=None,
+    )
+
+
+def test_estimate_request_tokens():
+    """_estimate_request_tokens should extract max_tokens from request data."""
+    handler_cls = _PROXY_MaxParallelRequestsHandler
+    assert handler_cls._estimate_request_tokens({"max_tokens": 500}) == 500
+    assert handler_cls._estimate_request_tokens({"max_completion_tokens": 300}) == 300
+    assert handler_cls._estimate_request_tokens({}) == 0
+    assert handler_cls._estimate_request_tokens({"max_tokens": 0}) == 0
+    assert handler_cls._estimate_request_tokens({"max_tokens": -1}) == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_respect_tpm_limit(handler, user_api_key_dict):
+    """
+    Reproduce issue #18730: 5 concurrent requests with max_tokens=50 each
+    against a TPM limit of 100. Without the fix, all 5 pass (250 tokens).
+    With the fix, only 2 should pass (100 tokens reserved).
+    """
+    cache = MagicMock()
+    allowed_count = 0
+    rejected_count = 0
+
+    for i in range(5):
+        data = {"model": "gpt-4", "max_tokens": 50, "metadata": {}}
+        try:
+            await handler.async_pre_call_hook(
+                user_api_key_dict=user_api_key_dict,
+                cache=cache,
+                data=data,
+                call_type="completion",
+            )
+            allowed_count += 1
+        except Exception:
+            rejected_count += 1
+
+    # With TPM limit of 100 and max_tokens=50 per request,
+    # only 2 requests should be allowed (2 * 50 = 100 <= TPM limit)
+    assert allowed_count == 2, (
+        f"Expected 2 requests allowed (2 * 50 = 100 TPM), "
+        f"but got {allowed_count} allowed"
+    )
+    assert rejected_count == 3
+
+
+@pytest.mark.asyncio
+async def test_reservation_cleared_after_success(handler, user_api_key_dict):
+    """After a request completes, its reservation should be reconciled
+    with actual usage, freeing capacity for new requests."""
+    cache = MagicMock()
+
+    # First request: reserves 50 tokens
+    data = {"model": "gpt-4", "max_tokens": 50, "metadata": {}}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=cache,
+        data=data,
+        call_type="completion",
+    )
+
+    # Simulate successful completion with only 20 actual tokens
+    response = MagicMock(spec=ModelResponse)
+    response.usage = MagicMock()
+    response.usage.total_tokens = 20
+
+    kwargs = {
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "test-key-123",
+                "_reserved_estimated_tokens": 50,
+            }
+        }
+    }
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=response,
+        start_time=None,
+        end_time=None,
+    )
+
+    # Now a second request should be able to use the freed capacity
+    # (100 TPM - 20 actual = 80 remaining, so 50 should fit)
+    data2 = {"model": "gpt-4", "max_tokens": 50, "metadata": {}}
+    try:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=cache,
+            data=data2,
+            call_type="completion",
+        )
+        second_allowed = True
+    except Exception:
+        second_allowed = False
+
+    assert second_allowed, "Second request should be allowed after first completed with lower actual usage"
+
+
+@pytest.mark.asyncio
+async def test_reservation_released_on_failure(handler, user_api_key_dict):
+    """If a request fails, its reserved tokens should be released."""
+    cache = MagicMock()
+
+    # Reserve 50 tokens
+    data = {"model": "gpt-4", "max_tokens": 50, "metadata": {}}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=cache,
+        data=data,
+        call_type="completion",
+    )
+
+    # Simulate failure — should release the 50 reserved tokens
+    kwargs = {
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "test-key-123",
+                "_reserved_estimated_tokens": 50,
+            }
+        },
+        "exception": "Connection error",
+    }
+    await handler.async_log_failure_event(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=None,
+        end_time=None,
+    )
+
+    # After failure release, should be able to use the full 100 TPM again
+    data2 = {"model": "gpt-4", "max_tokens": 90, "metadata": {}}
+    try:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=cache,
+            data=data2,
+            call_type="completion",
+        )
+        allowed = True
+    except Exception:
+        allowed = False
+
+    assert allowed, "Request should be allowed after failed request released its reservation"


### PR DESCRIPTION
## Summary

Fixes #18730 — concurrent requests bypass TPM rate limits because `current_tpm` is only updated after request completion.

**Root cause**: `check_key_in_limits` checks `current_tpm < tpm_limit` but never reserves tokens at pre-call time. TPM is only incremented in `async_log_success_event` after the request completes. When 5 concurrent requests arrive simultaneously, all 5 read `current_tpm=0` and pass — a classic TOCTOU (time-of-check-time-of-use) race condition.

**Fix**: Reserve estimated tokens (`max_tokens` from request data) at pre-call time. Reconcile with actual usage on completion:
- **Pre-call**: Add `max_tokens` to `current_tpm` when checking limits (reservation)
- **Success**: Subtract reservation, add actual `total_tokens` from response
- **Failure**: Release reservation (subtract `max_tokens` from `current_tpm`)

This follows the same reservation pattern described in the issue (AWS Bedrock style) and used by other rate limiting systems.

### Changes

- `litellm/proxy/hooks/parallel_request_limiter.py`:
  - Added `_estimate_request_tokens()` static method to extract `max_tokens` / `max_completion_tokens` from request data
  - `check_key_in_limits`: Now checks `current_tpm + estimated_tokens <= tpm_limit` and includes the estimate in the cached `current_tpm`
  - `async_pre_call_hook`: Stores `_reserved_estimated_tokens` in request metadata for reconciliation
  - `async_log_success_event`: Subtracts reservation, adds actual tokens across all rate limit types (key, model-per-key, user, team, end-user)
  - `async_log_failure_event`: Releases reserved tokens

- `tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py`: 4 new tests
  - `test_estimate_request_tokens` — unit test for token extraction
  - `test_concurrent_requests_respect_tpm_limit` — reproduces the exact issue (5 requests × 50 tokens against 100 TPM limit; only 2 should pass)
  - `test_reservation_cleared_after_success` — verifies capacity is freed after completion with actual usage
  - `test_reservation_released_on_failure` — verifies reservation is released on failure

## Test plan

- [x] 4 new mocked tests pass (`pytest tests/test_litellm/proxy/hooks/test_parallel_request_limiter_tpm_reservation.py`)
- [ ] Verify no regression on existing parallel request limiter tests
- [ ] Manual test with concurrent requests against proxy with TPM limit