### PR TITLE
 fix(proxy): preserve pre-call 429 behavior without fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ litellm/proxy/log.txt
 proxy_server_config_@.yaml
 .gitignore
 proxy_server_config_2.yaml
+proxy_server.log
+proxy_server_config.yaml
 litellm/proxy/secret_managers/credentials.json
 hosted_config.yaml
 litellm/proxy/tests/node_modules

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -17,10 +17,14 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.hooks.parallel_request_limiter_v3 import (
     RateLimitDescriptor,
     RateLimitDescriptorRateLimitObject,
+    RateLimitStatus,
     _PROXY_MaxParallelRequestsHandler_v3,
 )
 from litellm.proxy.hooks.rate_limiter_utils import convert_priority_to_percent
 from litellm.proxy.utils import InternalUsageCache
+from litellm.router_utils.fallback_event_handlers import (
+    _check_non_standard_fallback_format,
+)
 from litellm.types.router import ModelGroupInfo
 from litellm.types.utils import CallTypesLiteral
 
@@ -471,44 +475,43 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             f"Read-only check: {json.dumps(check_response, indent=2)}"
         )
 
-        # PHASE 2: Decide which limits to enforce
-        # Only proceed if the overall rate limiter verdict is OVER_LIMIT.
-        # This preserves backward-compatible behavior for existing users.
-        # Exception: for model_saturation_check, also enforce if limit_remaining <= 0
-        # (exact-capacity boundary condition).
+        # PHASE 2: Decide which limits to enforce.
+        # Helper to raise a uniform 429 for model saturation, used in both the
+        # OVER_LIMIT branch and the exact-capacity boundary check below.
+        def _raise_model_saturation_exceeded(status: RateLimitStatus) -> None:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": f"Model capacity reached for {model}. "
+                    f"Priority: {priority}, "
+                    f"Rate limit type: {status['rate_limit_type']}, "
+                    f"Remaining: {status['limit_remaining']}"
+                },
+                headers={
+                    "retry-after": str(self.v3_limiter.window_size),
+                    "rate_limit_type": str(status["rate_limit_type"]),
+                    "x-litellm-priority": priority or "default",
+                },
+            )
+
+        # Always scan statuses for the model saturation boundary condition
+        # (limit_remaining <= 0).  The rate limiter may report overall_code=OK
+        # in the same window tick that fills the last slot; we must still block
+        # that request so the counter stays accurate.
+        for status in check_response["statuses"]:
+            if (
+                status["descriptor_key"] == "model_saturation_check"
+                and status["limit_remaining"] <= 0
+            ):
+                _raise_model_saturation_exceeded(status)
+
+        # For OVER_LIMIT responses, also enforce priority limits when saturated.
         if check_response["overall_code"] == "OVER_LIMIT":
             for status in check_response["statuses"]:
                 descriptor_key = status["descriptor_key"]
-                is_over_limit = status["code"] == "OVER_LIMIT"
-                
-                # For model saturation, also consider the boundary condition: limit_remaining <= 0
-                # This ensures exact-capacity scenarios are treated as over-limit.
-                if (
-                    descriptor_key == "model_saturation_check"
-                    and status["limit_remaining"] <= 0
-                ):
-                    is_over_limit = True
-
-                if is_over_limit:
-                    # Model-wide limit exceeded (ALWAYS enforce)
-                    if descriptor_key == "model_saturation_check":
-                        raise HTTPException(
-                            status_code=429,
-                            detail={
-                                "error": f"Model capacity reached for {model}. "
-                                f"Priority: {priority}, "
-                                f"Rate limit type: {status['rate_limit_type']}, "
-                                f"Remaining: {status['limit_remaining']}"
-                            },
-                            headers={
-                                "retry-after": str(self.v3_limiter.window_size),
-                                "rate_limit_type": str(status["rate_limit_type"]),
-                                "x-litellm-priority": priority or "default",
-                            },
-                        )
-
+                if status["code"] == "OVER_LIMIT":
                     # Priority limit exceeded (ONLY enforce when saturated)
