### PR TITLE
fix(prompt_studio): fall back to dotprompt_content from DB when Prompt Studio editor loads

### DIFF
--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -581,6 +581,25 @@ async def get_prompt_info(
         # If content extraction fails, continue without content
         pass
 
+    # Fallback: if no content was extracted from the callback, read dotprompt_content
+    # from the prompt spec (populated when prompts are saved via Prompt Studio UI or
+    # PUT /prompts/{id}). Fixes #23935 — editor opened blank after saving via UI.
+    if prompt_template is None:
+        stored_content = getattr(prompt_spec.litellm_params, "dotprompt_content", None)
+        if stored_content is None and prompt_spec.litellm_params:
+            # Also check prompt_data for content
+            prompt_data = getattr(prompt_spec.litellm_params, "prompt_data", None)
+            if isinstance(prompt_data, dict):
+                stored_content = prompt_data.get("content")
+            elif hasattr(prompt_data, "content"):
+                stored_content = prompt_data.content
+        if stored_content:
+            prompt_template = PromptTemplateBase(
+                litellm_prompt_id=prompt_spec.prompt_id,
+                content=stored_content,
+                metadata={},
+            )
+
     # Create response with content
     return PromptInfoResponse(
         prompt_spec=prompt_spec_response,


### PR DESCRIPTION
## Summary

Fixes #23935

When prompts are saved via the Prompt Studio UI or `PUT /prompts/{id}`, the content is stored in `litellm_params.dotprompt_content` (and sometimes `prompt_data.content`). However, the `GET /prompts/{id}/info` endpoint only read content from the in-memory prompt callback, which is only populated for file-based dotprompt — not for UI-saved prompts.

Result: the Prompt Studio editor always opened blank after saving via the UI.

## Changes

Added a fallback in `get_prompt_info()`: after checking the callback, read `litellm_params.dotprompt_content` and `prompt_data.content` from the stored `PromptSpec` to populate `raw_prompt_template` when the callback did not yield content.

## Testing

1. Open Prompt Studio
2. Create and save a prompt via the UI
3. Reopen the prompt — editor now shows the saved content instead of being blank