### PR TITLE
[Fix] Key Update Endpoint Returns 401 Instead of 404 for Nonexistent Keys

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1654,7 +1654,7 @@ async def _get_and_validate_existing_key(
         LiteLLM_VerificationToken: The existing key row
 
     Raises:
-        HTTPException: If key is not found
+        ProxyException: 404 if key is not found
     """
     if prisma_client is None:
         raise HTTPException(
@@ -1662,12 +1662,7 @@ async def _get_and_validate_existing_key(
             detail={"error": "Database not connected"},
         )
 
-    from litellm.proxy.proxy_server import hash_token
-
-    if token.startswith("sk-"):
-        hashed_token = hash_token(token=token)
-    else:
-        hashed_token = token
+    hashed_token = _hash_token_if_needed(token=token)
 
     existing_key_row = await prisma_client.db.litellm_verificationtoken.find_unique(
         where={"token": hashed_token}
@@ -2116,27 +2111,10 @@ async def update_key_fn(
         key = data_json.pop("key")
 
         # get the row from db
-        if prisma_client is None:
-            raise Exception("Not connected to DB!")
-
-        from litellm.proxy.proxy_server import hash_token
-
-        if data.key.startswith("sk-"):
-            hashed_token = hash_token(token=data.key)
-        else:
-            hashed_token = data.key
-
-        existing_key_row = await prisma_client.db.litellm_verificationtoken.find_unique(
-            where={"token": hashed_token}
+        existing_key_row = await _get_and_validate_existing_key(
+            token=data.key,
+            prisma_client=prisma_client,
         )
-
-        if existing_key_row is None:
-            raise ProxyException(
-                message=f"Key not found. Passed key={data.key}",
-                type=ProxyErrorTypes.not_found_error,
-                param="key",
-                code=status.HTTP_404_NOT_FOUND,
-            )
 
         await _validate_update_key_data(
             data=data,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1662,16 +1662,23 @@ async def _get_and_validate_existing_key(
             detail={"error": "Database not connected"},
         )
 
-    existing_key_row = await prisma_client.get_data(
-        token=token,
-        table_name="key",
-        query_type="find_unique",
+    from litellm.proxy.proxy_server import hash_token
+
+    if token.startswith("sk-"):
+        hashed_token = hash_token(token=token)
+    else:
+        hashed_token = token
+
+    existing_key_row = await prisma_client.db.litellm_verificationtoken.find_unique(
+        where={"token": hashed_token}
     )
 
     if existing_key_row is None:
-        raise HTTPException(
-            status_code=404,
-            detail={"error": f"Key not found: {token}"},
+        raise ProxyException(
+            message=f"Key not found. Passed key={token}",
+            type=ProxyErrorTypes.not_found_error,
+            param="key",
+            code=status.HTTP_404_NOT_FOUND,
         )
 
     return existing_key_row
@@ -2112,14 +2119,23 @@ async def update_key_fn(
         if prisma_client is None:
             raise Exception("Not connected to DB!")
 
-        existing_key_row = await prisma_client.get_data(
-            token=data.key, table_name="key", query_type="find_unique"
+        from litellm.proxy.proxy_server import hash_token
+
+        if data.key.startswith("sk-"):
+            hashed_token = hash_token(token=data.key)
+        else:
+            hashed_token = data.key
+
+        existing_key_row = await prisma_client.db.litellm_verificationtoken.find_unique(
+            where={"token": hashed_token}
         )
 
         if existing_key_row is None:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": f"Team not found, passed team_id={data.team_id}"},
+            raise ProxyException(
+                message=f"Key not found. Passed key={data.key}",
+                type=ProxyErrorTypes.not_found_error,
+                param="key",
+                code=status.HTTP_404_NOT_FOUND,
             )
 
         await _validate_update_key_data(

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1679,6 +1679,56 @@ async def test_unblock_key_nonexistent_key_returns_404(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_update_key_nonexistent_key_returns_404(monkeypatch):
+    """
+    Test that update_key_fn returns 404 (not misleading 401) when the body
+    key doesn't exist in the database, even when the caller is authenticated
+    as a proxy admin via the Authorization header.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_user_api_key_cache = MagicMock()
+    mock_proxy_logging_obj = MagicMock()
+
+    # find_unique returns None → key does not exist
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.user_api_key_cache", mock_user_api_key_cache
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+
+    mock_request = MagicMock()
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-admin", user_id="admin_user"
+    )
+
+    data = UpdateKeyRequest(key="sk-does-not-exist-key")
+
+    with pytest.raises(ProxyException) as exc_info:
+        await update_key_fn(
+            request=mock_request,
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+        )
+
+    assert exc_info.value.code == "404"
+    assert "not found" in str(exc_info.value.message).lower()
+    assert "Authentication Error" not in str(exc_info.value.message)
+
+
+@pytest.mark.asyncio
 async def test_block_key_existing_key_succeeds(monkeypatch):
     """
     Test that block_key successfully blocks an existing key and


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
`/key/update` returns `401` for a nonexistent body `key` even when the `Authorization` header contains a valid master key. This happens because `prisma_client.get_data()` treats the token as an auth credential and raises a 401 when it doesn't exist in the DB.

### Fix
Replace `prisma_client.get_data()` with direct Prisma `find_unique()` in both `_get_and_validate_existing_key()` and `update_key_fn()`, matching the pattern used in the `/key/block` and `/key/unblock` fix (PR #23977). Also fixes an incorrect "Team not found" error message in `update_key_fn`.

## Testing
```bash
curl -s -X POST "http://localhost:4000/key/update" \
  -H "Authorization: Bearer $MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"key":"sk-does-not-exist"}'
# Before: 401 "invalid user key"
# After:  404 "Key not found"
```

## Type

🐛 Bug Fix