### PR TITLE
fix(openrouter): strip openrouter/ prefix in image edit requests

### DIFF
--- a/litellm/llms/openrouter/image_edit/transformation.py
+++ b/litellm/llms/openrouter/image_edit/transformation.py
@@ -156,6 +156,10 @@ class OpenRouterImageEditConfig(BaseImageEditConfig):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> Tuple[Dict, RequestFiles]:
+        # Strip 'openrouter/' prefix if present (router passes the full model name)
+        if model.startswith("openrouter/"):
+            model = model.replace("openrouter/", "", 1)
+
         content_parts: List[Dict[str, Any]] = []
 
         # Add source image(s) as base64 data URLs

--- a/tests/test_litellm/llms/openrouter/image_edit/test_openrouter_image_edit_transformation.py
+++ b/tests/test_litellm/llms/openrouter/image_edit/test_openrouter_image_edit_transformation.py
@@ -240,6 +240,24 @@ class TestOpenRouterImageEditTransformation:
         # Files should be empty (JSON mode)
         assert list(files) == []
 
+    def test_transform_image_edit_request_strips_openrouter_prefix(self):
+        """Test that openrouter/ prefix is stripped from model name in request.
+
+        When the proxy/router passes the model, it includes the openrouter/
+        prefix. OpenRouter rejects this as an invalid model ID.
+        Regression test for https://github.com/BerriAI/litellm/issues/22305
+        """
+        data, _ = self.config.transform_image_edit_request(
+            model="openrouter/google/gemini-2.5-flash-image",
+            prompt="Edit this",
+            image=self.sample_image_bytes,
+            image_edit_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert data["model"] == "google/gemini-2.5-flash-image"
+
     def test_transform_image_edit_request_with_bytesio(self):
         """Test request transformation with BytesIO image input."""
         image = BytesIO(self.sample_image_bytes)


### PR DESCRIPTION
## Relevant issues

Fixes #22305

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

When using the proxy/router with OpenRouter image edit models, the router passes `openrouter/google/gemini-2.5-flash-image` as the model name. OpenRouter rejects this as an invalid model ID.

The fix strips the `openrouter/` prefix in `transform_image_edit_request`, matching the existing pattern in the embedding config (`embedding/transformation.py:113`).