-                    elif descriptor_key == "priority_model" and should_enforce_priority:
+                    if descriptor_key == "priority_model" and should_enforce_priority:
                         verbose_proxy_logger.debug(
                             f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
                             f"priority: {priority}"
@@ -529,28 +532,6 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                                 "x-litellm-saturation": f"{saturation:.2%}",
                             },
                         )
-        else:
-            # Even if overall_code is OK, enforce the model saturation boundary condition
-            for status in check_response["statuses"]:
-                descriptor_key = status["descriptor_key"]
-                if (
-                    descriptor_key == "model_saturation_check"
-                    and status["limit_remaining"] <= 0
-                ):
-                    raise HTTPException(
-                        status_code=429,
-                        detail={
-                            "error": f"Model capacity reached for {model}. "
-                            f"Priority: {priority}, "
-                            f"Rate limit type: {status['rate_limit_type']}, "
-                            f"Remaining: {status['limit_remaining']}"
-                        },
-                        headers={
-                            "retry-after": str(self.v3_limiter.window_size),
-                            "rate_limit_type": str(status["rate_limit_type"]),
-                            "x-litellm-priority": priority or "default",
-                        },
-                    )
 
 
         # PHASE 3: Increment counters separately to avoid early-exit issues
@@ -632,6 +613,11 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         def _has_fallback_for_model(_fallbacks: Optional[list], _model: str) -> bool:
             if not _fallbacks:
                 return False
+            # Non-standard formats (flat string list or LiteLLMParams dict list) are
+            # treated as model-agnostic fallbacks — the router will try them regardless
+            # of which model group triggered the rate limit.
+            if _check_non_standard_fallback_format(_fallbacks):
+                return True
             for item in _fallbacks:
                 if isinstance(item, dict):
                     if _model in item or "*" in item:

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -433,7 +433,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             data: Request data dictionary
 
         Raises:
