### PR TITLE
fix(anthropic): preserve cache directive on file-type content blocks

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2441,11 +2441,14 @@ def anthropic_messages_pt(  # noqa: PLR0915
                         elif m.get("type", "") == "document":
                             user_content.append(cast(AnthropicMessagesDocumentParam, m))
                         elif m.get("type", "") == "file":
-                            user_content.append(
-                                anthropic_process_openai_file_message(
-                                    cast(ChatCompletionFileObject, m)
-                                )
+                            _file_content_element = anthropic_process_openai_file_message(
+                                cast(ChatCompletionFileObject, m)
                             )
+                            _file_content_element = add_cache_control_to_content(
+                                anthropic_content_element=_file_content_element,
+                                original_content_element=dict(m),
+                            )
+                            user_content.append(_file_content_element)
                 elif isinstance(user_message_types_block["content"], str):
                     _anthropic_content_text_element: AnthropicMessagesTextParam = {
                         "type": "text",

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2027,3 +2027,56 @@ def test_sanitize_messages_combined_case_a_and_case_d():
         )
     finally:
         litellm.modify_params = original
+
+
+def test_anthropic_messages_pt_file_block_preserves_cache_control():
+    """
+    Test that cache_control is preserved on file-type content blocks
+    when translated to Anthropic document params.
+    Regression test for https://github.com/BerriAI/litellm/issues/23873
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt,
+    )
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": "doc.pdf",
+                        "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+                    },
+                    "cache_control": {"type": "ephemeral"},
+                },
+                {
+                    "type": "text",
+                    "text": "Summarize this document.",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        }
+    ]
+
+    result = anthropic_messages_pt(
+        messages, model="claude-sonnet-4-20250514", llm_provider="anthropic"
+    )
+
+    content_blocks = result[0]["content"]
+    assert len(content_blocks) == 2
+
+    # Document block (from file) should preserve cache_control
+    doc_block = content_blocks[0]
+    assert doc_block["type"] == "document"
+    assert "cache_control" in doc_block, (
+        "cache_control was dropped from file/document block"
+    )
+    assert doc_block["cache_control"]["type"] == "ephemeral"
+
+    # Text block should also preserve cache_control
+    text_block = content_blocks[1]
+    assert text_block["type"] == "text"
+    assert "cache_control" in text_block
+    assert text_block["cache_control"]["type"] == "ephemeral"


### PR DESCRIPTION
## Relevant issues

Fixes #23873

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`cache_control` was dropped from `file`-type content blocks when translating to Anthropic's document params in `anthropic_messages_pt()`. The `text` and `image_url` block types both call `add_cache_control_to_content()` to preserve this field, but `file` blocks (handled by `anthropic_process_openai_file_message()`) did not.

This meant prompt caching for PDF/document inputs never took effect even when `cache_control: {"type": "ephemeral"}` was explicitly set.

**Fix**: Apply `add_cache_control_to_content()` to the result of `anthropic_process_openai_file_message()`, matching the pattern used for `text` and `image_url` blocks.