### PR TITLE
fix: add mid-stream fallback support for anthropic_messages route type

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -24,6 +24,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    AsyncIterator,
     Callable,
     Dict,
     Generator,
@@ -400,9 +401,9 @@ class Router:
         )  # names of models under litellm_params. ex. azure/chatgpt-v-2
         self.deployment_latency_map = {}
         ### CACHING ###
-        cache_type: Literal[
-            "local", "redis", "redis-semantic", "s3", "disk"
-        ] = "local"  # default to an in-memory cache
+        cache_type: Literal["local", "redis", "redis-semantic", "s3", "disk"] = (
+            "local"  # default to an in-memory cache
+        )
         redis_cache = None
         cache_config: Dict[str, Any] = {}
 
@@ -450,9 +451,9 @@ class Router:
         self.default_max_parallel_requests = default_max_parallel_requests
         self.provider_default_deployment_ids: List[str] = []
         self.pattern_router = PatternMatchRouter()
-        self.team_pattern_routers: Dict[
-            str, PatternMatchRouter
-        ] = {}  # {"TEAM_ID": PatternMatchRouter}
+        self.team_pattern_routers: Dict[str, PatternMatchRouter] = (
+            {}
+        )  # {"TEAM_ID": PatternMatchRouter}
         self.auto_routers: Dict[str, "AutoRouter"] = {}
         self.complexity_routers: Dict[str, "ComplexityRouter"] = {}
 
@@ -638,9 +639,9 @@ class Router:
                     )
                 )
 
-        self.model_group_retry_policy: Optional[
-            Dict[str, RetryPolicy]
-        ] = model_group_retry_policy
+        self.model_group_retry_policy: Optional[Dict[str, RetryPolicy]] = (
+            model_group_retry_policy
+        )
 
         self.allowed_fails_policy: Optional[AllowedFailsPolicy] = None
         if allowed_fails_policy is not None:
@@ -2021,7 +2022,10 @@ class Router:
 
     async def _acompletion(  # noqa: PLR0915
         self, model: str, messages: List[Dict[str, str]], **kwargs
-    ) -> Union[ModelResponse, CustomStreamWrapper,]:
+    ) -> Union[
+        ModelResponse,
+        CustomStreamWrapper,
+    ]:
         """
         - Get an available deployment
         - call it with a semaphore over the call
@@ -3786,6 +3790,14 @@ class Router:
         """
         Helper function to make a generic LLM API call through the router, this allows you to use retries/fallbacks with litellm router
         """
+        # Save kwargs for streaming fallback before they get mutated by deployment resolution.
+        # original_generic_function is a named param (not in **kwargs), so we must
+        # explicitly include it for the fallback path to be able to re-invoke the LLM call.
+        input_kwargs_for_streaming_fallback = kwargs.copy()
+        input_kwargs_for_streaming_fallback["model"] = model
+        input_kwargs_for_streaming_fallback["original_generic_function"] = (
+            original_generic_function
+        )
 
         passthrough_on_no_deployment = kwargs.pop("passthrough_on_no_deployment", False)
         function_name = "_ageneric_api_call_with_fallbacks"
@@ -3852,6 +3864,23 @@ class Router:
                 f"ageneric_api_call_with_fallbacks(model={model_name})\033[32m 200 OK\033[0m"
             )
 
+            # Wrap streaming responses with mid-stream fallback detection.
+            # For anthropic_messages (and other generic streaming endpoints),
+            # the response is an AsyncIterator that yields raw SSE bytes.
+            # Without this wrapper, mid-stream errors (e.g. Anthropic returning
+            # an "overloaded" SSE error event after HTTP 200) pass through
+            # silently to the client with no fallback attempt.
+            if hasattr(response, "__aiter__") and not isinstance(
+                response, (dict, list, str)
+            ):
+                llm_provider = data.get("custom_llm_provider", "")
+                response = await self._ageneric_streaming_iterator(
+                    streaming_response=response,
+                    model=model,
+                    llm_provider=llm_provider,
+                    initial_kwargs=input_kwargs_for_streaming_fallback,
+                )
+
             return response
         except Exception as e:
             verbose_router_logger.info(
@@ -3860,6 +3889,184 @@ class Router:
             if model is not None:
                 self.fail_calls[model] += 1
             raise e
+
+    async def _ageneric_streaming_iterator(  # noqa: PLR0915
+        self,
+        streaming_response: Any,
+        model: str,
+        llm_provider: str,
+        initial_kwargs: dict,
+    ) -> AsyncIterator:
+        """
+        Wraps a generic streaming response (e.g. from anthropic_messages) with
+        mid-stream error detection and fallback support.
+
+        Monitors SSE chunks for provider error events in the SSE stream
+        (e.g. Anthropic's overloaded_error, internal_server_error) and triggers
+        the router's fallback system when detected.
+
+        Mirrors the pattern from ``_acompletion_streaming_iterator`` /
+        ``FallbackStreamWrapper`` used for the OpenAI chat path.
+        """
+        from litellm.exceptions import (
+            InternalServerError,
+            ServiceUnavailableError,
+        )
+
+        async def stream_with_error_detection():
+            """Async generator that detects SSE error events and triggers fallback."""
+            fallback_response = None
+            # Track whether we've seen an "event: error" line in a previous chunk
+            # but haven't yet found its "data:" line (handles TCP frame splitting).
+            pending_error_event = False
+            try:
+                async for chunk in streaming_response:
+                    # Check if this chunk contains an SSE error event
+                    error_info = _detect_sse_error_event(chunk, pending_error_event)
+                    if error_info is not None:
+                        error_type, error_message = error_info
+                        pending_error_event = False
+                        verbose_router_logger.warning(
+                            "_ageneric_streaming_iterator: detected mid-stream SSE error: "
+                            "type=%s, message=%s",
+                            error_type,
+                            error_message,
+                        )
+                        # Raise an exception so the fallback system can catch it
+                        if "overloaded" in error_type.lower():
+                            raise ServiceUnavailableError(
+                                message=f"Mid-stream SSE error: {error_message}",
+                                model=model,
+                                llm_provider=llm_provider,
+                            )
+                        else:
+                            raise InternalServerError(
+                                message=f"Mid-stream SSE error: {error_message}",
+                                model=model,
+                                llm_provider=llm_provider,
+                            )
+                    # Track "event: error" seen without data in same chunk
+                    chunk_str = (
+                        chunk.decode("utf-8")
+                        if isinstance(chunk, bytes)
+                        else str(chunk)
+                    )
+                    if "event: error" in chunk_str:
+                        pending_error_event = True
+                    yield chunk
+            except (ServiceUnavailableError, InternalServerError) as e:
+                verbose_router_logger.info(
+                    "_ageneric_streaming_iterator: mid-stream error detected for model=%s, "
+                    "attempting fallback. Error: %s",
+                    model,
+                    str(e),
+                )
+                # Attempt fallback using the router's fallback system
+                fallbacks = initial_kwargs.get("fallbacks", self.fallbacks)
+                model_group = initial_kwargs.get("model", model)
+                initial_kwargs["original_function"] = (
+                    self._ageneric_api_call_with_fallbacks_helper
+                )
+                self._update_kwargs_before_fallbacks(
+                    model=model_group,
+                    kwargs=initial_kwargs,
+                    metadata_variable_name="litellm_metadata",
+                )
+                try:
+                    fallback_response = (
+                        await self.async_function_with_fallbacks_common_utils(
+                            e=e,
+                            disable_fallbacks=initial_kwargs.get(
+                                "disable_fallbacks", False
+                            ),
+                            fallbacks=fallbacks,
+                            context_window_fallbacks=None,
+                            content_policy_fallbacks=None,
+                            model_group=model_group,
+                            args=(),
+                            kwargs=initial_kwargs,
+                        )
+                    )
+                    # If fallback returns a streaming response, yield its chunks
+                    if hasattr(fallback_response, "__aiter__"):
+                        async for fallback_chunk in fallback_response:
+                            yield fallback_chunk
+                except Exception as fallback_error:
+                    verbose_router_logger.error(
+                        "_ageneric_streaming_iterator: fallback also failed: %s",
+                        fallback_error,
+                    )
+                    raise fallback_error
+            finally:
+                # Close the underlying streams to release HTTP connections back to
+                # the connection pool, even on client disconnect. Shield from anyio
+                # cancellation so the awaits can complete. Mirrors the cleanup in
+                # _acompletion_streaming_iterator.
+                with anyio.CancelScope(shield=True):
+                    if hasattr(streaming_response, "aclose"):
+                        try:
+                            await streaming_response.aclose()
+                        except BaseException as exc:
+                            verbose_router_logger.debug(
+                                "_ageneric_streaming_iterator: error closing streaming_response: %s",
+                                exc,
+                            )
+                    if fallback_response is not None and hasattr(
+                        fallback_response, "aclose"
+                    ):
+                        try:
+                            await fallback_response.aclose()
+                        except BaseException as exc:
+                            verbose_router_logger.debug(
+                                "_ageneric_streaming_iterator: error closing fallback_response: %s",
+                                exc,
+                            )
+
+        def _detect_sse_error_event(
+            chunk: bytes,
+            pending_error_event: bool = False,
+        ) -> Optional[Tuple[str, str]]:
+            """
+            Parse an SSE chunk to detect provider error events.
+
+            Anthropic SSE error events look like::
+
+                event: error
+                data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+
+            Handles the case where ``event: error`` and ``data: ...`` arrive in
+            separate TCP frames by accepting ``pending_error_event`` state.
+
+            Returns ``(error_type, error_message)`` if an error is detected,
+            ``None`` otherwise.
+            """
+            try:
+                chunk_str = (
+                    chunk.decode("utf-8") if isinstance(chunk, bytes) else str(chunk)
+                )
+                has_event_error = "event: error" in chunk_str or pending_error_event
+                if not has_event_error:
+                    return None
+                # Extract the data line(s)
+                for line in chunk_str.split("\n"):
+                    line = line.strip()
+                    if line.startswith("data: "):
+                        data_str = line[6:]
+                        try:
+                            data = json.loads(data_str)
+                            if data.get("type") == "error" and "error" in data:
+                                error_obj = data["error"]
+                                return (
+                                    error_obj.get("type", "unknown_error"),
+                                    error_obj.get("message", "Unknown error"),
+                                )
+                        except (json.JSONDecodeError, KeyError):
+                            continue
+                return None
+            except Exception:
+                return None
+
+        return stream_with_error_detection()
 
     def _generic_api_call_with_fallbacks(
         self, model: str, original_function: Callable, **kwargs
@@ -4246,9 +4453,9 @@ class Router:
                 healthy_deployments=healthy_deployments, responses=responses
             )
             returned_response = cast(OpenAIFileObject, responses[0])
-            returned_response._hidden_params[
-                "model_file_id_mapping"
-            ] = model_file_id_mapping
+            returned_response._hidden_params["model_file_id_mapping"] = (
+                model_file_id_mapping
+            )
             return returned_response
         except Exception as e:
             verbose_router_logger.exception(
@@ -5275,11 +5482,11 @@ class Router:
 
             if isinstance(e, litellm.ContextWindowExceededError):
                 if context_window_fallbacks is not None:
-                    context_window_fallback_model_group: Optional[
-                        List[str]
-                    ] = self._get_fallback_model_group_from_fallbacks(
-                        fallbacks=context_window_fallbacks,
-                        model_group=model_group,
+                    context_window_fallback_model_group: Optional[List[str]] = (
+                        self._get_fallback_model_group_from_fallbacks(
+                            fallbacks=context_window_fallbacks,
+                            model_group=model_group,
+                        )
                     )
                     if context_window_fallback_model_group is None:
                         raise original_exception
@@ -5311,11 +5518,11 @@ class Router:
                     e.message += "\n{}".format(error_message)
             elif isinstance(e, litellm.ContentPolicyViolationError):
                 if content_policy_fallbacks is not None:
-                    content_policy_fallback_model_group: Optional[
-                        List[str]
-                    ] = self._get_fallback_model_group_from_fallbacks(
-                        fallbacks=content_policy_fallbacks,
-                        model_group=model_group,
+                    content_policy_fallback_model_group: Optional[List[str]] = (
+                        self._get_fallback_model_group_from_fallbacks(
+                            fallbacks=content_policy_fallbacks,
+                            model_group=model_group,
+                        )
                     )
                     if content_policy_fallback_model_group is None:
                         raise original_exception
@@ -5537,9 +5744,9 @@ class Router:
         )
         ## ADD RETRY TRACKING TO METADATA - used for spend logs retry tracking
         _metadata["attempted_retries"] = 0
-        _metadata[
-            "max_retries"
-        ] = num_retries  # Updated after overrides in exception handler
+        _metadata["max_retries"] = (
+            num_retries  # Updated after overrides in exception handler
+        )
         try:
             self._handle_mock_testing_rate_limit_error(
                 model_group=model_group, kwargs=kwargs
@@ -6658,26 +6865,26 @@ class Router:
         """
         from litellm.router_strategy.auto_router.auto_router import AutoRouter
 
-        auto_router_config_path: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_config_path
+        auto_router_config_path: Optional[str] = (
+            deployment.litellm_params.auto_router_config_path
+        )
         auto_router_config: Optional[str] = deployment.litellm_params.auto_router_config
         if auto_router_config_path is None and auto_router_config is None:
             raise ValueError(
                 "auto_router_config_path or auto_router_config is required for auto-router deployments. Please set it in the litellm_params"
             )
 
-        default_model: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_default_model
+        default_model: Optional[str] = (
+            deployment.litellm_params.auto_router_default_model
+        )
         if default_model is None:
             raise ValueError(
                 "auto_router_default_model is required for auto-router deployments. Please set it in the litellm_params"
             )
 
-        embedding_model: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_embedding_model
+        embedding_model: Optional[str] = (
+            deployment.litellm_params.auto_router_embedding_model
+        )
         if embedding_model is None:
             raise ValueError(
                 "auto_router_embedding_model is required for auto-router deployments. Please set it in the litellm_params"
@@ -6720,13 +6927,13 @@ class Router:
             ComplexityRouter,
         )
 
-        complexity_router_config: Optional[
-            dict
-        ] = deployment.litellm_params.complexity_router_config
+        complexity_router_config: Optional[dict] = (
+            deployment.litellm_params.complexity_router_config
+        )
 
-        default_model: Optional[
-            str
-        ] = deployment.litellm_params.complexity_router_default_model
+        default_model: Optional[str] = (
+            deployment.litellm_params.complexity_router_default_model
+        )
 
         # If no default model specified, try to get from config tiers
         if default_model is None and complexity_router_config:
@@ -7337,9 +7544,9 @@ class Router:
 
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:
-            credentials[
-                "custom_llm_provider"
-            ] = deployment.litellm_params.custom_llm_provider
+            credentials["custom_llm_provider"] = (
+                deployment.litellm_params.custom_llm_provider
+            )
         elif "/" in deployment.litellm_params.model:
             # Extract provider from "provider/model" format
             credentials["custom_llm_provider"] = deployment.litellm_params.model.split(

--- a/poetry.lock
+++ b/poetry.lock
@@ -3219,15 +3219,15 @@ files = [
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.56"
+version = "0.4.57"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 optional = true
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-    {file = "litellm_proxy_extras-0.4.56-py3-none-any.whl", hash = "sha256:52dbe3b5358c790e77e12f1ec5ef8e7508b383c2aaf41299750b6fb400908ee7"},
-    {file = "litellm_proxy_extras-0.4.56.tar.gz", hash = "sha256:63ad59baa0defccc5c929cfd933ee7e32a6614b0fc5fa0fc45a12d7608e33f08"},
+    {file = "litellm_proxy_extras-0.4.57-py3-none-any.whl", hash = "sha256:04538223cd80318a72d70c6e10f701598e58c763368296a6503c674c92fbdb62"},
+    {file = "litellm_proxy_extras-0.4.57.tar.gz", hash = "sha256:ef9b95dc42237614216833bd5d46ebf9dea1caa5ea14ea1a66d7f7842b224ec2"},
 ]
 
 [[package]]
@@ -7994,4 +7994,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "1f3bbf967451633fb6290ba88980bdf4fbf83420024b14e862d1da717d903684"
+content-hash = "22cdc8096e0c8296827734393f5ab6e66088f397b5295caa1d277466d1fde1e8"

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -646,8 +646,15 @@ def test_arouter_responses_api_bridge():
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.headers = {"content-type": "application/json"}
-    mock_response.json.return_value = {"id": "resp_test", "object": "response", "status": "completed", "output": []}
-    mock_response.text = '{"id": "resp_test", "object": "response", "status": "completed", "output": []}'
+    mock_response.json.return_value = {
+        "id": "resp_test",
+        "object": "response",
+        "status": "completed",
+        "output": [],
+    }
+    mock_response.text = (
+        '{"id": "resp_test", "object": "response", "status": "completed", "output": []}'
+    )
 
     with patch.object(client, "post", return_value=mock_response) as mock_post:
         try:
@@ -2147,7 +2154,10 @@ def test_get_deployment_credentials_with_provider_aws_bedrock_runtime_endpoint()
     )
 
     assert credentials is not None
-    assert credentials["aws_bedrock_runtime_endpoint"] == "https://bedrock-runtime.us-east-1.amazonaws.com"
+    assert (
+        credentials["aws_bedrock_runtime_endpoint"]
+        == "https://bedrock-runtime.us-east-1.amazonaws.com"
+    )
     assert credentials["aws_access_key_id"] == "test-access-key"
     assert credentials["aws_secret_access_key"] == "test-secret-key"
     assert credentials["aws_region_name"] == "us-east-1"
@@ -2169,11 +2179,11 @@ def test_get_deployment_credentials_with_provider_resolves_credential_name():
             credential_values={
                 "api_key": "resolved-api-key",
                 "api_base": "https://resolved.openai.azure.com",
-                "api_version": "2024-02-01"
-            }
+                "api_version": "2024-02-01",
+            },
         )
     ]
