### PR TITLE
fix(proxy): preserve pre-call 429 behavior without fallbacks

### DIFF
--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -433,7 +433,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             data: Request data dictionary
 
         Raises:
-            HTTPException: If any limit is exceeded
+            litellm.RateLimitError: If any limit is exceeded (allows router fallbacks)
         """
         import json
 
@@ -472,50 +472,42 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         )
 
         # PHASE 2: Decide which limits to enforce
-        if check_response["overall_code"] == "OVER_LIMIT":
-            for status in check_response["statuses"]:
-                if status["code"] == "OVER_LIMIT":
-                    descriptor_key = status["descriptor_key"]
+        # Check both OVER_LIMIT status and limit_remaining <= 0 (at capacity)
+        for status in check_response["statuses"]:
+            descriptor_key = status["descriptor_key"]
+            is_over_limit = (
+                status["code"] == "OVER_LIMIT" or status["limit_remaining"] <= 0
+            )
 
-                    # Model-wide limit exceeded (ALWAYS enforce)
-                    if descriptor_key == "model_saturation_check":
-                        raise HTTPException(
-                            status_code=429,
-                            detail={
-                                "error": f"Model capacity reached for {model}. "
-                                f"Priority: {priority}, "
-                                f"Rate limit type: {status['rate_limit_type']}, "
-                                f"Remaining: {status['limit_remaining']}"
-                            },
-                            headers={
-                                "retry-after": str(self.v3_limiter.window_size),
-                                "rate_limit_type": str(status["rate_limit_type"]),
-                                "x-litellm-priority": priority or "default",
-                            },
-                        )
+            if is_over_limit:
+                # Model-wide limit exceeded (ALWAYS enforce)
+                if descriptor_key == "model_saturation_check":
+                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
+                    raise litellm.RateLimitError(
+                        message=f"Model capacity reached for {model}. "
+                        f"Priority: {priority}, "
+                        f"Rate limit type: {status['rate_limit_type']}, "
+                        f"Remaining: {status['limit_remaining']}",
+                        model=model,
+                        llm_provider="litellm_proxy",
+                    )
 
-                    # Priority limit exceeded (ONLY enforce when saturated)
-                    elif descriptor_key == "priority_model" and should_enforce_priority:
-                        verbose_proxy_logger.debug(
-                            f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
-                            f"priority: {priority}"
-                        )
-                        raise HTTPException(
-                            status_code=429,
-                            detail={
-                                "error": f"Priority-based rate limit exceeded. "
-                                f"Priority: {priority}, "
-                                f"Rate limit type: {status['rate_limit_type']}, "
-                                f"Remaining: {status['limit_remaining']}, "
-                                f"Model saturation: {saturation:.1%}"
-                            },
-                            headers={
-                                "retry-after": str(self.v3_limiter.window_size),
-                                "rate_limit_type": str(status["rate_limit_type"]),
-                                "x-litellm-priority": priority or "default",
-                                "x-litellm-saturation": f"{saturation:.2%}",
-                            },
-                        )
+                # Priority limit exceeded (ONLY enforce when saturated)
+                elif descriptor_key == "priority_model" and should_enforce_priority:
+                    verbose_proxy_logger.debug(
+                        f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
+                        f"priority: {priority}"
+                    )
+                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
+                    raise litellm.RateLimitError(
+                        message=f"Priority-based rate limit exceeded. "
+                        f"Priority: {priority}, "
+                        f"Rate limit type: {status['rate_limit_type']}, "
+                        f"Remaining: {status['limit_remaining']}, "
+                        f"Model saturation: {saturation:.1%}",
+                        model=model,
+                        llm_provider="litellm_proxy",
+                    )
 
         # PHASE 3: Increment counters separately to avoid early-exit issues
         # Model counter must ALWAYS increment, but priority counter might be over limit
@@ -579,6 +571,10 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         - Model counter increments but priority check fails → model over-capacity
         - Priority counter increments but not enforced → inaccurate metrics
 
+        When rate limit is exceeded:
+        - If fallbacks are configured: sets marker on data for router fallback path
+        - If no fallbacks are configured: raises litellm.RateLimitError
+
         Args:
             user_api_key_dict: User authentication and metadata
             cache: Dual cache instance
@@ -586,8 +582,22 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             call_type: Type of API call being made
 
         Returns:
-            None if request is allowed, otherwise raises HTTPException
+            None if request is allowed
+            Raises RateLimitError if rate limit exceeded and no fallback path exists
         """
