### PR TITLE
fix: map OpenRouter prompt_tokens_details to Anthropic cache fields in Usage

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1467,6 +1467,9 @@ class PromptTokensDetailsWrapper(
     image_count: Optional[int] = None
     """Number of images sent to the model. Used for Vertex AI multimodal embeddings."""
 
+    cache_write_tokens: Optional[int] = None
+    """Tokens written to the prompt cache in this request (OpenRouter extension for Anthropic models)."""
+
     video_length_seconds: Optional[float] = None
     """Length of videos sent to the model. Used for Vertex AI multimodal embeddings."""
 
@@ -1653,6 +1656,24 @@ class Usage(SafeAttributeModel, CompletionUsage):
             params["prompt_cache_hit_tokens"], int
         ):
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
+
+        ## OPENROUTER / OPENAI FORMAT MAPPING ##
+        # OpenRouter (and other OpenAI-compatible providers) return cache token counts
+        # in prompt_tokens_details rather than as top-level Anthropic fields.
+        # Populate the private Anthropic-style fields from prompt_tokens_details when
+        # the explicit Anthropic params (cache_creation_input_tokens,
+        # cache_read_input_tokens) were not provided, so that downstream consumers
+        # (cost calculators, streaming adapters, logging hooks) see the correct values.
+        _ptd = getattr(self, "prompt_tokens_details", None)
+        if _ptd is not None:
+            if not self._cache_read_input_tokens:
+                _cached = getattr(_ptd, "cached_tokens", 0) or 0
+                if _cached > 0:
+                    self._cache_read_input_tokens = _cached
+            if not self._cache_creation_input_tokens:
+                _writes = getattr(_ptd, "cache_write_tokens", 0) or 0
+                if _writes > 0:
+                    self._cache_creation_input_tokens = _writes
 
         for k, v in params.items():
             setattr(self, k, v)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1662,10 +1662,13 @@ class Usage(SafeAttributeModel, CompletionUsage):
         ## OPENROUTER / OPENAI FORMAT MAPPING ##
         # OpenRouter (and other OpenAI-compatible providers) return cache token counts
         # in prompt_tokens_details rather than as top-level Anthropic fields.
-        # Populate the private Anthropic-style fields from prompt_tokens_details when
-        # the explicit Anthropic params (cache_creation_input_tokens,
-        # cache_read_input_tokens) were not provided, so that downstream consumers
-        # (cost calculators, streaming adapters, logging hooks) see the correct values.
+        # Populate both the private Anthropic-style fields AND the public
+        # prompt_tokens_details fields from prompt_tokens_details when the explicit
+        # Anthropic params (cache_creation_input_tokens, cache_read_input_tokens)
+        # were not provided, so that ALL downstream consumers see the correct values:
+        #   - streaming adapter / Langfuse: reads _cache_*_input_tokens (private)
+        #   - cost calculator (_parse_prompt_tokens_details): reads
+        #       prompt_tokens_details.cache_creation_tokens (public field on wrapper)
         _ptd = getattr(self, "prompt_tokens_details", None)
         if _ptd is not None:
             if not self._cache_read_input_tokens:
@@ -1676,6 +1679,10 @@ class Usage(SafeAttributeModel, CompletionUsage):
                 _writes = getattr(_ptd, "cache_write_tokens", 0) or 0
                 if _writes > 0:
                     self._cache_creation_input_tokens = _writes
+                    # Also populate the public field that the cost calculator reads
+                    # (_parse_prompt_tokens_details reads cache_creation_tokens, not
+                    # the private _cache_creation_input_tokens attribute)
+                    _ptd.cache_creation_tokens = _writes
 
         for k, v in params.items():
             setattr(self, k, v)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1681,8 +1681,11 @@ class Usage(SafeAttributeModel, CompletionUsage):
                     self._cache_creation_input_tokens = _writes
                     # Also populate the public field that the cost calculator reads
                     # (_parse_prompt_tokens_details reads cache_creation_tokens, not