-    
+
     router = litellm.Router(
         model_list=[
             {
@@ -2197,7 +2207,7 @@ def test_get_deployment_credentials_with_provider_resolves_credential_name():
     assert credentials["custom_llm_provider"] == "azure"
     # Ensure credential name is removed after resolution
     assert "litellm_credential_name" not in credentials
-    
+
     # Cleanup
     litellm.credential_list = []
 
@@ -2302,7 +2312,10 @@ async def test_aguardrail_helper():
 
     # Mock the original function
     async def mock_original_function(**kwargs):
-        return {"result": "success", "selected_guardrail": kwargs.get("selected_guardrail")}
+        return {
+            "result": "success",
+            "selected_guardrail": kwargs.get("selected_guardrail"),
+        }
 
     result = await router._aguardrail_helper(
         model="content-filter",
@@ -2336,7 +2349,10 @@ async def test_aguardrail():
 
     # Mock the original function
     async def mock_original_function(**kwargs):
-        return {"result": "success", "selected_guardrail": kwargs.get("selected_guardrail")}
+        return {
+            "result": "success",
+            "selected_guardrail": kwargs.get("selected_guardrail"),
+        }
 
     result = await router.aguardrail(
         guardrail_name="content-filter",
@@ -2345,6 +2361,7 @@ async def test_aguardrail():
 
     assert result["result"] == "success"
     assert result["selected_guardrail"]["id"] == "guardrail-1"
+
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_call_type_is_cached():
@@ -2417,36 +2434,33 @@ async def test_anthropic_messages_call_type_is_cached():
                 additional_headers=None,
             ),
         )
-    
+
     cache = DualCache()
     deployment_check = PromptCachingDeploymentCheck(cache=cache)
     prompt_cache = PromptCachingCache(cache=cache)
-    
+
     # Create messages with enough tokens to pass the caching threshold
     test_messages = [
         {
-            "role": "user", 
+            "role": "user",
             "content": [
                 {
-                    "type": "text", 
+                    "type": "text",
                     "text": "test long message here" * 1024,
-                    "cache_control": {
-                        "type": "ephemeral",
-                        "ttl": "5m"
-                    }
+                    "cache_control": {"type": "ephemeral", "ttl": "5m"},
                 }
-            ]
+            ],
         }
     ]
     test_model_id = "test-model-id-123"
-    
+
     # Create a payload with anthropic_messages call type
     payload = create_standard_logging_payload()
     payload["call_type"] = CallTypes.anthropic_messages.value
     payload["messages"] = test_messages
     payload["model"] = "anthropic/claude-3-5-sonnet-20240620"
     payload["model_id"] = test_model_id
-    
+
     # Log the success event (should cache the model_id)
     await deployment_check.async_log_success_event(
         kwargs={"standard_logging_object": payload},
@@ -2454,19 +2468,23 @@ async def test_anthropic_messages_call_type_is_cached():
         start_time=1234567890.0,
         end_time=1234567891.0,
     )
-    
+
     # Small delay to ensure cache write completes
     await asyncio.sleep(0.1)
-    
+
     # Verify that the model_id was actually cached
     cached_result = await prompt_cache.async_get_model_id(
         messages=test_messages,
         tools=None,
     )
-    
+
     # This assertion will FAIL if anthropic_messages is filtered out
-    assert cached_result is not None, "Model ID should be cached for anthropic_messages call type"
-    assert cached_result["model_id"] == test_model_id, f"Expected {test_model_id}, got {cached_result['model_id']}"
+    assert (
+        cached_result is not None
+    ), "Model ID should be cached for anthropic_messages call type"
+    assert (
+        cached_result["model_id"] == test_model_id
+    ), f"Expected {test_model_id}, got {cached_result['model_id']}"
 
 
 def test_update_kwargs_with_deployment_propagates_model_tags():
@@ -2682,9 +2700,7 @@ def test_credential_name_injected_as_tag():
     )
 
     kwargs: dict = {"metadata": {"tags": ["A.101"]}}
-    deployment = router.get_deployment_by_model_group_name(
-        model_group_name="xai-model"
-    )
+    deployment = router.get_deployment_by_model_group_name(model_group_name="xai-model")
     router._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs)
 
     assert "Credential: xAI" in kwargs["metadata"]["tags"]