-            litellm.RateLimitError: If any limit is exceeded (allows router fallbacks)
+            HTTPException: If any limit is exceeded
         """
         import json
 
@@ -472,42 +472,86 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         )
 
         # PHASE 2: Decide which limits to enforce
-        # Check both OVER_LIMIT status and limit_remaining <= 0 (at capacity)
-        for status in check_response["statuses"]:
-            descriptor_key = status["descriptor_key"]
-            is_over_limit = (
-                status["code"] == "OVER_LIMIT" or status["limit_remaining"] <= 0
-            )
+        # Only proceed if the overall rate limiter verdict is OVER_LIMIT.
+        # This preserves backward-compatible behavior for existing users.
+        # Exception: for model_saturation_check, also enforce if limit_remaining <= 0
+        # (exact-capacity boundary condition).
+        if check_response["overall_code"] == "OVER_LIMIT":
+            for status in check_response["statuses"]:
+                descriptor_key = status["descriptor_key"]
+                is_over_limit = status["code"] == "OVER_LIMIT"
+                
+                # For model saturation, also consider the boundary condition: limit_remaining <= 0
+                # This ensures exact-capacity scenarios are treated as over-limit.
+                if (
+                    descriptor_key == "model_saturation_check"
+                    and status["limit_remaining"] <= 0
+                ):
+                    is_over_limit = True
 
-            if is_over_limit:
-                # Model-wide limit exceeded (ALWAYS enforce)
-                if descriptor_key == "model_saturation_check":
-                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
-                    raise litellm.RateLimitError(
-                        message=f"Model capacity reached for {model}. "
-                        f"Priority: {priority}, "
-                        f"Rate limit type: {status['rate_limit_type']}, "
-                        f"Remaining: {status['limit_remaining']}",
-                        model=model,
-                        llm_provider="litellm_proxy",
+                if is_over_limit:
+                    # Model-wide limit exceeded (ALWAYS enforce)
+                    if descriptor_key == "model_saturation_check":
+                        raise HTTPException(
+                            status_code=429,
+                            detail={
+                                "error": f"Model capacity reached for {model}. "
+                                f"Priority: {priority}, "
+                                f"Rate limit type: {status['rate_limit_type']}, "
+                                f"Remaining: {status['limit_remaining']}"
+                            },
+                            headers={
+                                "retry-after": str(self.v3_limiter.window_size),
+                                "rate_limit_type": str(status["rate_limit_type"]),
+                                "x-litellm-priority": priority or "default",
+                            },
+                        )
+
+                    # Priority limit exceeded (ONLY enforce when saturated)
+                    elif descriptor_key == "priority_model" and should_enforce_priority:
+                        verbose_proxy_logger.debug(
+                            f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
+                            f"priority: {priority}"
+                        )
+                        raise HTTPException(
+                            status_code=429,
+                            detail={
+                                "error": f"Priority-based rate limit exceeded. "
+                                f"Priority: {priority}, "
+                                f"Rate limit type: {status['rate_limit_type']}, "
+                                f"Remaining: {status['limit_remaining']}, "
+                                f"Model saturation: {saturation:.1%}"
+                            },
+                            headers={
+                                "retry-after": str(self.v3_limiter.window_size),
+                                "rate_limit_type": str(status["rate_limit_type"]),
+                                "x-litellm-priority": priority or "default",
+                                "x-litellm-saturation": f"{saturation:.2%}",
+                            },
+                        )
+        else:
+            # Even if overall_code is OK, enforce the model saturation boundary condition
+            for status in check_response["statuses"]:
+                descriptor_key = status["descriptor_key"]
+                if (
+                    descriptor_key == "model_saturation_check"
+                    and status["limit_remaining"] <= 0
+                ):
+                    raise HTTPException(
+                        status_code=429,
+                        detail={
+                            "error": f"Model capacity reached for {model}. "
+                            f"Priority: {priority}, "
+                            f"Rate limit type: {status['rate_limit_type']}, "
+                            f"Remaining: {status['limit_remaining']}"
+                        },
+                        headers={
+                            "retry-after": str(self.v3_limiter.window_size),
+                            "rate_limit_type": str(status["rate_limit_type"]),
+                            "x-litellm-priority": priority or "default",
+                        },
                     )
 
-                # Priority limit exceeded (ONLY enforce when saturated)
-                elif descriptor_key == "priority_model" and should_enforce_priority:
-                    verbose_proxy_logger.debug(
-                        f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
-                        f"priority: {priority}"
-                    )
-                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
-                    raise litellm.RateLimitError(
-                        message=f"Priority-based rate limit exceeded. "
-                        f"Priority: {priority}, "
-                        f"Rate limit type: {status['rate_limit_type']}, "
-                        f"Remaining: {status['limit_remaining']}, "
-                        f"Model saturation: {saturation:.1%}",
-                        model=model,
-                        llm_provider="litellm_proxy",
-                    )
 
         # PHASE 3: Increment counters separately to avoid early-exit issues
         # Model counter must ALWAYS increment, but priority counter might be over limit
@@ -572,8 +616,8 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         - Priority counter increments but not enforced → inaccurate metrics
 
         When rate limit is exceeded:
-        - If fallbacks are configured: sets marker on data for router fallback path
-        - If no fallbacks are configured: raises litellm.RateLimitError
+        - If model-specific fallback is configured: sets marker on data for router fallback
+        - If no fallback is configured for this model: raises HTTPException fail-fast
 
         Args:
             user_api_key_dict: User authentication and metadata
@@ -583,20 +627,16 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
 
         Returns:
             None if request is allowed
-            Raises RateLimitError if rate limit exceeded and no fallback path exists
+            Raises HTTPException if rate limit exceeded and no fallback path exists
         """
