### PR TITLE
[Fix] response_cost_calculator ignores custom_pricing for providers with response cost

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1699,11 +1699,12 @@ def response_cost_calculator(
             if isinstance(response_object, BaseModel):
                 if hasattr(response_object, "_hidden_params"):
                     response_object._hidden_params["optional_params"] = optional_params
-                    provider_response_cost = get_response_cost_from_hidden_params(
-                        response_object._hidden_params
-                    )
-                    if provider_response_cost is not None:
-                        return provider_response_cost
+                    if not custom_pricing:
+                        provider_response_cost = get_response_cost_from_hidden_params(
+                            response_object._hidden_params
+                        )
+                        if provider_response_cost is not None:
+                            return provider_response_cost
 
             response_cost = completion_cost(
                 completion_response=response_object,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -124,12 +124,12 @@ def test_custom_pricing_skips_provider_response_cost():
     )
 
     # Must use custom pricing, NOT provider response cost
-    assert result != provider_usd_cost, (
-        f"Should not use provider response cost ({provider_usd_cost})"
-    )
-    assert result == pytest.approx(expected_custom_cost), (
-        f"Got {result}, expected {expected_custom_cost} from custom pricing"
-    )
+    assert (
+        result != provider_usd_cost
+    ), f"Should not use provider response cost ({provider_usd_cost})"
+    assert result == pytest.approx(
+        expected_custom_cost
+    ), f"Got {result}, expected {expected_custom_cost} from custom pricing"
 
 
 def test_provider_response_cost_used_when_no_custom_pricing():
@@ -140,9 +140,7 @@ def test_provider_response_cost_used_when_no_custom_pricing():
 
     class MockResponse(BaseModel):
         _hidden_params = {
-            "additional_headers": {
-                "llm_provider-x-litellm-response-cost": 0.0000024
-            }
+            "additional_headers": {"llm_provider-x-litellm-response-cost": 0.0000024}
         }
 
     result = response_cost_calculator(
@@ -156,9 +154,7 @@ def test_provider_response_cost_used_when_no_custom_pricing():
         custom_pricing=False,
     )
 
-    assert result == 0.0000024, (
-        f"Should use provider response cost, got {result}"
-    )
+    assert result == 0.0000024, f"Should use provider response cost, got {result}"
 
 
 def test_custom_pricing_without_provider_response_cost():
@@ -211,9 +207,9 @@ def test_custom_pricing_without_provider_response_cost():
     expected_cost = (
         prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
     )
-    assert result == pytest.approx(expected_cost), (
-        f"Got {result}, expected {expected_cost} from custom pricing"
-    )
+    assert result == pytest.approx(
+        expected_cost
+    ), f"Got {result}, expected {expected_cost} from custom pricing"
 
 
 def test_cost_calculator_with_usage(monkeypatch):
@@ -272,6 +268,7 @@ def test_cost_calculator_with_usage(monkeypatch):
 
     # Invalidate caches after modifying litellm.model_cost
     from litellm.utils import _invalidate_model_cost_lowercase_map
+
     _invalidate_model_cost_lowercase_map()
 
     result = response_cost_calculator(
@@ -677,9 +674,7 @@ def test_azure_audio_output_cost_calculation():
     model_info = litellm.get_model_info("azure/gpt-audio-2025-08-28")
 
     # Calculate expected cost
-    expected_input_cost = (
-        model_info["input_cost_per_token"] * 17  # text tokens
-    )
+    expected_input_cost = model_info["input_cost_per_token"] * 17  # text tokens
     expected_output_cost = (
         model_info["output_cost_per_token"] * 110  # text tokens
         + model_info["output_cost_per_audio_token"] * 482  # audio tokens
@@ -691,14 +686,14 @@ def test_azure_audio_output_cost_calculation():
     wrong_total_cost = expected_input_cost + wrong_output_cost
 
     # Verify audio tokens are NOT charged at text rate (the bug)
-    assert abs(cost - wrong_total_cost) > 0.001, (
-        "Bug: Audio tokens are being charged at text token rate"
-    )
+    assert (
+        abs(cost - wrong_total_cost) > 0.001
+    ), "Bug: Audio tokens are being charged at text token rate"
 
     # Verify cost matches
-    assert abs(cost - expected_total_cost) < 0.0000001, (
-        f"Expected cost {expected_total_cost}, got {cost}"
-    )
+    assert (
+        abs(cost - expected_total_cost) < 0.0000001
+    ), f"Expected cost {expected_total_cost}, got {cost}"
 
 
 def test_default_image_cost_calculator(monkeypatch):
@@ -1205,12 +1200,12 @@ def test_azure_ai_cache_cost_calculation():
     print(f"Output cost: {output_cost}, Expected: {expected_output_cost}")
     print(f"Total cost: {total_cost}")
 
-    assert abs(input_cost - expected_input_cost) < 1e-10, (
-        f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
-    )
-    assert abs(output_cost - expected_output_cost) < 1e-10, (
-        f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
-    )
+    assert (
+        abs(input_cost - expected_input_cost) < 1e-10
+    ), f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
+    assert (
+        abs(output_cost - expected_output_cost) < 1e-10
+    ), f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
 
 
 def test_cost_discount_vertex_ai():
@@ -2078,7 +2073,9 @@ def test_gemini_implicit_caching_cost_calculation():
         f"Cached tokens may not be using reduced pricing."
     )
 
-    print("✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly")
+    print(
+        "✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly"
+    )
 
 
 def test_additional_costs_only_for_azure_ai():

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -67,6 +67,155 @@ def test_cost_calculator_with_response_cost_in_additional_headers():
     assert result == 1000
 
 
+def test_custom_pricing_skips_provider_response_cost():
+    """
+    When custom_pricing=True and provider response cost exists in hidden_params,
+    response_cost_calculator should ignore the provider cost and use custom pricing
+    via completion_cost() instead.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    # Register custom pricing in model_cost
+    custom_input_cost = 0.00015  # KRW per token
+    custom_output_cost = 0.0006  # KRW per token
+    litellm.register_model(
+        {
+            "openrouter/openai/gpt-4.1-nano": {
+                "input_cost_per_token": custom_input_cost,
+                "output_cost_per_token": custom_output_cost,
+                "litellm_provider": "openrouter",
+            }
+        }
+    )
+
+    prompt_tokens = 12
+    completion_tokens = 3
+    provider_usd_cost = 0.0000024  # USD cost from OpenRouter
+
+    response = ModelResponse(
+        id="test-id",
+        model="openrouter/openai/gpt-4.1-nano",
+        choices=[],
+        usage=Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+    # Simulate OpenRouter setting provider response cost in hidden_params
+    response._hidden_params["additional_headers"] = {
+        "llm_provider-x-litellm-response-cost": provider_usd_cost
+    }
+
+    result = response_cost_calculator(
+        response_object=response,
+        model="openrouter/openai/gpt-4.1-nano",
+        custom_llm_provider="openrouter",
+        call_type="acompletion",
+        optional_params={},
+        cache_hit=None,
+        base_model=None,
+        custom_pricing=True,
+    )
+
+    expected_custom_cost = (
+        prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
+    )
+
+    # Must use custom pricing, NOT provider response cost
+    assert result != provider_usd_cost, (
+        f"Should not use provider response cost ({provider_usd_cost})"
+    )
+    assert result == pytest.approx(expected_custom_cost), (
+        f"Got {result}, expected {expected_custom_cost} from custom pricing"
+    )
+
+
+def test_provider_response_cost_used_when_no_custom_pricing():
+    """
+    When custom_pricing is False/None and provider response cost exists,
+    response_cost_calculator should return the provider cost (existing behavior).
+    """
+
+    class MockResponse(BaseModel):
+        _hidden_params = {
+            "additional_headers": {
+                "llm_provider-x-litellm-response-cost": 0.0000024
+            }
+        }
+
+    result = response_cost_calculator(
+        response_object=MockResponse(),
+        model="openrouter/openai/gpt-4.1-nano",
+        custom_llm_provider="openrouter",
+        call_type="acompletion",
+        optional_params={},
+        cache_hit=None,
+        base_model=None,
+        custom_pricing=False,
+    )
+
+    assert result == 0.0000024, (
+        f"Should use provider response cost, got {result}"
+    )
+
+
+def test_custom_pricing_without_provider_response_cost():
+    """
+    When custom_pricing=True and no provider response cost exists,
+    response_cost_calculator should use custom pricing via completion_cost().
+    This verifies existing behavior is preserved.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    custom_input_cost = 0.001
+    custom_output_cost = 0.002
+    litellm.register_model(
+        {
+            "deepinfra/meta-llama/Llama-3.2-3B-Instruct": {
+                "input_cost_per_token": custom_input_cost,
+                "output_cost_per_token": custom_output_cost,
+                "litellm_provider": "deepinfra",
+            }
+        }
+    )
+
+    prompt_tokens = 10
+    completion_tokens = 5
+
+    response = ModelResponse(
+        id="test-id",
+        model="deepinfra/meta-llama/Llama-3.2-3B-Instruct",
+        choices=[],
+        usage=Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+    # No provider response cost in hidden_params
+
+    result = response_cost_calculator(
+        response_object=response,
+        model="deepinfra/meta-llama/Llama-3.2-3B-Instruct",
+        custom_llm_provider="deepinfra",
+        call_type="acompletion",
+        optional_params={},
+        cache_hit=None,
+        base_model=None,
+        custom_pricing=True,
+    )
+
+    expected_cost = (
+        prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
+    )
+    assert result == pytest.approx(expected_cost), (
+        f"Got {result}, expected {expected_cost} from custom pricing"
+    )
+
+
 def test_cost_calculator_with_usage(monkeypatch):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -89,47 +89,50 @@ def test_custom_pricing_skips_provider_response_cost():
         }
     )
 
-    prompt_tokens = 12
-    completion_tokens = 3
-    provider_usd_cost = 0.0000024  # USD cost from OpenRouter
+    try:
+        prompt_tokens = 12
+        completion_tokens = 3
+        provider_usd_cost = 0.0000024  # USD cost from OpenRouter
 
-    response = ModelResponse(
-        id="test-id",
-        model="openrouter/openai/gpt-4.1-nano",
-        choices=[],
-        usage=Usage(
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            total_tokens=prompt_tokens + completion_tokens,
-        ),
-    )
-    # Simulate OpenRouter setting provider response cost in hidden_params
-    response._hidden_params["additional_headers"] = {
-        "llm_provider-x-litellm-response-cost": provider_usd_cost
-    }
+        response = ModelResponse(
+            id="test-id",
+            model="openrouter/openai/gpt-4.1-nano",
+            choices=[],
+            usage=Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+        # Simulate OpenRouter setting provider response cost in hidden_params
+        response._hidden_params["additional_headers"] = {
+            "llm_provider-x-litellm-response-cost": provider_usd_cost
+        }
 
-    result = response_cost_calculator(
-        response_object=response,
-        model="openrouter/openai/gpt-4.1-nano",
-        custom_llm_provider="openrouter",
-        call_type="acompletion",
-        optional_params={},
-        cache_hit=None,
-        base_model=None,
-        custom_pricing=True,
-    )
+        result = response_cost_calculator(
+            response_object=response,
+            model="openrouter/openai/gpt-4.1-nano",
+            custom_llm_provider="openrouter",
+            call_type="acompletion",
+            optional_params={},
+            cache_hit=None,
+            base_model=None,
+            custom_pricing=True,
+        )
 
-    expected_custom_cost = (
-        prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
-    )
+        expected_custom_cost = (
+            prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
+        )
 
-    # Must use custom pricing, NOT provider response cost
-    assert (
-        result != provider_usd_cost
-    ), f"Should not use provider response cost ({provider_usd_cost})"
-    assert result == pytest.approx(
-        expected_custom_cost
-    ), f"Got {result}, expected {expected_custom_cost} from custom pricing"
+        # Must use custom pricing, NOT provider response cost
+        assert (
+            result != provider_usd_cost
+        ), f"Should not use provider response cost ({provider_usd_cost})"
+        assert result == pytest.approx(
+            expected_custom_cost
+        ), f"Got {result}, expected {expected_custom_cost} from custom pricing"
+    finally:
+        litellm.model_cost.pop("openrouter/openai/gpt-4.1-nano", None)
 
 
 def test_provider_response_cost_used_when_no_custom_pricing():
@@ -178,38 +181,41 @@ def test_custom_pricing_without_provider_response_cost():
         }
     )
 
