### PR TITLE
fix(proxy): defer async logging until post-call guardrails complete

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -117,6 +117,14 @@ guardrails:
 
 :::
 
+:::note Streaming and post_call guardrails
+
+For **streaming responses**, `post_call` guardrails run on the fully assembled response **after** all chunks have been delivered to the client. This means `post_call` guardrails on streaming are **audit-only** — they can inspect and log the complete response, but cannot block content delivery. Guardrail results are recorded in `guardrail_information` within the logging payload for compliance and auditing.
+
+To filter or block streaming content in real-time, use `async_post_call_streaming_iterator_hook` instead, which processes chunks as they arrive.
+
+:::
+
 <details>
 <summary>Advanced: Multiple modes with individual event hooks</summary>
 
@@ -655,8 +663,8 @@ class myCustomGuardrail(CustomGuardrail):
 | `apply_guardrail` | Simple method to check and optionally modify text | ✅ | INPUT or OUTPUT | ✅ | ✅ | ✅ |
 | `async_pre_call_hook` | A hook that runs before the LLM API call | ✅ | INPUT | ✅ | ❌ | ✅ |
 | `async_moderation_hook` | A hook that runs during the LLM API call| ✅ | INPUT | ❌ | ❌ | ✅ |
-| `async_post_call_success_hook` | A hook that runs after a successful LLM API call| ✅ | INPUT, OUTPUT | ❌ | ✅ | ✅ |
-| `async_post_call_streaming_iterator_hook` | A hook that processes streaming responses | ✅ | OUTPUT | ❌ | ✅ | ✅ |
+| `async_post_call_success_hook` | A hook that runs after a successful LLM API call. For streaming, runs on the assembled response after delivery (audit-only, cannot block). | ✅ | INPUT, OUTPUT | ❌ | ✅ | ✅ (non-streaming only) |
+| `async_post_call_streaming_iterator_hook` | A hook that processes streaming responses in real-time (can filter/block chunks) | ✅ | OUTPUT | ❌ | ✅ | ✅ |
 
 
 ## Frequently Asked Questions

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2136,22 +2136,36 @@ class CustomStreamWrapper:
                     self.sent_stream_usage = True
                     return response
 
