### PR TITLE
fix(gemini): pass model to context caching URL builder for custom api_base

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -110,6 +110,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_project: Optional[str],
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
+        model: Optional[str] = None,
     ) -> Optional[str]:
         """
         Checks if content already cached.
@@ -129,6 +130,7 @@ class ContextCachingEndpoints(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=vertex_auth_header,
+            model=model,
         )
 
         page_token: Optional[str] = None
@@ -202,6 +204,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_project: Optional[str],
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
+        model: Optional[str] = None,
     ) -> Optional[str]:
         """
         Checks if content already cached.
@@ -221,6 +224,7 @@ class ContextCachingEndpoints(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=vertex_auth_header,
+            model=model,
         )
 
         page_token: Optional[str] = None
@@ -379,6 +383,7 @@ class ContextCachingEndpoints(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=vertex_auth_header,
+            model=model,
         )
         if google_cache_name:
             return non_cached_messages, optional_params, google_cache_name
@@ -523,6 +528,7 @@ class ContextCachingEndpoints(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=vertex_auth_header,
+            model=model,
         )
 
         if google_cache_name:

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -51,6 +51,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_project: Optional[str],
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
+        model: Optional[str] = None,
     ) -> Tuple[Optional[str], str]:
         """
         Internal function. Returns the token and url for the call.
@@ -89,7 +90,7 @@ class ContextCachingEndpoints(VertexBase):
             stream=None,
             auth_header=auth_header,
             url=url,
-            model=None,
+            model=model,
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_api_version="v1beta1"
@@ -342,6 +343,7 @@ class ContextCachingEndpoints(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=vertex_auth_header,
+            model=model,
         )
 
         headers = {
@@ -488,6 +490,7 @@ class ContextCachingEndpoints(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=vertex_auth_header,
+            model=model,
         )
 
         headers = {

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1318,3 +1318,40 @@ class TestVertexAIGlobalLocation:
             expected_url = "https://aiplatform.googleapis.com/v1beta1/projects/test-project/locations/global/cachedContents"
             assert url == expected_url, f"Expected {expected_url}, got {url}"
             assert "global-aiplatform" not in url, "URL should not contain 'global-aiplatform' prefix"
+
+    def test_gemini_context_caching_with_custom_api_base_passes_model(self):
+        """Gemini context caching with custom api_base must pass model to _check_custom_proxy.
+
+        Regression test for https://github.com/BerriAI/litellm/issues/23846
+        Previously model was hardcoded to None, causing ValueError when api_base was set.
+        """
+        caching = ContextCachingEndpoints()
+
+        auth_header, url = caching._get_token_and_url_context_caching(
+            gemini_api_key="test-key",
+            custom_llm_provider="gemini",
+            api_base="https://my-proxy.example.com",
+            vertex_project=None,
+            vertex_location=None,
+            vertex_auth_header=None,
+            model="gemini-1.5-pro",
+        )
+
+        assert "models/gemini-1.5-pro" in url
+        assert url.startswith("https://my-proxy.example.com/")
+
+    def test_gemini_context_caching_without_api_base_ignores_model(self):
+        """Without custom api_base, model param is not needed (default URL is used)."""
+        caching = ContextCachingEndpoints()
+
+        auth_header, url = caching._get_token_and_url_context_caching(
+            gemini_api_key="test-key",
+            custom_llm_provider="gemini",
+            api_base=None,
+            vertex_project=None,
+            vertex_location=None,
+            vertex_auth_header=None,
+        )
+
+        assert "generativelanguage.googleapis.com" in url
+        assert "cachedContents" in url


### PR DESCRIPTION
## Relevant issues

Fixes #23846

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`_get_token_and_url_context_caching()` in `vertex_ai_context_caching.py` was hardcoding `model=None` when calling `_check_custom_proxy()`. This works fine without a custom `api_base` (the default Google URL doesn't need the model in the path), but raises `ValueError: Model parameter is required for Gemini custom API base URLs` when `api_base` is set — because proxy URLs are constructed as `{api_base}/models/{model}:cachedContents`.

### Fix
- Added optional `model` parameter to `_get_token_and_url_context_caching()` (default `None`, backward-compatible)
- Propagated `model` from the two callers that have it (`check_and_create_cache` and `async_check_and_create_cache`)
- The two list-only callers (`check_cache`, `async_check_cache`) don't need model since listing doesn't require it in the URL