### PR TITLE
fix(proxy): instantiate OTEL callback at startup instead of deferring…

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -46,21 +46,26 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
                 isinstance(callback, str)
                 and callback in litellm._known_custom_logger_compatible_callbacks
             ):
-                # Instantiate the callback class (e.g., OpenTelemetry) instead
-                # of just adding the string. This ensures open_telemetry_logger
-                # and similar globals are set at startup, not deferred to
-                # add_deployment() which may fail silently when
-                # store_model_in_db is true.
-                from litellm.utils import (
-                    _add_custom_logger_callback_to_specific_event,
-                )
+                # Eagerly instantiate the callback class (e.g. OpenTelemetry)
+                # so that proxy-level globals like open_telemetry_logger are
+                # set at startup. Without this, store_model_in_db=true causes
+                # the async model-loading path to skip callback instantiation
+                # entirely, leaving the logger as None.
+                try:
+                    from litellm.utils import (
+                        _add_custom_logger_callback_to_specific_event,
+                    )
 
-                _add_custom_logger_callback_to_specific_event(
-                    callback, "success"
-                )
-                _add_custom_logger_callback_to_specific_event(
-                    callback, "failure"
-                )
+                    _add_custom_logger_callback_to_specific_event(callback, "success")
+                    _add_custom_logger_callback_to_specific_event(callback, "failure")
+                except Exception as e:
+                    verbose_proxy_logger.error(
+                        f"Failed to initialize callback '{callback}' at startup: {e}. "
+                        "Check that the required environment variables are set."
+                    )
+                    # Still add the string so it can be retried later during
+                    # request processing (preserves pre-existing behaviour).
+                    imported_list.append(callback)
             elif isinstance(callback, str) and callback == "presidio":
                 from litellm.proxy.guardrails.guardrail_hooks.presidio import (
                     _OPTIONAL_PresidioPIIMasking,

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -46,7 +46,21 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
                 isinstance(callback, str)
                 and callback in litellm._known_custom_logger_compatible_callbacks
             ):
