### PR TITLE
fix(responses): restore deepseek codex bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -240,10 +240,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             if key in ("max_tokens", "max_completion_tokens"):
                 responses_api_request["max_output_tokens"] = value
             elif key == "tools" and value is not None:
-                responses_api_request[
-                    "tools"
-                ] = self._convert_tools_to_responses_format(
-                    cast(List[Dict[str, Any]], value)
+                responses_api_request["tools"] = (
+                    self._convert_tools_to_responses_format(
+                        cast(List[Dict[str, Any]], value)
+                    )
                 )
             elif key == "response_format":
                 text_format = self._transform_response_format_to_text_format(value)
@@ -1058,9 +1058,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 )
 
                 if provider_specific_fields:
-                    function_chunk[
-                        "provider_specific_fields"
-                    ] = provider_specific_fields
+                    function_chunk["provider_specific_fields"] = (
+                        provider_specific_fields
+                    )
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
@@ -1133,9 +1133,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 # Add provider_specific_fields to function if present
                 if provider_specific_fields:
-                    function_chunk[
-                        "provider_specific_fields"
-                    ] = provider_specific_fields
+                    function_chunk["provider_specific_fields"] = (
+                        provider_specific_fields
+                    )
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -270,6 +270,90 @@ class OpenAIResponsesHandler(BaseTranslation):
             remapped = self._remap_tools_to_responses_api_format(guardrailed_tools)
             data["tools"] = self._merge_tools_after_guardrail(original_tools, remapped)
 
+    @staticmethod
+    def _extract_reasoning_fallback_text_from_outputs(outputs: List[Any]) -> str:
+        """
+        DeepSeek reasoner may place the user-visible final answer inside a
+        `reasoning` output item while the paired `message` item is empty.
+
+        This extracts reasoning output text as a fallback visible assistant text.
+        """
+        reasoning_parts: List[str] = []
+
+        for item in outputs:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "reasoning":
+                continue
+
+            content = item.get("content") or []
+            if not isinstance(content, list):
+                continue
+
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") != "output_text":
+                    continue
+
+                text = str(block.get("text") or "")
+                if text.strip():
+                    reasoning_parts.append(text.strip())
+
+        return "\n\n".join(reasoning_parts).strip()
+
+    @staticmethod
+    def _inject_fallback_text_into_response_outputs(
+        outputs: List[Any], fallback_text: str
+    ) -> List[Any]:
+        """
+        Ensure the response outputs contain a visible assistant `message` item
+        so downstream clients like Codex can render the text.
+        """
+        if not fallback_text.strip():
+            return outputs
+
+        for item in outputs:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "message":
+                continue
+
+            content = item.get("content") or []
+            if not isinstance(content, list):
+                item["content"] = [
+                    {"type": "output_text", "text": fallback_text, "annotations": []}
+                ]
+                return outputs
+
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "output_text":
+                    current_text = str(block.get("text") or "")
+                    if not current_text.strip():
+                        block["text"] = fallback_text
+                    return outputs
+
+            # message exists but has no output_text block
+            content.append(
+                {"type": "output_text", "text": fallback_text, "annotations": []}
+            )
+            return outputs
+
+        # no message item exists at all
+        outputs.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {"type": "output_text", "text": fallback_text, "annotations": []}
+                ],
+            }
+        )
+        return outputs
+
     def _extract_input_text_and_images(
         self,
         message: Any,  # Can be Dict[str, Any] or ResponseInputParam
@@ -495,9 +579,36 @@ class OpenAIResponsesHandler(BaseTranslation):
                 handle_raw_dict_callback=None,
             )
 
+            fallback_text = ""
+            tool_calls = None
+            text = None
+
             if model_response_choices:
                 tool_calls = model_response_choices[0].message.tool_calls
                 text = model_response_choices[0].message.content
+
+            # DeepSeek reasoner fallback:
+            # if normal assistant message content is empty, extract visible text from reasoning item
+            if not text or not str(text).strip():
+                fallback_text = self._extract_reasoning_fallback_text_from_outputs(
+                    outputs
+                )
+                if fallback_text:
+                    text = fallback_text
+                    # Write the text back into response.output so downstream clients can render it
+                    if (
+                        isinstance(final_chunk, dict)
+                        and isinstance(final_chunk.get("response"), dict)
+                        and isinstance(final_chunk["response"].get("output"), list)
+                    ):
+                        final_chunk["response"]["output"] = (
+                            self._inject_fallback_text_into_response_outputs(
+                                final_chunk["response"]["output"],
+                                fallback_text,
+                            )
+                        )
+
+            if model_response_choices or fallback_text:
                 guardrail_inputs = GenericGuardrailAPIInputs()
                 if text:
                     guardrail_inputs["texts"] = [text]

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -76,6 +76,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self.sent_response_created_event: bool = False
         self.sent_response_in_progress_event: bool = False
         self.sent_output_item_added_event: bool = False
+        self.sent_message_output_item_added_event: bool = False
+        self.sent_reasoning_output_item_added_event: bool = False
         self.sent_content_part_added_event: bool = False
         self.sent_output_text_done_event: bool = False
         self.sent_output_content_part_done_event: bool = False
@@ -770,16 +772,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 raise StopAsyncIteration
 
     def _ensure_output_item_for_chunk(self, chunk: ModelResponseStream) -> None:
-        # Change: Never return a value, just enqueue output item events
-        if self.sent_output_item_added_event:
-            return
         delta = chunk.choices[0].delta
 