+        def _should_defer_to_router_fallback(_data: dict) -> bool:
+            """
+            Defer rate-limit handling to router only when a fallback path exists.
+
+            This preserves legacy behavior (raise in pre-call) for no-fallback setups.
+            """
+            request_fallbacks = _data.get("fallbacks")
+            if request_fallbacks:
+                return True
+
+            router_fallbacks = getattr(getattr(self, "llm_router", None), "fallbacks", None)
+            return bool(router_fallbacks)
+
         if "model" not in data:
             return None
 
@@ -631,7 +641,17 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                 data=data,
             )
 
-        except HTTPException:
+        except litellm.RateLimitError as e:
+            if _should_defer_to_router_fallback(data):
+                # Mark request so router fallback flow can consume the error.
+                verbose_proxy_logger.info(
+                    f"Rate limit exceeded for {model} (priority={priority}), "
+                    f"marking for router fallback"
+                )
+                data["_litellm_rate_limit_error"] = e
+                return None
+
+            # No fallback path configured: preserve fail-fast behavior.
             raise
         except Exception as e:
             verbose_proxy_logger.error(

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -433,7 +433,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             data: Request data dictionary
 
         Raises:
-            litellm.RateLimitError: If any limit is exceeded (allows router fallbacks)
+            HTTPException: If any limit is exceeded
         """
         import json
 
@@ -472,24 +472,33 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         )
 
         # PHASE 2: Decide which limits to enforce
-        # Check both OVER_LIMIT status and limit_remaining <= 0 (at capacity)
+        # Keep backward-compatible behavior for priority checks and only treat
+        # model capacity as exhausted when remaining capacity is <= 0.
         for status in check_response["statuses"]:
             descriptor_key = status["descriptor_key"]
-            is_over_limit = (
-                status["code"] == "OVER_LIMIT" or status["limit_remaining"] <= 0
-            )
+            is_over_limit = status["code"] == "OVER_LIMIT"
+            if (
+                descriptor_key == "model_saturation_check"
+                and status["limit_remaining"] <= 0
+            ):
+                is_over_limit = True
 
             if is_over_limit:
                 # Model-wide limit exceeded (ALWAYS enforce)
                 if descriptor_key == "model_saturation_check":
-                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
-                    raise litellm.RateLimitError(
-                        message=f"Model capacity reached for {model}. "
-                        f"Priority: {priority}, "
-                        f"Rate limit type: {status['rate_limit_type']}, "
-                        f"Remaining: {status['limit_remaining']}",
-                        model=model,
-                        llm_provider="litellm_proxy",
+                    raise HTTPException(
+                        status_code=429,
+                        detail={
+                            "error": f"Model capacity reached for {model}. "
+                            f"Priority: {priority}, "
+                            f"Rate limit type: {status['rate_limit_type']}, "
+                            f"Remaining: {status['limit_remaining']}"
+                        },
+                        headers={
+                            "retry-after": str(self.v3_limiter.window_size),
+                            "rate_limit_type": str(status["rate_limit_type"]),
+                            "x-litellm-priority": priority or "default",
+                        },
                     )
 
                 # Priority limit exceeded (ONLY enforce when saturated)
@@ -498,15 +507,21 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                         f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
                         f"priority: {priority}"
                     )
-                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
-                    raise litellm.RateLimitError(
-                        message=f"Priority-based rate limit exceeded. "
-                        f"Priority: {priority}, "
-                        f"Rate limit type: {status['rate_limit_type']}, "
-                        f"Remaining: {status['limit_remaining']}, "
-                        f"Model saturation: {saturation:.1%}",
-                        model=model,
-                        llm_provider="litellm_proxy",
+                    raise HTTPException(
+                        status_code=429,
+                        detail={
+                            "error": f"Priority-based rate limit exceeded. "
+                            f"Priority: {priority}, "
+                            f"Rate limit type: {status['rate_limit_type']}, "
+                            f"Remaining: {status['limit_remaining']}, "
+                            f"Model saturation: {saturation:.1%}"
+                        },
+                        headers={
+                            "retry-after": str(self.v3_limiter.window_size),
+                            "rate_limit_type": str(status["rate_limit_type"]),
+                            "x-litellm-priority": priority or "default",
+                            "x-litellm-saturation": f"{saturation:.2%}",
+                        },
                     )
 
         # PHASE 3: Increment counters separately to avoid early-exit issues
@@ -572,8 +587,8 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         - Priority counter increments but not enforced → inaccurate metrics
 
         When rate limit is exceeded:
-        - If fallbacks are configured: sets marker on data for router fallback path
-        - If no fallbacks are configured: raises litellm.RateLimitError
+        - If model-specific fallback is configured: sets marker on data for router fallback
+        - If no fallback is configured for this model: raises HTTPException fail-fast
 
         Args:
             user_api_key_dict: User authentication and metadata
@@ -583,20 +598,41 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
 
         Returns:
             None if request is allowed
-            Raises RateLimitError if rate limit exceeded and no fallback path exists
+            Raises HTTPException if rate limit exceeded and no fallback path exists
         """
-        def _should_defer_to_router_fallback(_data: dict) -> bool:
+        def _to_ratelimit_error(http_exception: HTTPException) -> litellm.RateLimitError:
+            detail = http_exception.detail
+            if isinstance(detail, dict):
+                message = str(detail.get("error") or detail)
+            else:
+                message = str(detail)
+            return litellm.RateLimitError(
+                message=message,
+                model=model,
+                llm_provider="litellm_proxy",
+            )
+
+        def _has_fallback_for_model(_fallbacks: Optional[list], _model: str) -> bool:
+            if not _fallbacks:
+                return False
+            for item in _fallbacks:
+                if isinstance(item, dict):
+                    if _model in item or "*" in item:
+                        return True
+            return False
+
+        def _should_defer_to_router_fallback(_data: dict, _model: str) -> bool:
             """
             Defer rate-limit handling to router only when a fallback path exists.
 
             This preserves legacy behavior (raise in pre-call) for no-fallback setups.
             """
             request_fallbacks = _data.get("fallbacks")
-            if request_fallbacks:
+            if _has_fallback_for_model(request_fallbacks, _model):
                 return True
 
             router_fallbacks = getattr(getattr(self, "llm_router", None), "fallbacks", None)
-            return bool(router_fallbacks)
+            return _has_fallback_for_model(router_fallbacks, _model)
 
         if "model" not in data:
             return None
@@ -641,14 +677,14 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                 data=data,
             )
 