-                imported_list.append(callback)
+                # Instantiate the callback class (e.g., OpenTelemetry) instead
+                # of just adding the string. This ensures open_telemetry_logger
+                # and similar globals are set at startup, not deferred to
+                # add_deployment() which may fail silently when
+                # store_model_in_db is true.
+                from litellm.utils import (
+                    _add_custom_logger_callback_to_specific_event,
+                )
+
+                _add_custom_logger_callback_to_specific_event(
+                    callback, "success"
+                )
+                _add_custom_logger_callback_to_specific_event(
+                    callback, "failure"
+                )
             elif isinstance(callback, str) and callback == "presidio":
                 from litellm.proxy.guardrails.guardrail_hooks.presidio import (
                     _OPTIONAL_PresidioPIIMasking,

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -51,21 +51,29 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
                 # set at startup. Without this, store_model_in_db=true causes
                 # the async model-loading path to skip callback instantiation
                 # entirely, leaving the logger as None.
-                try:
-                    from litellm.utils import (
-                        _add_custom_logger_callback_to_specific_event,
-                    )
+                #
+                # Each event is registered independently so a failure in one
+                # does not leave the callback half-registered.
+                from litellm.utils import (
+                    _add_custom_logger_callback_to_specific_event,
+                )
 
-                    _add_custom_logger_callback_to_specific_event(callback, "success")
-                    _add_custom_logger_callback_to_specific_event(callback, "failure")
-                except Exception as e:
-                    verbose_proxy_logger.error(
-                        f"Failed to initialize callback '{callback}' at startup: {e}. "
-                        "Check that the required environment variables are set."
-                    )
-                    # Still add the string so it can be retried later during
-                    # request processing (preserves pre-existing behaviour).
-                    imported_list.append(callback)
+                for event in ("success", "failure"):
+                    try:
+                        _add_custom_logger_callback_to_specific_event(callback, event)
+                    except Exception as e:
+                        verbose_proxy_logger.error(
+                            f"Failed to initialize callback '{callback}' "
+                            f"for {event} event at startup: {e}. "
+                            "Check that the required environment variables "
+                            "are set."
+                        )
+                # Always add to imported_list so litellm.callbacks stays in
+                # sync — it is read by health endpoints, hot-reload, and
+                # spend tracking. On success the instance is already in the
+                # success/failure lists; the string here keeps the canonical
+                # config list complete.
+                imported_list.append(callback)
             elif isinstance(callback, str) and callback == "presidio":
                 from litellm.proxy.guardrails.guardrail_hooks.presidio import (
                     _OPTIONAL_PresidioPIIMasking,

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -81,3 +81,78 @@ def test_normalize_callback_names_none_returns_empty_list():
 def test_normalize_callback_names_lowercases_strings():
     assert normalize_callback_names(["SQS", "S3", "CUSTOM_CALLBACK"]) == ["sqs", "s3", "custom_callback"]
 
+
+def test_initialize_callbacks_on_proxy_instantiates_otel():
+    """
+    Test that initialize_callbacks_on_proxy() actually instantiates the
+    OpenTelemetry callback class (not just adding the string "otel").
+
+    Regression test for: when store_model_in_db=true, OTEL callback was
+    never instantiated because initialize_callbacks_on_proxy() only added
+    the string "otel" to litellm.callbacks without creating the instance.
+    """
+    import litellm
+    from litellm.proxy.common_utils.callback_utils import (
+        initialize_callbacks_on_proxy,
+    )
+    from litellm.integrations.opentelemetry import OpenTelemetry
+
+    # Save original state
+    original_callbacks = litellm.callbacks[:]
+    original_success = litellm.success_callback[:]
+    original_async_success = litellm._async_success_callback[:]
+    original_failure = litellm.failure_callback[:]
+    original_async_failure = litellm._async_failure_callback[:]
+
+    try:
+        # Clear callbacks
+        litellm.callbacks = []
+        litellm.success_callback = []
+        litellm._async_success_callback = []
+        litellm.failure_callback = []
+        litellm._async_failure_callback = []
+
+        initialize_callbacks_on_proxy(
+            value=["otel"],
+            premium_user=False,
+            config_file_path="",
+            litellm_settings={},
+        )
+
+        # Verify an OpenTelemetry instance exists in success callbacks
+        otel_in_success = any(
+            isinstance(cb, OpenTelemetry)
+            for cb in litellm.success_callback + litellm._async_success_callback
+        )
+        assert otel_in_success, (
+            "OpenTelemetry instance not found in success callbacks. "
+            f"success_callback={litellm.success_callback}, "
+            f"_async_success_callback={litellm._async_success_callback}"
+        )
+
+        # Verify an OpenTelemetry instance exists in failure callbacks
+        otel_in_failure = any(
+            isinstance(cb, OpenTelemetry)
+            for cb in litellm.failure_callback + litellm._async_failure_callback
+        )
+        assert otel_in_failure, (
+            "OpenTelemetry instance not found in failure callbacks."
+        )
+
+        # Verify open_telemetry_logger is set on proxy_server
+        from litellm.proxy import proxy_server
+
+        assert proxy_server.open_telemetry_logger is not None, (
+            "proxy_server.open_telemetry_logger should be set after "
+            "initializing otel callback"
+        )
+        assert isinstance(proxy_server.open_telemetry_logger, OpenTelemetry)
+
+    finally:
+        # Restore original state
+        litellm.callbacks = original_callbacks
+        litellm.success_callback = original_success
+        litellm._async_success_callback = original_async_success
+        litellm.failure_callback = original_failure
+        litellm._async_failure_callback = original_async_failure
+

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -79,7 +79,11 @@ def test_normalize_callback_names_none_returns_empty_list():
 
 
 def test_normalize_callback_names_lowercases_strings():
-    assert normalize_callback_names(["SQS", "S3", "CUSTOM_CALLBACK"]) == ["sqs", "s3", "custom_callback"]
+    assert normalize_callback_names(["SQS", "S3", "CUSTOM_CALLBACK"]) == [
+        "sqs",
+        "s3",
+        "custom_callback",
+    ]
 
 
 def test_initialize_callbacks_on_proxy_instantiates_otel():
@@ -96,6 +100,8 @@ def test_initialize_callbacks_on_proxy_instantiates_otel():
         initialize_callbacks_on_proxy,
     )
     from litellm.integrations.opentelemetry import OpenTelemetry
+    from litellm.litellm_core_utils import litellm_logging
+    from litellm.proxy import proxy_server
 
     # Save original state
     original_callbacks = litellm.callbacks[:]
@@ -103,6 +109,8 @@ def test_initialize_callbacks_on_proxy_instantiates_otel():
     original_async_success = litellm._async_success_callback[:]
     original_failure = litellm.failure_callback[:]
     original_async_failure = litellm._async_failure_callback[:]
+    original_otel_logger = getattr(proxy_server, "open_telemetry_logger", None)
+    original_in_memory_loggers = litellm_logging._in_memory_loggers[:]
 
     try:
         # Clear callbacks
@@ -135,13 +143,9 @@ def test_initialize_callbacks_on_proxy_instantiates_otel():
             isinstance(cb, OpenTelemetry)
             for cb in litellm.failure_callback + litellm._async_failure_callback
         )
