### PR TITLE
fix(openai): handle missing 'id' field in streaming chunks for MiniMax

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -806,7 +806,7 @@ class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):
             choices = self._map_reasoning_to_reasoning_content(choices)
 
             kwargs = {
-                "id": chunk["id"],
+                "id": chunk.get("id"),
                 "object": "chat.completion.chunk",
                 "created": chunk.get("created"),
                 "model": chunk.get("model"),

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -281,6 +281,45 @@ class TestOpenAIChatCompletionStreamingHandler:
         # Verify that reasoning_content is not set (it should be deleted by Delta.__init__)
         assert not hasattr(parsed_chunk.choices[0].delta, "reasoning_content")
 
+    def test_chunk_parser_without_id_field(self):
+        """
+        Test that chunk_parser works when chunk is missing the 'id' field.
+
+        Some OpenAI-compatible providers (e.g., MiniMax) return streaming chunks
+        without an 'id' field in certain cases. This should not raise KeyError.
+
+        Regression test for: KeyError: 'id' when using MiniMax m2.5 model
+        """
+        handler = OpenAIChatCompletionStreamingHandler(
+            streaming_response=None, sync_stream=True
+        )
+
+        # Simulate a chunk without 'id' field (as returned by MiniMax)
+        chunk = {
+            "object": "chat.completion.chunk",
+            "created": 1769511767,
+            "model": "minimax/m2.5",
+            "choices": [
+                {
+                    "delta": {
+                        "content": "Hello",
+                        "role": "assistant",
+                    },
+                    "finish_reason": None,
+                    "index": 0,
+                }
+            ],
+        }
+
+        # Parse the chunk - should not raise KeyError
+        parsed_chunk = handler.chunk_parser(chunk)
+
+        # Verify that content is present and id was auto-generated
+        assert parsed_chunk.choices[0].delta.content == "Hello"
+        assert parsed_chunk.choices[0].delta.role == "assistant"
+        # ModelResponseStream auto-generates an id when None is passed
+        assert parsed_chunk.id is not None
+
 
 class TestPromptCacheKeyIntegration:
     """Tests for prompt_cache_key support"""


### PR DESCRIPTION
- Change chunk["id"] to chunk.get("id") for compatibility with MiniMax and other OpenAI-compatible providers
- ModelResponseStream auto-generates id when None is passed
- Add regression test test_chunk_parser_without_id_field

## Relevant issues

Fixes KeyError: 'id' when using MiniMax m2.5 model with streaming responses

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem
When using MiniMax m2.5 model (or other OpenAI-compatible providers), streaming responses may include chunks without an `id` field. The code at `gpt_transformation.py:809` used `chunk["id"]` which throws `KeyError: 'id'` when the field is missing.

### Solution
- Changed `chunk["id"]` to `chunk.get("id")` in `litellm/llms/openai/chat/gpt_transformation.py`
- When `id` is `None`, `ModelResponseStream` automatically generates one via `_generate_id()`

### Files Changed
- `litellm/llms/openai/chat/gpt_transformation.py` - Fix KeyError by using safe dict access
- `tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py` - Add regression test
