### PR TITLE
fix(vertex_ai): exclude system_instruction, tools, toolConfig when cached_content is set

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -1,22 +1,18 @@
 """
-Transformation logic from OpenAI format to Gemini format.
+Transformation logic from OpenAI format to Gemini format. 
 
 Why separate file? Make it easy to see how transformation works
 """
-import json
+
 import os
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union, cast
 
 import httpx
 from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.prompt_templates.common_utils import (
-    _get_image_mime_type_from_url,
-)
 from litellm.litellm_core_utils.prompt_templates.factory import (
-    convert_generic_image_chunk_to_openai_image_obj,
     convert_to_anthropic_image_obj,
     convert_to_gemini_tool_call_invoke,
     convert_to_gemini_tool_call_result,
@@ -31,11 +27,8 @@ from litellm.types.files import (
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantMessage,
-    ChatCompletionAudioObject,
-    ChatCompletionFileObject,
     ChatCompletionImageObject,
     ChatCompletionTextObject,
-    ChatCompletionUserMessage,
 )
 from litellm.types.llms.vertex_ai import *
 from litellm.types.llms.vertex_ai import (
@@ -47,7 +40,6 @@ from litellm.types.llms.vertex_ai import (
     ToolConfig,
     Tools,
 )
-from litellm.types.utils import GenericImageParsingChunk, LlmProviders
 
 from ..common_utils import (
     _check_text_in_content,
@@ -63,127 +55,9 @@ else:
     LiteLLMLoggingObj = Any
 
 
-def _convert_detail_to_media_resolution_enum(
-    detail: Optional[str],
-) -> Optional[Dict[str, str]]:
-    if detail == "low":
-        return {"level": "MEDIA_RESOLUTION_LOW"}
-    elif detail == "medium":
-        return {"level": "MEDIA_RESOLUTION_MEDIUM"}
-    elif detail == "high":
-        return {"level": "MEDIA_RESOLUTION_HIGH"}
-    elif detail == "ultra_high":
-        return {"level": "MEDIA_RESOLUTION_ULTRA_HIGH"}
-    return None
-
-
-def _get_highest_media_resolution(
-    current: Optional[str], new_detail: Optional[str]
-) -> Optional[str]:
+def _process_gemini_image(image_url: str, format: Optional[str] = None) -> PartType:
     """
-    Compare two media resolution values and return the highest one.
-    Resolution hierarchy: ultra_high > high > medium > low > None
-    """
-    resolution_priority = {"ultra_high": 4, "high": 3, "medium": 2, "low": 1}
-    current_priority = resolution_priority.get(current, 0) if current else 0
-    new_priority = resolution_priority.get(new_detail, 0) if new_detail else 0
-
-    if new_priority > current_priority:
-        return new_detail
-    return current
-
-
-def _extract_max_media_resolution_from_messages(
-    messages: List[AllMessageValues],
-) -> Optional[str]:
-    """
-    Extract the highest media resolution (detail) from image content in messages.
-
-    This is used to set the global media_resolution in generation_config for
-    Gemini 2.x models which don't support per-part media resolution.
-
-    Args:
-        messages: List of messages in OpenAI format
-
-    Returns:
-        The highest detail level found ("high", "low", or None)
-    """
-    max_resolution: Optional[str] = None
-    for msg in messages:
-        content = msg.get("content")
-        if isinstance(content, list):
-            for item in content:
-                if not isinstance(item, dict):
-                    continue
-                detail: Optional[str] = None
-                if item.get("type") == "image_url":
-                    image_url = item.get("image_url")
-                    if isinstance(image_url, dict):
-                        detail = image_url.get("detail")
-                elif item.get("type") == "file":
-                    file_obj = item.get("file")
-                    if isinstance(file_obj, dict):
-                        detail = file_obj.get("detail")
-                if detail:
-                    max_resolution = _get_highest_media_resolution(
-                        max_resolution, detail
-                    )
-    return max_resolution
-
-
-def _apply_gemini_3_metadata(
-    part: PartType,
-    model: Optional[str],
-    media_resolution_enum: Optional[Dict[str, str]],
-    video_metadata: Optional[Dict[str, Any]],
-) -> PartType:
-    """
-    Apply the unique media_resolution and video_metadata parameters of Gemini 3+
-    """
-    if model is None:
-        return part
-
-    from .vertex_and_google_ai_studio_gemini import VertexGeminiConfig
-
-    if not VertexGeminiConfig._is_gemini_3_or_newer(model):
-        return part
-
-    part_dict = dict(part)
-
-    if media_resolution_enum is not None:
-        part_dict["media_resolution"] = media_resolution_enum
-
-    if video_metadata is not None:
-        gemini_video_metadata = {}
-        if "fps" in video_metadata:
-            gemini_video_metadata["fps"] = video_metadata["fps"]
-        if "start_offset" in video_metadata:
-            gemini_video_metadata["startOffset"] = video_metadata["start_offset"]
-        if "end_offset" in video_metadata:
-            gemini_video_metadata["endOffset"] = video_metadata["end_offset"]
-        if gemini_video_metadata:
-            part_dict["video_metadata"] = gemini_video_metadata
-
-    return cast(PartType, part_dict)
-
-
-def _process_gemini_media(
-    image_url: str,
-    format: Optional[str] = None,
-    media_resolution_enum: Optional[Dict[str, str]] = None,
-    model: Optional[str] = None,
-    video_metadata: Optional[Dict[str, Any]] = None,
-) -> PartType:
-    """
-    Given a media URL (image, audio, or video), return the appropriate PartType for Gemini
-    By the way, actually video_metadata can only be used with videos; it cannot be used with images, audio, or files. However, I haven't made any special handling because vertex returns a parameter error.
-
-    Args:
-        image_url: The URL or base64 string of the media (image, audio, or video)
-        format: The MIME type of the media
-        media_resolution_enum: Media resolution level (for Gemini 3+)
-        model: The model name (to check version compatibility)
-        video_metadata: Video-specific metadata (fps, start_offset, end_offset)
+    Given an image URL, return the appropriate PartType for Gemini
     """
 
     try:
@@ -204,93 +78,55 @@ def _process_gemini_media(
             else:
                 mime_type = format
             file_data = FileDataType(mime_type=mime_type, file_uri=image_url)
-            part: PartType = {"file_data": file_data}
-            return _apply_gemini_3_metadata(
-                part, model, media_resolution_enum, video_metadata
-            )
+
+            return PartType(file_data=file_data)
         elif (
             "https://" in image_url
             and (image_type := format or _get_image_mime_type_from_url(image_url))
             is not None
         ):
-            file_data = FileDataType(mime_type=image_type, file_uri=image_url)
-            part = {"file_data": file_data}
-            return _apply_gemini_3_metadata(
-                part, model, media_resolution_enum, video_metadata
-            )
+
+            file_data = FileDataType(file_uri=image_url, mime_type=image_type)
+            return PartType(file_data=file_data)
         elif "http://" in image_url or "https://" in image_url or "base64" in image_url:
+            # https links for unsupported mime types and base64 images
             image = convert_to_anthropic_image_obj(image_url, format=format)
-            _blob: BlobType = {"data": image["data"], "mime_type": image["media_type"]}
-            part = {"inline_data": cast(BlobType, _blob)}
-            return _apply_gemini_3_metadata(
-                part, model, media_resolution_enum, video_metadata
-            )
+            _blob = BlobType(data=image["data"], mime_type=image["media_type"])
+            return PartType(inline_data=_blob)
         raise Exception("Invalid image received - {}".format(image_url))
     except Exception as e:
         raise e
 
 
-def _snake_to_camel(snake_str: str) -> str:
-    """Convert snake_case to camelCase"""
-    components = snake_str.split("_")
-    return components[0] + "".join(x.capitalize() for x in components[1:])
-
-
-def _camel_to_snake(camel_str: str) -> str:
-    """Convert camelCase to snake_case"""
-    import re
-
-    return re.sub(r"(?<!^)(?=[A-Z])", "_", camel_str).lower()
-
-
-def _get_equivalent_key(key: str, available_keys: set) -> Optional[str]:
+def _get_image_mime_type_from_url(url: str) -> Optional[str]:
     """
-    Get the equivalent key from available keys, checking both camelCase and snake_case variants
+    Get mime type for common image URLs
+    See gemini mime types: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-understanding#image-requirements
+
+    Supported by Gemini:
+     - PNG (`image/png`)
+     - JPEG (`image/jpeg`)
+     - WebP (`image/webp`)
+    Example:
+        url = https://example.com/image.jpg
+        Returns: image/jpeg
     """
-    if key in available_keys:
-        return key
-
-    # Try camelCase version
-    camel_key = _snake_to_camel(key)
-    if camel_key in available_keys:
-        return camel_key
-
-    # Try snake_case version
-    snake_key = _camel_to_snake(key)
-    if snake_key in available_keys:
-        return snake_key
-
+    url = url.lower()
+    if url.endswith((".jpg", ".jpeg")):
+        return "image/jpeg"
+    elif url.endswith(".png"):
+        return "image/png"
+    elif url.endswith(".webp"):
+        return "image/webp"
+    elif url.endswith(".mp4"):
+        return "video/mp4"
+    elif url.endswith(".pdf"):
+        return "application/pdf"
     return None
-
-
-def check_if_part_exists_in_parts(
-    parts: List[PartType], part: PartType, excluded_keys: List[str] = []
-) -> bool:
-    """
-    Check if a part exists in a list of parts
-    Handles both camelCase and snake_case key variations (e.g., function_call vs functionCall)
-    """
-    keys_to_compare = set(part.keys()) - set(excluded_keys)
-    for p in parts:
-        p_keys = set(p.keys())
-        # Check if all keys in part have equivalent values in p
-        match_found = True
-        for key in keys_to_compare:
-            equivalent_key = _get_equivalent_key(key, p_keys)
-            if equivalent_key is None or p.get(equivalent_key, None) != part.get(
-                key, None
-            ):
-                match_found = False
-                break
-
-        if match_found:
-            return True
-    return False
 
 
 def _gemini_convert_messages_with_history(  # noqa: PLR0915
     messages: List[AllMessageValues],
-    model: Optional[str] = None,
 ) -> List[ContentType]:
     """
     Converts given messages from OpenAI format to Gemini format
@@ -317,7 +153,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 _message_content = messages[msg_i].get("content")
                 if _message_content is not None and isinstance(_message_content, list):
                     _parts: List[PartType] = []
-                    for element_idx, element in enumerate(_message_content):
+                    for element in _message_content:
                         if (
                             element["type"] == "text"
                             and "text" in element
@@ -330,83 +166,21 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                             element = cast(ChatCompletionImageObject, element)
                             img_element = element
                             format: Optional[str] = None
-                            media_resolution_enum: Optional[Dict[str, str]] = None
                             if isinstance(img_element["image_url"], dict):
                                 image_url = img_element["image_url"]["url"]
                                 format = img_element["image_url"].get("format")
-                                detail = img_element["image_url"].get("detail")
-                                media_resolution_enum = (
-                                    _convert_detail_to_media_resolution_enum(detail)
-                                )
                             else:
                                 image_url = img_element["image_url"]
-                            _part = _process_gemini_media(
-                                image_url=image_url,
-                                format=format,
-                                media_resolution_enum=media_resolution_enum,
-                                model=model,
+                            _part = _process_gemini_image(
+                                image_url=image_url, format=format
                             )
                             _parts.append(_part)
-                        elif element["type"] == "input_audio":
-                            audio_element = cast(ChatCompletionAudioObject, element)
-                            audio_data = audio_element["input_audio"].get("data")
-                            audio_format = audio_element["input_audio"].get("format")
-                            if audio_data is not None and audio_format is not None:
-                                audio_format_modified = (
-                                    "audio/" + audio_format
-                                    if audio_format.startswith("audio/") is False
-                                    else audio_format
-                                )  # Gemini expects audio/wav, audio/mp3, etc.
-                                openai_image_str = (
-                                    convert_generic_image_chunk_to_openai_image_obj(
-                                        image_chunk=GenericImageParsingChunk(
-                                            type="base64",
-                                            media_type=audio_format_modified,
-                                            data=audio_data,
-                                        )
-                                    )
-                                )
-                                _part = _process_gemini_media(
-                                    image_url=openai_image_str,
-                                    format=audio_format_modified,
-                                    model=model,
-                                )
-                                _parts.append(_part)
-                        elif element["type"] == "file":
-                            file_element = cast(ChatCompletionFileObject, element)
-                            file_id = file_element["file"].get("file_id")
-                            format = file_element["file"].get("format")
-                            file_data = file_element["file"].get("file_data")
-                            detail = file_element["file"].get("detail")
-                            video_metadata = file_element["file"].get("video_metadata")
-                            passed_file = file_id or file_data
-                            if passed_file is None:
-                                raise Exception(
-                                    "Unknown file type. Please pass in a file_id or file_data"
-                                )
-
-                            # Convert detail to media_resolution_enum
-                            media_resolution_enum = (
-                                _convert_detail_to_media_resolution_enum(detail)
-                            )
-
-                            try:
-                                _part = _process_gemini_media(
-                                    image_url=passed_file,
-                                    format=format,
-                                    model=model,
-                                    media_resolution_enum=media_resolution_enum,
-                                    video_metadata=video_metadata,
-                                )
-                                _parts.append(_part)
-                            except Exception:
-                                raise Exception(
-                                    "Unable to determine mime type for file_id: {}, set this explicitly using message[{}].content[{}].file.format".format(
-                                        file_id, msg_i, element_idx
-                                    )
-                                )
                     user_content.extend(_parts)
-                elif _message_content is not None and isinstance(_message_content, str):
+                elif (
+                    _message_content is not None
+                    and isinstance(_message_content, str)
+                    and len(_message_content) > 0
+                ):
                     _part = PartType(text=_message_content)
                     user_content.append(_part)
 
@@ -436,35 +210,6 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     msg_dict = messages[msg_i]  # type: ignore
                 assistant_msg = ChatCompletionAssistantMessage(**msg_dict)  # type: ignore
                 _message_content = assistant_msg.get("content", None)
-                reasoning_content = assistant_msg.get("reasoning_content", None)
-                thinking_blocks = assistant_msg.get("thinking_blocks")
-                if reasoning_content is not None:
-                    assistant_content.append(
-                        PartType(thought=True, text=reasoning_content)
-                    )
-                if thinking_blocks is not None:
-                    for block in thinking_blocks:
-                        if block["type"] == "thinking":
-                            block_thinking_str = block.get("thinking")
-                            block_signature = block.get("signature")
-                            if (
-                                block_thinking_str is not None
-                                and block_signature is not None
-                            ):
-                                try:
-                                    assistant_content.append(
-                                        PartType(
-                                            thoughtSignature=block_signature,
-                                            **json.loads(block_thinking_str),
-                                        )
-                                    )
-                                except Exception:
-                                    assistant_content.append(
-                                        PartType(
-                                            thoughtSignature=block_signature,
-                                            text=block_thinking_str,
-                                        )
-                                    )
                 if _message_content is not None and isinstance(_message_content, list):
                     _parts = []
                     for element in _message_content:
@@ -472,72 +217,23 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                             if element["type"] == "text":
                                 _part = PartType(text=element["text"])
                                 _parts.append(_part)
-
                     assistant_content.extend(_parts)
-                elif _message_content is not None and isinstance(_message_content, str):
-                    assistant_text = _message_content
-                    # Check if message has thought_signatures in provider_specific_fields
-                    provider_specific_fields = assistant_msg.get(
-                        "provider_specific_fields"
-                    )
-                    thought_signatures = None
-                    if provider_specific_fields and isinstance(
-                        provider_specific_fields, dict
-                    ):
-                        thought_signatures = provider_specific_fields.get(
-                            "thought_signatures"
-                        )
-
-                    # If we have thought signatures, add them to the part
-                    if (
-                        thought_signatures
-                        and isinstance(thought_signatures, list)
-                        and len(thought_signatures) > 0
-                    ):
-                        # Use the first signature for the text part (Gemini expects one signature per part)
-                        assistant_content.append(PartType(text=assistant_text, thoughtSignature=thought_signatures[0]))  # type: ignore
-                    else:
-                        assistant_content.append(PartType(text=assistant_text))  # type: ignore
-
-                ## HANDLE ASSISTANT IMAGES FIELD
-                # Process images field if present (for generated images from assistant)
-                assistant_images = assistant_msg.get("images")
-                if assistant_images is not None and isinstance(assistant_images, list):
-                    for image_item in assistant_images:
-                        if isinstance(image_item, dict):
-                            image_url_obj = image_item.get("image_url")
-                            if isinstance(image_url_obj, dict):
-                                assistant_image_url = image_url_obj.get("url")
-                                format = image_url_obj.get("format")
-                                detail = image_url_obj.get("detail")
-                                media_resolution_enum = (
-                                    _convert_detail_to_media_resolution_enum(detail)
-                                )
-                                if assistant_image_url:
-                                    _part = _process_gemini_media(
-                                        image_url=assistant_image_url,
-                                        format=format,
-                                        media_resolution_enum=media_resolution_enum,
-                                        model=model,
-                                    )
-                                    assistant_content.append(_part)
+                elif (
+                    _message_content is not None
+                    and isinstance(_message_content, str)
+                    and _message_content
+                ):
+                    assistant_text = _message_content  # either string or none
+                    assistant_content.append(PartType(text=assistant_text))  # type: ignore
 
                 ## HANDLE ASSISTANT FUNCTION CALL
                 if (
                     assistant_msg.get("tool_calls", []) is not None
                     or assistant_msg.get("function_call") is not None
                 ):  # support assistant tool invoke conversion
-                    gemini_tool_call_parts = convert_to_gemini_tool_call_invoke(
-                        assistant_msg, model=model
+                    assistant_content.extend(
+                        convert_to_gemini_tool_call_invoke(assistant_msg)
                     )
-                    ## check if gemini_tool_call already exists in assistant_content
-                    for gemini_tool_call_part in gemini_tool_call_parts:
-                        if not check_if_part_exists_in_parts(
-                            assistant_content,
-                            gemini_tool_call_part,
-                            excluded_keys=["thoughtSignature"],
-                        ):
-                            assistant_content.append(gemini_tool_call_part)
                     last_message_with_tool_calls = assistant_msg
 
                 msg_i += 1
@@ -555,16 +251,12 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     messages[msg_i], last_message_with_tool_calls  # type: ignore
                 )
                 msg_i += 1
-                # Handle both single part and list of parts (for Computer Use with images)
-                if isinstance(_part, list):
-                    tool_call_responses.extend(_part)
-                else:
-                    tool_call_responses.append(_part)
+                tool_call_responses.append(_part)
             if msg_i < len(messages) and (
                 messages[msg_i]["role"] not in tool_call_message_roles
             ):
                 if len(tool_call_responses) > 0:
-                    contents.append(ContentType(role="user", parts=tool_call_responses))
+                    contents.append(ContentType(parts=tool_call_responses))
                     tool_call_responses = []
 
             if msg_i == init_msg_i:  # prevent infinite loops
@@ -574,48 +266,13 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                     )
                 )
         if len(tool_call_responses) > 0:
-            contents.append(ContentType(role="user", parts=tool_call_responses))
-
-        if len(contents) == 0:
-            verbose_logger.warning(
-                """
-                No contents in messages. Contents are required. See
-                https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.publishers.models/generateContent#request-body.
-                If the original request did not comply to OpenAI API requirements it should have failed by now,
-                but LiteLLM does not check for missing messages.
-                Setting an empty content to prevent an 400 error.
-                Relevant Issue - https://github.com/BerriAI/litellm/issues/9733
-                """
-            )
-            contents.append(ContentType(role="user", parts=[PartType(text=" ")]))
+            contents.append(ContentType(parts=tool_call_responses))
         return contents
     except Exception as e:
         raise e
 
 
-# Keys that LiteLLM consumes internally and must never be forwarded to the
-_LITELLM_INTERNAL_EXTRA_BODY_KEYS: frozenset = frozenset({"cache", "tags"})
-
-
-def _pop_and_merge_extra_body(data: RequestBody, optional_params: dict) -> None:
-    """Pop extra_body from optional_params and shallow-merge into data, deep-merging dict values."""
-    extra_body: Optional[dict] = optional_params.pop("extra_body", None)
-    if extra_body is not None:
-        data_dict: dict = data  # type: ignore[assignment]
-        for k, v in extra_body.items():
-            if k in _LITELLM_INTERNAL_EXTRA_BODY_KEYS:
-                continue
-            if (
-                k in data_dict
-                and isinstance(data_dict[k], dict)
-                and isinstance(v, dict)
-            ):
-                data_dict[k].update(v)
-            else:
-                data_dict[k] = v
-
-
-def _transform_request_body(  # noqa: PLR0915
+def _transform_request_body(
     messages: List[AllMessageValues],
     model: str,
     optional_params: dict,
@@ -658,73 +315,39 @@ def _transform_request_body(  # noqa: PLR0915
     try:
         if custom_llm_provider == "gemini":
             content = litellm.GoogleAIStudioGeminiConfig()._transform_messages(
-                messages=messages, model=model
+                messages=messages
             )
         else:
             content = litellm.VertexGeminiConfig()._transform_messages(
-                messages=messages, model=model
+                messages=messages
             )
         tools: Optional[Tools] = optional_params.pop("tools", None)
         tool_choice: Optional[ToolConfig] = optional_params.pop("tool_choice", None)
         safety_settings: Optional[List[SafetSettingsConfig]] = optional_params.pop(
             "safety_settings", None
         )  # type: ignore
-        # Drop output_config as it's not supported by Vertex AI
-        optional_params.pop("output_config", None)
         config_fields = GenerationConfig.__annotations__.keys()
 
-        # If the LiteLLM client sends Gemini-supported parameter "labels", add it
-        # as "labels" field to the request sent to the Gemini backend.
-        labels: Optional[dict[str, str]] = optional_params.pop("labels", None)
-        # If the LiteLLM client sends OpenAI-supported parameter "metadata", add it
-        # as "labels" field to the request sent to the Gemini backend.
-        if labels is None and "metadata" in litellm_params:
-            metadata = litellm_params["metadata"]
-            if metadata is not None and "requester_metadata" in metadata:
-                rm = metadata["requester_metadata"]
-                labels = {k: v for k, v in rm.items() if isinstance(v, str)}
-
         filtered_params = {
-            k: v
-            for k, v in optional_params.items()
-            if _get_equivalent_key(k, set(config_fields))
+            k: v for k, v in optional_params.items() if k in config_fields
         }
 
         generation_config: Optional[GenerationConfig] = GenerationConfig(
             **filtered_params
         )
-
-        # For Gemini 2.x models, add media_resolution to generation_config (global)
-        # Gemini 3+ supports per-part media_resolution, but 2.x only supports global
-        # Gemini 1.x does not support mediaResolution at all
-        if "gemini-2" in model:
-            max_media_resolution = _extract_max_media_resolution_from_messages(messages)
-            if max_media_resolution:
-                media_resolution_value = _convert_detail_to_media_resolution_enum(
-                    max_media_resolution
-                )
-                if media_resolution_value and generation_config is not None:
-                    generation_config["mediaResolution"] = media_resolution_value[
-                        "level"
-                    ]
-
         data = RequestBody(contents=content)
-        if system_instructions is not None:
+        if system_instructions is not None and cached_content is None:
             data["system_instruction"] = system_instructions
-        if tools is not None:
+        if tools is not None and cached_content is None:
             data["tools"] = tools
-        if tool_choice is not None:
+        if tool_choice is not None and cached_content is None:
             data["toolConfig"] = tool_choice
         if safety_settings is not None:
             data["safetySettings"] = safety_settings
-        if generation_config is not None and len(generation_config) > 0:
+        if generation_config is not None:
             data["generationConfig"] = generation_config
         if cached_content is not None:
             data["cachedContent"] = cached_content
-        # Only add labels for Vertex AI endpoints (not Google GenAI/AI Studio) and only if non-empty
-        if labels and custom_llm_provider != LlmProviders.GEMINI:
-            data["labels"] = labels
-        _pop_and_merge_extra_body(data, optional_params)
     except Exception as e:
         raise e
 
@@ -743,34 +366,25 @@ def sync_transform_request_body(
     logging_obj: LiteLLMLoggingObj,
     custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
     litellm_params: dict,
-    vertex_project: Optional[str],
-    vertex_location: Optional[str],
-    vertex_auth_header: Optional[str],
 ) -> RequestBody:
     from ..context_caching.vertex_ai_context_caching import ContextCachingEndpoints
 
     context_caching_endpoints = ContextCachingEndpoints()
 
-    (
-        messages,
-        optional_params,
-        cached_content,
-    ) = context_caching_endpoints.check_and_create_cache(
-        messages=messages,
-        optional_params=optional_params,
-        api_key=gemini_api_key or "dummy",
-        api_base=api_base,
-        model=model,
-        client=client,
-        timeout=timeout,
-        extra_headers=extra_headers,
-        cached_content=optional_params.pop("cached_content", None),
-        logging_obj=logging_obj,
-        custom_llm_provider=custom_llm_provider,
-        vertex_project=vertex_project,
-        vertex_location=vertex_location,
-        vertex_auth_header=vertex_auth_header,
-    )
+    if gemini_api_key is not None:
+        messages, cached_content = context_caching_endpoints.check_and_create_cache(
+            messages=messages,
+            api_key=gemini_api_key,
+            api_base=api_base,
+            model=model,
+            client=client,
+            timeout=timeout,
+            extra_headers=extra_headers,
+            cached_content=optional_params.pop("cached_content", None),
+            logging_obj=logging_obj,
+        )
+    else:  # [TODO] implement context caching for gemini as well
+        cached_content = optional_params.pop("cached_content", None)
 
     return _transform_request_body(
         messages=messages,
@@ -794,34 +408,27 @@ async def async_transform_request_body(
     logging_obj: litellm.litellm_core_utils.litellm_logging.Logging,  # type: ignore
     custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
     litellm_params: dict,
-    vertex_project: Optional[str],
-    vertex_location: Optional[str],
-    vertex_auth_header: Optional[str],
 ) -> RequestBody:
     from ..context_caching.vertex_ai_context_caching import ContextCachingEndpoints
 
     context_caching_endpoints = ContextCachingEndpoints()
 
-    (
-        messages,
-        optional_params,
-        cached_content,
-    ) = await context_caching_endpoints.async_check_and_create_cache(
-        messages=messages,
-        optional_params=optional_params,
-        api_key=gemini_api_key or "dummy",
-        api_base=api_base,
-        model=model,
-        client=client,
-        timeout=timeout,
-        extra_headers=extra_headers,
-        cached_content=optional_params.pop("cached_content", None),
-        logging_obj=logging_obj,
-        custom_llm_provider=custom_llm_provider,
-        vertex_project=vertex_project,
-        vertex_location=vertex_location,
-        vertex_auth_header=vertex_auth_header,
-    )
+    if gemini_api_key is not None:
+        messages, cached_content = (
+            await context_caching_endpoints.async_check_and_create_cache(
+                messages=messages,
+                api_key=gemini_api_key,
+                api_base=api_base,
+                model=model,
+                client=client,
+                timeout=timeout,
+                extra_headers=extra_headers,
+                cached_content=optional_params.pop("cached_content", None),
+                logging_obj=logging_obj,
+            )
+        )
+    else:  # [TODO] implement context caching for gemini as well
+        cached_content = optional_params.pop("cached_content", None)
 
     return _transform_request_body(
         messages=messages,
@@ -831,15 +438,6 @@ async def async_transform_request_body(
         cached_content=cached_content,
         optional_params=optional_params,
     )
-
-
-def _default_user_message_when_system_message_passed() -> ChatCompletionUserMessage:
-    """
-    Returns a default user message when a "system" message is passed in gemini fails.
-
-    This adds a blank user message to the messages list, to ensure that gemini doesn't fail the request.
-    """
-    return ChatCompletionUserMessage(content=".", role="user")
 
 
 def _transform_system_message(
@@ -876,13 +474,6 @@ def _transform_system_message(
                 messages.pop(idx)
 
     if len(system_content_blocks) > 0:
-        #########################################################
-        # If no messages are passed in, add a blank user message
-        # Relevant Issue - https://github.com/BerriAI/litellm/issues/13769
-        #########################################################
-        if len(messages) == 0:
-            messages.append(_default_user_message_when_system_message_passed())
-        #########################################################
         return SystemInstructions(parts=system_content_blocks), messages
 
     return None, messages

--- a/tests/llm_translation/test_vertex.py
+++ b/tests/llm_translation/test_vertex.py
@@ -1,0 +1,1394 @@
+import json
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+
+import litellm.litellm_core_utils
+import litellm.litellm_core_utils.prompt_templates
+import litellm.litellm_core_utils.prompt_templates.factory
+
+load_dotenv()
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+import pytest
+import litellm
+from litellm import get_optional_params
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.llms.vertex_ai.gemini.transformation import _process_gemini_image
+from litellm.types.llms.vertex_ai import PartType, BlobType
+import httpx
+
+
+def test_completion_pydantic_obj_2():
+    from pydantic import BaseModel
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    litellm.set_verbose = True
+
+    class CalendarEvent(BaseModel):
+        name: str
+        date: str
+        participants: list[str]
+
+    class EventsList(BaseModel):
+        events: list[CalendarEvent]
+
+    messages = [
+        {"role": "user", "content": "List important events from the 20th century."}
+    ]
+    expected_request_body = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [{"text": "List important events from the 20th century."}],
+            }
+        ],
+        "generationConfig": {
+            "response_mime_type": "application/json",
+            "response_schema": {
+                "properties": {
+                    "events": {
+                        "items": {
+                            "properties": {
+                                "name": {"type": "string"},
+                                "date": {"type": "string"},
+                                "participants": {
+                                    "items": {"type": "string"},
+                                    "type": "array",
+                                },
+                            },
+                            "required": [
+                                "name",
+                                "date",
+                                "participants",
+                            ],
+                            "type": "object",
+                        },
+                        "type": "array",
+                    }
+                },
+                "required": [
+                    "events",
+                ],
+                "type": "object",
+            },
+        },
+    }
+    client = HTTPHandler()
+    with patch.object(client, "post", new=MagicMock()) as mock_post:
+        mock_post.return_value = expected_request_body
+        try:
+            litellm.completion(
+                model="gemini/gemini-1.5-pro",
+                messages=messages,
+                response_format=EventsList,
+                client=client,
+            )
+        except Exception as e:
+            print(e)
+
+        mock_post.assert_called_once()
+
+        print(mock_post.call_args.kwargs)
+
+        assert mock_post.call_args.kwargs["json"] == expected_request_body
+
+
+def test_build_vertex_schema():
+    from litellm.llms.vertex_ai.common_utils import (
+        _build_vertex_schema,
+    )
+    import json
+
+    schema = {
+        "type": "object",
+        "$id": "my-special-id",
+        "properties": {
+            "recipes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"recipe_name": {"type": "string"}},
+                    "required": ["recipe_name"],
+                },
+            }
+        },
+        "required": ["recipes"],
+    }
+
+    new_schema = _build_vertex_schema(schema)
+    print(f"new_schema: {new_schema}")
+    assert new_schema["type"] == schema["type"]
+    assert new_schema["properties"] == schema["properties"]
+    assert "required" in new_schema and new_schema["required"] == schema["required"]
+    assert "$id" not in new_schema
+
+
+@pytest.mark.parametrize(
+    "tools, key",
+    [
+        ([{"googleSearch": {}}], "googleSearch"),
+        ([{"googleSearchRetrieval": {}}], "googleSearchRetrieval"),
+        ([{"code_execution": {}}], "code_execution"),
+    ],
+)
+def test_vertex_tool_params(tools, key):
+
+    optional_params = get_optional_params(
+        model="gemini-1.5-pro",
+        custom_llm_provider="vertex_ai",
+        tools=tools,
+    )
+    print(optional_params)
+    assert optional_params["tools"][0][key] == {}
+
+
+@pytest.mark.parametrize(
+    "tool, expect_parameters",
+    [
+        (
+            {
+                "name": "test_function",
+                "description": "test_function_description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"test_param": {"type": "string"}},
+                },
+            },
+            True,
+        ),
+        (
+            {
+                "name": "test_function",
+            },
+            False,
+        ),
+    ],
+)
+def test_vertex_function_translation(tool, expect_parameters):
+    """
+    If param not set, don't set it in the request
+    """
+
+    tools = [tool]
+    optional_params = get_optional_params(
+        model="gemini-1.5-pro",
+        custom_llm_provider="vertex_ai",
+        tools=tools,
+    )
+    print(optional_params)
+    if expect_parameters:
+        assert "parameters" in optional_params["tools"][0]["function_declarations"][0]
+    else:
+        assert (
+            "parameters" not in optional_params["tools"][0]["function_declarations"][0]
+        )
+
+
+def test_function_calling_with_gemini():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    litellm.set_verbose = True
+    client = HTTPHandler()
+    with patch.object(client, "post", new=MagicMock()) as mock_post:
+        try:
+            litellm.completion(
+                model="gemini/gemini-1.5-pro-002",
+                messages=[
+                    {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "You are a helpful assistant that can interact with a computer to solve tasks.\n<IMPORTANT>\n* If user provides a path, you should NOT assume it's relative to the current working directory. Instead, you should explore the file system to find the file before working on it.\n</IMPORTANT>\n",
+                            }
+                        ],
+                        "role": "system",
+                    },
+                    {
+                        "content": [{"type": "text", "text": "Hey, how's it going?"}],
+                        "role": "user",
+                    },
+                ],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "finish",
+                            "description": "Finish the interaction when the task is complete OR if the assistant cannot proceed further with the task.",
+                        },
+                    },
+                ],
+                client=client,
+            )
+        except Exception as e:
+            print(e)
+        mock_post.assert_called_once()
+        print(mock_post.call_args.kwargs)
+
+        assert mock_post.call_args.kwargs["json"]["tools"] == [
+            {
+                "function_declarations": [
+                    {
+                        "name": "finish",
+                        "description": "Finish the interaction when the task is complete OR if the assistant cannot proceed further with the task.",
+                    }
+                ]
+            }
+        ]
+
+
+def test_multiple_function_call():
+    litellm.set_verbose = True
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    client = HTTPHandler()
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "do test"}]},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "test"}],
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "function": {"arguments": '{"arg": "test"}', "name": "test"},
+                    "id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+                    "type": "function",
+                },
+                {
+                    "index": 1,
+                    "function": {"arguments": '{"arg": "test2"}', "name": "test2"},
+                    "id": "call_2414e8f9-283a-002b-182a-1290ab912c02",
+                    "type": "function",
+                },
+            ],
+        },
+        {
+            "tool_call_id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+            "role": "tool",
+            "name": "test",
+            "content": [{"type": "text", "text": "42"}],
+        },
+        {
+            "tool_call_id": "call_2414e8f9-283a-002b-182a-1290ab912c02",
+            "role": "tool",
+            "name": "test2",
+            "content": [{"type": "text", "text": "15"}],
+        },
+        {"role": "user", "content": [{"type": "text", "text": "tell me the results."}]},
+    ]
+
+    response_body = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": 'The `default_api.test` function call returned a JSON object indicating a successful execution.  The `fields` key contains a nested dictionary with a `key` of "content" and a `value` with a `string_value` of "42".\n\nSimilarly, the `default_api.test2` function call also returned a JSON object showing successful execution.  The `fields` key contains a nested dictionary with a `key` of "content" and a `value` with a `string_value` of "15".\n\nIn short, both test functions executed successfully and returned different numerical string values ("42" and "15").  The significance of these numbers depends on the internal logic of the `test` and `test2` functions within the `default_api`.\n'
+                        }
+                    ],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+                "avgLogprobs": -0.20577410289219447,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 128,
+            "candidatesTokenCount": 168,
+            "totalTokenCount": 296,
+        },
+        "modelVersion": "gemini-1.5-flash-002",
+    }
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_body
+
+    with patch.object(client, "post", return_value=mock_response) as mock_post:
+        r = litellm.completion(
+            messages=messages, model="gemini/gemini-1.5-flash-002", client=client
+        )
+        assert len(r.choices) > 0
+
+        print(mock_post.call_args.kwargs["json"])
+
+        assert mock_post.call_args.kwargs["json"] == {
+            "contents": [
+                {"role": "user", "parts": [{"text": "do test"}]},
+                {
+                    "role": "model",
+                    "parts": [
+                        {"text": "test"},
+                        {"function_call": {"name": "test", "args": {"arg": "test"}}},
+                        {"function_call": {"name": "test2", "args": {"arg": "test2"}}},
+                    ],
+                },
+                {
+                    "parts": [
+                        {
+                            "function_response": {
+                                "name": "test",
+                                "response": {"content": "42"},
+                            }
+                        },
+                        {
+                            "function_response": {
+                                "name": "test2",
+                                "response": {"content": "15"},
+                            }
+                        },
+                    ]
+                },
+                {"role": "user", "parts": [{"text": "tell me the results."}]},
+            ],
+            "generationConfig": {},
+        }
+
+
+def test_multiple_function_call_changed_text_pos():
+    litellm.set_verbose = True
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    client = HTTPHandler()
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "do test"}]},
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "function": {"arguments": '{"arg": "test"}', "name": "test"},
+                    "id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+                    "type": "function",
+                },
+                {
+                    "index": 1,
+                    "function": {"arguments": '{"arg": "test2"}', "name": "test2"},
+                    "id": "call_2414e8f9-283a-002b-182a-1290ab912c02",
+                    "type": "function",
+                },
+            ],
+            "role": "assistant",
+            "content": [{"type": "text", "text": "test"}],
+        },
+        {
+            "tool_call_id": "call_2414e8f9-283a-002b-182a-1290ab912c02",
+            "role": "tool",
+            "name": "test2",
+            "content": [{"type": "text", "text": "15"}],
+        },
+        {
+            "tool_call_id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+            "role": "tool",
+            "name": "test",
+            "content": [{"type": "text", "text": "42"}],
+        },
+        {"role": "user", "content": [{"type": "text", "text": "tell me the results."}]},
+    ]
+
+    response_body = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": 'The code executed two functions, `test` and `test2`.\n\n* **`test`**:  Returned a dictionary indicating that the "key" field has a "value" field containing a string value of "42".  This is likely a response from a function that processed the input "test" and returned a calculated or pre-defined value.\n\n* **`test2`**: Returned a dictionary indicating that the "key" field has a "value" field containing a string value of "15". Similar to `test`, this suggests a function that processes the input "test2" and returns a specific result.\n\nIn short, both functions appear to be simple tests that return different hardcoded or calculated values based on their input arguments.\n'
+                        }
+                    ],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+                "avgLogprobs": -0.32848488592332409,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 128,
+            "candidatesTokenCount": 155,
+            "totalTokenCount": 283,
+        },
+        "modelVersion": "gemini-1.5-flash-002",
+    }
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_body
+
+    with patch.object(client, "post", return_value=mock_response) as mock_post:
+        resp = litellm.completion(
+            messages=messages, model="gemini/gemini-1.5-flash-002", client=client
+        )
+        assert len(resp.choices) > 0
+        mock_post.assert_called_once()
+
+        print(mock_post.call_args.kwargs["json"]["contents"])
+
+        assert mock_post.call_args.kwargs["json"]["contents"] == [
+            {"role": "user", "parts": [{"text": "do test"}]},
+            {
+                "role": "model",
+                "parts": [
+                    {"text": "test"},
+                    {"function_call": {"name": "test", "args": {"arg": "test"}}},
+                    {"function_call": {"name": "test2", "args": {"arg": "test2"}}},
+                ],
+            },
+            {
+                "parts": [
+                    {
+                        "function_response": {
+                            "name": "test2",
+                            "response": {"content": "15"},
+                        }
+                    },
+                    {
+                        "function_response": {
+                            "name": "test",
+                            "response": {"content": "42"},
+                        }
+                    },
+                ]
+            },
+            {"role": "user", "parts": [{"text": "tell me the results."}]},
+        ]
+
+
+def test_function_calling_with_gemini_multiple_results():
+    litellm.set_verbose = True
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    client = HTTPHandler()
+    # Step 1: send the conversation and available functions to the model
+    messages = [
+        {
+            "role": "user",
+            "content": "What's the weather like in San Francisco, Tokyo, and Paris? - give me 3 responses",
+        }
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state",
+                        },
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                        },
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+
+    response_body = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "get_current_weather",
+                                "args": {"location": "San Francisco"},
+                            }
+                        },
+                        {
+                            "functionCall": {
+                                "name": "get_current_weather",
+                                "args": {"location": "Tokyo"},
+                            }
+                        },
+                        {
+                            "functionCall": {
+                                "name": "get_current_weather",
+                                "args": {"location": "Paris"},
+                            }
+                        },
+                    ],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+                "avgLogprobs": -0.0040788948535919189,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 90,
+            "candidatesTokenCount": 22,
+            "totalTokenCount": 112,
+        },
+        "modelVersion": "gemini-1.5-flash-002",
+    }
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_body
+
+    with patch.object(client, "post", return_value=mock_response):
+        response = litellm.completion(
+            model="gemini/gemini-1.5-flash-002",
+            messages=messages,
+            tools=tools,
+            tool_choice="required",
+            client=client,
+        )
+        print("Response\n", response)
+
+        assert len(response.choices[0].message.tool_calls) == 3
+
+        expected_locations = ["San Francisco", "Tokyo", "Paris"]
+        for idx, tool_call in enumerate(response.choices[0].message.tool_calls):
+            json_args = json.loads(tool_call.function.arguments)
+            assert json_args["location"] == expected_locations[idx]
+
+
+def test_logprobs_unit_test():
+    from litellm import VertexGeminiConfig
+
+    result = VertexGeminiConfig()._transform_logprobs(
+        logprobs_result={
+            "topCandidates": [
+                {
+                    "candidates": [
+                        {"token": "```", "logProbability": -1.5496514e-06},
+                        {"token": "`", "logProbability": -13.375002},
+                        {"token": "``", "logProbability": -21.875002},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "tool", "logProbability": 0},
+                        {"token": "too", "logProbability": -29.031433},
+                        {"token": "to", "logProbability": -34.11199},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "code", "logProbability": 0},
+                        {"token": "co", "logProbability": -28.114716},
+                        {"token": "c", "logProbability": -29.283161},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "\n", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "print", "logProbability": 0},
+                        {"token": "p", "logProbability": -19.7494},
+                        {"token": "prin", "logProbability": -21.117342},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "(", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "default", "logProbability": 0},
+                        {"token": "get", "logProbability": -16.811178},
+                        {"token": "ge", "logProbability": -19.031078},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "api", "logProbability": 0},
+                        {"token": "ap", "logProbability": -26.501019},
+                        {"token": "a", "logProbability": -30.905857},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": ".", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "get", "logProbability": 0},
+                        {"token": "ge", "logProbability": -19.984676},
+                        {"token": "g", "logProbability": -20.527714},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "current", "logProbability": 0},
+                        {"token": "cur", "logProbability": -28.193565},
+                        {"token": "cu", "logProbability": -29.636738},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "weather", "logProbability": 0},
+                        {"token": "we", "logProbability": -27.887215},
+                        {"token": "wea", "logProbability": -31.851082},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "(", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "location", "logProbability": 0},
+                        {"token": "loc", "logProbability": -19.152641},
+                        {"token": " location", "logProbability": -21.981709},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": '="', "logProbability": -0.034490786},
+                        {"token": "='", "logProbability": -3.398928},
+                        {"token": "=", "logProbability": -7.6194153},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "San", "logProbability": -6.5561944e-06},
+                        {"token": '\\"', "logProbability": -12.015556},
+                        {"token": "Paris", "logProbability": -14.647776},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": " Francisco", "logProbability": -3.5760596e-07},
+                        {"token": " Frans", "logProbability": -14.83527},
+                        {"token": " francisco", "logProbability": -19.796852},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": '"))', "logProbability": -6.079254e-06},
+                        {"token": ",", "logProbability": -12.106029},
+                        {"token": '",', "logProbability": -14.56927},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "\n", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "print", "logProbability": -0.04140338},
+                        {"token": "```", "logProbability": -3.2049975},
+                        {"token": "p", "logProbability": -22.087523},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "(", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "default", "logProbability": 0},
+                        {"token": "get", "logProbability": -20.266342},
+                        {"token": "de", "logProbability": -20.906395},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "api", "logProbability": 0},
+                        {"token": "ap", "logProbability": -27.712265},
+                        {"token": "a", "logProbability": -31.986958},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": ".", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "get", "logProbability": 0},
+                        {"token": "g", "logProbability": -23.569286},
+                        {"token": "ge", "logProbability": -23.829632},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "current", "logProbability": 0},
+                        {"token": "cur", "logProbability": -30.125153},
+                        {"token": "curr", "logProbability": -31.756569},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "weather", "logProbability": 0},
+                        {"token": "we", "logProbability": -27.743786},
+                        {"token": "w", "logProbability": -30.594503},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "(", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "location", "logProbability": 0},
+                        {"token": "loc", "logProbability": -21.177715},
+                        {"token": " location", "logProbability": -22.166002},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": '="', "logProbability": -1.5617967e-05},
+                        {"token": "='", "logProbability": -11.080961},
+                        {"token": "=", "logProbability": -15.164277},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "Tokyo", "logProbability": -3.0041514e-05},
+                        {"token": "tokyo", "logProbability": -10.650261},
+                        {"token": "Paris", "logProbability": -12.096886},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": '"))', "logProbability": -1.1922384e-07},
+                        {"token": '",', "logProbability": -16.61921},
+                        {"token": ",", "logProbability": -17.911102},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "\n", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "print", "logProbability": -3.5760596e-07},
+                        {"token": "```", "logProbability": -14.949171},
+                        {"token": "p", "logProbability": -24.321035},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "(", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "default", "logProbability": 0},
+                        {"token": "de", "logProbability": -27.885206},
+                        {"token": "def", "logProbability": -28.40597},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "api", "logProbability": 0},
+                        {"token": "ap", "logProbability": -25.905933},
+                        {"token": "a", "logProbability": -30.408901},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": ".", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "get", "logProbability": 0},
+                        {"token": "g", "logProbability": -22.274963},
+                        {"token": "ge", "logProbability": -23.285828},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "current", "logProbability": 0},
+                        {"token": "cur", "logProbability": -28.442535},
+                        {"token": "curr", "logProbability": -29.95087},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "_", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "weather", "logProbability": 0},
+                        {"token": "we", "logProbability": -27.307909},
+                        {"token": "w", "logProbability": -31.076736},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "(", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "location", "logProbability": 0},
+                        {"token": "loc", "logProbability": -21.535915},
+                        {"token": "lo", "logProbability": -23.028284},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": '="', "logProbability": -8.821511e-06},
+                        {"token": "='", "logProbability": -11.700986},
+                        {"token": "=", "logProbability": -14.50358},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "Paris", "logProbability": 0},
+                        {"token": "paris", "logProbability": -18.07075},
+                        {"token": "Par", "logProbability": -21.911625},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": '"))', "logProbability": 0},
+                        {"token": '")', "logProbability": -17.916853},
+                        {"token": ",", "logProbability": -18.318272},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "\n", "logProbability": 0},
+                        {"token": "ont", "logProbability": -1.2676506e30},
+                        {"token": " п", "logProbability": -1.2676506e30},
+                    ]
+                },
+                {
+                    "candidates": [
+                        {"token": "```", "logProbability": -3.5763796e-06},
+                        {"token": "print", "logProbability": -12.535343},
+                        {"token": "``", "logProbability": -19.670813},
+                    ]
+                },
+            ],
+            "chosenCandidates": [
+                {"token": "```", "logProbability": -1.5496514e-06},
+                {"token": "tool", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "code", "logProbability": 0},
+                {"token": "\n", "logProbability": 0},
+                {"token": "print", "logProbability": 0},
+                {"token": "(", "logProbability": 0},
+                {"token": "default", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "api", "logProbability": 0},
+                {"token": ".", "logProbability": 0},
+                {"token": "get", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "current", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "weather", "logProbability": 0},
+                {"token": "(", "logProbability": 0},
+                {"token": "location", "logProbability": 0},
+                {"token": '="', "logProbability": -0.034490786},
+                {"token": "San", "logProbability": -6.5561944e-06},
+                {"token": " Francisco", "logProbability": -3.5760596e-07},
+                {"token": '"))', "logProbability": -6.079254e-06},
+                {"token": "\n", "logProbability": 0},
+                {"token": "print", "logProbability": -0.04140338},
+                {"token": "(", "logProbability": 0},
+                {"token": "default", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "api", "logProbability": 0},
+                {"token": ".", "logProbability": 0},
+                {"token": "get", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "current", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "weather", "logProbability": 0},
+                {"token": "(", "logProbability": 0},
+                {"token": "location", "logProbability": 0},
+                {"token": '="', "logProbability": -1.5617967e-05},
+                {"token": "Tokyo", "logProbability": -3.0041514e-05},
+                {"token": '"))', "logProbability": -1.1922384e-07},
+                {"token": "\n", "logProbability": 0},
+                {"token": "print", "logProbability": -3.5760596e-07},
+                {"token": "(", "logProbability": 0},
+                {"token": "default", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "api", "logProbability": 0},
+                {"token": ".", "logProbability": 0},
+                {"token": "get", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "current", "logProbability": 0},
+                {"token": "_", "logProbability": 0},
+                {"token": "weather", "logProbability": 0},
+                {"token": "(", "logProbability": 0},
+                {"token": "location", "logProbability": 0},
+                {"token": '="', "logProbability": -8.821511e-06},
+                {"token": "Paris", "logProbability": 0},
+                {"token": '"))', "logProbability": 0},
+                {"token": "\n", "logProbability": 0},
+                {"token": "```", "logProbability": -3.5763796e-06},
+            ],
+        }
+    )
+
+    print(result)
+
+
+def test_logprobs():
+    litellm.set_verbose = True
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    client = HTTPHandler()
+
+    response_body = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "I do not have access to real-time information, including current weather conditions.  To get the current weather in San Francisco, I recommend checking a reliable weather website or app such as Google Weather, AccuWeather, or the National Weather Service.\n"
+                        }
+                    ],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+                "avgLogprobs": -0.04666396617889404,
+                "logprobsResult": {
+                    "chosenCandidates": [
+                        {"token": "I", "logProbability": -1.08472495e-05},
+                        {"token": " do", "logProbability": -0.00012611414},
+                        {"token": " not", "logProbability": 0},
+                        {"token": " have", "logProbability": 0},
+                        {"token": " access", "logProbability": -0.0008849616},
+                        {"token": " to", "logProbability": 0},
+                        {"token": " real", "logProbability": -1.1922384e-07},
+                        {"token": "-", "logProbability": 0},
+                        {"token": "time", "logProbability": 0},
+                        {"token": " information", "logProbability": -2.2409657e-05},
+                        {"token": ",", "logProbability": 0},
+                        {"token": " including", "logProbability": 0},
+                        {"token": " current", "logProbability": -0.14274147},
+                        {"token": " weather", "logProbability": 0},
+                        {"token": " conditions", "logProbability": -0.0056300927},
+                        {"token": ".", "logProbability": -3.5760596e-07},
+                        {"token": "  ", "logProbability": -0.06392521},
+                        {"token": "To", "logProbability": -2.3844768e-07},
+                        {"token": " get", "logProbability": -0.058974747},
+                        {"token": " the", "logProbability": 0},
+                        {"token": " current", "logProbability": 0},
+                        {"token": " weather", "logProbability": -2.3844768e-07},
+                        {"token": " in", "logProbability": -2.3844768e-07},
+                        {"token": " San", "logProbability": 0},
+                        {"token": " Francisco", "logProbability": 0},
+                        {"token": ",", "logProbability": 0},
+                        {"token": " I", "logProbability": -0.6188003},
+                        {"token": " recommend", "logProbability": -1.0370523e-05},
+                        {"token": " checking", "logProbability": -0.00014005086},
+                        {"token": " a", "logProbability": 0},
+                        {"token": " reliable", "logProbability": -1.5496514e-06},
+                        {"token": " weather", "logProbability": -8.344534e-07},
+                        {"token": " website", "logProbability": -0.0078000566},
+                        {"token": " or", "logProbability": -1.1922384e-07},
+                        {"token": " app", "logProbability": 0},
+                        {"token": " such", "logProbability": -0.9289338},
+                        {"token": " as", "logProbability": 0},
+                        {"token": " Google", "logProbability": -0.0046935496},
+                        {"token": " Weather", "logProbability": 0},
+                        {"token": ",", "logProbability": 0},
+                        {"token": " Accu", "logProbability": 0},
+                        {"token": "Weather", "logProbability": -0.00013909786},
+                        {"token": ",", "logProbability": 0},
+                        {"token": " or", "logProbability": -0.31303275},
+                        {"token": " the", "logProbability": -0.17583296},
+                        {"token": " National", "logProbability": -0.010806266},
+                        {"token": " Weather", "logProbability": 0},
+                        {"token": " Service", "logProbability": 0},
+                        {"token": ".", "logProbability": -0.00068947335},
+                        {"token": "\n", "logProbability": 0},
+                    ]
+                },
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 11,
+            "candidatesTokenCount": 50,
+            "totalTokenCount": 61,
+        },
+        "modelVersion": "gemini-1.5-flash-002",
+    }
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_body
+
+    with patch.object(client, "post", return_value=mock_response):
+
+        resp = litellm.completion(
+            model="gemini/gemini-1.5-flash-002",
+            messages=[
+                {"role": "user", "content": "What's the weather like in San Francisco?"}
+            ],
+            logprobs=True,
+            client=client,
+        )
+        print(resp)
+
+        assert resp.choices[0].logprobs is not None
+
+
+def test_process_gemini_image():
+    """Test the _process_gemini_image function for different image sources"""
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _process_gemini_image,
+    )
+    from litellm.types.llms.vertex_ai import PartType, FileDataType, BlobType
+
+    # Test GCS URI
+    gcs_result = _process_gemini_image("gs://bucket/image.png")
+    assert gcs_result["file_data"] == FileDataType(
+        mime_type="image/png", file_uri="gs://bucket/image.png"
+    )
+
+    # Test gs url with format specified
+    gcs_result = _process_gemini_image("gs://bucket/image", format="image/jpeg")
+    assert gcs_result["file_data"] == FileDataType(
+        mime_type="image/jpeg", file_uri="gs://bucket/image"
+    )
+
+    # Test HTTPS JPG URL
+    https_result = _process_gemini_image("https://example.com/image.jpg")
+    print("https_result JPG", https_result)
+    assert https_result["file_data"] == FileDataType(
+        mime_type="image/jpeg", file_uri="https://example.com/image.jpg"
+    )
+
+    # Test HTTPS PNG URL
+    https_result = _process_gemini_image("https://example.com/image.png")
+    print("https_result PNG", https_result)
+    assert https_result["file_data"] == FileDataType(
+        mime_type="image/png", file_uri="https://example.com/image.png"
+    )
+
+    # Test HTTPS VIDEO URL
+    https_result = _process_gemini_image("https://cloud-samples-data/video/animals.mp4")
+    print("https_result PNG", https_result)
+    assert https_result["file_data"] == FileDataType(
+        mime_type="video/mp4", file_uri="https://cloud-samples-data/video/animals.mp4"
+    )
+
+    # Test HTTPS PDF URL
+    https_result = _process_gemini_image("https://cloud-samples-data/pdf/animals.pdf")
+    print("https_result PDF", https_result)
+    assert https_result["file_data"] == FileDataType(
+        mime_type="application/pdf",
+        file_uri="https://cloud-samples-data/pdf/animals.pdf",
+    )
+
+    # Test base64 image
+    base64_image = "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
+    base64_result = _process_gemini_image(base64_image)
+    print("base64_result", base64_result)
+    assert base64_result["inline_data"]["mime_type"] == "image/jpeg"
+    assert base64_result["inline_data"]["data"] == "/9j/4AAQSkZJRg..."
+
+
+def test_get_image_mime_type_from_url():
+    """Test the _get_image_mime_type_from_url function for different image URLs"""
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _get_image_mime_type_from_url,
+    )
+
+    # Test JPEG images
+    assert (
+        _get_image_mime_type_from_url("https://example.com/image.jpg") == "image/jpeg"
+    )
+    assert (
+        _get_image_mime_type_from_url("https://example.com/image.jpeg") == "image/jpeg"
+    )
+    assert (
+        _get_image_mime_type_from_url("https://example.com/IMAGE.JPG") == "image/jpeg"
+    )
+
+    # Test PNG images
+    assert _get_image_mime_type_from_url("https://example.com/image.png") == "image/png"
+    assert _get_image_mime_type_from_url("https://example.com/IMAGE.PNG") == "image/png"
+
+    # Test WebP images
+    assert (
+        _get_image_mime_type_from_url("https://example.com/image.webp") == "image/webp"
+    )
+    assert (
+        _get_image_mime_type_from_url("https://example.com/IMAGE.WEBP") == "image/webp"
+    )
+
+    # Test unsupported formats
+    assert _get_image_mime_type_from_url("https://example.com/image.gif") is None
+    assert _get_image_mime_type_from_url("https://example.com/image.bmp") is None
+    assert _get_image_mime_type_from_url("https://example.com/image") is None
+    assert _get_image_mime_type_from_url("invalid_url") is None
+
+
+@pytest.mark.parametrize(
+    "model, expected_url",
+    [
+        (
+            "textembedding-gecko@001",
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/publishers/google/models/textembedding-gecko@001:predict",
+        ),
+        (
+            "123456789",
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/endpoints/123456789:predict",
+        ),
+    ],
+)
+def test_vertex_embedding_url(model, expected_url):
+    """
+    Test URL generation for embedding models, including numeric model IDs (fine-tuned models
+
+    Relevant issue: https://github.com/BerriAI/litellm/issues/6482
+
+    When a fine-tuned embedding model is used, the URL is different from the standard one.
+    """
+    from litellm.llms.vertex_ai.common_utils import _get_vertex_url
+
+    url, endpoint = _get_vertex_url(
+        mode="embedding",
+        model=model,
+        stream=False,
+        vertex_project="project-id",
+        vertex_location="us-central1",
+        vertex_api_version="v1",
+    )
+
+    assert url == expected_url
+    assert endpoint == "predict"
+
+
+import pytest
+from unittest.mock import Mock, patch
+from typing import Dict, Any
+
+# Import your actual module here
+# from your_module import _process_gemini_image, PartType, FileDataType, BlobType
+
+
+@pytest.fixture
+def mock_convert_url_to_base64():
+    with patch(
+        "litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64",
+    ) as mock:
+        # Setup the mock to return a valid image object
+        mock.return_value = "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
+        yield mock
+
+
+@pytest.fixture
+def mock_blob():
+    return Mock(spec=BlobType)
+
+
+@pytest.mark.parametrize(
+    "http_url",
+    [
+        "http://img1.etsystatic.com/260/0/7813604/il_fullxfull.4226713999_q86e.jpg",
+        "http://example.com/image.jpg",
+        "http://subdomain.domain.com/path/to/image.png",
+    ],
+)
+def test_process_gemini_image_http_url(
+    http_url: str, mock_convert_url_to_base64: Mock, mock_blob: Mock
+) -> None:
+    """
+    Test that _process_gemini_image correctly handles HTTP URLs.
+
+    Args:
+        http_url: Test HTTP URL
+        mock_convert_to_anthropic: Mocked convert_to_anthropic_image_obj function
+        mock_blob: Mocked BlobType instance
+
+    Vertex AI supports image urls. Ensure no network requests are made.
+    """
+    expected_image_data = "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
+    mock_convert_url_to_base64.return_value = expected_image_data
+    # Act
+    result = _process_gemini_image(http_url)
+
+
+def test_transform_request_body_with_cached_content_excludes_system_tools():
+    """
+    When cached_content is provided, system_instruction, tools, and toolConfig
+    should NOT be set in the request body — they are already embedded in the cache.
+    """
+    from litellm.llms.vertex_ai.gemini.transformation import _transform_request_body
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+    ]
+    optional_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    }
+
+    result = _transform_request_body(
+        messages=messages,
+        model="gemini-2.0-flash",
+        optional_params=optional_params,
+        custom_llm_provider="vertex_ai",
+        litellm_params={},
+        cached_content="cachedContents/abc123",
+    )
+
+    assert "system_instruction" not in result, "system_instruction must be omitted when cached_content is set"
+    assert "tools" not in result, "tools must be omitted when cached_content is set"
+    assert "toolConfig" not in result, "toolConfig must be omitted when cached_content is set"
+    assert result["cachedContent"] == "cachedContents/abc123"
+
+
+def test_transform_request_body_without_cached_content_includes_system_tools():
+    """
+    When cached_content is None, system_instruction, tools, and toolConfig
+    should be included normally in the request body.
+    Uses gemini-2.0-flash which supports system messages on vertex_ai.
+    """
+    from litellm.llms.vertex_ai.gemini.transformation import _transform_request_body
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+    ]
+    optional_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+    }
+
+    result = _transform_request_body(
+        messages=messages,
+        model="gemini-2.0-flash",
+        optional_params=optional_params,
+        custom_llm_provider="vertex_ai",
+        litellm_params={},
+        cached_content=None,
+    )
+
+    assert "system_instruction" in result, "system_instruction should be set when cached_content is None"
+    assert "tools" in result, "tools should be set when cached_content is None"
+    assert "cachedContent" not in result
+    # assert result["file_data"]["file_uri"] == http_url


### PR DESCRIPTION
## Relevant issues

  <!-- e.g. "Fixes #000" -->

  ## Pre-Submission checklist

  - [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm)
  directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before
  requesting a maintainer review

  ## Delays in PR merge?

  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack
  (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

  ## CI (LiteLLM team)

  > **CI status guideline:**
  >
  > - 50-55 passing tests: main is stable with minor issues.
  > - 45-49 passing tests: acceptable but needs attention
  > - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

  - [ ] **Branch creation CI run**
         Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

  🐛 Bug Fix

  ## Changes

  When a `cached_content` name is provided to the Vertex AI Gemini transformation, the cache already contains system instructions
  and tool definitions baked in. Re-sending `system_instruction`, `tools`, and `toolConfig` in the same request body causes a Vertex
   AI API error.

  This fix guards all three fields so they are only included in the request when `cached_content` is **not** set.

  Two unit tests were added to `tests/llm_translation/test_vertex.py`:
  - `test_transform_request_body_with_cached_content_excludes_system_tools` — asserts that `system_instruction`, `tools`, and
  `toolConfig` are absent from the body when `cached_content` is present.
  - `test_transform_request_body_without_cached_content_includes_system_tools` — asserts those fields are still included in the
  normal (no-cache) path.