### PR TITLE
fix(core): map Anthropic 'refusal' finish reason to 'content_filter'

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -64,6 +64,7 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "end_turn": "stop",
     "max_tokens": "length",
     "tool_use": "tool_calls",
+    "refusal": "content_filter",
     "compaction": "length",
     # Cohere
     "COMPLETE": "stop",

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -74,6 +74,9 @@ class TestMapFinishReasonAnthropic:
     def test_compaction(self):
         assert map_finish_reason("compaction") == "length"
 
+    def test_refusal(self):
+        assert map_finish_reason("refusal") == "content_filter"
+
 
 class TestMapFinishReasonGemini:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Relevant issues

Fixes #23793

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## Type

🐛 Bug Fix

## Changes

Anthropic's `refusal` stop_reason was missing from `_FINISH_REASON_MAP`, causing it to fall through to the default `stop`. Mapped it to `content_filter` since it indicates the model refused to respond due to safety policies.