### PR TITLE
[Fix] UI - Logs: Guardrail Mode Type Crash on Non-String Values

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.test.tsx
@@ -151,6 +151,35 @@ describe("GuardrailViewer", () => {
     expect(screen.queryByText(/Raw Bedrock Guardrail Response/)).not.toBeInTheDocument();
   });
 
+  it("renders without crashing when guardrail_mode is null", () => {
+    const data = makeGuardrailInformation({ guardrail_mode: null });
+    renderWithProviders(<GuardrailViewer data={data} />);
+
+    expect(screen.getByText("Guardrails & Policy Compliance")).toBeInTheDocument();
+    // Null mode should display as dash
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when guardrail_mode is an object", () => {
+    const data = makeGuardrailInformation({
+      guardrail_mode: { default: "pre_call", tags: {} },
+    });
+    renderWithProviders(<GuardrailViewer data={data} />);
+
+    expect(screen.getByText("Guardrails & Policy Compliance")).toBeInTheDocument();
+    expect(screen.getByText("PRE-CALL")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when guardrail_mode is an array", () => {
+    const data = makeGuardrailInformation({
+      guardrail_mode: ["pre_call", "post_call"],
+    });
+    renderWithProviders(<GuardrailViewer data={data} />);
+
+    expect(screen.getByText("Guardrails & Policy Compliance")).toBeInTheDocument();
+    expect(screen.getByText("PRE-CALL")).toBeInTheDocument();
+  });
+
   it("integration: renders with real Bedrock details without mocks", async () => {
     const user = userEvent.setup();
     const data = makeGuardrailInformation({

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.test.tsx
@@ -170,14 +170,18 @@ describe("GuardrailViewer", () => {
     expect(screen.getByText("PRE-CALL")).toBeInTheDocument();
   });
 
-  it("renders without crashing when guardrail_mode is an array", () => {
+  it("renders without crashing when guardrail_mode is an array and shows in both timeline buckets", () => {
     const data = makeGuardrailInformation({
       guardrail_mode: ["pre_call", "post_call"],
     });
     renderWithProviders(<GuardrailViewer data={data} />);
 
     expect(screen.getByText("Guardrails & Policy Compliance")).toBeInTheDocument();
+    // Mode badge shows first element formatted
     expect(screen.getByText("PRE-CALL")).toBeInTheDocument();
+    // Entry should appear in both pre-call and post-call timeline sections
+    expect(screen.getByText(/Pre-call guardrail:/)).toBeInTheDocument();
+    expect(screen.getByText(/Post-call guardrail:/)).toBeInTheDocument();
   });
 
   it("integration: renders with real Bedrock details without mocks", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -84,11 +84,17 @@ const PROVIDERS_WITH_CUSTOM_RENDERERS = new Set([
 const resolveMode = (mode: GuardrailInformation["guardrail_mode"]): string | null => {
   if (mode == null) return null;
   if (typeof mode === "string") return mode;
-  if (Array.isArray(mode)) return mode[0] ?? null;
+  if (Array.isArray(mode)) {
+    const first = mode[0];
+    return typeof first === "string" ? first : null;
+  }
   if (typeof mode === "object" && "default" in mode) {
     const def = mode.default;
     if (typeof def === "string") return def;
-    if (Array.isArray(def)) return def[0] ?? null;
+    if (Array.isArray(def)) {
+      const first = def[0];
+      return typeof first === "string" ? first : null;
+    }
   }
   return null;
 };

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -78,8 +78,8 @@ const PROVIDERS_WITH_CUSTOM_RENDERERS = new Set([
 ]);
 
 /**
- * Extracts a plain string from guardrail_mode, which may be a string,
- * an array of strings, an object with a "default" key, or null.
+ * Extracts a plain string from guardrail_mode for display purposes.
+ * Returns the first mode when multiple are present.
  */
 const resolveMode = (mode: GuardrailInformation["guardrail_mode"]): string | null => {
   if (mode == null) return null;
@@ -91,6 +91,25 @@ const resolveMode = (mode: GuardrailInformation["guardrail_mode"]): string | nul
     if (Array.isArray(def)) return def[0] ?? null;
   }
   return null;
+};
+
+/**
+ * Checks whether guardrail_mode includes the given target stage.
+ * Handles arrays (multi-stage guardrails) by checking all elements.
+ */
+const modeMatches = (
+  mode: GuardrailInformation["guardrail_mode"],
+  target: string,
+): boolean => {
+  if (mode == null) return false;
+  if (typeof mode === "string") return mode === target;
+  if (Array.isArray(mode)) return mode.includes(target);
+  if (typeof mode === "object" && "default" in mode) {
+    const def = mode.default;
+    if (typeof def === "string") return def === target;
+    if (Array.isArray(def)) return (def as string[]).includes(target);
+  }
+  return false;
 };
 
 const formatMode = (mode: GuardrailInformation["guardrail_mode"]): string => {
@@ -317,13 +336,13 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
     // Request received
     items.push({ type: "request", label: "Request received", offsetMs: 0 });
 
-    // Pre-call guardrails
-    const preCalls = sorted.filter((e) => resolveMode(e.guardrail_mode) === "pre_call");
-    const postCalls = sorted.filter((e) => {
-      const m = resolveMode(e.guardrail_mode);
-      return m === "post_call" || m === "logging_only";
-    });
-    const duringCalls = sorted.filter((e) => resolveMode(e.guardrail_mode) === "during_call");
+    // Pre-call guardrails — use modeMatches so array modes (e.g. ["pre_call", "post_call"])
+    // place the entry in every matching bucket.
+    const preCalls = sorted.filter((e) => modeMatches(e.guardrail_mode, "pre_call"));
+    const postCalls = sorted.filter(
+      (e) => modeMatches(e.guardrail_mode, "post_call") || modeMatches(e.guardrail_mode, "logging_only"),
+    );
+    const duringCalls = sorted.filter((e) => modeMatches(e.guardrail_mode, "during_call"));
 
     for (const e of preCalls) {
       const offsetMs = Math.round((e.end_time - baseTime) * 1000);

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -107,7 +107,7 @@ const modeMatches = (
   if (typeof mode === "object" && "default" in mode) {
     const def = mode.default;
     if (typeof def === "string") return def === target;
-    if (Array.isArray(def)) return (def as string[]).includes(target);
+    if (Array.isArray(def)) return def.some((x) => typeof x === "string" && x === target);
   }
   return false;
 };

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -40,7 +40,7 @@ interface GuardrailInformation {
   duration: number;
   end_time: number;
   start_time: number;
-  guardrail_mode: string;
+  guardrail_mode: string | string[] | Record<string, unknown> | null;
   guardrail_name: string;
   guardrail_status: string;
   guardrail_response: GuardrailEntity[] | BedrockGuardrailResponse | any;
@@ -77,9 +77,25 @@ const PROVIDERS_WITH_CUSTOM_RENDERERS = new Set([
   "litellm_content_filter",
 ]);
 
-const formatMode = (mode: unknown): string => {
-  if (mode == null || mode === "") return "—";
-  const s = typeof mode === "string" ? mode : String(mode);
+/**
+ * Extracts a plain string from guardrail_mode, which may be a string,
+ * an array of strings, an object with a "default" key, or null.
+ */
+const resolveMode = (mode: GuardrailInformation["guardrail_mode"]): string | null => {
+  if (mode == null) return null;
+  if (typeof mode === "string") return mode;
+  if (Array.isArray(mode)) return mode[0] ?? null;
+  if (typeof mode === "object" && "default" in mode) {
+    const def = mode.default;
+    if (typeof def === "string") return def;
+    if (Array.isArray(def)) return def[0] ?? null;
+  }
+  return null;
+};
+
+const formatMode = (mode: GuardrailInformation["guardrail_mode"]): string => {
+  const s = resolveMode(mode);
+  if (s == null || s === "") return "—";
   return s.replace(/_/g, "-").toUpperCase();
 };
 
@@ -302,9 +318,12 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
     items.push({ type: "request", label: "Request received", offsetMs: 0 });
 
     // Pre-call guardrails
-    const preCalls = sorted.filter((e) => e.guardrail_mode === "pre_call");
-    const postCalls = sorted.filter((e) => e.guardrail_mode === "post_call" || e.guardrail_mode === "logging_only");
-    const duringCalls = sorted.filter((e) => e.guardrail_mode === "during_call");
+    const preCalls = sorted.filter((e) => resolveMode(e.guardrail_mode) === "pre_call");
+    const postCalls = sorted.filter((e) => {
+      const m = resolveMode(e.guardrail_mode);
+      return m === "post_call" || m === "logging_only";
+    });
+    const duringCalls = sorted.filter((e) => resolveMode(e.guardrail_mode) === "during_call");
 
     for (const e of preCalls) {
       const offsetMs = Math.round((e.end_time - baseTime) * 1000);

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/__tests__/fixtures.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/__tests__/fixtures.ts
@@ -23,7 +23,7 @@ export interface GuardrailInformation {
   duration: number;
   end_time: number;
   start_time: number;
-  guardrail_mode: string;
+  guardrail_mode: string | string[] | Record<string, unknown> | null;
   guardrail_name: string;
   guardrail_status: string;
   guardrail_response: GuardrailEntity[] | BedrockGuardrailResponse;


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
When a log entry's `guardrail_mode` is a non-string value (null, array, or object), opening the log drawer crashes the UI with `guardrail_mode.replace is not a function`. The backend Python type `StandardLoggingGuardrailInformation.guardrail_mode` is `Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], GuardrailMode]]`, but the UI typed it as just `string`.

### Fix
Updated the `GuardrailInformation` interface to accept `string | string[] | Record<string, unknown> | null`. Added a `resolveMode()` helper that extracts a plain string from any of these shapes (arrays → first element, objects → `default` key). Updated `formatMode` and `RequestLifecycle` filtering to use `resolveMode`.

## Testing
- Added 3 unit tests covering null, object (`{default: "pre_call"}`), and array (`["pre_call", "post_call"]`) values for `guardrail_mode`
- All 12 GuardrailViewer tests pass

## Type

🐛 Bug Fix
✅ Test