### PR TITLE
fix(vertex_ai): respect vertex_count_tokens_location override in count_tokens handler

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -107,10 +107,11 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         vertex_project = self.get_vertex_ai_project(litellm_params)
         vertex_location = self.get_vertex_ai_location(litellm_params)
 
-        # Map empty location/cluade models to a supported region for count-tokens endpoint
+        # Map empty location/claude models to a supported region for count-tokens endpoint
         # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+        # Respect vertex_count_tokens_location override if provided
         if not vertex_location or "claude" in model.lower():
-            vertex_location = "us-central1"
+            vertex_location = litellm_params.get("vertex_count_tokens_location") or "us-central1"
 
         # Get access token and resolved project ID
         access_token, project_id = await self._ensure_access_token_async(


### PR DESCRIPTION
When using Claude models on Vertex AI with a non-us-central1 location, the count_tokens endpoint always routes to us-central1 regardless of `vertex_count_tokens_location` config. This causes 500 errors if the project does not have Claude count-tokens available in us-central1.

## Root Cause

In `vertex_ai_partner_models/count_tokens/handler.py`, the code hardcodes `us-central1` for Claude models without checking for the `vertex_count_tokens_location` override:

```python
if not vertex_location or "claude" in model.lower():
    vertex_location = "us-central1"
```

## Fix

Check for `vertex_count_tokens_location` in litellm_params before defaulting to us-central1:

```python
if not vertex_location or "claude" in model.lower():
    vertex_location = litellm_params.get("vertex_count_tokens_location") or "us-central1"
```

Fixes #23872