-        self._sequence_number += 1
-        self.sent_output_item_added_event = True
-
         # Reasoning-first
-        if hasattr(delta, "reasoning_content") and delta.reasoning_content:
+        if (
+            hasattr(delta, "reasoning_content")
+            and delta.reasoning_content
+            and not self.sent_reasoning_output_item_added_event
+        ):
+            self._sequence_number += 1
+            self.sent_output_item_added_event = True
+            self.sent_reasoning_output_item_added_event = True
             self._reasoning_active = True
             if self._cached_reasoning_item_id is None:
                 self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
@@ -799,32 +802,27 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             )
             event.__dict__["sequence_number"] = self._sequence_number
             self._pending_response_events.append(event)
-            return
 
-        # Tool-first
-        if hasattr(delta, "tool_calls") and delta.tool_calls:
-            # Tool calls already handled via _queue_tool_call_delta_events
-            # DO NOT create message item
-            return
-
-        # Default: message
-        self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
-        event = OutputItemAddedEvent(
-            type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
-            output_index=0,
-            item=BaseLiteLLMOpenAIResponseObject(
-                **{
-                    "id": self._cached_item_id,
-                    "type": "message",
-                    "role": "assistant",
-                    "status": "in_progress",
-                    "content": [],
-                }
-            ),
-        )
-        event.__dict__["sequence_number"] = self._sequence_number
-        self._pending_response_events.append(event)
-        return
+        if delta.content and not self.sent_message_output_item_added_event:
+            self._sequence_number += 1
+            self.sent_output_item_added_event = True
+            self.sent_message_output_item_added_event = True
+            self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
+            event = OutputItemAddedEvent(
+                type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+                output_index=0,
+                item=BaseLiteLLMOpenAIResponseObject(
+                    **{
+                        "id": self._cached_item_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "in_progress",
+                        "content": [],
+                    }
+                ),
+            )
+            event.__dict__["sequence_number"] = self._sequence_number
+            self._pending_response_events.append(event)
 
     async def __anext__(
         self,
@@ -921,11 +919,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
                         response_api_chunk = (
                             self._transform_chat_completion_chunk_to_response_api_chunk(
-                                chunk
+                                chunk, drain_pending_first=False
                             )
                         )
                         if response_api_chunk:
-                            self._pending_response_events.append(response_api_chunk)
+                            return response_api_chunk
 
                     if self._pending_response_events:
                         return self._pending_response_events.pop(0)
@@ -964,9 +962,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 try:
                     chunk = self.litellm_custom_stream_wrapper.__next__()
                     self._ensure_output_item_for_chunk(chunk)
-                    # Emit any just-queued output_item event
-                    if self._pending_response_events:
-                        return self._pending_response_events.pop(0)
                     self.collected_chat_completion_chunks.append(
                         self._snapshot_chunk_for_stream_chunk_builder(
                             cast(ModelResponseStream, chunk)
@@ -974,11 +969,13 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     )
                     response_api_chunk = (
                         self._transform_chat_completion_chunk_to_response_api_chunk(
-                            chunk
+                            chunk, drain_pending_first=False
                         )
                     )
                     if response_api_chunk:
                         return response_api_chunk
+                    if self._pending_response_events:
+                        return self._pending_response_events.pop(0)
                     # Otherwise, loop to next chunk
                 except StopIteration:
                     return self.common_done_event_logic(sync_mode=True)
@@ -988,7 +985,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             raise e
 
     def _transform_chat_completion_chunk_to_response_api_chunk(
-        self, chunk: ModelResponseStream
+        self, chunk: ModelResponseStream, drain_pending_first: bool = True
     ) -> Optional[ResponsesAPIStreamingResponse]:
         """
         Transform a chat completion chunk to a response API chunk.
@@ -997,6 +994,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         and the ReasoningSummaryTextDeltaEvent, which is used by the responses API to emit reasoning content.
         It also handles emitting annotation.added events when annotations are detected in the chunk.
         """
+        if drain_pending_first and self._pending_response_events:
+            return self._pending_response_events.pop(0)
+
         if self._cached_item_id is None and chunk.id:
             self._cached_item_id = chunk.id
         item_id = self._cached_item_id or chunk.id
@@ -1028,22 +1028,23 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                             annotation=annotation_dict,
                         )
                         self._pending_annotation_events.append(event)
-        # Priority 1: Handle reasoning content (highest priority)
+        generated_events: List[ResponsesAPIStreamingResponse] = []
+
         if (
             chunk.choices
             and hasattr(chunk.choices[0].delta, "reasoning_content")
             and chunk.choices[0].delta.reasoning_content
         ):
             reasoning_content = chunk.choices[0].delta.reasoning_content
-
-            return ReasoningSummaryTextDeltaEvent(
-                type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA,
-                item_id=f"rs_{hash(str(reasoning_content))}",
-                output_index=0,
-                delta=reasoning_content,
+            generated_events.append(
+                ReasoningSummaryTextDeltaEvent(
+                    type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA,
+                    item_id=f"rs_{hash(str(reasoning_content))}",
+                    output_index=0,
+                    delta=reasoning_content,
+                )
             )
 
-        # Priority 2: Handle text deltas
         delta_content = self._get_delta_string_from_streaming_choices(chunk.choices)
         if delta_content:
             self._sequence_number += 1
@@ -1055,30 +1056,26 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 delta=delta_content,
             )
             text_delta_event.__dict__["sequence_number"] = self._sequence_number
-            return text_delta_event
+            generated_events.append(text_delta_event)
 
-        # Priority 3: Handle tool call deltas (if any) -> queue events and emit them
-        # For each tool call delta, we emit events one at a time to match OpenAI's streaming behavior
         if (
             chunk.choices
             and hasattr(chunk.choices[0].delta, "tool_calls")
             and chunk.choices[0].delta.tool_calls
         ):
             self._queue_tool_call_delta_events(chunk.choices[0].delta.tool_calls)
-            # Return one pending tool event at a time
-            if self._pending_tool_events:
-                return self._pending_tool_events.pop(0)
 
-        # Priority 4: If we have pending annotation events, emit the next one
-        # This happens when the current chunk has no text/reasoning content
         if (
             hasattr(self, "_pending_annotation_events")
             and self._pending_annotation_events
         ):
             event = self._pending_annotation_events.pop(0)
-            return event
+            generated_events.append(event)
 
-        # Priority 5: If we have pending tool events (from earlier chunk), emit the next one
+        if generated_events:
+            self._pending_response_events.extend(generated_events)
+            return self._pending_response_events.pop(0)
+
         if self._pending_tool_events:
             return self._pending_tool_events.pop(0)
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -110,6 +110,47 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._reasoning_item_id: Optional[str] = None
         self._accumulated_reasoning_content_parts: List[str] = []
 
+    def _get_or_assign_reasoning_item_id(self) -> str:
+        if self._reasoning_item_id:
+            return self._reasoning_item_id
+        if self._cached_reasoning_item_id is None:
+            self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
+        self._reasoning_item_id = self._cached_reasoning_item_id
+        return self._reasoning_item_id
+
+    def _queue_reasoning_done_events(self) -> None:
+        if not self._reasoning_active or self._reasoning_done_emitted:
+            return
+
+        reasoning_content = "".join(self._accumulated_reasoning_content_parts)
+        reasoning_item_id = self._get_or_assign_reasoning_item_id()
+
+        self._sequence_number += 1
+        text_done_event = self.create_reasoning_summary_text_done_event(
+            reasoning_item_id=reasoning_item_id,
+            reasoning_content=reasoning_content,
+            sequence_number=self._sequence_number,
+        )
+
+        self._sequence_number += 1
+        part_done_event = self.create_reasoning_summary_part_done_event(
+            reasoning_item_id=reasoning_item_id,
+            reasoning_content=reasoning_content,
+            sequence_number=self._sequence_number,
+        )
+
+        self._sequence_number += 1
+        reasoning_output_item_done_event = self.create_reasoning_output_item_done_event(
+            reasoning_item_id=reasoning_item_id,
+            reasoning_content=reasoning_content,
+            sequence_number=self._sequence_number,
+        )
+        self._pending_response_events.extend(
+            [text_done_event, part_done_event, reasoning_output_item_done_event]
+        )
+        self._reasoning_done_emitted = True
+        self._reasoning_active = False
+
     def _get_or_assign_tool_output_index(self, call_id: str) -> int:
         existing = self._tool_output_index_by_call_id.get(call_id)
         if existing is not None:
@@ -739,6 +780,10 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
     def common_done_event_logic(
         self, sync_mode: bool = True
     ) -> BaseLiteLLMOpenAIResponseObject:
+        if self._reasoning_active and not self._reasoning_done_emitted:
+            self._queue_reasoning_done_events()
+        if self._pending_response_events:
+            return self._pending_response_events.pop(0)
         if not self.litellm_model_response or isinstance(
             self.litellm_model_response, TextCompletionResponse
         ):
@@ -868,54 +913,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                                     delta.reasoning_content
                                 )
                             if self._is_reasoning_end(chunk):
