### PR TITLE
Preserve router model_group in generic API logs

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3890,6 +3890,7 @@ class Router:
                 model=model,
                 messages=kwargs.get("messages", None),
                 specific_deployment=kwargs.pop("specific_deployment", None),
+                request_kwargs=kwargs,
             )
             self._update_kwargs_with_deployment(
                 deployment=deployment, kwargs=kwargs, function_name="generic_api_call"

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3874,9 +3874,17 @@ class Router:
             The response from the handler function
         """
         handler_name = original_function.__name__
+        metadata_variable_name = _get_router_metadata_variable_name(
+            function_name="generic_api_call"
+        )
         try:
             verbose_router_logger.debug(
                 f"Inside _generic_api_call() - handler: {handler_name}, model: {model}; kwargs: {kwargs}"
+            )
+            self._update_kwargs_before_fallbacks(
+                model=model,
+                kwargs=kwargs,
+                metadata_variable_name=metadata_variable_name,
             )
             deployment = self.get_available_deployment(
                 model=model,

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1568,6 +1568,43 @@ def test_handle_clientside_credential_with_deployment_model_name(model_list):
     print("✓ _handle_clientside_credential test passed!")
 
 
+def test_sync_generic_api_call_preserves_requested_model_group_in_logs():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet-4-6",
+                "litellm_params": {
+                    "model": "bedrock/global.anthropic.claude-sonnet-4-6",
+                    "aws_access_key_id": "test-access-key",
+                    "aws_secret_access_key": "test-secret-key",
+                    "aws_region_name": "us-west-2",
+                },
+            }
+        ]
+    )
+
+    captured_kwargs = {}
+
+    def mock_original_function(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {"status": "ok"}
+
+    response = router._generic_api_call_with_fallbacks(
+        model="claude-sonnet-4-6",
+        original_function=mock_original_function,
+    )
+
+    assert response == {"status": "ok"}
+    assert captured_kwargs["model"] == "bedrock/global.anthropic.claude-sonnet-4-6"
+    assert (
+        captured_kwargs["litellm_metadata"]["model_group"] == "claude-sonnet-4-6"
+    )
+    assert (
+        captured_kwargs["litellm_metadata"]["deployment"]
+        == "bedrock/global.anthropic.claude-sonnet-4-6"
+    )
+
+
 @pytest.mark.parametrize(
     "function_name, expected_metadata_key",
     [

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1583,26 +1583,74 @@ def test_sync_generic_api_call_preserves_requested_model_group_in_logs():
         ]
     )
 
-    captured_kwargs = {}
+    try:
+        captured_kwargs = {}
 
-    def mock_original_function(**kwargs):
-        captured_kwargs.update(kwargs)
-        return {"status": "ok"}
+        def mock_original_function(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {"status": "ok"}
 
-    response = router._generic_api_call_with_fallbacks(
-        model="claude-sonnet-4-6",
-        original_function=mock_original_function,
+        response = router._generic_api_call_with_fallbacks(
+            model="claude-sonnet-4-6",
+            original_function=mock_original_function,
+        )
+
+        assert response == {"status": "ok"}
+        assert (
+            captured_kwargs["model"] == "bedrock/global.anthropic.claude-sonnet-4-6"
+        )
+        assert (
+            captured_kwargs["litellm_metadata"]["model_group"] == "claude-sonnet-4-6"
+        )
+        assert (
+            captured_kwargs["litellm_metadata"]["deployment"]
+            == "bedrock/global.anthropic.claude-sonnet-4-6"
+        )
+    finally:
+        router.discard()
+
+
+def test_sync_generic_api_call_uses_request_kwargs_for_deployment_selection():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "regional-model",
+                "litellm_params": {
+                    "model": "anthropic/us-model",
+                    "api_key": "test-api-key",
+                    "region_name": "us",
+                },
+            },
+            {
+                "model_name": "regional-model",
+                "litellm_params": {
+                    "model": "anthropic/eu-model",
+                    "api_key": "test-api-key",
+                    "region_name": "eu",
+                },
+            },
+        ],
+        enable_pre_call_checks=True,
     )
 
-    assert response == {"status": "ok"}
-    assert captured_kwargs["model"] == "bedrock/global.anthropic.claude-sonnet-4-6"
-    assert (
-        captured_kwargs["litellm_metadata"]["model_group"] == "claude-sonnet-4-6"
-    )
-    assert (
-        captured_kwargs["litellm_metadata"]["deployment"]
-        == "bedrock/global.anthropic.claude-sonnet-4-6"
-    )
+    try:
+        captured_kwargs = {}
+
+        def mock_original_function(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {"status": "ok"}
+
+        response = router._generic_api_call_with_fallbacks(
+            model="regional-model",
+            original_function=mock_original_function,
+            messages=[{"role": "user", "content": "Hello from Europe"}],
+            allowed_model_region="eu",
+        )
+
+        assert response == {"status": "ok"}
+        assert captured_kwargs["model"] == "anthropic/eu-model"
+    finally:
+        router.discard()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- seed router metadata before the sync generic API path swaps `kwargs["model"]` to the deployment model
- preserve `model_group` as the requested router/local model name while keeping `model` as the provider-qualified deployment model
- add a regression test covering a Bedrock deployment behind a local model alias

Fixes #24046

## Testing
- conda run -n litellm pytest tests/router_unit_tests/test_router_helper_utils.py -k "sync_generic_api_call_preserves_requested_model_group_in_logs or handle_clientside_credential_with_deployment_model_name" -x -vv
