### PR TITLE
Fix: PassThrough endpoints with auth: false still require Authorization header

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -89,7 +89,9 @@ class JWTHandler:
         self.leeway = leeway
 
     @staticmethod
-    def is_jwt(token: str):
+    def is_jwt(token: Optional[str]):
+        if token is None or not isinstance(token, str):
+            return False
         parts = token.split(".")
         return len(parts) == 3
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -558,6 +558,19 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         pass_through_endpoints: Optional[List[dict]] = general_settings.get(
             "pass_through_endpoints", None
         )
+        ## EARLY EXIT: Pass-through routes with auth disabled must skip all auth parsing.
+        ## This avoids NoneType.split() when api_key is None and JWT/OAuth2 parsing runs.
+        if pass_through_endpoints is not None:
+            for ep in pass_through_endpoints:
+                if not isinstance(ep, dict):
+                    continue
+                ep_path = ep.get("path", "")
+                route_matches = route == ep_path or (
+                    ep.get("include_subpath") is True
+                    and route.startswith(ep_path + "/")
+                )
+                if route_matches and ep.get("auth") is not True:
+                    return UserAPIKeyAuth()
         ## CHECK IF X-LITELM-API-KEY IS PASSED IN - supercedes Authorization header
         api_key, passed_in_key = get_api_key(
             custom_litellm_key_header=custom_litellm_key_header,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -560,6 +560,8 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         )
         ## EARLY EXIT: Pass-through routes with auth disabled must skip all auth parsing.
         ## This avoids NoneType.split() when api_key is None and JWT/OAuth2 parsing runs.
+        ## Align with registration logic (pass_through_endpoints.py): auth required when
+        ## auth is True or str(auth).lower() == "true".
         if pass_through_endpoints is not None:
             for ep in pass_through_endpoints:
                 if not isinstance(ep, dict):
@@ -569,7 +571,11 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     ep.get("include_subpath") is True
                     and route.startswith(ep_path + "/")
                 )
-                if route_matches and ep.get("auth") is not True:
+                ep_auth = ep.get("auth")
+                auth_required = ep_auth is True or (
+                    ep_auth is not None and str(ep_auth).lower() == "true"
+                )
+                if route_matches and not auth_required:
                     return UserAPIKeyAuth()
         ## CHECK IF X-LITELM-API-KEY IS PASSED IN - supercedes Authorization header
         api_key, passed_in_key = get_api_key(

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -562,7 +562,8 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         pass_through_endpoints: Optional[List[dict]] = general_settings.get(
             "pass_through_endpoints", None
         )
-        ## EARLY EXIT: Pass-through routes with auth disabled must skip all auth parsing.
+        ## EARLY EXIT: after pre_db_read_auth_checks, skip auth parsing for auth-disabled pass-through routes.
+        ## pre_db_read_auth_checks (IP/body/route safety) should still run for these requests.
         ## This avoids NoneType.split() when api_key is None and JWT/OAuth2 parsing runs.
         ## Default: auth required when auth is not set (None). Only bypass when explicitly false.
         if pass_through_endpoints is not None:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -418,8 +418,12 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
     if pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
             if isinstance(endpoint, dict) and endpoint.get("path", "") == route:
-                ## IF AUTH DISABLED
-                if endpoint.get("auth") is not True:
+                ## IF AUTH DISABLED (explicitly false). Default: auth required.
+                ep_auth = endpoint.get("auth")
+                auth_explicitly_false = ep_auth is False or (
+                    isinstance(ep_auth, str) and str(ep_auth).lower() == "false"
+                )
+                if auth_explicitly_false:
                     return UserAPIKeyAuth()
                 ## IF AUTH ENABLED
                 ### IF CUSTOM PARSER REQUIRED
@@ -560,8 +564,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         )
         ## EARLY EXIT: Pass-through routes with auth disabled must skip all auth parsing.
         ## This avoids NoneType.split() when api_key is None and JWT/OAuth2 parsing runs.
-        ## Align with registration logic (pass_through_endpoints.py): auth required when
-        ## auth is True or str(auth).lower() == "true".
+        ## Default: auth required when auth is not set (None). Only bypass when explicitly false.
         if pass_through_endpoints is not None:
             for ep in pass_through_endpoints:
                 if not isinstance(ep, dict):
@@ -572,8 +575,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     and route.startswith(ep_path + "/")
                 )
                 ep_auth = ep.get("auth")
