### PR TITLE
fix(mistral): preserve diarization segments in transcription response

### DIFF
--- a/litellm/llms/mistral/audio_transcription/transformation.py
+++ b/litellm/llms/mistral/audio_transcription/transformation.py
@@ -148,5 +148,12 @@ class MistralAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
 
         text = response_json.get("text") or ""
         response = TranscriptionResponse(text=text)
+
+        # Preserve Mistral-specific fields (e.g. diarization segments)
+        if "segments" in response_json:
+            response["segments"] = response_json["segments"]
+        if "language" in response_json:
+            response["language"] = response_json["language"]
+
         response._hidden_params = response_json
         return response

--- a/tests/test_litellm/llms/mistral/audio_transcription/test_mistral_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/mistral/audio_transcription/test_mistral_audio_transcription_transformation.py
@@ -158,6 +158,50 @@ def test_mistral_audio_transcription_response_transform():
     assert response.text == "Four score and seven years ago..."
 
 
+def test_mistral_audio_transcription_response_transform_diarized():
+    """Test that diarized responses preserve segments and language."""
+    config = MistralAudioTranscriptionConfig()
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.json.return_value = {
+        "model": "voxtral-mini-latest",
+        "text": "Hello, how are you? I am fine.",
+        "language": None,
+        "segments": [
+            {
+                "text": "Hello, how are you?",
+                "start": 0.3,
+                "end": 2.1,
+                "speaker_id": "speaker_1",
+                "type": "transcription_segment",
+            },
+            {
+                "text": "I am fine.",
+                "start": 2.5,
+                "end": 3.8,
+                "speaker_id": "speaker_2",
+                "type": "transcription_segment",
+            },
+        ],
+        "usage": {
+            "prompt_audio_seconds": 4,
+            "prompt_tokens": 5,
+            "total_tokens": 50,
+            "completion_tokens": 20,
+        },
+    }
+
+    response = config.transform_audio_transcription_response(mock_response)
+
+    assert isinstance(response, TranscriptionResponse)
+    assert response.text == "Hello, how are you? I am fine."
+    assert response["segments"] is not None
+    assert len(response["segments"]) == 2
+    assert response["segments"][0]["speaker_id"] == "speaker_1"
+    assert response["segments"][1]["speaker_id"] == "speaker_2"
+    assert response["language"] is None
+
+
 def test_mistral_audio_transcription_response_transform_empty():
     config = MistralAudioTranscriptionConfig()
 


### PR DESCRIPTION
## Relevant issues

Fixes #23890

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When using Mistral's Voxtral model with `diarize=true`, the API returns `segments` (with `speaker_id`, timestamps) and `language` fields. These were being dropped in `transform_audio_transcription_response` which only extracted `text`.

Now `segments` and `language` are preserved on the `TranscriptionResponse` object, matching the pattern used by other providers like Deepgram.