### PR TITLE
fix(anthropic): pass logging_obj to client.post for litellm_overhead_time_ms

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -85,7 +85,12 @@ async def make_call(
 
     try:
         response = await client.post(
-            api_base, headers=headers, data=data, stream=True, timeout=timeout
+            api_base,
+            headers=headers,
+            data=data,
+            stream=True,
+            timeout=timeout,
+            logging_obj=logging_obj,
         )
     except httpx.HTTPStatusError as e:
         error_headers = getattr(e, "headers", None)
@@ -138,7 +143,12 @@ def make_sync_call(
 
     try:
         response = client.post(
-            api_base, headers=headers, data=data, stream=True, timeout=timeout
+            api_base,
+            headers=headers,
+            data=data,
+            stream=True,
+            timeout=timeout,
+            logging_obj=logging_obj,
         )
     except httpx.HTTPStatusError as e:
         error_headers = getattr(e, "headers", None)
@@ -262,7 +272,11 @@ class AnthropicChatCompletion(BaseLLM):
 
         try:
             response = await async_handler.post(
-                api_base, headers=headers, json=data, timeout=timeout
+                api_base,
+                headers=headers,
+                json=data,
+                timeout=timeout,
+                logging_obj=logging_obj,
             )
         except Exception as e:
             ## LOGGING
@@ -465,6 +479,7 @@ class AnthropicChatCompletion(BaseLLM):
                         headers=headers,
                         data=json.dumps(data),
                         timeout=timeout,
+                        logging_obj=logging_obj,
                     )
                 except Exception as e:
                     status_code = getattr(e, "status_code", 500)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -1,11 +1,40 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
-from litellm.llms.anthropic.chat.handler import ModelResponseIterator
+from litellm.llms.anthropic.chat.handler import ModelResponseIterator, make_call
 from litellm.types.llms.openai import (
     ChatCompletionToolCallChunk,
     ChatCompletionToolCallFunctionChunk,
 )
+
+
+@pytest.mark.asyncio
+async def test_make_call_passes_logging_obj_to_client_post():
+    """make_call must pass logging_obj to client.post so track_llm_api_timing can set llm_api_duration_ms for litellm_overhead_time_ms."""
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.aiter_lines = MagicMock(return_value=iter([b'data: {"type":"message_start"}\n', b'data: {"type":"message_delta"}\n']))
+    mock_client.post.return_value = mock_response
+
+    logging_obj = MagicMock()
+
+    await make_call(
+        client=mock_client,
+        api_base="https://api.anthropic.com/v1/messages",
+        headers={},
+        data="{}",
+        model="claude-3-5-haiku",
+        messages=[{"role": "user", "content": "Hi"}],
+        logging_obj=logging_obj,
+        timeout=60.0,
+        json_mode=False,
+    )
+
+    mock_client.post.assert_called_once()
+    call_kwargs = mock_client.post.call_args[1]
+    assert call_kwargs.get("logging_obj") is logging_obj
 
 
 def test_redacted_thinking_content_block_delta():


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (anthropic chat handler tests: `poetry run pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py -v`)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- **Fix:** Pass `logging_obj` from the Anthropic chat handler into every `client.post()` / `async_handler.post()` call so the `@track_llm_api_timing()` decorator on the HTTP handler can set `model_call_details["llm_api_duration_ms"]`. Without it, `litellm_overhead_time_ms` stayed null when using Anthropic with `LITELLM_DETAILED_TIMING=true`.
- **Files:** `litellm/llms/anthropic/chat/handler.py` (4 call sites: async/sync streaming in `make_call`/`make_sync_call`, async/sync non-streaming in `acompletion`/`completion`).
- **Test:** `test_make_call_passes_logging_obj_to_client_post` in `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py` ensures `make_call` passes `logging_obj` to `client.post`.
