### PR TITLE
fix: kwargs add alias

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -952,12 +952,52 @@ def _apply_cost_margin(
     return base_cost, margin_percent, margin_fixed_amount, margin_total_amount
 
 
+def _calculate_reasoning_tokens_cost(
+    usage: Optional["Usage"],
+    model: str,
+    custom_llm_provider: str,
+) -> float:
+    """
+    Calculate the cost of reasoning tokens separately.
+
+    This mirrors the logic in generic_cost_per_token() but returns the
+    reasoning cost as a standalone value (it is already included in
+    output_cost / completion_tokens_cost).
+    """
+    if usage is None:
+        return 0.0
+
+    completion_tokens_details = getattr(usage, "completion_tokens_details", None)
+    if completion_tokens_details is None:
+        return 0.0
+
+    reasoning_tokens = getattr(completion_tokens_details, "reasoning_tokens", None) or 0
+    if reasoning_tokens <= 0:
+        return 0.0
+
+    try:
+        model_info = litellm.get_model_info(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+    except Exception:
+        return 0.0
+
+    output_cost_per_reasoning_token = model_info.get(
+        "output_cost_per_reasoning_token", None
+    )
+    if output_cost_per_reasoning_token is None:
+        output_cost_per_reasoning_token = model_info.get("output_cost_per_token", 0.0)
+
+    return float(reasoning_tokens) * float(output_cost_per_reasoning_token)
+
+
 def _store_cost_breakdown_in_logging_obj(
     litellm_logging_obj: Optional[LitellmLoggingObject],
     prompt_tokens_cost_usd_dollar: float,
     completion_tokens_cost_usd_dollar: float,
     cost_for_built_in_tools_cost_usd_dollar: float,
     total_cost_usd_dollar: float,
+    reasoning_tokens_cost_usd_dollar: float = 0.0,
     additional_costs: Optional[dict] = None,
     original_cost: Optional[float] = None,
     discount_percent: Optional[float] = None,
@@ -993,6 +1033,7 @@ def _store_cost_breakdown_in_logging_obj(
             output_cost=completion_tokens_cost_usd_dollar,
             total_cost=total_cost_usd_dollar,
             cost_for_built_in_tools_cost_usd_dollar=cost_for_built_in_tools_cost_usd_dollar,
+            reasoning_tokens_cost=reasoning_tokens_cost_usd_dollar,
             additional_costs=additional_costs,
             original_cost=original_cost,
             discount_percent=discount_percent,
@@ -1583,6 +1624,13 @@ def completion_cost(  # noqa: PLR0915
                     margin_fixed_amount = 0.0
                     margin_total_amount = 0.0
 
+                # Calculate reasoning tokens cost separately
+                reasoning_tokens_cost = _calculate_reasoning_tokens_cost(
+                    usage=cost_per_token_usage_object,
+                    model=model,
+                    custom_llm_provider=custom_llm_provider,
+                )
+
                 # Store cost breakdown in logging object if available
                 if litellm_logging_obj is not None:
                     _store_cost_breakdown_in_logging_obj(
@@ -1591,6 +1639,7 @@ def completion_cost(  # noqa: PLR0915
                         completion_tokens_cost_usd_dollar=completion_tokens_cost_usd_dollar,
                         cost_for_built_in_tools_cost_usd_dollar=cost_for_built_in_tools,
                         total_cost_usd_dollar=_final_cost,
+                        reasoning_tokens_cost_usd_dollar=reasoning_tokens_cost,
                         original_cost=original_cost,
                         additional_costs=additional_costs,
                         discount_percent=discount_percent,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -27,6 +27,7 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
     _get_service_tier_cost_key,
     _parse_prompt_tokens_details,
     calculate_cost_component,
+    calculate_detailed_cost_breakdowns,
     generic_cost_per_token,
     get_billable_input_tokens,
     select_cost_metric_for_model,
@@ -952,45 +953,6 @@ def _apply_cost_margin(
     return base_cost, margin_percent, margin_fixed_amount, margin_total_amount
 
 
-def _calculate_reasoning_tokens_cost(
-    usage: Optional["Usage"],
-    model: str,
-    custom_llm_provider: str,
-) -> float:
-    """
-    Calculate the cost of reasoning tokens separately.
-
-    This mirrors the logic in generic_cost_per_token() but returns the
-    reasoning cost as a standalone value (it is already included in
-    output_cost / completion_tokens_cost).
-    """
-    if usage is None:
-        return 0.0
-
-    completion_tokens_details = getattr(usage, "completion_tokens_details", None)
-    if completion_tokens_details is None:
-        return 0.0
-
-    reasoning_tokens = getattr(completion_tokens_details, "reasoning_tokens", None) or 0
-    if reasoning_tokens <= 0:
-        return 0.0
-
-    try:
-        model_info = litellm.get_model_info(
-            model=model, custom_llm_provider=custom_llm_provider
-        )
-    except Exception:
-        return 0.0
-
-    output_cost_per_reasoning_token = model_info.get(
-        "output_cost_per_reasoning_token", None
-    )
-    if output_cost_per_reasoning_token is None:
-        output_cost_per_reasoning_token = model_info.get("output_cost_per_token", 0.0)
-
-    return float(reasoning_tokens) * float(output_cost_per_reasoning_token)
-
-
 def _store_cost_breakdown_in_logging_obj(
     litellm_logging_obj: Optional[LitellmLoggingObject],
     prompt_tokens_cost_usd_dollar: float,
@@ -998,6 +960,8 @@ def _store_cost_breakdown_in_logging_obj(
     cost_for_built_in_tools_cost_usd_dollar: float,
     total_cost_usd_dollar: float,
     reasoning_tokens_cost_usd_dollar: float = 0.0,
+    input_cost_breakdown: Optional[dict] = None,
+    output_cost_breakdown: Optional[dict] = None,
     additional_costs: Optional[dict] = None,
     original_cost: Optional[float] = None,
     discount_percent: Optional[float] = None,
@@ -1015,6 +979,8 @@ def _store_cost_breakdown_in_logging_obj(
         completion_tokens_cost_usd_dollar: Cost of completion tokens (includes reasoning if applicable)
         cost_for_built_in_tools_cost_usd_dollar: Cost of built-in tools
         total_cost_usd_dollar: Total cost of request
+        input_cost_breakdown: Per-token-type input cost breakdown
+        output_cost_breakdown: Per-token-type output cost breakdown
         additional_costs: Free-form additional costs dict (e.g., {"azure_model_router_flat_cost": 0.00014})
         original_cost: Cost before discount
         discount_percent: Discount percentage applied (0.05 = 5%)
@@ -1034,6 +1000,8 @@ def _store_cost_breakdown_in_logging_obj(
             total_cost=total_cost_usd_dollar,
             cost_for_built_in_tools_cost_usd_dollar=cost_for_built_in_tools_cost_usd_dollar,
             reasoning_tokens_cost=reasoning_tokens_cost_usd_dollar,
+            input_cost_breakdown=input_cost_breakdown,
+            output_cost_breakdown=output_cost_breakdown,
             additional_costs=additional_costs,
             original_cost=original_cost,
             discount_percent=discount_percent,
@@ -1230,7 +1198,9 @@ def completion_cost(  # noqa: PLR0915
                         and _usage["prompt_tokens_details"] != {}
                         and _usage["prompt_tokens_details"]
                     ):
-                        prompt_tokens_details = _usage.get("prompt_tokens_details") or {}
+                        prompt_tokens_details = (
+                            _usage.get("prompt_tokens_details") or {}
+                        )
                         cache_read_input_tokens = prompt_tokens_details.get(
                             "cached_tokens", 0
                         )
@@ -1556,7 +1526,9 @@ def completion_cost(  # noqa: PLR0915
                 if custom_llm_provider == "azure_ai":
                     model_for_additional_costs = request_model_for_cost
                     if completion_response is not None:
-                        hidden_params = getattr(completion_response, "_hidden_params", None) or {}
+                        hidden_params = (
+                            getattr(completion_response, "_hidden_params", None) or {}
+                        )
                         hidden_model = hidden_params.get("model") or hidden_params.get(
                             "litellm_model_name"
                         )
@@ -1624,12 +1596,28 @@ def completion_cost(  # noqa: PLR0915
                     margin_fixed_amount = 0.0
                     margin_total_amount = 0.0
 
-                # Calculate reasoning tokens cost separately
-                reasoning_tokens_cost = _calculate_reasoning_tokens_cost(
-                    usage=cost_per_token_usage_object,
-                    model=model,
-                    custom_llm_provider=custom_llm_provider,
-                )
+                # Calculate detailed per-token-type cost breakdowns
+                _input_cost_breakdown: Optional[dict] = None
+                _output_cost_breakdown: Optional[dict] = None
+                reasoning_tokens_cost = 0.0
+                if cost_per_token_usage_object is not None:
+                    try:
+                        (
+                            _input_cost_breakdown,
+                            _output_cost_breakdown,
+                        ) = calculate_detailed_cost_breakdowns(
+                            model=model,
+                            usage=cost_per_token_usage_object,
+                            custom_llm_provider=custom_llm_provider,
+                            service_tier=service_tier,
+                        )
+                        # Extract reasoning cost from the output breakdown
+                        if _output_cost_breakdown:
+                            reasoning_tokens_cost = _output_cost_breakdown.get(
+                                "reasoning_token_cost", 0.0
+                            )
+                    except Exception:
+                        pass
 
                 # Store cost breakdown in logging object if available
                 if litellm_logging_obj is not None:
@@ -1640,6 +1628,8 @@ def completion_cost(  # noqa: PLR0915
                         cost_for_built_in_tools_cost_usd_dollar=cost_for_built_in_tools,
                         total_cost_usd_dollar=_final_cost,
                         reasoning_tokens_cost_usd_dollar=reasoning_tokens_cost,
+                        input_cost_breakdown=_input_cost_breakdown,
+                        output_cost_breakdown=_output_cost_breakdown,
                         original_cost=original_cost,
                         additional_costs=additional_costs,
                         discount_percent=discount_percent,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -352,9 +352,9 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
-        self.sync_streaming_chunks: List[Any] = (
-            []
-        )  # for generating complete stream response
+        self.sync_streaming_chunks: List[
+            Any
+        ] = []  # for generating complete stream response
         self.log_raw_request_response = log_raw_request_response
 
         # Initialize dynamic callbacks
@@ -782,9 +782,9 @@ class Logging(LiteLLMLoggingBaseClass):
                         prompt_spec=prompt_spec,
                         dynamic_callback_params=dynamic_callback_params,
                     ):
-                        self.model_call_details["prompt_integration"] = (
-                            logger.__class__.__name__
-                        )
+                        self.model_call_details[
+                            "prompt_integration"
+                        ] = logger.__class__.__name__
                         return logger
                 except Exception:
                     # If check fails, continue to next logger
@@ -852,9 +852,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if anthropic_cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
             non_default_params
         ):
-            self.model_call_details["prompt_integration"] = (
-                anthropic_cache_control_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = anthropic_cache_control_logger.__class__.__name__
             return anthropic_cache_control_logger
 
         #########################################################
@@ -866,9 +866,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 internal_usage_cache=None,
                 llm_router=None,
             )
-            self.model_call_details["prompt_integration"] = (
-                vector_store_custom_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = vector_store_custom_logger.__class__.__name__
             # Add to global callbacks so post-call hooks are invoked
             if (
                 vector_store_custom_logger
@@ -928,9 +928,9 @@ class Logging(LiteLLMLoggingBaseClass):
             model
         ):  # if model name was changes pre-call, overwrite the initial model call name with the new one
             self.model_call_details["model"] = model
-        self.model_call_details["litellm_params"]["api_base"] = (
-            self._get_masked_api_base(additional_args.get("api_base", ""))
-        )
+        self.model_call_details["litellm_params"][
+            "api_base"
+        ] = self._get_masked_api_base(additional_args.get("api_base", ""))
 
     def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
         # Log the exact input to the LLM API
@@ -959,10 +959,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:
-                        _metadata["raw_request"] = (
-                            "redacted by litellm. \
+                        _metadata[
+                            "raw_request"
+                        ] = "redacted by litellm. \
                             'litellm.turn_off_message_logging=True'"
-                        )
                     else:
                         curl_command = self._get_request_curl_command(
                             api_base=additional_args.get("api_base", ""),
@@ -973,34 +973,34 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         _metadata["raw_request"] = str(curl_command)
                         # split up, so it's easier to parse in the UI
-                        self.model_call_details["raw_request_typed_dict"] = (
-                            RawRequestTypedDict(
-                                raw_request_api_base=str(
-                                    additional_args.get("api_base") or ""
-                                ),
-                                raw_request_body=self._get_raw_request_body(
-                                    additional_args.get("complete_input_dict", {})
-                                ),
-                                # NOTE: setting ignore_sensitive_headers to True will cause
-                                # the Authorization header to be leaked when calls to the health
-                                # endpoint are made and fail.
-                                raw_request_headers=self._get_masked_headers(
-                                    additional_args.get("headers", {}) or {},
-                                ),
-                                error=None,
-                            )
+                        self.model_call_details[
+                            "raw_request_typed_dict"
+                        ] = RawRequestTypedDict(
+                            raw_request_api_base=str(
+                                additional_args.get("api_base") or ""
+                            ),
+                            raw_request_body=self._get_raw_request_body(
+                                additional_args.get("complete_input_dict", {})
+                            ),
+                            # NOTE: setting ignore_sensitive_headers to True will cause
+                            # the Authorization header to be leaked when calls to the health
+                            # endpoint are made and fail.
+                            raw_request_headers=self._get_masked_headers(
+                                additional_args.get("headers", {}) or {},
+                            ),
+                            error=None,
                         )
                 except Exception as e:
-                    self.model_call_details["raw_request_typed_dict"] = (
-                        RawRequestTypedDict(
-                            error=str(e),
-                        )
+                    self.model_call_details[
+                        "raw_request_typed_dict"
+                    ] = RawRequestTypedDict(
+                        error=str(e),
                     )
-                    _metadata["raw_request"] = (
-                        "Unable to Log \
+                    _metadata[
+                        "raw_request"
+                    ] = "Unable to Log \
                         raw request: {}".format(
-                            str(e)
-                        )
+                        str(e)
                     )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
@@ -1301,13 +1301,13 @@ class Logging(LiteLLMLoggingBaseClass):
         for callback in callbacks:
             try:
                 if isinstance(callback, CustomLogger):
-                    response: Optional[MCPPostCallResponseObject] = (
-                        await callback.async_post_mcp_tool_call_hook(
-                            kwargs=kwargs,
-                            response_obj=post_mcp_tool_call_response_obj,
-                            start_time=start_time,
-                            end_time=end_time,
-                        )
+                    response: Optional[
+                        MCPPostCallResponseObject
+                    ] = await callback.async_post_mcp_tool_call_hook(
+                        kwargs=kwargs,
+                        response_obj=post_mcp_tool_call_response_obj,
+                        start_time=start_time,
+                        end_time=end_time,
                     )
                     ######################################################################
                     # if any of the callbacks modify the response, use the modified response
@@ -1352,6 +1352,8 @@ class Logging(LiteLLMLoggingBaseClass):
         total_cost: float,
         cost_for_built_in_tools_cost_usd_dollar: float,
         reasoning_tokens_cost: float = 0.0,
+        input_cost_breakdown: Optional[dict] = None,
+        output_cost_breakdown: Optional[dict] = None,
         additional_costs: Optional[dict] = None,
         original_cost: Optional[float] = None,
         discount_percent: Optional[float] = None,
@@ -1368,6 +1370,8 @@ class Logging(LiteLLMLoggingBaseClass):
             output_cost: Cost of output/completion tokens
             cost_for_built_in_tools_cost_usd_dollar: Cost of built-in tools
             total_cost: Total cost of request
+            input_cost_breakdown: Per-token-type input cost breakdown
+            output_cost_breakdown: Per-token-type output cost breakdown
             additional_costs: Free-form additional costs dict (e.g., {"azure_model_router_flat_cost": 0.00014})
             original_cost: Cost before discount
             discount_percent: Discount percentage (0.05 = 5%)
@@ -1386,6 +1390,12 @@ class Logging(LiteLLMLoggingBaseClass):
 
         if reasoning_tokens_cost > 0:
             self.cost_breakdown["reasoning_tokens_cost"] = reasoning_tokens_cost
+
+        # Store per-token-type cost breakdowns if provided
+        if input_cost_breakdown and len(input_cost_breakdown) > 0:
+            self.cost_breakdown["input_cost_breakdown"] = input_cost_breakdown
+        if output_cost_breakdown and len(output_cost_breakdown) > 0:
+            self.cost_breakdown["output_cost_breakdown"] = output_cost_breakdown
 
         # Store additional costs if provided (free-form dict for extensibility)
         if (
@@ -1506,9 +1516,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
             return None
 
         try:
@@ -1534,9 +1544,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
 
         return None
 
@@ -1692,9 +1702,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 result=logging_result
             )
 
-        self.model_call_details["standard_logging_object"] = (
-            self._build_standard_logging_payload(logging_result, start_time, end_time)
-        )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = self._build_standard_logging_payload(logging_result, start_time, end_time)
 
         if (
             standard_logging_payload := self.model_call_details.get(
@@ -1772,9 +1782,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 end_time = datetime.datetime.now()
             if self.completion_start_time is None:
                 self.completion_start_time = end_time
-                self.model_call_details["completion_start_time"] = (
-                    self.completion_start_time
-                )
+                self.model_call_details[
+                    "completion_start_time"
+                ] = self.completion_start_time
 
             self.model_call_details["log_event_type"] = "successful_api_call"
             self.model_call_details["end_time"] = end_time
@@ -1811,10 +1821,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         end_time=end_time,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
-                    self.model_call_details["standard_logging_object"] = (
-                        self._build_standard_logging_payload(
-                            result, start_time, end_time
-                        )
+                    self.model_call_details[
+                        "standard_logging_object"
+                    ] = self._build_standard_logging_payload(
+                        result, start_time, end_time
                     )
                     if (
                         standard_logging_payload := self.model_call_details.get(
@@ -1823,9 +1833,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     ) is not None:
                         emit_standard_logging_payload(standard_logging_payload)
             elif standard_logging_object is not None:
-                self.model_call_details["standard_logging_object"] = (
-                    standard_logging_object
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = standard_logging_object
             else:
                 self.model_call_details["response_cost"] = None
 
@@ -1983,17 +1993,17 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details["complete_streaming_response"] = (
-                    complete_streaming_response
-                )
-                self.model_call_details["response_cost"] = (
-                    self._response_cost_calculator(result=complete_streaming_response)
-                )
+                self.model_call_details[
+                    "complete_streaming_response"
+                ] = complete_streaming_response
+                self.model_call_details[
+                    "response_cost"
+                ] = self._response_cost_calculator(result=complete_streaming_response)
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(
-                        complete_streaming_response, start_time, end_time
-                    )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = self._build_standard_logging_payload(
+                    complete_streaming_response, start_time, end_time
                 )
                 if (
                     standard_logging_payload := self.model_call_details.get(
@@ -2327,10 +2337,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
                             openMeterLogger.log_success_event(
@@ -2354,10 +2364,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
 
@@ -2496,9 +2506,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if complete_streaming_response is not None:
             print_verbose("Async success callbacks: Got a complete streaming response")
 
-            self.model_call_details["async_complete_streaming_response"] = (
-                complete_streaming_response
-            )
+            self.model_call_details[
+                "async_complete_streaming_response"
+            ] = complete_streaming_response
 
             try:
                 if self.model_call_details.get("cache_hit", False) is True:
@@ -2509,10 +2519,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details["response_cost"] = (
-                        self._response_cost_calculator(
-                            result=complete_streaming_response
-                        )
+                    self.model_call_details[
+                        "response_cost"
+                    ] = self._response_cost_calculator(
+                        result=complete_streaming_response
                     )
 
                 verbose_logger.debug(
@@ -2525,10 +2535,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["response_cost"] = None
 
             ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details["standard_logging_object"] = (
-                self._build_standard_logging_payload(
-                    complete_streaming_response, start_time, end_time
-                )
+            self.model_call_details[
+                "standard_logging_object"
+            ] = self._build_standard_logging_payload(
+                complete_streaming_response, start_time, end_time
             )
 
             # print standard logging payload
@@ -2555,9 +2565,9 @@ class Logging(LiteLLMLoggingBaseClass):
             # _success_handler_helper_fn
             if self.model_call_details.get("standard_logging_object") is None:
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(result, start_time, end_time)
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = self._build_standard_logging_payload(result, start_time, end_time)
 
                 # print standard logging payload
                 if (
@@ -2800,18 +2810,18 @@ class Logging(LiteLLMLoggingBaseClass):
 
         ## STANDARDIZED LOGGING PAYLOAD
 
-        self.model_call_details["standard_logging_object"] = (
-            get_standard_logging_object_payload(
-                kwargs=self.model_call_details,
-                init_response_obj={},
-                start_time=start_time,
-                end_time=end_time,
-                logging_obj=self,
-                status="failure",
-                error_str=str(exception),
-                original_exception=exception,
-                standard_built_in_tools_params=self.standard_built_in_tools_params,
-            )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = get_standard_logging_object_payload(
+            kwargs=self.model_call_details,
+            init_response_obj={},
+            start_time=start_time,
+            end_time=end_time,
+            logging_obj=self,
+            status="failure",
+            error_str=str(exception),
+            original_exception=exception,
+            standard_built_in_tools_params=self.standard_built_in_tools_params,
         )
         return start_time, end_time
 
@@ -3775,9 +3785,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 service_name=arize_config.project_name,
             )
 
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, ArizeLogger)
@@ -3803,13 +3813,13 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
                 else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={arize_phoenix_config.project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"openinference.project.name={arize_phoenix_config.project_name}"
 
             # Set Phoenix project name from environment variable
             phoenix_project_name = os.environ.get("PHOENIX_PROJECT_NAME", None)
@@ -3817,19 +3827,19 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={phoenix_project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"{existing_attrs},openinference.project.name={phoenix_project_name}"
                 else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={phoenix_project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"openinference.project.name={phoenix_project_name}"
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:
-                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                    arize_phoenix_config.otlp_auth_headers
-                )
+                os.environ[
+                    "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+                ] = arize_phoenix_config.otlp_auth_headers
 
             for callback in _in_memory_loggers:
                 if (
@@ -3908,7 +3918,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             from litellm.integrations.focus.focus_logger import FocusLogger
 
             for callback in _in_memory_loggers:
-                if type(callback) is FocusLogger:  # exact match; exclude subclasses like VantageLogger
+                if (
+                    type(callback) is FocusLogger
+                ):  # exact match; exclude subclasses like VantageLogger
                     return callback  # type: ignore
             focus_logger = FocusLogger()
             _in_memory_loggers.append(focus_logger)
@@ -4014,9 +4026,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 exporter="otlp_http",
                 endpoint="https://langtrace.ai/api/trace",
             )
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"api_key={os.getenv('LANGTRACE_API_KEY')}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, OpenTelemetry)
@@ -4290,7 +4302,9 @@ def get_custom_logger_compatible_class(  # noqa: PLR0915
             from litellm.integrations.focus.focus_logger import FocusLogger
 
             for callback in _in_memory_loggers:
-                if type(callback) is FocusLogger:  # exact match; exclude subclasses like VantageLogger
+                if (
+                    type(callback) is FocusLogger
+                ):  # exact match; exclude subclasses like VantageLogger
                     return callback
         elif logging_integration == "vantage":
             from litellm.integrations.vantage.vantage_logger import VantageLogger
@@ -4939,10 +4953,10 @@ class StandardLoggingPayloadSetup:
             for key in StandardLoggingHiddenParams.__annotations__.keys():
                 if key in hidden_params:
                     if key == "additional_headers":
-                        clean_hidden_params["additional_headers"] = (
-                            StandardLoggingPayloadSetup.get_additional_headers(
-                                hidden_params[key]
-                            )
+                        clean_hidden_params[
+                            "additional_headers"
+                        ] = StandardLoggingPayloadSetup.get_additional_headers(
+                            hidden_params[key]
                         )
                     else:
                         clean_hidden_params[key] = hidden_params[key]  # type: ignore
@@ -5581,9 +5595,9 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
     ):
         for k, v in metadata["user_api_key_metadata"].items():
             if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[k] = (
-                    "scrubbed_by_litellm_for_sensitive_keys"
-                )
+                cleaned_user_api_key_metadata[
+                    k
+                ] = "scrubbed_by_litellm_for_sensitive_keys"
             else:
                 cleaned_user_api_key_metadata[k] = v
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1385,8 +1385,13 @@ class Logging(LiteLLMLoggingBaseClass):
             input_cost=input_cost,
             output_cost=output_cost,
             total_cost=total_cost,
-            tool_usage_cost=cost_for_built_in_tools_cost_usd_dollar,
         )
+
+        # Only include fields when they carry meaningful (non-zero) values
+        if cost_for_built_in_tools_cost_usd_dollar > 0:
+            self.cost_breakdown[
+                "tool_usage_cost"
+            ] = cost_for_built_in_tools_cost_usd_dollar
 
         if reasoning_tokens_cost > 0:
             self.cost_breakdown["reasoning_tokens_cost"] = reasoning_tokens_cost
@@ -1405,20 +1410,18 @@ class Logging(LiteLLMLoggingBaseClass):
         ):
             self.cost_breakdown["additional_costs"] = additional_costs
 
-        # Store discount information if provided
-        if original_cost is not None:
+        # Store discount/margin info only when actually applied (non-zero)
+        if original_cost is not None and discount_amount and discount_amount > 0:
             self.cost_breakdown["original_cost"] = original_cost
-        if discount_percent is not None:
+        if discount_percent is not None and discount_percent > 0:
             self.cost_breakdown["discount_percent"] = discount_percent
-        if discount_amount is not None:
+        if discount_amount is not None and discount_amount > 0:
             self.cost_breakdown["discount_amount"] = discount_amount
-
-        # Store margin information if provided
-        if margin_percent is not None:
+        if margin_percent is not None and margin_percent > 0:
             self.cost_breakdown["margin_percent"] = margin_percent
-        if margin_fixed_amount is not None:
+        if margin_fixed_amount is not None and margin_fixed_amount > 0:
             self.cost_breakdown["margin_fixed_amount"] = margin_fixed_amount
-        if margin_total_amount is not None:
+        if margin_total_amount is not None and margin_total_amount > 0:
             self.cost_breakdown["margin_total_amount"] = margin_total_amount
 
     def _response_cost_calculator(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1351,6 +1351,7 @@ class Logging(LiteLLMLoggingBaseClass):
         output_cost: float,
         total_cost: float,
         cost_for_built_in_tools_cost_usd_dollar: float,
+        reasoning_tokens_cost: float = 0.0,
         additional_costs: Optional[dict] = None,
         original_cost: Optional[float] = None,
         discount_percent: Optional[float] = None,
@@ -1382,6 +1383,9 @@ class Logging(LiteLLMLoggingBaseClass):
             total_cost=total_cost,
             tool_usage_cost=cost_for_built_in_tools_cost_usd_dollar,
         )
+
+        if reasoning_tokens_cost > 0:
+            self.cost_breakdown["reasoning_tokens_cost"] = reasoning_tokens_cost
 
         # Store additional costs if provided (free-form dict for extensibility)
         if (
@@ -4689,6 +4693,7 @@ class StandardLoggingPayloadSetup:
             user_api_key_team_id=None,
             user_api_key_org_id=None,
             user_api_key_project_id=None,
+            user_api_key_project_alias=None,
             user_api_key_user_id=None,
             user_api_key_team_alias=None,
             user_api_key_user_email=None,

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -549,23 +549,40 @@ def _calculate_input_cost(
     cache_creation_cost: float,
     cache_creation_cost_above_1hr: float,
     service_tier: Optional[str] = None,
-) -> float:
+) -> Tuple[float, dict]:
     """
     Calculates the input cost for a given model, prompt tokens, and completion tokens.
+
+    Returns:
+        Tuple[float, dict] - (total_input_cost, per_token_type_breakdown)
+        The breakdown dict only contains keys whose cost > 0.
     """
-    prompt_cost = float(prompt_tokens_details["text_tokens"]) * prompt_base_cost
+    breakdown: dict = {}
+
+    prompt_token_cost = float(prompt_tokens_details["text_tokens"]) * prompt_base_cost
+    if prompt_token_cost > 0:
+        breakdown["prompt_token_cost"] = prompt_token_cost
+    prompt_cost = prompt_token_cost
 
     ### CACHE READ COST - Now uses tiered pricing
-    prompt_cost += float(prompt_tokens_details["cache_hit_tokens"]) * cache_read_cost
+    cached_token_cost = (
+        float(prompt_tokens_details["cache_hit_tokens"]) * cache_read_cost
+    )
+    if cached_token_cost > 0:
+        breakdown["cached_token_cost"] = cached_token_cost
+    prompt_cost += cached_token_cost
 
     ### AUDIO COST
     if prompt_tokens_details["audio_tokens"]:
         audio_cost_key = _get_service_tier_cost_key(
             "input_cost_per_audio_token", service_tier
         )
-        prompt_cost += calculate_cost_component(
+        audio_cost = calculate_cost_component(
             model_info, audio_cost_key, prompt_tokens_details["audio_tokens"]
         )
+        if audio_cost > 0:
+            breakdown["audio_token_cost"] = audio_cost
+        prompt_cost += audio_cost
 
     ### IMAGE TOKEN COST
     if prompt_tokens_details["image_tokens"]:
@@ -574,16 +591,19 @@ def _calculate_input_cost(
         image_token_cost_key = "input_cost_per_image_token"
         if model_info.get(image_token_cost_key) is None:
             image_token_cost_key = "input_cost_per_token"
-        prompt_cost += calculate_cost_component(
+        image_cost = calculate_cost_component(
             model_info, image_token_cost_key, prompt_tokens_details["image_tokens"]
         )
+        if image_cost > 0:
+            breakdown["image_token_cost"] = image_cost
+        prompt_cost += image_cost
 
     ### CACHE WRITING COST - Now uses tiered pricing
     if (
         prompt_tokens_details["cache_creation_tokens"]
         or prompt_tokens_details["cache_creation_token_details"] is not None
     ):
-        prompt_cost += calculate_cache_writing_cost(
+        cc_cost = calculate_cache_writing_cost(
             cache_creation_tokens=prompt_tokens_details["cache_creation_tokens"],
             cache_creation_token_details=prompt_tokens_details[
                 "cache_creation_token_details"
@@ -591,6 +611,9 @@ def _calculate_input_cost(
             cache_creation_cost_above_1hr=cache_creation_cost_above_1hr,
             cache_creation_cost=cache_creation_cost,
         )
+        if cc_cost > 0:
+            breakdown["cache_creation_cost"] = cc_cost
+        prompt_cost += cc_cost
 
     ### CHARACTER COST
     if prompt_tokens_details["character_count"]:
@@ -614,7 +637,101 @@ def _calculate_input_cost(
             prompt_tokens_details["video_length_seconds"],
         )
 
-    return prompt_cost
+    return prompt_cost, breakdown
+
+
+def _calculate_output_cost(
+    usage: Usage,
+    model_info: ModelInfo,
+    completion_base_cost: float,
+) -> Tuple[float, dict]:
+    """
+    Calculates the output cost with a per-token-type breakdown.
+
+    Returns:
+        Tuple[float, dict] - (total_output_cost, per_token_type_breakdown)
+        The breakdown dict only contains keys whose cost > 0.
+    """
+    breakdown: dict = {}
+    text_tokens = 0
+    audio_tokens = 0
+    reasoning_tokens = 0
+    image_tokens = 0
+    is_text_tokens_total = False
+
+    if usage.completion_tokens_details is not None:
+        completion_tokens_details = _parse_completion_tokens_details(usage)
+        audio_tokens = completion_tokens_details["audio_tokens"]
+        text_tokens = completion_tokens_details["text_tokens"]
+        reasoning_tokens = completion_tokens_details["reasoning_tokens"]
+        image_tokens = completion_tokens_details["image_tokens"]
+
+    has_token_breakdown = image_tokens > 0 or audio_tokens > 0 or reasoning_tokens > 0
+    if text_tokens == 0:
+        if has_token_breakdown:
+            text_tokens = max(
+                0,
+                usage.completion_tokens
+                - reasoning_tokens
+                - audio_tokens
+                - image_tokens,
+            )
+        else:
+            text_tokens = usage.completion_tokens
+            is_text_tokens_total = True
+
+    ## TEXT COST
+    completion_token_cost = float(text_tokens) * completion_base_cost
+    if completion_token_cost > 0:
+        breakdown["completion_token_cost"] = completion_token_cost
+    completion_cost = completion_token_cost
+
+    ## AUDIO COST
+    if not is_text_tokens_total and audio_tokens is not None and audio_tokens > 0:
+        _output_cost_per_audio_token = _get_cost_per_unit(
+            model_info, "output_cost_per_audio_token", None
+        )
+        _output_cost_per_audio_token = (
+            _output_cost_per_audio_token
+            if _output_cost_per_audio_token is not None
+            else completion_base_cost
+        )
+        audio_cost = float(audio_tokens) * _output_cost_per_audio_token
+        if audio_cost > 0:
+            breakdown["audio_token_cost"] = audio_cost
+        completion_cost += audio_cost
+
+    ## REASONING COST
+    if not is_text_tokens_total and reasoning_tokens and reasoning_tokens > 0:
+        _output_cost_per_reasoning_token = _get_cost_per_unit(
+            model_info, "output_cost_per_reasoning_token", None
+        )
+        _output_cost_per_reasoning_token = (
+            _output_cost_per_reasoning_token
+            if _output_cost_per_reasoning_token is not None
+            else completion_base_cost
+        )
+        reasoning_cost = float(reasoning_tokens) * _output_cost_per_reasoning_token
+        if reasoning_cost > 0:
+            breakdown["reasoning_token_cost"] = reasoning_cost
+        completion_cost += reasoning_cost
+
+    ## IMAGE COST
+    if not is_text_tokens_total and image_tokens and image_tokens > 0:
+        _output_cost_per_image_token = _get_cost_per_unit(
+            model_info, "output_cost_per_image_token", None
+        )
+        _output_cost_per_image_token = (
+            _output_cost_per_image_token
+            if _output_cost_per_image_token is not None
+            else completion_base_cost
+        )
+        img_cost = float(image_tokens) * _output_cost_per_image_token
+        if img_cost > 0:
+            breakdown["image_token_cost"] = img_cost
+        completion_cost += img_cost
+
+    return completion_cost, breakdown
 
 
 def generic_cost_per_token(  # noqa: PLR0915
@@ -696,7 +813,7 @@ def generic_cost_per_token(  # noqa: PLR0915
         model_info=model_info, usage=usage, service_tier=service_tier
     )
 
-    prompt_cost = _calculate_input_cost(
+    prompt_cost, _input_breakdown = _calculate_input_cost(
         prompt_tokens_details=prompt_tokens_details,
         model_info=model_info,
         prompt_base_cost=prompt_base_cost,
@@ -707,78 +824,104 @@ def generic_cost_per_token(  # noqa: PLR0915
     )
 
     ## CALCULATE OUTPUT COST
-    text_tokens = 0
-    audio_tokens = 0
-    reasoning_tokens = 0
-    image_tokens = 0
-    is_text_tokens_total = False
-    if usage.completion_tokens_details is not None:
-        completion_tokens_details = _parse_completion_tokens_details(usage)
-        audio_tokens = completion_tokens_details["audio_tokens"]
-        text_tokens = completion_tokens_details["text_tokens"]
-        reasoning_tokens = completion_tokens_details["reasoning_tokens"]
-        image_tokens = completion_tokens_details["image_tokens"]
-
-    # Handle text_tokens calculation:
-    # 1. If text_tokens is explicitly provided and > 0, use it
-    # 2. If there's a breakdown (reasoning/audio/image tokens), calculate text_tokens as the remainder
-    # 3. If no breakdown at all, assume all completion_tokens are text_tokens
-    has_token_breakdown = image_tokens > 0 or audio_tokens > 0 or reasoning_tokens > 0
-    if text_tokens == 0:
-        if has_token_breakdown:
-            # Calculate text tokens as remainder when we have a breakdown
-            # This handles cases like OpenAI's reasoning models where text_tokens isn't provided
-            text_tokens = max(
-                0,
-                usage.completion_tokens
-                - reasoning_tokens
-                - audio_tokens
-                - image_tokens,
-            )
-        else:
-            # No breakdown at all, all tokens are text tokens
-            text_tokens = usage.completion_tokens
-            is_text_tokens_total = True
-    ## TEXT COST
-    completion_cost = float(text_tokens) * completion_base_cost
-
-    ## AUDIO COST
-    if not is_text_tokens_total and audio_tokens is not None and audio_tokens > 0:
-        _output_cost_per_audio_token = _get_cost_per_unit(
-            model_info, "output_cost_per_audio_token", None
-        )
-        _output_cost_per_audio_token = (
-            _output_cost_per_audio_token
-            if _output_cost_per_audio_token is not None
-            else completion_base_cost
-        )
-        completion_cost += float(audio_tokens) * _output_cost_per_audio_token
-
-    ## REASONING COST
-    if not is_text_tokens_total and reasoning_tokens and reasoning_tokens > 0:
-        _output_cost_per_reasoning_token = _get_cost_per_unit(
-            model_info, "output_cost_per_reasoning_token", None
-        )
-        _output_cost_per_reasoning_token = (
-            _output_cost_per_reasoning_token
-            if _output_cost_per_reasoning_token is not None
-            else completion_base_cost
-        )
-        completion_cost += float(reasoning_tokens) * _output_cost_per_reasoning_token
-
-    ## IMAGE COST
-    if not is_text_tokens_total and image_tokens and image_tokens > 0:
-        _output_cost_per_image_token = _get_cost_per_unit(
-            model_info, "output_cost_per_image_token", None
-        )
-        _output_cost_per_image_token = (
-            _output_cost_per_image_token
-            if _output_cost_per_image_token is not None
-            else completion_base_cost
-        )
-        completion_cost += float(image_tokens) * _output_cost_per_image_token
+    completion_cost, _output_breakdown = _calculate_output_cost(
+        usage=usage,
+        model_info=model_info,
+        completion_base_cost=completion_base_cost,
+    )
 
     return prompt_cost, completion_cost
+
+
+def calculate_detailed_cost_breakdowns(
+    model: str,
+    usage: Usage,
+    custom_llm_provider: str,
+    service_tier: Optional[str] = None,
+) -> Tuple[dict, dict]:
+    """
+    Calculate per-token-type cost breakdowns for input and output.
+
+    Reuses _calculate_input_cost and _calculate_output_cost to avoid
+    duplicating cost calculation logic.
+
+    Returns:
+        Tuple[dict, dict] - (input_cost_breakdown, output_cost_breakdown)
+        Each dict only contains keys whose cost > 0.
+    """
+    empty: dict = {}
+
+    try:
+        model_info = get_model_info(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+    except Exception:
+        return empty, empty
+
+    # Parse and fix prompt token details (same logic as generic_cost_per_token)
+    prompt_tokens_details = PromptTokensDetailsResult(
+        cache_hit_tokens=0,
+        cache_creation_tokens=0,
+        cache_creation_token_details=None,
+        text_tokens=usage.prompt_tokens,
+        audio_tokens=0,
+        image_tokens=0,
+        character_count=0,
+        image_count=0,
+        video_length_seconds=0.0,
+    )
+    if usage.prompt_tokens_details:
+        prompt_tokens_details = _parse_prompt_tokens_details(usage)
+
+    cache_hit = prompt_tokens_details["cache_hit_tokens"]
+    text_tokens = prompt_tokens_details["text_tokens"]
+    audio_tokens = prompt_tokens_details["audio_tokens"]
+    cache_creation = prompt_tokens_details["cache_creation_tokens"]
+    image_tokens = prompt_tokens_details["image_tokens"]
+
+    total_details = (
+        text_tokens + cache_hit + audio_tokens + cache_creation + image_tokens
+    )
+    has_double_counting = cache_hit > 0 and total_details > usage.prompt_tokens
+
+    if (
+        text_tokens == 0 and prompt_tokens_details["image_count"] == 0
+    ) or has_double_counting:
+        prompt_tokens_details["text_tokens"] = (
+            usage.prompt_tokens
+            - cache_hit
+            - audio_tokens
+            - cache_creation
+            - image_tokens
+        )
+
+    (
+        prompt_base_cost,
+        completion_base_cost,
+        cache_creation_cost,
+        cache_creation_cost_above_1hr,
+        cache_read_cost,
+    ) = _get_token_base_cost(
+        model_info=model_info, usage=usage, service_tier=service_tier
+    )
+
+    _total_input, input_breakdown = _calculate_input_cost(
+        prompt_tokens_details=prompt_tokens_details,
+        model_info=model_info,
+        prompt_base_cost=prompt_base_cost,
+        cache_read_cost=cache_read_cost,
+        cache_creation_cost=cache_creation_cost,
+        cache_creation_cost_above_1hr=cache_creation_cost_above_1hr,
+        service_tier=service_tier,
+    )
+
+    _total_output, output_breakdown = _calculate_output_cost(
+        usage=usage,
+        model_info=model_info,
+        completion_base_cost=completion_base_cost,
+    )
+
+    return input_breakdown, output_breakdown
 
 
 def calculate_image_response_cost_from_usage(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2414,6 +2414,7 @@ class LiteLLM_VerificationTokenView(LiteLLM_VerificationToken):
     organization_metadata: Optional[dict] = None
 
     # Project Params
+    project_alias: Optional[str] = None
     project_metadata: Optional[dict] = None
 
     # Time stamps
@@ -3221,6 +3222,7 @@ class SpendLogsMetadata(TypedDict):
     user_api_key_alias: Optional[str]
     user_api_key_team_id: Optional[str]
     user_api_key_project_id: Optional[str]
+    user_api_key_project_alias: Optional[str]
     user_api_key_org_id: Optional[str]
     user_api_key_user_id: Optional[str]
     user_api_key_team_alias: Optional[str]

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -830,6 +830,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         )
                         if _jwt_project_obj is not None:
                             valid_token.project_metadata = _jwt_project_obj.metadata
+                            valid_token.project_alias = _jwt_project_obj.project_alias
 
                     # run through common checks
                     _ = await common_checks(
@@ -1420,6 +1421,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 )
                 if _project_obj is not None:
                     valid_token.project_metadata = _project_obj.metadata
+                    valid_token.project_alias = _project_obj.project_alias
 
             global_proxy_spend = None
             if (
@@ -1873,6 +1875,7 @@ async def _run_post_custom_auth_checks(
         )
         if _project_obj is not None:
             valid_token.project_metadata = _project_obj.metadata
+            valid_token.project_alias = _project_obj.project_alias
 
     if general_settings.get("custom_auth_run_common_checks", False):
         _ = await common_checks(

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -66,6 +66,7 @@ class _ProxyDBLogger(CustomLogger):
                 user_api_key_team_id=user_api_key_dict.team_id,
                 user_api_key_org_id=user_api_key_dict.org_id,
                 user_api_key_project_id=user_api_key_dict.project_id,
+                user_api_key_project_alias=user_api_key_dict.project_alias,
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,
                 user_api_key_request_route=user_api_key_dict.request_route,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -658,6 +658,7 @@ class LiteLLMProxyRequestSetup:
             user_api_key_max_budget=user_api_key_dict.max_budget,
             user_api_key_team_id=user_api_key_dict.team_id,
             user_api_key_project_id=user_api_key_dict.project_id,
+            user_api_key_project_alias=user_api_key_dict.project_alias,
             user_api_key_user_id=user_api_key_dict.user_id,
             user_api_key_org_id=user_api_key_dict.org_id,
             user_api_key_team_alias=user_api_key_dict.team_alias,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -509,6 +509,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 user_api_key_team_id=user_api_key_dict.team_id,
                 user_api_key_org_id=user_api_key_dict.org_id,
                 user_api_key_project_id=user_api_key_dict.project_id,
+                user_api_key_project_alias=user_api_key_dict.project_alias,
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,
                 user_api_key_request_route=user_api_key_dict.request_route,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2929,6 +2929,7 @@ class PrismaClient:
                             t.members_with_roles AS team_members_with_roles,
                             t.object_permission_id AS team_object_permission_id,
                             t.organization_id as org_id,
+                            p.project_alias AS project_alias,
                             tm.spend AS team_member_spend,
                             m.aliases AS team_model_aliases,
                             -- Added comma to separate b.* columns
@@ -2946,6 +2947,7 @@ class PrismaClient:
                         LEFT JOIN "LiteLLM_TeamMembership" AS tm ON v.team_id = tm.team_id AND tm.user_id = v.user_id
                         LEFT JOIN "LiteLLM_ModelTable" m ON t.model_id = m.id
                         LEFT JOIN "LiteLLM_BudgetTable" AS b ON v.budget_id = b.budget_id
+                        LEFT JOIN "LiteLLM_ProjectTable" AS p ON v.project_id = p.project_id
                         LEFT JOIN "LiteLLM_OrganizationTable" AS o ON v.organization_id = o.organization_id
                         LEFT JOIN "LiteLLM_BudgetTable" AS b2 ON o.budget_id = b2.budget_id
                         WHERE v.token = '{token}'

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2488,6 +2488,7 @@ class StandardLoggingUserAPIKeyMetadata(TypedDict):
     user_api_key_org_id: Optional[str]
     user_api_key_team_id: Optional[str]
     user_api_key_project_id: Optional[str]
+    user_api_key_project_alias: Optional[str]
     user_api_key_user_id: Optional[str]
     user_api_key_user_email: Optional[str]
     user_api_key_team_alias: Optional[str]
@@ -2776,6 +2777,7 @@ class CostBreakdown(TypedDict, total=False):
     output_cost: (
         float  # Cost of output/completion tokens (includes reasoning if applicable)
     )
+    reasoning_tokens_cost: float  # Cost of reasoning/thinking tokens (subset of output_cost)
     total_cost: float  # Total cost (input + output + tool usage)
     tool_usage_cost: float  # Cost of usage of built-in tools
     additional_costs: Dict[

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2768,15 +2768,36 @@ class CachingDetails(TypedDict):
     """
 
 
+class InputCostBreakdown(TypedDict, total=False):
+    """Per-token-type cost breakdown for input/prompt tokens."""
+
+    prompt_token_cost: float  # Cost of text prompt tokens
+    cached_token_cost: float  # Cost of cache-hit (read) tokens
+    cache_creation_cost: float  # Cost of cache creation tokens
+    audio_token_cost: float  # Cost of audio input tokens
+    image_token_cost: float  # Cost of image input tokens
+
+
+class OutputCostBreakdown(TypedDict, total=False):
+    """Per-token-type cost breakdown for output/completion tokens."""
+
+    completion_token_cost: float  # Cost of text completion tokens
+    reasoning_token_cost: float  # Cost of reasoning/thinking tokens
+    audio_token_cost: float  # Cost of audio output tokens
+    image_token_cost: float  # Cost of image output tokens
+
+
 class CostBreakdown(TypedDict, total=False):
     """
     Detailed cost breakdown for a request
     """
 
     input_cost: float  # Cost of input/prompt tokens
+    input_cost_breakdown: InputCostBreakdown  # Per-token-type input cost breakdown
     output_cost: (
         float  # Cost of output/completion tokens (includes reasoning if applicable)
     )
+    output_cost_breakdown: OutputCostBreakdown  # Per-token-type output cost breakdown
     reasoning_tokens_cost: float  # Cost of reasoning/thinking tokens (subset of output_cost)
     total_cost: float  # Total cost (input + output + tool usage)
     tool_usage_cost: float  # Cost of usage of built-in tools

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1,21 +1,15 @@
-import json
 import os
 import sys
 
 import pytest
-from fastapi.testclient import TestClient
 
 import litellm
-from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
-    StandardBuiltInToolCostTracking,
-)
 from litellm.llms.gemini.image_generation.cost_calculator import (
     cost_calculator as gemini_image_generation_cost_calculator,
 )
 from litellm.llms.vertex_ai.image_generation.cost_calculator import (
     cost_calculator as vertex_image_generation_cost_calculator,
 )
-from litellm.types.llms.openai import FileSearchTool, WebSearchOptions
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
     ImageObject,
@@ -23,9 +17,7 @@ from litellm.types.utils import (
     ImageUsage,
     ImageUsageInputTokensDetails,
     ModelInfo,
-    ModelResponse,
     PromptTokensDetailsWrapper,
-    StandardBuiltInToolsParams,
 )
 
 sys.path.insert(
@@ -73,11 +65,9 @@ def test_reasoning_tokens_no_price_set():
         model_cost_map["input_cost_per_token"] * usage.prompt_tokens,
         10,
     )
-    print(f"completion_cost: {completion_cost}")
     expected_completion_cost = (
         model_cost_map["output_cost_per_token"] * usage.completion_tokens
     )
-    print(f"expected_completion_cost: {expected_completion_cost}")
     assert round(completion_cost, 10) == round(
         expected_completion_cost,
         10,
@@ -318,8 +308,12 @@ def test_generic_cost_per_token_gpt54_above_272k_tokens():
         usage=usage,
         custom_llm_provider=custom_llm_provider,
     )
-    expected_prompt = model_cost_map["input_cost_per_token_above_272k_tokens"] * prompt_tokens
-    expected_completion = model_cost_map["output_cost_per_token_above_272k_tokens"] * completion_tokens
+    expected_prompt = (
+        model_cost_map["input_cost_per_token_above_272k_tokens"] * prompt_tokens
+    )
+    expected_completion = (
+        model_cost_map["output_cost_per_token_above_272k_tokens"] * completion_tokens
+    )
     assert round(prompt_cost, 10) == round(expected_prompt, 10)
     assert round(completion_cost, 10) == round(expected_completion, 10)
 
@@ -407,7 +401,11 @@ def test_string_cost_values():
         completion_tokens=500,
         total_tokens=1650,
         prompt_tokens_details=PromptTokensDetailsWrapper(
-            audio_tokens=100, cached_tokens=200, text_tokens=700, image_tokens=None, cache_creation_tokens=150
+            audio_tokens=100,
+            cached_tokens=200,
+            text_tokens=700,
+            image_tokens=None,
+            cache_creation_tokens=150,
         ),
         completion_tokens_details=CompletionTokensDetailsWrapper(
             audio_tokens=50,
@@ -673,7 +671,7 @@ def test_cache_writing_cost_with_zero_creation_tokens_and_ephemeral_details():
 
     model_info: ModelInfo = {}
 
-    result = _calculate_input_cost(
+    result, breakdown = _calculate_input_cost(
         prompt_tokens_details=prompt_tokens_details,
         model_info=model_info,
         prompt_base_cost=0.0,
@@ -684,8 +682,11 @@ def test_cache_writing_cost_with_zero_creation_tokens_and_ephemeral_details():
 
     # Expected: (100 * 3.75e-06) + (200 * 6e-06) = 0.000375 + 0.0012 = 0.001575
     expected = (100 * cache_creation_cost) + (200 * cache_creation_cost_above_1hr)
-    assert result > 0, "Cost should not be zero when ephemeral token details are present"
+    assert (
+        result > 0
+    ), "Cost should not be zero when ephemeral token details are present"
     assert round(result, 6) == round(expected, 6)
+    assert "cache_creation_cost" in breakdown
 
 
 def test_service_tier_flex_pricing():
@@ -693,52 +694,56 @@ def test_service_tier_flex_pricing():
     # Set up environment for local model cost map
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
-    
+
     # Test with gpt-5-nano which has flex pricing
     model = "gpt-5-nano"
     custom_llm_provider = "openai"
-    
+
     # Create usage object
-    usage = Usage(
-        prompt_tokens=1000,
-        completion_tokens=500,
-        total_tokens=1500
-    )
-    
+    usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
     # Test standard pricing
     std_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier=None
+        service_tier=None,
     )
     std_total = std_cost[0] + std_cost[1]
-    
+
     # Test flex pricing
     flex_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier="flex"
+        service_tier="flex",
     )
     flex_total = flex_cost[0] + flex_cost[1]
-    
+
     # Verify flex is approximately 50% of standard
     assert std_total > 0, "Standard cost should be greater than 0"
     assert flex_total > 0, "Flex cost should be greater than 0"
-    
+
     flex_ratio = flex_total / std_total
-    assert 0.45 <= flex_ratio <= 0.55, f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
-    
+    assert (
+        0.45 <= flex_ratio <= 0.55
+    ), f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
+
     # Verify specific costs match expected values
     # gpt-5-nano flex: input=2.5e-08, output=2e-07
     expected_flex_prompt = 1000 * 2.5e-08  # 0.000025
     expected_flex_completion = 500 * 2e-07  # 0.0001
     expected_flex_total = expected_flex_prompt + expected_flex_completion
-    
-    assert abs(flex_cost[0] - expected_flex_prompt) < 1e-10, f"Flex prompt cost mismatch: {flex_cost[0]} vs {expected_flex_prompt}"
-    assert abs(flex_cost[1] - expected_flex_completion) < 1e-10, f"Flex completion cost mismatch: {flex_cost[1]} vs {expected_flex_completion}"
-    assert abs(flex_total - expected_flex_total) < 1e-10, f"Flex total cost mismatch: {flex_total} vs {expected_flex_total}"
+
+    assert (
+        abs(flex_cost[0] - expected_flex_prompt) < 1e-10
+    ), f"Flex prompt cost mismatch: {flex_cost[0]} vs {expected_flex_prompt}"
+    assert (
+        abs(flex_cost[1] - expected_flex_completion) < 1e-10
+    ), f"Flex completion cost mismatch: {flex_cost[1]} vs {expected_flex_completion}"
+    assert (
+        abs(flex_total - expected_flex_total) < 1e-10
+    ), f"Flex total cost mismatch: {flex_total} vs {expected_flex_total}"
 
 
 def test_service_tier_default_pricing():
@@ -746,46 +751,50 @@ def test_service_tier_default_pricing():
     # Set up environment for local model cost map
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
-    
+
     # Test with gpt-5-nano
     model = "gpt-5-nano"
     custom_llm_provider = "openai"
-    
+
     # Create usage object
-    usage = Usage(
-        prompt_tokens=1000,
-        completion_tokens=500,
-        total_tokens=1500
-    )
-    
+    usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
     # Test with no service tier (should use standard)
     default_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier=None
+        service_tier=None,
     )
-    
+
     # Test with explicit standard service tier
     standard_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier="standard"
+        service_tier="standard",
     )
-    
+
     # Both should be identical
-    assert abs(default_cost[0] - standard_cost[0]) < 1e-10, "Default and standard prompt costs should be identical"
-    assert abs(default_cost[1] - standard_cost[1]) < 1e-10, "Default and standard completion costs should be identical"
-    
+    assert (
+        abs(default_cost[0] - standard_cost[0]) < 1e-10
+    ), "Default and standard prompt costs should be identical"
+    assert (
+        abs(default_cost[1] - standard_cost[1]) < 1e-10
+    ), "Default and standard completion costs should be identical"
+
     # Verify specific costs match expected standard values
     # gpt-5-nano standard: input=5e-08, output=4e-07
     expected_standard_prompt = 1000 * 5e-08  # 0.00005
     expected_standard_completion = 500 * 4e-07  # 0.0002
     expected_standard_total = expected_standard_prompt + expected_standard_completion
-    
-    assert abs(default_cost[0] - expected_standard_prompt) < 1e-10, f"Standard prompt cost mismatch: {default_cost[0]} vs {expected_standard_prompt}"
-    assert abs(default_cost[1] - expected_standard_completion) < 1e-10, f"Standard completion cost mismatch: {default_cost[1]} vs {expected_standard_completion}"
+
+    assert (
+        abs(default_cost[0] - expected_standard_prompt) < 1e-10
+    ), f"Standard prompt cost mismatch: {default_cost[0]} vs {expected_standard_prompt}"
+    assert (
+        abs(default_cost[1] - expected_standard_completion) < 1e-10
+    ), f"Standard completion cost mismatch: {default_cost[1]} vs {expected_standard_completion}"
 
 
 def test_service_tier_fallback_pricing():
@@ -793,62 +802,66 @@ def test_service_tier_fallback_pricing():
     # Set up environment for local model cost map
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
-    
+
     # Test with gpt-4 which doesn't have flex pricing keys
     model = "gpt-4"
     custom_llm_provider = "openai"
-    
+
     # Create usage object
-    usage = Usage(
-        prompt_tokens=1000,
-        completion_tokens=500,
-        total_tokens=1500
-    )
-    
+    usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
     # Test standard pricing
     std_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier=None
+        service_tier=None,
     )
     std_total = std_cost[0] + std_cost[1]
-    
+
     # Test flex pricing (should fall back to standard since gpt-4 doesn't have flex keys)
     flex_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier="flex"
+        service_tier="flex",
     )
     flex_total = flex_cost[0] + flex_cost[1]
-    
+
     # Test priority pricing (should fall back to standard since gpt-4 doesn't have priority keys)
     priority_cost = generic_cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider=custom_llm_provider,
-        service_tier="priority"
+        service_tier="priority",
     )
     priority_total = priority_cost[0] + priority_cost[1]
-    
+
     # All should be identical (fallback to standard)
-    assert abs(std_total - flex_total) < 1e-10, f"Standard and flex costs should be identical (fallback): {std_total} vs {flex_total}"
-    assert abs(std_total - priority_total) < 1e-10, f"Standard and priority costs should be identical (fallback): {std_total} vs {priority_total}"
-    
+    assert (
+        abs(std_total - flex_total) < 1e-10
+    ), f"Standard and flex costs should be identical (fallback): {std_total} vs {flex_total}"
+    assert (
+        abs(std_total - priority_total) < 1e-10
+    ), f"Standard and priority costs should be identical (fallback): {std_total} vs {priority_total}"
+
     # Verify costs are reasonable (not zero)
     assert std_total > 0, "Standard cost should be greater than 0"
     assert flex_total > 0, "Flex cost should be greater than 0 (fallback)"
     assert priority_total > 0, "Priority cost should be greater than 0 (fallback)"
-    
+
     # Verify specific costs match expected gpt-4 values
     # gpt-4 standard: input=3e-05, output=6e-05
     expected_standard_prompt = 1000 * 3e-05  # 0.03
     expected_standard_completion = 500 * 6e-05  # 0.03
     expected_standard_total = expected_standard_prompt + expected_standard_completion
-    
-    assert abs(std_cost[0] - expected_standard_prompt) < 1e-10, f"Standard prompt cost mismatch: {std_cost[0]} vs {expected_standard_prompt}"
-    assert abs(std_cost[1] - expected_standard_completion) < 1e-10, f"Standard completion cost mismatch: {std_cost[1]} vs {expected_standard_completion}"
+
+    assert (
+        abs(std_cost[0] - expected_standard_prompt) < 1e-10
+    ), f"Standard prompt cost mismatch: {std_cost[0]} vs {expected_standard_prompt}"
+    assert (
+        abs(std_cost[1] - expected_standard_completion) < 1e-10
+    ), f"Standard completion cost mismatch: {std_cost[1]} vs {expected_standard_completion}"
 
 
 @pytest.mark.parametrize(
@@ -908,7 +921,9 @@ def test_gemini_image_generation_cost_with_zero_text_tokens(model: str):
     output_cost_per_token = model_cost_map.get("output_cost_per_token", 0)
 
     expected_image_cost = 1120 * output_cost_per_image_token
-    expected_reasoning_cost = 225 * output_cost_per_token  # reasoning uses base token cost
+    expected_reasoning_cost = (
+        225 * output_cost_per_token
+    )  # reasoning uses base token cost
     expected_completion_cost = expected_image_cost + expected_reasoning_cost
 
     # The bug was: all completion tokens were treated as text tokens only.
@@ -917,9 +932,9 @@ def test_gemini_image_generation_cost_with_zero_text_tokens(model: str):
         f"Completion cost should be significantly larger than text-only bugged path. "
         f"Expected > {bugged_text_only_cost * 2:.6f}, got {completion_cost:.6f}"
     )
-    assert round(completion_cost, 4) == round(expected_completion_cost, 4), (
-        f"Expected completion cost ${expected_completion_cost:.6f}, got ${completion_cost:.6f}"
-    )
+    assert round(completion_cost, 4) == round(
+        expected_completion_cost, 4
+    ), f"Expected completion cost ${expected_completion_cost:.6f}, got ${completion_cost:.6f}"
 
 
 def test_vertex_image_generation_cost_prefers_token_usage_metadata():
@@ -957,7 +972,9 @@ def test_vertex_image_generation_cost_prefers_token_usage_metadata():
     )
 
     expected_prompt_cost = prompt_tokens * model_info["input_cost_per_token"]
-    expected_completion_cost = output_image_tokens * model_info["output_cost_per_image_token"]
+    expected_completion_cost = (
+        output_image_tokens * model_info["output_cost_per_image_token"]
+    )
     expected_total_cost = expected_prompt_cost + expected_completion_cost
 
     assert round(cost, 10) == round(expected_total_cost, 10)
@@ -1024,7 +1041,9 @@ def test_gemini_image_generation_cost_prefers_token_usage_metadata():
     )
 
     expected_prompt_cost = prompt_tokens * model_info["input_cost_per_token"]
-    expected_completion_cost = output_image_tokens * model_info["output_cost_per_image_token"]
+    expected_completion_cost = (
+        output_image_tokens * model_info["output_cost_per_image_token"]
+    )
     expected_total_cost = expected_prompt_cost + expected_completion_cost
 
     assert round(cost, 10) == round(expected_total_cost, 10)
@@ -1120,16 +1139,19 @@ def test_reasoning_tokens_without_text_tokens_gpt5_nano():
     expected_prompt_cost = 17 * 0.05 / 1_000_000
     expected_completion_cost = 977 * 0.40 / 1_000_000  # ALL tokens, not just reasoning
 
-    assert abs(prompt_cost - expected_prompt_cost) < 1e-10, \
-        f"Prompt cost incorrect: {prompt_cost} vs {expected_prompt_cost}"
+    assert (
+        abs(prompt_cost - expected_prompt_cost) < 1e-10
+    ), f"Prompt cost incorrect: {prompt_cost} vs {expected_prompt_cost}"
 
-    assert abs(completion_cost - expected_completion_cost) < 1e-10, \
-        f"Completion cost incorrect: {completion_cost} vs {expected_completion_cost}"
+    assert (
+        abs(completion_cost - expected_completion_cost) < 1e-10
+    ), f"Completion cost incorrect: {completion_cost} vs {expected_completion_cost}"
 
     # Verify it's NOT using only reasoning_tokens (the bug)
     wrong_cost = 768 * 0.40 / 1_000_000  # Only reasoning tokens
-    assert abs(completion_cost - wrong_cost) > 1e-6, \
-        "Bug detected: Cost calculation is using only reasoning_tokens instead of all completion_tokens!"
+    assert (
+        abs(completion_cost - wrong_cost) > 1e-6
+    ), "Bug detected: Cost calculation is using only reasoning_tokens instead of all completion_tokens!"
 
 
 def test_image_count_prevents_text_tokens_fallback():

--- a/tests/test_litellm/test_callback_kwargs_enhancements.py
+++ b/tests/test_litellm/test_callback_kwargs_enhancements.py
@@ -1,16 +1,14 @@
 """
-Tests for two callback kwargs enhancements:
+Tests for callback kwargs enhancements:
 1. project_alias in StandardLoggingUserAPIKeyMetadata
 2. reasoning_tokens_cost in CostBreakdown
+3. input_cost_breakdown / output_cost_breakdown in CostBreakdown
 """
 
-import json
 import os
 import sys
 from datetime import datetime
-from unittest.mock import MagicMock
 
-import pytest
 
 import litellm
 from litellm.proxy._types import UserAPIKeyAuth
@@ -18,7 +16,9 @@ from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
     CostBreakdown,
+    InputCostBreakdown,
     ModelResponse,
+    OutputCostBreakdown,
     PromptTokensDetailsWrapper,
     StandardLoggingUserAPIKeyMetadata,
     Usage,
@@ -409,3 +409,286 @@ class TestReasoningTokensCostInCostBreakdown:
         assert cost > 0
         assert logging_obj.cost_breakdown is not None
         assert logging_obj.cost_breakdown.get("reasoning_tokens_cost", 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Issue 3: input_cost_breakdown / output_cost_breakdown in CostBreakdown
+# ---------------------------------------------------------------------------
+
+
+class TestDetailedCostBreakdowns:
+    """Tests for per-token-type cost breakdowns (input_cost_breakdown / output_cost_breakdown)."""
+
+    def test_input_cost_breakdown_typed_dict(self):
+        """InputCostBreakdown TypedDict should accept all token-type cost fields."""
+        breakdown = InputCostBreakdown(
+            prompt_token_cost=0.003,
+            cached_token_cost=0.0005,
+            audio_token_cost=0.001,
+            image_token_cost=0.0,
+        )
+        assert breakdown["prompt_token_cost"] == 0.003
+        assert breakdown["cached_token_cost"] == 0.0005
+
+    def test_output_cost_breakdown_typed_dict(self):
+        """OutputCostBreakdown TypedDict should accept all token-type cost fields."""
+        breakdown = OutputCostBreakdown(
+            completion_token_cost=0.006,
+            reasoning_token_cost=0.0018,
+            audio_token_cost=0.0,
+            image_token_cost=0.0,
+        )
+        assert breakdown["completion_token_cost"] == 0.006
+        assert breakdown["reasoning_token_cost"] == 0.0018
+
+    def test_cost_breakdown_includes_input_output_breakdowns(self):
+        """CostBreakdown should accept input_cost_breakdown and output_cost_breakdown."""
+        breakdown = CostBreakdown(
+            input_cost=0.0045,
+            input_cost_breakdown=InputCostBreakdown(
+                prompt_token_cost=0.003,
+                cached_token_cost=0.0005,
+                audio_token_cost=0.001,
+            ),
+            output_cost=0.0078,
+            output_cost_breakdown=OutputCostBreakdown(
+                completion_token_cost=0.006,
+                reasoning_token_cost=0.0018,
+            ),
+            total_cost=0.0123,
+            tool_usage_cost=0.0,
+        )
+        assert breakdown["input_cost_breakdown"]["prompt_token_cost"] == 0.003
+        assert breakdown["output_cost_breakdown"]["reasoning_token_cost"] == 0.0018
+
+    def test_set_cost_breakdown_stores_input_output_breakdowns(self):
+        """Logging.set_cost_breakdown should store input/output cost breakdowns."""
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        logging_obj = Logging(
+            model="o1",
+            messages=[{"role": "user", "content": "Think"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-breakdown",
+            function_id="test-function",
+        )
+
+        input_bd = {"prompt_token_cost": 0.003, "cached_token_cost": 0.0005}
+        output_bd = {"completion_token_cost": 0.006, "reasoning_token_cost": 0.0018}
+
+        logging_obj.set_cost_breakdown(
+            input_cost=0.0035,
+            output_cost=0.0078,
+            total_cost=0.0113,
+            cost_for_built_in_tools_cost_usd_dollar=0.0,
+            reasoning_tokens_cost=0.0018,
+            input_cost_breakdown=input_bd,
+            output_cost_breakdown=output_bd,
+        )
+
+        assert logging_obj.cost_breakdown is not None
+        assert "input_cost_breakdown" in logging_obj.cost_breakdown
+        assert "output_cost_breakdown" in logging_obj.cost_breakdown
+        assert (
+            logging_obj.cost_breakdown["input_cost_breakdown"]["prompt_token_cost"]
+            == 0.003
+        )
+        assert (
+            logging_obj.cost_breakdown["output_cost_breakdown"]["reasoning_token_cost"]
+            == 0.0018
+        )
+
+    def test_completion_cost_populates_input_output_breakdowns_with_reasoning(self):
+        """completion_cost() should populate input/output cost breakdowns for reasoning models."""
+        from litellm.cost_calculator import completion_cost
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        logging_obj = Logging(
+            model="o1",
+            messages=[{"role": "user", "content": "Think"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-detailed-breakdown",
+            function_id="test-function",
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-test",
+            model="o1",
+            usage=Usage(
+                prompt_tokens=100,
+                completion_tokens=500,
+                total_tokens=600,
+                completion_tokens_details=CompletionTokensDetailsWrapper(
+                    reasoning_tokens=400,
+                    text_tokens=100,
+                ),
+                prompt_tokens_details=PromptTokensDetailsWrapper(
+                    text_tokens=100,
+                ),
+            ),
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Answer"},
+                    "finish_reason": "stop",
+                }
+            ],
+        )
+
+        cost = completion_cost(
+            completion_response=response,
+            model="o1",
+            custom_llm_provider="openai",
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert cost > 0
+        assert logging_obj.cost_breakdown is not None
+
+        # Should have input_cost_breakdown with prompt_token_cost
+        assert "input_cost_breakdown" in logging_obj.cost_breakdown
+        input_bd = logging_obj.cost_breakdown["input_cost_breakdown"]
+        assert "prompt_token_cost" in input_bd
+        assert input_bd["prompt_token_cost"] > 0
+
+        # Should have output_cost_breakdown with reasoning and completion
+        assert "output_cost_breakdown" in logging_obj.cost_breakdown
+        output_bd = logging_obj.cost_breakdown["output_cost_breakdown"]
+        assert "reasoning_token_cost" in output_bd
+        assert output_bd["reasoning_token_cost"] > 0
+        assert "completion_token_cost" in output_bd
+        assert output_bd["completion_token_cost"] > 0
+
+    def test_completion_cost_populates_breakdowns_simple_model(self):
+        """completion_cost() should populate breakdowns for a simple model (no reasoning)."""
+        from litellm.cost_calculator import completion_cost
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        logging_obj = Logging(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-simple-breakdown",
+            function_id="test-function",
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-test",
+            model="gpt-4o",
+            usage=Usage(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+            ),
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hi!"},
+                    "finish_reason": "stop",
+                }
+            ],
+        )
+
+        cost = completion_cost(
+            completion_response=response,
+            model="gpt-4o",
+            custom_llm_provider="openai",
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert cost > 0
+        assert logging_obj.cost_breakdown is not None
+
+        # For simple models, should have input_cost_breakdown with prompt_token_cost
+        assert "input_cost_breakdown" in logging_obj.cost_breakdown
+        assert (
+            logging_obj.cost_breakdown["input_cost_breakdown"]["prompt_token_cost"] > 0
+        )
+
+        # For simple models, output_cost_breakdown should have completion_token_cost
+        assert "output_cost_breakdown" in logging_obj.cost_breakdown
+        assert (
+            logging_obj.cost_breakdown["output_cost_breakdown"]["completion_token_cost"]
+            > 0
+        )
+
+        # No reasoning_token_cost in output breakdown since no reasoning tokens
+        assert (
+            "reasoning_token_cost"
+            not in logging_obj.cost_breakdown["output_cost_breakdown"]
+        )
+
+    def test_calculate_detailed_cost_breakdowns_directly(self):
+        """Test the calculate_detailed_cost_breakdowns function directly."""
+        from litellm.litellm_core_utils.llm_cost_calc.utils import (
+            calculate_detailed_cost_breakdowns,
+        )
+
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        usage = Usage(
+            prompt_tokens=100,
+            completion_tokens=500,
+            total_tokens=600,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=400,
+                text_tokens=100,
+            ),
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                text_tokens=100,
+            ),
+        )
+
+        input_bd, output_bd = calculate_detailed_cost_breakdowns(
+            model="o1",
+            usage=usage,
+            custom_llm_provider="openai",
+        )
+
+        # Input should have prompt_token_cost
+        assert "prompt_token_cost" in input_bd
+        assert input_bd["prompt_token_cost"] > 0
+
+        # Output should have both reasoning and completion costs
+        assert "reasoning_token_cost" in output_bd
+        assert output_bd["reasoning_token_cost"] > 0
+        assert "completion_token_cost" in output_bd
+        assert output_bd["completion_token_cost"] > 0
+
+    def test_empty_breakdowns_when_no_usage(self):
+        """Breakdowns should be empty dicts when there are no token details."""
+        from litellm.litellm_core_utils.llm_cost_calc.utils import (
+            calculate_detailed_cost_breakdowns,
+        )
+
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        usage = Usage(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+        )
+
+        input_bd, output_bd = calculate_detailed_cost_breakdowns(
+            model="gpt-4o",
+            usage=usage,
+            custom_llm_provider="openai",
+        )
+
+        # Both breakdowns should be empty (no costs > 0)
+        assert len(input_bd) == 0
+        assert len(output_bd) == 0

--- a/tests/test_litellm/test_callback_kwargs_enhancements.py
+++ b/tests/test_litellm/test_callback_kwargs_enhancements.py
@@ -1,0 +1,411 @@
+"""
+Tests for two callback kwargs enhancements:
+1. project_alias in StandardLoggingUserAPIKeyMetadata
+2. reasoning_tokens_cost in CostBreakdown
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+import litellm
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    CostBreakdown,
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    StandardLoggingUserAPIKeyMetadata,
+    Usage,
+)
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+
+# ---------------------------------------------------------------------------
+# Issue 1: project_alias in callback kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestProjectAliasInCallbackKwargs:
+    """Tests that project_alias is exposed in callback kwargs metadata."""
+
+    def test_project_alias_field_exists_on_standard_logging_user_api_key_metadata(
+        self,
+    ):
+        """StandardLoggingUserAPIKeyMetadata TypedDict should have user_api_key_project_alias."""
+        metadata = StandardLoggingUserAPIKeyMetadata(
+            user_api_key_hash="test-hash",
+            user_api_key_alias="test-alias",
+            user_api_key_spend=0.0,
+            user_api_key_max_budget=None,
+            user_api_key_budget_reset_at=None,
+            user_api_key_org_id=None,
+            user_api_key_team_id="team-1",
+            user_api_key_project_id="proj-1",
+            user_api_key_project_alias="my-project",
+            user_api_key_user_id="user-1",
+            user_api_key_user_email=None,
+            user_api_key_team_alias="my-team",
+            user_api_key_end_user_id=None,
+            user_api_key_request_route=None,
+            user_api_key_auth_metadata=None,
+        )
+        assert metadata["user_api_key_project_alias"] == "my-project"
+
+    def test_project_alias_none_when_not_set(self):
+        """project_alias should be None when key has no project."""
+        metadata = StandardLoggingUserAPIKeyMetadata(
+            user_api_key_hash="test-hash",
+            user_api_key_alias=None,
+            user_api_key_spend=None,
+            user_api_key_max_budget=None,
+            user_api_key_budget_reset_at=None,
+            user_api_key_org_id=None,
+            user_api_key_team_id=None,
+            user_api_key_project_id=None,
+            user_api_key_project_alias=None,
+            user_api_key_user_id=None,
+            user_api_key_user_email=None,
+            user_api_key_team_alias=None,
+            user_api_key_end_user_id=None,
+            user_api_key_request_route=None,
+            user_api_key_auth_metadata=None,
+        )
+        assert metadata["user_api_key_project_alias"] is None
+
+    def test_get_sanitized_user_information_includes_project_alias(self):
+        """get_sanitized_user_information_from_key should populate project_alias from UserAPIKeyAuth."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key-hash",
+            key_alias="test-alias",
+            user_id="test-user",
+            project_id="proj-123",
+            project_alias="My Cool Project",
+            team_id="team-1",
+            team_alias="my-team",
+        )
+
+        result = LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(
+            user_api_key_dict=user_api_key_dict
+        )
+
+        assert result["user_api_key_project_id"] == "proj-123"
+        assert result["user_api_key_project_alias"] == "My Cool Project"
+
+    def test_get_sanitized_user_information_project_alias_none_when_no_project(self):
+        """project_alias should be None when UserAPIKeyAuth has no project."""
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key-hash",
+            user_id="test-user",
+        )
+
+        result = LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(
+            user_api_key_dict=user_api_key_dict
+        )
+
+        assert result["user_api_key_project_id"] is None
+        assert result["user_api_key_project_alias"] is None
+
+    def test_project_alias_in_standard_logging_metadata(self):
+        """project_alias should flow through to StandardLoggingMetadata in the logging payload."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            StandardLoggingPayloadSetup,
+        )
+
+        metadata = {
+            "user_api_key_project_id": "proj-123",
+            "user_api_key_project_alias": "My Cool Project",
+            "user_api_key_team_id": "team-1",
+            "user_api_key_team_alias": "my-team",
+        }
+
+        result = StandardLoggingPayloadSetup.get_standard_logging_metadata(metadata)
+        assert result["user_api_key_project_alias"] == "My Cool Project"
+
+    def test_project_alias_defaults_to_none_in_logging_metadata(self):
+        """When no project_alias in metadata, it should default to None."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            StandardLoggingPayloadSetup,
+        )
+
+        result = StandardLoggingPayloadSetup.get_standard_logging_metadata({})
+        assert result["user_api_key_project_alias"] is None
+
+    def test_verification_token_view_has_project_alias(self):
+        """LiteLLM_VerificationTokenView should have project_alias field."""
+        from litellm.proxy._types import LiteLLM_VerificationTokenView
+
+        token_view = LiteLLM_VerificationTokenView(
+            token="test-token",
+            project_id="proj-123",
+            project_alias="My Project",
+        )
+        assert token_view.project_alias == "My Project"
+
+    def test_verification_token_view_project_alias_defaults_none(self):
+        """project_alias should default to None on LiteLLM_VerificationTokenView."""
+        from litellm.proxy._types import LiteLLM_VerificationTokenView
+
+        token_view = LiteLLM_VerificationTokenView(token="test-token")
+        assert token_view.project_alias is None
+
+
+# ---------------------------------------------------------------------------
+# Issue 2: reasoning_tokens_cost in CostBreakdown
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningTokensCostInCostBreakdown:
+    """Tests that reasoning_tokens_cost is broken out in CostBreakdown."""
+
+    def test_cost_breakdown_includes_reasoning_tokens_cost_field(self):
+        """CostBreakdown TypedDict should accept reasoning_tokens_cost."""
+        breakdown = CostBreakdown(
+            input_cost=0.001,
+            output_cost=0.005,
+            total_cost=0.006,
+            tool_usage_cost=0.0,
+            reasoning_tokens_cost=0.003,
+        )
+        assert breakdown["reasoning_tokens_cost"] == 0.003
+
+    def test_reasoning_tokens_cost_is_subset_of_output_cost(self):
+        """reasoning_tokens_cost should be <= output_cost since it's included in it."""
+        breakdown = CostBreakdown(
+            input_cost=0.001,
+            output_cost=0.005,
+            total_cost=0.006,
+            tool_usage_cost=0.0,
+            reasoning_tokens_cost=0.003,
+        )
+        assert breakdown["reasoning_tokens_cost"] <= breakdown["output_cost"]
+
+    def test_cost_breakdown_reasoning_tokens_cost_zero_when_no_reasoning(self):
+        """When no reasoning tokens, reasoning_tokens_cost should be 0."""
+        breakdown = CostBreakdown(
+            input_cost=0.001,
+            output_cost=0.002,
+            total_cost=0.003,
+            tool_usage_cost=0.0,
+            reasoning_tokens_cost=0.0,
+        )
+        assert breakdown["reasoning_tokens_cost"] == 0.0
+
+    def test_set_cost_breakdown_stores_reasoning_tokens_cost(self):
+        """Logging.set_cost_breakdown should store reasoning_tokens_cost."""
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        logging_obj = Logging(
+            model="o1",
+            messages=[{"role": "user", "content": "Think about this"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-123",
+            function_id="test-function",
+        )
+
+        logging_obj.set_cost_breakdown(
+            input_cost=0.001,
+            output_cost=0.010,
+            total_cost=0.011,
+            cost_for_built_in_tools_cost_usd_dollar=0.0,
+            reasoning_tokens_cost=0.006,
+        )
+
+        assert logging_obj.cost_breakdown is not None
+        assert logging_obj.cost_breakdown["reasoning_tokens_cost"] == 0.006
+        assert logging_obj.cost_breakdown["input_cost"] == 0.001
+        assert logging_obj.cost_breakdown["output_cost"] == 0.010
+
+    def test_reasoning_tokens_cost_in_standard_logging_payload(self):
+        """reasoning_tokens_cost should appear in StandardLoggingPayload's cost_breakdown."""
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging,
+            get_standard_logging_object_payload,
+        )
+
+        logging_obj = Logging(
+            model="o1",
+            messages=[{"role": "user", "content": "Think step by step"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-reasoning-123",
+            function_id="test-function",
+        )
+
+        logging_obj.set_cost_breakdown(
+            input_cost=0.001,
+            output_cost=0.010,
+            total_cost=0.011,
+            cost_for_built_in_tools_cost_usd_dollar=0.0,
+            reasoning_tokens_cost=0.006,
+        )
+
+        mock_response = {
+            "id": "chatcmpl-reasoning",
+            "object": "chat.completion",
+            "model": "o1",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 500,
+                "total_tokens": 510,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 400,
+                    "text_tokens": 100,
+                },
+            },
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Here's my answer"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        kwargs = {
+            "model": "o1",
+            "messages": [{"role": "user", "content": "Think step by step"}],
+            "response_cost": 0.011,
+            "custom_llm_provider": "openai",
+        }
+
+        payload = get_standard_logging_object_payload(
+            kwargs=kwargs,
+            init_response_obj=mock_response,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+            status="success",
+        )
+
+        assert payload is not None
+        assert payload["cost_breakdown"] is not None
+        assert payload["cost_breakdown"]["reasoning_tokens_cost"] == 0.006
+        assert payload["cost_breakdown"]["input_cost"] == 0.001
+        assert payload["cost_breakdown"]["output_cost"] == 0.010
+
+    def test_cost_breakdown_without_reasoning_tokens_cost_still_works(self):
+        """Existing CostBreakdown usage without reasoning_tokens_cost should still work (total=False)."""
+        breakdown = CostBreakdown(
+            input_cost=0.001,
+            output_cost=0.002,
+            total_cost=0.003,
+            tool_usage_cost=0.0,
+        )
+        # reasoning_tokens_cost is optional (total=False on CostBreakdown)
+        assert "reasoning_tokens_cost" not in breakdown
+
+    def test_completion_cost_populates_reasoning_tokens_cost(self):
+        """completion_cost() should populate reasoning_tokens_cost in the logging object's cost_breakdown."""
+        from litellm.cost_calculator import completion_cost
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        logging_obj = Logging(
+            model="o1",
+            messages=[{"role": "user", "content": "Think"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-cost-calc",
+            function_id="test-function",
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-test",
+            model="o1",
+            usage=Usage(
+                prompt_tokens=100,
+                completion_tokens=500,
+                total_tokens=600,
+                completion_tokens_details=CompletionTokensDetailsWrapper(
+                    reasoning_tokens=400,
+                    text_tokens=100,
+                ),
+                prompt_tokens_details=PromptTokensDetailsWrapper(
+                    text_tokens=100,
+                ),
+            ),
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Answer"},
+                    "finish_reason": "stop",
+                }
+            ],
+        )
+
+        cost = completion_cost(
+            completion_response=response,
+            model="o1",
+            custom_llm_provider="openai",
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert cost > 0
+        assert logging_obj.cost_breakdown is not None
+        assert "reasoning_tokens_cost" in logging_obj.cost_breakdown
+        # reasoning_tokens_cost should be > 0 since there are 400 reasoning tokens
+        assert logging_obj.cost_breakdown["reasoning_tokens_cost"] > 0
+        # reasoning_tokens_cost should be <= output_cost
+        assert (
+            logging_obj.cost_breakdown["reasoning_tokens_cost"]
+            <= logging_obj.cost_breakdown["output_cost"]
+        )
+
+    def test_completion_cost_no_reasoning_tokens_zero_cost(self):
+        """When there are no reasoning tokens, reasoning_tokens_cost should be 0."""
+        from litellm.cost_calculator import completion_cost
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        logging_obj = Logging(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.now(),
+            litellm_call_id="test-no-reasoning",
+            function_id="test-function",
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-test",
+            model="gpt-4o",
+            usage=Usage(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+            ),
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hi!"},
+                    "finish_reason": "stop",
+                }
+            ],
+        )
+
+        cost = completion_cost(
+            completion_response=response,
+            model="gpt-4o",
+            custom_llm_provider="openai",
+            litellm_logging_obj=logging_obj,
+        )
+
+        assert cost > 0
+        assert logging_obj.cost_breakdown is not None
+        assert logging_obj.cost_breakdown.get("reasoning_tokens_cost", 0.0) == 0.0


### PR DESCRIPTION
### Issue 1: project_alias in callback kwargs

When a callback fires, project_id was already in kwargs["standard_logging_object"]["metadata"] but the human-readable project_alias was missing. We added it following the same pattern as team_alias.
<img width="790" height="473" alt="image" src="https://github.com/user-attachments/assets/5cea4eb3-0261-46b8-a646-19c0d70cf4bd" />



### Issue 2: reasoning_tokens_cost in CostBreakdown

CostBreakdown had input_cost and output_cost but reasoning token cost was folded into output_cost. We broke it out as a separate field so users can track reasoning costs independently.