### PR TITLE
fix(langsmith): populate usage_metadata in outputs for Cost column

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -153,11 +153,33 @@ class LangsmithLogger(CustomBatchLogger):
                     if key in requester_metadata and key not in extra_metadata:
                         extra_metadata[key] = requester_metadata[key]
 
+            outputs = payload["response"]
+            if isinstance(outputs, dict):
+                cost_breakdown = payload.get("cost_breakdown")
+                input_cost = (
+                    cost_breakdown.get("input_cost", 0.0)
+                    if cost_breakdown
+                    else 0.0
+                )
+                output_cost = (
+                    cost_breakdown.get("output_cost", 0.0)
+                    if cost_breakdown
+                    else 0.0
+                )
+                outputs["usage_metadata"] = {
+                    "input_tokens": payload.get("prompt_tokens", 0),
+                    "output_tokens": payload.get("completion_tokens", 0),
+                    "total_tokens": payload.get("total_tokens", 0),
+                    "input_token_cost": input_cost,
+                    "output_token_cost": output_cost,
+                    "total_cost": payload.get("response_cost", 0.0),
+                }
+
             data = {
                 "name": run_name,
                 "run_type": "llm",  # this should always be llm, since litellm always logs llm calls. Langsmith allow us to log "chain"
                 "inputs": payload,
-                "outputs": payload["response"],
+                "outputs": outputs,
                 "session_name": project_name,
                 "start_time": payload["startTime"],
                 "end_time": payload["endTime"],

--- a/tests/logging_callback_tests/test_langsmith_unit_test.py
+++ b/tests/logging_callback_tests/test_langsmith_unit_test.py
@@ -448,11 +448,144 @@ async def test_langsmith_key_based_logging():
             actual_body["post"][0]["session_name"]
             == expected_body["post"][0]["session_name"]
         )
-        
+
+        # Verify usage_metadata is populated in outputs (fixes #24001)
+        usage_metadata = actual_body["post"][0]["outputs"].get("usage_metadata")
+        assert usage_metadata is not None, "usage_metadata should be present in outputs"
+        assert "total_cost" in usage_metadata
+        assert "input_tokens" in usage_metadata
+        assert "output_tokens" in usage_metadata
+        assert "total_tokens" in usage_metadata
+        assert usage_metadata["input_tokens"] == 10
+        assert usage_metadata["output_tokens"] == 20
+        assert usage_metadata["total_tokens"] == 30
+        assert isinstance(usage_metadata["total_cost"], (int, float))
+
         mock_get_client.stop()
 
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+
+@pytest.mark.asyncio
+async def test_langsmith_usage_metadata_populated():
+    """
+    Verify that _prepare_log_data injects usage_metadata into outputs
+    so LangSmith can display the Cost column. (Fixes #24001)
+    """
+    logger = LangsmithLogger(langsmith_api_key="test-key")
+    credentials = logger.default_credentials
+
+    fake_payload = {
+        "id": "test-id",
+        "trace_id": "test-trace",
+        "call_type": "completion",
+        "stream": False,
+        "response_cost": 0.0035,
+        "cost_breakdown": {
+            "input_cost": 0.001,
+            "output_cost": 0.0025,
+        },
+        "status": "success",
+        "total_tokens": 150,
+        "prompt_tokens": 50,
+        "completion_tokens": 100,
+        "startTime": 1700000000.0,
+        "endTime": 1700000001.0,
+        "response_time": 1.0,
+        "model": "gpt-4o-mini",
+        "metadata": {},
+        "cache_hit": None,
+        "cache_key": None,
+        "request_tags": [],
+        "response": {
+            "id": "chatcmpl-test",
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 50, "completion_tokens": 100, "total_tokens": 150},
+        },
+        "error_str": None,
+        "messages": [{"role": "user", "content": "say hi"}],
+    }
+
+    kwargs = {
+        "litellm_params": {"metadata": {}},
+        "standard_logging_object": fake_payload,
+    }
+
+    data = logger._prepare_log_data(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=None,
+        end_time=None,
+        credentials=credentials,
+    )
+
+    # Verify usage_metadata was injected into outputs
+    assert "usage_metadata" in data["outputs"]
+    um = data["outputs"]["usage_metadata"]
+    assert um["input_tokens"] == 50
+    assert um["output_tokens"] == 100
+    assert um["total_tokens"] == 150
+    assert um["total_cost"] == 0.0035
+    assert um["input_token_cost"] == 0.001
+    assert um["output_token_cost"] == 0.0025
+
+
+@pytest.mark.asyncio
+async def test_langsmith_usage_metadata_without_cost_breakdown():
+    """
+    Verify usage_metadata works when cost_breakdown is None.
+    """
+    logger = LangsmithLogger(langsmith_api_key="test-key")
+    credentials = logger.default_credentials
+
+    fake_payload = {
+        "id": "test-id",
+        "trace_id": "test-trace",
+        "call_type": "completion",
+        "stream": False,
+        "response_cost": 0.005,
+        "cost_breakdown": None,
+        "status": "success",
+        "total_tokens": 200,
+        "prompt_tokens": 80,
+        "completion_tokens": 120,
+        "startTime": 1700000000.0,
+        "endTime": 1700000001.0,
+        "response_time": 1.0,
+        "model": "gpt-4o-mini",
+        "metadata": {},
+        "cache_hit": None,
+        "cache_key": None,
+        "request_tags": [],
+        "response": {
+            "id": "chatcmpl-test",
+            "choices": [{"message": {"content": "hello"}}],
+            "usage": {"prompt_tokens": 80, "completion_tokens": 120, "total_tokens": 200},
+        },
+        "error_str": None,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    kwargs = {
+        "litellm_params": {"metadata": {}},
+        "standard_logging_object": fake_payload,
+    }
+
+    data = logger._prepare_log_data(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=None,
+        end_time=None,
+        credentials=credentials,
+    )
+
+    um = data["outputs"]["usage_metadata"]
+    assert um["total_cost"] == 0.005
+    assert um["input_token_cost"] == 0.0
+    assert um["output_token_cost"] == 0.0
+    assert um["input_tokens"] == 80
+    assert um["output_tokens"] == 120
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #24001

- **Bug**: `LangsmithLogger._prepare_log_data` sets `data["outputs"]` to `payload["response"]` but never includes `usage_metadata`. LangSmith reads cost exclusively from `outputs["usage_metadata"]["total_cost"]`, so the Cost column always shows "–".
- **Fix**: Inject `usage_metadata` dict (with `input_tokens`, `output_tokens`, `total_tokens`, `input_token_cost`, `output_token_cost`, `total_cost`) into `outputs` before building the run data, using values from `StandardLoggingPayload` and its `cost_breakdown`.
- **Tests**: Added two unit tests for `_prepare_log_data` (with and without `cost_breakdown`), plus assertions in the existing integration test to verify `usage_metadata` is present in the posted outputs.

## Test plan

- [x] `test_langsmith_usage_metadata_populated` — verifies `usage_metadata` fields match payload values when `cost_breakdown` is present
- [x] `test_langsmith_usage_metadata_without_cost_breakdown` — verifies graceful fallback (costs = 0.0) when `cost_breakdown` is `None`
- [x] `test_langsmith_key_based_logging` — existing integration test now also asserts `usage_metadata` is in outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)