### PR TITLE
[Feature] UI - Leftnav: Add external link icon to Learning Resources

### DIFF
--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -13,6 +13,7 @@ import {
   CreditCardOutlined,
   DatabaseOutlined,
   ExperimentOutlined,
+  ExportOutlined,
   FileTextOutlined,
   FolderOutlined,
   KeyOutlined,
@@ -400,7 +401,7 @@ const Sidebar: React.FC<SidebarProps> = ({ setPage, defaultSelectedKey, collapse
           onClick={(e) => e.stopPropagation()}
           style={{ color: "inherit", textDecoration: "none" }}
         >
-          {label}
+          {label} <ExportOutlined style={{ fontSize: 10, marginLeft: 4 }} />
         </a>
       );
     }


### PR DESCRIPTION
## Summary

### Problem
The "Learning Resources" nav item opens an external page but has no visual indicator distinguishing it from internal navigation links.

### Fix
Added an `ExportOutlined` antd icon next to nav labels that have an `external_url`, so users can tell at a glance that the link opens in a new tab.

## Testing
- Verified the icon renders next to "Learning Resources" in the left nav
- Icon applies generically to any nav item with `external_url`

## Type
🆕 New Feature