-                                reasoning_content = "".join(
-                                    self._accumulated_reasoning_content_parts
-                                )
-
-                                # Ensure we have a valid reasoning_item_id
-                                reasoning_item_id = (
-                                    self._reasoning_item_id
-                                    or self._cached_reasoning_item_id
-                                    or f"rs_{uuid.uuid4()}"
-                                )
-
-                                # Create text.done event first with its own sequence number
-                                self._sequence_number += 1
-                                text_done_event = (
-                                    self.create_reasoning_summary_text_done_event(
-                                        reasoning_item_id=reasoning_item_id,
-                                        reasoning_content=reasoning_content,
-                                        sequence_number=self._sequence_number,
-                                    )
-                                )
-
-                                # Create part.done event second with its own sequence number
-                                self._sequence_number += 1
-                                part_done_event = (
-                                    self.create_reasoning_summary_part_done_event(
-                                        reasoning_item_id=reasoning_item_id,
-                                        reasoning_content=reasoning_content,
-                                        sequence_number=self._sequence_number,
-                                    )
-                                )
-
-                                self._sequence_number += 1
-                                reasoning_output_item_done_event = (
-                                    self.create_reasoning_output_item_done_event(
-                                        reasoning_item_id=reasoning_item_id,
-                                        reasoning_content=reasoning_content,
-                                        sequence_number=self._sequence_number,
-                                    )
-                                )
-                                self._pending_response_events.extend(
-                                    [
-                                        text_done_event,
-                                        part_done_event,
-                                        reasoning_output_item_done_event,
-                                    ]
-                                )
-                                self._reasoning_done_emitted = True
-                                self._reasoning_active = False
+                                self._queue_reasoning_done_events()
 
                         response_api_chunk = (
                             self._transform_chat_completion_chunk_to_response_api_chunk(
@@ -967,6 +965,18 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                             cast(ModelResponseStream, chunk)
                         )
                     )
