### PR TITLE
feat: upgrade minimax default model to MiniMax-M3

### DIFF
--- a/docs/my-website/docs/providers/minimax.md
+++ b/docs/my-website/docs/providers/minimax.md
@@ -11,10 +11,14 @@ Litellm provides anthropic specs compatible support for minmax
 
 ## Supported Models
 
-MiniMax offers three models through their Anthropic-compatible API:
+MiniMax offers the following models through their Anthropic-compatible API:
 
 | Model | Description | Input Cost | Output Cost | Prompt Caching Read | Prompt Caching Write |
 |-------|-------------|------------|-------------|---------------------|----------------------|
+| **MiniMax-M2.7** | Latest flagship model with enhanced reasoning and coding | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
+| **MiniMax-M2.7-lightning** | High-speed version of M2.7 for low-latency scenarios | $0.3/M tokens | $2.4/M tokens | $0.03/M tokens | $0.375/M tokens |
+| **MiniMax-M2.5** | Advanced reasoning, Agentic capabilities | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
+| **MiniMax-M2.5-lightning** | High-speed version of M2.5 | $0.3/M tokens | $2.4/M tokens | $0.03/M tokens | $0.375/M tokens |
 | **MiniMax-M2.1** | Powerful Multi-Language Programming with Enhanced Programming Experience (~60 tps) | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
 | **MiniMax-M2.1-lightning** | Faster and More Agile (~100 tps) | $0.3/M tokens | $2.4/M tokens | $0.03/M tokens | $0.375/M tokens |
 | **MiniMax-M2** | Agentic capabilities, Advanced reasoning | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |

--- a/docs/my-website/docs/providers/minimax.md
+++ b/docs/my-website/docs/providers/minimax.md
@@ -15,8 +15,9 @@ MiniMax offers the following models through their Anthropic-compatible API:
 
 | Model | Description | Input Cost | Output Cost | Prompt Caching Read | Prompt Caching Write |
 |-------|-------------|------------|-------------|---------------------|----------------------|
-| **MiniMax-M2.7** | Latest flagship model with enhanced reasoning and coding | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
-| **MiniMax-M2.7-lightning** | High-speed version of M2.7 for low-latency scenarios | $0.3/M tokens | $2.4/M tokens | $0.03/M tokens | $0.375/M tokens |
+| **MiniMax-M3** | Latest flagship model with 512K context, 128K output, and image input support (default) | $0.6/M tokens | $2.4/M tokens | $0.12/M tokens | — |
+| **MiniMax-M2.7** | Previous flagship model with enhanced reasoning and coding | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
+| **MiniMax-M2.7-highspeed** | High-speed version of M2.7 for low-latency scenarios | $0.3/M tokens | $2.4/M tokens | $0.03/M tokens | $0.375/M tokens |
 | **MiniMax-M2.5** | Advanced reasoning, Agentic capabilities | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
 | **MiniMax-M2.5-lightning** | High-speed version of M2.5 | $0.3/M tokens | $2.4/M tokens | $0.03/M tokens | $0.375/M tokens |
 | **MiniMax-M2.1** | Powerful Multi-Language Programming with Enhanced Programming Experience (~60 tps) | $0.3/M tokens | $1.2/M tokens | $0.03/M tokens | $0.375/M tokens |
@@ -32,7 +33,7 @@ MiniMax offers the following models through their Anthropic-compatible API:
 import litellm
 
 response = litellm.anthropic.messages.acreate(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "Hello, how are you?"}],
     api_key="your-minimax-api-key",
     api_base="https://api.minimax.io/anthropic/v1/messages",
@@ -53,17 +54,17 @@ export MINIMAX_API_BASE="https://api.minimax.io/anthropic/v1/messages"
 import litellm
 
 response = litellm.anthropic.messages.acreate(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "Hello!"}],
     max_tokens=1000
 )
 ```
 
-### With Thinking (M2.1 Feature)
+### With Thinking
 
 ```python
 response = litellm.anthropic.messages.acreate(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "Solve: 2+2=?"}],
     thinking={"type": "enabled", "budget_tokens": 1000},
     api_key="your-minimax-api-key"
@@ -96,7 +97,7 @@ tools = [
 ]
 
 response = litellm.anthropic.messages.acreate(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "What's the weather in SF?"}],
     tools=tools,
     api_key="your-minimax-api-key",
