### PR TITLE
fix: support response_text key for Cloudflare Workers AI Nemotron models

### DIFF
--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -147,9 +147,9 @@ class CloudflareChatConfig(BaseConfig):
     ) -> ModelResponse:
         completion_response = raw_response.json()
 
-        model_response.choices[0].message.content = completion_response["result"][  # type: ignore
-            "response"
-        ]
+        # Support both "response" and "response_text" keys (newer models like Nemotron use "response_text")
+        result = completion_response["result"]
+        model_response.choices[0].message.content = result.get("response") or result.get("response_text", "")  # type: ignore
 
         prompt_tokens = litellm.utils.get_token_count(messages=messages, model=model)
         completion_tokens = len(


### PR DESCRIPTION
## Summary
Fixes Issue #24065 - Cloudflare Workers AI API Error when using Nemotron 3 120B model.

## Problem
The Cloudflare Workers AI transformation code assumes the response always contains a `result.response` key, but newer models like `@cf/nvidia/nemotron-3-120b-a12b` return `result.response_text` instead.

## Solution
Added fallback support to check for both `response` and `response_text` keys:

```python
result = completion_response["result"]
model_response.choices[0].message.content = result.get("response") or result.get("response_text", "")
```

## Changes
- `litellm/llms/cloudflare/chat/transformation.py`: Added fallback for response key