-        def _should_defer_to_router_fallback(_data: dict) -> bool:
-            """
-            Defer rate-limit handling to router only when a fallback path exists.
-
-            This preserves legacy behavior (raise in pre-call) for no-fallback setups.
-            """
-            request_fallbacks = _data.get("fallbacks")
-            if request_fallbacks:
-                return True
-
-            router_fallbacks = getattr(getattr(self, "llm_router", None), "fallbacks", None)
-            return bool(router_fallbacks)
+        def _has_fallback_for_model(_fallbacks: Optional[list], _model: str) -> bool:
+            if not _fallbacks:
+                return False
+            for item in _fallbacks:
+                if isinstance(item, dict):
+                    if _model in item or "*" in item:
+                        return True
+            return False
 
         if "model" not in data:
             return None
@@ -605,6 +645,37 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         priority = self._get_priority_from_user_api_key_dict(
             user_api_key_dict=user_api_key_dict
         )
+
+        def _to_ratelimit_error(http_exception: HTTPException) -> litellm.RateLimitError:
+            detail = http_exception.detail
+            if isinstance(detail, dict):
+                message = str(detail.get("error") or detail)
+            else:
+                message = str(detail)
+            return litellm.RateLimitError(
+                message=message,
+                model=model,
+                llm_provider="litellm_proxy",
+            )
+
+        def _should_defer_to_router_fallback(_data: dict, _model: str) -> bool:
+            """
+            Defer rate-limit handling to router only when a fallback path exists.
+
+            This preserves legacy behavior (raise in pre-call) for no-fallback setups.
+            Respects the disable_fallbacks flag to preserve fail-fast behavior when
+            fallbacks are explicitly disabled.
+            """
+            # If fallbacks are explicitly disabled, always fail fast
+            if _data.get("disable_fallbacks", False):
+                return False
+
+            request_fallbacks = _data.get("fallbacks")
+            if _has_fallback_for_model(request_fallbacks, _model):
+                return True
+
+            router_fallbacks = getattr(getattr(self, "llm_router", None), "fallbacks", None)
+            return _has_fallback_for_model(router_fallbacks, _model)
 
         # Get model configuration
         model_group_info: Optional[
@@ -641,14 +712,14 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                 data=data,
             )
 
-        except litellm.RateLimitError as e:
-            if _should_defer_to_router_fallback(data):
+        except HTTPException as e:
+            if _should_defer_to_router_fallback(data, model):
                 # Mark request so router fallback flow can consume the error.
                 verbose_proxy_logger.info(
                     f"Rate limit exceeded for {model} (priority={priority}), "
                     f"marking for router fallback"
                 )
-                data["_litellm_rate_limit_error"] = e
+                data["_litellm_rate_limit_error"] = _to_ratelimit_error(e)
                 return None
 
             # No fallback path configured: preserve fail-fast behavior.

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -433,7 +433,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             data: Request data dictionary
 
         Raises:
-            HTTPException: If any limit is exceeded
+            litellm.RateLimitError: If any limit is exceeded (allows router fallbacks)
         """
         import json
 
@@ -472,50 +472,42 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         )
 
         # PHASE 2: Decide which limits to enforce
-        if check_response["overall_code"] == "OVER_LIMIT":
-            for status in check_response["statuses"]:
-                if status["code"] == "OVER_LIMIT":
-                    descriptor_key = status["descriptor_key"]
+        # Check both OVER_LIMIT status and limit_remaining <= 0 (at capacity)
+        for status in check_response["statuses"]:
+            descriptor_key = status["descriptor_key"]
+            is_over_limit = (
+                status["code"] == "OVER_LIMIT" or status["limit_remaining"] <= 0
+            )
 
-                    # Model-wide limit exceeded (ALWAYS enforce)
-                    if descriptor_key == "model_saturation_check":
-                        raise HTTPException(
-                            status_code=429,
-                            detail={
-                                "error": f"Model capacity reached for {model}. "
-                                f"Priority: {priority}, "
-                                f"Rate limit type: {status['rate_limit_type']}, "
-                                f"Remaining: {status['limit_remaining']}"
-                            },
-                            headers={
-                                "retry-after": str(self.v3_limiter.window_size),
-                                "rate_limit_type": str(status["rate_limit_type"]),
-                                "x-litellm-priority": priority or "default",
-                            },
-                        )
+            if is_over_limit:
+                # Model-wide limit exceeded (ALWAYS enforce)
+                if descriptor_key == "model_saturation_check":
+                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
+                    raise litellm.RateLimitError(
+                        message=f"Model capacity reached for {model}. "
+                        f"Priority: {priority}, "
+                        f"Rate limit type: {status['rate_limit_type']}, "
+                        f"Remaining: {status['limit_remaining']}",
+                        model=model,
+                        llm_provider="litellm_proxy",
+                    )
 
-                    # Priority limit exceeded (ONLY enforce when saturated)
-                    elif descriptor_key == "priority_model" and should_enforce_priority:
-                        verbose_proxy_logger.debug(
-                            f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
-                            f"priority: {priority}"
-                        )
-                        raise HTTPException(
-                            status_code=429,
-                            detail={
-                                "error": f"Priority-based rate limit exceeded. "
-                                f"Priority: {priority}, "
-                                f"Rate limit type: {status['rate_limit_type']}, "
-                                f"Remaining: {status['limit_remaining']}, "
-                                f"Model saturation: {saturation:.1%}"
-                            },
-                            headers={
-                                "retry-after": str(self.v3_limiter.window_size),
-                                "rate_limit_type": str(status["rate_limit_type"]),
-                                "x-litellm-priority": priority or "default",
-                                "x-litellm-saturation": f"{saturation:.2%}",
-                            },
-                        )
+                # Priority limit exceeded (ONLY enforce when saturated)
+                elif descriptor_key == "priority_model" and should_enforce_priority:
+                    verbose_proxy_logger.debug(
+                        f"Enforcing priority limits for {model}, saturation: {saturation:.1%}, "
+                        f"priority: {priority}"
+                    )
+                    # Raise RateLimitError instead of HTTPException to allow router fallbacks
+                    raise litellm.RateLimitError(
+                        message=f"Priority-based rate limit exceeded. "
+                        f"Priority: {priority}, "
+                        f"Rate limit type: {status['rate_limit_type']}, "
+                        f"Remaining: {status['limit_remaining']}, "
+                        f"Model saturation: {saturation:.1%}",
+                        model=model,
+                        llm_provider="litellm_proxy",
+                    )
 
         # PHASE 3: Increment counters separately to avoid early-exit issues
         # Model counter must ALWAYS increment, but priority counter might be over limit
@@ -579,6 +571,10 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         - Model counter increments but priority check fails → model over-capacity
         - Priority counter increments but not enforced → inaccurate metrics
 
+        When rate limit is exceeded:
+        - If fallbacks are configured: sets marker on data for router fallback path
+        - If no fallbacks are configured: raises litellm.RateLimitError
+
         Args:
             user_api_key_dict: User authentication and metadata
             cache: Dual cache instance
@@ -586,8 +582,22 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             call_type: Type of API call being made
 
         Returns:
-            None if request is allowed, otherwise raises HTTPException
+            None if request is allowed
+            Raises RateLimitError if rate limit exceeded and no fallback path exists
         """
+        def _should_defer_to_router_fallback(_data: dict) -> bool:
+            """
+            Defer rate-limit handling to router only when a fallback path exists.
+
+            This preserves legacy behavior (raise in pre-call) for no-fallback setups.
+            """
+            request_fallbacks = _data.get("fallbacks")
+            if request_fallbacks:
+                return True
+
+            router_fallbacks = getattr(getattr(self, "llm_router", None), "fallbacks", None)
+            return bool(router_fallbacks)
+
         if "model" not in data:
             return None
 