-    prompt_tokens = 10
-    completion_tokens = 5
+    try:
+        prompt_tokens = 10
+        completion_tokens = 5
 
-    response = ModelResponse(
-        id="test-id",
-        model="deepinfra/meta-llama/Llama-3.2-3B-Instruct",
-        choices=[],
-        usage=Usage(
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            total_tokens=prompt_tokens + completion_tokens,
-        ),
-    )
-    # No provider response cost in hidden_params
+        response = ModelResponse(
+            id="test-id",
+            model="deepinfra/meta-llama/Llama-3.2-3B-Instruct",
+            choices=[],
+            usage=Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+        # No provider response cost in hidden_params
 
-    result = response_cost_calculator(
-        response_object=response,
-        model="deepinfra/meta-llama/Llama-3.2-3B-Instruct",
-        custom_llm_provider="deepinfra",
-        call_type="acompletion",
-        optional_params={},
-        cache_hit=None,
-        base_model=None,
-        custom_pricing=True,
-    )
+        result = response_cost_calculator(
+            response_object=response,
+            model="deepinfra/meta-llama/Llama-3.2-3B-Instruct",
+            custom_llm_provider="deepinfra",
+            call_type="acompletion",
+            optional_params={},
+            cache_hit=None,
+            base_model=None,
+            custom_pricing=True,
+        )
 
-    expected_cost = (
-        prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
-    )
-    assert result == pytest.approx(
-        expected_cost
-    ), f"Got {result}, expected {expected_cost} from custom pricing"
+        expected_cost = (
+            prompt_tokens * custom_input_cost + completion_tokens * custom_output_cost
+        )
+        assert result == pytest.approx(
+            expected_cost
+        ), f"Got {result}, expected {expected_cost} from custom pricing"
+    finally:
+        litellm.model_cost.pop("deepinfra/meta-llama/Llama-3.2-3B-Instruct", None)
 
 
 def test_cost_calculator_with_usage(monkeypatch):


### PR DESCRIPTION
## Relevant issues

When custom per-token pricing is configured via `litellm_params` (e.g., `input_cost_per_token`, `output_cost_per_token`), providers like OpenRouter that include `usage.cost` in their response body silently override the custom pricing. The `custom_pricing` parameter on `response_cost_calculator()` is never checked before the provider cost early return.

## Summary

### Failure Path (Before Fix)

`response_cost_calculator()` extracts the provider-reported cost from `_hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"]` and returns it immediately — before checking whether `custom_pricing=True`. This means any provider that reports cost in the response (currently OpenRouter chat and image generation) will bypass custom pricing, discount, and margin logic in `completion_cost()`.

```python
# cost_calculator.py – response_cost_calculator()
if hasattr(response_object, "_hidden_params"):
    response_object._hidden_params["optional_params"] = optional_params
    provider_response_cost = get_response_cost_from_hidden_params(...)
    if provider_response_cost is not None:
        return provider_response_cost  # ← returns before checking custom_pricing
```

**Concrete example:** Setting `input_cost_per_token=0.00015` / `output_cost_per_token=0.0006` (KRW) on an OpenRouter model — spend is recorded as OpenRouter's USD `usage.cost` instead of the configured custom price.

### Fix

Add `if not custom_pricing:` guard around the provider response cost block. When `custom_pricing=True`, the function falls through to `completion_cost()` which already handles custom pricing, discount, and margin correctly.

```python
if hasattr(response_object, "_hidden_params"):
    response_object._hidden_params["optional_params"] = optional_params
    if not custom_pricing:
        provider_response_cost = get_response_cost_from_hidden_params(...)
        if provider_response_cost is not None:
            return provider_response_cost
```

- `custom_pricing=None` (default) and `custom_pricing=False` → existing behavior preserved
- `custom_pricing=True` → skips provider cost, uses `completion_cost()` path

## Testing

3 new unit tests added to `tests/test_litellm/test_cost_calculator.py`:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_custom_pricing_skips_provider_response_cost` | `custom_pricing=True` + provider cost exists | Custom pricing used, provider cost ignored |
| `test_provider_response_cost_used_when_no_custom_pricing` | `custom_pricing=False` + provider cost exists | Provider cost returned (existing behavior) |
| `test_custom_pricing_without_provider_response_cost` | `custom_pricing=True` + no provider cost | Custom pricing via `completion_cost()` (existing behavior) |

Full `test_cost_calculator.py` suite: **38/38 passed**, no regressions.

## Type

🐛 Bug Fix
✅ Test