### PR TITLE
fix(core): preserve unmapped finish_reason and add 'refusal' mapping

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -98,16 +98,18 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "content_filter": "content_filter",
     # Anthropic Sonnet 4
     "content_filtered": "content_filter",
+    # Anthropic refusal
+    "refusal": "refusal",
 }
 
 
-def map_finish_reason(finish_reason: str) -> OpenAIChatCompletionFinishReason:
+def map_finish_reason(finish_reason: str) -> str:
     mapped = _FINISH_REASON_MAP.get(finish_reason)
     if mapped is None:
         verbose_logger.warning(
-            "Unmapped finish_reason '%s', defaulting to 'stop'", finish_reason
+            "Unmapped finish_reason '%s', passing through as-is", finish_reason
         )
-        return "stop"
+        return finish_reason
     return mapped
 
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -2131,6 +2131,7 @@ OpenAIChatCompletionFinishReason = Literal[
     "function_call",
     "tool_calls",
     "length",
+    "refusal",
     "guardrail_intervened",
     "eos",
     "finish_reason_unspecified",

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -55,7 +55,7 @@ def test_reconstruct_model_name_returns_original_for_other_providers():
 # map_finish_reason tests
 # ---------------------------------------------------------------------------
 
-VALID_OPENAI_FINISH_REASONS = {"stop", "length", "tool_calls", "function_call", "content_filter"}
+VALID_OPENAI_FINISH_REASONS = {"stop", "length", "tool_calls", "function_call", "content_filter", "refusal"}
 
 
 class TestMapFinishReasonAnthropic:
@@ -68,6 +68,7 @@ class TestMapFinishReasonAnthropic:
             ("tool_use", "tool_calls"),
             ("compaction", "length"),
             ("content_filtered", "content_filter"),
+            ("refusal", "refusal"),
         ],
     )
     def test_anthropic_finish_reasons(self, provider_reason: str, expected: str) -> None:
@@ -132,11 +133,11 @@ class TestMapFinishReasonOpenAIPassthrough:
 
 
 class TestMapFinishReasonUnknown:
-    def test_unknown_value_defaults_to_stop(self):
-        assert map_finish_reason("some_unknown_value") == "stop"
+    def test_unknown_value_passes_through(self):
+        assert map_finish_reason("some_unknown_value") == "some_unknown_value"
 
-    def test_empty_string_defaults_to_stop(self):
-        assert map_finish_reason("") == "stop"
+    def test_empty_string_passes_through(self):
+        assert map_finish_reason("") == ""
 
 
 class TestFinishReasonMapOutputsAreValid:


### PR DESCRIPTION
## Summary

Fixes #23793

### Problem

`map_finish_reason()` was changed (in commit a4fc73f8) to default unmapped finish reasons to `"stop"`, which is lossy. Previously, unmapped values were returned as-is, allowing callers to handle provider-specific finish reasons correctly. Additionally, Anthropic's `"refusal"` stop reason ([docs](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons#refusal)) was missing from the mapping.

### Changes

1. **Restore pass-through behavior for unmapped finish reasons** — Instead of defaulting to `"stop"`, unmapped values are now returned as-is (with a warning log). This preserves information for callers.

2. **Add `"refusal"` to the finish reason map** — Maps Anthropic's `"refusal"` stop reason correctly.

3. **Add `"refusal"` to `OpenAIChatCompletionFinishReason` type** — Ensures the type includes this valid reason.

4. **Update tests** — Tests reflect the new pass-through behavior for unknown values and include the new `"refusal"` mapping.

### Files Changed

- `litellm/litellm_core_utils/core_helpers.py` — Pass-through unmapped values, add `"refusal"` to map
- `litellm/types/llms/openai.py` — Add `"refusal"` to finish reason literal type
- `tests/test_litellm/litellm_core_utils/test_core_helpers.py` — Update tests