@@ -631,7 +641,17 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                 data=data,
             )
 
-        except HTTPException:
+        except litellm.RateLimitError as e:
+            if _should_defer_to_router_fallback(data):
+                # Mark request so router fallback flow can consume the error.
+                verbose_proxy_logger.info(
+                    f"Rate limit exceeded for {model} (priority={priority}), "
+                    f"marking for router fallback"
+                )
+                data["_litellm_rate_limit_error"] = e
+                return None
+
+            # No fallback path configured: preserve fail-fast behavior.
             raise
         except Exception as e:
             verbose_proxy_logger.error(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5426,6 +5426,15 @@ class Router:
         mock_timeout = kwargs.pop("mock_timeout", None)
 
         try:
+            # Check if request was rate-limited by pre-call hook (dynamic_rate_limiter_v3)
+            # If so, raise the error immediately to trigger fallback logic
+            rate_limit_error = kwargs.pop("_litellm_rate_limit_error", None)
+            if rate_limit_error is not None:
+                verbose_router_logger.info(
+                    f"Rate limit detected from pre-call hook for {model_group}, triggering fallback"
+                )
+                raise rate_limit_error
+            
             self._handle_mock_testing_fallbacks(
                 kwargs=kwargs,
                 model_group=model_group,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5433,9 +5433,18 @@ class Router:
             # rate-limit errors should follow normal fallback logic, not mock testing.
             rate_limit_error = kwargs.pop("_litellm_rate_limit_error", None)
             if rate_limit_error is not None:
-                verbose_router_logger.info(
-                    f"Rate limit detected from pre-call hook for {model_group}, triggering fallback"
-                )
+                if disable_fallbacks:
+                    # The pre-call hook should have raised HTTPException directly
+                    # when disable_fallbacks=True.  Log a warning if we reach here
+                    # unexpectedly (e.g. data dict and kwargs diverged).
+                    verbose_router_logger.debug(
+                        f"Unexpected: _litellm_rate_limit_error marker set for "
+                        f"{model_group} but disable_fallbacks=True. Raising directly."
+                    )
+                else:
+                    verbose_router_logger.info(
+                        f"Rate limit detected from pre-call hook for {model_group}, triggering fallback"
+                    )
                 raise rate_limit_error
             
             self._handle_mock_testing_fallbacks(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5427,7 +5427,10 @@ class Router:
 
         try:
             # Check if request was rate-limited by pre-call hook (dynamic_rate_limiter_v3)
-            # If so, raise the error immediately to trigger fallback logic
+            # If so, raise the error immediately to trigger fallback logic.
+            # Note: This is raised before _handle_mock_testing_fallbacks, so rate-limited
+            # requests skip the mock testing path. This is intentional — in production,
+            # rate-limit errors should follow normal fallback logic, not mock testing.
             rate_limit_error = kwargs.pop("_litellm_rate_limit_error", None)
             if rate_limit_error is not None:
                 verbose_router_logger.info(

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
@@ -1656,7 +1657,7 @@ async def test_rate_limit_error_marker_set_for_router_fallback():
     )
     await handler.internal_usage_cache.async_set_cache(
         key=model_counter_key,
-        value=10,  # at limit
+        value=11,  # over limit
         ttl=60,
         litellm_parent_otel_span=None,
         local_only=False,
@@ -1738,7 +1739,7 @@ async def test_priority_limit_enforced_only_when_saturated_sets_fallback_marker(
     )
     await handler.internal_usage_cache.async_set_cache(
         key=priority_counter_key,
-        value=20,  # at low-priority allocation
+        value=21,  # over low-priority allocation
         ttl=60,
         litellm_parent_otel_span=None,
         local_only=False,
@@ -1779,3 +1780,204 @@ async def test_priority_limit_enforced_only_when_saturated_sets_fallback_marker(
         call_type="completion",
     )
     assert "_litellm_rate_limit_error" not in data_unsaturated
+
+
+@pytest.mark.asyncio
+async def test_no_fallback_raises_fail_fast_rate_limit():
+    """
+    Ensure no-fallback path preserves fail-fast pre-call behavior.
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.0}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+    model = "no-fallback-model"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 10,
+                },
+            }
+        ]
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=11,  # over model limit
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+
+    data = {"model": model, "messages": [{"role": "user", "content": "test"}]}
+    with pytest.raises(HTTPException):
+        await handler.async_pre_call_hook(
+            user_api_key_dict=low_priority_user,
+            cache=dual_cache,
+            data=data,
+            call_type="completion",
+        )
+
+    assert "_litellm_rate_limit_error" not in data
+
+
+@pytest.mark.asyncio
+async def test_disable_fallbacks_preserves_fail_fast():
+    """
+    Ensure disable_fallbacks=True preserves fail-fast HTTPException behavior
+    even when router fallbacks are configured.
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.0}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+    model = "ptu-model"
+    fallback_model = "fallback-model"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 10,
+                },
+            },
+            {
+                "model_name": fallback_model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                },
+            },
+        ],
+        fallbacks=[{model: [fallback_model]}],
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    # Set model counter to exceed limit
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=11,
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+
+    # Request with disable_fallbacks=True should still raise HTTPException
+    data = {
+        "model": model,
+        "messages": [{"role": "user", "content": "test"}],
+        "disable_fallbacks": True,
+    }
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=low_priority_user,
+            cache=dual_cache,
+            data=data,
+            call_type="completion",
+        )
+
+    assert exc_info.value.status_code == 429
+    assert "_litellm_rate_limit_error" not in data
+
+
+@pytest.mark.asyncio
+async def test_limit_remaining_zero_boundary_condition():
+    """
+    Test the boundary condition where limit_remaining == 0 to ensure the
+    rate limiter correctly identifies this as an over-limit condition.
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.0}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+    model = "test-model"
+    fallback_model = "fallback-model"
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 10,
+                },
+            },
+            {
+                "model_name": fallback_model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                },
+            },
+        ],
+        fallbacks=[{model: [fallback_model]}],
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    # Set model counter exactly at capacity (limit_remaining will be 0)
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=10,
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+
+    # Request with configured fallback should set the marker
+    data = {"model": model, "messages": [{"role": "user", "content": "test"}]}
+    result = await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    # Pre-call hook returns None and sets the marker for router to handle
+    assert result is None
+    assert "_litellm_rate_limit_error" in data
+    assert isinstance(data["_litellm_rate_limit_error"], litellm.RateLimitError)
+

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -1601,3 +1601,181 @@ async def test_async_log_success_event_uses_team_priority_from_auth_metadata():
     assert "default_pool" not in priority_keys[0], (
         f"Priority key should NOT use 'default_pool', should use team's priority. Got: {priority_keys[0]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_marker_set_for_router_fallback():
+    """
+    Validate pre-call behavior for router fallback integration.
+
+    When primary model capacity is exhausted, dynamic_rate_limiter_v3 should:
+    - avoid raising HTTPException in pre-call hook
+    - set _litellm_rate_limit_error in request data
+    - store a litellm.RateLimitError that router can use for fallback
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.0}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+
+    model = "ptu-primary"
+    fallback_model = "paygo-fallback"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 10,
+                },
+            },
+            {
+                "model_name": fallback_model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                },
+            },
+        ],
+        fallbacks=[{model: [fallback_model]}],
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=10,  # at limit
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+
+    data = {"model": model, "messages": [{"role": "user", "content": "test"}]}
+    result = await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is None
+    assert "_litellm_rate_limit_error" in data
+    assert isinstance(data["_litellm_rate_limit_error"], litellm.RateLimitError)
+    assert "Model capacity reached" in str(data["_litellm_rate_limit_error"])
+
+
+@pytest.mark.asyncio
+async def test_priority_limit_enforced_only_when_saturated_sets_fallback_marker():
+    """
+    Validate saturation-aware priority enforcement with fallback marker behavior.
+    """
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"high": 0.8, "low": 0.2}
+    litellm.priority_reservation_settings.saturation_threshold = 0.5
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+    model = "test-model"
+    fallback_model = "fallback-model"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "rpm": 100,
+                },
+            },
+            {
+                "model_name": fallback_model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                },
+            },
+        ],
+        fallbacks=[{model: [fallback_model]}],
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    low_priority_user = UserAPIKeyAuth()
+    low_priority_user.metadata = {"priority": "low"}
+    low_priority_user.user_id = "low_user"
+
+    model_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="model_saturation_check",
+        value=model,
+        rate_limit_type="requests",
+    )
+    priority_counter_key = handler.v3_limiter.create_rate_limit_keys(
+        key="priority_model",
+        value=f"{model}:low",
+        rate_limit_type="requests",
+    )
+
+    # Saturated case -> enforce priority limit -> marker must be set
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=60,  # 60% saturation > threshold 50%
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=priority_counter_key,
+        value=20,  # at low-priority allocation
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    data_saturated = {"model": model, "messages": [{"role": "user", "content": "a"}]}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data_saturated,
+        call_type="completion",
+    )
+    assert "_litellm_rate_limit_error" in data_saturated
+    assert isinstance(data_saturated["_litellm_rate_limit_error"], litellm.RateLimitError)
+    assert "Priority-based rate limit exceeded" in str(
+        data_saturated["_litellm_rate_limit_error"]
+    )
+
+    # Unsaturated case -> do not enforce priority limit -> marker must NOT be set
+    await handler.internal_usage_cache.async_set_cache(
+        key=model_counter_key,
+        value=30,  # 30% saturation < threshold 50%
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    await handler.internal_usage_cache.async_set_cache(
+        key=priority_counter_key,
+        value=20,
+        ttl=60,
+        litellm_parent_otel_span=None,
+        local_only=False,
+    )
+    data_unsaturated = {"model": model, "messages": [{"role": "user", "content": "b"}]}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=low_priority_user,
+        cache=dual_cache,
+        data=data_unsaturated,
+        call_type="completion",
+    )
+    assert "_litellm_rate_limit_error" not in data_unsaturated

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import HTTPException
+from starlette.exceptions import HTTPException
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 


