### PR TITLE
fix(vertex-ai): validate claude model count-tokens region against supported regions only

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -42,6 +42,14 @@ class VertexAIModelRoute(str, Enum):
 
 VERTEX_AI_MODEL_ROUTES = [f"{route.value}/" for route in VertexAIModelRoute]
 
+# Supported regions for Claude count-tokens endpoint on Vertex AI
+# https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+VERTEX_AI_CLAUDE_COUNT_TOKENS_SUPPORTED_REGIONS = {
+    "us-east5",
+    "europe-west1",
+    "asia-southeast1",
+}
+
 
 def get_vertex_ai_model_route(
     model: str, litellm_params: Optional[dict] = None

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -8,7 +8,10 @@ their respective publisher-specific count-tokens endpoints.
 from typing import Any, Dict, Optional
 
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
-from litellm.llms.vertex_ai.common_utils import get_vertex_base_url
+from litellm.llms.vertex_ai.common_utils import (
+    VERTEX_AI_CLAUDE_COUNT_TOKENS_SUPPORTED_REGIONS,
+    get_vertex_base_url,
+)
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 
 
@@ -107,9 +110,12 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         vertex_project = self.get_vertex_ai_project(litellm_params)
         vertex_location = self.get_vertex_ai_location(litellm_params)
 
-        # Map empty location/cluade models to a supported region for count-tokens endpoint
-        # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
-        if not vertex_location or "claude" in model.lower():
+        # For Claude models, validate region is supported for count-tokens
+        # https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+        if "claude" in model.lower():
+            if not vertex_location or vertex_location not in VERTEX_AI_CLAUDE_COUNT_TOKENS_SUPPORTED_REGIONS:
+                vertex_location = "us-east5"
+        elif not vertex_location:
             vertex_location = "us-central1"
 
         # Get access token and resolved project ID

--- a/tests/proxy_unit_tests/test_proxy_token_counter.py
+++ b/tests/proxy_unit_tests/test_proxy_token_counter.py
@@ -873,6 +873,69 @@ def test_vertex_ai_partner_models_token_counting_endpoint(vertex_location):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "vertex_location, expected_location",
+    [
+        # Supported region should be preserved
+        ("europe-west1", "europe-west1"),
+        # Unsupported region should fall back to us-east5
+        ("global", "us-east5"),
+        ("us-central1", "us-east5"),
+    ],
+)
+async def test_vertex_ai_claude_count_tokens_region_validation(
+    vertex_location, expected_location
+):
+    """
+    Test that handle_count_tokens_request validates the region for Claude models
+    and only falls back to us-east5 for unsupported regions.
+
+    Supported regions per:
+    https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+    """
+    from litellm.llms.vertex_ai.vertex_ai_partner_models.count_tokens.handler import (
+        VertexAIPartnerModelsTokenCounter,
+    )
+
+    counter = VertexAIPartnerModelsTokenCounter()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"input_tokens": 10}
+
+    with patch.object(
+        counter, "get_vertex_ai_credentials", return_value=None
+    ), patch.object(
+        counter, "get_vertex_ai_project", return_value="test-project"
+    ), patch.object(
+        counter, "get_vertex_ai_location", return_value=vertex_location
+    ), patch.object(
+        counter,
+        "_ensure_access_token_async",
+        new_callable=AsyncMock,
+        return_value=("fake-token", "test-project"),
+    ), patch(
+        "litellm.llms.vertex_ai.vertex_ai_partner_models.count_tokens.handler.get_async_httpx_client"
+    ) as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        await counter.handle_count_tokens_request(
+            model="claude-3-5-sonnet-20241022",
+            request_data={"messages": [{"role": "user", "content": "Hello"}]},
+            litellm_params={},
+        )
+
+        # Verify the endpoint URL uses the expected location
+        call_args = mock_client.post.call_args
+        endpoint_url = call_args[0][0] if call_args[0] else call_args[1].get("url", "")
+        assert f"/locations/{expected_location}/" in endpoint_url, (
+            f"Expected location '{expected_location}' in URL, got: {endpoint_url}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_bedrock_token_counter_error_propagation_bedrock_error():
     """
     Test that BedrockTokenCounter properly returns error response when BedrockError is raised.


### PR DESCRIPTION
[PR #20348](https://github.com/BerriAI/litellm/pull/20348) fixed a 404 error when calling `count_tokens` with `vertex_location: global` for Claude models. It mapped all Claude count_tokens requests to `us-central1`, regardless of the configured region. This causes a data residency problem in Europe because all token counting requests are routed to the US, even when the user explicitly configured an EU region like `europe-west1`.

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix


## Changes
- Only override the region when it is **not supported** by the Claude count_tokens endpoint
- Preserve supported regions (EU/Asia) so token counting stays in the configured region
- Fall back to `us-east5` (a supported region) instead of `us-central1` (which is not supported)
- Add Unit Test