### PR TITLE
fix(router): handle None num_retries in async_function_with_retries

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -400,9 +400,9 @@ class Router:
         )  # names of models under litellm_params. ex. azure/chatgpt-v-2
         self.deployment_latency_map = {}
         ### CACHING ###
-        cache_type: Literal[
-            "local", "redis", "redis-semantic", "s3", "disk"
-        ] = "local"  # default to an in-memory cache
+        cache_type: Literal["local", "redis", "redis-semantic", "s3", "disk"] = (
+            "local"  # default to an in-memory cache
+        )
         redis_cache = None
         cache_config: Dict[str, Any] = {}
 
@@ -450,9 +450,9 @@ class Router:
         self.default_max_parallel_requests = default_max_parallel_requests
         self.provider_default_deployment_ids: List[str] = []
         self.pattern_router = PatternMatchRouter()
-        self.team_pattern_routers: Dict[
-            str, PatternMatchRouter
-        ] = {}  # {"TEAM_ID": PatternMatchRouter}
+        self.team_pattern_routers: Dict[str, PatternMatchRouter] = (
+            {}
+        )  # {"TEAM_ID": PatternMatchRouter}
         self.auto_routers: Dict[str, "AutoRouter"] = {}
         self.complexity_routers: Dict[str, "ComplexityRouter"] = {}
 
@@ -638,9 +638,9 @@ class Router:
                     )
                 )
 
-        self.model_group_retry_policy: Optional[
-            Dict[str, RetryPolicy]
-        ] = model_group_retry_policy
+        self.model_group_retry_policy: Optional[Dict[str, RetryPolicy]] = (
+            model_group_retry_policy
+        )
 
         self.allowed_fails_policy: Optional[AllowedFailsPolicy] = None
         if allowed_fails_policy is not None:
@@ -2021,7 +2021,10 @@ class Router:
 
     async def _acompletion(  # noqa: PLR0915
         self, model: str, messages: List[Dict[str, str]], **kwargs
-    ) -> Union[ModelResponse, CustomStreamWrapper,]:
+    ) -> Union[
+        ModelResponse,
+        CustomStreamWrapper,
+    ]:
         """
         - Get an available deployment
         - call it with a semaphore over the call
@@ -4246,9 +4249,9 @@ class Router:
                 healthy_deployments=healthy_deployments, responses=responses
             )
             returned_response = cast(OpenAIFileObject, responses[0])
-            returned_response._hidden_params[
-                "model_file_id_mapping"
-            ] = model_file_id_mapping
+            returned_response._hidden_params["model_file_id_mapping"] = (
+                model_file_id_mapping
+            )
             return returned_response
         except Exception as e:
             verbose_router_logger.exception(
@@ -5275,11 +5278,11 @@ class Router:
 
             if isinstance(e, litellm.ContextWindowExceededError):
                 if context_window_fallbacks is not None:
-                    context_window_fallback_model_group: Optional[
-                        List[str]
-                    ] = self._get_fallback_model_group_from_fallbacks(
-                        fallbacks=context_window_fallbacks,
-                        model_group=model_group,
+                    context_window_fallback_model_group: Optional[List[str]] = (
+                        self._get_fallback_model_group_from_fallbacks(
+                            fallbacks=context_window_fallbacks,
+                            model_group=model_group,
+                        )
                     )
                     if context_window_fallback_model_group is None:
                         raise original_exception
@@ -5311,11 +5314,11 @@ class Router:
                     e.message += "\n{}".format(error_message)
             elif isinstance(e, litellm.ContentPolicyViolationError):
                 if content_policy_fallbacks is not None:
-                    content_policy_fallback_model_group: Optional[
-                        List[str]
-                    ] = self._get_fallback_model_group_from_fallbacks(
-                        fallbacks=content_policy_fallbacks,
-                        model_group=model_group,
+                    content_policy_fallback_model_group: Optional[List[str]] = (
+                        self._get_fallback_model_group_from_fallbacks(
+                            fallbacks=content_policy_fallbacks,
+                            model_group=model_group,
+                        )
                     )
                     if content_policy_fallback_model_group is None:
                         raise original_exception
@@ -5523,7 +5526,9 @@ class Router:
             "model_group_retry_policy", self.model_group_retry_policy
         )
         model_group: Optional[str] = kwargs.get("model")
-        num_retries = kwargs.pop("num_retries")
+        num_retries = kwargs.pop("num_retries", None)
+        if num_retries is None:
+            num_retries = self.num_retries or 0
 
         ## ADD MODEL GROUP SIZE TO METADATA - used for model_group_rate_limit_error tracking
         _metadata: dict = kwargs.get("litellm_metadata", kwargs.get("metadata")) or {}
@@ -5537,9 +5542,9 @@ class Router:
         )
         ## ADD RETRY TRACKING TO METADATA - used for spend logs retry tracking
         _metadata["attempted_retries"] = 0
-        _metadata[
-            "max_retries"
-        ] = num_retries  # Updated after overrides in exception handler
+        _metadata["max_retries"] = (
+            num_retries  # Updated after overrides in exception handler
+        )
         try:
             self._handle_mock_testing_rate_limit_error(
                 model_group=model_group, kwargs=kwargs
@@ -6658,26 +6663,26 @@ class Router:
         """
         from litellm.router_strategy.auto_router.auto_router import AutoRouter
 