-        assert otel_in_failure, (
-            "OpenTelemetry instance not found in failure callbacks."
-        )
+        assert otel_in_failure, "OpenTelemetry instance not found in failure callbacks."
 
         # Verify open_telemetry_logger is set on proxy_server
-        from litellm.proxy import proxy_server
-
         assert proxy_server.open_telemetry_logger is not None, (
             "proxy_server.open_telemetry_logger should be set after "
             "initializing otel callback"
@@ -149,10 +153,78 @@ def test_initialize_callbacks_on_proxy_instantiates_otel():
         assert isinstance(proxy_server.open_telemetry_logger, OpenTelemetry)
 
     finally:
-        # Restore original state
+        # Restore ALL global state to prevent leaking into other tests
         litellm.callbacks = original_callbacks
         litellm.success_callback = original_success
         litellm._async_success_callback = original_async_success
         litellm.failure_callback = original_failure
         litellm._async_failure_callback = original_async_failure
+        proxy_server.open_telemetry_logger = original_otel_logger
+        litellm_logging._in_memory_loggers = original_in_memory_loggers
 
+
+@patch("litellm.utils._add_custom_logger_callback_to_specific_event")
+def test_initialize_callbacks_on_proxy_calls_instantiation_for_known_callbacks(
+    mock_add_callback,
+):
+    """
+    Verify that initialize_callbacks_on_proxy calls
+    _add_custom_logger_callback_to_specific_event for each known callback
+    in the config, registering it for both success and failure events.
+
+    This is a unit test that mocks the instantiation to avoid requiring
+    real env vars or creating real logger instances.
+    """
+    from litellm.proxy.common_utils.callback_utils import (
+        initialize_callbacks_on_proxy,
+    )
+
+    initialize_callbacks_on_proxy(
+        value=["otel"],
+        premium_user=False,
+        config_file_path="",
+        litellm_settings={},
+    )
+
+    # Should be called twice: once for "success", once for "failure"
+    assert mock_add_callback.call_count == 2
+    mock_add_callback.assert_any_call("otel", "success")
+    mock_add_callback.assert_any_call("otel", "failure")
+
+
+@patch(
+    "litellm.utils._add_custom_logger_callback_to_specific_event",
+    side_effect=Exception("Missing LOGFIRE_TOKEN"),
+)
+def test_initialize_callbacks_on_proxy_handles_instantiation_failure(
+    mock_add_callback,
+):
+    """
+    Verify that if a callback fails to instantiate (e.g. missing env vars),
+    the proxy does not crash — it logs the error and falls back to adding
+    the string for deferred instantiation.
+    """
+    import litellm
+    from litellm.proxy.common_utils.callback_utils import (
+        initialize_callbacks_on_proxy,
+    )
+
+    original_callbacks = litellm.callbacks[:]
+
+    try:
+        litellm.callbacks = []
+
+        initialize_callbacks_on_proxy(
+            value=["logfire"],
+            premium_user=False,
+            config_file_path="",
+            litellm_settings={},
+        )
+
+        # The string should be added as a fallback so it can be retried later
+        assert "logfire" in litellm.callbacks, (
+            "Failed callback should be added as string fallback. "
+            f"callbacks={litellm.callbacks}"
+        )
+    finally:
+        litellm.callbacks = original_callbacks

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -221,6 +221,13 @@ def test_initialize_callbacks_on_proxy_handles_instantiation_failure(
             litellm_settings={},
         )
 
+        # Verify the mock was actually called (guards against "logfire"
+        # being silently removed from _known_custom_logger_compatible_callbacks).
+        assert mock_add_callback.call_count >= 1, (
+            "Expected _add_custom_logger_callback_to_specific_event to be "
+            f"called, but call_count={mock_add_callback.call_count}"
+        )
+
         # The string should be added as a fallback so it can be retried later
         assert "logfire" in litellm.callbacks, (
             "Failed callback should be added as string fallback. "

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -221,12 +221,14 @@ def test_initialize_callbacks_on_proxy_handles_instantiation_failure(
             litellm_settings={},
         )
 
-        # Verify the mock was actually called (guards against "logfire"
+        # Verify the mock was called for both events (guards against "logfire"
         # being silently removed from _known_custom_logger_compatible_callbacks).
-        assert mock_add_callback.call_count >= 1, (
+        assert mock_add_callback.call_count == 2, (
             "Expected _add_custom_logger_callback_to_specific_event to be "
-            f"called, but call_count={mock_add_callback.call_count}"
+            f"called twice (success + failure), but call_count={mock_add_callback.call_count}"
         )
+        mock_add_callback.assert_any_call("logfire", "success")
+        mock_add_callback.assert_any_call("logfire", "failure")
 
         # The string should be added as a fallback so it can be retried later
         assert "logfire" in litellm.callbacks, (


### PR DESCRIPTION
## Summary

Fixes a bug where the OpenTelemetry callback was never instantiated when `store_model_in_db: true` is set in the proxy config.

**Root cause:** `initialize_callbacks_on_proxy()` only appended the string `"otel"` to `litellm.callbacks` instead of creating the actual `OpenTelemetry` class instance. Normally, the instance gets created later during model loading from YAML. But with `store_model_in_db: true`, models load asynchronously from the database — and that async path never triggers callback instantiation. As a result, `proxy_server.open_telemetry_logger` stayed `None` forever and no OTEL traces/logs were exported.

**Fix:** Eagerly call `_add_custom_logger_callback_to_specific_event()` for both "success" and "failure" events during `initialize_callbacks_on_proxy()`. This instantiates the callback class at startup (leveraging the existing `_in_memory_loggers` cache for idempotency) and sets `proxy_server.open_telemetry_logger` regardless of which model-loading path runs.

**Error handling:** If a callback fails to instantiate (e.g. missing env vars), the error is logged and the string is still added to `litellm.callbacks` for deferred retry — the proxy does not crash.

**`litellm.callbacks` kept in sync:** The callback string is always appended to `imported_list` (both success and failure paths), so `litellm.callbacks` remains the canonical config list for health endpoints, hot-reload, and spend tracking.

## Changes

- `litellm/proxy/common_utils/callback_utils.py` — Replace deferred string-only append with eager instantiation via `_add_custom_logger_callback_to_specific_event()`, wrapped in try/except for graceful failure. Callback string always added to `imported_list` to keep `litellm.callbacks` in sync.
- `tests/test_litellm/proxy/common_utils/test_callback_utils.py` — Three new tests:
  1. **Real-instantiation regression test** — Verifies `OpenTelemetry` instance appears in success/failure callback lists and `proxy_server.open_telemetry_logger` is set. Properly restores all globals (`_in_memory_loggers`, `open_telemetry_logger`) in finally block.
  2. **Mocked unit test** — Verifies `_add_custom_logger_callback_to_specific_event` is called with correct args ("success" + "failure").
  3. **Mocked failure-fallback test** — Verifies proxy doesn't crash on instantiation failure and the string fallback is added to `litellm.callbacks`.

## Test output

```
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_get_remaining_tokens_and_requests_from_request_data PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_initialize_callbacks_on_proxy_calls_instantiation_for_known_callbacks PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_initialize_callbacks_on_proxy_handles_instantiation_failure PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_initialize_callbacks_on_proxy_instantiates_otel PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_normalize_callback_names_lowercases_strings PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_normalize_callback_names_none_returns_empty_list PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_process_callback_with_env_vars PASSED
tests/test_litellm/proxy/common_utils/test_callback_utils.py::test_process_callback_with_no_required_env_vars PASSED
========================= 8 passed =========================
```

## verification with Jaeger

<img width="1701" height="717" alt="image" src="https://github.com/user-attachments/assets/b8d1265e-9a68-4155-93e4-b33bfcee69a1" />


# Flow 

<img width="614" height="799" alt="image" src="https://github.com/user-attachments/assets/09916dd7-69a8-49f7-875c-9c8d077ba341" />
