### PR TITLE
fix(transcription): fix cost_per_second calculation for audio transcription models

### DIFF
--- a/litellm/llms/openai/cost_calculation.py
+++ b/litellm/llms/openai/cost_calculation.py
@@ -114,7 +114,7 @@ def cost_per_second(
         )
         ## COST PER SECOND ##
         completion_cost = model_info["output_cost_per_second"] * duration
-    elif (
+    if (
         "input_cost_per_second" in model_info
         and model_info["input_cost_per_second"] is not None
     ):
@@ -123,7 +123,6 @@ def cost_per_second(
         )
         ## COST PER SECOND ##
         prompt_cost = model_info["input_cost_per_second"] * duration
-        completion_cost = 0.0
 
     return prompt_cost, completion_cost
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5653,7 +5653,7 @@
         "input_cost_per_second": 0.0001,
         "litellm_provider": "azure",
         "mode": "audio_transcription",
-        "output_cost_per_second": 0.0001
+        "output_cost_per_second": 0.0
     },
     "azure_ai/Cohere-embed-v3-english": {
         "input_cost_per_token": 1e-07,
@@ -31924,7 +31924,7 @@
         "input_cost_per_second": 0.0001,
         "litellm_provider": "openai",
         "mode": "audio_transcription",
-        "output_cost_per_second": 0.0001,
+        "output_cost_per_second": 0.0,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5653,7 +5653,7 @@
         "input_cost_per_second": 0.0001,
         "litellm_provider": "azure",
         "mode": "audio_transcription",
-        "output_cost_per_second": 0.0001
+        "output_cost_per_second": 0.0
     },
     "azure_ai/Cohere-embed-v3-english": {
         "input_cost_per_token": 1e-07,
@@ -31924,7 +31924,7 @@
         "input_cost_per_second": 0.0001,
         "litellm_provider": "openai",
         "mode": "audio_transcription",
-        "output_cost_per_second": 0.0001,
+        "output_cost_per_second": 0.0,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -16,6 +17,7 @@ from litellm.cost_calculator import (
     handle_realtime_stream_cost_calculation,
     response_cost_calculator,
 )
+from litellm.llms.openai.cost_calculation import cost_per_second
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
@@ -1970,3 +1972,53 @@ def test_additional_costs_only_for_azure_ai():
         completion_tokens=50,
     )
     assert result is None, "Vertex AI should have no additional costs"
+
+
+class TestCostPerSecondArithmetic:
+    """Unit tests for the cost_per_second arithmetic itself.
+
+    The tests in TestCostCalculatorReadsDurationFromHiddenParams mock
+    openai_cost_per_second entirely — they verify that the right duration
+    is forwarded, but never that the math inside cost_per_second is correct.
+    These tests cover the arithmetic directly.
+    """
+
+    def test_input_cost_per_second_only(self):
+        """input_cost_per_second * duration = prompt_cost; completion_cost = 0."""
+        with patch("litellm.llms.openai.cost_calculation.get_model_info") as mock_info:
+            mock_info.return_value = {
+                "input_cost_per_second": 0.0001,
+                "output_cost_per_second": 0.0,
+            }
+            prompt_cost, completion_cost_val = cost_per_second(
+                model="whisper-1", custom_llm_provider="openai", duration=60.0
+            )
+        assert prompt_cost == pytest.approx(0.006)
+        assert completion_cost_val == 0.0
+
+    def test_both_input_and_output_cost_per_second(self):
+        """When both fields are set, they are applied independently."""
+        with patch("litellm.llms.openai.cost_calculation.get_model_info") as mock_info:
+            mock_info.return_value = {
+                "input_cost_per_second": 0.002,
+                "output_cost_per_second": 0.003,
+            }
+            prompt_cost, completion_cost_val = cost_per_second(
+                model="some-model", custom_llm_provider="openai", duration=10.0
+            )
+        assert prompt_cost == pytest.approx(0.02)
+        assert completion_cost_val == pytest.approx(0.03)
+
+    def test_zero_duration_returns_zero_cost(self):
+        """A zero-duration transcription must cost nothing regardless of the rate."""
+        with patch("litellm.llms.openai.cost_calculation.get_model_info") as mock_info:
+            mock_info.return_value = {
+                "input_cost_per_second": 0.0001,
+                "output_cost_per_second": 0.0,
+            }
+            prompt_cost, completion_cost_val = cost_per_second(
+                model="whisper-1", custom_llm_provider="openai", duration=0.0
+            )
+        assert prompt_cost == 0.0
+        assert completion_cost_val == 0.0
+


### PR DESCRIPTION
## Summary

- **Fix `cost_per_second()` logic** in `litellm/llms/openai/cost_calculation.py`: `input_cost_per_second` was computed only if `output_cost_per_second` was absent (`elif`), causing incorrect cost calculation for transcription models that bill on input duration only (like Deepgram). Changed `elif` to `if` so both fields are evaluated independently. Also removed an erroneous `completion_cost = 0.0` assignment.
- **Fix `output_cost_per_second` pricing** for `whisper-1` and `azure/whisper-1`: was incorrectly set to `0.0001` — audio transcription is billed on input duration only, output should be `0.0`
- **Add `TestCostPerSecondArithmetic`** unit tests covering the arithmetic directly: input-only billing, both fields independent, and zero-duration edge case

Closes #23558