+                    if self._reasoning_active and not self._reasoning_done_emitted:
+                        delta = chunk.choices[0].delta if chunk.choices else None
+                        if (
+                            delta
+                            and hasattr(delta, "reasoning_content")
+                            and delta.reasoning_content
+                        ):
+                            self._accumulated_reasoning_content_parts.append(
+                                delta.reasoning_content
+                            )
+                        if self._is_reasoning_end(chunk):
+                            self._queue_reasoning_done_events()
                     response_api_chunk = (
                         self._transform_chat_completion_chunk_to_response_api_chunk(
                             chunk, drain_pending_first=False
@@ -1039,7 +1049,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             generated_events.append(
                 ReasoningSummaryTextDeltaEvent(
                     type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA,
-                    item_id=f"rs_{hash(str(reasoning_content))}",
+                    item_id=self._get_or_assign_reasoning_item_id(),
                     output_index=0,
                     delta=reasoning_content,
                 )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -153,6 +153,53 @@ class LiteLLMCompletionResponsesConfig:
         return tool_choice
 
     @staticmethod
+    def _transform_responses_api_reasoning_to_chat_completion_message(
+        reasoning_item: Any,
+    ) -> List[
+        Union[
+            AllMessageValues,
+            GenericChatCompletionMessage,
+            ChatCompletionResponseMessage,
+        ]
+    ]:
+        """
+        Transform a Responses API reasoning item into a visible assistant message.
+
+        DeepSeek may place the user-visible final text in a `reasoning` item while the
+        paired `message` item is empty. Codex expects assistant-visible content, so we
+        bridge reasoning text into a normal assistant message here.
+        """
+        if not isinstance(reasoning_item, dict):
+            return []
+
+        content_blocks = reasoning_item.get("content") or []
+        text_parts: List[str] = []
+
+        for block in content_blocks:
+            if not isinstance(block, dict):
+                continue
+
+            block_type = str(block.get("type") or "")
+            if block_type not in ("output_text", "text"):
+                continue
+
+            text = str(block.get("text") or "")
+            text = LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                text
+            )
+            if text.strip():
+                text_parts.append(text.strip())
+
+        bridged_text = "\n\n".join(text_parts).strip()
+
+        return [
+            GenericChatCompletionMessage(
+                role="assistant",
+                content=bridged_text,
+            )
+        ]
+
+    @staticmethod
     def transform_responses_api_request_to_chat_completion_request(
         model: str,
         input: Union[str, ResponseInputParam],
@@ -190,11 +237,36 @@ class LiteLLMCompletionResponsesConfig:
                 # reasoning could be a string directly
                 reasoning_effort = reasoning_param
 
-        litellm_completion_request: dict = {
-            "messages": LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+        messages = (
+            LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
                 input=input,
                 responses_api_request=responses_api_request,
-            ),
+            )
+        )
+
+        deepseek_reasoning_required = False
+        if custom_llm_provider == "deepseek":
+            model_l = (model or "").lower()
+            if "reasoner" in model_l or "r1" in model_l:
+                deepseek_reasoning_required = True
+            if reasoning_effort and reasoning_effort != "none":
+                deepseek_reasoning_required = True
+            if responses_api_request.get("thinking") is not None:
+                deepseek_reasoning_required = True
+
+        if deepseek_reasoning_required:
+            messages = (
+                LiteLLMCompletionResponsesConfig._ensure_deepseek_reasoning_content(
+                    messages=messages
+                )
+            )
+
+        messages = LiteLLMCompletionResponsesConfig._coalesce_assistant_messages_between_tool_calls_and_tool_outputs(
+            messages=messages
+        )
+
+        litellm_completion_request: dict = {
+            "messages": messages,
             "model": model,
             "tool_choice": LiteLLMCompletionResponsesConfig._transform_tool_choice(
                 responses_api_request.get("tool_choice")
@@ -340,6 +412,30 @@ class LiteLLMCompletionResponsesConfig:
                         "custom_llm_provider", ""
                     ),
                 )
+
+        deepseek_reasoning_required = False
+        if litellm_completion_request.get("custom_llm_provider") == "deepseek":
+            model_l = str(litellm_completion_request.get("model") or "").lower()
+            if "reasoner" in model_l or "r1" in model_l:
+                deepseek_reasoning_required = True
+            if (
+                litellm_completion_request.get("reasoning_effort")
+                and litellm_completion_request.get("reasoning_effort") != "none"
+            ):
+                deepseek_reasoning_required = True
+            if litellm_completion_request.get("thinking") is not None:
+                deepseek_reasoning_required = True
+
+        if deepseek_reasoning_required:
+            combined_messages = (
+                LiteLLMCompletionResponsesConfig._ensure_deepseek_reasoning_content(
+                    messages=combined_messages
+                )
+            )
+
+        combined_messages = LiteLLMCompletionResponsesConfig._coalesce_assistant_messages_between_tool_calls_and_tool_outputs(
+            messages=combined_messages
+        )
 
         litellm_completion_request["messages"] = combined_messages
         litellm_completion_request["litellm_trace_id"] = chat_completion_session.get(
@@ -973,20 +1069,235 @@ class LiteLLMCompletionResponsesConfig:
             return LiteLLMCompletionResponsesConfig._transform_responses_api_function_call_to_chat_completion_message(
                 function_call=input_item
             )
+        elif LiteLLMCompletionResponsesConfig._is_input_item_reasoning(input_item):
+            return LiteLLMCompletionResponsesConfig._transform_responses_api_reasoning_to_chat_completion_message(
+                reasoning_item=input_item
+            )
         else:
             content = input_item.get("content")
-            # Handle None content: Responses API allows None content, but GenericChatCompletionMessage requires content
-            # Since guardrails skip None content anyway, we return empty list to exclude it from structured messages
             if content is None:
                 return []
+
+            role = input_item.get("role") or "user"
+            transformed_content = LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+                content
+            )
+
+            if role == "assistant":
+                if isinstance(transformed_content, str):
+                    transformed_content = LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                        transformed_content
+                    )
+                elif isinstance(transformed_content, list):
+                    cleaned_parts: List[Union[str, Dict[str, Any]]] = []
+                    for part in transformed_content:
+                        if isinstance(part, str):
+                            cleaned_parts.append(
+                                LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                                    part
+                                )
+                            )
+                        elif isinstance(part, dict):
+                            part_copy = dict(part)
+                            text_val = part_copy.get("text")
+                            if text_val is not None:
+                                part_copy["text"] = (
+                                    LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                                        str(text_val)
+                                    )
+                                )
+                            cleaned_parts.append(part_copy)
+                        else:
+                            cleaned_parts.append(part)
+                    transformed_content = cleaned_parts
+
+                if LiteLLMCompletionResponsesConfig._is_effectively_empty_assistant_content(
+                    transformed_content
+                ):
+                    return []
+
             return [
                 GenericChatCompletionMessage(
-                    role=input_item.get("role") or "user",
-                    content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
-                        content
-                    ),
+                    role=role,
+                    content=transformed_content,
                 )
             ]