-                auth_required = ep_auth is True or (
-                    ep_auth is not None and str(ep_auth).lower() == "true"
+                auth_required = not (
+                    ep_auth is False
+                    or (isinstance(ep_auth, str) and str(ep_auth).lower() == "false")
                 )
                 if route_matches and not auth_required:
                     return UserAPIKeyAuth()

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2258,8 +2258,11 @@ async def initialize_pass_through_endpoints(
         _default_query_params = endpoint.get("default_query_params", None)
         _auth = endpoint.get("auth", None)
         _dependencies = None
-        if _auth is not None and str(_auth).lower() == "true":
-            if premium_user is not True:
+        auth_explicitly_false = _auth is False or (
+            isinstance(_auth, str) and str(_auth).lower() == "false"
+        )
+        if not auth_explicitly_false:
+            if _auth is not None and str(_auth).lower() == "true" and premium_user is not True:
                 raise ValueError(
                     "Error Setting Authentication on Pass Through Endpoint: {}".format(
                         CommonProxyErrors.not_premium_user.value

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1106,6 +1106,10 @@ def create_pass_through_route(
     from litellm._uuid import uuid
     from litellm.proxy.types_utils.utils import get_instance_fn
 
+    # When auth is disabled (dependencies is None), skip user_api_key_auth to allow
+    # requests without Authorization header. Use a default UserAPIKeyAuth() instead.
+    _require_auth = dependencies is not None and len(dependencies) > 0
+
     try:
         if isinstance(target, CustomLogger):
             adapter = target
@@ -1114,130 +1118,287 @@ def create_pass_through_route(
         adapter_id = str(uuid.uuid4())
         litellm.adapters = [{"id": adapter_id, "adapter": adapter}]
 
-        async def endpoint_func(  # type: ignore
-            request: Request,
-            fastapi_response: Response,
-            user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-            subpath: str = "",  # captures sub-paths when include_subpath=True
-            custom_body: Optional[
-                dict
-            ] = None,  # accepted for signature compatibility with URL-based path; not forwarded because chat_completion_pass_through_endpoint does not support it
-        ):
-            return await chat_completion_pass_through_endpoint(
-                fastapi_response=fastapi_response,
-                request=request,
-                adapter_id=adapter_id,
-                user_api_key_dict=user_api_key_dict,
-            )
+        if _require_auth:
+
+            async def endpoint_func(  # type: ignore
+                request: Request,
+                fastapi_response: Response,
+                user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+                subpath: str = "",  # captures sub-paths when include_subpath=True
+                custom_body: Optional[
+                    dict
+                ] = None,  # accepted for signature compatibility with URL-based path; not forwarded because chat_completion_pass_through_endpoint does not support it
+            ):
+                return await chat_completion_pass_through_endpoint(
+                    fastapi_response=fastapi_response,
+                    request=request,
+                    adapter_id=adapter_id,
+                    user_api_key_dict=user_api_key_dict,
+                )
+        else:
+
+            async def endpoint_func(  # type: ignore
+                request: Request,
+                fastapi_response: Response,
+                user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+                subpath: str = "",  # captures sub-paths when include_subpath=True
+                custom_body: Optional[
+                    dict
+                ] = None,  # accepted for signature compatibility with URL-based path; not forwarded because chat_completion_pass_through_endpoint does not support it
+            ):
+                return await chat_completion_pass_through_endpoint(
+                    fastapi_response=fastapi_response,
+                    request=request,
+                    adapter_id=adapter_id,
+                    user_api_key_dict=user_api_key_dict or UserAPIKeyAuth(),
+                )
 
     except Exception:
         verbose_proxy_logger.debug("Defaulting to target being a url.")
 
-        async def endpoint_func(  # type: ignore
-            request: Request,
-            fastapi_response: Response,
-            user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-            subpath: str = "",  # captures sub-paths when include_subpath=True
-            custom_body: Optional[
-                dict
-            ] = None,  # caller-supplied body takes precedence over request-parsed body
-        ):
-            from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
-                InitPassThroughEndpointHelpers,
-            )
+        if _require_auth:
 
-            path = request.url.path
-
-            # Parse request data based on content type
-            (
-                query_params_data,
-                custom_body_data,
-                file_data,
-                stream,
-            ) = await _parse_request_data_by_content_type(request)
-
-            if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(
-                route=path
+            async def endpoint_func(  # type: ignore
+                request: Request,
+                fastapi_response: Response,
+                user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+                subpath: str = "",  # captures sub-paths when include_subpath=True
+                custom_body: Optional[
+                    dict
+                ] = None,  # caller-supplied body takes precedence over request-parsed body
             ):
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
+                from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+                    InitPassThroughEndpointHelpers,
                 )
 
-            passthrough_params = (
-                InitPassThroughEndpointHelpers.get_registered_pass_through_route(
-                    route=path, method=request.method
+                path = request.url.path
+
+                # Parse request data based on content type
+                (
+                    query_params_data,
+                    custom_body_data,
+                    file_data,
+                    stream,
+                ) = await _parse_request_data_by_content_type(request)
+
+                if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(
+                    route=path
+                ):
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
+                    )
+
+                passthrough_params = (
+                    InitPassThroughEndpointHelpers.get_registered_pass_through_route(
+                        route=path, method=request.method
+                    )
                 )
-            )
-            target_params = {
-                "target": target,
-                "custom_headers": custom_headers,
-                "forward_headers": _forward_headers,
-                "merge_query_params": _merge_query_params,
-                "cost_per_request": cost_per_request,
-                "guardrails": None,
-            }
+                target_params = {
+                    "target": target,
+                    "custom_headers": custom_headers,
+                    "forward_headers": _forward_headers,
+                    "merge_query_params": _merge_query_params,
+                    "cost_per_request": cost_per_request,
+                    "guardrails": None,
+                }
 
-            if passthrough_params is not None:
-                target_params.update(passthrough_params.get("passthrough_params", {}))
+                if passthrough_params is not None:
+                    target_params.update(
+                        passthrough_params.get("passthrough_params", {})
+                    )
 
-            # Extract and cast parameters with proper types
-            param_target = target_params.get("target") or target
-            param_custom_headers = target_params.get("custom_headers", custom_headers)
-            param_forward_headers = target_params.get(
-                "forward_headers", _forward_headers
-            )
-            param_merge_query_params = target_params.get(
-                "merge_query_params", _merge_query_params
-            )
-            param_cost_per_request = target_params.get(
-                "cost_per_request", cost_per_request
-            )
-            param_guardrails = target_params.get("guardrails", None)
-            param_default_query_params = target_params.get("default_query_params", None)
-
-            # Construct the full target URL with subpath if needed
-            full_target = (
-                HttpPassThroughEndpointHelpers.construct_target_url_with_subpath(
-                    base_target=cast(str, param_target),
-                    subpath=subpath,
-                    include_subpath=include_subpath,
+                # Extract and cast parameters with proper types
+                param_target = target_params.get("target") or target
+                param_custom_headers = target_params.get(
+                    "custom_headers", custom_headers
                 )
-            )
+                param_forward_headers = target_params.get(
+                    "forward_headers", _forward_headers
+                )
+                param_merge_query_params = target_params.get(
+                    "merge_query_params", _merge_query_params
+                )
+                param_cost_per_request = target_params.get(
+                    "cost_per_request", cost_per_request
+                )
+                param_guardrails = target_params.get("guardrails", None)
+                param_default_query_params = target_params.get(
+                    "default_query_params", None
+                )
 
-            # Ensure custom_headers is a dict
-            headers_dict = (
-                param_custom_headers if isinstance(param_custom_headers, dict) else {}
-            )
+                # Construct the full target URL with subpath if needed
+                full_target = (
+                    HttpPassThroughEndpointHelpers.construct_target_url_with_subpath(
+                        base_target=cast(str, param_target),
+                        subpath=subpath,
+                        include_subpath=include_subpath,
+                    )
+                )
 
-            # Ensure query_params and custom_body are dicts or None
-            final_query_params = (
-                query_params_data if isinstance(query_params_data, dict) else {}
-            )
-            if query_params:
-                final_query_params.update(query_params)
-            # Caller-supplied custom_body takes precedence over the request-parsed body
-            final_custom_body: Optional[dict] = None
-            if custom_body is not None:
-                final_custom_body = custom_body
-            elif isinstance(custom_body_data, dict):
-                final_custom_body = custom_body_data
+                # Ensure custom_headers is a dict
+                headers_dict = (
+                    param_custom_headers
+                    if isinstance(param_custom_headers, dict)
+                    else {}
+                )
 
-            return await pass_through_request(  # type: ignore
-                request=request,
-                target=full_target,
-                custom_headers=headers_dict,
-                user_api_key_dict=user_api_key_dict,
-                forward_headers=cast(Optional[bool], param_forward_headers),
-                merge_query_params=cast(Optional[bool], param_merge_query_params),
-                query_params=final_query_params,
-                default_query_params=cast(Optional[dict], param_default_query_params),
-                stream=is_streaming_request or stream,
-                custom_body=final_custom_body,
-                cost_per_request=cast(Optional[float], param_cost_per_request),
-                custom_llm_provider=custom_llm_provider,
-                guardrails_config=cast(Optional[dict], param_guardrails),
-            )
+                # Ensure query_params and custom_body are dicts or None
+                final_query_params = (
+                    query_params_data if isinstance(query_params_data, dict) else {}
+                )
+                if query_params:
+                    final_query_params.update(query_params)
+                # Caller-supplied custom_body takes precedence over request-parsed body
+                final_custom_body: Optional[dict] = None
+                if custom_body is not None:
+                    final_custom_body = custom_body
+                elif isinstance(custom_body_data, dict):
+                    final_custom_body = custom_body_data
+
+                return await pass_through_request(  # type: ignore
+                    request=request,
+                    target=full_target,
+                    custom_headers=headers_dict,
+                    user_api_key_dict=user_api_key_dict,
+                    forward_headers=cast(Optional[bool], param_forward_headers),
+                    merge_query_params=cast(
+                        Optional[bool], param_merge_query_params
+                    ),
+                    query_params=final_query_params,
+                    default_query_params=cast(
+                        Optional[dict], param_default_query_params
+                    ),
+                    stream=is_streaming_request or stream,
+                    custom_body=final_custom_body,
+                    cost_per_request=cast(
+                        Optional[float], param_cost_per_request
+                    ),
+                    custom_llm_provider=custom_llm_provider,
+                    guardrails_config=cast(Optional[dict], param_guardrails),
+                )
+        else:
+
+            async def endpoint_func(  # type: ignore
+                request: Request,
+                fastapi_response: Response,
+                user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+                subpath: str = "",  # captures sub-paths when include_subpath=True
+                custom_body: Optional[
+                    dict
+                ] = None,  # caller-supplied body takes precedence over request-parsed body
+            ):
+                from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+                    InitPassThroughEndpointHelpers,
+                )
+
+                path = request.url.path
+
+                # Parse request data based on content type
+                (
+                    query_params_data,
+                    custom_body_data,
+                    file_data,
+                    stream,
+                ) = await _parse_request_data_by_content_type(request)
+
+                if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(
+                    route=path
+                ):
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
+                    )
+
+                passthrough_params = (
+                    InitPassThroughEndpointHelpers.get_registered_pass_through_route(
+                        route=path, method=request.method
+                    )
+                )
+                target_params = {
+                    "target": target,
+                    "custom_headers": custom_headers,
+                    "forward_headers": _forward_headers,
+                    "merge_query_params": _merge_query_params,
+                    "cost_per_request": cost_per_request,
+                    "guardrails": None,
+                }
+
+                if passthrough_params is not None:
+                    target_params.update(
+                        passthrough_params.get("passthrough_params", {})
+                    )
+
+                # Extract and cast parameters with proper types
+                param_target = target_params.get("target") or target
+                param_custom_headers = target_params.get(
+                    "custom_headers", custom_headers
+                )
+                param_forward_headers = target_params.get(
+                    "forward_headers", _forward_headers
+                )
+                param_merge_query_params = target_params.get(
+                    "merge_query_params", _merge_query_params
+                )
+                param_cost_per_request = target_params.get(
+                    "cost_per_request", cost_per_request
+                )
+                param_guardrails = target_params.get("guardrails", None)
+                param_default_query_params = target_params.get(
+                    "default_query_params", None
+                )
+
+                # Construct the full target URL with subpath if needed
+                full_target = (
+                    HttpPassThroughEndpointHelpers.construct_target_url_with_subpath(
+                        base_target=cast(str, param_target),
+                        subpath=subpath,
+                        include_subpath=include_subpath,
+                    )
+                )
+
+                # Ensure custom_headers is a dict
+                headers_dict = (
+                    param_custom_headers
+                    if isinstance(param_custom_headers, dict)
+                    else {}
+                )
+
+                # Ensure query_params and custom_body are dicts or None
+                final_query_params = (
+                    query_params_data if isinstance(query_params_data, dict) else {}
+                )
+                if query_params:
+                    final_query_params.update(query_params)
+                # Caller-supplied custom_body takes precedence over request-parsed body
+                final_custom_body = None
+                if custom_body is not None:
+                    final_custom_body = custom_body
+                elif isinstance(custom_body_data, dict):
+                    final_custom_body = custom_body_data
+
+                _user_api_key_dict = user_api_key_dict or UserAPIKeyAuth()
+                return await pass_through_request(  # type: ignore
+                    request=request,
+                    target=full_target,
+                    custom_headers=headers_dict,
+                    user_api_key_dict=_user_api_key_dict,
+                    forward_headers=cast(Optional[bool], param_forward_headers),
+                    merge_query_params=cast(
+                        Optional[bool], param_merge_query_params
+                    ),
+                    query_params=final_query_params,
+                    default_query_params=cast(
+                        Optional[dict], param_default_query_params
+                    ),
+                    stream=is_streaming_request or stream,
+                    custom_body=final_custom_body,
+                    cost_per_request=cast(
+                        Optional[float], param_cost_per_request
+                    ),
+                    custom_llm_provider=custom_llm_provider,
+                    guardrails_config=cast(Optional[dict], param_guardrails),
+                )
 
     return endpoint_func
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1102,13 +1102,122 @@ def create_pass_through_route(
     default_query_params: Optional[dict] = None,
     guardrails: Optional[Dict[str, Any]] = None,
 ):
-    # check if target is an adapter.py or a url
     from litellm._uuid import uuid
     from litellm.proxy.types_utils.utils import get_instance_fn
 
-    # When auth is disabled (dependencies is None), skip user_api_key_auth to allow
-    # requests without Authorization header. Use a default UserAPIKeyAuth() instead.
     _require_auth = dependencies is not None and len(dependencies) > 0
+
+    def _resolve_user_api_key(
+        user_api_key_dict: Optional[UserAPIKeyAuth],
+    ) -> UserAPIKeyAuth:
+        return user_api_key_dict or UserAPIKeyAuth()
+
+    async def _url_passthrough_handler_impl(
+        request: Request,
+        user_api_key_dict: UserAPIKeyAuth,
+        subpath: str,
+        custom_body: Optional[dict],
+    ):
+        """Shared URL pass-through logic. user_api_key_dict is always valid (never None)."""
+        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+            InitPassThroughEndpointHelpers,
+        )
+
+        path = request.url.path
+        (
+            query_params_data,
+            custom_body_data,
+            file_data,
+            stream,
+        ) = await _parse_request_data_by_content_type(request)
+
+        if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(
+            route=path
+        ):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
+            )
+
+        passthrough_params = (
+            InitPassThroughEndpointHelpers.get_registered_pass_through_route(
+                route=path, method=request.method
+            )
+        )
+        target_params = {
+            "target": target,
+            "custom_headers": custom_headers,
+            "forward_headers": _forward_headers,
+            "merge_query_params": _merge_query_params,
+            "cost_per_request": cost_per_request,
+            "guardrails": None,
+        }
+        if passthrough_params is not None:
+            target_params.update(
+                passthrough_params.get("passthrough_params", {})
+            )
+
+        param_target = target_params.get("target") or target
+        param_custom_headers = target_params.get("custom_headers", custom_headers)
+        param_forward_headers = target_params.get(
+            "forward_headers", _forward_headers
+        )
+        param_merge_query_params = target_params.get(
+            "merge_query_params", _merge_query_params
+        )
+        param_cost_per_request = target_params.get(
+            "cost_per_request", cost_per_request
+        )
+        param_guardrails = target_params.get("guardrails", None)
+        param_default_query_params = target_params.get(
+            "default_query_params", None
+        )
+
+        full_target = (
+            HttpPassThroughEndpointHelpers.construct_target_url_with_subpath(
+                base_target=cast(str, param_target),
+                subpath=subpath,
+                include_subpath=include_subpath,
+            )
+        )
+
+        headers_dict = (
+            param_custom_headers
+            if isinstance(param_custom_headers, dict)
+            else {}
+        )
+        final_query_params = (
+            query_params_data if isinstance(query_params_data, dict) else {}
+        )
+        if query_params:
+            final_query_params.update(query_params)
+        final_custom_body: Optional[dict] = None
+        if custom_body is not None:
+            final_custom_body = custom_body
+        elif isinstance(custom_body_data, dict):
+            final_custom_body = custom_body_data
+
+        return await pass_through_request(  # type: ignore
+            request=request,
+            target=full_target,
+            custom_headers=headers_dict,
+            user_api_key_dict=user_api_key_dict,
+            forward_headers=cast(Optional[bool], param_forward_headers),
+            merge_query_params=cast(
+                Optional[bool], param_merge_query_params
+            ),
+            query_params=final_query_params,
+            default_query_params=cast(
+                Optional[dict], param_default_query_params
+            ),
+            stream=is_streaming_request or stream,
+            custom_body=final_custom_body,
+            cost_per_request=cast(
+                Optional[float], param_cost_per_request
+            ),
+            custom_llm_provider=custom_llm_provider,
+            guardrails_config=cast(Optional[dict], param_guardrails),
+        )
 
     try:
         if isinstance(target, CustomLogger):
@@ -1124,10 +1233,8 @@ def create_pass_through_route(
                 request: Request,
                 fastapi_response: Response,
                 user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-                subpath: str = "",  # captures sub-paths when include_subpath=True
-                custom_body: Optional[
-                    dict
-                ] = None,  # accepted for signature compatibility with URL-based path; not forwarded because chat_completion_pass_through_endpoint does not support it
+                subpath: str = "",
+                custom_body: Optional[dict] = None,
             ):
                 return await chat_completion_pass_through_endpoint(
                     fastapi_response=fastapi_response,
@@ -1141,18 +1248,15 @@ def create_pass_through_route(
                 request: Request,
                 fastapi_response: Response,
                 user_api_key_dict: Optional[UserAPIKeyAuth] = None,
-                subpath: str = "",  # captures sub-paths when include_subpath=True
-                custom_body: Optional[
-                    dict
-                ] = None,  # accepted for signature compatibility with URL-based path; not forwarded because chat_completion_pass_through_endpoint does not support it
+                subpath: str = "",
+                custom_body: Optional[dict] = None,
             ):
                 return await chat_completion_pass_through_endpoint(
                     fastapi_response=fastapi_response,
                     request=request,
                     adapter_id=adapter_id,
-                    user_api_key_dict=user_api_key_dict or UserAPIKeyAuth(),
+                    user_api_key_dict=_resolve_user_api_key(user_api_key_dict),
                 )
-
     except Exception:
         verbose_proxy_logger.debug("Defaulting to target being a url.")
 
@@ -1162,120 +1266,11 @@ def create_pass_through_route(
                 request: Request,
                 fastapi_response: Response,
                 user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-                subpath: str = "",  # captures sub-paths when include_subpath=True
-                custom_body: Optional[
-                    dict
-                ] = None,  # caller-supplied body takes precedence over request-parsed body
+                subpath: str = "",
+                custom_body: Optional[dict] = None,
             ):
-                from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
-                    InitPassThroughEndpointHelpers,
-                )
-
-                path = request.url.path
-
-                # Parse request data based on content type
-                (
-                    query_params_data,
-                    custom_body_data,
-                    file_data,
-                    stream,
-                ) = await _parse_request_data_by_content_type(request)
-
-                if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(
-                    route=path
-                ):
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
-                    )
-
-                passthrough_params = (
-                    InitPassThroughEndpointHelpers.get_registered_pass_through_route(
-                        route=path, method=request.method
-                    )
-                )
-                target_params = {
-                    "target": target,
-                    "custom_headers": custom_headers,
-                    "forward_headers": _forward_headers,
-                    "merge_query_params": _merge_query_params,
-                    "cost_per_request": cost_per_request,
-                    "guardrails": None,
-                }
-
-                if passthrough_params is not None:
-                    target_params.update(
-                        passthrough_params.get("passthrough_params", {})
-                    )
-
-                # Extract and cast parameters with proper types
-                param_target = target_params.get("target") or target
-                param_custom_headers = target_params.get(
-                    "custom_headers", custom_headers
-                )
-                param_forward_headers = target_params.get(
-                    "forward_headers", _forward_headers
-                )
-                param_merge_query_params = target_params.get(
-                    "merge_query_params", _merge_query_params
-                )
-                param_cost_per_request = target_params.get(
-                    "cost_per_request", cost_per_request
-                )
-                param_guardrails = target_params.get("guardrails", None)
-                param_default_query_params = target_params.get(
-                    "default_query_params", None
-                )
-
-                # Construct the full target URL with subpath if needed
-                full_target = (
-                    HttpPassThroughEndpointHelpers.construct_target_url_with_subpath(
-                        base_target=cast(str, param_target),
-                        subpath=subpath,
-                        include_subpath=include_subpath,
-                    )
-                )
-
-                # Ensure custom_headers is a dict
-                headers_dict = (
-                    param_custom_headers
-                    if isinstance(param_custom_headers, dict)
-                    else {}
-                )
-
-                # Ensure query_params and custom_body are dicts or None
-                final_query_params = (
-                    query_params_data if isinstance(query_params_data, dict) else {}
-                )
-                if query_params:
-                    final_query_params.update(query_params)
-                # Caller-supplied custom_body takes precedence over request-parsed body
-                final_custom_body: Optional[dict] = None
-                if custom_body is not None:
-                    final_custom_body = custom_body
-                elif isinstance(custom_body_data, dict):
-                    final_custom_body = custom_body_data
-
-                return await pass_through_request(  # type: ignore
-                    request=request,
-                    target=full_target,
-                    custom_headers=headers_dict,
-                    user_api_key_dict=user_api_key_dict,
-                    forward_headers=cast(Optional[bool], param_forward_headers),
-                    merge_query_params=cast(
-                        Optional[bool], param_merge_query_params
-                    ),
-                    query_params=final_query_params,
-                    default_query_params=cast(
-                        Optional[dict], param_default_query_params
-                    ),
-                    stream=is_streaming_request or stream,
-                    custom_body=final_custom_body,
-                    cost_per_request=cast(
-                        Optional[float], param_cost_per_request
-                    ),
-                    custom_llm_provider=custom_llm_provider,
-                    guardrails_config=cast(Optional[dict], param_guardrails),
+                return await _url_passthrough_handler_impl(
+                    request, user_api_key_dict, subpath, custom_body
                 )
         else:
 
@@ -1283,121 +1278,14 @@ def create_pass_through_route(
                 request: Request,
                 fastapi_response: Response,
                 user_api_key_dict: Optional[UserAPIKeyAuth] = None,
-                subpath: str = "",  # captures sub-paths when include_subpath=True
-                custom_body: Optional[
-                    dict
-                ] = None,  # caller-supplied body takes precedence over request-parsed body
+                subpath: str = "",
+                custom_body: Optional[dict] = None,
             ):
-                from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
-                    InitPassThroughEndpointHelpers,
-                )
-
-                path = request.url.path
-
-                # Parse request data based on content type
-                (
-                    query_params_data,
-                    custom_body_data,
-                    file_data,
-                    stream,
-                ) = await _parse_request_data_by_content_type(request)
-
-                if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(
-                    route=path
-                ):
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
-                    )
-
-                passthrough_params = (
-                    InitPassThroughEndpointHelpers.get_registered_pass_through_route(
-                        route=path, method=request.method
-                    )
-                )
-                target_params = {
-                    "target": target,
-                    "custom_headers": custom_headers,
-                    "forward_headers": _forward_headers,
-                    "merge_query_params": _merge_query_params,
-                    "cost_per_request": cost_per_request,
-                    "guardrails": None,
-                }
-
-                if passthrough_params is not None:
-                    target_params.update(
-                        passthrough_params.get("passthrough_params", {})
-                    )
-
-                # Extract and cast parameters with proper types
-                param_target = target_params.get("target") or target
-                param_custom_headers = target_params.get(
-                    "custom_headers", custom_headers
-                )
-                param_forward_headers = target_params.get(
-                    "forward_headers", _forward_headers
-                )
-                param_merge_query_params = target_params.get(
-                    "merge_query_params", _merge_query_params
-                )
-                param_cost_per_request = target_params.get(
-                    "cost_per_request", cost_per_request
-                )
-                param_guardrails = target_params.get("guardrails", None)
-                param_default_query_params = target_params.get(
-                    "default_query_params", None
-                )
-
-                # Construct the full target URL with subpath if needed
-                full_target = (
-                    HttpPassThroughEndpointHelpers.construct_target_url_with_subpath(
-                        base_target=cast(str, param_target),
-                        subpath=subpath,
-                        include_subpath=include_subpath,
-                    )
-                )
-
-                # Ensure custom_headers is a dict
-                headers_dict = (
-                    param_custom_headers
-                    if isinstance(param_custom_headers, dict)
-                    else {}
-                )
-
-                # Ensure query_params and custom_body are dicts or None
-                final_query_params = (
-                    query_params_data if isinstance(query_params_data, dict) else {}
-                )
-                if query_params:
-                    final_query_params.update(query_params)
-                # Caller-supplied custom_body takes precedence over request-parsed body
-                final_custom_body = None
-                if custom_body is not None:
-                    final_custom_body = custom_body
-                elif isinstance(custom_body_data, dict):
-                    final_custom_body = custom_body_data
-
-                _user_api_key_dict = user_api_key_dict or UserAPIKeyAuth()
-                return await pass_through_request(  # type: ignore
-                    request=request,
-                    target=full_target,
-                    custom_headers=headers_dict,
-                    user_api_key_dict=_user_api_key_dict,
-                    forward_headers=cast(Optional[bool], param_forward_headers),
-                    merge_query_params=cast(
-                        Optional[bool], param_merge_query_params
-                    ),
-                    query_params=final_query_params,
-                    default_query_params=cast(
-                        Optional[dict], param_default_query_params
-                    ),
-                    stream=is_streaming_request or stream,
-                    custom_body=final_custom_body,
-                    cost_per_request=cast(
-                        Optional[float], param_cost_per_request
-                    ),
-                    custom_llm_provider=custom_llm_provider,
-                    guardrails_config=cast(Optional[dict], param_guardrails),
+                return await _url_passthrough_handler_impl(
+                    request,
+                    _resolve_user_api_key(user_api_key_dict),
+                    subpath,
+                    custom_body,
                 )
 
     return endpoint_func

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1094,6 +1094,7 @@ def create_pass_through_route(
     _forward_headers: Optional[bool] = False,
     _merge_query_params: Optional[bool] = False,
     dependencies: Optional[List] = None,
+    require_auth: Optional[bool] = None,
     include_subpath: Optional[bool] = False,
     cost_per_request: Optional[float] = None,
     custom_llm_provider: Optional[str] = None,
@@ -1105,7 +1106,11 @@ def create_pass_through_route(
     from litellm._uuid import uuid
     from litellm.proxy.types_utils.utils import get_instance_fn
 
-    _require_auth = dependencies is not None and len(dependencies) > 0
+    _require_auth = (
+        require_auth
+        if require_auth is not None
+        else dependencies is not None and len(dependencies) > 0
+    )
 
     def _resolve_user_api_key(
         user_api_key_dict: Optional[UserAPIKeyAuth],
@@ -1918,6 +1923,7 @@ class InitPassThroughEndpointHelpers:
         forward_headers: Optional[bool],
         merge_query_params: Optional[bool],
         dependencies: Optional[List],
+        require_auth: Optional[bool],
         cost_per_request: Optional[float],
         endpoint_id: str,
         guardrails: Optional[dict] = None,
@@ -1959,6 +1965,7 @@ class InitPassThroughEndpointHelpers:
                 forward_headers,
                 merge_query_params,
                 dependencies,
+                require_auth=require_auth,
                 cost_per_request=cost_per_request,
                 default_query_params=default_query_params,
                 guardrails=guardrails,
@@ -1994,6 +2001,7 @@ class InitPassThroughEndpointHelpers:
         forward_headers: Optional[bool],
         merge_query_params: Optional[bool],
         dependencies: Optional[List],
+        require_auth: Optional[bool],
         cost_per_request: Optional[float],
         endpoint_id: str,
         guardrails: Optional[dict] = None,
@@ -2035,6 +2043,7 @@ class InitPassThroughEndpointHelpers:
                 forward_headers,
                 merge_query_params,
                 dependencies,
+                require_auth=require_auth,
                 include_subpath=True,
                 cost_per_request=cost_per_request,
                 default_query_params=default_query_params,
@@ -2262,15 +2271,19 @@ async def initialize_pass_through_endpoints(
             isinstance(_auth, str) and str(_auth).lower() == "false"
         )
         if not auth_explicitly_false:
-            if _auth is not None and str(_auth).lower() == "true" and premium_user is not True:
+            if (
+                _auth is not None
+                and str(_auth).lower() == "true"
+                and premium_user is not True
+            ):
                 raise ValueError(
                     "Error Setting Authentication on Pass Through Endpoint: {}".format(
                         CommonProxyErrors.not_premium_user.value
                     )
                 )
-            _dependencies = [Depends(user_api_key_auth)]
             # Only add to openai_routes when auth is explicitly true (preserve original scope)
             if _auth is not None and str(_auth).lower() == "true":
+                _dependencies = [Depends(user_api_key_auth)]
                 LiteLLMRoutes.openai_routes.value.append(_path)
 
         if _target is None:
@@ -2294,6 +2307,7 @@ async def initialize_pass_through_endpoints(
             forward_headers=_forward_headers,
             merge_query_params=_merge_query_params,
             dependencies=_dependencies,
+            require_auth=not auth_explicitly_false,
             cost_per_request=endpoint.get("cost_per_request", None),
             endpoint_id=endpoint_id,
             guardrails=_guardrails,
@@ -2318,6 +2332,7 @@ async def initialize_pass_through_endpoints(
                 forward_headers=_forward_headers,
                 merge_query_params=_merge_query_params,
                 dependencies=_dependencies,
+                require_auth=not auth_explicitly_false,
                 cost_per_request=endpoint.get("cost_per_request", None),
                 endpoint_id=endpoint_id,
                 guardrails=_guardrails,
@@ -2625,6 +2640,16 @@ async def update_pass_through_endpoints(
     # Re-register the route with updated headers
     _custom_headers: Optional[dict] = updated_endpoint.headers or {}
     _custom_headers = await set_env_variables_in_header(custom_headers=_custom_headers)
+    _updated_auth = updated_endpoint.auth
+    _updated_auth_explicitly_false = _updated_auth is False or (
+        isinstance(_updated_auth, str) and str(_updated_auth).lower() == "false"
+    )
+    _updated_require_auth = not _updated_auth_explicitly_false
+    _updated_dependencies = (
+        [Depends(user_api_key_auth)]
+        if _updated_auth is not None and str(_updated_auth).lower() == "true"
+        else None
+    )
 
     if updated_endpoint.include_subpath:
         InitPassThroughEndpointHelpers.add_subpath_route(
@@ -2634,7 +2659,8 @@ async def update_pass_through_endpoints(
             custom_headers=_custom_headers,
             forward_headers=None,  # Defaults not available in model? assuming None logic handles it
             merge_query_params=None,
-            dependencies=None,
+            dependencies=_updated_dependencies,
+            require_auth=_updated_require_auth,
             cost_per_request=updated_endpoint.cost_per_request,
             endpoint_id=updated_endpoint.id or endpoint_id or "",
             guardrails=getattr(updated_endpoint, "guardrails", None),
@@ -2649,7 +2675,8 @@ async def update_pass_through_endpoints(
             custom_headers=_custom_headers,
             forward_headers=None,
             merge_query_params=None,
-            dependencies=None,
+            dependencies=_updated_dependencies,
+            require_auth=_updated_require_auth,
             cost_per_request=updated_endpoint.cost_per_request,
             endpoint_id=updated_endpoint.id or endpoint_id or "",
             guardrails=getattr(updated_endpoint, "guardrails", None),
@@ -2718,6 +2745,16 @@ async def create_pass_through_endpoints(
     # Register the new route
     _custom_headers: Optional[dict] = created_endpoint.headers or {}
     _custom_headers = await set_env_variables_in_header(custom_headers=_custom_headers)
+    _created_auth = created_endpoint.auth
+    _created_auth_explicitly_false = _created_auth is False or (
+        isinstance(_created_auth, str) and str(_created_auth).lower() == "false"
+    )
+    _created_require_auth = not _created_auth_explicitly_false
+    _created_dependencies = (
+        [Depends(user_api_key_auth)]
+        if _created_auth is not None and str(_created_auth).lower() == "true"
+        else None
+    )
 
     if created_endpoint.include_subpath:
         InitPassThroughEndpointHelpers.add_subpath_route(
@@ -2727,7 +2764,8 @@ async def create_pass_through_endpoints(
             custom_headers=_custom_headers,
             forward_headers=None,
             merge_query_params=None,
-            dependencies=None,
+            dependencies=_created_dependencies,
+            require_auth=_created_require_auth,
             cost_per_request=created_endpoint.cost_per_request,
             endpoint_id=created_endpoint.id or "",
             guardrails=getattr(created_endpoint, "guardrails", None),
@@ -2742,7 +2780,8 @@ async def create_pass_through_endpoints(
             custom_headers=_custom_headers,
             forward_headers=None,
             merge_query_params=None,
-            dependencies=None,
+            dependencies=_created_dependencies,
+            require_auth=_created_require_auth,
             cost_per_request=created_endpoint.cost_per_request,
             endpoint_id=created_endpoint.id or "",
             guardrails=getattr(created_endpoint, "guardrails", None),

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2269,7 +2269,9 @@ async def initialize_pass_through_endpoints(
                     )
                 )
             _dependencies = [Depends(user_api_key_auth)]
-            LiteLLMRoutes.openai_routes.value.append(_path)
+            # Only add to openai_routes when auth is explicitly true (preserve original scope)
+            if _auth is not None and str(_auth).lower() == "true":
+                LiteLLMRoutes.openai_routes.value.append(_path)
 
         if _target is None:
             continue

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1074,6 +1074,11 @@ async def test_auth_builder_with_oidc_userinfo_disabled():
         assert result["user_object"] == user_object
 
 
+def test_is_jwt_returns_false_for_none():
+    """JWTHandler.is_jwt(None) returns False to avoid NoneType.split() when token is missing."""
+    assert JWTHandler.is_jwt(None) is False
+
+
 def test_get_team_id_from_header():
     """Test get_team_id_from_header returns team when valid, None when missing, raises on invalid."""
     from fastapi import HTTPException

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
@@ -5,54 +5,37 @@ Regression test for the bug where auth: false pass-through routes still required
 an Authorization header and failed with 'NoneType' object has no attribute 'split'
 when no header was provided.
 """
-import asyncio
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import yaml
-from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
-
-def _initialize_proxy_with_config(config: dict, tmp_path) -> TestClient:
-    """Initialize proxy with config and return TestClient."""
-    from litellm.proxy.proxy_server import (
-        app,
-        cleanup_router_config_variables,
-        initialize,
-    )
-
-    cleanup_router_config_variables()
-    config_fp = tmp_path / "proxy_config.yaml"
-    config_fp.write_text(yaml.safe_dump(config))
-    asyncio.run(initialize(config=str(config_fp), debug=True))
-    return TestClient(app, raise_server_exceptions=False)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
 
 
-def test_passthrough_auth_false_without_authorization_header(tmp_path):
+@pytest.mark.asyncio
+async def test_early_exit_for_pass_through_auth_false():
     """
-    With auth: false, a pass-through request without Authorization header should succeed.
-
-    Previously this returned 401 with 'NoneType' object has no attribute 'split'
-    when JWT or OAuth2 auth was enabled.
+    _user_api_key_auth_builder returns UserAPIKeyAuth() early for pass-through
+    routes with auth: false, avoiding NoneType.split when api_key is None.
     """
-    config = {
-        "model_list": [
-            {
-                "model_name": "gpt-4o-mini",
-                "litellm_params": {
-                    "model": "openai/gpt-4o-mini",
-                    "api_key": "sk-fake",
-                    "api_base": "https://httpbin.org",
-                },
-            }
-        ],
-        "general_settings": {
-            "master_key": "sk-1234",
-            "enable_jwt_auth": True,  # Triggers the bug path when auth runs
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.path = "/v1/cuopt/request"
+
+    with patch(
+        "litellm.proxy.auth.user_api_key_auth.get_request_route",
+        return_value="/v1/cuopt/request",
+    ), patch(
+        "litellm.proxy.auth.user_api_key_auth.pre_db_read_auth_checks",
+        new_callable=AsyncMock,
+    ), patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {
             "pass_through_endpoints": [
                 {
                     "path": "/v1/cuopt/request",
@@ -63,38 +46,15 @@ def test_passthrough_auth_false_without_authorization_header(tmp_path):
                 }
             ],
         },
-    }
-
-    with patch(
-        "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
-    ) as mock_get_client:
-        # Use MagicMock to avoid httpx.Response raise_for_status requiring request
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-type": "application/json"}
-        mock_response.content = b'{"json": {"test": "data"}}'
-        mock_response.text = '{"json": {"test": "data"}}'
-        mock_response.aread = AsyncMock(return_value=mock_response.content)
-        mock_response.raise_for_status = MagicMock()  # no-op for 200
-        mock_response.json = MagicMock(return_value={"json": {"test": "data"}})
-        mock_async_client = MagicMock()
-        mock_async_client.request = AsyncMock(return_value=mock_response)
-        mock_client_obj = MagicMock()
-        mock_client_obj.client = mock_async_client
-        mock_get_client.return_value = mock_client_obj
-
-        client = _initialize_proxy_with_config(config=config, tmp_path=tmp_path)
-
-        response = client.post(
-            "/v1/cuopt/request",
-            json={"test": "data"},
-            headers={"Content-Type": "application/json"},
+    ):
+        result = await _user_api_key_auth_builder(
+            request=request,
+            api_key="",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data={},
         )
 
-        assert response.status_code != 401, (
-            f"Expected success but got 401: {response.text}"
-        )
-        assert "split" not in response.text, (
-            f"Should not contain NoneType.split error: {response.text}"
-        )
-        assert response.status_code == 200
+    assert isinstance(result, UserAPIKeyAuth)

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
@@ -1,0 +1,100 @@
+"""
+Test that pass-through endpoints with auth: false work without Authorization header.
+
+Regression test for the bug where auth: false pass-through routes still required
+an Authorization header and failed with 'NoneType' object has no attribute 'split'
+when no header was provided.
+"""
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+
+def _initialize_proxy_with_config(config: dict, tmp_path) -> TestClient:
+    """Initialize proxy with config and return TestClient."""
+    from litellm.proxy.proxy_server import (
+        app,
+        cleanup_router_config_variables,
+        initialize,
+    )
+
+    cleanup_router_config_variables()
+    config_fp = tmp_path / "proxy_config.yaml"
+    config_fp.write_text(yaml.safe_dump(config))
+    asyncio.run(initialize(config=str(config_fp), debug=True))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_passthrough_auth_false_without_authorization_header(tmp_path):
+    """
+    With auth: false, a pass-through request without Authorization header should succeed.
+
+    Previously this returned 401 with 'NoneType' object has no attribute 'split'
+    when JWT or OAuth2 auth was enabled.
+    """
+    config = {
+        "model_list": [
+            {
+                "model_name": "gpt-4o-mini",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "sk-fake",
+                    "api_base": "https://httpbin.org",
+                },
+            }
+        ],
+        "general_settings": {
+            "master_key": "sk-1234",
+            "enable_jwt_auth": True,  # Triggers the bug path when auth runs
+            "pass_through_endpoints": [
+                {
+                    "path": "/v1/cuopt/request",
+                    "target": "https://httpbin.org/post",
+                    "auth": False,
+                    "headers": {"content-type": "application/json"},
+                    "forward_headers": True,
+                }
+            ],
+        },
+    }
+
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+    ) as mock_get_client:
+        # Use MagicMock to avoid httpx.Response raise_for_status requiring request
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.content = b'{"json": {"test": "data"}}'
+        mock_response.text = '{"json": {"test": "data"}}'
+        mock_response.aread = AsyncMock(return_value=mock_response.content)
+        mock_response.raise_for_status = MagicMock()  # no-op for 200
+        mock_response.json = MagicMock(return_value={"json": {"test": "data"}})
+        mock_async_client = MagicMock()
+        mock_async_client.request = AsyncMock(return_value=mock_response)
+        mock_client_obj = MagicMock()
+        mock_client_obj.client = mock_async_client
+        mock_get_client.return_value = mock_client_obj
+
+        client = _initialize_proxy_with_config(config=config, tmp_path=tmp_path)
+
+        response = client.post(
+            "/v1/cuopt/request",
+            json={"test": "data"},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code != 401, (
+            f"Expected success but got 401: {response.text}"
+        )
+        assert "split" not in response.text, (
+            f"Should not contain NoneType.split error: {response.text}"
+        )
+        assert response.status_code == 200

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
@@ -13,7 +13,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
 
 
@@ -65,10 +65,12 @@ async def test_default_auth_required_when_auth_not_set():
     """
     When auth is not set (None), pass-through routes default to requiring auth.
     Backward compatibility: previously Depends(user_api_key_auth) was always applied.
+    With no valid key supplied, auth must raise (proves we did not bypass).
     """
     request = MagicMock()
     request.url = MagicMock()
     request.url.path = "/v1/custom/endpoint"
+    request.headers = {}
 
     with patch(
         "litellm.proxy.auth.user_api_key_auth.get_request_route",
@@ -87,18 +89,19 @@ async def test_default_auth_required_when_auth_not_set():
                 }
             ],
         },
+    ), patch(
+        "litellm.proxy.proxy_server.master_key",
+        "sk-test-master-key",
     ):
-        # Should NOT early-exit; will proceed to auth flow (may fail with 401 if no key)
-        result = await _user_api_key_auth_builder(
-            request=request,
-            api_key="",
-            azure_api_key_header="",
-            anthropic_api_key_header=None,
-            google_ai_studio_api_key_header=None,
-            azure_apim_header=None,
-            request_data={},
-        )
-        # Without valid key, we get an error or UserAPIKeyAuth - the key is that we did NOT
-        # early-return UserAPIKeyAuth() (which would mean auth was bypassed).
-        # If we got here without exception, the route required auth (no early exit).
-        assert result is not None
+        # Auth required but no valid key: must raise (proves auth was not bypassed)
+        with pytest.raises(ProxyException) as exc_info:
+            await _user_api_key_auth_builder(
+                request=request,
+                api_key="",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+        assert "Malformed API Key" in exc_info.value.message or "Authentication Error" in exc_info.value.message

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_false.py
@@ -58,3 +58,47 @@ async def test_early_exit_for_pass_through_auth_false():
         )
 
     assert isinstance(result, UserAPIKeyAuth)
+
+
+@pytest.mark.asyncio
+async def test_default_auth_required_when_auth_not_set():
+    """
+    When auth is not set (None), pass-through routes default to requiring auth.
+    Backward compatibility: previously Depends(user_api_key_auth) was always applied.
+    """
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.path = "/v1/custom/endpoint"
+
+    with patch(
+        "litellm.proxy.auth.user_api_key_auth.get_request_route",
+        return_value="/v1/custom/endpoint",
+    ), patch(
+        "litellm.proxy.auth.user_api_key_auth.pre_db_read_auth_checks",
+        new_callable=AsyncMock,
+    ), patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {
+            "pass_through_endpoints": [
+                {
+                    "path": "/v1/custom/endpoint",
+                    "target": "https://httpbin.org/post",
+                    # auth not set - should default to required (no early exit)
+                }
+            ],
+        },
+    ):
+        # Should NOT early-exit; will proceed to auth flow (may fail with 401 if no key)
+        result = await _user_api_key_auth_builder(
+            request=request,
+            api_key="",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data={},
+        )
+        # Without valid key, we get an error or UserAPIKeyAuth - the key is that we did NOT
+        # early-return UserAPIKeyAuth() (which would mean auth was bypassed).
+        # If we got here without exception, the route required auth (no early exit).
+        assert result is not None


### PR DESCRIPTION
## Relevant issues
PassThrough endpoints configured with auth: false still require an Authorization header. Without it, LiteLLM returns 401 with:
Authentication Error, 'NoneType' object has no attribute 'split' (401)
This blocks clients that cannot send auth headers (e.g. some upstream models) and forces workarounds like dummy Authorization headers.

Cause:
- Auth always enforced – create_pass_through_route always used Depends(user_api_key_auth) in the handler, even when dependencies was None for auth: false.
- Pass-through check too late – The auth: false pass-through check ran only after JWT/OAuth2 parsing. With no Authorization header, api_key was None, and jwt_handler.is_jwt(token=None) called token.split(".") and raised the error.

**Please complete all items before asking a LiteLLM maintainer to review your PR**
Before:
<img width="546" height="137" alt="Screenshot 2026-03-16 at 5 15 30 PM" src="https://github.com/user-attachments/assets/c555e495-fea7-48f1-a22d-01799674c393" />

After:
<img width="554" height="381" alt="Screenshot 2026-03-16 at 5 12 25 PM" src="https://github.com/user-attachments/assets/08aef952-44c5-4582-97d2-b079ca612b49" />

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes
- Early pass-through check – In _user_api_key_auth_builder, return UserAPIKeyAuth() immediately for pass-through routes with auth: false, before any auth parsing.
- Conditional auth in pass-through routes – When dependencies is None, register the handler without Depends(user_api_key_auth) and pass a default UserAPIKeyAuth().
- Defensive None handling – In JWTHandler.is_jwt(), return False when token is None or not a string.