### PR TITLE
fix(adapter): add additionalProperties: false for OpenAI strict mode in Anthropic adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -843,15 +843,18 @@ class LiteLLMAnthropicMessagesAdapter:
     @staticmethod
     def _add_additional_properties_false(schema: dict) -> None:
         """
-        Recursively add 'additionalProperties': false to all object schemas.
+        Recursively ensure object schemas comply with OpenAI strict mode.
 
-        OpenAI's strict mode requires this at every object nesting level.
+        OpenAI's strict mode requires:
+        1. 'additionalProperties': false at every object nesting level
+        2. All property keys listed in 'required'
         """
         if not isinstance(schema, dict):
             return
 
         if schema.get("type") == "object" and "properties" in schema:
             schema["additionalProperties"] = False
+            schema["required"] = list(schema["properties"].keys())
             for prop in schema["properties"].values():
                 LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(prop)
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 import json
 from typing import (
@@ -824,6 +825,11 @@ class LiteLLMAnthropicMessagesAdapter:
         if not schema:
             return None
 
+        # Deep copy to avoid mutating the original schema
+        schema = copy.deepcopy(schema)
+        # OpenAI strict mode requires additionalProperties: false on every object
+        self._add_additional_properties_false(schema)
+
         # Convert to OpenAI response_format structure
         return {
             "type": "json_schema",
@@ -833,6 +839,37 @@ class LiteLLMAnthropicMessagesAdapter:
                 "strict": True,
             },
         }
