### PR TITLE
Add OpenAI GPT-5.4 mini and nano model support

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18747,6 +18747,154 @@
         "supports_none_reasoning_effort": false,
         "supports_xhigh_reasoning_effort": true
     },
+    "gpt-5.4-mini": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "output_cost_per_token_batches": 2.25e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gpt-5.4-mini-2026-03-17": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "output_cost_per_token_batches": 2.25e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gpt-5.4-nano": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_batches": 1e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "output_cost_per_token_batches": 6.25e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gpt-5.4-nano-2026-03-17": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_batches": 1e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "output_cost_per_token_batches": 6.25e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
     "gpt-5-pro": {
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18747,6 +18747,154 @@
         "supports_none_reasoning_effort": false,
         "supports_xhigh_reasoning_effort": true
     },
+    "gpt-5.4-mini": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "output_cost_per_token_batches": 2.25e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gpt-5.4-mini-2026-03-17": {
+        "cache_read_input_token_cost": 7.5e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-06,
+        "output_cost_per_token_batches": 2.25e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gpt-5.4-nano": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_batches": 1e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "output_cost_per_token_batches": 6.25e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "gpt-5.4-nano-2026-03-17": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_batches": 1e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.25e-06,
+        "output_cost_per_token_batches": 6.25e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
     "gpt-5-pro": {
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -15,6 +15,53 @@ def gpt5_config() -> OpenAIGPT5Config:
     return OpenAIGPT5Config()
 
 
+@pytest.fixture(scope="module", autouse=True)
+def register_gpt_5_4_mini_nano_models() -> None:
+    # The default model cost map is fetched remotely at import time.
+    # Register the branch-local GPT-5.4 mini/nano entries so tests do not
+    # depend on the upstream raw JSON being updated before this change lands.
+    litellm.register_model(
+        {
+            "gpt-5.4-mini": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "max_tokens": 128000,
+                "supports_reasoning": True,
+                "supports_tool_choice": True,
+                "supports_none_reasoning_effort": True,
+                "supports_xhigh_reasoning_effort": True,
+            },
+            "gpt-5.4-mini-2026-03-17": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "max_tokens": 128000,
+                "supports_reasoning": True,
+                "supports_tool_choice": True,
+                "supports_none_reasoning_effort": True,
+                "supports_xhigh_reasoning_effort": True,
+            },
+            "gpt-5.4-nano": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "max_tokens": 128000,
+                "supports_reasoning": True,
+                "supports_tool_choice": True,
+                "supports_none_reasoning_effort": True,
+                "supports_xhigh_reasoning_effort": True,
+            },
+            "gpt-5.4-nano-2026-03-17": {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "max_tokens": 128000,
+                "supports_reasoning": True,
+                "supports_tool_choice": True,
+                "supports_none_reasoning_effort": True,
+                "supports_xhigh_reasoning_effort": True,
+            },
+        }
+    )
+
+
 def test_gpt5_supports_reasoning_effort(config: OpenAIConfig):
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5")
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5-mini")
@@ -267,6 +314,14 @@ def test_gpt5_1_model_detection(gpt5_config: OpenAIGPT5Config):
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.1-chat-latest", "none")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.2", "none")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.2-2025-12-11", "none")
+    assert gpt5_config._supports_reasoning_effort_level("gpt-5.4-mini", "none")
+    assert gpt5_config._supports_reasoning_effort_level(
+        "gpt-5.4-mini-2026-03-17", "none"
+    )
+    assert gpt5_config._supports_reasoning_effort_level("gpt-5.4-nano", "none")
+    assert gpt5_config._supports_reasoning_effort_level(
+        "gpt-5.4-nano-2026-03-17", "none"
+    )
     # codex/pro/chat variants do not support none
     assert not gpt5_config._supports_reasoning_effort_level("gpt-5.1-codex", "none")
     assert not gpt5_config._supports_reasoning_effort_level("gpt-5.1-codex-max", "none")
@@ -319,6 +374,26 @@ def test_gpt5_4_pro_allows_reasoning_effort_xhigh(config: OpenAIConfig):
         non_default_params={"reasoning_effort": "xhigh"},
         optional_params={},
         model="gpt-5.4-pro",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "xhigh"
+
+
+def test_gpt5_4_mini_allows_reasoning_effort_xhigh(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="gpt-5.4-mini",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "xhigh"
+
+
+def test_gpt5_4_nano_allows_reasoning_effort_xhigh(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "xhigh"},
+        optional_params={},
+        model="gpt-5.4-nano",
         drop_params=False,
     )
     assert params["reasoning_effort"] == "xhigh"