@@ -2709,9 +2725,7 @@ def test_credential_name_not_duplicated_in_tags():
     )
 
     kwargs: dict = {"metadata": {"tags": ["Credential: xAI", "A.101"]}}
-    deployment = router.get_deployment_by_model_group_name(
-        model_group_name="xai-model"
-    )
+    deployment = router.get_deployment_by_model_group_name(model_group_name="xai-model")
     router._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs)
 
     assert kwargs["metadata"]["tags"].count("Credential: xAI") == 1
@@ -2733,9 +2747,7 @@ def test_credential_name_not_injected_when_absent():
     )
 
     kwargs: dict = {"metadata": {"tags": ["A.101"]}}
-    deployment = router.get_deployment_by_model_group_name(
-        model_group_name="gpt-model"
-    )
+    deployment = router.get_deployment_by_model_group_name(model_group_name="gpt-model")
     router._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs)
 
     assert kwargs["metadata"]["tags"] == ["A.101"]
@@ -2835,3 +2847,218 @@ def test_combine_fallback_usage():
     assert chunk.usage.prompt_tokens == 10
     assert chunk.usage.completion_tokens == 5
     assert chunk.usage.total_tokens == 15
+
+
+# ---------------------------------------------------------------------------
+# Tests for _ageneric_streaming_iterator (mid-stream fallback for
+# anthropic_messages and other generic streaming routes)
+# ---------------------------------------------------------------------------
+
+
+class _MockAsyncIterator:
+    """Async iterator that yields items and optionally raises after a given index."""
+
+    def __init__(self, items, close_called=None):
+        self.items = items
+        self.index = 0
+        self._close_called = close_called
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.index >= len(self.items):
+            raise StopAsyncIteration
+        item = self.items[self.index]
+        self.index += 1
+        return item
+
+    async def aclose(self):
+        if self._close_called is not None:
+            self._close_called.append(True)
+
+
+@pytest.mark.asyncio
+async def test_ageneric_streaming_iterator_normal_flow():
+    """Normal streaming: all chunks pass through, no error detected."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-opus",
+                "litellm_params": {"model": "anthropic/claude-opus", "api_key": "k"},
+            },
+        ],
+    )
+
+    chunks = [
+        b'event: message_start\ndata: {"type":"message_start"}\n\n',
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"Hi"}}\n\n',
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]
+    close_log = []
+    mock_stream = _MockAsyncIterator(chunks, close_called=close_log)
+
+    result = await router._ageneric_streaming_iterator(
+        streaming_response=mock_stream,
+        model="claude-opus",
+        llm_provider="anthropic",
+        initial_kwargs={"model": "claude-opus"},
+    )
+
+    collected = []
+    async for chunk in result:
+        collected.append(chunk)
+
+    assert collected == chunks
+    # Stream should be closed after iteration
+    assert len(close_log) == 1
+
+
+@pytest.mark.asyncio
+async def test_ageneric_streaming_iterator_detects_overloaded_error():
+    """SSE error event (overloaded) in a single chunk triggers fallback."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-opus",
+                "litellm_params": {"model": "anthropic/claude-opus", "api_key": "k1"},
+            },
+            {
+                "model_name": "bedrock-opus",
+                "litellm_params": {
+                    "model": "bedrock/claude-opus",
+                    "api_key": "k2",
+                },
+            },
+        ],
+        fallbacks=[{"claude-opus": ["bedrock-opus"]}],
+    )
+
+    error_chunk = (
+        b'event: error\ndata: {"type":"error","error":'
+        b'{"type":"overloaded_error","message":"Overloaded"}}\n\n'
+    )
+    chunks = [
+        b'event: message_start\ndata: {"type":"message_start"}\n\n',
+        error_chunk,
+    ]
+    mock_stream = _MockAsyncIterator(chunks)
+
+    # Mock the fallback path so it doesn't make real HTTP calls
+    fallback_chunks = [b"fallback_chunk_1", b"fallback_chunk_2"]
+    mock_fallback = _MockAsyncIterator(fallback_chunks)
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=mock_fallback,
+    ) as mock_fallback_fn:
+        result = await router._ageneric_streaming_iterator(
+            streaming_response=mock_stream,
+            model="claude-opus",
+            llm_provider="anthropic",
+            initial_kwargs={
+                "model": "claude-opus",
+                "original_generic_function": AsyncMock(),
+            },
+        )
+
+        collected = []
+        async for chunk in result:
+            collected.append(chunk)
+
+        # First chunk passes through, then error detected, fallback triggered
+        assert collected[0] == chunks[0]
+        assert collected[1:] == fallback_chunks
+        # Verify fallback was called
+        assert mock_fallback_fn.called
+
+
+@pytest.mark.asyncio
+async def test_ageneric_streaming_iterator_detects_split_sse_error():
+    """SSE error event split across two TCP chunks is still detected."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-opus",
+                "litellm_params": {"model": "anthropic/claude-opus", "api_key": "k1"},
+            },
+            {
+                "model_name": "bedrock-opus",
+                "litellm_params": {
+                    "model": "bedrock/claude-opus",
+                    "api_key": "k2",
+                },
+            },
+        ],
+        fallbacks=[{"claude-opus": ["bedrock-opus"]}],
+    )
+
+    # "event: error" in one chunk, "data:" in next chunk
+    chunks = [
+        b'event: message_start\ndata: {"type":"message_start"}\n\n',
+        b"event: error\n",
+        b'data: {"type":"error","error":{"type":"internal_server_error","message":"Internal"}}\n\n',
+    ]
+    mock_stream = _MockAsyncIterator(chunks)
+
+    fallback_chunks = [b"fallback_ok"]
+    mock_fallback = _MockAsyncIterator(fallback_chunks)
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=mock_fallback,
+    ):
+        result = await router._ageneric_streaming_iterator(
+            streaming_response=mock_stream,
+            model="claude-opus",
+            llm_provider="anthropic",
+            initial_kwargs={
+                "model": "claude-opus",
+                "original_generic_function": AsyncMock(),
+            },
+        )
+
+        collected = []
+        async for chunk in result:
+            collected.append(chunk)
+
+        # First two chunks pass through (event: error alone doesn't trigger),
+        # third chunk has data: with pending_error_event=True → triggers fallback
+        assert collected[0] == chunks[0]
+        assert collected[1] == chunks[1]
+        assert collected[2:] == fallback_chunks
+
+
+@pytest.mark.asyncio
+async def test_ageneric_streaming_iterator_no_false_positive():
+    """Chunks containing 'error' in message content don't trigger false positives."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-opus",
+                "litellm_params": {"model": "anthropic/claude-opus", "api_key": "k"},
+            },
+        ],
+    )
+
+    chunks = [
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"An error occurred in the system"}}\n\n',
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":" but it was handled"}}\n\n',
+    ]
+    mock_stream = _MockAsyncIterator(chunks)
+
+    result = await router._ageneric_streaming_iterator(
+        streaming_response=mock_stream,
+        model="claude-opus",
+        llm_provider="anthropic",
+        initial_kwargs={"model": "claude-opus"},
+    )
+
+    collected = []
+    async for chunk in result:
+        collected.append(chunk)
+
+    # All chunks pass through — no false trigger
+    assert collected == chunks


