### PR TITLE
fix(moonshot): preserve reasoning_content on Pydantic Message objects in multi-turn tool calls

### DIFF
--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -147,9 +147,11 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         message that contains tool_calls (multi-turn tool-calling flows).
 
         For each such message that is missing the field:
-          1. Promote provider_specific_fields["reasoning_content"] if present and non-empty
+          1. Check if reasoning_content exists at the top level (for Pydantic models
+             that have the attribute but don't support 'in' operator)
+          2. Promote provider_specific_fields["reasoning_content"] if present and non-empty
              (this is where LiteLLM stores it from a previous response)
-          2. Otherwise inject a single space — the minimum value the API accepts
+          3. Otherwise inject a single space — the minimum value the API accepts
         Messages that already carry the field, or are not assistant/tool-call messages,
         are appended as-is (no copy made).
         """
@@ -158,7 +160,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             if (
                 msg.get("role") == "assistant"
                 and msg.get("tool_calls")
-                and "reasoning_content" not in msg
+                and not msg.get("reasoning_content")  # Check using .get() which works for both dicts and Pydantic models
             ):
                 patched = dict(cast(dict, msg))
                 provider_fields = patched.get("provider_specific_fields") or {}

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -617,5 +617,5 @@ class TestMoonshotConfig:
         # Apply fill_reasoning_content
         result = config.fill_reasoning_content(messages)
 
-        # reasoning_content should be preserved in the assistant message
+        assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"
         assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -615,7 +615,8 @@ class TestMoonshotConfig:
         ]
 
         # Apply fill_reasoning_content
-        result = config.fill_reasoning_content(messages)
-
+        assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"
+        # Verify non-assistant or non-tool-call messages are not modified
+        assert result[0].get("reasoning_content") is None
         assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"
         assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -551,3 +551,71 @@ class TestMoonshotConfig:
         # reasoning_content must not have been injected
         for msg in result["messages"]:
             assert "reasoning_content" not in msg
+
+    def test_reasoning_content_preserved_on_pydantic_message_object(self):
+        """reasoning_content on Pydantic Message objects is preserved (not overwritten with placeholder).
+
+        Regression test for: https://github.com/BerriAI/litellm/issues/23765
+        The issue was that 'reasoning_content' in msg doesn't work for Pydantic models
+        because they don't support the 'in' operator the same way as dicts.
+        """
+        from litellm.types.utils import Message
+
+        config = MoonshotChatConfig()
+
+        # Create a Pydantic Message object with reasoning_content (as would come from API response)
+        message_with_reasoning = Message(
+            role="assistant",
+            content=None,
+            reasoning_content="<thinking>User wants weather</thinking>",
+            tool_calls=[
+                {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+            ],
+        )
+
+        messages = [message_with_reasoning]
+
+        result = config.fill_reasoning_content(messages)
+
+        # reasoning_content should be preserved, not replaced with placeholder
+        assert result[0].get("reasoning_content") == "<thinking>User wants weather</thinking>"
+
+    def test_reasoning_content_preserved_in_multi_turn_flow(self):
+        """reasoning_content is preserved through multi-turn conversation flow.
+
+        This tests the complete flow: API response -> Message object -> dict -> fill_reasoning_content
+        """
+        from litellm.types.utils import Message
+        from litellm.utils import convert_to_dict
+
+        config = MoonshotChatConfig()
+
+        # Simulate API response with reasoning_content
+        api_response = {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "<thinking>Planning to call weather tool</thinking>",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": '{}'}}
+            ],
+        }
+
+        # Convert to Message object (as LiteLLM does)
+        message_obj = Message(**api_response)
+
+        # Convert back to dict (when building next request)
+        message_dict = convert_to_dict(message_obj)
+
+        # Build multi-turn conversation
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            message_dict,
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"temp": 72}'},
+            {"role": "user", "content": "Thanks!"},
+        ]
+
+        # Apply fill_reasoning_content
+        result = config.fill_reasoning_content(messages)
+
+        # reasoning_content should be preserved in the assistant message
+        assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -615,8 +615,7 @@ class TestMoonshotConfig:
         ]
 
         # Apply fill_reasoning_content
-        assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"
-        # Verify non-assistant or non-tool-call messages are not modified
-        assert result[0].get("reasoning_content") is None
-        assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"
+        result = config.fill_reasoning_content(messages)
+
+        # reasoning_content should be preserved in the assistant message
         assert result[1].get("reasoning_content") == "<thinking>Planning to call weather tool</thinking>"


### PR DESCRIPTION
## Problem
Moonshot/Kimi K2.5 thinking mode breaks multi-turn tool calls because "reasoning_content" was being stripped from assistant messages in conversation history.

The root cause was in the "fill_reasoning_content" method. The condition `'reasoning_content' not in msg` doesn't work correctly for Pydantic Message objects because they don't support the `in` operator the same way as dicts.

## Fix
Changed the condition from:
```python
"reasoning_content" not in msg
```
to:
```python
not msg.get("reasoning_content")
```

This works correctly for both dicts and Pydantic models because the `.get()` method is available on both types.

## Changes
- Modified: `litellm/llms/moonshot/chat/transformation.py`
- Added 2 regression tests in `tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py`

Fixes #23765