+
+    @staticmethod
+    def _strip_deepseek_thinking_markers(text: str) -> str:
+        """
+        Some DeepSeek models emit delimiter tokens inside assistant-visible content.
+        If we persist these as standalone assistant messages, they can violate
+        DeepSeek's tool-call sequencing requirements.
+        """
+        if not isinstance(text, str):
+            return str(text) if text is not None else ""
+        markers = (
+            "<｜end▁of▁thinking｜>",
+            "<|end_of_thinking|>",
+            "</think>",
+            "<think>",
+        )
+        for marker in markers:
+            text = text.replace(marker, "")
+        return text
+
+    @staticmethod
+    def _coalesce_assistant_messages_between_tool_calls_and_tool_outputs(
+        messages: Sequence[
+            Union[
+                AllMessageValues,
+                GenericChatCompletionMessage,
+                ChatCompletionResponseMessage,
+            ]
+        ],
+    ) -> List[
+        Union[
+            AllMessageValues,
+            GenericChatCompletionMessage,
+            ChatCompletionResponseMessage,
+        ]
+    ]:
+        """
+        DeepSeek requires assistant(tool_calls) to be immediately followed by tool
+        messages for each tool_call_id. If the client inserts assistant text in
+        between, merge that text into the preceding assistant(tool_calls) message.
+        """
+        fixed: List[
+            Union[
+                AllMessageValues,
+                GenericChatCompletionMessage,
+                ChatCompletionResponseMessage,
+            ]
+        ] = []
+        pending_tool_call_ids: Optional[set] = None
+        last_tool_calls_idx: Optional[int] = None
+
+        def _merge_assistant_content(*, target: dict, src: dict) -> None:
+            src_content = src.get("content")
+            if not src_content:
+                return
+            tgt_content = target.get("content")
+
+            if isinstance(tgt_content, str) and isinstance(src_content, str):
+                if tgt_content.strip():
+                    target["content"] = (
+                        tgt_content.rstrip() + "\n\n" + src_content.lstrip()
+                    )
+                else:
+                    target["content"] = src_content
+                return
+
+            def _to_list(v: Any) -> list:
+                if v is None:
+                    return []
+                if isinstance(v, list):
+                    return v
+                return [v]
+
+            target["content"] = _to_list(tgt_content) + _to_list(src_content)
+
+        for message in messages:
+            if not isinstance(message, dict):
+                fixed.append(message)
+                continue
+
+            role = message.get("role")
+            tool_calls = message.get("tool_calls")
+
+            if role == "assistant" and tool_calls:
+                ids: set = set()
+                for tc in tool_calls:
+                    if isinstance(tc, dict):
+                        tc_id = tc.get("id")
+                    else:
+                        tc_id = getattr(tc, "id", None)
+                    if tc_id:
+                        ids.add(str(tc_id))
+                pending_tool_call_ids = ids or set()
+                fixed.append(message)
+                last_tool_calls_idx = len(fixed) - 1
+                continue
+
+            if pending_tool_call_ids is not None and len(pending_tool_call_ids) > 0:
+                if role == "tool":
+                    tool_call_id = message.get("tool_call_id")
+                    if tool_call_id and str(tool_call_id) in pending_tool_call_ids:
+                        pending_tool_call_ids.remove(str(tool_call_id))
+                    fixed.append(message)
+                    continue
+
+                if (
+                    role == "assistant"
+                    and not tool_calls
+                    and last_tool_calls_idx is not None
+                ):
+                    try:
+                        _merge_assistant_content(
+                            target=cast(dict, fixed[last_tool_calls_idx]),
+                            src=message,
+                        )
+                    except Exception:
+                        pass
+                    continue
+
+                continue
+
+            fixed.append(message)
+
+            if pending_tool_call_ids is not None and len(pending_tool_call_ids) == 0:
+                pending_tool_call_ids = None
+                last_tool_calls_idx = None
+
+        return fixed
+
+    @staticmethod
+    def _is_effectively_empty_assistant_content(
+        transformed_content: Union[str, List[Union[str, Dict[str, Any]]]],
+    ) -> bool:
+        """
+        Return True if assistant content is effectively empty, including when it only
+        contains DeepSeek thinking delimiter tokens.
+        """
+        if isinstance(transformed_content, str):
+            normalized = (
+                LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                    transformed_content
+                )
+            )
+            return normalized.strip() == ""
+
+        if isinstance(transformed_content, list):
+            for part in transformed_content:
+                if isinstance(part, str):
+                    normalized = LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                        part
+                    )
+                    if normalized.strip() != "":
+                        return False
+                elif isinstance(part, dict):
+                    text_val = part.get("text")
+                    if text_val is None:
+                        return False
+                    normalized = LiteLLMCompletionResponsesConfig._strip_deepseek_thinking_markers(
+                        str(text_val)
+                    )
+                    if normalized.strip() != "":
+                        return False
+                else:
+                    return False
+            return True
+
+        return False
+
+    @staticmethod
+    def _is_input_item_reasoning(input_item: Any) -> bool:
+        """
+        Detect Responses API reasoning items, including DeepSeek/OpenAI-style outputs.
+        """
+        if not isinstance(input_item, dict):
+            return False
+        return str(input_item.get("type") or "") == "reasoning"
 
     @staticmethod
     def _is_input_item_tool_call_output(input_item: Any) -> bool:
@@ -2055,9 +2366,9 @@ class LiteLLMCompletionResponsesConfig:
                 hasattr(completion_details, "reasoning_tokens")
                 and completion_details.reasoning_tokens is not None
             ):
-                output_details_dict[
-                    "reasoning_tokens"
-                ] = completion_details.reasoning_tokens
+                output_details_dict["reasoning_tokens"] = (
+                    completion_details.reasoning_tokens
+                )
             else:
                 output_details_dict["reasoning_tokens"] = 0
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -15,6 +15,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
 )
+from litellm.utils import supports_reasoning
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionImageObject,
@@ -246,13 +247,15 @@ class LiteLLMCompletionResponsesConfig:
 
         deepseek_reasoning_required = False
         if custom_llm_provider == "deepseek":
-            model_l = (model or "").lower()
-            if "reasoner" in model_l or "r1" in model_l:
-                deepseek_reasoning_required = True
             if reasoning_effort and reasoning_effort != "none":
                 deepseek_reasoning_required = True
             if responses_api_request.get("thinking") is not None:
                 deepseek_reasoning_required = True
+            if not deepseek_reasoning_required:
+                deepseek_reasoning_required = supports_reasoning(
+                    model=model or "",
+                    custom_llm_provider=custom_llm_provider,
+                )
 
         if deepseek_reasoning_required:
             messages = (
@@ -415,9 +418,6 @@ class LiteLLMCompletionResponsesConfig:
 
         deepseek_reasoning_required = False
         if litellm_completion_request.get("custom_llm_provider") == "deepseek":
-            model_l = str(litellm_completion_request.get("model") or "").lower()
-            if "reasoner" in model_l or "r1" in model_l:
-                deepseek_reasoning_required = True
             if (
                 litellm_completion_request.get("reasoning_effort")
                 and litellm_completion_request.get("reasoning_effort") != "none"
@@ -425,6 +425,13 @@ class LiteLLMCompletionResponsesConfig:
                 deepseek_reasoning_required = True
             if litellm_completion_request.get("thinking") is not None:
                 deepseek_reasoning_required = True
+            if not deepseek_reasoning_required:
+                deepseek_reasoning_required = supports_reasoning(
+                    model=str(litellm_completion_request.get("model") or ""),
+                    custom_llm_provider=litellm_completion_request.get(
+                        "custom_llm_provider"
+                    ),
+                )
 
         if deepseek_reasoning_required:
             combined_messages = (

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py
@@ -100,6 +100,14 @@ class TestReasoningContentStreaming:
         assert transformed_chunk.delta == "First, let me analyze..."
         assert transformed_chunk.type == "response.reasoning_summary_text.delta"
 
+        follow_up_chunk = (
+            iterator._transform_chat_completion_chunk_to_response_api_chunk(chunk)
+        )
+
+        assert follow_up_chunk is not None
+        assert follow_up_chunk.delta == "Here is the answer"
+        assert follow_up_chunk.type == "response.output_text.delta"
+
     def test_no_reasoning_content(self):
         """Test handling when no reasoning content is present"""
         # Setup

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -22,6 +22,20 @@ from litellm.types.utils import (
 )
 
 
+class _StaticSyncStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self._index = 0
+        self.logging_obj = AsyncMock()
+
+    def __next__(self):
+        if self._index >= len(self._chunks):
+            raise StopIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
 def test_tool_call_delta_is_emitted_as_responses_events():
     iterator = LiteLLMCompletionStreamingIterator(
         model="test-model",
@@ -68,6 +82,113 @@ def test_tool_call_delta_is_emitted_as_responses_events():
     assert evt2.output_index == 1
     # The delta will be a chunk of the arguments, not the full arguments
     assert len(evt2.delta) <= 10  # Chunks are max 10 characters
+
+
+def test_sync_iterator_emits_message_then_text_for_same_chunk():
+    chunk = ModelResponseStream(
+        id="chunk-sync-1",
+        created=123,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="DeepSeek final answer",
+                ),
+            )
+        ],
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=_StaticSyncStream([chunk]),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    evt1 = next(iterator)
+    evt2 = next(iterator)
+    evt3 = next(iterator)
+
+    assert evt1.type == ResponsesAPIStreamEvents.RESPONSE_CREATED
+    assert evt2.type == ResponsesAPIStreamEvents.RESPONSE_IN_PROGRESS
+    assert evt3.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+
+    evt4 = next(iterator)
+    assert evt4.type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+    assert evt4.delta == "DeepSeek final answer"
+
+
+def test_sync_iterator_emits_message_item_when_text_arrives_after_tool_call():
+    tool_chunk = ModelResponseStream(
+        id="chunk-tool-1",
+        created=123,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "call_late_text",
+                            "type": "function",
+                            "function": {"name": "do_thing", "arguments": "{}"},
+                        }
+                    ],
+                ),
+            )
+        ],
+    )
+    text_chunk = ModelResponseStream(
+        id="chunk-text-1",
+        created=124,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="Final answer after tool call",
+                ),
+            )
+        ],
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=_StaticSyncStream([tool_chunk, text_chunk]),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    seen_events = []
+    for _ in range(8):
+        seen_events.append(next(iterator))
+
+    message_item_events = [
+        evt
+        for evt in seen_events
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+        and getattr(getattr(evt, "item", None), "type", None) == "message"
+    ]
+    text_delta_events = [
+        evt
+        for evt in seen_events
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+    ]
+
+    assert len(message_item_events) == 1
+    assert len(text_delta_events) == 1
+    assert text_delta_events[0].delta == "Final answer after tool call"
 
 
 def test_tool_calls_present_only_in_final_response_are_emitted_before_completed():