-        except litellm.RateLimitError as e:
-            if _should_defer_to_router_fallback(data):
+        except HTTPException as e:
+            if _should_defer_to_router_fallback(data, model):
                 # Mark request so router fallback flow can consume the error.
                 verbose_proxy_logger.info(
                     f"Rate limit exceeded for {model} (priority={priority}), "
                     f"marking for router fallback"
                 )
-                data["_litellm_rate_limit_error"] = e
+                data["_litellm_rate_limit_error"] = _to_ratelimit_error(e)
                 return None
 
             # No fallback path configured: preserve fail-fast behavior.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5426,6 +5426,15 @@ class Router:
         mock_timeout = kwargs.pop("mock_timeout", None)
 
         try:
+            # Check if request was rate-limited by pre-call hook (dynamic_rate_limiter_v3)
+            # If so, raise the error immediately to trigger fallback logic
+            rate_limit_error = kwargs.pop("_litellm_rate_limit_error", None)
+            if rate_limit_error is not None:
+                verbose_router_logger.info(
+                    f"Rate limit detected from pre-call hook for {model_group}, triggering fallback"
+                )
+                raise rate_limit_error
+            
             self._handle_mock_testing_fallbacks(
                 kwargs=kwargs,
                 model_group=model_group,

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -1601,3 +1601,181 @@ async def test_async_log_success_event_uses_team_priority_from_auth_metadata():
     assert "default_pool" not in priority_keys[0], (
         f"Priority key should NOT use 'default_pool', should use team's priority. Got: {priority_keys[0]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_marker_set_for_router_fallback():
+    """
+    Validate pre-call behavior for router fallback integration.
+
+    When primary model capacity is exhausted, dynamic_rate_limiter_v3 should:
+    - avoid raising HTTPException in pre-call hook
+    - set _litellm_rate_limit_error in request data
+    - store a litellm.RateLimitError that router can use for fallback
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.0}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+
+    model = "ptu-primary"
+    fallback_model = "paygo-fallback"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 10,
+                },
+            },
+            {
+                "model_name": fallback_model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                },
+            },
+        ],
+        fallbacks=[{model: [fallback_model]}],
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=10,  # at limit
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+
+    data = {"model": model, "messages": [{"role": "user", "content": "test"}]}
+    result = await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is None
+    assert "_litellm_rate_limit_error" in data
+    assert isinstance(data["_litellm_rate_limit_error"], litellm.RateLimitError)
+    assert "Model capacity reached" in str(data["_litellm_rate_limit_error"])
+
+
+@pytest.mark.asyncio
+async def test_priority_limit_enforced_only_when_saturated_sets_fallback_marker():
+    """
+    Validate saturation-aware priority enforcement with fallback marker behavior.
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.2}
+    litellm.priority_reservation_settings.saturation_threshold = 0.5
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+    model = "test-model"
+    fallback_model = "fallback-model"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 100,
+                },
+            },
+            {
+                "model_name": fallback_model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                },
+            },
+        ],
+        fallbacks=[{model: [fallback_model]}],
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    priority_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="priority_model",
+        value=f"{model}:low",
+        rate_limit_type="requests",
+    )
+
+    # Saturated case -> enforce priority limit -> marker must be set
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=60,  # 60% saturation > threshold 50%
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=priority_counter_key,
+        value=20,  # at low-priority allocation
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    data_saturated = {"model": model, "messages": [{"role": "user", "content": "a"}]}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data_saturated,
+        call_type="completion",
+    )
+    assert "_litellm_rate_limit_error" in data_saturated
+    assert isinstance(data_saturated["_litellm_rate_limit_error"], litellm.RateLimitError)
+    assert "Priority-based rate limit exceeded" in str(
+        data_saturated["_litellm_rate_limit_error"]
+    )
+
+    # Unsaturated case -> do not enforce priority limit -> marker must NOT be set
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=30,  # 30% saturation < threshold 50%
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=priority_counter_key,
+        value=20,
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    data_unsaturated = {"model": model, "messages": [{"role": "user", "content": "b"}]}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data_unsaturated,
+        call_type="completion",
+    )
+    assert "_litellm_rate_limit_error" not in data_unsaturated

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
@@ -1738,7 +1739,7 @@ async def test_priority_limit_enforced_only_when_saturated_sets_fallback_marker(
     )
     await handler.internal_usage_cache.async_set_cache(
         key=priority_counter_key,
-        value=20,  # at low-priority allocation
+        value=21,  # over low-priority allocation
         ttl=60,
         litellm_parent_otel_span=None,
         local_only=False,
@@ -1779,3 +1780,58 @@ async def test_priority_limit_enforced_only_when_saturated_sets_fallback_marker(
         call_type="completion",
     )
     assert "_litellm_rate_limit_error" not in data_unsaturated
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_raises_fail_fast_rate_limit():
+    """
+    Ensure no-fallback path preserves fail-fast pre-call behavior.
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.0}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+    model = "no-fallback-model"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 10,
+                },
+            }
+        ]
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=10,  # at model limit
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+
+    data = {"model": model, "messages": [{"role": "user", "content": "test"}]}
+    with pytest.raises(HTTPException):
+        await handler.async_pre_call_hook(
+            user_api_key_dict=low_priority_user,
+            cache=dual_cache,
+            data=data,
+            call_type="completion",
+        )
+
+    assert "_litellm_rate_limit_error" not in data


### PR DESCRIPTION
Fixes #23749

## Summary
- Make `dynamic_rate_limiter_v3` fallback-aware: if fallback routes exist, set `_litellm_rate_limit_error` for router handling; if no fallback exists, keep fail-fast behavior by raising `RateLimitError` from pre-call.
- Keep router-side handling for `_litellm_rate_limit_error` so configured fallbacks can redirect rate-limited calls.
- Add test coverage in `tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py` for fallback-marker behavior with configured fallbacks.

**Before**
<img width="1101" height="237" alt="image" src="https://github.com/user-attachments/assets/c0fb4e53-a577-4376-a7c8-57a3fee63917" />

**Now**
<img width="1101" height="452" alt="image" src="https://github.com/user-attachments/assets/0a7d26e6-7d60-4000-9dad-d1b5ad6303c3" />

