### PR TITLE
fix: strip empty text content blocks in /v1/messages endpoint

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -165,6 +165,41 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
         return headers, api_base
 
+    def _sanitize_empty_text_content_blocks(
+        self, messages: List[Dict]
+    ) -> List[Dict]:
+        """
+        Remove empty text content blocks from messages.
+
+        Claude's API returns assistant messages with empty text blocks
+        ({"type": "text", "text": ""}) alongside tool_use blocks, but rejects
+        them when sent back: '400: text content blocks must be non-empty'.
+        """
+        result = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                result.append(message)
+                continue
+
+            filtered_content = [
+                block
+                for block in content
+                if not (
+                    isinstance(block, dict)
+                    and block.get("type") == "text"
+                    and (not block.get("text") or not str(block["text"]).strip())
+                )
+            ]
+
+            if filtered_content != content:
+                if not filtered_content:
+                    filtered_content = [{"type": "text", "text": "..."}]
+                result.append({**message, "content": filtered_content})
+            else:
+                result.append(message)
+        return result
+
     def transform_anthropic_messages_request(
         self,
         model: str,
@@ -179,6 +214,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
         This takes in a request in the Anthropic /v1/messages API spec -> transforms it to /v1/messages API spec (i.e) no transformation is needed
         """
+        messages = self._sanitize_empty_text_content_blocks(messages)
         max_tokens = anthropic_messages_optional_request_params.pop("max_tokens", None)
         if max_tokens is None:
             raise AnthropicError(

--- a/poetry.lock
+++ b/poetry.lock
@@ -8018,4 +8018,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "eda34dfd8b35474beffee18893d6782c7b3d0d3d2c610f66237eb97176f43527"
+content-hash = "2cf958f1a04fd5f1ab0e5cfc33bdbf441b518ed6c82d0f2546bf64cd3d2f89be"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_v1_messages_empty_text_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_v1_messages_empty_text_sanitization.py
@@ -1,0 +1,234 @@
+"""
+Tests for AnthropicMessagesConfig._sanitize_empty_text_content_blocks()
+
+Covers the fix for https://github.com/BerriAI/litellm/issues/22930:
+Claude returns assistant messages with empty text blocks alongside tool_use,
+but rejects them when sent back (400: text content blocks must be non-empty).
+"""
+
+import copy
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+config = AnthropicMessagesConfig()
+
+
+class TestSanitizeEmptyTextBlocks:
+    """Unit tests for _sanitize_empty_text_content_blocks"""
+
+    def test_empty_text_block_stripped_alongside_tool_use(self):
+        """Main bug scenario: empty text block next to tool_use should be removed."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_123",
+                        "name": "get_weather",
+                        "input": {"location": "NYC"},
+                    },
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result) == 1
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["type"] == "tool_use"
+
+    def test_non_empty_text_blocks_preserved(self):
+        """Non-empty text blocks should be kept as-is."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Here is the result:"},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_456",
+                        "name": "search",
+                        "input": {"q": "test"},
+                    },
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result[0]["content"]) == 2
+        assert result[0]["content"][0]["text"] == "Here is the result:"
+
+    def test_whitespace_only_text_blocks_stripped(self):
+        """Whitespace-only text blocks should be treated as empty."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "   \n\t  "},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_789",
+                        "name": "calc",
+                        "input": {},
+                    },
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["type"] == "tool_use"
+
+    def test_all_empty_content_replaced_with_placeholder(self):
+        """If all blocks are empty text, replace with a placeholder."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": "  "},
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0] == {"type": "text", "text": "..."}
+
+    def test_string_content_untouched(self):
+        """Messages with string content should pass through unchanged."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert result == messages
+
+    def test_no_content_key_untouched(self):
+        """Messages without a content key should pass through."""
+        messages = [{"role": "assistant", "tool_calls": []}]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert result == messages
+
+    def test_user_message_content_also_sanitized(self):
+        """User messages with list content should also be sanitized."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": "actual question"},
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["text"] == "actual question"
+
+    def test_tool_result_blocks_untouched(self):
+        """tool_result blocks should never be stripped (they don't have type=text)."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_123",
+                        "content": "result data",
+                    },
+                    {"type": "text", "text": ""},
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["type"] == "tool_result"
+
+    def test_input_immutability(self):
+        """Original messages must not be mutated."""
+        original_messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_imm",
+                        "name": "fn",
+                        "input": {},
+                    },
+                ],
+            }
+        ]
+        snapshot = copy.deepcopy(original_messages)
+        config._sanitize_empty_text_content_blocks(original_messages)
+        assert original_messages == snapshot
+
+    def test_none_text_value_treated_as_empty(self):
+        """A text block with text=None should be treated as empty."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": None},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_none",
+                        "name": "fn",
+                        "input": {},
+                    },
+                ],
+            }
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        assert len(result[0]["content"]) == 1
+        assert result[0]["content"][0]["type"] == "tool_use"
+
+    def test_multi_message_end_to_end(self):
+        """End-to-end scenario with multiple conversation turns."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_w1",
+                        "name": "get_weather",
+                        "input": {"location": "NYC"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_w1",
+                        "content": "72F and sunny",
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "The weather in NYC is 72F and sunny."},
+                ],
+            },
+        ]
+        result = config._sanitize_empty_text_content_blocks(messages)
+        # First user message: string content, unchanged
+        assert result[0]["content"] == "What's the weather?"
+        # Assistant with tool_use: empty text removed
+        assert len(result[1]["content"]) == 1
+        assert result[1]["content"][0]["type"] == "tool_use"
+        # Tool result: unchanged
+        assert len(result[2]["content"]) == 1
+        assert result[2]["content"][0]["type"] == "tool_result"
+        # Final assistant: non-empty text preserved
+        assert len(result[3]["content"]) == 1
+        assert "72F" in result[3]["content"][0]["text"]
+
+    def test_empty_messages_list(self):
+        """Empty messages list should return empty list."""
+        assert config._sanitize_empty_text_content_blocks([]) == []


### PR DESCRIPTION
## Relevant issues
Fixes #22930

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Moves empty text content block sanitization from the generic HTTP handler (llm_http_handler.py) into the Anthropic-specific provider config
  (AnthropicMessagesConfig.transform_anthropic_messages_request()).

  Problem: Claude's API returns assistant messages with empty text blocks ({"type": "text", "text": ""}) alongside tool_use blocks in multi-turn conversations. While
  Anthropic returns these, it rejects them when sent back, causing 400: text content blocks must be non-empty. The previous fix (PR #23097) was reverted (PR #23232)
  because it crashed on bare string messages. The current v1 fix works but places Anthropic-specific logic in the generic HTTP handler.

  What changed:
  - Removed _sanitize_anthropic_messages_empty_text_blocks() standalone function and its call from llm_http_handler.py
  - Added _sanitize_empty_text_content_blocks() as a method on AnthropicMessagesConfig in transformation.py, called at the top of transform_anthropic_messages_request()
  - Updated tests to import from the new location and removed the non-dict message test (no longer needed since messages are List[Dict] at this layer)

  Why this is better:
  1. transform_anthropic_messages_request() is the designated place for Anthropic-specific request transformations
  2. Clean type contract — no isinstance(message, dict) guards needed
  3. Bedrock, Vertex AI, and Azure AI all call super().transform_anthropic_messages_request(), so they inherit the fix automatically
  4. Keeps llm_http_handler.py generic with no provider-specific logic