### PR TITLE
chore(deps): add pyroscope-io==1.0.4 for Pyroscope profiling support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ a2a-sdk>=0.3.22 ; python_version >= "3.10"
 grpcio>=1.62.3,!=1.68.*,!=1.69.*,!=1.70.*,!=1.71.0,!=1.71.1,!=1.72.0,!=1.72.1,!=1.73.0; python_version < "3.14"
 grpcio>=1.75.0; python_version >= "3.14"
 sentry_sdk==2.21.0 # for sentry error handling
+pyroscope-io==1.0.4 # for Pyroscope profiling (LITELLM_ENABLE_PYROSCOPE)
 detect-secrets==1.5.0 # Enterprise - secret detection / masking in LLM requests
 tzdata==2025.1 # IANA time zone database
 litellm-proxy-extras==0.4.56 # for proxy extras - e.g. prisma migrations


### PR DESCRIPTION
## Relevant issues

  <!-- e.g. "Fixes #000" -->

  ## Pre-Submission checklist

  - [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see
  details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

  ## Delays in PR merge?

  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

  ## CI (LiteLLM team)

  - [ ] **Branch creation CI run**
         Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

  🚄 Infrastructure

  ## Changes

  Add `pyroscope-io==1.0.4` to `requirements.txt` so that the proxy server
  can run Pyroscope profiling when `LITELLM_ENABLE_PYROSCOPE` is set.

  Without this package installed, LiteLLM logs a `WARNING` on every startup:

  > `LITELLM_ENABLE_PYROSCOPE is set but the 'pyroscope-io' package is not installed. Pyroscope profiling will not run.`