### PR TITLE
fix(otel): read completion_tokens_details for reasoning/cached token counts

### DIFF
--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -236,12 +236,41 @@ def _set_usage_outputs(span: "Span", response_obj, span_attrs):
     prompt_tokens = usage.get("prompt_tokens") or usage.get("input_tokens")
     if prompt_tokens:
         safe_set_attribute(span, span_attrs.LLM_TOKEN_COUNT_PROMPT, prompt_tokens)
-    reasoning_tokens = usage.get("output_tokens_details", {}).get("reasoning_tokens")
+    # Chat Completions API uses "completion_tokens_details"; Responses API
+    # uses "output_tokens_details". Check both so the span is populated
+    # regardless of which API produced the usage object.
+    completion_details = usage.get("completion_tokens_details") or usage.get(
+        "output_tokens_details"
+    ) or {}
+    reasoning_tokens = completion_details.get("reasoning_tokens")
     if reasoning_tokens:
         safe_set_attribute(
             span,
             span_attrs.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING,
             reasoning_tokens,
+        )
+    audio_tokens = completion_details.get("audio_tokens")
+    if audio_tokens:
+        safe_set_attribute(
+            span,
+            span_attrs.LLM_TOKEN_COUNT_COMPLETION_DETAILS_AUDIO,
+            audio_tokens,
+        )
+
+    prompt_details = usage.get("prompt_tokens_details") or {}
+    cached_tokens = prompt_details.get("cached_tokens")
+    if cached_tokens:
+        safe_set_attribute(
+            span,
+            span_attrs.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+            cached_tokens,
+        )
+    audio_input_tokens = prompt_details.get("audio_tokens")
+    if audio_input_tokens:
+        safe_set_attribute(
+            span,
+            span_attrs.LLM_TOKEN_COUNT_PROMPT_DETAILS_AUDIO,
+            audio_input_tokens,
         )
 
 

--- a/tests/test_litellm/integrations/arize/test_arize_utils.py
+++ b/tests/test_litellm/integrations/arize/test_arize_utils.py
@@ -374,3 +374,41 @@ def test_construct_dynamic_arize_headers():
         "arize-space-id": "test_space_key",
         "api_key": "test_api_key"
     }
+
+
+def test_set_usage_outputs_chat_completions_details():
+    """Regression test for #23990: _set_usage_outputs must read
+    completion_tokens_details (Chat Completions API) in addition to
+    output_tokens_details (Responses API)."""
+    from unittest.mock import MagicMock
+
+    from litellm.integrations.arize._utils import _set_usage_outputs
+
+    span = MagicMock()
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "completion_tokens_details": {
+            "reasoning_tokens": 20,
+            "audio_tokens": 5,
+        },
+        "prompt_tokens_details": {
+            "cached_tokens": 30,
+            "audio_tokens": 3,
+        },
+    }
+
+    _set_usage_outputs(span, usage)
+
+    set_calls = {
+        call.args[1]: call.args[2]
+        for call in span.set_attribute.call_args_list
+        if len(call.args) >= 3
+    }
+
+    assert set_calls.get(SpanAttributes.LLM_TOKEN_COUNT_TOTAL) == 150
+    assert set_calls.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION) == 50
+    assert set_calls.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT) == 100
+    assert set_calls.get(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING) == 20
+    assert set_calls.get(SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ) == 30


### PR DESCRIPTION
## Summary

Fixes #23990

The OTEL callback's `_set_usage_outputs` never reported `reasoning_tokens` on Chat Completions API spans because it looked up `output_tokens_details` (Responses API key) instead of `completion_tokens_details` (Chat Completions API key).

## Root Cause

Line 239 in `litellm/integrations/arize/_utils.py`:

```python
reasoning_tokens = usage.get("output_tokens_details", {}).get("reasoning_tokens")
```

Chat Completions API returns `completion_tokens_details`, not `output_tokens_details`. Since `Usage.get()` returns `{}` for the missing key, `reasoning_tokens` was always `None`.

## Fix

- Check both `completion_tokens_details` (Chat Completions) and `output_tokens_details` (Responses API) with a fallback chain
- Extract `prompt_tokens_details` fields (`cached_tokens`, `audio_tokens`) which were never reported despite having corresponding `SpanAttributes` constants
- Extract completion `audio_tokens` for the same reason

## Testing

Added `test_set_usage_outputs_chat_completions_details` that verifies reasoning tokens and cached tokens are correctly extracted from Chat Completions API usage objects.