### PR TITLE
fix(vertex_ai): respect thinking_level in model config for Gemini 3+

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -885,25 +885,25 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ) -> GeminiThinkingConfig:
         thinking_enabled = thinking_param.get("type") == "enabled"
         thinking_budget = thinking_param.get("budget_tokens")
+        # thinking_level is a LiteLLM extension (not in AnthropicThinkingParam)
+        thinking_level = thinking_param.get("thinking_level")  # type: ignore[misc]
 
         params: GeminiThinkingConfig = {}
 
         # For Gemini 3+ models, use thinkingLevel instead of thinkingBudget
         if model and VertexGeminiConfig._is_gemini_3_or_newer(model):
             if thinking_enabled:
-                if thinking_budget is None or thinking_budget == 0:
+                if thinking_level is not None:
+                    # thinking_level explicitly provided — use it directly
+                    return VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+                        thinking_level, model
+                    )
+                elif thinking_budget is not None and thinking_budget == 0:
                     params["includeThoughts"] = False
                 else:
+                    # thinking is enabled with no budget/level — enable thinking
                     params["includeThoughts"] = True
-                    if thinking_budget >= 10000:
-                        is_gemini3flash = (
-                            "gemini-3-flash-preview" in model.lower()
-                            or "gemini-3-flash" in model.lower()
-                        )
-                        params["thinkingLevel"] = (
-                            "minimal" if is_gemini3flash else "low"
-                        )
-                    else:
+                    if thinking_budget is not None:
                         is_gemini3flash = (
                             "gemini-3-flash-preview" in model.lower()
                             or "gemini-3-flash" in model.lower()

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -877,6 +877,34 @@ def test_vertex_ai_map_thinking_param_with_budget_tokens_0():
     }
 
 
+def test_vertex_ai_map_thinking_param_with_thinking_level_gemini3():
+    """
+    Regression test: when thinking param has thinking_level (e.g. from model config),
+    _map_thinking_param must honour it and set includeThoughts=True instead of False.
+    Previously budget_tokens=None triggered includeThoughts=False, ignoring thinking_level.
+    """
+    v = VertexGeminiConfig()
+    # thinking_level provided — should map to thinkingLevel + includeThoughts=True
+    result = v._map_thinking_param(
+        thinking_param={"type": "enabled", "thinking_level": "high"},  # type: ignore[arg-type]
+        model="gemini-3.1-pro-preview",
+    )
+    assert result == {"thinkingLevel": "high", "includeThoughts": True}
+
+    result_medium = v._map_thinking_param(
+        thinking_param={"type": "enabled", "thinking_level": "medium"},  # type: ignore[arg-type]
+        model="gemini-3.1-pro-preview",
+    )
+    assert result_medium == {"thinkingLevel": "medium", "includeThoughts": True}
+
+    # thinking enabled with no budget/level — should still enable thinking
+    result_no_budget = v._map_thinking_param(
+        thinking_param={"type": "enabled"},  # type: ignore[arg-type]
+        model="gemini-3.1-pro-preview",
+    )
+    assert result_no_budget.get("includeThoughts") is True
+
+
 def test_vertex_ai_map_tools():
     v = VertexGeminiConfig()
     optional_params = {}


### PR DESCRIPTION
## Summary

Fixed a regression where the `thinking_level` field from Vertex AI model configs was being ignored, causing requests to be sent with `includeThoughts=False` even when thinking was explicitly enabled with a specific level.

## Changes

- `_map_thinking_param` now reads and respects the `thinking_level` field
- When `thinking_level` is provided, uses it to set the appropriate `thinkingLevel` with `includeThoughts=True`  
- When thinking is enabled with no budget/level, now correctly enables thinking instead of disabling it
- Added regression test to prevent future breakage

## Testing

- All existing tests pass
- New test: `test_vertex_ai_map_thinking_param_with_thinking_level_gemini3` covers the three scenarios above