@@ -120,11 +241,11 @@ def test_tool_calls_present_only_in_final_response_are_emitted_before_completed(
             delta_events.append(evt)
         else:
             break
-    
+
     # Verify we got delta events
     assert len(delta_events) > 0
     # Verify they reconstruct the original arguments
-    concatenated_args = ''.join(evt.delta for evt in delta_events)
+    concatenated_args = "".join(evt.delta for evt in delta_events)
     assert concatenated_args == '{"y":2}'
 
     # The last event should be FUNCTION_CALL_ARGUMENTS_DONE
@@ -142,8 +263,8 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     """
     Test that large tool call arguments are split into smaller chunks (size 10)
     to replicate OpenAI's native streaming behavior.
-    
-    This is especially important for providers like Bedrock that send complete 
+
+    This is especially important for providers like Bedrock that send complete
     arguments at once, which need to be split to match OpenAI's token-by-token streaming.
     """
     iterator = LiteLLMCompletionStreamingIterator(
@@ -154,7 +275,9 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     )
 
     # Create a chunk with a large arguments string that should be split
-    large_arguments = '{"param1": "value1", "param2": "value2", "param3": "value3"}'  # 67 chars
+    large_arguments = (
+        '{"param1": "value1", "param2": "value2", "param3": "value3"}'  # 67 chars
+    )
     chunk = ModelResponseStream(
         id="chunk-1",
         created=123,
@@ -171,7 +294,10 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
                         {
                             "id": "call_test",
                             "type": "function",
-                            "function": {"name": "test_function", "arguments": large_arguments},
+                            "function": {
+                                "name": "test_function",
+                                "arguments": large_arguments,
+                            },
                         }
                     ],
                 ),
@@ -181,13 +307,13 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
 
     # Process the chunk once - it queues all events internally
     evt = iterator._transform_chat_completion_chunk_to_response_api_chunk(chunk)
-    
+
     # First event should be OUTPUT_ITEM_ADDED
     assert evt is not None
     assert evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
     assert evt.output_index == 1
-    assert hasattr(evt, '__dict__') and 'sequence_number' in evt.__dict__
-    
+    assert hasattr(evt, "__dict__") and "sequence_number" in evt.__dict__
+
     # Collect all remaining delta events from the pending queue by creating empty chunks
     delta_events = []
     empty_chunk = ModelResponseStream(
@@ -203,29 +329,31 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
             )
         ],
     )
-    
+
     # Keep draining pending events (expected: ceil(67 / 10) = 7 delta events)
     while iterator._pending_tool_events:
-        evt = iterator._transform_chat_completion_chunk_to_response_api_chunk(empty_chunk)
+        evt = iterator._transform_chat_completion_chunk_to_response_api_chunk(
+            empty_chunk
+        )
         if evt and evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA:
             delta_events.append(evt)
-    
+
     # Verify multiple delta events were created (at least 6 chunks for 67 chars)
     assert len(delta_events) >= 6  # 67 chars split into chunks of max 10 chars each
-    
+
     # Verify each delta is at most 10 characters
     for evt in delta_events:
         assert len(evt.delta) <= 10
         assert evt.item_id == "call_test"
         assert evt.output_index == 1
