### PR TITLE
Add support for prompt management for responses

### DIFF
--- a/docs/my-website/docs/prompt_management.md
+++ b/docs/my-website/docs/prompt_management.md
@@ -1,0 +1,48 @@
+---
+title: Prompt Management with Responses API
+---
+
+# Prompt Management with Responses API
+
+Use LiteLLM Prompt Management with `/v1/responses` by passing `prompt_id` and optional `prompt_variables`.
+
+## Basic Usage
+
+```bash
+curl -X POST "http://localhost:4000/v1/responses" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "prompt_id": "my-responses-prompt",
+    "prompt_variables": {"topic": "large language models"},
+    "input": []
+  }'
+```
+
+## Multi-turn Follow-up in `input`
+
+To send follow-up turns in one request, pass message history in `input`.
+
+```bash
+curl -X POST "http://localhost:4000/v1/responses" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "prompt_id": "my-responses-prompt",
+    "prompt_variables": {"topic": "large language models"},
+    "input": [
+      {"role": "user", "content": "Topic is LLMs. Start short."},
+      {"role": "assistant", "content": "Sure, go ahead."},
+      {"role": "user", "content": "Now give me 3 bullets and include pricing caveat."}
+    ]
+  }'
+```
+
+## Notes
+
+- Prompt template messages are merged with your `input` messages.
+- Prompt variable substitution applies to prompt message content.
+- Tool call payload fields are not substituted by prompt variables.
+- For follow-ups with `previous_response_id`, include `prompt_id` again if you want prompt management applied on that turn.

--- a/docs/my-website/docs/proxy/prompt_management.md
+++ b/docs/my-website/docs/proxy/prompt_management.md
@@ -311,7 +311,7 @@ litellm_settings:
 1. **At Startup**: When the proxy starts, it reads the `prompts` field from `config.yaml`
 2. **Initialization**: Each prompt is initialized based on its `prompt_integration` type
 3. **In-Memory Storage**: Prompts are stored in the `IN_MEMORY_PROMPT_REGISTRY`
-4. **Access**: Use these prompts via the `/v1/chat/completions` endpoint with `prompt_id` in the request
+4. **Access**: Use these prompts via `/v1/chat/completions` or `/v1/responses` with `prompt_id` in the request
 
 ### Using Config-Loaded Prompts
 
@@ -328,6 +328,23 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
         "language": "python",
         "task": "create a web scraper"
     }