-                    # the private _cache_creation_input_tokens attribute)
-                    _ptd.cache_creation_tokens = _writes
+                    # the private _cache_creation_input_tokens attribute).
+                    # Guard against overwriting a value already set by a prior
+                    # Anthropic-native mapping pass.
+                    if not getattr(_ptd, "cache_creation_tokens", None):
+                        _ptd.cache_creation_tokens = _writes
 
         for k, v in params.items():
             setattr(self, k, v)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1493,6 +1493,8 @@ class PromptTokensDetailsWrapper(
             del self.cache_creation_tokens
         if self.cache_creation_token_details is None:
             del self.cache_creation_token_details
+        if self.cache_write_tokens is None:
+            del self.cache_write_tokens
 
 
 class ServerToolUse(BaseModel):

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -361,3 +361,42 @@ def test_usage_openrouter_cache_tokens_from_prompt_tokens_details():
     assert "cache_write_tokens" not in ptd
     # cache_creation_tokens should also be absent when no writes were reported
     assert "cache_creation_tokens" not in ptd
+
+    # If cache_creation_tokens is already set on the wrapper (e.g. from a prior
+    # Anthropic-native mapping pass), the OpenRouter block must not overwrite it.
+    usage_no_overwrite = Usage(
+        prompt_tokens=18500,
+        completion_tokens=120,
+        total_tokens=18620,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cache_creation_tokens=999,  # pre-existing value
+            cache_write_tokens=400,     # OpenRouter field — must NOT win
+        ),
+    )
+    assert usage_no_overwrite.prompt_tokens_details.cache_creation_tokens == 999
+
+
+def test_usage_openrouter_cache_tokens_dict_path():
+    """In production, prompt_tokens_details arrives as a plain dict (parsed from JSON).
+    The dict branch (isinstance(..., dict) → PromptTokensDetailsWrapper(**d)) must also
+    populate both the private fields and cache_creation_tokens for cost calculation."""
+    from litellm.types.utils import Usage
+
+    # Plain dict — the real code path from JSON-parsed API responses
+    usage = Usage(
+        prompt_tokens=18500,
+        completion_tokens=120,
+        total_tokens=18620,
+        prompt_tokens_details={
+            "cached_tokens": 17000,
+            "cache_write_tokens": 400,
+        },
+    )
+
+    # Both the streaming-adapter path (private fields) …
+    assert usage._cache_read_input_tokens == 17000
+    assert usage._cache_creation_input_tokens == 400
+
+    # … and the cost-calculator path (public wrapper field) must be populated.
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cache_creation_tokens == 400

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -323,9 +323,15 @@ def test_usage_openrouter_cache_tokens_from_prompt_tokens_details():
         ),
     )
 
-    # Private Anthropic-style fields must be populated from prompt_tokens_details
+    # Private Anthropic-style fields (streaming adapter / Langfuse path)
     assert usage._cache_read_input_tokens == 17000
     assert usage._cache_creation_input_tokens == 400
+
+    # Public prompt_tokens_details fields (cost-calculator path).
+    # _parse_prompt_tokens_details in llm_cost_calc/utils.py reads
+    # prompt_tokens_details.cache_creation_tokens — it must be populated too.
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cache_creation_tokens == 400  # cost-calc path
 
     # When Anthropic native params are provided they must take precedence over
     # prompt_tokens_details so existing callers are not broken.
@@ -353,3 +359,5 @@ def test_usage_openrouter_cache_tokens_from_prompt_tokens_details():
     dumped = usage_no_writes.model_dump()
     ptd = dumped.get("prompt_tokens_details", {})
     assert "cache_write_tokens" not in ptd
+    # cache_creation_tokens should also be absent when no writes were reported
+    assert "cache_creation_tokens" not in ptd

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -304,3 +304,52 @@ def test_delta_maps_reasoning_to_reasoning_content():
     # When neither is present, reasoning_content is not set (OpenAI spec)
     delta4 = Delta(content="hello")
     assert not hasattr(delta4, "reasoning_content")
