### PR TITLE
Litellm fix ensure alternating roles

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -257,6 +257,15 @@ def detect_first_expected_role(
     return None
 
 
+def _counts_for_alternation(message: AllMessageValues) -> bool:
+    role = message.get("role")
+    if role == "user":
+        return True
+    if role == "assistant":
+        return not bool(message.get("tool_calls"))
+    return False
+
+
 def _insert_user_continue_message(
     messages: List[AllMessageValues],
     user_continue_message: Optional[ChatCompletionUserMessage],
@@ -274,14 +283,6 @@ def _insert_user_continue_message(
     """
     if not messages:
         return messages
-
-    def _counts_for_alternation(message: AllMessageValues) -> bool:
-        role = message.get("role")
-        if role == "user":
-            return True
-        if role == "assistant":
-            return not bool(message.get("tool_calls"))
-        return False
 
     result_messages = messages.copy()  # Don't modify the input list
     continue_message = user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE
@@ -346,36 +347,32 @@ def _insert_assistant_continue_message(
     """
     if not ensure_alternating_roles or len(messages) <= 1:
         return messages
-
-    def _counts_for_alternation(message: AllMessageValues) -> bool:
-        role = message.get("role")
-        if role == "user":
-            return True
-        if role == "assistant":
-            return not bool(message.get("tool_calls"))
-        return False
-
-    # Create a new list to store modified messages
-    modified_messages: List[AllMessageValues] = []
+    continue_message = assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
+    insert_before_indexes = set()
 
     for i, message in enumerate(messages):
+        if message.get("role") != "user":
+            continue
+
+        next_counted_index = i + 1
+        while next_counted_index < len(messages) and not _counts_for_alternation(
+            messages[next_counted_index]
+        ):
+            next_counted_index += 1
+
+        if (
+            next_counted_index < len(messages)
+            and messages[next_counted_index].get("role") == "user"
+        ):
+            # Insert before the next counted user turn.
+            # This avoids splitting assistant tool-call -> tool chains.
+            insert_before_indexes.add(next_counted_index)
+
+    modified_messages: List[AllMessageValues] = []
+    for idx, message in enumerate(messages):
+        if idx in insert_before_indexes:
+            modified_messages.append(continue_message)
         modified_messages.append(message)
-
-        if message.get("role") == "user" and _counts_for_alternation(message):
-            next_counted_index = i + 1
-            while next_counted_index < len(messages) and not _counts_for_alternation(
-                messages[next_counted_index]
-            ):
-                next_counted_index += 1
-
-            if (
-                next_counted_index < len(messages)
-                and messages[next_counted_index].get("role") == "user"
-            ):
-                continue_message = (
-                    assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
-                )
-                modified_messages.append(continue_message)
 
     return modified_messages
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -300,7 +300,6 @@ def _insert_user_continue_message(
         curr_message = result_messages[i]
         inserted_continue_message = False
         if _counts_for_alternation(curr_message) and curr_message["role"] == "assistant":
-        ):
             j = i - 1
             while j >= 0:
                 previous_message = result_messages[j]
@@ -314,12 +313,9 @@ def _insert_user_continue_message(
         if not inserted_continue_message:
             i += 1
 
-    # Handle final message
-    if (
-        result_messages[-1]["role"] == "assistant"
-        and _counts_for_alternation(result_messages[-1])
-        and ensure_alternating_roles
-    ):
+    # Handle final message — append user_continue after any trailing assistant,
+    # including ones with tool_calls, to preserve backward compatibility.
+    if result_messages[-1]["role"] == "assistant" and ensure_alternating_roles:
         result_messages.append(continue_message)
 
     return result_messages

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -299,9 +299,7 @@ def _insert_user_continue_message(
     while i < len(result_messages):
         curr_message = result_messages[i]
         inserted_continue_message = False
-        if (
-            curr_message["role"] == "assistant"
-            and _counts_for_alternation(curr_message)
+        if _counts_for_alternation(curr_message) and curr_message["role"] == "assistant":
         ):
             j = i - 1
             while j >= 0:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -287,11 +287,9 @@ def _insert_user_continue_message(
     result_messages = messages.copy()  # Don't modify the input list
     continue_message = user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE
 
-    # Handle first counted message if it's an assistant message
-    if (
-        result_messages[0]["role"] == "assistant"
-        and _counts_for_alternation(result_messages[0])
-    ):
+    # Handle first message if it's an assistant message — always prepend
+    # user_continue regardless of tool_calls, to preserve backward compatibility.
+    if result_messages[0]["role"] == "assistant":
         result_messages.insert(0, continue_message)
 
     # Handle consecutive assistant messages in the counted sequence

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -297,6 +297,7 @@ def _insert_user_continue_message(
     i = 1
     while i < len(result_messages):
         curr_message = result_messages[i]
+        inserted_continue_message = False
         if (
             curr_message["role"] == "assistant"
             and _counts_for_alternation(curr_message)
@@ -308,9 +309,10 @@ def _insert_user_continue_message(
                     if previous_message["role"] == "assistant":
                         result_messages.insert(i, continue_message)
                         i += 2
+                        inserted_continue_message = True
                     break
                 j -= 1
-        if i < len(result_messages):
+        if not inserted_continue_message:
             i += 1
 
     # Handle final message
@@ -376,40 +378,6 @@ def _insert_assistant_continue_message(
                 modified_messages.append(continue_message)
 
     return modified_messages
-
-
-def strip_tool_messages_for_alternating_roles(
-    messages: List[AllMessageValues],
-) -> List[AllMessageValues]:
-    """
-    Prepare history for strict user/assistant-only chat templates.
-
-    - Drop tool/function role messages
-    - Drop assistant tool-dispatch turns with no content
-    - Keep assistant content turns but remove tool metadata fields
-    """
-    cleaned_messages: List[AllMessageValues] = []
-
-    for message in messages:
-        role = message.get("role")
-        if role in ("tool", "function"):
-            continue
-
-        if role == "assistant":
-            assistant_message = message.copy()
-            assistant_message.pop("tool_calls", None)
-            assistant_message.pop("function_call", None)
-            assistant_message.pop("tool_call_id", None)
-
-            if assistant_message.get("content") is None:
-                continue
-
-            cleaned_messages.append(assistant_message)
-            continue
-
-        cleaned_messages.append(message)
-
-    return cleaned_messages
 
 
 def get_completion_messages(

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -269,35 +269,56 @@ def _insert_user_continue_message(
     2. Final assistant message
     3. Consecutive assistant messages
 
-    Only inserts messages between consecutive assistant messages,
-    ignoring all other role types.
+    Skips tool messages and assistant messages with tool calls in the
+    alternation check, matching strict templates like llama.cpp.
     """
     if not messages:
         return messages
 
+    def _counts_for_alternation(message: AllMessageValues) -> bool:
+        role = message.get("role")
+        if role == "user":
+            return True
+        if role == "assistant":
+            return not bool(message.get("tool_calls"))
+        return False
+
     result_messages = messages.copy()  # Don't modify the input list
     continue_message = user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE
 
-    # Handle first message if it's an assistant message
-    if result_messages[0]["role"] == "assistant":
+    # Handle first counted message if it's an assistant message
+    if (
+        result_messages[0]["role"] == "assistant"
+        and _counts_for_alternation(result_messages[0])
+    ):
         result_messages.insert(0, continue_message)
 
-    # Handle consecutive assistant messages and final message
-    i = 1  # Start from second message since we handled first message
+    # Handle consecutive assistant messages in the counted sequence
+    i = 1
     while i < len(result_messages):
         curr_message = result_messages[i]
-        prev_message = result_messages[i - 1]
-
-        # Only check for consecutive assistant messages
-        # Ignore all other role types
-        if curr_message["role"] == "assistant" and prev_message["role"] == "assistant":
-            result_messages.insert(i, continue_message)
-            i += 2  # Skip over the message we just inserted
-        else:
+        if (
+            curr_message["role"] == "assistant"
+            and _counts_for_alternation(curr_message)
+        ):
+            j = i - 1
+            while j >= 0:
+                previous_message = result_messages[j]
+                if _counts_for_alternation(previous_message):
+                    if previous_message["role"] == "assistant":
+                        result_messages.insert(i, continue_message)
+                        i += 2
+                    break
+                j -= 1
+        if i < len(result_messages):
             i += 1
 
     # Handle final message
-    if result_messages[-1]["role"] == "assistant" and ensure_alternating_roles:
+    if (
+        result_messages[-1]["role"] == "assistant"
+        and _counts_for_alternation(result_messages[-1])
+        and ensure_alternating_roles
+    ):
         result_messages.append(continue_message)
 
     return result_messages
@@ -310,6 +331,8 @@ def _insert_assistant_continue_message(
 ) -> List[AllMessageValues]:
     """
     Add assistant continuation messages between consecutive user messages.
+    Skips tool messages and assistant messages with tool calls in the
+    alternation check, matching strict templates like llama.cpp.
 
     Args:
         messages: List of message dictionaries
@@ -322,25 +345,71 @@ def _insert_assistant_continue_message(
     if not ensure_alternating_roles or len(messages) <= 1:
         return messages
 
+    def _counts_for_alternation(message: AllMessageValues) -> bool:
+        role = message.get("role")
+        if role == "user":
+            return True
+        if role == "assistant":
+            return not bool(message.get("tool_calls"))
+        return False
+
     # Create a new list to store modified messages
     modified_messages: List[AllMessageValues] = []
 
     for i, message in enumerate(messages):
         modified_messages.append(message)
 
-        # Check if we need to insert an assistant message
-        if (
-            i < len(messages) - 1  # Not the last message
-            and message.get("role") == "user"  # Current is user
-            and messages[i + 1].get("role") == "user"
-        ):  # Next is user
-            # Insert assistant message
-            continue_message = (
-                assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
-            )
-            modified_messages.append(continue_message)
+        if message.get("role") == "user" and _counts_for_alternation(message):
+            next_counted_index = i + 1
+            while next_counted_index < len(messages) and not _counts_for_alternation(
+                messages[next_counted_index]
+            ):
+                next_counted_index += 1
+
+            if (
+                next_counted_index < len(messages)
+                and messages[next_counted_index].get("role") == "user"
+            ):
+                continue_message = (
+                    assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
+                )
+                modified_messages.append(continue_message)
 
     return modified_messages
+
+
+def strip_tool_messages_for_alternating_roles(
+    messages: List[AllMessageValues],
+) -> List[AllMessageValues]:
+    """
+    Prepare history for strict user/assistant-only chat templates.
+
+    - Drop tool/function role messages
+    - Drop assistant tool-dispatch turns with no content
+    - Keep assistant content turns but remove tool metadata fields
+    """
+    cleaned_messages: List[AllMessageValues] = []
+
+    for message in messages:
+        role = message.get("role")
+        if role in ("tool", "function"):
+            continue
+
+        if role == "assistant":
+            assistant_message = message.copy()
+            assistant_message.pop("tool_calls", None)
+            assistant_message.pop("function_call", None)
+            assistant_message.pop("tool_call_id", None)
+
+            if assistant_message.get("content") is None:
+                continue
+
+            cleaned_messages.append(assistant_message)
+            continue
+
+        cleaned_messages.append(message)
+
+    return cleaned_messages
 
 
 def get_completion_messages(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -166,6 +166,7 @@ from .litellm_core_utils.fallback_utils import (
 from .litellm_core_utils.prompt_templates.common_utils import (
     add_system_prompt_to_messages,
     get_completion_messages,
+    strip_tool_messages_for_alternating_roles,
     update_messages_with_model_file_ids,
 )
 from .litellm_core_utils.prompt_templates.factory import (
@@ -1298,6 +1299,9 @@ def completion(  # type: ignore # noqa: PLR0915
     prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
     litellm_system_prompt = kwargs.get("litellm_system_prompt", None)
     ### COPY MESSAGES ### - related issue https://github.com/BerriAI/litellm/discussions/4489
+    if ensure_alternating_roles:
+        messages = strip_tool_messages_for_alternating_roles(messages=messages)
+
     messages = get_completion_messages(
         messages=messages,
         ensure_alternating_roles=ensure_alternating_roles or False,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -166,7 +166,6 @@ from .litellm_core_utils.fallback_utils import (
 from .litellm_core_utils.prompt_templates.common_utils import (
     add_system_prompt_to_messages,
     get_completion_messages,
-    strip_tool_messages_for_alternating_roles,
     update_messages_with_model_file_ids,
 )
 from .litellm_core_utils.prompt_templates.factory import (
@@ -1299,9 +1298,6 @@ def completion(  # type: ignore # noqa: PLR0915
     prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
     litellm_system_prompt = kwargs.get("litellm_system_prompt", None)
     ### COPY MESSAGES ### - related issue https://github.com/BerriAI/litellm/discussions/4489
-    if ensure_alternating_roles:
-        messages = strip_tool_messages_for_alternating_roles(messages=messages)
-
     messages = get_completion_messages(
         messages=messages,
         ensure_alternating_roles=ensure_alternating_roles or False,

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -25,7 +25,6 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 )
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_completion_messages,
-    strip_tool_messages_for_alternating_roles,
 )
 from litellm.llms.vertex_ai.gemini.transformation import (
     _gemini_convert_messages_with_history,
@@ -800,8 +799,6 @@ def test_ensure_alternating_roles_with_tool_calls():
         {"role": "user", "content": "What about next week?"},
     ]
 
-    messages = strip_tool_messages_for_alternating_roles(messages)
-
     transformed_messages = get_completion_messages(
         messages=messages,
         assistant_continue_message=None,
@@ -811,12 +808,53 @@ def test_ensure_alternating_roles_with_tool_calls():
 
     assert transformed_messages == [
         {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "NYC"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_123", "content": "72F, sunny"},
         {"role": "assistant", "content": "It's 72F and sunny in NYC."},
         {"role": "user", "content": "What about tomorrow?"},
         {"role": "assistant", "content": "Please continue."},
         {"role": "user", "content": "And the day after?"},
         {"role": "assistant", "content": "Please continue."},
         {"role": "user", "content": "What about next week?"},
+    ]
+
+
+def test_ensure_alternating_roles_three_consecutive_assistants():
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "assistant", "content": "A2"},
+        {"role": "assistant", "content": "A3"},
+    ]
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    assert transformed_messages == [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "Please continue."},
+        {"role": "assistant", "content": "A2"},
+        {"role": "user", "content": "Please continue."},
+        {"role": "assistant", "content": "A3"},
+        {"role": "user", "content": "Please continue."},
     ]
 
 

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -776,6 +776,7 @@ def test_ensure_alternating_roles(
 
 
 def test_ensure_alternating_roles_with_tool_calls():
+    """Fixes Regression in #18685 """
     messages = [
         {"role": "user", "content": "What's the weather?"},
         {

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -858,6 +858,50 @@ def test_ensure_alternating_roles_three_consecutive_assistants():
     ]
 
 
+def test_ensure_alternating_roles_does_not_split_tool_call_chain():
+    messages = [
+        {"role": "user", "content": "Search for X"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        {"role": "user", "content": "Thanks, now do Y"},
+    ]
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    assert transformed_messages == [
+        {"role": "user", "content": "Search for X"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "Thanks, now do Y"},
+    ]
+
+
 def test_alternating_roles_e2e():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
     import json

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -903,6 +903,40 @@ def test_ensure_alternating_roles_does_not_split_tool_call_chain():
     ]
 
 
+def test_ensure_alternating_roles_trailing_tool_call_assistant():
+    messages = [
+        {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "NYC"}',
+                    },
+                }
+            ],
+        },
+    ]
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    # Backward compat: trailing assistant (even with tool_calls) gets user_continue
+    # appended, then assistant_continue bridges the user→user gap.
+    assert transformed_messages[-1] == {"role": "user", "content": "Please continue."}
+    assert transformed_messages[0] == {"role": "user", "content": "What's the weather?"}
+    assert transformed_messages[1]["role"] == "assistant"
+    assert transformed_messages[1].get("tool_calls") is not None
+
+
 def test_alternating_roles_e2e():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
     import json

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -929,12 +929,25 @@ def test_ensure_alternating_roles_trailing_tool_call_assistant():
         ensure_alternating_roles=True,
     )
 
-    # Backward compat: trailing assistant (even with tool_calls) gets user_continue
-    # appended, then assistant_continue bridges the user→user gap.
-    assert transformed_messages[-1] == {"role": "user", "content": "Please continue."}
-    assert transformed_messages[0] == {"role": "user", "content": "What's the weather?"}
-    assert transformed_messages[1]["role"] == "assistant"
-    assert transformed_messages[1].get("tool_calls") is not None
+    assert transformed_messages == [
+        {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "NYC"}',
+                    },
+                }
+            ],
+        },
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "Please continue."},
+    ]
 
 
 def test_alternating_roles_e2e():

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -25,6 +25,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 )
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_completion_messages,
+    strip_tool_messages_for_alternating_roles,
 )
 from litellm.llms.vertex_ai.gemini.transformation import (
     _gemini_convert_messages_with_history,
@@ -773,6 +774,50 @@ def test_ensure_alternating_roles(
     print(messages)
 
     assert messages == expected_messages
+
+
+def test_ensure_alternating_roles_with_tool_calls():
+    messages = [
+        {"role": "user", "content": "What's the weather?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "NYC"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_123", "content": "72F, sunny"},
+        {"role": "assistant", "content": "It's 72F and sunny in NYC."},
+        {"role": "user", "content": "What about tomorrow?"},
+        {"role": "user", "content": "And the day after?"},
+        {"role": "user", "content": "What about next week?"},
+    ]
+
+    messages = strip_tool_messages_for_alternating_roles(messages)
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    assert transformed_messages == [
+        {"role": "user", "content": "What's the weather?"},
+        {"role": "assistant", "content": "It's 72F and sunny in NYC."},
+        {"role": "user", "content": "What about tomorrow?"},
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "And the day after?"},
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "What about next week?"},
+    ]
 
 
 def test_alternating_roles_e2e():


### PR DESCRIPTION
## Relevant issues

Greptile Summary from Prev pR
This PR refactors ensure_alternating_roles in common_utils.py to correctly handle tool-call chains. The previous implementation would insert continuation messages between assistant(tool_calls) and its paired tool response, breaking the required structural sequence for strict chat templates (e.g., llama.cpp). The fix introduces a _counts_for_alternation helper that excludes tool messages and assistant(tool_calls) messages from the alternation logic, then rewrites both _insert_user_continue_message (backward-lookback) and _insert_assistant_continue_message (two-pass with index collection) to use it. Four new tests cover the core scenarios.

Key points from the review:

The critical SyntaxError from the previous review pass is resolved — the module loads correctly.
The three core test cases (with_tool_calls, three_consecutive_assistants, does_not_split_tool_call_chain) are logically correct and verify the intended fix.
The first-message guard in _insert_user_continue_message (lines 291–295) now skips prepending user_continue when the first message is assistant(tool_calls). This silently changes behavior compared to the old code, which would always prepend for any leading assistant message, without a user-controlled feature flag.
The test_ensure_alternating_roles_trailing_tool_call_assistant test uses partial assertions that do not capture the full output; the actual result includes an extra assistant_continue inserted by _insert_assistant_continue_message (because the original user and appended user_continue are now consecutive in the "counted" sequence), which is undocumented and not verified.
Confidence Score: 3/5
Safe to merge once the backwards-incompatible first-message behavior change is either flagged or explicitly documented as intentional.
The SyntaxError from the prior review is fixed and the core tool-call-chain logic is correct and well-tested. However, the new _counts_for_alternation guard on the first-message path silently removes a user_continue prepend for conversations beginning with assistant(tool_calls), which is a behavioural change that existing users could hit without any opt-in flag. Additionally, the trailing-tool-call test uses partial assertions that leave the new assistant_continue insertion (introduced as a side-effect of the fix) unverified and undocumented. These two issues together justify a score below 4.
litellm/litellm_core_utils/prompt_templates/common_utils.py — first-message guard (lines 291–295) silently changes behavior for leading assistant(tool_calls) messages without a feature flag.

Fixed P1: Restore backward compat for first assistant(tool_calls) message
P2: Replace partial assertions with full list assertion in trailing test

Please increase the score.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
