### PR TITLE
fix(langsmith): populate usage_metadata so Cost column works

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -153,11 +153,23 @@ class LangsmithLogger(CustomBatchLogger):
                     if key in requester_metadata and key not in extra_metadata:
                         extra_metadata[key] = requester_metadata[key]
 
+            outputs = payload["response"]
+            if isinstance(outputs, dict):
+                cost_breakdown = payload.get("cost_breakdown") or {}
+                outputs["usage_metadata"] = {
+                    "input_tokens": payload.get("prompt_tokens", 0),
+                    "output_tokens": payload.get("completion_tokens", 0),
+                    "total_tokens": payload.get("total_tokens", 0),
+                    "input_token_cost": cost_breakdown.get("input_cost", 0.0),
+                    "output_token_cost": cost_breakdown.get("output_cost", 0.0),
+                    "total_cost": payload.get("response_cost", 0.0),
+                }
+
             data = {
                 "name": run_name,
                 "run_type": "llm",  # this should always be llm, since litellm always logs llm calls. Langsmith allow us to log "chain"
                 "inputs": payload,
-                "outputs": payload["response"],
+                "outputs": outputs,
                 "session_name": project_name,
                 "start_time": payload["startTime"],
                 "end_time": payload["endTime"],

--- a/tests/logging_callback_tests/test_langsmith_unit_test.py
+++ b/tests/logging_callback_tests/test_langsmith_unit_test.py
@@ -456,6 +456,120 @@ async def test_langsmith_key_based_logging():
 
 
 @pytest.mark.asyncio
+async def test_prepare_log_data_includes_usage_metadata():
+    """
+    Test that _prepare_log_data populates outputs["usage_metadata"] with
+    token counts and cost from the StandardLoggingPayload, so the LangSmith
+    Cost column is populated.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/24001
+    """
+    logger = LangsmithLogger(langsmith_api_key="test-key")
+    credentials = logger.default_credentials
+
+    mock_payload = {
+        "metadata": {},
+        "response": {
+            "id": "chatcmpl-test",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 15,
+                "completion_tokens": 25,
+                "total_tokens": 40,
+            },
+        },
+        "startTime": 1000.0,
+        "endTime": 1001.0,
+        "request_tags": [],
+        "error_str": None,
+        "status": "success",
+        "prompt_tokens": 15,
+        "completion_tokens": 25,
+        "total_tokens": 40,
+        "response_cost": 0.00123,
+        "cost_breakdown": {
+            "input_cost": 0.00045,
+            "output_cost": 0.00078,
+            "total_cost": 0.00123,
+            "tool_usage_cost": 0.0,
+        },
+    }
+
+    kwargs = {
+        "litellm_params": {"metadata": {}},
+        "standard_logging_object": mock_payload,
+    }
+
+    data = logger._prepare_log_data(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=None,
+        end_time=None,
+        credentials=credentials,
+    )
+
+    # outputs must contain usage_metadata for LangSmith Cost column
+    assert "usage_metadata" in data["outputs"]
+    usage_meta = data["outputs"]["usage_metadata"]
+    assert usage_meta["input_tokens"] == 15
+    assert usage_meta["output_tokens"] == 25
+    assert usage_meta["total_tokens"] == 40
+    assert usage_meta["total_cost"] == 0.00123
+    assert usage_meta["input_token_cost"] == 0.00045
+    assert usage_meta["output_token_cost"] == 0.00078
+
+
+@pytest.mark.asyncio
+async def test_prepare_log_data_usage_metadata_without_cost_breakdown():
+    """
+    Test that usage_metadata is populated even when cost_breakdown is None.
+    """
+    logger = LangsmithLogger(langsmith_api_key="test-key")
+    credentials = logger.default_credentials
+
+    mock_payload = {
+        "metadata": {},
+        "response": {
+            "id": "chatcmpl-test",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30,
+            },
+        },
+        "startTime": 1000.0,
+        "endTime": 1001.0,
+        "request_tags": [],
+        "error_str": None,
+        "status": "success",
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+        "response_cost": 0.005,
+        "cost_breakdown": None,
+    }
+
+    kwargs = {
+        "litellm_params": {"metadata": {}},
+        "standard_logging_object": mock_payload,
+    }
+
+    data = logger._prepare_log_data(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=None,
+        end_time=None,
+        credentials=credentials,
+    )
+
+    usage_meta = data["outputs"]["usage_metadata"]
+    assert usage_meta["total_cost"] == 0.005
+    assert usage_meta["input_token_cost"] == 0.0
+    assert usage_meta["output_token_cost"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_langsmith_queue_logging():
     try:
         # Initialize LangsmithLogger


### PR DESCRIPTION
## Summary
- **LangSmith reads cost from `outputs["usage_metadata"]["total_cost"]`**, but `LangsmithLogger._prepare_log_data` never populated that key, leaving the Cost column empty for all litellm runs.
- Injects `usage_metadata` (token counts + cost from `StandardLoggingPayload`) into `data["outputs"]` before returning, matching the structure LangSmith's native wrappers produce.
- Adds two unit tests covering the fix (with and without `cost_breakdown`).

Fixes #24001

## Test plan
- [x] `test_prepare_log_data_includes_usage_metadata` — verifies token counts + cost fields are present in outputs
- [x] `test_prepare_log_data_usage_metadata_without_cost_breakdown` — verifies graceful fallback when `cost_breakdown` is `None`
- [ ] Manual: run `litellm.completion` with `"langsmith"` callback → Cost column in LangSmith now shows dollar amount