### PR TITLE
fix: respect vertex_count_tokens_location in Claude count_tokens handler (#23872)

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -105,12 +105,20 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         # Extract Vertex AI credentials and settings
         vertex_credentials = self.get_vertex_ai_credentials(litellm_params)
         vertex_project = self.get_vertex_ai_project(litellm_params)
-        vertex_location = self.get_vertex_ai_location(litellm_params)
+        vertex_location = (
+            litellm_params.get("vertex_count_tokens_location")
+            or self.get_vertex_ai_location(litellm_params)
+        )
 
-        # Map empty location/cluade models to a supported region for count-tokens endpoint
+        # Map empty location/claude models to a supported region for count-tokens endpoint.
+        # vertex_count_tokens_location takes precedence; only apply us-central1 default
+        # when no explicit count-tokens location is configured.
         # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
-        if not vertex_location or "claude" in model.lower():
-            vertex_location = "us-central1"
+        if not vertex_location or (
+            "claude" in model.lower()
+            and not litellm_params.get("vertex_count_tokens_location")
+        ):
+            vertex_location = vertex_location or "us-central1"
 
         # Get access token and resolved project ID
         access_token, project_id = await self._ensure_access_token_async(

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -110,15 +110,15 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
             or self.get_vertex_ai_location(litellm_params)
         )
 
-        # Map empty location/claude models to a supported region for count-tokens endpoint.
-        # vertex_count_tokens_location takes precedence; only apply us-central1 default
-        # when no explicit count-tokens location is configured.
+        # For Claude models, count-tokens only works in us-central1 unless
+        # vertex_count_tokens_location is explicitly configured to override.
         # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
-        if not vertex_location or (
-            "claude" in model.lower()
-            and not litellm_params.get("vertex_count_tokens_location")
+        if "claude" in model.lower() and not litellm_params.get(
+            "vertex_count_tokens_location"
         ):
-            vertex_location = vertex_location or "us-central1"
+            vertex_location = "us-central1"
+        elif not vertex_location:
+            vertex_location = "us-central1"
 
         # Get access token and resolved project ID
         access_token, project_id = await self._ensure_access_token_async(

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -105,17 +105,16 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         # Extract Vertex AI credentials and settings
         vertex_credentials = self.get_vertex_ai_credentials(litellm_params)
         vertex_project = self.get_vertex_ai_project(litellm_params)
+        vertex_count_tokens_location = litellm_params.get("vertex_count_tokens_location")
         vertex_location = (
-            litellm_params.get("vertex_count_tokens_location")
+            vertex_count_tokens_location
             or self.get_vertex_ai_location(litellm_params)
         )
 
         # For Claude models, count-tokens only works in us-central1 unless
         # vertex_count_tokens_location is explicitly configured to override.
         # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
-        if "claude" in model.lower() and not litellm_params.get(
-            "vertex_count_tokens_location"
-        ):
+        if "claude" in model.lower() and not vertex_count_tokens_location:
             vertex_location = "us-central1"
         elif not vertex_location:
             vertex_location = "us-central1"

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -5,6 +5,7 @@ This handler provides token counting for partner models hosted on Vertex AI.
 Unlike Gemini models which use Google's token counting API, partner models use
 their respective publisher-specific count-tokens endpoints.
 """
+
 from typing import Any, Dict, Optional
 
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
@@ -105,10 +106,11 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         # Extract Vertex AI credentials and settings
         vertex_credentials = self.get_vertex_ai_credentials(litellm_params)
         vertex_project = self.get_vertex_ai_project(litellm_params)
-        vertex_count_tokens_location = litellm_params.get("vertex_count_tokens_location")
-        vertex_location = (
-            vertex_count_tokens_location
-            or self.get_vertex_ai_location(litellm_params)
+        vertex_count_tokens_location = litellm_params.get(
+            "vertex_count_tokens_location"
+        )
+        vertex_location = vertex_count_tokens_location or self.get_vertex_ai_location(
+            litellm_params
         )
 
         # For Claude models, count-tokens only works in us-central1 unless


### PR DESCRIPTION
## Summary

Respects `vertex_count_tokens_location` when routing Claude count_tokens requests on Vertex AI. Previously, the handler always overrode the location to `us-central1` for Claude models, ignoring the explicit count-tokens location and causing 500 errors for projects without Claude count-tokens in us-central1.

## Root Cause

In `handler.py`, the condition `if not vertex_location or "claude" in model.lower()` always overrode to `us-central1` for any Claude model. `vertex_count_tokens_location` (resolved in `common_utils.py`) was never consulted in the handler.

## Fix

* Resolve `vertex_count_tokens_location` first into a local variable, then fall back to `get_vertex_ai_location()`
* Only apply the `us-central1` default for Claude when no explicit `vertex_count_tokens_location` is configured
* Extract the location param to avoid redundant dict lookups

## Testing

* Python syntax verified
* Logic preserves existing behavior when `vertex_count_tokens_location` is not set
* Backwards-compatible: users without `vertex_count_tokens_location` still get `us-central1` for Claude

Fixes #23872