-        assert hasattr(evt, '__dict__') and 'sequence_number' in evt.__dict__
-    
+        assert hasattr(evt, "__dict__") and "sequence_number" in evt.__dict__
+
     # Verify all deltas concatenated equal the original arguments
-    concatenated = ''.join(evt.delta for evt in delta_events)
+    concatenated = "".join(evt.delta for evt in delta_events)
     assert concatenated == large_arguments
-    
+
     # Verify sequence numbers are increasing
-    sequence_numbers = [evt.__dict__['sequence_number'] for evt in delta_events]
+    sequence_numbers = [evt.__dict__["sequence_number"] for evt in delta_events]
     assert sequence_numbers == sorted(sequence_numbers)
     assert len(set(sequence_numbers)) == len(sequence_numbers)  # All unique
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -10,6 +10,8 @@ before response.completed.
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )
@@ -31,6 +33,20 @@ class _StaticSyncStream:
     def __next__(self):
         if self._index >= len(self._chunks):
             raise StopIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+
+class _StaticAsyncStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self._index = 0
+        self.logging_obj = AsyncMock()
+
+    async def __anext__(self):
+        if self._index >= len(self._chunks):
+            raise StopAsyncIteration
         chunk = self._chunks[self._index]
         self._index += 1
         return chunk
@@ -189,6 +205,168 @@ def test_sync_iterator_emits_message_item_when_text_arrives_after_tool_call():
     assert len(message_item_events) == 1
     assert len(text_delta_events) == 1
     assert text_delta_events[0].delta == "Final answer after tool call"
+
+
+def test_sync_iterator_emits_reasoning_done_events_before_completion():
+    reasoning_chunk = ModelResponseStream(
+        id="chunk-reasoning-1",
+        created=123,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="",
+                    reasoning_content="step1 ",
+                ),
+            )
+        ],
+    )
+    text_chunk = ModelResponseStream(
+        id="chunk-text-1",
+        created=124,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="answer",
+                ),
+            )
+        ],
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=_StaticSyncStream([reasoning_chunk, text_chunk]),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    seen_events = []
+    while True:
+        try:
+            seen_events.append(next(iterator))
+        except StopIteration:
+            break
+
+    event_types = [event.type for event in seen_events]
+    assert ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DONE in event_types
+    assert ResponsesAPIStreamEvents.REASONING_SUMMARY_PART_DONE in event_types
+
+    reasoning_item_done_indexes = [
+        idx
+        for idx, event in enumerate(seen_events)
+        if event.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
+        and getattr(getattr(event, "item", None), "type", None) == "reasoning"
+    ]
+    response_completed_index = event_types.index(
+        ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+    )
+
+    assert len(reasoning_item_done_indexes) == 1
+    assert reasoning_item_done_indexes[0] < response_completed_index
+
+
+@pytest.mark.asyncio
+async def test_async_mixed_reasoning_chunk_closes_reasoning_item_before_completion():
+    mixed_chunk = ModelResponseStream(
+        id="chunk-mixed-1",
+        created=123,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="final answer",
+                    reasoning_content="thinking...",
+                ),
+            )
+        ],
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=_StaticAsyncStream([mixed_chunk]),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    seen_events = []
+    while True:
+        try:
+            seen_events.append(await iterator.__anext__())
+        except StopAsyncIteration:
+            break
+
+    event_types = [event.type for event in seen_events]
+    assert ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DONE in event_types
+    assert ResponsesAPIStreamEvents.REASONING_SUMMARY_PART_DONE in event_types
+
+    reasoning_item_done_indexes = [
+        idx
+        for idx, event in enumerate(seen_events)
+        if event.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
+        and getattr(getattr(event, "item", None), "type", None) == "reasoning"
+    ]
+    response_completed_index = event_types.index(
+        ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+    )
+
+    assert len(reasoning_item_done_indexes) == 1
+    assert reasoning_item_done_indexes[0] < response_completed_index
+
+
+def test_reasoning_delta_item_id_matches_reasoning_output_item_id():
+    chunk = ModelResponseStream(
+        id="chunk-reasoning-id-1",
+        created=123,
+        model="test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content="",
+                    reasoning_content="thinking...",
+                ),
+            )
+        ],
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    iterator._ensure_output_item_for_chunk(chunk)
+    output_item_added_event = iterator._pending_response_events.pop(0)
+    reasoning_delta_event = (
+        iterator._transform_chat_completion_chunk_to_response_api_chunk(chunk)
+    )
+
+    assert output_item_added_event is not None
+    assert reasoning_delta_event is not None
+    assert output_item_added_event.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+    assert (
+        reasoning_delta_event.type
+        == ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA
+    )
+    assert output_item_added_event.item.type == "reasoning"
+    assert reasoning_delta_event.item_id == output_item_added_event.item.id
 
 
 def test_tool_calls_present_only_in_final_response_are_emitted_before_completed():


### PR DESCRIPTION
## Summary
- restore the DeepSeek chat -> Responses bridge used by Codex-style clients
- preserve assistant text when reasoning and normal text share a stream chunk
- keep text output visible after tool calls instead of dropping same-chunk deltas
- add regression coverage for reasoning/text and tool-call streaming edge cases

## Testing
- `./.venv/bin/pytest -q tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py`
- `./.venv/bin/pytest -q tests/test_litellm/responses/litellm_completion_transformation`
  - local review note: this directory still has pre-existing failures unrelated to this patch in `test_litellm_completion_responses.py`, `test_tool_call_chain.py`, and one proxy/cold-storage dependency path
