### PR TITLE
fix(core): map Anthropic 'refusal' finish reason to 'content_filter'

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -94,6 +94,8 @@ def map_finish_reason(
         return "length"
     elif finish_reason == "tool_use":  # anthropic
         return "tool_calls"
+    elif finish_reason == "refusal":  # anthropic - model refused to respond
+        return "content_filter"
     elif finish_reason == "compaction":
         return "length"
     return finish_reason

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -1,6 +1,52 @@
 """Tests for litellm_core_utils.core_helpers module."""
 
-from litellm.litellm_core_utils.core_helpers import reconstruct_model_name
+import pytest
+
+from litellm.litellm_core_utils.core_helpers import map_finish_reason, reconstruct_model_name
+
+
+# ---------------------------------------------------------------------------
+# map_finish_reason
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Anthropic-specific mappings
+        ("stop_sequence", "stop"),
+        ("end_turn", "stop"),
+        ("max_tokens", "length"),
+        ("tool_use", "tool_calls"),
+        ("refusal", "content_filter"),  # Anthropic refuses to respond
+        ("compaction", "length"),
+        # Cohere
+        ("COMPLETE", "stop"),
+        ("MAX_TOKENS", "length"),
+        ("ERROR_TOXIC", "content_filter"),
+        ("ERROR", "stop"),
+        # Vertex AI
+        ("SAFETY", "content_filter"),
+        ("RECITATION", "content_filter"),
+        ("STOP", "stop"),
+        ("MALFORMED_FUNCTION_CALL", "malformed_function_call"),
+        # HuggingFace
+        ("eos_token", "stop"),
+        # Pass-through for unknown reasons
+        ("unknown_reason", "unknown_reason"),
+    ],
+)
+def test_map_finish_reason(raw: str, expected: str):
+    """map_finish_reason should normalise provider-specific finish reasons."""
+    assert map_finish_reason(raw) == expected
+
+
+def test_map_finish_reason_anthropic_refusal_returns_content_filter():
+    """Anthropic 'refusal' finish reason must map to OpenAI 'content_filter'."""
+    result = map_finish_reason("refusal")
+    assert result == "content_filter", (
+        f"Expected 'content_filter' for Anthropic 'refusal', got {result!r}"
+    )
 
 
 def test_reconstruct_model_name_prefers_deployment_value():


### PR DESCRIPTION
## Problem

Anthropic models can return `"refusal"` as a `finish_reason` (documented at https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons#refusal) when the model declines to respond to a request. This reason was not handled in `map_finish_reason()`, so it either passed through unmapped or was previously mapped to `"stop"` (lossy).

## Solution

Add an explicit mapping for `"refusal"` → `"content_filter"`, which aligns with the OpenAI convention for model-refused responses and preserves the semantics of the refusal for downstream consumers.

```python
elif finish_reason == "refusal":  # anthropic - model refused to respond
    return "content_filter"
```

## Testing

- Syntax verified with Python AST parser
- Aligns with OpenAI's `content_filter` finish reason used for refusals

Fixes #23793