-                asyncio.create_task(
-                    self.logging_obj.async_success_handler(
+                _deferred_cb = getattr(
+                    self.logging_obj,
+                    "_on_deferred_stream_complete",
+                    None,
+                )
+                if _deferred_cb is not None:
+                    # Proxy has post-call guardrails — let the closure
+                    # run guardrails on the assembled response, then
+                    # fire logging with guardrail_information populated.
+                    self.logging_obj._on_deferred_stream_complete = None  # type: ignore[attr-defined]
+                    asyncio.create_task(
+                        _deferred_cb(complete_streaming_response, cache_hit)
+                    )
+                else:
+                    asyncio.create_task(
+                        self.logging_obj.async_success_handler(
+                            complete_streaming_response,
+                            cache_hit=cache_hit,
+                            start_time=None,
+                            end_time=None,
+                        )
+                    )
+
+                    executor.submit(
+                        self.logging_obj.success_handler,
                         complete_streaming_response,
                         cache_hit=cache_hit,
                         start_time=None,
                         end_time=None,
                     )
-                )
-
-                executor.submit(
-                    self.logging_obj.success_handler,
-                    complete_streaming_response,
-                    cache_hit=cache_hit,
-                    start_time=None,
-                    end_time=None,
-                )
 
                 raise StopAsyncIteration  # Re-raise StopIteration
             else:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -46,6 +46,8 @@ from litellm.proxy.dd_span_tagger import DDSpanTagger
 from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import ServerToolUse
 
 # Type alias for streaming chunk serializer (chunk after hooks + cost injection -> wire format)
@@ -1245,9 +1247,6 @@ class ProxyBaseLLMRequestProcessing:
         identical logging output, just fires it slightly later, so
         false-positives are harmless.
         """
-        from litellm.integrations.custom_guardrail import CustomGuardrail
-        from litellm.types.guardrails import GuardrailEventHooks
-
         for cb in litellm.callbacks:
             if (
                 not isinstance(cb, str)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1168,16 +1168,15 @@ class ProxyBaseLLMRequestProcessing:
                     )
 
             ### CALL HOOKS ### - modify outgoing data
-            # Skip when the deferred streaming closure is set on a CSW
-            # response — the closure will run post_call_success_hook on the
-            # assembled response at stream end.  Running it here too would
-            # double-invoke guardrails (side effects, billing, audit logs).
-            # Non-CSW responses (dict fallthroughs) always reach here without
-            # the closure, so the hook runs inline as before.
-            if not getattr(logging_obj, "_on_deferred_stream_complete", None):
-                response = await proxy_logging_obj.post_call_success_hook(
-                    data=self.data, user_api_key_dict=user_api_key_dict, response=response
-                )
+            # If we reach here with a streaming closure still set, it means
+            # no early-return route consumed the CSW (hypothetical fallthrough).
+            # Clear the closure so guardrails run inline as before — this
+            # preserves blocking behavior and avoids double invocation.
+            if getattr(logging_obj, "_on_deferred_stream_complete", None):
+                logging_obj._on_deferred_stream_complete = None  # type: ignore[attr-defined]
+            response = await proxy_logging_obj.post_call_success_hook(
+                data=self.data, user_api_key_dict=user_api_key_dict, response=response
+            )
         finally:
             # Enqueue deferred logging after post-call guardrails have written
             # guardrail_information to metadata.  The finally block ensures

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1098,7 +1098,12 @@ class ProxyBaseLLMRequestProcessing:
             _enqueue_fn = getattr(logging_obj, "_enqueue_deferred_logging", None)
             if _enqueue_fn is not None:
                 logging_obj._enqueue_deferred_logging = None  # type: ignore[attr-defined]
-                _enqueue_fn()
+                try:
+                    _enqueue_fn()
+                except Exception as e:
+                    verbose_proxy_logger.exception(
+                        "Error firing deferred logging: %s", e
+                    )
 
         # Always return the client-requested model name (not provider-prefixed internal identifiers)
         # for OpenAI-compatible responses.

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -930,7 +930,11 @@ class ProxyBaseLLMRequestProcessing:
 
         # Defer async logging when post-call guardrails are configured so the
         # StandardLoggingPayload is built after guardrails write to metadata.
-        if self._has_post_call_guardrails():
+        # Only for non-streaming: streaming returns early in wrapper_async
+        # before the closure-storage point, so the flag would be unused.
+        if self._has_post_call_guardrails() and not self._is_streaming_request(
+            data=self.data, is_streaming_request=is_streaming_request
+        ):
             logging_obj._defer_async_logging = True  # type: ignore
 
         tasks = []
@@ -1253,10 +1257,8 @@ class ProxyBaseLLMRequestProcessing:
         false-positives are harmless.
         """
         for cb in litellm.callbacks:
-            if (
-                not isinstance(cb, str)
-                and isinstance(cb, CustomGuardrail)
-                and cb._event_hook_is_event_type(GuardrailEventHooks.post_call)
+            if isinstance(cb, CustomGuardrail) and cb._event_hook_is_event_type(
+                GuardrailEventHooks.post_call
             ):
                 return True
         return False

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1063,6 +1063,15 @@ class ProxyBaseLLMRequestProcessing:
                             executor,
                         )
 
+                        # NOTE: This closure runs after all chunks have been
+                        # delivered to the client.  Blocking guardrails that
+                        # raise HTTPException cannot prevent content delivery
+                        # for streaming — this is an inherent limitation of
+                        # SSE streaming, not specific to this deferral.  The
+                        # purpose here is to populate guardrail_information in
+                        # the logging payload for audit/compliance, not to
+                        # block content.  Per-chunk filtering should use
+                        # async_post_call_streaming_hook instead.
                         try:
                             _response = await proxy_logging_obj.post_call_success_hook(
                                 data=_captured_data,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1168,9 +1168,16 @@ class ProxyBaseLLMRequestProcessing:
                     )
 
             ### CALL HOOKS ### - modify outgoing data
-            response = await proxy_logging_obj.post_call_success_hook(
-                data=self.data, user_api_key_dict=user_api_key_dict, response=response
-            )
+            # Skip when the deferred streaming closure is set on a CSW
+            # response — the closure will run post_call_success_hook on the
+            # assembled response at stream end.  Running it here too would
+            # double-invoke guardrails (side effects, billing, audit logs).
+            # Non-CSW responses (dict fallthroughs) always reach here without
+            # the closure, so the hook runs inline as before.
+            if not getattr(logging_obj, "_on_deferred_stream_complete", None):
+                response = await proxy_logging_obj.post_call_success_hook(
+                    data=self.data, user_api_key_dict=user_api_key_dict, response=response
+                )
         finally:
             # Enqueue deferred logging after post-call guardrails have written
             # guardrail_information to metadata.  The finally block ensures

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1055,6 +1055,7 @@ class ProxyBaseLLMRequestProcessing:
                     _captured_data = self.data
                     _captured_user_api_key_dict = user_api_key_dict
                     _captured_logging_obj = logging_obj
+                    _captured_proxy_logging_obj = proxy_logging_obj
 
                     async def _on_deferred_stream_complete(
                         assembled_response, cache_hit
@@ -1073,7 +1074,7 @@ class ProxyBaseLLMRequestProcessing:
                         # block content.  Per-chunk filtering should use
                         # async_post_call_streaming_hook instead.
                         try:
-                            _response = await proxy_logging_obj.post_call_success_hook(
+                            _response = await _captured_proxy_logging_obj.post_call_success_hook(
                                 data=_captured_data,
                                 user_api_key_dict=_captured_user_api_key_dict,
                                 response=assembled_response,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -801,7 +801,7 @@ class ProxyBaseLLMRequestProcessing:
                 json.dumps(self.data, indent=4, default=str),
             )
 
-    async def base_process_llm_request(
+    async def base_process_llm_request(  # noqa: PLR0915
         self,
         request: Request,
         fastapi_response: Response,
@@ -926,6 +926,11 @@ class ProxyBaseLLMRequestProcessing:
             llm_router=llm_router,
         )
 
+        # Defer async logging when post-call guardrails are configured so the
+        # StandardLoggingPayload is built after guardrails write to metadata.
+        if self._has_post_call_guardrails():
+            logging_obj._defer_async_logging = True  # type: ignore
+
         tasks = []
         # Start the moderation check (during_call_hook) as early as possible
         # This gives it a head start to mask/validate input while the proxy handles routing
@@ -962,124 +967,136 @@ class ProxyBaseLLMRequestProcessing:
 
         response = responses[1]
 
-        hidden_params = getattr(response, "_hidden_params", {}) or {}
-        model_id = self._get_model_id_from_response(hidden_params, self.data)
+        try:
+            hidden_params = getattr(response, "_hidden_params", {}) or {}
+            model_id = self._get_model_id_from_response(hidden_params, self.data)
 
-        cache_key, api_base, response_cost = (
-            hidden_params.get("cache_key", None) or "",
-            hidden_params.get("api_base", None) or "",
-            hidden_params.get("response_cost", None) or "",
-        )
-        fastest_response_batch_completion, additional_headers = (
-            hidden_params.get("fastest_response_batch_completion", None),
-            hidden_params.get("additional_headers", {}) or {},
-        )
-
-        # Post Call Processing
-        if llm_router is not None:
-            self.data["deployment"] = llm_router.get_deployment(model_id=model_id)
-        asyncio.create_task(
-            proxy_logging_obj.update_request_status(
-                litellm_call_id=self.data.get("litellm_call_id", ""), status="success"
+            cache_key, api_base, response_cost = (
+                hidden_params.get("cache_key", None) or "",
+                hidden_params.get("api_base", None) or "",
+                hidden_params.get("response_cost", None) or "",
             )
-        )
-        if self._is_streaming_request(
-            data=self.data, is_streaming_request=is_streaming_request
-        ) or self._is_streaming_response(
-            response
-        ):  # use generate_responses to stream responses
-            custom_headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
-                user_api_key_dict=user_api_key_dict,
-                call_id=logging_obj.litellm_call_id,
-                model_id=model_id,
-                cache_key=cache_key,
-                api_base=api_base,
-                version=version,
-                response_cost=response_cost,
-                model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
-                fastest_response_batch_completion=fastest_response_batch_completion,
-                request_data=self.data,
-                hidden_params=hidden_params,
-                litellm_logging_obj=logging_obj,
-                **additional_headers,
+            fastest_response_batch_completion, additional_headers = (
+                hidden_params.get("fastest_response_batch_completion", None),
+                hidden_params.get("additional_headers", {}) or {},
             )
 
-            # Call response headers hook for streaming success
-            callback_headers = await proxy_logging_obj.post_call_response_headers_hook(
-                data=self.data,
-                user_api_key_dict=user_api_key_dict,
-                response=response,
-                request_headers=dict(request.headers),
+            # Post Call Processing
+            if llm_router is not None:
+                self.data["deployment"] = llm_router.get_deployment(model_id=model_id)
+            asyncio.create_task(
+                proxy_logging_obj.update_request_status(
+                    litellm_call_id=self.data.get("litellm_call_id", ""), status="success"
+                )
             )
-            if callback_headers:
-                custom_headers.update(callback_headers)
+            if self._is_streaming_request(
+                data=self.data, is_streaming_request=is_streaming_request
+            ) or self._is_streaming_response(
+                response
+            ):  # use generate_responses to stream responses
+                custom_headers = ProxyBaseLLMRequestProcessing.get_custom_headers(
+                    user_api_key_dict=user_api_key_dict,
+                    call_id=logging_obj.litellm_call_id,
+                    model_id=model_id,
+                    cache_key=cache_key,
+                    api_base=api_base,
+                    version=version,
+                    response_cost=response_cost,
+                    model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
+                    fastest_response_batch_completion=fastest_response_batch_completion,
+                    request_data=self.data,
+                    hidden_params=hidden_params,
+                    litellm_logging_obj=logging_obj,
+                    **additional_headers,
+                )
 
-            # Preserve the original client-requested model (pre-alias mapping) for downstream
-            # streaming generators. Pre-call processing can rewrite `self.data["model"]` for
-            # aliasing/routing, but the OpenAI-compatible response `model` field should reflect
-            # what the client sent.
-            if requested_model_from_client:
-                self.data[
-                    "_litellm_client_requested_model"
-                ] = requested_model_from_client
-            if route_type == "allm_passthrough_route":
-                # Check if response is an async generator
-                if self._is_streaming_response(response):
-                    if asyncio.iscoroutine(response):
-                        generator = await response
-                    else:
-                        generator = response
+                # Call response headers hook for streaming success
+                callback_headers = await proxy_logging_obj.post_call_response_headers_hook(
+                    data=self.data,
+                    user_api_key_dict=user_api_key_dict,
+                    response=response,
+                    request_headers=dict(request.headers),
+                )
+                if callback_headers:
+                    custom_headers.update(callback_headers)
 
-                    # For passthrough routes, stream directly without error parsing
-                    # since we're dealing with raw binary data (e.g., AWS event streams)
-                    return StreamingResponse(
-                        content=generator,
-                        status_code=status.HTTP_200_OK,
-                        headers=custom_headers,
-                    )
-                else:
-                    # Traditional HTTP response with aiter_bytes
-                    return StreamingResponse(
-                        content=response.aiter_bytes(),
-                        status_code=response.status_code,
-                        headers=custom_headers,
-                    )
-            elif route_type == "anthropic_messages":
-                # Check if response is actually a streaming response (async generator)
-                # Non-streaming responses (dict) should be returned directly
-                # This handles cases like websearch_interception agentic loop
-                # which returns a non-streaming dict even for streaming requests
-                if self._is_streaming_response(response):
-                    selected_data_generator = (
-                        ProxyBaseLLMRequestProcessing.async_sse_data_generator(
-                            response=response,
-                            user_api_key_dict=user_api_key_dict,
-                            request_data=self.data,
-                            proxy_logging_obj=proxy_logging_obj,
+                # Preserve the original client-requested model (pre-alias mapping) for downstream
+                # streaming generators. Pre-call processing can rewrite `self.data["model"]` for
+                # aliasing/routing, but the OpenAI-compatible response `model` field should reflect
+                # what the client sent.
+                if requested_model_from_client:
+                    self.data[
+                        "_litellm_client_requested_model"
+                    ] = requested_model_from_client
+                if route_type == "allm_passthrough_route":
+                    # Check if response is an async generator
+                    if self._is_streaming_response(response):
+                        if asyncio.iscoroutine(response):
+                            generator = await response
+                        else:
+                            generator = response
+
+                        # For passthrough routes, stream directly without error parsing
+                        # since we're dealing with raw binary data (e.g., AWS event streams)
+                        return StreamingResponse(
+                            content=generator,
+                            status_code=status.HTTP_200_OK,
+                            headers=custom_headers,
                         )
+                    else:
+                        # Traditional HTTP response with aiter_bytes
+                        return StreamingResponse(
+                            content=response.aiter_bytes(),
+                            status_code=response.status_code,
+                            headers=custom_headers,
+                        )
+                elif route_type == "anthropic_messages":
+                    # Check if response is actually a streaming response (async generator)
+                    # Non-streaming responses (dict) should be returned directly
+                    # This handles cases like websearch_interception agentic loop
+                    # which returns a non-streaming dict even for streaming requests
+                    if self._is_streaming_response(response):
+                        selected_data_generator = (
+                            ProxyBaseLLMRequestProcessing.async_sse_data_generator(
+                                response=response,
+                                user_api_key_dict=user_api_key_dict,
+                                request_data=self.data,
+                                proxy_logging_obj=proxy_logging_obj,
+                            )
+                        )
+                        return await create_response(
+                            generator=selected_data_generator,
+                            media_type="text/event-stream",
+                            headers=custom_headers,
+                        )
+                    # Non-streaming response - fall through to normal response handling
+                elif select_data_generator:
+                    selected_data_generator = select_data_generator(
+                        response=response,
+                        user_api_key_dict=user_api_key_dict,
+                        request_data=self.data,
                     )
                     return await create_response(
                         generator=selected_data_generator,
                         media_type="text/event-stream",
                         headers=custom_headers,
                     )
-                # Non-streaming response - fall through to normal response handling
-            elif select_data_generator:
-                selected_data_generator = select_data_generator(
-                    response=response,
-                    user_api_key_dict=user_api_key_dict,
-                    request_data=self.data,
-                )
-                return await create_response(
-                    generator=selected_data_generator,
-                    media_type="text/event-stream",
-                    headers=custom_headers,
-                )
 
-        ### CALL HOOKS ### - modify outgoing data
-        response = await proxy_logging_obj.post_call_success_hook(
-            data=self.data, user_api_key_dict=user_api_key_dict, response=response
-        )
+            ### CALL HOOKS ### - modify outgoing data
+            response = await proxy_logging_obj.post_call_success_hook(
+                data=self.data, user_api_key_dict=user_api_key_dict, response=response
+            )
+        finally:
+            # Enqueue deferred logging after post-call guardrails have written
+            # guardrail_information to metadata.  The finally block ensures
+            # logging fires even if a guardrail raises (matching the current
+            # behavior where create_task fires before post_call_success_hook).
+            # For streaming early-returns: no closure is stored (wrapper_async
+            # returns before line 1946), so _enqueue_fn is None — this is a no-op.
+            _enqueue_fn = getattr(logging_obj, "_enqueue_deferred_logging", None)
+            if _enqueue_fn is not None:
+                logging_obj._enqueue_deferred_logging = None  # type: ignore[attr-defined]
+                _enqueue_fn()
 
         # Always return the client-requested model name (not provider-prefixed internal identifiers)
         # for OpenAI-compatible responses.
@@ -1215,6 +1232,29 @@ class ProxyBaseLLMRequestProcessing:
             return True
         if "stream" in data and data["stream"] is True:
             return True
+        return False
+
+    @staticmethod
+    def _has_post_call_guardrails() -> bool:
+        """
+        Check if any registered callback is a post-call guardrail.
+
+        Uses the global litellm.callbacks list rather than per-request
+        should_run_guardrail() — intentionally conservative so that the
+        check is simple and stateless.  The deferral path produces
+        identical logging output, just fires it slightly later, so
+        false-positives are harmless.
+        """
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        for cb in litellm.callbacks:
+            if (
+                not isinstance(cb, str)
+                and isinstance(cb, CustomGuardrail)
+                and cb._event_hook_is_event_type(GuardrailEventHooks.post_call)
+            ):
+                return True
         return False
 
     async def _handle_llm_api_exception(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -930,9 +930,13 @@ class ProxyBaseLLMRequestProcessing:
 
         # Defer async logging when post-call guardrails are configured so the
         # StandardLoggingPayload is built after guardrails write to metadata.
-        # Only for non-streaming: streaming returns early in wrapper_async
-        # before the closure-storage point, so the flag would be unused.
-        if self._has_post_call_guardrails() and not self._is_streaming_request(
+        # Cache the result to avoid scanning litellm.callbacks twice.
+        _has_post_call_guardrails = self._has_post_call_guardrails()
+
+        # Non-streaming: defer the create_task in wrapper_async so the
+        # SLP is built after guardrails write to metadata.  Streaming
+        # uses a separate closure mechanism (see below).
+        if _has_post_call_guardrails and not self._is_streaming_request(
             data=self.data, is_streaming_request=is_streaming_request
         ):
             logging_obj._defer_async_logging = True  # type: ignore
@@ -1034,6 +1038,81 @@ class ProxyBaseLLMRequestProcessing:
                     self.data[
                         "_litellm_client_requested_model"
                     ] = requested_model_from_client
+                # Streaming: attach a closure that CSW.__anext__ will call
+                # at stream end instead of firing logging directly.  The
+                # closure runs post_call_success_hook on the assembled
+                # response (so guardrail_information is populated), then
+                # fires both logging handlers.
+                # Only for CustomStreamWrapper — raw async generators from
+                # passthrough routes bypass CSW and would orphan the closure.
+                from litellm.litellm_core_utils.streaming_handler import (
+                    CustomStreamWrapper,
+                )
+
+                if _has_post_call_guardrails and isinstance(
+                    response, CustomStreamWrapper
+                ):
+                    _captured_data = self.data
+                    _captured_user_api_key_dict = user_api_key_dict
+                    _captured_logging_obj = logging_obj
+
+                    async def _on_deferred_stream_complete(
+                        assembled_response, cache_hit
+                    ):
+                        from litellm.litellm_core_utils.thread_pool_executor import (
+                            executor,
+                        )
+
+                        try:
+                            _response = await proxy_logging_obj.post_call_success_hook(
+                                data=_captured_data,
+                                user_api_key_dict=_captured_user_api_key_dict,
+                                response=assembled_response,
+                            )
+                        except Exception as e:
+                            verbose_proxy_logger.exception(
+                                "Error running post-call guardrails on streaming response: %s",
+                                e,
+                            )
+                            _response = assembled_response
+                            # Mark as blocked only for intentional guardrail
+                            # blocks, not transient errors.
+                            if isinstance(e, HTTPException) and hasattr(
+                                _captured_logging_obj, "model_call_details"
+                            ):
+                                _captured_logging_obj.model_call_details.setdefault(
+                                    "metadata", {}
+                                )["guardrail_blocked"] = True
+
+                        try:
+                            asyncio.create_task(
+                                _captured_logging_obj.async_success_handler(
+                                    _response,
+                                    cache_hit=cache_hit,
+                                    start_time=None,
+                                    end_time=None,
+                                )
+                            )
+                        except Exception as e:
+                            verbose_proxy_logger.exception(
+                                "Error in deferred streaming async logging: %s", e,
+                            )
+
+                        try:
+                            executor.submit(
+                                _captured_logging_obj.success_handler,
+                                _response,
+                                cache_hit=cache_hit,
+                                start_time=None,
+                                end_time=None,
+                            )
+                        except Exception as e:
+                            verbose_proxy_logger.exception(
+                                "Error in deferred streaming sync logging: %s", e,
+                            )
+
+                    logging_obj._on_deferred_stream_complete = _on_deferred_stream_complete  # type: ignore[attr-defined]
+
                 if route_type == "allm_passthrough_route":
                     # Check if response is an async generator
                     if self._is_streaming_response(response):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1951,8 +1951,9 @@ def client(original_function):  # noqa: PLR0915
                 # SLO is built.  Store a closure the proxy will call after
                 # post_call_success_hook so guardrail_information is in metadata.
                 # Only create_task is deferred; sync callbacks fire immediately
-                # to preserve existing behavior for billing/rate-limiting.
+                # (below, outside the if/else) for billing/rate-limiting.
                 def _enqueue_deferred_logging() -> None:
+                    # Must be called from within a running event loop.
                     asyncio.create_task(
                         _client_async_logging_helper(
                             logging_obj=logging_obj,
@@ -1964,11 +1965,6 @@ def client(original_function):  # noqa: PLR0915
                     )
 
                 logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging  # type: ignore
-                logging_obj.handle_sync_success_callbacks_for_async_calls(
-                    result=result,
-                    start_time=start_time,
-                    end_time=end_time,
-                )
             else:
                 asyncio.create_task(
                     _client_async_logging_helper(
@@ -1979,11 +1975,13 @@ def client(original_function):  # noqa: PLR0915
                         is_completion_with_fallbacks=is_completion_with_fallbacks,
                     )
                 )
-                logging_obj.handle_sync_success_callbacks_for_async_calls(
-                    result=result,
-                    start_time=start_time,
-                    end_time=end_time,
-                )
+
+            # Sync callbacks always fire immediately regardless of deferral
+            logging_obj.handle_sync_success_callbacks_for_async_calls(
+                result=result,
+                start_time=start_time,
+                end_time=end_time,
+            )
             # REBUILD EMBEDDING CACHING
             if (
                 isinstance(result, EmbeddingResponse)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1950,8 +1950,8 @@ def client(original_function):  # noqa: PLR0915
                 # Proxy has post-call guardrails that must complete before the
                 # SLO is built.  Store a closure the proxy will call after
                 # post_call_success_hook so guardrail_information is in metadata.
-                # Both async (create_task) and sync callbacks are deferred so
-                # all callbacks see consistent guardrail_information state.
+                # Only create_task is deferred; sync callbacks fire immediately
+                # to preserve existing behavior for billing/rate-limiting.
                 def _enqueue_deferred_logging() -> None:
                     asyncio.create_task(
                         _client_async_logging_helper(
@@ -1962,13 +1962,13 @@ def client(original_function):  # noqa: PLR0915
                             is_completion_with_fallbacks=is_completion_with_fallbacks,
                         )
                     )
-                    logging_obj.handle_sync_success_callbacks_for_async_calls(
-                        result=result,
-                        start_time=start_time,
-                        end_time=end_time,
-                    )
 
                 logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging  # type: ignore
+                logging_obj.handle_sync_success_callbacks_for_async_calls(
+                    result=result,
+                    start_time=start_time,
+                    end_time=end_time,
+                )
             else:
                 asyncio.create_task(
                     _client_async_logging_helper(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1944,10 +1944,14 @@ def client(original_function):  # noqa: PLR0915
             )
 
             # LOG SUCCESS - handle streaming success logging in the _next_ object
+            # NOTE: streaming requests return early (before this point) via
+            # CustomStreamWrapper, so this block is non-streaming only.
             if getattr(logging_obj, "_defer_async_logging", False):
                 # Proxy has post-call guardrails that must complete before the
                 # SLO is built.  Store a closure the proxy will call after
                 # post_call_success_hook so guardrail_information is in metadata.
+                # Both async (create_task) and sync callbacks are deferred so
+                # all callbacks see consistent guardrail_information state.
                 def _enqueue_deferred_logging() -> None:
                     asyncio.create_task(
                         _client_async_logging_helper(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1944,20 +1944,42 @@ def client(original_function):  # noqa: PLR0915
             )
 
             # LOG SUCCESS - handle streaming success logging in the _next_ object
-            asyncio.create_task(
-                _client_async_logging_helper(
-                    logging_obj=logging_obj,
+            if getattr(logging_obj, "_defer_async_logging", False):
+                # Proxy has post-call guardrails that must complete before the
+                # SLO is built.  Store a closure the proxy will call after
+                # post_call_success_hook so guardrail_information is in metadata.
+                def _enqueue_deferred_logging() -> None:
+                    asyncio.create_task(
+                        _client_async_logging_helper(
+                            logging_obj=logging_obj,
+                            result=result,
+                            start_time=start_time,
+                            end_time=end_time,
+                            is_completion_with_fallbacks=is_completion_with_fallbacks,
+                        )
+                    )
+                    logging_obj.handle_sync_success_callbacks_for_async_calls(
+                        result=result,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+
+                logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging  # type: ignore
+            else:
+                asyncio.create_task(
+                    _client_async_logging_helper(
+                        logging_obj=logging_obj,
+                        result=result,
+                        start_time=start_time,
+                        end_time=end_time,
+                        is_completion_with_fallbacks=is_completion_with_fallbacks,
+                    )
+                )
+                logging_obj.handle_sync_success_callbacks_for_async_calls(
                     result=result,
                     start_time=start_time,
                     end_time=end_time,
-                    is_completion_with_fallbacks=is_completion_with_fallbacks,
                 )
-            )
-            logging_obj.handle_sync_success_callbacks_for_async_calls(
-                result=result,
-                start_time=start_time,
-                end_time=end_time,
-            )
             # REBUILD EMBEDDING CACHING
             if (
                 isinstance(result, EmbeddingResponse)

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -514,3 +514,90 @@ class TestDeferredStreamingClosure:
         assert mock_logging_obj.model_call_details["metadata"].get(
             "guardrail_blocked"
         ) is not True
+
+    @pytest.mark.asyncio
+    async def test_production_closure_calls_post_call_success_hook(self):
+        """Integration test: a closure built with the same structure as the
+        production _on_deferred_stream_complete calls
+        post_call_success_hook on the assembled response, then fires
+        async_success_handler with the guardrail-modified response.
+
+        Uses a mock proxy_logging_obj to verify the hook is called and
+        the response flows to async_success_handler correctly."""
+        hook_called = False
+        logged_response = None
+        modified_response = MagicMock()
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {"metadata": {}}
+
+        async def track_async_success(*args, **kwargs):
+            nonlocal logged_response
+            logged_response = args[0] if args else None
+
+        mock_logging_obj.async_success_handler = track_async_success
+
+        # Mock proxy_logging_obj with a post_call_success_hook that
+        # simulates guardrail execution
+        mock_proxy_logging = MagicMock()
+
+        async def mock_hook(**kwargs):
+            nonlocal hook_called
+            hook_called = True
+            return modified_response
+
+        mock_proxy_logging.post_call_success_hook = mock_hook
+
+        # Build the closure using the exact production pattern
+        _captured_data = {"model": "gpt-4", "metadata": {}}
+        _captured_user_api_key_dict = UserAPIKeyAuth(api_key="test")
+        _captured_logging_obj = mock_logging_obj
+        _captured_proxy_logging_obj = mock_proxy_logging
+
+        async def _on_deferred_stream_complete(assembled_response, cache_hit):
+            try:
+                _response = await _captured_proxy_logging_obj.post_call_success_hook(
+                    data=_captured_data,
+                    user_api_key_dict=_captured_user_api_key_dict,
+                    response=assembled_response,
+                )
+            except Exception as e:
+                _response = assembled_response
+                if isinstance(e, HTTPException) and hasattr(
+                    _captured_logging_obj, "model_call_details"
+                ):
+                    _captured_logging_obj.model_call_details.setdefault(
+                        "metadata", {}
+                    )["guardrail_blocked"] = True
+
+            try:
+                asyncio.create_task(
+                    _captured_logging_obj.async_success_handler(
+                        _response,
+                        cache_hit=cache_hit,
+                        start_time=None,
+                        end_time=None,
+                    )
+                )
+            except Exception:
+                pass
+
+        mock_logging_obj._on_deferred_stream_complete = _on_deferred_stream_complete
+
+        resp = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+            stream=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        async for _ in resp:
+            pass
+
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert hook_called is True, \
+            "Production closure must call post_call_success_hook"
+        assert logged_response is modified_response, \
+            "Production closure must pass guardrail-modified response to logging"

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -109,6 +109,34 @@ class TestHasPostCallGuardrails:
         with patch("litellm.callbacks", ["langfuse", CustomLogger()]):
             assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is False
 
+    def test_returns_true_for_list_with_post_call(self):
+        """event_hook as a list containing post_call should trigger deferral."""
+
+        class ListGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(
+                    guardrail_name="list-post",
+                    default_on=True,
+                    event_hook=[GuardrailEventHooks.pre_call, GuardrailEventHooks.post_call],
+                )
+
+        with patch("litellm.callbacks", [ListGuardrail()]):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is True
+
+    def test_returns_false_for_list_without_post_call(self):
+        """event_hook as a list without post_call should not trigger deferral."""
+
+        class ListGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(
+                    guardrail_name="list-pre",
+                    default_on=True,
+                    event_hook=[GuardrailEventHooks.pre_call],
+                )
+
+        with patch("litellm.callbacks", [ListGuardrail()]):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is False
+
 
 # ---------------------------------------------------------------------------
 # 2. Deferral mechanism: flag → closure stored, create_task skipped

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -297,3 +297,220 @@ async def test_deferred_logging_fires_on_guardrail_exception():
 
     assert enqueue_called is True, "Deferred logging should fire even on guardrail exception"
     assert logging_obj._enqueue_deferred_logging is None, "Closure should be cleared after firing"
+
+
+# ---------------------------------------------------------------------------
+# 5. Streaming deferred logging via closure
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredStreamingClosure:
+    """Tests for the streaming closure-based deferred logging."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_closure_defers_logging(self):
+        """When _on_deferred_stream_complete is set, CSW calls the closure
+        instead of firing async_success_handler directly."""
+        mock_logging_obj = MagicMock()
+        callback_called = False
+        callback_args = {}
+
+        async def mock_callback(assembled_response, cache_hit):
+            nonlocal callback_called, callback_args
+            callback_called = True
+            callback_args = {"response": assembled_response, "cache_hit": cache_hit}
+
+        mock_logging_obj._on_deferred_stream_complete = mock_callback
+
+        resp = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+            stream=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        async for _ in resp:
+            pass
+
+        await asyncio.sleep(0)
+
+        assert callback_called is True, "Closure should be called at stream end"
+        assert callback_args["response"] is not None
+        assert mock_logging_obj._on_deferred_stream_complete is None
+
+    @pytest.mark.asyncio
+    async def test_streaming_no_closure_fires_normally(self):
+        """Regression: without closure, CSW fires logging immediately."""
+        created_tasks = []
+        real_create_task = asyncio.create_task
+
+        def tracking_create_task(coro):
+            task = real_create_task(coro)
+            created_tasks.append(task)
+            return task
+
+        resp = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+            stream=True,
+        )
+        with patch("asyncio.create_task", side_effect=tracking_create_task):
+            async for _ in resp:
+                pass
+
+        assert len(created_tasks) >= 1
+        for task in created_tasks:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_closure_runs_guardrails_before_logging(self):
+        """The closure passes the guardrail-modified response to handlers."""
+        mock_logging_obj = MagicMock()
+        modified_response = MagicMock()
+        logged_response = None
+
+        async def mock_post_call(**kwargs):
+            return modified_response
+
+        async def mock_async_success(*args, **kwargs):
+            nonlocal logged_response
+            logged_response = args[0] if args else None
+
+        mock_logging_obj.async_success_handler = mock_async_success
+
+        async def closure(assembled_response, cache_hit):
+            try:
+                resp = await mock_post_call(response=assembled_response)
+            except Exception:
+                resp = assembled_response
+            asyncio.create_task(
+                mock_logging_obj.async_success_handler(
+                    resp, cache_hit=cache_hit, start_time=None, end_time=None
+                )
+            )
+
+        mock_logging_obj._on_deferred_stream_complete = closure
+
+        resp = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+            stream=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        async for _ in resp:
+            pass
+
+        # Two sleeps: outer create_task (CSW calls closure) then
+        # inner create_task (closure calls async_success_handler)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert logged_response is modified_response, \
+            "Logging should receive the guardrail-modified response"
+
+    @pytest.mark.asyncio
+    async def test_closure_logs_even_on_guardrail_exception(self):
+        """If the guardrail raises HTTPException, logging still fires
+        and guardrail_blocked is set in metadata."""
+        logging_called = False
+
+        async def failing_hook(**kwargs):
+            raise HTTPException(status_code=400, detail="Blocked")
+
+        async def mock_async_success(*args, **kwargs):
+            nonlocal logging_called
+            logging_called = True
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {"metadata": {}}
+        mock_logging_obj.async_success_handler = mock_async_success
+
+        async def closure(assembled_response, cache_hit):
+            try:
+                resp = await failing_hook(response=assembled_response)
+            except Exception as e:
+                resp = assembled_response
+                if isinstance(e, HTTPException) and hasattr(
+                    mock_logging_obj, "model_call_details"
+                ):
+                    mock_logging_obj.model_call_details.setdefault(
+                        "metadata", {}
+                    )["guardrail_blocked"] = True
+            asyncio.create_task(
+                mock_logging_obj.async_success_handler(
+                    resp, cache_hit=cache_hit, start_time=None, end_time=None
+                )
+            )
+
+        mock_logging_obj._on_deferred_stream_complete = closure
+
+        resp = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+            stream=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        async for _ in resp:
+            pass
+
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert logging_called is True, "Logging should fire even when guardrail raises"
+        assert mock_logging_obj.model_call_details["metadata"].get(
+            "guardrail_blocked"
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_transient_error_does_not_set_guardrail_blocked(self):
+        """Transient errors (not HTTPException) should NOT set guardrail_blocked."""
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {"metadata": {}}
+
+        async def mock_async_success(*args, **kwargs):
+            pass
+
+        mock_logging_obj.async_success_handler = mock_async_success
+
+        async def closure(assembled_response, cache_hit):
+            try:
+                raise ConnectionError("Network timeout")
+            except Exception as e:
+                resp = assembled_response
+                if isinstance(e, HTTPException) and hasattr(
+                    mock_logging_obj, "model_call_details"
+                ):
+                    mock_logging_obj.model_call_details.setdefault(
+                        "metadata", {}
+                    )["guardrail_blocked"] = True
+            asyncio.create_task(
+                mock_logging_obj.async_success_handler(
+                    resp, cache_hit=cache_hit, start_time=None, end_time=None
+                )
+            )
+
+        mock_logging_obj._on_deferred_stream_complete = closure
+
+        resp = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+            stream=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        async for _ in resp:
+            pass
+
+        await asyncio.sleep(0)
+
+        assert mock_logging_obj.model_call_details["metadata"].get(
+            "guardrail_blocked"
+        ) is not True

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -123,7 +123,8 @@ async def test_deferred_flag_stores_and_executes_closure():
     """
     When _defer_async_logging is True on logging_obj:
     1. wrapper_async stores a callable closure instead of calling create_task
-    2. Calling the closure fires create_task + handle_sync_success_callbacks
+    2. Calling the closure fires create_task
+    3. Sync callbacks fire immediately (not deferred)
     """
     mock_logging_obj = MagicMock()
     mock_logging_obj._defer_async_logging = True
@@ -141,7 +142,10 @@ async def test_deferred_flag_stores_and_executes_closure():
     enqueue_fn = mock_logging_obj._enqueue_deferred_logging
     assert callable(enqueue_fn), "Closure should be stored on logging_obj"
 
-    # --- Part 2: calling the closure fires the logging machinery ---
+    # --- Part 2: sync callbacks fired immediately (not in closure) ---
+    mock_logging_obj.handle_sync_success_callbacks_for_async_calls.assert_called_once()
+
+    # --- Part 3: calling the closure fires create_task ---
     created_tasks = []
     real_create_task = asyncio.create_task
 
@@ -154,7 +158,6 @@ async def test_deferred_flag_stores_and_executes_closure():
         enqueue_fn()
 
     assert len(created_tasks) >= 1, "Closure should fire asyncio.create_task"
-    mock_logging_obj.handle_sync_success_callbacks_for_async_calls.assert_called_once()
 
     # Clean up tasks
     for task in created_tasks:

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1,0 +1,271 @@
+"""
+Tests for Bug 3 fix: deferred logging for post-call guardrails.
+
+When post-call guardrails are configured, the async logging task is deferred
+until after post_call_success_hook completes. This ensures the
+StandardLoggingPayload is built after guardrails write guardrail_information
+to metadata.
+
+Test coverage:
+- Detection: _has_post_call_guardrails correctly identifies post-call guardrails
+- Deferral: wrapper_async stores closure instead of calling create_task
+- Execution: stored closure fires create_task + sync callbacks when called
+- Exception: deferred logging fires even if post_call_success_hook raises
+- Regression: without flag, create_task fires normally
+"""
+
+import asyncio
+import os
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.utils import ProxyLogging
+from litellm.types.guardrails import GuardrailEventHooks
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class PostCallGuardrail(CustomGuardrail):
+    """A post-call guardrail."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="post-call",
+            default_on=True,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+    async def async_post_call_success_hook(
+        self, data: dict, user_api_key_dict: UserAPIKeyAuth, response: Any
+    ) -> Any:
+        return response
+
+
+class PreCallGuardrail(CustomGuardrail):
+    """A pre-call-only guardrail — should NOT trigger deferral."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="pre-call",
+            default_on=True,
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+
+
+class AllEventsGuardrail(CustomGuardrail):
+    """A guardrail with event_hook=None (runs on all events)."""
+
+    def __init__(self):
+        super().__init__(
+            guardrail_name="all-events",
+            default_on=True,
+            event_hook=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1. _has_post_call_guardrails detection
+#
+# Breakable scenario: wrong detection → flag set when it shouldn't be
+# (unnecessary deferral, harmless) or not set when it should be (bug persists).
+# ---------------------------------------------------------------------------
+
+
+class TestHasPostCallGuardrails:
+    def test_returns_true_for_post_call_guardrail(self):
+        with patch("litellm.callbacks", [PostCallGuardrail()]):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is True
+
+    def test_returns_true_for_event_hook_none(self):
+        """event_hook=None means 'all events', including post_call."""
+        with patch("litellm.callbacks", [AllEventsGuardrail()]):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is True
+
+    def test_returns_false_for_pre_call_only(self):
+        with patch("litellm.callbacks", [PreCallGuardrail()]):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is False
+
+    def test_returns_false_for_no_callbacks(self):
+        with patch("litellm.callbacks", []):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is False
+
+    def test_ignores_non_guardrail_callbacks(self):
+        """String callbacks and CustomLogger instances are not guardrails."""
+        with patch("litellm.callbacks", ["langfuse", CustomLogger()]):
+            assert ProxyBaseLLMRequestProcessing._has_post_call_guardrails() is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Deferral mechanism: flag → closure stored, create_task skipped
+#
+# Breakable scenario: flag is set but create_task fires anyway (race persists),
+# or closure is not stored (logging lost).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deferred_flag_stores_and_executes_closure():
+    """
+    When _defer_async_logging is True on logging_obj:
+    1. wrapper_async stores a callable closure instead of calling create_task
+    2. Calling the closure fires create_task + handle_sync_success_callbacks
+    """
+    mock_logging_obj = MagicMock()
+    mock_logging_obj._defer_async_logging = True
+    mock_logging_obj._enqueue_deferred_logging = None
+
+    # Use mock_response to avoid real API call
+    await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="Hello!",
+        litellm_logging_obj=mock_logging_obj,
+    )
+
+    # --- Part 1: closure was stored ---
+    enqueue_fn = mock_logging_obj._enqueue_deferred_logging
+    assert callable(enqueue_fn), "Closure should be stored on logging_obj"
+
+    # --- Part 2: calling the closure fires the logging machinery ---
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    def tracking_create_task(coro):
+        task = real_create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    with patch("asyncio.create_task", side_effect=tracking_create_task):
+        enqueue_fn()
+
+    assert len(created_tasks) >= 1, "Closure should fire asyncio.create_task"
+    mock_logging_obj.handle_sync_success_callbacks_for_async_calls.assert_called_once()
+
+    # Clean up tasks
+    for task in created_tasks:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# 3. Regression: without flag, create_task fires normally
+#
+# Breakable scenario: the if/else in wrapper_async is wrong and the else
+# branch (no flag) also defers → logging broken for ALL requests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_flag_fires_create_task_normally():
+    """
+    When _defer_async_logging is NOT set, wrapper_async calls
+    asyncio.create_task as before (existing behavior preserved).
+    """
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    def tracking_create_task(coro):
+        task = real_create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    with patch("asyncio.create_task", side_effect=tracking_create_task):
+        await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello!",
+        )
+
+    # At least one create_task call (for _client_async_logging_helper)
+    assert len(created_tasks) >= 1
+
+    # Clean up tasks
+    for task in created_tasks:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# 4. Exception path: deferred logging fires even if post_call_success_hook raises
+#
+# Breakable scenario: guardrail blocks content (raises HTTPException), the
+# finally block doesn't run or doesn't call the closure → logging silently lost.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deferred_logging_fires_on_guardrail_exception():
+    """
+    If post_call_success_hook raises (e.g., guardrail blocks content),
+    the deferred logging closure must still fire (via try/finally).
+    """
+    enqueue_called = False
+
+    def mock_enqueue():
+        nonlocal enqueue_called
+        enqueue_called = True
+
+    class BlockingGuardrail(CustomGuardrail):
+        def __init__(self):
+            super().__init__(
+                guardrail_name="blocker",
+                default_on=True,
+                event_hook=GuardrailEventHooks.post_call,
+            )
+
+        async def async_post_call_success_hook(
+            self, data: dict, user_api_key_dict: UserAPIKeyAuth, response: Any
+        ) -> Any:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=400, detail="Content blocked")
+
+    guardrail = BlockingGuardrail()
+
+    # Simulate the proxy's try/finally pattern with a raising guardrail
+    logging_obj = MagicMock()
+    logging_obj._enqueue_deferred_logging = mock_enqueue
+
+    with patch("litellm.callbacks", [guardrail]):
+        proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            try:
+                await proxy_logging.post_call_success_hook(
+                    data={"model": "gpt-4", "metadata": {}},
+                    response=MagicMock(),
+                    user_api_key_dict=UserAPIKeyAuth(api_key="test"),
+                )
+            finally:
+                # This mirrors the proxy's finally block
+                _enqueue_fn = getattr(logging_obj, "_enqueue_deferred_logging", None)
+                if _enqueue_fn is not None:
+                    logging_obj._enqueue_deferred_logging = None
+                    _enqueue_fn()
+
+    assert enqueue_called is True, "Deferred logging should fire even on guardrail exception"
+    assert logging_obj._enqueue_deferred_logging is None, "Closure should be cleared after firing"

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -21,6 +21,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
@@ -238,8 +239,6 @@ async def test_deferred_logging_fires_on_guardrail_exception():
         async def async_post_call_success_hook(
             self, data: dict, user_api_key_dict: UserAPIKeyAuth, response: Any
         ) -> Any:
-            from fastapi import HTTPException
-
             raise HTTPException(status_code=400, detail="Content blocked")
 
     guardrail = BlockingGuardrail()
@@ -250,8 +249,6 @@ async def test_deferred_logging_fires_on_guardrail_exception():
 
     with patch("litellm.callbacks", [guardrail]):
         proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
-
-        from fastapi import HTTPException
 
         with pytest.raises(HTTPException):
             try:


### PR DESCRIPTION
## Relevant issues

Related to #23910 (request_data passthrough + full moderation response logging for post-call guardrails)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

**Problem**: `guardrail_information` is `None` in `StandardLoggingPayload` because logging fires before post-call guardrails have written to metadata.

- **Non-streaming**: `asyncio.create_task` in `wrapper_async` fires before `post_call_success_hook` runs
- **Streaming**: logging fires at stream exhaustion in `CustomStreamWrapper.__anext__` without guardrail data from the assembled response

### Non-streaming fix

When post-call guardrails are configured, defer the `create_task` call by storing a closure on `logging_obj._enqueue_deferred_logging`. The proxy calls this closure in a `try/finally` block after `post_call_success_hook` completes. Sync callbacks (`handle_sync_success_callbacks_for_async_calls`) fire immediately as before — only the async logging task (which builds `StandardLoggingPayload`) is deferred.

**Files changed**:
- `litellm/utils.py` — conditional deferral: when `_defer_async_logging` flag is set, store closure instead of calling `create_task`
- `litellm/proxy/common_request_processing.py` — `_has_post_call_guardrails()` detection, flag setting, `try/finally` to call deferred closure after `post_call_success_hook`

### Streaming fix

Store a `_on_deferred_stream_complete` closure on `logging_obj` that captures proxy context. `CustomStreamWrapper.__anext__` checks for this closure at stream end and calls it instead of firing logging directly. The closure runs `post_call_success_hook` on the **assembled** response (so guardrails can inspect full content and write `guardrail_information` to metadata), then fires both logging handlers.

The closure is only attached for `CustomStreamWrapper` responses (checked via `isinstance`), not raw async generators from passthrough routes. For routes that consume the CSW via a generator (all current production streaming paths), the closure fires at stream end. If a CSW response falls through to the inline `post_call_success_hook` without being consumed by a generator (a hypothetical path not exercised by current callers), the closure is cleared and the inline hook runs as before — preserving blocking guardrail behavior with no double invocation.

**Files changed**:
- `litellm/proxy/common_request_processing.py` — closure setup inside the streaming block (only for CSW + post-call guardrails), closure cleared on fallthrough to inline hook
- `litellm/litellm_core_utils/streaming_handler.py` — `CustomStreamWrapper.__anext__` checks for closure at stream end

### Tests (`tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py`)

**Non-streaming** (7 tests):
- `_has_post_call_guardrails` detection (post_call, pre_call, event_hook=None, string callbacks, empty, list variants)
- Deferred flag stores and executes closure correctly
- Regression: without flag, `create_task` fires normally
- Exception path: deferred logging fires even if guardrail raises

**Streaming** (5 tests):
- Closure defers logging at stream end (called, cleared, response stored)
- Regression: without closure, logging fires immediately
- Closure passes guardrail-modified response to logging handlers
- Exception resilience: logging fires even when guardrail raises HTTPException, `guardrail_blocked` set in metadata
- Transient errors do NOT set `guardrail_blocked`

**Companion PR**: #23910 fixes *what* gets written to metadata. This PR fixes *when* the logging snapshot is taken.