### PR TITLE
[Fix] Add contents:write permission to ghcr_deploy release job

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -369,7 +369,8 @@ jobs:
   release:
     name: "New LiteLLM Release"
     needs: [docker-hub-deploy, build-and-push-image, build-and-push-image-database]
-
+    permissions:
+      contents: write
     runs-on: "ubuntu-latest"
    
     steps:


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
The `release` job in `ghcr_deploy.yml` failed with `Resource not accessible by integration` when calling `repos.createRelease`. Other jobs in the workflow explicitly set `permissions` with `contents: read`, which caused GitHub to scope the default token down for all jobs — including the `release` job which had no permissions block.

### Fix
Added `contents: write` to the `release` job's permissions so the `GITHUB_TOKEN` can create GitHub releases.

## Testing
- Verified the workflow YAML is valid
- The fix aligns with [GitHub's documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) on job-level permission scoping

## Type
🐛 Bug Fix
🚄 Infrastructure