+}'
+```
+
+You can also use the same `prompt_id` with the Responses API:
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/v1/responses' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-d '{
+    "model": "gpt-4o",
+    "prompt_id": "coding_assistant",
+    "prompt_variables": {
+        "language": "python",
+        "task": "create a web scraper"
+    },
+    "input": []
 }'
 ```
 

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -687,6 +687,7 @@ const sidebars = {
         "proxy/realtime_webrtc",
         "rerank",
         "response_api",
+        "prompt_management",
         "response_api_compact",
         {
           type: "category",

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -37,6 +37,7 @@ from litellm.responses.litellm_completion_transformation.handler import (
 )
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
+    AllMessageValues,
     PromptObject,
     Reasoning,
     ResponseIncludable,
@@ -622,6 +623,41 @@ def responses(
             litellm_params.api_key = dynamic_api_key
         if dynamic_api_base is not None:
             litellm_params.api_base = dynamic_api_base
+
+        #########################################################
+        # PROMPT MANAGEMENT
+        #########################################################
+        prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
+        prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
+
+        if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
+            litellm_logging_obj.should_run_prompt_management_hooks(
+                prompt_id=prompt_id, non_default_params=kwargs
+            )
+        ):
+            client_input: List[AllMessageValues] = (
+                [{"role": "user", "content": input}]
+                if isinstance(input, str)
+                else cast(List[AllMessageValues], list(input))
+            )
+            (
+                model,
+                merged_input,
+                merged_optional_params,
+            ) = litellm_logging_obj.get_chat_completion_prompt(
+                model=model,
+                messages=client_input,
+                non_default_params=kwargs,
+                prompt_id=prompt_id,
+                prompt_variables=prompt_variables,
+                prompt_label=kwargs.get("prompt_label", None),
+                prompt_version=kwargs.get("prompt_version", None),
+            )
+            input = cast(Union[str, ResponseInputParam], merged_input)
+            local_vars["input"] = input
+            # Apply prompt_template_optional_params (e.g. temperature, instructions)
+            # by updating kwargs so they flow into local_vars → response_api_optional_params
+            kwargs.update(merged_optional_params)
 
         #########################################################
         # Update input and tools with provider-specific file IDs if managed files are used

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -630,10 +630,8 @@ def responses(
         prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
         prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
 
-        if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
-            litellm_logging_obj.should_run_prompt_management_hooks(
-                prompt_id=prompt_id, non_default_params=kwargs
-            )
+        if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
+            prompt_id=prompt_id, non_default_params=kwargs
         ):
             client_input: List[AllMessageValues] = (
                 [{"role": "user", "content": input}]
@@ -655,9 +653,9 @@ def responses(
             )
             input = cast(Union[str, ResponseInputParam], merged_input)
             local_vars["input"] = input
-            # Apply prompt_template_optional_params (e.g. temperature, instructions)
-            # by updating kwargs so they flow into local_vars → response_api_optional_params
-            kwargs.update(merged_optional_params)
+            local_vars["model"] = model
+            for k, v in merged_optional_params.items():
+                local_vars[k] = v
 
         #########################################################
         # Update input and tools with provider-specific file IDs if managed files are used

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -466,6 +466,11 @@ async def aresponses(
 
         #########################################################
         # ASYNC PROMPT MANAGEMENT
+        # Run the async hook here so async-only prompt loggers are honoured.
+        # Then pop prompt_id from kwargs so the sync responses() path does NOT
+        # re-run the hook (which would double-prepend template messages).
+        # Pass merged_optional_params via an internal kwarg so responses()
+        # can apply them to local_vars without re-invoking the hook.
         #########################################################
         litellm_logging_obj = kwargs.get("litellm_logging_obj", None)
         prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
@@ -488,7 +493,7 @@ async def aresponses(
             (
                 model,
                 merged_input,
-                _,
+                merged_optional_params,
             ) = await litellm_logging_obj.async_get_chat_completion_prompt(
                 model=model,
                 messages=client_input,
@@ -503,6 +508,8 @@ async def aresponses(
                 _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                     model=model
                 )
+            kwargs.pop("prompt_id", None)
+            kwargs["_async_prompt_merged_params"] = merged_optional_params
 
         func = partial(
             responses,
@@ -666,47 +673,57 @@ def responses(
 
         #########################################################
         # PROMPT MANAGEMENT
+        # If aresponses() already ran the async hook, it pops prompt_id and
+        # passes the result via _async_prompt_merged_params — apply those
+        # directly and skip the sync hook to avoid double-merging.
         #########################################################
-        prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
-        prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
-        original_model = model
-
-        if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
-            prompt_id=prompt_id, non_default_params=kwargs
-        ):
-            if isinstance(input, str):
-                client_input: List[AllMessageValues] = [
-                    {"role": "user", "content": input}
-                ]
-            else:
-                client_input = [
-                    item  # type: ignore[misc]
-                    for item in input
-                    if isinstance(item, dict) and "role" in item
-                ]
-            (
-                model,
-                merged_input,
-                merged_optional_params,
-            ) = litellm_logging_obj.get_chat_completion_prompt(
-                model=model,
-                messages=client_input,
-                non_default_params=kwargs,
-                prompt_id=prompt_id,
-                prompt_variables=prompt_variables,
-                prompt_label=kwargs.get("prompt_label", None),
-                prompt_version=kwargs.get("prompt_version", None),
-            )
-            input = cast(Union[str, ResponseInputParam], merged_input)
-            local_vars["input"] = input
-            local_vars["model"] = model
-            if model != original_model:
-                _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                    model=model
-                )
-                local_vars["custom_llm_provider"] = custom_llm_provider
-            for k, v in merged_optional_params.items():
+        _async_merged = kwargs.pop("_async_prompt_merged_params", None)
+        if _async_merged is not None:
+            for k, v in _async_merged.items():
                 local_vars[k] = v
+        else:
+            prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
+            prompt_variables = cast(
+                Optional[dict], kwargs.get("prompt_variables", None)
+            )
+            original_model = model
+
+            if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
+                prompt_id=prompt_id, non_default_params=kwargs
+            ):
+                if isinstance(input, str):
+                    client_input: List[AllMessageValues] = [
+                        {"role": "user", "content": input}
+                    ]
+                else:
+                    client_input = [
+                        item  # type: ignore[misc]
+                        for item in input
+                        if isinstance(item, dict) and "role" in item
+                    ]
+                (
+                    model,
+                    merged_input,
+                    merged_optional_params,
+                ) = litellm_logging_obj.get_chat_completion_prompt(
+                    model=model,
+                    messages=client_input,
+                    non_default_params=kwargs,
+                    prompt_id=prompt_id,
+                    prompt_variables=prompt_variables,
+                    prompt_label=kwargs.get("prompt_label", None),
+                    prompt_version=kwargs.get("prompt_version", None),
+                )
+                input = cast(Union[str, ResponseInputParam], merged_input)
+                local_vars["input"] = input
+                local_vars["model"] = model
+                if model != original_model:
+                    _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                        model=model
+                    )
+                    local_vars["custom_llm_provider"] = custom_llm_provider
+                for k, v in merged_optional_params.items():
+                    local_vars[k] = v
 
         #########################################################
         # Update input and tools with provider-specific file IDs if managed files are used

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -470,6 +470,7 @@ async def aresponses(
         litellm_logging_obj = kwargs.get("litellm_logging_obj", None)
         prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
         prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
+        original_model = model
 
         if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
             prompt_id=prompt_id, non_default_params=kwargs
@@ -487,7 +488,7 @@ async def aresponses(
             (
                 model,
                 merged_input,
-                merged_optional_params,
+                _,
             ) = await litellm_logging_obj.async_get_chat_completion_prompt(
                 model=model,
                 messages=client_input,
@@ -498,14 +499,10 @@ async def aresponses(
                 prompt_version=kwargs.get("prompt_version", None),
             )
             input = cast(Union[str, ResponseInputParam], merged_input)
-            if "/" in model:
+            if model != original_model:
                 _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                     model=model
                 )
-                local_vars["custom_llm_provider"] = custom_llm_provider
-            for k, v in merged_optional_params.items():
-                if k in local_vars:
-                    local_vars[k] = v
 
         func = partial(
             responses,
@@ -672,6 +669,7 @@ def responses(
         #########################################################
         prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
         prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
+        original_model = model
 
         if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
             prompt_id=prompt_id, non_default_params=kwargs
@@ -702,7 +700,7 @@ def responses(
             input = cast(Union[str, ResponseInputParam], merged_input)
             local_vars["input"] = input
             local_vars["model"] = model
-            if "/" in model:
+            if model != original_model:
                 _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                     model=model
                 )

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -464,6 +464,49 @@ async def aresponses(
             # Update local_vars with detected provider (fixes #19782)
             local_vars["custom_llm_provider"] = custom_llm_provider
 
+        #########################################################
+        # ASYNC PROMPT MANAGEMENT
+        #########################################################
+        litellm_logging_obj = kwargs.get("litellm_logging_obj", None)
+        prompt_id = cast(Optional[str], kwargs.get("prompt_id", None))
+        prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
+
+        if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
+            prompt_id=prompt_id, non_default_params=kwargs
+        ):
+            if isinstance(input, str):
+                client_input: List[AllMessageValues] = [
+                    {"role": "user", "content": input}
+                ]
+            else:
+                client_input = [
+                    item  # type: ignore[misc]
+                    for item in input
+                    if isinstance(item, dict) and "role" in item
+                ]
+            (
+                model,
+                merged_input,
+                merged_optional_params,
+            ) = await litellm_logging_obj.async_get_chat_completion_prompt(
+                model=model,
+                messages=client_input,
+                non_default_params=kwargs,
+                prompt_id=prompt_id,
+                prompt_variables=prompt_variables,
+                prompt_label=kwargs.get("prompt_label", None),
+                prompt_version=kwargs.get("prompt_version", None),
+            )
+            input = cast(Union[str, ResponseInputParam], merged_input)
+            if "/" in model:
+                _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                    model=model
+                )
+                local_vars["custom_llm_provider"] = custom_llm_provider
+            for k, v in merged_optional_params.items():
+                if k in local_vars:
+                    local_vars[k] = v
+
         func = partial(
             responses,
             input=input,
@@ -633,11 +676,16 @@ def responses(
         if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
             prompt_id=prompt_id, non_default_params=kwargs
         ):
-            client_input: List[AllMessageValues] = (
-                [{"role": "user", "content": input}]
-                if isinstance(input, str)
-                else cast(List[AllMessageValues], list(input))
-            )
+            if isinstance(input, str):
+                client_input: List[AllMessageValues] = [
+                    {"role": "user", "content": input}
+                ]
+            else:
+                client_input = [
+                    item  # type: ignore[misc]
+                    for item in input
+                    if isinstance(item, dict) and "role" in item
+                ]
             (
                 model,
                 merged_input,
@@ -654,6 +702,11 @@ def responses(
             input = cast(Union[str, ResponseInputParam], merged_input)
             local_vars["input"] = input
             local_vars["model"] = model
+            if "/" in model:
+                _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                    model=model
+                )
+                local_vars["custom_llm_provider"] = custom_llm_provider
             for k, v in merged_optional_params.items():
                 local_vars[k] = v
 

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -158,7 +158,7 @@ class TestResponsesAPIPromptManagement:
         ]
         # Simulate get_chat_completion_prompt returning merged optional params
         # that include a template-defined temperature
-        merged_kwargs = {"temperature": 0.2, "prompt_id": "t", "litellm_logging_obj": None}
+        merged_kwargs = {"temperature": 0.2}
 
         logging_obj = MagicMock()
         logging_obj.__class__ = LiteLLMLoggingObj
@@ -209,3 +209,68 @@ class TestResponsesAPIPromptManagement:
         # The model passed to the downstream handler should be the overridden one
         handler_call_kwargs = mock_handler.call_args.kwargs
         assert handler_call_kwargs.get("model") == "openai/gpt-4o-mini"
+
+    def test_non_message_input_items_filtered(self):
+        """[F] Non-message items in ResponseInputParam (e.g. function_call_output) are
+        filtered out before being passed to the prompt hook, avoiding malformed merges."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "system", "content": "You are helpful."},  # type: ignore[list-item]
+        ]
+        mixed_input = [
+            {"role": "user", "content": "Hello"},
+            {"type": "function_call_output", "call_id": "abc", "output": "42"},
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=template_messages + [{"role": "user", "content": "Hello"}],  # type: ignore[operator]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            import litellm
+            litellm.responses(
+                input=mixed_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="filter-test",
+                litellm_logging_obj=logging_obj,
+            )
+
+        call_kwargs = logging_obj.get_chat_completion_prompt.call_args.kwargs
+        passed_messages = call_kwargs["messages"]
+        assert all(isinstance(m, dict) and "role" in m for m in passed_messages)
+        assert len(passed_messages) == 1
+
+    def test_model_override_re_resolves_provider(self):
+        """[G] When the prompt template overrides the model to a different provider,
+        custom_llm_provider is re-resolved so downstream routing uses the correct provider."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "user", "content": "Hi"},  # type: ignore[list-item]
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="anthropic/claude-3-5-sonnet",
+            merged_messages=template_messages,
+        )
+
+        patches = _patch_responses_dispatch()
+        with (
+            patch(
+                "litellm.responses.main.litellm.get_llm_provider",
+                side_effect=[
+                    ("gpt-4o", "openai", None, None),
+                    ("claude-3-5-sonnet", "anthropic", None, None),
+                ],
+            ),
+            patches[1],
+            patches[2],
+            patches[3] as mock_handler,
+        ):
+            import litellm
+            litellm.responses(
+                input="Hi",
+                model="gpt-4o",
+                prompt_id="cross-provider",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_call_kwargs = mock_handler.call_args.kwargs
+        assert handler_call_kwargs.get("custom_llm_provider") == "anthropic"

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -1,0 +1,211 @@
+"""
+Unit tests for prompt management support in the Responses API.
+
+Covers:
+  A) str input is coerced to a message list before merging with the template
+  B) list input is merged with the template
+  C) no prompt_id → hook is skipped, input is unchanged
+  D) model override from the prompt template is applied
+"""
+
+from typing import List
+from unittest.mock import MagicMock, patch
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.types.llms.openai import AllMessageValues
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_logging_obj(
+    merged_model: str,
+    merged_messages: List[AllMessageValues],
+    should_run: bool = True,
+) -> MagicMock:
+    """Return a mock LiteLLMLoggingObj pre-configured for prompt management."""
+    logging_obj = MagicMock()
+    # Make isinstance(logging_obj, LiteLLMLoggingObj) return True
+    logging_obj.__class__ = LiteLLMLoggingObj
+    logging_obj.should_run_prompt_management_hooks.return_value = should_run
+    logging_obj.get_chat_completion_prompt.return_value = (
+        merged_model,
+        merged_messages,
+        {},
+    )
+    # Instance attribute accessed by post-call metadata utilities
+    logging_obj.model_call_details = {}
+    return logging_obj
+
+
+def _patch_responses_dispatch():
+    """Patch everything after the prompt management block so tests stay unit-level."""
+    return [
+        patch(
+            "litellm.responses.main.litellm.get_llm_provider",
+            return_value=("gpt-4o", "openai", None, None),
+        ),
+        patch(
+            "litellm.responses.mcp.litellm_proxy_mcp_handler."
+            "LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway",
+            return_value=False,
+        ),
+        patch(
+            "litellm.responses.main.ProviderConfigManager"
+            ".get_provider_responses_api_config",
+            return_value=None,
+        ),
+        patch(
+            "litellm.responses.main.litellm_completion_transformation_handler"
+            ".response_api_handler",
+            return_value=MagicMock(),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestResponsesAPIPromptManagement:
+
+    def test_str_input_coerced_and_merged(self):
+        """[A] str input is wrapped into a message list before being passed to the hook."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "system", "content": "You are a summariser."},  # type: ignore[list-item]
+        ]
+        client_message: List[AllMessageValues] = [
+            {"role": "user", "content": "Tell me about AI."},  # type: ignore[list-item]
+        ]
+        expected_merged = template_messages + client_message
+
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=expected_merged,
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            import litellm
+            litellm.responses(
+                input="Tell me about AI.",
+                model="gpt-4o",
+                prompt_id="summariser-prompt",
+                prompt_variables={},
+                litellm_logging_obj=logging_obj,
+            )
+
+        logging_obj.get_chat_completion_prompt.assert_called_once()
+        call_kwargs = logging_obj.get_chat_completion_prompt.call_args.kwargs
+        # str was coerced to a single user message before being passed to the hook
+        assert call_kwargs["messages"] == [
+            {"role": "user", "content": "Tell me about AI."}
+        ]
+        assert call_kwargs["prompt_id"] == "summariser-prompt"
+
+    def test_list_input_merged_with_template(self):
+        """[B] list input is passed directly to the hook and merged with the template."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "system", "content": "You are helpful."},  # type: ignore[list-item]
+        ]
+        client_messages = [
+            {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
+        ]
+        expected_merged = template_messages + client_messages  # type: ignore[operator]
+
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=expected_merged,  # type: ignore[arg-type]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            import litellm
+            litellm.responses(
+                input=client_messages,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="helper-prompt",
+                litellm_logging_obj=logging_obj,
+            )
+
+        logging_obj.get_chat_completion_prompt.assert_called_once()
+        call_kwargs = logging_obj.get_chat_completion_prompt.call_args.kwargs
+        assert call_kwargs["messages"] == client_messages
+
+    def test_no_prompt_id_skips_hook(self):
+        """[C] When prompt_id is absent, prompt management hooks are not called."""
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[],
+            should_run=False,
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            import litellm
+            litellm.responses(
+                input="Hello",
+                model="gpt-4o",
+                litellm_logging_obj=logging_obj,
+            )
+
+        logging_obj.get_chat_completion_prompt.assert_not_called()
+
+    def test_optional_params_from_template_applied(self):
+        """[E] prompt_template_optional_params (e.g. temperature) flow into the request."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "user", "content": "Hello"},  # type: ignore[list-item]
+        ]
+        # Simulate get_chat_completion_prompt returning merged optional params
+        # that include a template-defined temperature
+        merged_kwargs = {"temperature": 0.2, "prompt_id": "t", "litellm_logging_obj": None}
+
+        logging_obj = MagicMock()
+        logging_obj.__class__ = LiteLLMLoggingObj
+        logging_obj.should_run_prompt_management_hooks.return_value = True
+        logging_obj.get_chat_completion_prompt.return_value = (
+            "openai/gpt-4o",
+            template_messages,
+            merged_kwargs,
+        )
+        logging_obj.model_call_details = {}
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+            litellm.responses(
+                input="Hello",
+                model="gpt-4o",
+                prompt_id="t",
+                litellm_logging_obj=logging_obj,
+            )
+
+        # temperature from the template should reach the downstream handler via local_vars
+        handler_call_kwargs = mock_handler.call_args.kwargs
+        request_params = handler_call_kwargs.get("responses_api_request", {})
+        assert request_params.get("temperature") == 0.2
+
+    def test_model_override_from_template(self):
+        """[D] Model returned by the prompt hook overrides the original request model."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "user", "content": "{{query}}"},  # type: ignore[list-item]
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o-mini",  # overridden model from template
+            merged_messages=template_messages,
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+            litellm.responses(
+                input="What is AI?",
+                model="gpt-4o",
+                prompt_id="query-prompt",
+                prompt_variables={"query": "What is AI?"},
+                litellm_logging_obj=logging_obj,
+            )
+
+        # The model passed to the downstream handler should be the overridden one
+        handler_call_kwargs = mock_handler.call_args.kwargs
+        assert handler_call_kwargs.get("model") == "openai/gpt-4o-mini"

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -6,10 +6,18 @@ Covers:
   B) list input is merged with the template
   C) no prompt_id → hook is skipped, input is unchanged
   D) model override from the prompt template is applied
+  E) prompt_template_optional_params flow into the request
+  F) non-message items in input are filtered out
+  G) model override re-resolves provider
+  H) async path calls async_get_chat_completion_prompt
+  I) async path propagates optional params to downstream handler
 """
 
+import asyncio
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.types.llms.openai import AllMessageValues
@@ -22,18 +30,19 @@ def _make_logging_obj(
     merged_model: str,
     merged_messages: List[AllMessageValues],
     should_run: bool = True,
+    merged_optional_params: dict = None,
 ) -> MagicMock:
     """Return a mock LiteLLMLoggingObj pre-configured for prompt management."""
+    if merged_optional_params is None:
+        merged_optional_params = {}
     logging_obj = MagicMock()
-    # Make isinstance(logging_obj, LiteLLMLoggingObj) return True
     logging_obj.__class__ = LiteLLMLoggingObj
     logging_obj.should_run_prompt_management_hooks.return_value = should_run
-    logging_obj.get_chat_completion_prompt.return_value = (
-        merged_model,
-        merged_messages,
-        {},
+    prompt_return = (merged_model, merged_messages, merged_optional_params)
+    logging_obj.get_chat_completion_prompt.return_value = prompt_return
+    logging_obj.async_get_chat_completion_prompt = AsyncMock(
+        return_value=prompt_return
     )
-    # Instance attribute accessed by post-call metadata utilities
     logging_obj.model_call_details = {}
     return logging_obj
 
@@ -274,3 +283,99 @@ class TestResponsesAPIPromptManagement:
 
         handler_call_kwargs = mock_handler.call_args.kwargs
         assert handler_call_kwargs.get("custom_llm_provider") == "anthropic"
+
+
+class TestAsyncResponsesAPIPromptManagement:
+    """Tests for the async aresponses() prompt management path.
+
+    aresponses() calls async_get_chat_completion_prompt at the outer async level
+    (for async-only prompt loggers), then delegates to responses() via
+    run_in_executor where the sync hook also runs — mirroring acompletion() in
+    main.py. Optional params are handled by the sync responses() path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_calls_async_hook(self):
+        """[H] aresponses() invokes async_get_chat_completion_prompt before
+        dispatching to the sync responses() path."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "system", "content": "You are helpful."},  # type: ignore[list-item]
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=template_messages + [{"role": "user", "content": "Hi"}],  # type: ignore[list-item]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            import litellm
+            await litellm.aresponses(
+                input="Hi",
+                model="gpt-4o",
+                prompt_id="async-test",
+                prompt_variables={},
+                litellm_logging_obj=logging_obj,
+            )
+
+        logging_obj.async_get_chat_completion_prompt.assert_called_once()
+        call_kwargs = logging_obj.async_get_chat_completion_prompt.call_args.kwargs
+        assert call_kwargs["prompt_id"] == "async-test"
+
+    @pytest.mark.asyncio
+    async def test_async_optional_params_propagated(self):
+        """[I] Template-defined optional params (e.g. temperature) reach the downstream
+        handler when called via aresponses(). The sync responses() path applies them
+        via local_vars."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "user", "content": "Hello"},  # type: ignore[list-item]
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=template_messages,
+            merged_optional_params={"temperature": 0.7},
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+            await litellm.aresponses(
+                input="Hello",
+                model="gpt-4o",
+                prompt_id="async-temp",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_call_kwargs = mock_handler.call_args.kwargs
+        request_params = handler_call_kwargs.get("responses_api_request", {})
+        assert request_params.get("temperature") == 0.7
+
+    @pytest.mark.asyncio
+    async def test_async_non_message_items_filtered(self):
+        """[J] Non-message items are filtered in the async path too."""
+        template_messages: List[AllMessageValues] = [
+            {"role": "system", "content": "Be helpful."},  # type: ignore[list-item]
+        ]
+        mixed_input = [
+            {"role": "user", "content": "Hello"},
+            {"type": "function_call_output", "call_id": "abc", "output": "42"},
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=template_messages + [{"role": "user", "content": "Hello"}],  # type: ignore[operator]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3]:
+            import litellm
+            await litellm.aresponses(
+                input=mixed_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="async-filter",
+                litellm_logging_obj=logging_obj,
+            )
+
+        logging_obj.async_get_chat_completion_prompt.assert_called_once()
+        call_kwargs = logging_obj.async_get_chat_completion_prompt.call_args.kwargs
+        passed_messages = call_kwargs["messages"]
+        assert all(isinstance(m, dict) and "role" in m for m in passed_messages)
+        assert len(passed_messages) == 1

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -288,16 +288,16 @@ class TestResponsesAPIPromptManagement:
 class TestAsyncResponsesAPIPromptManagement:
     """Tests for the async aresponses() prompt management path.
 
-    aresponses() calls async_get_chat_completion_prompt at the outer async level
-    (for async-only prompt loggers), then delegates to responses() via
-    run_in_executor where the sync hook also runs — mirroring acompletion() in
-    main.py. Optional params are handled by the sync responses() path.
+    aresponses() calls async_get_chat_completion_prompt at the outer async
+    level, then pops prompt_id from kwargs and passes merged_optional_params
+    via an internal kwarg. The sync responses() path sees no prompt_id and
+    skips the sync hook entirely — preventing double-merge of template messages.
     """
 
     @pytest.mark.asyncio
-    async def test_async_calls_async_hook(self):
-        """[H] aresponses() invokes async_get_chat_completion_prompt before
-        dispatching to the sync responses() path."""
+    async def test_async_calls_async_hook_not_sync(self):
+        """[H] aresponses() invokes async_get_chat_completion_prompt and the
+        sync get_chat_completion_prompt is NOT called (no double-merge)."""
         template_messages: List[AllMessageValues] = [
             {"role": "system", "content": "You are helpful."},  # type: ignore[list-item]
         ]
@@ -318,14 +318,14 @@ class TestAsyncResponsesAPIPromptManagement:
             )
 
         logging_obj.async_get_chat_completion_prompt.assert_called_once()
+        logging_obj.get_chat_completion_prompt.assert_not_called()
         call_kwargs = logging_obj.async_get_chat_completion_prompt.call_args.kwargs
         assert call_kwargs["prompt_id"] == "async-test"
 
     @pytest.mark.asyncio
     async def test_async_optional_params_propagated(self):
-        """[I] Template-defined optional params (e.g. temperature) reach the downstream
-        handler when called via aresponses(). The sync responses() path applies them
-        via local_vars."""
+        """[I] Template-defined optional params (e.g. temperature) from the async
+        hook reach the downstream handler — they are NOT silently discarded."""
         template_messages: List[AllMessageValues] = [
             {"role": "user", "content": "Hello"},  # type: ignore[list-item]
         ]
@@ -345,6 +345,7 @@ class TestAsyncResponsesAPIPromptManagement:
                 litellm_logging_obj=logging_obj,
             )
 
+        logging_obj.get_chat_completion_prompt.assert_not_called()
         handler_call_kwargs = mock_handler.call_args.kwargs
         request_params = handler_call_kwargs.get("responses_api_request", {})
         assert request_params.get("temperature") == 0.7
@@ -375,6 +376,7 @@ class TestAsyncResponsesAPIPromptManagement:
             )
 
         logging_obj.async_get_chat_completion_prompt.assert_called_once()
+        logging_obj.get_chat_completion_prompt.assert_not_called()
         call_kwargs = logging_obj.async_get_chat_completion_prompt.call_args.kwargs
         passed_messages = call_kwargs["messages"]
         assert all(isinstance(m, dict) and "role" in m for m in passed_messages)


### PR DESCRIPTION
## Relevant issues

Greptile Summary from Prev PR
This PR adds prompt management support (via prompt_id / prompt_variables) to the Responses API (/v1/responses), mirroring the existing chat-completions flow. It inserts a prompt management block into both responses() (sync) and aresponses() (async) in litellm/responses/main.py, adds 7 mock unit tests, and ships documentation.

The sync path in responses() is architecturally sound and the claimed fixes for the unsafe cast and provider re-resolution are correctly implemented there. However, one previously-flagged issue remains unresolved and a test coverage gap leaves it undetected:

merged_optional_params silently discarded in aresponses() (P1): In the async path, template-defined optional params (e.g. temperature, top_p) are written to local_vars — a dict snapshot created by locals() — but the partial(responses, ..., temperature=temperature, ...) call immediately below uses the actual (unchanged) local variables, not the snapshot. Any optional-param overrides from the prompt template are effectively a no-op in the async path.
No async tests (P1): All 7 tests exercise litellm.responses() (sync). Zero tests call litellm.aresponses(), which means the async prompt management block — one of the three explicitly claimed fixes — has no test coverage and the bug above goes undetected.
"/" in model heuristic for provider re-resolution (P2): Provider re-resolution is skipped for models returned by the prompt hook without a slash prefix (e.g. "claude-3-5-sonnet"), leaving custom_llm_provider pointing at the original provider and causing mis-routing. The same pattern exists in both the sync and async blocks.
Confidence Score: 2/5
Not safe to merge — the async path has a logic bug that silently discards prompt-template optional params, and there are no async tests to catch it.
The sync responses() path is correct and well-tested. The async aresponses() path has a P1 logic bug: merged_optional_params from the prompt hook are stored in a locals() snapshot (local_vars) but the partial() call uses the original local variable bindings, so template params never reach the downstream handler. Additionally, all 7 tests only cover the sync path, so the async fix claimed in the PR description is entirely unverified. The "/" in model heuristic is a P2 correctness issue shared by both paths.
litellm/responses/main.py (async prompt management block, lines 467–508) and tests/test_litellm/responses/test_responses_prompt_management.py (missing async coverage)

All the P1,P0s, have been fixed
Important
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
