### PR TITLE
[Fix] Pass metadata to Anthropic /v1/messages pass-through

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -46,8 +46,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             "inference_geo",
             "speed",
             "output_config",
-            # TODO: Add Anthropic `metadata` support
-            # "metadata",
+            "metadata",
         ]
 
     def _remove_scope_from_cache_control(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -215,6 +215,35 @@ def test_anthropic_messages_pass_through_includes_metadata():
     assert result.get("metadata") == {"user_id": "user-123"}
 
 
+def test_anthropic_messages_handler_forwards_metadata_through_full_flow():
+    """
+    Test that metadata flows through the full anthropic_messages_handler path
+    and reaches the HTTP handler with the correct value.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.handler.base_llm_http_handler.anthropic_messages_handler",
+        return_value=MagicMock(),
+    ) as mock_handler:
+        try:
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "Hello"}],
+                model="anthropic/claude-3-5-sonnet-20240620",
+                api_key="test-api-key",
+                metadata={"user_id": "user-123"},
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        mock_handler.assert_called_once()
+        call_kwargs = mock_handler.call_args.kwargs
+        assert call_kwargs["anthropic_messages_optional_request_params"].get("metadata") == {"user_id": "user-123"}
+
+
 class TestThinkingParameterTransformation:
     """Core tests for thinking parameter transformation logic."""
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -190,6 +190,31 @@ def test_openai_model_with_thinking_converts_to_reasoning():
         assert "thinking" not in call_kwargs, "thinking should NOT be passed directly to litellm.responses"
 
 
+def test_anthropic_messages_pass_through_includes_metadata():
+    """
+    Test that metadata is included in the transformed request body
+    when passed to the Anthropic messages pass-through.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+        AnthropicMessagesConfig,
+    )
+    from litellm.types.router import GenericLiteLLMParams
+
+    config = AnthropicMessagesConfig()
+    result = config.transform_anthropic_messages_request(
+        model="claude-3-5-sonnet-20240620",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params={
+            "max_tokens": 100,
+            "metadata": {"user_id": "user-123"},
+        },
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("metadata") == {"user_id": "user-123"}
+
+
 class TestThinkingParameterTransformation:
     """Core tests for thinking parameter transformation logic."""
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -190,31 +190,6 @@ def test_openai_model_with_thinking_converts_to_reasoning():
         assert "thinking" not in call_kwargs, "thinking should NOT be passed directly to litellm.responses"
 
 
-def test_anthropic_messages_pass_through_includes_metadata():
-    """
-    Test that metadata is included in the transformed request body
-    when passed to the Anthropic messages pass-through.
-    """
-    from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
-        AnthropicMessagesConfig,
-    )
-    from litellm.types.router import GenericLiteLLMParams
-
-    config = AnthropicMessagesConfig()
-    result = config.transform_anthropic_messages_request(
-        model="claude-3-5-sonnet-20240620",
-        messages=[{"role": "user", "content": "Hello"}],
-        anthropic_messages_optional_request_params={
-            "max_tokens": 100,
-            "metadata": {"user_id": "user-123"},
-        },
-        litellm_params=GenericLiteLLMParams(),
-        headers={},
-    )
-
-    assert result.get("metadata") == {"user_id": "user-123"}
-
-
 def test_anthropic_messages_handler_forwards_metadata_through_full_flow():
     """
     Test that metadata flows through the full anthropic_messages_handler path


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: https://github.com/BerriAI/litellm/actions/runs/23249561657

- [x] **CI run for the last commit**  
       Link: https://github.com/BerriAI/litellm/actions/runs/23347024109

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

`get_supported_anthropic_messages_params()` in `AnthropicMessagesConfig` had `"metadata"` commented out with a TODO note, making the method inconsistent with `AnthropicMessagesRequestOptionalParams` (the TypedDict that drives the actual production filtering), which already included the field.

Note: the production request path in `handler.py` filters params via `get_type_hints(AnthropicMessagesRequestOptionalParams).keys()`, so `metadata` was already flowing through correctly at runtime. This change brings `get_supported_anthropic_messages_params()` in sync with the TypedDict definition and removes the stale TODO.

Added a test that exercises the full `anthropic_messages_handler` flow and confirms `metadata` reaches `anthropic_messages_optional_request_params` before the HTTP call.