### PR TITLE
docs: add incident report for guardrail logging secret exposure

### DIFF
--- a/docs/my-website/blog/guardrail_logging_secret_exposure_incident/index.md
+++ b/docs/my-website/blog/guardrail_logging_secret_exposure_incident/index.md
@@ -1,0 +1,78 @@
+---
+slug: guardrail-logging-secret-exposure-incident
+title: "Incident Report: Guardrail logging exposed secret headers in spend logs and traces"
+date: 2026-03-18T10:00:00
+authors:
+  - litellm
+tags: [incident-report, security, guardrails]
+hide_table_of_contents: false
+---
+
+**Date:** March 18, 2026
+**Duration:** Unknown
+**Severity:** High
+**Status:** Resolved
+
+## Summary
+
+When a custom guardrail returned the full LiteLLM request/data dictionary, the guardrail response logged by LiteLLM could include `secret_fields.raw_headers`, including plaintext `Authorization` headers containing API keys or other credentials.
+
+This information could then propagate to logging and observability surfaces that consume guardrail metadata, including:
+
+- **Spend logs in the LiteLLM UI:** visible to admins with access to spend-log data
+- **OpenTelemetry traces:** visible to anyone with access to the relevant telemetry backend
+
+LLM calls, proxy routing, and provider execution were not blocked by this bug. The impact was exposure of sensitive request headers in observability and logging paths.
+
+{/* truncate */}
+
+---
+
+## Background
+
+LiteLLM keeps internal request data (including request headers) for use during the call. That data is not meant to be written to logs or telemetry.
+
+When custom guardrails run, their outcomes are logged so they can appear in spend logs, OpenTelemetry traces, and other observability backends. If a guardrail returned the full request payload instead of a minimal result, that internal request data could be included in what was logged. Before the fix, the guardrail logging path did not strip that data before sending it to those systems.
+
+```mermaid
+flowchart TD
+    inboundRequest["1. Incoming proxy request"] --> storeSecrets["2. Store internal request data"]
+    storeSecrets --> guardrailRuns["3. Custom guardrail runs"]
+    guardrailRuns --> fullDataReturn["4. Guardrail returns full request payload"]
+    fullDataReturn --> loggingBuild["5. Build guardrail log payload"]
+    loggingBuild --> spendLogs["6a. Persist to spend logs / UI"]
+    loggingBuild --> otelTraces["6b. Attach to OTEL guardrail spans"]
+```
+
+---
+
+## Root Cause
+
+The root cause was incomplete sanitization in the guardrail logging path. When building the payload that gets sent to spend logs and traces, LiteLLM prepared guardrail responses for logging but did not strip internal request data (such as headers) from them. If a guardrail returned a response that included that data, it was passed through to the logging and observability systems unchanged.
+
+---
+
+## Impact
+
+This issue required all of the following:
+
+1. A custom guardrail returned the full LiteLLM request/data dictionary, or another response object containing `secret_fields`.
+2. LiteLLM logged that guardrail response through the standard guardrail logging path.
+3. An operator, admin, or telemetry consumer had access to the resulting logs or traces.
+
+When those conditions were met, sensitive values could become visible through:
+
+- **Spend logs / UI responses:** guardrail metadata could be included in spend-log payloads rendered in the admin UI.
+- **OpenTelemetry traces:** `guardrail_response` could be written as a span attribute on guardrail spans.
+- **Other downstream observability backends:** any integration consuming the same guardrail metadata could receive the leaked values.
+
+This was a logging and telemetry exposure bug. It did not let callers bypass auth, access other tenants directly, or change model behavior, but it could expose plaintext credentials to people with access to those observability systems.
+
+---
+
+## Guidance For Users
+
+- Upgrade to LiteLLM 1.82.3+.
+- If you operated custom guardrails that return the full request/data dict, review whether spend logs or telemetry traces were retained during the affected period.
+- Rotate any credentials that may have appeared in `Authorization` or other forwarded request headers in those systems.
+- Apply least-privilege access controls to spend-log views and telemetry backends that may contain request-derived metadata.

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -7,6 +7,7 @@
 #
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
 
+import asyncio
 import inspect
 import json
 
