### PR TITLE
fix(model-prices): correct supported_regions for Vertex AI DeepSeek models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30468,14 +30468,14 @@
         "mode": "chat",
         "output_cost_per_token": 5.4e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
+        "supported_regions": [
+            "us-central1"
+        ],
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supported_regions": [
-            "us-central1"
-        ]
+        "supports_tool_choice": true
     },
     "vertex_ai/gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30431,7 +30431,7 @@
         "output_cost_per_token": 5.4e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supported_regions": [
-            "us-west2"
+            "us-central1"
         ],
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -30451,7 +30451,7 @@
         "output_cost_per_token_batches": 8.4e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supported_regions": [
-            "us-west2"
+            "global"
         ],
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -30472,7 +30472,10 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supported_regions": [
+            "us-central1"
+        ]
     },
     "vertex_ai/gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -31092,7 +31095,10 @@
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
         "ocr_cost_per_page": 0.0003,
-        "source": "https://cloud.google.com/vertex-ai/pricing"
+        "source": "https://cloud.google.com/vertex-ai/pricing",
+        "supported_regions": [
+            "us-central1"
+        ]
     },
     "vertex_ai/openai/gpt-oss-120b-maas": {
         "input_cost_per_token": 1.5e-07,


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/23859

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - N/A, data-only change to model pricing JSON
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

The `supported_regions` for Vertex AI DeepSeek models were incorrect, causing 404 errors when calling `deepseek-v3.2-maas` (routed to `us-west2` instead of `global`).

Updated per [Google Cloud official docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/deepseek):

| Model | Before | After |
|-------|--------|-------|
| `deepseek-v3.2-maas` | `us-west2` | `global` |
| `deepseek-v3.1-maas` | `us-west2` | `us-central1` |
| `deepseek-r1-0528-maas` | _(missing)_ | `us-central1` |
| `deepseek-ocr-maas` | _(missing)_ | `us-central1` |