### PR DESCRIPTION
Fixes #23749

## Summary
- Make `dynamic_rate_limiter_v3` fallback-aware: if fallback routes exist, set `_litellm_rate_limit_error` for router handling; if no fallback exists, keep fail-fast behavior by raising `RateLimitError` from pre-call.
- Keep router-side handling for `_litellm_rate_limit_error` so configured fallbacks can redirect rate-limited calls.
- Add test coverage in `tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py` for fallback-marker behavior with configured fallbacks.
Config:
```
model_list:
  - model_name: ptu-primary
    litellm_params:
      model: gpt-3.5-turbo
      mock_response: "primary-ok"
      rpm: 1   # tiny capacity so we saturate immediately

  - model_name: paygo-fallback
    litellm_params:
      model: gpt-3.5-turbo
      mock_response: "fallback-ok"

litellm_settings:
  callbacks: ["dynamic_rate_limiter_v3"]
  priority_reservation:
    high: 0.7
    medium: 0.3
    low: 0.0
  fallbacks:
    - ptu-primary: ["paygo-fallback"]
```
**Before**
<img width="1101" height="237" alt="image" src="https://github.com/user-attachments/assets/c0fb4e53-a577-4376-a7c8-57a3fee63917" />

**Now**
<img width="1101" height="452" alt="image" src="https://github.com/user-attachments/assets/0a7d26e6-7d60-4000-9dad-d1b5ad6303c3" />