-        auto_router_config_path: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_config_path
+        auto_router_config_path: Optional[str] = (
+            deployment.litellm_params.auto_router_config_path
+        )
         auto_router_config: Optional[str] = deployment.litellm_params.auto_router_config
         if auto_router_config_path is None and auto_router_config is None:
             raise ValueError(
                 "auto_router_config_path or auto_router_config is required for auto-router deployments. Please set it in the litellm_params"
             )
 
-        default_model: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_default_model
+        default_model: Optional[str] = (
+            deployment.litellm_params.auto_router_default_model
+        )
         if default_model is None:
             raise ValueError(
                 "auto_router_default_model is required for auto-router deployments. Please set it in the litellm_params"
             )
 
-        embedding_model: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_embedding_model
+        embedding_model: Optional[str] = (
+            deployment.litellm_params.auto_router_embedding_model
+        )
         if embedding_model is None:
             raise ValueError(
                 "auto_router_embedding_model is required for auto-router deployments. Please set it in the litellm_params"
@@ -6720,13 +6725,13 @@ class Router:
             ComplexityRouter,
         )
 
-        complexity_router_config: Optional[
-            dict
-        ] = deployment.litellm_params.complexity_router_config
+        complexity_router_config: Optional[dict] = (
+            deployment.litellm_params.complexity_router_config
+        )
 
-        default_model: Optional[
-            str
-        ] = deployment.litellm_params.complexity_router_default_model
+        default_model: Optional[str] = (
+            deployment.litellm_params.complexity_router_default_model
+        )
 
         # If no default model specified, try to get from config tiers
         if default_model is None and complexity_router_config:
@@ -7337,9 +7342,9 @@ class Router:
 
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:
-            credentials[
-                "custom_llm_provider"
-            ] = deployment.litellm_params.custom_llm_provider
+            credentials["custom_llm_provider"] = (
+                deployment.litellm_params.custom_llm_provider
+            )
         elif "/" in deployment.litellm_params.model:
             # Extract provider from "provider/model" format
             credentials["custom_llm_provider"] = deployment.litellm_params.model.split(

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -195,7 +195,13 @@ class TestPerDeploymentNumRetries:
         Test that async_function_with_retries handles None num_retries
         without raising TypeError.
         GitHub Issue: #23699
+
+        The bug is in the except block: `if num_retries > 0` crashes with
+        TypeError when num_retries is None. We must raise an exception
+        from the original function to enter that code path.
         """
+        import litellm
+
         router = Router(
             model_list=[
                 {
@@ -209,19 +215,24 @@ class TestPerDeploymentNumRetries:
             num_retries=3,
         )
 
-        # Simulate the case where num_retries is None in kwargs
-        # (as happens with auto_router/complexity_router + tool results)
+        # The mock must raise so the except block (with the bug) is entered
         async def mock_original_function(*args, **kwargs):
-            return {"choices": [{"message": {"content": "ok"}}]}
+            raise litellm.RateLimitError(
+                message="rate limit",
+                llm_provider="openai",
+                model="gpt-4",
+            )
 
         kwargs = {
             "original_function": mock_original_function,
             "num_retries": None,
             "model": "test-model",
             "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {},
         }
 
-        # Should not raise TypeError: '>' not supported between
-        # instances of 'NoneType' and 'int'
-        response = await router.async_function_with_retries(**kwargs)
-        assert response is not None
+        # Before the fix, this raised:
+        #   TypeError: '>' not supported between instances of 'NoneType' and 'int'
+        # After the fix, it should raise RateLimitError (not TypeError)
+        with pytest.raises(litellm.RateLimitError):
+            await router.async_function_with_retries(**kwargs)

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -188,3 +188,40 @@ class TestPerDeploymentNumRetries:
 
         # Verify num_retries was converted from string to int
         assert exc.num_retries == 6
+
+    @pytest.mark.asyncio
+    async def test_async_function_with_retries_none_num_retries(self):
+        """
+        Test that async_function_with_retries handles None num_retries
+        without raising TypeError.
+        GitHub Issue: #23699
+        """
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {
+                        "model": "openai/gpt-4",
+                        "api_key": "test-key",
+                    },
+                },
+            ],
+            num_retries=3,
+        )
+
+        # Simulate the case where num_retries is None in kwargs
+        # (as happens with auto_router/complexity_router + tool results)
+        async def mock_original_function(*args, **kwargs):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        kwargs = {
+            "original_function": mock_original_function,
+            "num_retries": None,
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+
+        # Should not raise TypeError: '>' not supported between
+        # instances of 'NoneType' and 'int'
+        response = await router.async_function_with_retries(**kwargs)
+        assert response is not None


### PR DESCRIPTION
## Relevant issues

Fixes #23699

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Fix `TypeError: '>' not supported between instances of 'NoneType' and 'int'` in `async_function_with_retries` when using `auto_router/complexity_router` with tool results in message history.

When the complexity router resolves an inner model, `num_retries` is not propagated into kwargs. `kwargs.pop("num_retries")` returns `None`, and the comparison `if num_retries > 0:` raises a `TypeError`.

Fix: fall back to `self.num_retries` (router-level setting) or `0` when `num_retries` is `None`.