@@ -122,9 +123,9 @@ Create a `config.yaml`:
 
 ```yaml
 model_list:
-  - model_name: minimax/MiniMax-M2.1
+  - model_name: minimax/MiniMax-M3
     litellm_params:
-      model: minimax/MiniMax-M2.1
+      model: minimax/MiniMax-M3
       api_key: os.environ/MINIMAX_API_KEY
       api_base: https://api.minimax.io/anthropic/v1/messages
 ```
@@ -147,7 +148,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 message = client.messages.create(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     max_tokens=1000,
     system="You are a helpful assistant.",
     messages=[
@@ -182,7 +183,7 @@ You can use MiniMax's OpenAI-compatible API directly with LiteLLM:
 import litellm
 
 response = litellm.completion(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"}
@@ -205,7 +206,7 @@ export MINIMAX_API_BASE="https://api.minimax.io/v1"
 import litellm
 
 response = litellm.completion(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "Hello!"}]
 )
 ```
@@ -214,7 +215,7 @@ response = litellm.completion(
 
 ```python
 response = litellm.completion(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Solve: 2+2=?"}
@@ -251,7 +252,7 @@ tools = [
 ]
 
 response = litellm.completion(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "What's the weather in SF?"}],
     tools=tools,
     api_key="your-minimax-api-key",
@@ -263,7 +264,7 @@ response = litellm.completion(
 
 ```python
 response = litellm.completion(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "Tell me a story"}],
     stream=True,
     api_key="your-minimax-api-key",
@@ -292,9 +293,9 @@ Create a `config.yaml`:
 
 ```yaml
 model_list:
-  - model_name: minimax/MiniMax-M2.1
+  - model_name: minimax/MiniMax-M3
     litellm_params:
-      model: minimax/MiniMax-M2.1
+      model: minimax/MiniMax-M3
       api_key: os.environ/MINIMAX_API_KEY
       api_base: https://api.minimax.io/v1
 ```
@@ -317,7 +318,7 @@ from openai import OpenAI
 client = OpenAI()
 
 response = client.chat.completions.create(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hi, how are you?"},
@@ -340,7 +341,7 @@ from openai import OpenAI
 client = OpenAI()
 
 stream = client.chat.completions.create(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Tell me a story"},
@@ -377,7 +378,7 @@ Cost calculation works automatically using the pricing information in `model_pri
 Example:
 ```python
 response = litellm.completion(
-    model="minimax/MiniMax-M2.1",
+    model="minimax/MiniMax-M3",
     messages=[{"role": "user", "content": "Hello!"}],
     api_key="your-minimax-api-key"
 )

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,6 +17,10 @@ class MinimaxChatConfig(OpenAIGPTConfig):
     - China: https://api.minimaxi.com/v1
 
     Supported models:
+    - MiniMax-M2.7
+    - MiniMax-M2.7-lightning
+    - MiniMax-M2.5
+    - MiniMax-M2.5-lightning
     - MiniMax-M2.1
     - MiniMax-M2.1-lightning
     - MiniMax-M2

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -17,8 +17,9 @@ class MinimaxChatConfig(OpenAIGPTConfig):
     - China: https://api.minimaxi.com/v1
 
     Supported models:
+    - MiniMax-M3
     - MiniMax-M2.7
-    - MiniMax-M2.7-lightning
+    - MiniMax-M2.7-highspeed
     - MiniMax-M2.5
     - MiniMax-M2.5-lightning
     - MiniMax-M2.1

--- a/litellm/llms/minimax/messages/transformation.py
+++ b/litellm/llms/minimax/messages/transformation.py
@@ -18,6 +18,7 @@ class MinimaxMessagesConfig(AnthropicMessagesConfig):
     - China: https://api.minimaxi.com/anthropic
 
     Supported models:
+    - MiniMax-M3
     - MiniMax-M2.1
     - MiniMax-M2.1-lightning
     - MiniMax-M2

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21142,6 +21142,36 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
+    "minimax/MiniMax-M2.7-lightning": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
     "minimax/MiniMax-M2.5": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21142,36 +21142,6 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
-    "minimax/MiniMax-M2.7": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
-    "minimax/MiniMax-M2.7-lightning": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 2.4e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
     "minimax/MiniMax-M2.5": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
@@ -21188,6 +21158,36 @@
         "max_output_tokens": 8192
     },
     "minimax/MiniMax-M2.5-lightning": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
+    "minimax/MiniMax-M2.7-lightning": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 2.4e-06,
         "cache_read_input_token_cost": 3e-08,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21172,6 +21172,21 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M3": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 1.2e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "max_input_tokens": 512000,
+        "max_output_tokens": 128000
+    },
     "minimax/MiniMax-M2.7": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
@@ -21187,7 +21202,7 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
-    "minimax/MiniMax-M2.7-lightning": {
+    "minimax/MiniMax-M2.7-highspeed": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 2.4e-06,
         "cache_read_input_token_cost": 3e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21142,6 +21142,36 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
+    "minimax/MiniMax-M2.7-lightning": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
     "minimax/MiniMax-M2.5": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21142,36 +21142,6 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
-    "minimax/MiniMax-M2.7": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
-    "minimax/MiniMax-M2.7-lightning": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 2.4e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
     "minimax/MiniMax-M2.5": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
@@ -21188,6 +21158,36 @@
         "max_output_tokens": 8192
     },
     "minimax/MiniMax-M2.5-lightning": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192
+    },
+    "minimax/MiniMax-M2.7-lightning": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 2.4e-06,
         "cache_read_input_token_cost": 3e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21172,6 +21172,21 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M3": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 1.2e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "max_input_tokens": 512000,
+        "max_output_tokens": 128000
+    },
     "minimax/MiniMax-M2.7": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
@@ -21187,7 +21202,7 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
-    "minimax/MiniMax-M2.7-lightning": {
+    "minimax/MiniMax-M2.7-highspeed": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 2.4e-06,
         "cache_read_input_token_cost": 3e-08,


### PR DESCRIPTION
## Summary

Upgrade the `minimax` provider so that `MiniMax-M3` is the recommended default model. M3 is a 512K-context, 128K-output flagship with native image input support and a new pricing tier.

## Changes

- **`model_prices_and_context_window.json`** / **`litellm/model_prices_and_context_window_backup.json`** (kept in sync per repo convention):
  - Add `minimax/MiniMax-M3` with M3 specs (max_input=512000, max_output=128000, supports_vision=true, supports_reasoning, supports_prompt_caching, function calling / tool choice) and M3 pricing — input $0.6/M, output $2.4/M, cache_read $0.12/M. M3 has no active prompt-cache-write tier, so `cache_creation_input_token_cost` is intentionally omitted.
  - Rename `minimax/MiniMax-M2.7-lightning` → `minimax/MiniMax-M2.7-highspeed` to match the official upstream naming (M2.7 entry kept as-is).
- **`litellm/llms/minimax/chat/transformation.py`** / **`litellm/llms/minimax/messages/transformation.py`**: list `MiniMax-M3` at the top of the supported-models docstring; replace `M2.7-lightning` with `M2.7-highspeed` in chat docstring.
- **`docs/my-website/docs/providers/minimax.md`**: feature M3 as the default in the supported-models table, list M2.7 and M2.7-highspeed as kept alternatives, and switch every code/yaml example from `minimax/MiniMax-M2.1` to `minimax/MiniMax-M3`. Removed the "(M2.1 Feature)" qualifier from the thinking section since M3 also supports it.

Older entries (`M2`, `M2.1`, `M2.1-lightning`, `M2.5`, `M2.5-lightning`) are intentionally **kept** in the JSON cost map so existing callers continue to resolve to correct pricing — only the user-facing default and recommended-models list move to M3.

## Why

`MiniMax-M3` is the current minimax flagship: 512K context, up to 128K output, native multimodal (image input) on both OpenAI-compatible and Anthropic-compatible endpoints. Defaulting to M3 in docs/docstrings keeps new users on the latest model; keeping M2.7 and M2.7-highspeed in the recommended list preserves a stable lower-cost tier.

## Testing

- Both JSON files validated as well-formed and kept in sync (`python -m json.tool`).
- `pytest tests/test_litellm/llms/minimax/` → 7 passed, 7 skipped (network-gated).
- `pytest tests/test_litellm/llms/test_cache_control_and_reasoning.py -k minimax` → 5 passed.