+
+
+def test_usage_openrouter_cache_tokens_from_prompt_tokens_details():
+    """OpenRouter returns cache token counts in prompt_tokens_details (OpenAI format).
+    Usage.__init__ must map them to the Anthropic-style private fields so that cost
+    calculations and the Anthropic pass-through streaming adapter see correct values."""
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    # Simulate what OpenRouter sends in the final streaming chunk
+    usage = Usage(
+        prompt_tokens=18500,
+        completion_tokens=120,
+        total_tokens=18620,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=17000,
+            cache_write_tokens=400,
+        ),
+    )
+
+    # Private Anthropic-style fields must be populated from prompt_tokens_details
+    assert usage._cache_read_input_tokens == 17000
+    assert usage._cache_creation_input_tokens == 400
+
+    # When Anthropic native params are provided they must take precedence over
+    # prompt_tokens_details so existing callers are not broken.
+    usage_native = Usage(
+        prompt_tokens=18500,
+        completion_tokens=120,
+        total_tokens=18620,
+        cache_read_input_tokens=999,
+        cache_creation_input_tokens=888,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=17000,
+            cache_write_tokens=400,
+        ),
+    )
+    assert usage_native._cache_read_input_tokens == 999
+    assert usage_native._cache_creation_input_tokens == 888
+
+    # cache_write_tokens must not appear in serialised output when absent
+    usage_no_writes = Usage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=50),
+    )
+    dumped = usage_no_writes.model_dump()
+    ptd = dumped.get("prompt_tokens_details", {})
+    assert "cache_write_tokens" not in ptd


### PR DESCRIPTION
## Problem

When routing Anthropic models through **OpenRouter** via the LiteLLM proxy, cache token counts arrive in the final streaming chunk in OpenAI format:

```json
"usage": {
  "prompt_tokens": 18500,
  "prompt_tokens_details": {
    "cached_tokens": 17000,
    "cache_write_tokens": 400
  }
}
```

`Usage.__init__` correctly maps Anthropic native fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) and DeepSeek fields (`prompt_cache_hit_tokens`) to the private `_cache_read_input_tokens` / `_cache_creation_input_tokens` attributes, but **never maps `prompt_tokens_details.cached_tokens` / `prompt_tokens_details.cache_write_tokens`**.

Result: `_cache_read_input_tokens` and `_cache_creation_input_tokens` stay at 0 for all OpenRouter-routed Anthropic calls, even when prompt caching is active. This breaks:
- LiteLLM's own cost calculations for cached tokens
- The Anthropic experimental pass-through streaming adapter (`streaming_iterator.py`), which already has merge logic that reads `_cache_*_input_tokens` but gets 0s
- Any downstream consumer of `usage.cache_read_input_tokens` / `usage.cache_creation_input_tokens`

## Fix

**`litellm/types/utils.py` — `Usage.__init__`**

After the existing Anthropic and DeepSeek mapping blocks, add an OpenRouter / OpenAI-format mapping block:

```python
## OPENROUTER / OPENAI FORMAT MAPPING ##
_ptd = getattr(self, "prompt_tokens_details", None)
if _ptd is not None:
    if not self._cache_read_input_tokens:
        _cached = getattr(_ptd, "cached_tokens", 0) or 0
        if _cached > 0:
            self._cache_read_input_tokens = _cached
    if not self._cache_creation_input_tokens:
        _writes = getattr(_ptd, "cache_write_tokens", 0) or 0
        if _writes > 0:
            self._cache_creation_input_tokens = _writes
```

**`PromptTokensDetailsWrapper`**

Add `cache_write_tokens: Optional[int] = None` to explicitly type the OpenRouter extension field that carries cache write counts (previously accepted via `extra = "allow"` but untyped).

## Reproduction

1. Configure LiteLLM to route `anthropic/claude-*` via OpenRouter with `prompt-caching-2024-07-31` in `anthropic-beta`
2. Send a request with `cache_control: {type: "ephemeral"}` blocks
3. Check `response.usage.cache_creation_input_tokens` / `response.usage.cache_read_input_tokens` — both are 0 despite caching being active
4. Check OpenRouter dashboard — cache hits are recorded correctly there

## Testing

The `streaming_iterator.py` merge path (`holding_stop_reason_chunk` + usage chunk) already handles the case where stop_reason and usage arrive together. After this fix, `chunk.usage._cache_*_input_tokens` will be non-zero when OpenRouter reports cache activity, and the adapter will correctly include them in the `message_delta` usage event.

Made with [Cursor](https://cursor.com)