### PR TITLE
fix(gemini): detect data URL images in tool_result to prevent silent image dropping

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1503,6 +1503,24 @@ def convert_to_gemini_tool_call_result(  # noqa: PLR0915
     if "content" in message:
         if isinstance(message["content"], str):
             content_str = message["content"]
+            # Detect data URL images in string content (from Anthropic adapter's
+            # single-image tool_result conversion — it converts the image to a
+            # data URL string, which would otherwise be treated as plain text).
+            # Fixes: https://github.com/BerriAI/litellm/issues/23712
+            if content_str.startswith("data:image/"):
+                try:
+                    image_obj = convert_to_anthropic_image_obj(
+                        content_str, format=None
+                    )
+                    inline_data = BlobType(
+                        data=image_obj["data"],
+                        mime_type=image_obj["media_type"],
+                    )
+                    content_str = ""  # Image extracted, don't duplicate as text
+                except Exception as e:
+                    verbose_logger.warning(
+                        f"Failed to extract image from data URL in tool response: {e}"
+                    )
         elif isinstance(message["content"], List):
             content_list = message["content"]
             for content in content_list:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1393,10 +1393,10 @@ def convert_to_gemini_tool_call_invoke(
         if tool_calls is not None:
             for idx, tool in enumerate(tool_calls):
                 if "function" in tool:
-                    gemini_function_call: Optional[
-                        VertexFunctionCall
-                    ] = _gemini_tool_call_invoke_helper(
-                        function_call_params=tool["function"]
+                    gemini_function_call: Optional[VertexFunctionCall] = (
+                        _gemini_tool_call_invoke_helper(
+                            function_call_params=tool["function"]
+                        )
                     )
                     if gemini_function_call is not None:
                         part_dict: VertexPartType = {
@@ -1509,9 +1509,7 @@ def convert_to_gemini_tool_call_result(  # noqa: PLR0915
             # Fixes: https://github.com/BerriAI/litellm/issues/23712
             if content_str.startswith("data:image/"):
                 try:
-                    image_obj = convert_to_anthropic_image_obj(
-                        content_str, format=None
-                    )
+                    image_obj = convert_to_anthropic_image_obj(content_str, format=None)
                     inline_data = BlobType(
                         data=image_obj["data"],
                         mime_type=image_obj["media_type"],
@@ -1558,9 +1556,7 @@ def convert_to_gemini_tool_call_result(  # noqa: PLR0915
                         file_data = (
                             file_content.get("file_data", "")
                             if isinstance(file_content, dict)
-                            else file_content
-                            if isinstance(file_content, str)
-                            else ""
+                            else file_content if isinstance(file_content, str) else ""
                         )
 
                     if file_data:
@@ -2064,9 +2060,9 @@ def _sanitize_empty_text_content(
         if isinstance(content, str):
             if not content or not content.strip():
                 message = cast(AllMessageValues, dict(message))  # Make a copy
-                message[
-                    "content"
-                ] = "[System: Empty message content sanitised to satisfy protocol]"
+                message["content"] = (
+                    "[System: Empty message content sanitised to satisfy protocol]"
+                )
                 verbose_logger.debug(
                     f"_sanitize_empty_text_content: Replaced empty text content in {message.get('role')} message"
                 )
@@ -2406,9 +2402,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             # Convert ChatCompletionImageUrlObject to dict if needed
                             image_url_value = m["image_url"]
                             if isinstance(image_url_value, str):
-                                image_url_input: Union[
-                                    str, dict[str, Any]
-                                ] = image_url_value
+                                image_url_input: Union[str, dict[str, Any]] = (
+                                    image_url_value
+                                )
                             else:
                                 # ChatCompletionImageUrlObject or dict case - convert to dict
                                 image_url_input = {
@@ -2435,9 +2431,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             )
 
                             if "cache_control" in _content_element:
-                                _anthropic_content_element[
-                                    "cache_control"
-                                ] = _content_element["cache_control"]
+                                _anthropic_content_element["cache_control"] = (
+                                    _content_element["cache_control"]
+                                )
                             user_content.append(_anthropic_content_element)
                         elif m.get("type", "") == "text":
                             m = cast(ChatCompletionTextObject, m)
@@ -2475,9 +2471,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     )
 
                     if "cache_control" in _content_element:
-                        _anthropic_content_text_element[
-                            "cache_control"
-                        ] = _content_element["cache_control"]
+                        _anthropic_content_text_element["cache_control"] = (
+                            _content_element["cache_control"]
+                        )
 
                     user_content.append(_anthropic_content_text_element)
 
@@ -2610,9 +2606,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                         original_content_element=dict(assistant_content_block),
                     )
                     if "cache_control" in _content_element:
-                        _anthropic_text_content_element[
-                            "cache_control"
-                        ] = _content_element["cache_control"]
+                        _anthropic_text_content_element["cache_control"] = (
+                            _content_element["cache_control"]
+                        )
                     text_element = _anthropic_text_content_element
 
                 # Interleave: each thinking block precedes its server tool group.
@@ -2772,9 +2768,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     )
 
                     if "cache_control" in _content_element:
-                        _anthropic_text_content_element[
-                            "cache_control"
-                        ] = _content_element["cache_control"]
+                        _anthropic_text_content_element["cache_control"] = (
+                            _content_element["cache_control"]
+                        )
 
                     assistant_content.append(_anthropic_text_content_element)
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_image_in_tool_result.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_image_in_tool_result.py
@@ -1,0 +1,121 @@
+"""
+Tests for image handling in tool_result content.
+
+Fixes: https://github.com/BerriAI/litellm/issues/23712
+
+When Claude Code's Read tool returns an image (base64), the Anthropic adapter
+converts it to a data URL string. convert_to_gemini_tool_call_result() must
+detect this and create inline_data instead of treating it as plain text.
+"""
+
+import base64
+import pytest
+
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    convert_to_gemini_tool_call_result,
+)
+
+
+def _make_tool_message(content, tool_call_id="call_1"):
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": content,
+    }
+
+
+def _make_last_message(tool_call_id="call_1", name="Read"):
+    return {
+        "tool_calls": [
+            {
+                "id": tool_call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+        ]
+    }
+
+
+class TestImageInToolResult:
+
+    def test_data_url_image_creates_inline_data(self):
+        """A data URL image string should produce inline_data, not text."""
+        img_data = base64.b64encode(b"fake-png-data").decode()
+        data_url = f"data:image/png;base64,{img_data}"
+
+        msg = _make_tool_message(content=data_url)
+        last_msg = _make_last_message()
+
+        result = convert_to_gemini_tool_call_result(msg, last_msg)
+
+        # Should return a list: [function_response, inline_data]
+        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        assert len(result) == 2
+
+        # First part: function_response (with empty content since image was extracted)
+        assert "function_response" in result[0]
+
+        # Second part: inline_data with the image
+        assert "inline_data" in result[1]
+        assert result[1]["inline_data"]["mime_type"] == "image/png"
+        assert result[1]["inline_data"]["data"] == img_data
+
+    def test_plain_text_not_affected(self):
+        """Regular text content should not be treated as image."""
+        msg = _make_tool_message(content="def hello(): pass")
+        last_msg = _make_last_message()
+
+        result = convert_to_gemini_tool_call_result(msg, last_msg)
+
+        # Should return single part (not a list)
+        assert isinstance(result, dict)
+        assert "function_response" in result
+        assert result["function_response"]["response"]["content"] == "def hello(): pass"
+
+    def test_multi_item_text_and_image(self):
+        """Multi-item content with text + image_url should produce inline_data."""
+        img_data = base64.b64encode(b"fake-png").decode()
+
+        msg = _make_tool_message(content=[
+            {"type": "text", "text": "Image file: test.png"},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{img_data}"},
+            },
+        ])
+        last_msg = _make_last_message()
+
+        result = convert_to_gemini_tool_call_result(msg, last_msg)
+
+        # Should return list with function_response + inline_data
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert "function_response" in result[0]
+        assert "inline_data" in result[1]
+
+        # Text should be in function_response
+        assert "Image file: test.png" in str(result[0]["function_response"]["response"])
+
+    def test_data_url_with_jpeg(self):
+        """JPEG data URLs should also be handled."""
+        img_data = base64.b64encode(b"fake-jpeg").decode()
+        data_url = f"data:image/jpeg;base64,{img_data}"
+
+        msg = _make_tool_message(content=data_url)
+        last_msg = _make_last_message()
+
+        result = convert_to_gemini_tool_call_result(msg, last_msg)
+
+        assert isinstance(result, list)
+        assert result[1]["inline_data"]["mime_type"] == "image/jpeg"
+
+    def test_non_image_data_url_not_affected(self):
+        """Non-image data URLs (e.g. text/plain) should be treated as text."""
+        msg = _make_tool_message(content="data:text/plain;base64,aGVsbG8=")
+        last_msg = _make_last_message()
+
+        result = convert_to_gemini_tool_call_result(msg, last_msg)
+
+        # Should be a regular text response, not image
+        assert isinstance(result, dict)
+        assert "function_response" in result


### PR DESCRIPTION
## Summary

Fixes #23712 — Images in `tool_result` are silently dropped when routing Claude Code through LiteLLM to Gemini.

### Root Cause

When Claude Code's `Read` tool returns a base64 image, the Anthropic adapter converts it to a data URL string (`"data:image/png;base64,..."`). But `convert_to_gemini_tool_call_result()` treats all string content as plain text — the image data is passed to Gemini as a text string instead of `inline_data`.

### Fix

Detect `data:image/` prefix in string content and convert to Gemini's `inline_data` format using the existing `convert_to_anthropic_image_obj()` helper. ~15 lines in `factory.py`.

This matches the existing handling for multi-item content with `"image_url"` type (line 1512), just adds the same detection for the string content path.

### Reference

Production-tested approach in [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) — see [`parse_tool_result_content_with_images()`](https://github.com/weijiafu14/gemini-claude-bridge/blob/main/src/gemini_claude_bridge/image_utils.py).

## Test plan

- [x] 5 new tests added (`test_image_in_tool_result.py`)
- [x] All 173 existing Gemini tests pass (0 failures)
- [x] Covers: data URL PNG, data URL JPEG, multi-item text+image, plain text unaffected, non-image data URL unaffected