### PR TITLE
fix(cohere): strip index from tool_calls and name from tool messages

### DIFF
--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -161,6 +161,32 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
                 optional_params["seed"] = value
         return optional_params
 
+    @staticmethod
+    def _strip_cohere_unsupported_fields(
+        messages: List[AllMessageValues],
+    ) -> List[AllMessageValues]:
+        """Remove fields that Cohere's v2 API rejects.
+
+        * ``index`` on tool_calls inside assistant messages
+        * ``name`` on tool-role messages
+        """
+        cleaned: List[AllMessageValues] = []
+        for msg in messages:
+            if not isinstance(msg, dict):
+                cleaned.append(msg)
+                continue
+            role = msg.get("role")
+            if role == "assistant" and "tool_calls" in msg:
+                msg = {**msg}
+                msg["tool_calls"] = [
+                    {k: v for k, v in tc.items() if k != "index"}
+                    for tc in msg["tool_calls"]
+                ]
+            elif role == "tool" and "name" in msg:
+                msg = {k: v for k, v in msg.items() if k != "name"}
+            cleaned.append(msg)
+        return cleaned
+
     def transform_request(
         self,
         model: str,
@@ -172,6 +198,7 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
         """
         Cohere v2 chat api is in openai format, so we can use the openai transform request function to transform the request.
         """
+        messages = self._strip_cohere_unsupported_fields(messages)
         data = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -49,3 +49,57 @@ class TestCohereTransform:
 
         # The function should properly map max_tokens if max_completion_tokens is not provided
         assert result == {"temperature": 0.7, "max_tokens": 200}
+
+
+class TestCohereV2StripFields:
+    """Regression tests for #24031: Cohere v2 API rejects ``index`` on
+    tool_calls and ``name`` on tool-role messages."""
+
+    def test_strip_index_from_tool_calls(self):
+        from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "index": 0,
+                        "type": "function",
+                        "function": {"name": "get_time", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        cleaned = CohereV2ChatConfig._strip_cohere_unsupported_fields(messages)
+        tc = cleaned[0]["tool_calls"][0]
+        assert "index" not in tc
+        assert tc["id"] == "call_1"
+        assert tc["function"]["name"] == "get_time"
+
+    def test_strip_name_from_tool_message(self):
+        from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "get_time",
+                "content": "12:00",
+            }
+        ]
+        cleaned = CohereV2ChatConfig._strip_cohere_unsupported_fields(messages)
+        assert "name" not in cleaned[0]
+        assert cleaned[0]["content"] == "12:00"
+        assert cleaned[0]["tool_call_id"] == "call_1"
+
+    def test_non_tool_messages_unchanged(self):
+        from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        cleaned = CohereV2ChatConfig._strip_cohere_unsupported_fields(messages)
+        assert cleaned == messages


### PR DESCRIPTION
## Summary

Fixes #24031

Cohere's v2 chat API rejects the `index` field on tool_calls inside assistant messages and the `name` field on tool-role messages, even though these are standard OpenAI fields.

## Root Cause

When `CohereV2ChatConfig.transform_response` converts Cohere's response to OpenAI format, it adds `index` to each tool_call (line 238). When users append this assistant message back to the messages list for multi-turn tool calling, the `index` field is sent back to Cohere, which rejects it with:

```
unknown field: parameter 'index' is not a valid field
```

Similarly, OpenAI's tool response messages include a `name` field, which Cohere also rejects.

## Fix

Add `_strip_cohere_unsupported_fields()` to `CohereV2ChatConfig` that removes:
- `index` from tool_calls in assistant messages
- `name` from tool-role messages

This runs in `transform_request` before the messages are sent to Cohere.

## Testing

Added 3 unit tests:
1. `test_strip_index_from_tool_calls` — verifies `index` is removed from tool_calls
2. `test_strip_name_from_tool_message` — verifies `name` is removed from tool messages
3. `test_non_tool_messages_unchanged` — verifies non-tool messages are not modified