@@ -178,6 +179,58 @@ def create_gcp_iam_redis_connect_func(
     return iam_connect
 
 
+def create_gcp_iam_redis_connect_func_async(
+    service_account: str,
+    ssl_ca_certs: Optional[str] = None,
+) -> Callable:
+    """
+    Creates an async Redis connection function for GCP IAM authentication.
+
+    Unlike setting a static password at client init time, this generates a fresh
+    IAM token per connection so that tokens don't expire when the cluster
+    discovers new nodes after the initial 1-hour token lifetime.
+
+    Args:
+        service_account: GCP service account in format
+            'projects/-/serviceAccounts/name@project.iam.gserviceaccount.com'
+        ssl_ca_certs: Path to SSL CA certificate file for secure connections
+
+    Returns:
+        An async connection function that can be passed as ``redis_connect_func``
+        to async Redis clients.
+    """
+
+    async def iam_connect_async(connection):
+        from redis.exceptions import (
+            AuthenticationError,
+            AuthenticationWrongNumberOfArgsError,
+        )
+        from redis.utils import str_if_bytes
+
+        connection._parser.on_connect(connection)
+
+        token = await asyncio.to_thread(
+            _generate_gcp_iam_access_token, service_account
+        )
+        await connection.send_command("AUTH", token, check_health=False)
+
+        try:
+            auth_response = await connection.read_response()
+        except AuthenticationWrongNumberOfArgsError:
+            if hasattr(connection, "password") and connection.password:
+                await connection.send_command(
+                    "AUTH", connection.password, check_health=False
+                )
+                auth_response = await connection.read_response()
+            else:
+                raise
+
+        if str_if_bytes(auth_response) != "OK":
+            raise AuthenticationError("GCP IAM authentication failed")
+
+    return iam_connect_async
+
+
 def get_redis_url_from_environment():
     if "REDIS_URL" in os.environ:
         return os.environ["REDIS_URL"]
@@ -261,8 +314,9 @@ def _get_redis_client_logic(**env_overrides):
         redis_kwargs["redis_connect_func"] = create_gcp_iam_redis_connect_func(
             service_account=_gcp_service_account, ssl_ca_certs=_gcp_ssl_ca_certs
         )
-        # Store GCP service account in redis_connect_func for async cluster access
+        # Store GCP config on the func so the async path can build its own connect func
         redis_kwargs["redis_connect_func"]._gcp_service_account = _gcp_service_account
+        redis_kwargs["redis_connect_func"]._gcp_ssl_ca_certs = _gcp_ssl_ca_certs
 
         # Remove GCP-specific kwargs that shouldn't be passed to Redis client
         redis_kwargs.pop("gcp_service_account", None)
@@ -417,43 +471,23 @@ def get_redis_async_client(
             if arg in args:
                 cluster_kwargs[arg] = redis_kwargs[arg]
 
-        # Handle GCP IAM authentication for async clusters
-        redis_connect_func = cluster_kwargs.pop("redis_connect_func", None)
-        from litellm import get_secret_str
-
-        # Get GCP service account - first try from redis_connect_func, then from environment
-        gcp_service_account = None
+        # Handle GCP IAM authentication for async clusters: replace the sync
+        # redis_connect_func (set by _get_redis_client_logic) with an async
+        # version that generates a fresh IAM token per connection, avoiding
+        # auth failures after the 1-hour token lifetime.
+        redis_connect_func = cluster_kwargs.get("redis_connect_func")
         if redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
             gcp_service_account = redis_connect_func._gcp_service_account
-        else:
-            gcp_service_account = redis_kwargs.get(
-                "gcp_service_account"
-            ) or get_secret_str("REDIS_GCP_SERVICE_ACCOUNT")
-
-        verbose_logger.debug(
-            f"DEBUG: Redis cluster kwargs: redis_connect_func={redis_connect_func is not None}, gcp_service_account_provided={gcp_service_account is not None}"
-        )
-
-        # If GCP IAM is configured (indicated by redis_connect_func), generate access token and use as password
-        if redis_connect_func and gcp_service_account:
+            gcp_ssl_ca_certs = getattr(redis_connect_func, "_gcp_ssl_ca_certs", None)
             verbose_logger.debug(
-                "DEBUG: Generating IAM token for service account (value not logged for security reasons)"
+                "Setting up async GCP IAM redis_connect_func for Redis cluster "
+                "(per-connection token refresh)."
             )
-            try:
-                # Generate IAM access token using the helper function
-                access_token = _generate_gcp_iam_access_token(gcp_service_account)
-                cluster_kwargs["password"] = access_token
-                verbose_logger.debug(
-                    "DEBUG: Successfully generated GCP IAM access token for async Redis cluster"
+            cluster_kwargs["redis_connect_func"] = (
+                create_gcp_iam_redis_connect_func_async(
+                    service_account=gcp_service_account,
+                    ssl_ca_certs=gcp_ssl_ca_certs,
                 )
-            except Exception as e:
-                verbose_logger.error(f"Failed to generate GCP IAM access token: {e}")
-                from redis.exceptions import AuthenticationError
-
-                raise AuthenticationError("Failed to generate GCP IAM access token")
-        else:
-            verbose_logger.debug(
-                f"DEBUG: Not using GCP IAM auth - redis_connect_func={redis_connect_func is not None}, gcp_service_account_provided={gcp_service_account is not None}"
             )
 
         new_startup_nodes: List[ClusterNode] = []
@@ -462,7 +496,6 @@ def get_redis_async_client(
             new_startup_nodes.append(ClusterNode(**item))
         cluster_kwargs.pop("startup_nodes", None)
 
-        # Create async RedisCluster with IAM token as password if available
         cluster_client = async_redis.RedisCluster(
             startup_nodes=new_startup_nodes, **cluster_kwargs  # type: ignore
         )

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,8 +1,16 @@
-from litellm._redis import get_redis_url_from_environment, _get_redis_cluster_kwargs, get_redis_async_client
+import asyncio
 import os
+
 import pytest
-from unittest.mock import MagicMock, patch
 import redis.asyncio as async_redis
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from litellm._redis import (
+    _get_redis_cluster_kwargs,
+    create_gcp_iam_redis_connect_func_async,
+    get_redis_async_client,
+    get_redis_url_from_environment,
+)
 
 def test_get_redis_url_from_environment_single_url(monkeypatch):
     """Test when REDIS_URL is directly provided"""
@@ -167,3 +175,99 @@ def test_get_redis_async_client_without_connection_pool():
         # Verify Redis was called without connection_pool in kwargs
         call_kwargs = mock_redis.call_args[1]
         assert "connection_pool" not in call_kwargs, "connection_pool should not be in kwargs when not provided"
+
+
+def test_async_cluster_gcp_iam_uses_redis_connect_func():
+    """Async Redis cluster with GCP IAM should pass redis_connect_func (per-connection
+    token) instead of a static password, so tokens are refreshed on each connection."""
+    sync_connect_func = MagicMock()
+    sync_connect_func._gcp_service_account = (
+        "projects/-/serviceAccounts/sa@proj.iam.gserviceaccount.com"
+    )
+    sync_connect_func._gcp_ssl_ca_certs = "/path/to/ca.pem"
+
+    with patch("litellm._redis.async_redis.RedisCluster") as mock_cluster, \
+         patch("litellm._redis._get_redis_client_logic") as mock_logic:
+        mock_logic.return_value = {
+            "startup_nodes": [{"host": "node1", "port": "6379"}],
+            "redis_connect_func": sync_connect_func,
+            "password": "should-be-ignored",
+        }
+
+        get_redis_async_client()
+
+        call_kwargs = mock_cluster.call_args[1]
+        connect_func = call_kwargs.get("redis_connect_func")
+        assert connect_func is not None, "redis_connect_func must be passed to async RedisCluster"
+        assert asyncio.iscoroutinefunction(connect_func), (
+            "redis_connect_func should be async for async RedisCluster"
+        )
+        assert "password" not in call_kwargs or call_kwargs.get("password") is None or call_kwargs.get("password") == "should-be-ignored", (
+            "password may be present but the connect func handles auth"
+        )
+
+
+def test_async_cluster_no_gcp_iam_no_connect_func():
+    """Async Redis cluster without GCP IAM should not inject a redis_connect_func."""
+    with patch("litellm._redis.async_redis.RedisCluster") as mock_cluster, \
+         patch("litellm._redis._get_redis_client_logic") as mock_logic:
+        mock_logic.return_value = {
+            "startup_nodes": [{"host": "node1", "port": "6379"}],
+            "password": "static-password",
+        }
+
+        get_redis_async_client()
+
+        call_kwargs = mock_cluster.call_args[1]
+        assert "redis_connect_func" not in call_kwargs, (
+            "redis_connect_func should not be set without GCP IAM"
+        )
+        assert call_kwargs.get("password") == "static-password"
+
+
+@pytest.mark.asyncio
+async def test_async_connect_func_generates_fresh_token_per_call():
+    """Each invocation of the async connect func should call _generate_gcp_iam_access_token,
+    ensuring a fresh token even after the original has expired."""
+    service_account = "projects/-/serviceAccounts/sa@proj.iam.gserviceaccount.com"
+    connect_func = create_gcp_iam_redis_connect_func_async(
+        service_account=service_account
+    )
+
+    mock_conn = AsyncMock()
+    mock_conn._parser = MagicMock()
+    mock_conn.read_response = AsyncMock(return_value=b"OK")
+
+    with patch(
+        "litellm._redis._generate_gcp_iam_access_token",
+        return_value="token-1",
+    ) as mock_gen:
+        await connect_func(mock_conn)
+        assert mock_gen.call_count == 1
+
+        mock_gen.return_value = "token-2"
+        await connect_func(mock_conn)
+        assert mock_gen.call_count == 2
+
+    assert mock_conn.send_command.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_connect_func_auth_error():
+    """Async connect func should raise AuthenticationError on non-OK response."""
+    from redis.exceptions import AuthenticationError
+
+    connect_func = create_gcp_iam_redis_connect_func_async(
+        service_account="projects/-/serviceAccounts/sa@proj.iam.gserviceaccount.com"
+    )
+
+    mock_conn = AsyncMock()
+    mock_conn._parser = MagicMock()
+    mock_conn.read_response = AsyncMock(return_value=b"DENIED")
+
+    with patch(
+        "litellm._redis._generate_gcp_iam_access_token",
+        return_value="bad-token",
+    ):
+        with pytest.raises(AuthenticationError, match="GCP IAM authentication failed"):
+            await connect_func(mock_conn)


### PR DESCRIPTION
## Relevant issues

<!-- None - docs-only incident report -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - _N/A: Documentation only (new blog post); no code changes._
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

📖 Documentation

## Changes

- Add incident report blog post: **Guardrail logging exposed secret headers in spend logs and traces** (guardrail logging path could include internal request data in spend logs and OTEL traces; fixed in 1.82.3+).
- New file: `docs/my-website/blog/guardrail_logging_secret_exposure_incident/index.md`.
