### PR TITLE
fix: skip auth for pass-through endpoints when auth: false

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -583,10 +583,6 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             route=route,
             request=request,
         )
-
-        if _is_pass_through_endpoint_auth_disabled(pass_through_endpoints, route):
-            return UserAPIKeyAuth()
-
         # if user wants to pass LiteLLM_Master_Key as a custom header, example pass litellm keys as X-LiteLLM-Key: Bearer sk-1234
         custom_litellm_key_header_name = general_settings.get("litellm_key_header_name")
         if custom_litellm_key_header_name is not None:
@@ -632,6 +628,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 parent_otel_span=parent_otel_span,
             )
             return validated
+
+        if _is_pass_through_endpoint_auth_disabled(pass_through_endpoints, route):
+            return UserAPIKeyAuth(parent_otel_span=parent_otel_span)
 
         ### LITELLM-DEFINED AUTH FUNCTION ###
         #### IF JWT ####

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -399,6 +399,20 @@ def get_api_key(
     return api_key, passed_in_key
 
 
+def _is_pass_through_endpoint_auth_disabled(
+    pass_through_endpoints: Optional[List[dict]],
+    route: str,
+) -> bool:
+    """Return True when the route matches a config-based pass-through endpoint
+    whose ``auth`` flag is not explicitly ``True``."""
+    if pass_through_endpoints is None:
+        return False
+    for endpoint in pass_through_endpoints:
+        if isinstance(endpoint, dict) and endpoint.get("path", "") == route:
+            return endpoint.get("auth") is not True
+    return False
+
+
 async def check_api_key_for_custom_headers_or_pass_through_endpoints(
     request: Request,
     route: str,
@@ -415,12 +429,11 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
     if is_mapped_pass_through_route:
         if request.headers.get("litellm_user_api_key") is not None:
             api_key = request.headers.get("litellm_user_api_key") or ""
+    if _is_pass_through_endpoint_auth_disabled(pass_through_endpoints, route):
+        return UserAPIKeyAuth()
     if pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
             if isinstance(endpoint, dict) and endpoint.get("path", "") == route:
-                ## IF AUTH DISABLED
-                if endpoint.get("auth") is not True:
-                    return UserAPIKeyAuth()
                 ## IF AUTH ENABLED
                 ### IF CUSTOM PARSER REQUIRED
                 if (
@@ -570,6 +583,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             route=route,
             request=request,
         )
+
+        if _is_pass_through_endpoint_auth_disabled(pass_through_endpoints, route):
+            return UserAPIKeyAuth()
+
         # if user wants to pass LiteLLM_Master_Key as a custom header, example pass litellm keys as X-LiteLLM-Key: Bearer sk-1234
         custom_litellm_key_header_name = general_settings.get("litellm_key_header_name")
         if custom_litellm_key_header_name is not None:

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -18,7 +18,11 @@ from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import LiteLLM_JWTAuth, UserAPIKeyAuth
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.route_checks import RouteChecks
-from litellm.proxy.auth.user_api_key_auth import get_api_key, user_api_key_auth
+from litellm.proxy.auth.user_api_key_auth import (
+    _is_pass_through_endpoint_auth_disabled,
+    get_api_key,
+    user_api_key_auth,
+)
 
 
 def test_get_api_key():
@@ -685,3 +689,191 @@ class TestJWTOAuth2Coexistence:
             # OAuth2 should handle it since JWT auth is disabled
             mock_oauth2.assert_called_once_with(token=jwt_like_token)
             assert result.user_id == "oauth2-user"
+
+
+class TestIsPassThroughEndpointAuthDisabled:
+    """Tests for _is_pass_through_endpoint_auth_disabled helper."""
+
+    def test_should_return_false_when_pass_through_endpoints_is_none(self):
+        assert _is_pass_through_endpoint_auth_disabled(None, "/v1/foo") is False
+
+    def test_should_return_false_when_no_matching_route(self):
+        endpoints = [{"path": "/v1/bar", "auth": False}]
+        assert _is_pass_through_endpoint_auth_disabled(endpoints, "/v1/foo") is False
+
+    def test_should_return_true_when_auth_is_false(self):
+        endpoints = [{"path": "/v1/foo", "auth": False}]
+        assert _is_pass_through_endpoint_auth_disabled(endpoints, "/v1/foo") is True
+
+    def test_should_return_true_when_auth_is_not_set(self):
+        endpoints = [{"path": "/v1/foo", "target": "https://example.com"}]
+        assert _is_pass_through_endpoint_auth_disabled(endpoints, "/v1/foo") is True
+
+    def test_should_return_false_when_auth_is_true(self):
+        endpoints = [{"path": "/v1/foo", "auth": True}]
+        assert _is_pass_through_endpoint_auth_disabled(endpoints, "/v1/foo") is False
+
+    def test_should_skip_non_dict_entries(self):
+        endpoints = ["not_a_dict", {"path": "/v1/foo", "auth": False}]
+        assert _is_pass_through_endpoint_auth_disabled(endpoints, "/v1/foo") is True
+
+
+class TestPassThroughAuthDisabledE2E:
+    """End-to-end tests for pass-through endpoints with auth: false.
+
+    Ensures that requests without an Authorization header succeed when
+    a pass-through endpoint is configured with auth disabled.
+    """
+
+    @pytest.mark.asyncio
+    async def test_should_skip_auth_when_auth_false_and_no_auth_header(self):
+        """Core bug-fix test: auth: false + no Authorization header must not crash."""
+        pass_through_endpoints = [
+            {
+                "path": "/v1/cuopt/request",
+                "target": "https://example.com/cuopt/request",
+                "auth": False,
+            }
+        ]
+        general_settings = {
+            "pass_through_endpoints": pass_through_endpoints,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/cuopt/request"
+        mock_request.headers = {}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ):
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key=None,
+            )
+            assert isinstance(result, UserAPIKeyAuth)
+
+    @pytest.mark.asyncio
+    async def test_should_skip_auth_when_auth_not_set_and_no_auth_header(self):
+        """auth not specified defaults to disabled for pass-through endpoints."""
+        pass_through_endpoints = [
+            {
+                "path": "/v1/cuopt/request",
+                "target": "https://example.com/cuopt/request",
+            }
+        ]
+        general_settings = {
+            "pass_through_endpoints": pass_through_endpoints,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/cuopt/request"
+        mock_request.headers = {}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ):
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key=None,
+            )
+            assert isinstance(result, UserAPIKeyAuth)
+
+    @pytest.mark.asyncio
+    async def test_should_require_auth_when_auth_true(self):
+        """auth: true must still enforce authentication — missing key should fail."""
+        pass_through_endpoints = [
+            {
+                "path": "/v1/cuopt/request",
+                "target": "https://example.com/cuopt/request",
+                "auth": True,
+            }
+        ]
+        general_settings = {
+            "pass_through_endpoints": pass_through_endpoints,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/cuopt/request"
+        mock_request.headers = {}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ):
+            with pytest.raises(Exception):
+                await user_api_key_auth(
+                    request=mock_request,
+                    api_key=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_should_skip_auth_when_auth_false_with_jwt_enabled(self):
+        """auth: false must skip auth even when JWT auth is globally enabled.
+
+        This was the original crash scenario: is_jwt() called .split() on None api_key.
+        """
+        pass_through_endpoints = [
+            {
+                "path": "/v1/cuopt/request",
+                "target": "https://example.com/cuopt/request",
+                "auth": False,
+            }
+        ]
+        general_settings = {
+            "pass_through_endpoints": pass_through_endpoints,
+            "enable_jwt_auth": True,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/cuopt/request"
+        mock_request.headers = {}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ):
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key=None,
+            )
+            assert isinstance(result, UserAPIKeyAuth)
+
+    @pytest.mark.asyncio
+    async def test_should_skip_auth_when_auth_false_with_valid_auth_header(self):
+        """Even with a valid-looking auth header, auth: false should skip validation."""
+        pass_through_endpoints = [
+            {
+                "path": "/v1/cuopt/request",
+                "target": "https://example.com/cuopt/request",
+                "auth": False,
+            }
+        ]
+        general_settings = {
+            "pass_through_endpoints": pass_through_endpoints,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/cuopt/request"
+        mock_request.headers = {"authorization": "Bearer sk-some-key"}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ):
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key="Bearer sk-some-key",
+            )
+            assert isinstance(result, UserAPIKeyAuth)

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -18,6 +18,7 @@ from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import LiteLLM_JWTAuth, UserAPIKeyAuth
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.route_checks import RouteChecks
+from litellm.proxy._types import ProxyException
 from litellm.proxy.auth.user_api_key_auth import (
     _is_pass_through_endpoint_auth_disabled,
     get_api_key,
@@ -808,11 +809,13 @@ class TestPassThroughAuthDisabledE2E:
         ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
             "litellm.proxy.proxy_server.prisma_client", None
         ):
