### PR TITLE
fix: added thinking and reasoning support for all claude 4+ models on bedrock

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -199,7 +199,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         if (
             "claude-3-7-sonnet" in model
-            or AnthropicConfig._is_claude_4_6_model(model)
+            or "claude-sonnet-4" in model
+            or "claude-opus-4" in model
+            or "claude-haiku-4" in model
             or supports_reasoning(
                 model=model,
                 custom_llm_provider=self.custom_llm_provider,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -566,6 +566,7 @@ class AmazonConverseConfig(BaseConfig):
             "claude-3-7" in model
             or "claude-sonnet-4" in model
             or "claude-opus-4" in model
+            or "claude-haiku-4" in model
             or "deepseek.r1" in model
             or supports_reasoning(
                 model=model,

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -650,6 +650,37 @@ def test_get_supported_params_thinking():
     assert "thinking" in params
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        # Claude 3.7
+        "claude-3-7-sonnet-20250219",
+        "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0",
+        # Claude Sonnet 4.x
+        "claude-sonnet-4-20250514",
+        "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+        "claude-sonnet-4-5-20250929",
+        "bedrock/claude-sonnet-4-5-20250929-v1:0",
+        "claude-sonnet-4-6",
+        "bedrock/anthropic.claude-sonnet-4-6",
+        # Claude Opus 4.x
+        "claude-opus-4-20250514",
+        "bedrock/anthropic.claude-opus-4-20250514-v1:0",
+        "claude-opus-4-6",
+        "bedrock/anthropic.claude-opus-4-6-v1:0",
+        # Claude Haiku 4.x
+        "claude-haiku-4-5-20251001",
+        "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+    ],
+)
+def test_thinking_params_supported_for_all_claude_4x_models(model):
+    """All Claude 3.7+ models should support thinking and reasoning_effort params."""
+    config = AnthropicConfig()
+    params = config.get_supported_openai_params(model=model)
+    assert "thinking" in params, f"thinking not in supported params for {model}"
+    assert "reasoning_effort" in params, f"reasoning_effort not in supported params for {model}"
+
+
 def test_anthropic_memory_tool_auto_adds_beta_header():
     """
     Tests that LiteLLM automatically adds the required 'anthropic-beta' header

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -273,6 +273,26 @@ def test_get_supported_openai_params():
     assert "reasoning_effort" in supported_params
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "bedrock/converse/anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "bedrock/converse/anthropic.claude-sonnet-4-20250514-v1:0",
+        "bedrock/converse/anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/converse/anthropic.claude-sonnet-4-6",
+        "bedrock/converse/anthropic.claude-opus-4-20250514-v1:0",
+        "bedrock/converse/anthropic.claude-opus-4-6-v1:0",
+        "bedrock/converse/anthropic.claude-haiku-4-5-20251001-v1:0",
+    ],
+)
+def test_converse_thinking_params_supported_for_all_claude_4x_models(model):
+    """All Claude 3.7+ models on Bedrock Converse should support thinking and reasoning_effort."""
+    config = AmazonConverseConfig()
+    params = config.get_supported_openai_params(model=model)
+    assert "thinking" in params, f"thinking not in supported params for {model}"
+    assert "reasoning_effort" in params, f"reasoning_effort not in supported params for {model}"
+
+
 def test_get_supported_openai_params_bedrock_converse():
     """
     Test that all documented bedrock converse models have the same set of supported openai params when using


### PR DESCRIPTION
## Relevant issues

`thinking` and `reasoning_effort` params are not recognized for Claude 4.x models on Bedrock unless users add an allowed_openai_params workaround. This is because get_supported_openai_params() relies on supports_reasoning() which fails for  Bedrock Claude models due to a provider mismatch in the cost map lookup (litellm_provider: "anthropic" vs custom_llm_provider: "bedrock").

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Replaced the narrow model checks with broad substring matching that covers the full Claude 4.x+ family. 