### PR TITLE
fix(key_management): sanitize sensitive callback credentials from key metadata

### DIFF
--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.utils import StandardCallbackDynamicParams
 
@@ -29,6 +29,48 @@ _supported_callback_params = [
     "lunary_public_key",
     "turn_off_message_logging",
 ]
+
+# Sensitive params that should be redacted from metadata when returning key info
+SENSITIVE_CALLBACK_PARAMS = {
+    "langfuse_public_key",
+    "langfuse_secret",
+    "langfuse_secret_key",
+    "langfuse_host",
+    "gcs_path_service_account",
+    "langsmith_api_key",
+    "humanloop_api_key",
+    "arize_api_key",
+    "arize_space_key",
+    "posthog_api_key",
+    "braintrust_api_key",
+    "slack_webhook_url",
+    "lunary_public_key",
+}
+
+REDACTED_VALUE = "***REDACTED***"
+
+
+def sanitize_metadata_for_key_info(metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """
+    Sanitize metadata by redacting sensitive callback credentials before returning in key info.
+
+    This prevents API keys and secrets from being exposed when calling /key/info endpoint.
+
+    Args:
+        metadata: The metadata dictionary to sanitize
+
+    Returns:
+        A copy of the metadata with sensitive fields redacted
+    """
+    if metadata is None:
+        return None
+
+    sanitized = dict(metadata)
+    for param in SENSITIVE_CALLBACK_PARAMS:
+        if param in sanitized:
+            sanitized[param] = REDACTED_VALUE
+
+    return sanitized
 
 
 def initialize_standard_callback_dynamic_params(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2616,6 +2616,21 @@ async def info_key_fn_v2(
             except Exception:
                 # if using pydantic v1
                 k = k.dict()
+            # Sanitize metadata to prevent sensitive credentials from leaking
+            if k.get("metadata"):
+                from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+                    sanitize_metadata_for_key_info,
+                )
+
+                try:
+                    metadata_dict = json.loads(k["metadata"])
+                    if isinstance(metadata_dict, dict):
+                        k["metadata"] = json.dumps(
+                            sanitize_metadata_for_key_info(metadata_dict)
+                        )
+                except (json.JSONDecodeError, TypeError):
+                    # If metadata is not valid JSON, skip sanitization
+                    pass
             filtered_key_info.append(k)
         return {"key": data.keys, "info": filtered_key_info}
 
@@ -2698,6 +2713,22 @@ async def info_key_fn(
             # if using pydantic v1
             key_info = key_info.dict()
         key_info.pop("token")
+
+        # Sanitize metadata to prevent sensitive credentials from leaking
+        if key_info.get("metadata"):
+            from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+                sanitize_metadata_for_key_info,
+            )
+
+            try:
+                metadata_dict = json.loads(key_info["metadata"])
+                if isinstance(metadata_dict, dict):
+                    key_info["metadata"] = json.dumps(
+                        sanitize_metadata_for_key_info(metadata_dict)
+                    )
+            except (json.JSONDecodeError, TypeError):
+                # If metadata is not valid JSON, skip sanitization
+                pass
 
         # Attach object_permission if object_permission_id is set
         key_info = await attach_object_permission_to_dict(key_info, prisma_client)

--- a/tests/logging_callback_tests/test_dynamic_otel_keys.py
+++ b/tests/logging_callback_tests/test_dynamic_otel_keys.py
@@ -5,6 +5,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 
 from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
     initialize_standard_callback_dynamic_params,
+    sanitize_metadata_for_key_info,
+    REDACTED_VALUE,
 )
 
 
@@ -47,6 +49,79 @@ def test_dynamic_key_extraction_from_litellm_params_metadata():
     assert params.get("langfuse_secret_key") == "sk-litellm"
 
 
+def test_sanitize_metadata_for_key_info():
+    """
+    Test that sanitize_metadata_for_key_info correctly redacts sensitive callback credentials.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/23776
+    """
+    metadata = {
+        "langfuse_public_key": "pk-lf-12345",
+        "langfuse_secret_key": "sk-lf-secret",
+        "langfuse_secret": "sk-lf-alt-secret",
+        "langfuse_host": "https://langfuse.example.com",
+        "langsmith_api_key": "ls-api-key",
+        "arize_api_key": "arize-key",
+        "arize_space_key": "arize-space",
+        "humanloop_api_key": "humanloop-key",
+        "posthog_api_key": "posthog-key",
+        "braintrust_api_key": "braintrust-key",
+        "slack_webhook_url": "https://hooks.slack.com/services/xxx",
+        "lunary_public_key": "lunary-key",
+        "gcs_path_service_account": "gcs-service-account-json",
+        # Non-sensitive fields that should remain intact
+        "safe_field": "visible-value",
+        "model_rpm_limit": {"gpt-4": 100},
+        "trace_id": "trace-123",
+    }
+
+    sanitized = sanitize_metadata_for_key_info(metadata)
+
+    # Verify sensitive fields are redacted
+    assert sanitized["langfuse_public_key"] == REDACTED_VALUE
+    assert sanitized["langfuse_secret_key"] == REDACTED_VALUE
+    assert sanitized["langfuse_secret"] == REDACTED_VALUE
+    assert sanitized["langfuse_host"] == REDACTED_VALUE
+    assert sanitized["langsmith_api_key"] == REDACTED_VALUE
+    assert sanitized["arize_api_key"] == REDACTED_VALUE
+    assert sanitized["arize_space_key"] == REDACTED_VALUE
+    assert sanitized["humanloop_api_key"] == REDACTED_VALUE
+    assert sanitized["posthog_api_key"] == REDACTED_VALUE
+    assert sanitized["braintrust_api_key"] == REDACTED_VALUE
+    assert sanitized["slack_webhook_url"] == REDACTED_VALUE
+    assert sanitized["lunary_public_key"] == REDACTED_VALUE
+    assert sanitized["gcs_path_service_account"] == REDACTED_VALUE
+
+    # Verify non-sensitive fields remain intact
+    assert sanitized["safe_field"] == "visible-value"
+    assert sanitized["model_rpm_limit"] == {"gpt-4": 100}
+    assert sanitized["trace_id"] == "trace-123"
+
+    # Verify original metadata is not modified
+    assert metadata["langfuse_public_key"] == "pk-lf-12345"
+
+
+def test_sanitize_metadata_for_key_info_none():
+    """
+    Test that sanitize_metadata_for_key_info handles None input.
+    """
+    result = sanitize_metadata_for_key_info(None)
+    assert result is None
+
+
+def test_sanitize_metadata_for_key_info_empty():
+    """
+    Test that sanitize_metadata_for_key_info handles empty metadata.
+    """
+    result = sanitize_metadata_for_key_info({})
+    assert result == {}
+
+
 if __name__ == "__main__":
     test_dynamic_key_extraction_from_metadata()
     test_dynamic_key_extraction_from_litellm_params_metadata()
+    test_sanitize_metadata_for_key_info()
+    test_sanitize_metadata_for_key_info_none()
+    test_sanitize_metadata_for_key_info_empty()
+    print("All tests passed!")
+

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -961,6 +961,91 @@ async def test_key_info_returns_object_permission(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_key_info_sanitizes_sensitive_metadata(monkeypatch):
+    """
+    Test that /key/info correctly sanitizes sensitive callback credentials from metadata.
+
+    This test verifies that when calling /key/info for a key with Langfuse credentials
+    in metadata, the response has those credentials redacted to prevent information leakage.
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/23776
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.management_endpoints.key_management_endpoints import info_key_fn
+
+    # Mock prisma client
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # Mock key with sensitive metadata containing Langfuse credentials
+    test_key_token = "hashed_test_token_456"
+
+    sensitive_metadata = {
+        "langfuse_public_key": "pk-lf-12345",
+        "langfuse_secret_key": "sk-lf-secret-67890",
+        "langfuse_host": "https://langfuse.example.com",
+        "langsmith_api_key": "ls-api-key-secret",
+        "slack_webhook_url": "https://hooks.slack.com/services/T00/B00/XXX",
+        "safe_field": "this-should-remain-visible",
+        "model_rpm_limit": {"gpt-4": 100},
+    }
+
+    mock_key_info = MagicMock(spec=LiteLLM_VerificationToken)
+    mock_key_info.token = test_key_token
+    mock_key_info.object_permission_id = None
+    mock_key_info.user_id = "user123"
+    mock_key_info.team_id = None
+    mock_key_info.litellm_budget_table = None
+
+    # Mock the dict/model_dump methods
+    mock_key_info.model_dump.return_value = {
+        "token": test_key_token,
+        "object_permission_id": None,
+        "user_id": "user123",
+        "team_id": None,
+        "litellm_budget_table": None,
+        "metadata": json.dumps(sensitive_metadata),
+    }
+    mock_key_info.dict.return_value = mock_key_info.model_dump.return_value
+
+    # Mock find_unique for the key lookup
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_info
+    )
+
+    # Create user API key dict
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-test-key-789",
+    )
+
+    # Call info_key_fn
+    result = await info_key_fn(
+        key="sk-test-key-789",
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    # Assertions
+    assert "info" in result
+    assert "metadata" in result["info"]
+
+    # Parse the returned metadata
+    returned_metadata = json.loads(result["info"]["metadata"])
+
+    # Verify sensitive fields are redacted
+    assert returned_metadata["langfuse_public_key"] == "***REDACTED***"
+    assert returned_metadata["langfuse_secret_key"] == "***REDACTED***"
+    assert returned_metadata["langfuse_host"] == "***REDACTED***"
+    assert returned_metadata["langsmith_api_key"] == "***REDACTED***"
+    assert returned_metadata["slack_webhook_url"] == "***REDACTED***"
+
+    # Verify non-sensitive fields remain intact
+    assert returned_metadata["safe_field"] == "this-should-remain-visible"
+    assert returned_metadata["model_rpm_limit"] == {"gpt-4": 100}
+
+
+@pytest.mark.asyncio
 async def test_get_new_token_with_valid_key(monkeypatch):
     """Test get_new_token function when provided with a valid key that starts with 'sk-'"""
     from unittest.mock import AsyncMock


### PR DESCRIPTION
Redact sensitive API keys and secrets from metadata when returning key info via /key/info endpoints. Prevents credential leakage for Langfuse, Langsmith, Arize, and other callback integrations.

- Add sanitize_metadata_for_key_info() function
- Redact 13 sensitive callback parameters
- Apply sanitization in both info_key_fn and info_key_fn_v2
- Add unit tests for sanitization logic

Fixes #23776