-            with pytest.raises(Exception):
+            with pytest.raises(ProxyException) as exc_info:
                 await user_api_key_auth(
                     request=mock_request,
                     api_key=None,
                 )
+            assert "Authentication Error" in exc_info.value.message
+            assert exc_info.value.code == str(401)
 
     @pytest.mark.asyncio
     async def test_should_skip_auth_when_auth_false_with_jwt_enabled(self):
@@ -877,3 +880,47 @@ class TestPassThroughAuthDisabledE2E:
                 api_key="Bearer sk-some-key",
             )
             assert isinstance(result, UserAPIKeyAuth)
+
+    @pytest.mark.asyncio
+    async def test_should_still_run_enterprise_custom_auth_when_auth_false(self):
+        """Enterprise custom auth should still execute even when auth: false.
+
+        If enterprise_custom_auth returns a UserAPIKeyAuth, that takes precedence.
+        """
+        pass_through_endpoints = [
+            {
+                "path": "/v1/cuopt/request",
+                "target": "https://example.com/cuopt/request",
+                "auth": False,
+            }
+        ]
+        general_settings = {
+            "pass_through_endpoints": pass_through_endpoints,
+        }
+
+        custom_auth_response = UserAPIKeyAuth(
+            api_key="custom-key",
+            user_id="enterprise-user",
+        )
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/cuopt/request"
+        mock_request.headers = {}
+        mock_request.query_params = {}
+
+        mock_enterprise_auth = AsyncMock(return_value=custom_auth_response)
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.master_key", "sk-master"), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.enterprise_custom_auth",
+            mock_enterprise_auth,
+        ):
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key=None,
+            )
+            mock_enterprise_auth.assert_called_once()
+            assert result.user_id == "enterprise-user"


### PR DESCRIPTION
Made-with: Cursor

## Relevant issues
Pass-through endpoints with auth: false still require an Authorization header. Requests without it return 401 with:
Authentication Error, 'NoneType' object has no attribute 'split' (401)
This blocks clients that cannot send auth headers.

user_api_key_auth runs on every pass-through request because the handler always uses Depends(user_api_key_auth). The auth: false check lived in check_api_key_for_custom_headers_or_pass_through_endpoints, which runs after JWT/OAuth logic. With no auth header, api_key is None, and jwt_handler.is_jwt(token=api_key) calls token.split(".") on None, causing the crash.

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes
Add an early check right after get_api_key() in _user_api_key_auth_builder: if the route matches a pass-through endpoint with auth not explicitly True, return UserAPIKeyAuth() immediately and skip all JWT/OAuth/token parsing. Introduce _is_pass_through_endpoint_auth_disabled() to centralize this logic and reuse it in check_api_key_for_custom_headers_or_pass_through_endpoints. Add tests for pass-through endpoints without auth headers.