+
+    @staticmethod
+    def _add_additional_properties_false(schema: dict) -> None:
+        """
+        Recursively add 'additionalProperties': false to all object schemas.
+
+        OpenAI's strict mode requires this at every object nesting level.
+        """
+        if not isinstance(schema, dict):
+            return
+
+        if schema.get("type") == "object" and "properties" in schema:
+            schema["additionalProperties"] = False
+            for prop in schema["properties"].values():
+                LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(prop)
+
+        # Handle array items
+        if "items" in schema:
+            LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(schema["items"])
+
+        # Handle anyOf/oneOf/allOf
+        for key in ("anyOf", "oneOf", "allOf"):
+            if key in schema:
+                for sub_schema in schema[key]:
+                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(sub_schema)
+
+        # Handle $defs / definitions
+        for key in ("$defs", "definitions"):
+            if key in schema:
+                for def_schema in schema[key].values():
+                    LiteLLMAnthropicMessagesAdapter._add_additional_properties_false(def_schema)
 
     def _add_system_message_to_messages(
         self,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2004,6 +2004,7 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         assert result is not None
         schema = result["json_schema"]["schema"]
         assert schema["additionalProperties"] is False
+        assert schema["required"] == ["name"]
 
     def test_nested_objects_adds_additional_properties_false(self):
         output_format = {
@@ -2028,8 +2029,11 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         assert result is not None
         schema = result["json_schema"]["schema"]
         assert schema["additionalProperties"] is False
+        assert schema["required"] == ["user"]
         assert schema["properties"]["user"]["additionalProperties"] is False
+        assert schema["properties"]["user"]["required"] == ["name", "address"]
         assert schema["properties"]["user"]["properties"]["address"]["additionalProperties"] is False
+        assert schema["properties"]["user"]["properties"]["address"]["required"] == ["city"]
 
     def test_array_items_object_adds_additional_properties_false(self):
         output_format = {
@@ -2061,6 +2065,7 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         output_format = {"type": "json_schema", "schema": original_schema}
         self.adapter.translate_anthropic_output_format_to_openai(output_format)
         assert "additionalProperties" not in original_schema
+        assert "required" not in original_schema
 
     def test_defs_adds_additional_properties_false(self):
         output_format = {
@@ -2080,6 +2085,27 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         assert result is not None
         schema = result["json_schema"]["schema"]
         assert schema["$defs"]["Item"]["additionalProperties"] is False
+        assert schema["$defs"]["Item"]["required"] == ["value"]
+
+    def test_incomplete_required_gets_completed(self):
+        """OpenAI strict mode requires ALL properties in required."""
+        output_format = {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "age": {"type": "integer"},
+                    "email": {"type": "string"},
+                },
+                "required": ["name"],  # only 1 of 3
+            },
+        }
+        result = self.adapter.translate_anthropic_output_format_to_openai(output_format)
+        assert result is not None
+        schema = result["json_schema"]["schema"]
+        assert schema["additionalProperties"] is False
+        assert sorted(schema["required"]) == ["age", "email", "name"]
 
     def test_invalid_output_format_returns_none(self):
         assert self.adapter.translate_anthropic_output_format_to_openai("invalid") is None

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1984,3 +1984,104 @@ def test_translate_anthropic_to_openai_with_mixed_tools():
 
     # tool_name_mapping should be empty for short tool names
     assert tool_name_mapping == {}
+
+
+class TestTranslateAnthropicOutputFormatToOpenAI:
+    """Tests for translate_anthropic_output_format_to_openai adding additionalProperties: false."""
+
+    def setup_method(self):
+        self.adapter = LiteLLMAnthropicMessagesAdapter()
+
+    def test_simple_object_adds_additional_properties_false(self):
+        output_format = {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            },
+        }
+        result = self.adapter.translate_anthropic_output_format_to_openai(output_format)
+        assert result is not None
+        schema = result["json_schema"]["schema"]
+        assert schema["additionalProperties"] is False
+
+    def test_nested_objects_adds_additional_properties_false(self):
+        output_format = {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "address": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                            },
+                        },
+                    }
+                },
+            },
+        }
+        result = self.adapter.translate_anthropic_output_format_to_openai(output_format)
+        assert result is not None
+        schema = result["json_schema"]["schema"]
+        assert schema["additionalProperties"] is False
+        assert schema["properties"]["user"]["additionalProperties"] is False
+        assert schema["properties"]["user"]["properties"]["address"]["additionalProperties"] is False
+
+    def test_array_items_object_adds_additional_properties_false(self):
+        output_format = {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {"id": {"type": "integer"}},
+                        },
+                    }
+                },
+            },
+        }
+        result = self.adapter.translate_anthropic_output_format_to_openai(output_format)
+        assert result is not None
+        schema = result["json_schema"]["schema"]
+        assert schema["additionalProperties"] is False
+        assert schema["properties"]["items"]["items"]["additionalProperties"] is False
+
+    def test_does_not_mutate_original_schema(self):
+        original_schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        output_format = {"type": "json_schema", "schema": original_schema}
+        self.adapter.translate_anthropic_output_format_to_openai(output_format)
+        assert "additionalProperties" not in original_schema
+
+    def test_defs_adds_additional_properties_false(self):
+        output_format = {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {"ref": {"$ref": "#/$defs/Item"}},
+                "$defs": {
+                    "Item": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                    }
+                },
+            },
+        }
+        result = self.adapter.translate_anthropic_output_format_to_openai(output_format)
+        assert result is not None
+        schema = result["json_schema"]["schema"]
+        assert schema["$defs"]["Item"]["additionalProperties"] is False
+
+    def test_invalid_output_format_returns_none(self):
+        assert self.adapter.translate_anthropic_output_format_to_openai("invalid") is None
+        assert self.adapter.translate_anthropic_output_format_to_openai({"type": "text"}) is None
+        assert self.adapter.translate_anthropic_output_format_to_openai({"type": "json_schema"}) is None


### PR DESCRIPTION
## Relevant issues

Fixes #20997

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When `translate_anthropic_output_format_to_openai` translates Anthropic's `output_format` to OpenAI's `response_format`, it sets `strict: true` but does not add `additionalProperties: false` to the JSON schema. OpenAI requires `additionalProperties: false` at every object nesting level when using strict mode, causing all structured output requests routed to OpenAI models via the Anthropic adapter to fail with `BadRequestError`.

**Fix:** Recursively add `additionalProperties: false` to all object schemas before returning the translated response_format.