### PR DESCRIPTION
## Summary

Fixes #24004 — Mid-stream fallback is not supported for the `anthropic_messages` route type (`/v1/messages` endpoint).

### Problem

When Anthropic returns HTTP 200 and starts streaming, then sends an SSE error event (`overloaded_error` or `internal_server_error`) mid-stream, the router does not detect the error or attempt fallback. The error passes through silently to the client, and the request is logged as `status=success`.

The `acompletion` (OpenAI chat) path handles this correctly via `FallbackStreamWrapper` / `_acompletion_streaming_iterator` (router.py:2162-2167). The `anthropic_messages` path through `_ageneric_api_call_with_fallbacks_helper` returns the raw `AsyncIterator` with no fallback wrapping (router.py:3855).

### Production Impact

In our deployment (v1.81.14-stable, ~50 active users), we observed 510 Anthropic Overloaded/Internal Server Error events in a single 80-minute outage window with zero fallback attempts via the `anthropic_messages` path. Meanwhile, pre-stream failures (immediate HTTP 529) correctly triggered Bedrock fallback (274 successful fallback requests). The mid-stream errors were invisible in the DB (`status=success`) and only visible in pod stderr logs.

### Changes

**`litellm/router.py`:**

1. In `_ageneric_api_call_with_fallbacks_helper`: save `input_kwargs_for_streaming_fallback` before deployment resolution mutates kwargs (mirrors the pattern from `_acompletion` at line 2037). Before returning the response, check if it is a streaming `AsyncIterator` and wrap it with `_ageneric_streaming_iterator`.

2. New method `_ageneric_streaming_iterator`: wraps a generic streaming response with SSE error event detection. Monitors each yielded chunk for Anthropic SSE error events (`event: error
data: {"type":"error",...}`). When detected, raises `ServiceUnavailableError` or `InternalServerError` which triggers the router's existing fallback system via `async_function_with_fallbacks_common_utils`.

### How it works



### Test plan

- [ ] Existing router tests pass
- [ ] Manual verification with Anthropic overloaded simulation
- [ ] Verified syntax with `ast.parse()`