@@ -449,6 +524,28 @@ def test_gpt5_4_keeps_reasoning_effort_none_with_tools(config: OpenAIConfig):
     )
     assert params["reasoning_effort"] == "none"
     assert params["tools"] == tools
+
+
+def test_gpt5_4_mini_temperature_with_reasoning_effort_none(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.4, "reasoning_effort": "none"},
+        optional_params={},
+        model="gpt-5.4-mini",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.4
+    assert params["reasoning_effort"] == "none"
+
+
+def test_gpt5_4_nano_temperature_with_reasoning_effort_none(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.4, "reasoning_effort": "none"},
+        optional_params={},
+        model="gpt-5.4-nano",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.4
+    assert params["reasoning_effort"] == "none"
 
 
 def test_gpt5_2_keeps_reasoning_effort_with_tools(config: OpenAIConfig):

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -644,6 +644,40 @@ def test_responses_api_bridge_check_gpt_5_4_tools_plus_reasoning_routes_to_respo
     assert model_info.get("mode") == "responses"
 
 
+def test_responses_api_bridge_check_gpt_5_4_mini_tools_plus_reasoning_routes_to_responses():
+    """gpt-5.4-mini with both tools and reasoning_effort should route to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4-mini",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="xhigh",
+        )
+
+    assert model == "gpt-5.4-mini"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_4_nano_tools_plus_reasoning_routes_to_responses():
+    """gpt-5.4-nano with both tools and reasoning_effort should route to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4-nano",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort="xhigh",
+        )
+
+    assert model == "gpt-5.4-nano"
+    assert model_info.get("mode") == "responses"
+
+
 def test_responses_api_bridge_check_gpt_5_5_tools_plus_reasoning_routes_to_responses():
     """gpt-5.5+ with both tools and reasoning_effort should route to Responses API."""
     from litellm.main import responses_api_bridge_check
@@ -675,6 +709,40 @@ def test_responses_api_bridge_check_gpt_5_4_tools_without_reasoning_stays_chat()
         )
 
     assert model == "gpt-5.4"
+    assert model_info.get("mode") != "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_4_mini_tools_without_reasoning_stays_chat():
+    """gpt-5.4-mini with tools only should not be force-routed to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4-mini",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort=None,
+        )
+
+    assert model == "gpt-5.4-mini"
+    assert model_info.get("mode") != "responses"
+
+
+def test_responses_api_bridge_check_gpt_5_4_nano_tools_without_reasoning_stays_chat():
+    """gpt-5.4-nano with tools only should not be force-routed to Responses API."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-5.4-nano",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+            reasoning_effort=None,
+        )
+
+    assert model == "gpt-5.4-nano"
     assert model_info.get("mode") != "responses"
 
 


### PR DESCRIPTION
## Pre-Submission checklist                                                                                                                                                  
                                           
**Please complete all items before asking a LiteLLM maintainer to review your PR**                                                                                           
                                                                                      
- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requ
irement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type                                                                                                                                                     

🆕 New Feature  
✅ Test

## Changes

- Add official OpenAI model map entries for `gpt-5.4-mini`, `gpt-5.4-mini-2026-03-17`, `gpt-5.4-nano`, and `gpt-5.4-nano-2026-03-17` in both `model_prices_and_context_window
.json` and `litellm/model_prices_and_context_window_backup.json`
- Use the published GPT-5.4 mini / nano pricing and context limits from OpenAI's model docs:
  - `gpt-5.4-mini`: 400k input context, 128k max output, `$0.75 / 1M` input, `$0.075 / 1M` cached input, `$4.50 / 1M` output
  - `gpt-5.4-nano`: 400k input context, 128k max output, `$0.20 / 1M` input, `$0.02 / 1M` cached input, `$1.25 / 1M` output
- Mark both new GPT-5.4 variants as supporting `reasoning_effort="none"` and `reasoning_effort="xhigh"` so they follow the existing GPT-5.4 handling path
- Add focused regression coverage in `tests/test_litellm/llms/openai/test_gpt5_transformation.py` for:
  - model-map based `reasoning_effort="none"` detection
  - `reasoning_effort="xhigh"` acceptance
  - flexible `temperature` handling when `reasoning_effort="none"`
- Add focused regression coverage in `tests/test_litellm/test_main.py` for Responses API bridge behavior when `gpt-5.4-mini` / `gpt-5.4-nano` are used with:
  - `tools + reasoning_effort`
  - `tools` without `reasoning_effort`

## Validation

- `poetry run pytest tests/test_litellm/llms/openai/test_gpt5_transformation.py -x -vv`
- `poetry run pytest tests/test_litellm/test_main.py -x -vv`