### PR TITLE
fix: remove noisy Provider List log message causing log flooding

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -460,12 +460,6 @@ def get_llm_provider(  # noqa: PLR0915
         elif model.startswith("sap/"):
             custom_llm_provider = "sap"
         if not custom_llm_provider:
-            if litellm.suppress_debug_info is False:
-                print()  # noqa
-                print(  # noqa
-                    "\033[1;31mProvider List: https://docs.litellm.ai/docs/providers\033[0m"  # noqa
-                )  # noqa
-                print()  # noqa
             error_str = f"LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model={model}\n Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers"
             # maps to openai.NotFoundError, this is raised when openai does not recognize the llm
             raise litellm.exceptions.BadRequestError(  # type: ignore


### PR DESCRIPTION
## Problem
The print statement for 'Provider List: https://docs.litellm.ai/docs/providers' was being triggered repeatedly when using non-OpenAI models (like OpenRouter), causing log flooding as reported in #23879.

## Solution
Remove the redundant print statement. The error message already contains the documentation link ('Learn more: https://docs.litellm.ai/docs/providers'), so the separate print statement is unnecessary.

## Changes
- Removed the print() statements that output 'Provider List: https://docs.litellm.ai/docs/providers'
- The error message still directs users to the providers documentation

Fixes #23879