### PR TITLE
fix(proxy): pass-through subpath auth for non-admin users

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2033,13 +2033,13 @@ class InitPassThroughEndpointHelpers:
             route_info = _registered_pass_through_routes[key]
             path = route_info.get("path")
             if isinstance(path, str):
-                # Remove base path and wildcard path from openai_routes
                 openai_routes = LiteLLMRoutes.openai_routes.value
                 if path in openai_routes:
                     openai_routes.remove(path)
-                wildcard_path = path.rstrip("/") + "/*"
-                if wildcard_path in openai_routes:
-                    openai_routes.remove(wildcard_path)
+                if route_info.get("type") == "subpath":
+                    wildcard_path = path.rstrip("/") + "/*"
+                    if wildcard_path in openai_routes:
+                        openai_routes.remove(wildcard_path)
             del _registered_pass_through_routes[key]
             verbose_proxy_logger.debug(
                 "Removed pass-through route from registry: %s", key

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2022,13 +2022,24 @@ class InitPassThroughEndpointHelpers:
 
     @staticmethod
     def remove_endpoint_routes(endpoint_id: str):
-        """Remove all routes for a specific endpoint ID from the registry"""
+        """Remove all routes for a specific endpoint ID from the registry
+        and clean up corresponding entries from LiteLLMRoutes.openai_routes."""
         keys_to_remove = [
             key
             for key, value in _registered_pass_through_routes.items()
             if value["endpoint_id"] == endpoint_id
         ]
         for key in keys_to_remove:
+            route_info = _registered_pass_through_routes[key]
+            path = route_info.get("path")
+            if isinstance(path, str):
+                # Remove base path and wildcard path from openai_routes
+                openai_routes = LiteLLMRoutes.openai_routes.value
+                if path in openai_routes:
+                    openai_routes.remove(path)
+                wildcard_path = path.rstrip("/") + "/*"
+                if wildcard_path in openai_routes:
+                    openai_routes.remove(wildcard_path)
             del _registered_pass_through_routes[key]
             verbose_proxy_logger.debug(
                 "Removed pass-through route from registry: %s", key
@@ -2224,7 +2235,8 @@ async def initialize_pass_through_endpoints(
                     )
                 )
             _dependencies = [Depends(user_api_key_auth)]
-            LiteLLMRoutes.openai_routes.value.append(_path)
+            if _path not in LiteLLMRoutes.openai_routes.value:
+                LiteLLMRoutes.openai_routes.value.append(_path)
 
         if _target is None:
             continue

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -651,6 +651,7 @@ async def pass_through_request(  # noqa: PLR0915
     _parsed_body: Optional[dict] = None
     # kwargs for pass through endpoint, contains metadata, litellm_params, call_type, litellm_call_id, passthrough_logging_payload
     kwargs: Optional[dict] = None
+    logging_obj: Optional[Logging] = None
 
     #########################################################
     try:
@@ -2262,6 +2263,12 @@ async def initialize_pass_through_endpoints(
 
         # Add wildcard route for sub-paths
         if endpoint.get("include_subpath", False) is True:
+            # Register wildcard path in openai_routes so non-admin users
+            # can access subpath routes when auth is enabled
+            if _auth is not None and str(_auth).lower() == "true":
+                _wildcard_path = _path.rstrip("/") + "/*"
+                if _wildcard_path not in LiteLLMRoutes.openai_routes.value:
+                    LiteLLMRoutes.openai_routes.value.append(_wildcard_path)
             InitPassThroughEndpointHelpers.add_subpath_route(
                 app=app,
                 path=_path,

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1397,3 +1397,10 @@ async def test_initialize_pass_through_registers_wildcard_for_auth_subpath():
             assert wildcard_path not in LiteLLMRoutes.openai_routes.value
     finally:
         LiteLLMRoutes.openai_routes.value[:] = original_routes
+        # Clean up any routes registered during this test to avoid
+        # polluting the module-level _registered_pass_through_routes
+        registered = InitPassThroughEndpointHelpers.get_all_registered_pass_through_routes()
+        for k in registered:
+            InitPassThroughEndpointHelpers.remove_endpoint_routes(
+                k.split(":")[0]
+            )

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1331,39 +1331,69 @@ def test_non_org_admin_with_organizations_list():
     assert _user_is_org_admin({"organizations": ["org-1"]}, user_obj) is False
 
 
-def test_pass_through_subpath_auth_with_wildcard_in_openai_routes():
+@pytest.mark.asyncio
+async def test_initialize_pass_through_registers_wildcard_for_auth_subpath():
     """
-    Test that pass-through endpoints with include_subpath=true and auth=true
-    are accessible to non-admin users via wildcard route matching.
+    Test that initialize_pass_through_endpoints registers both base path and
+    wildcard path in openai_routes when auth=true and include_subpath=true,
+    and that subpath requests pass is_llm_api_route.
 
-    When auth=true and include_subpath=true, the wildcard path (e.g. /custom-endpoint/*)
-    should be added to openai_routes so that subpath requests like
-    /custom-endpoint/v1/infer are recognized as LLM API routes.
-
-    Regression test for: non-admin users getting 401 "Only proxy admin" error
-    on pass-through subpath requests.
+    Also verifies:
+    - Dedup: calling init twice does not duplicate entries
+    - Cleanup: removing the endpoint cleans up openai_routes
     """
     from litellm.proxy._types import LiteLLMRoutes
+    from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+        InitPassThroughEndpointHelpers,
+        initialize_pass_through_endpoints,
+    )
 
     base_path = "/v1/ocr/nvidia/community/nemoretriever-ocr-v1"
     wildcard_path = base_path + "/*"
 
-    # Simulate what init_pass_through_endpoints does when auth=true + include_subpath=true
+    endpoint_config = {
+        "path": base_path,
+        "target": "https://httpbin.org/post",
+        "include_subpath": True,
+        "auth": True,
+        "headers": {"content-type": "application/json"},
+    }
+
     original_routes = LiteLLMRoutes.openai_routes.value[:]
     try:
-        LiteLLMRoutes.openai_routes.value.append(base_path)
-        LiteLLMRoutes.openai_routes.value.append(wildcard_path)
+        with patch(
+            "litellm.proxy.proxy_server.app",
+            MagicMock(),
+        ), patch(
+            "litellm.proxy.proxy_server.premium_user",
+            True,
+        ), patch(
+            "litellm.proxy.proxy_server.config_passthrough_endpoints",
+            None,
+        ):
+            await initialize_pass_through_endpoints([endpoint_config])
 
-        # Exact path should match
-        assert RouteChecks.is_llm_api_route(base_path) is True
+            # Both base and wildcard paths should be registered
+            assert base_path in LiteLLMRoutes.openai_routes.value
+            assert wildcard_path in LiteLLMRoutes.openai_routes.value
 
-        # Subpath should match via wildcard
-        assert RouteChecks.is_llm_api_route(base_path + "/v1/infer") is True
+            # Subpath requests should pass the auth route check
+            assert RouteChecks.is_llm_api_route(base_path) is True
+            assert RouteChecks.is_llm_api_route(base_path + "/v1/infer") is True
 
-        # Deeper subpath should also match
-        assert RouteChecks.is_llm_api_route(base_path + "/v1/some/deep/path") is True
+            # Calling init again should not duplicate entries
+            await initialize_pass_through_endpoints([endpoint_config])
+            assert LiteLLMRoutes.openai_routes.value.count(base_path) == 1
+            assert LiteLLMRoutes.openai_routes.value.count(wildcard_path) == 1
 
-        # Unrelated route should not match
-        assert RouteChecks.is_llm_api_route("/v1/some-other-endpoint") is False
+            # Removing the endpoint should clean up openai_routes
+            # remove_endpoint_routes takes endpoint_id (UUID portion of
+            # the route key "{id}:exact:{path}:{methods}")
+            registered = InitPassThroughEndpointHelpers.get_all_registered_pass_through_routes()
+            endpoint_ids = {k.split(":")[0] for k in registered}
+            for eid in endpoint_ids:
+                InitPassThroughEndpointHelpers.remove_endpoint_routes(eid)
+            assert base_path not in LiteLLMRoutes.openai_routes.value
+            assert wildcard_path not in LiteLLMRoutes.openai_routes.value
     finally:
         LiteLLMRoutes.openai_routes.value[:] = original_routes

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1329,3 +1329,41 @@ def test_non_org_admin_with_organizations_list():
         organization_memberships=[membership],
     )
     assert _user_is_org_admin({"organizations": ["org-1"]}, user_obj) is False
+
+
+def test_pass_through_subpath_auth_with_wildcard_in_openai_routes():
+    """
+    Test that pass-through endpoints with include_subpath=true and auth=true
+    are accessible to non-admin users via wildcard route matching.
+
+    When auth=true and include_subpath=true, the wildcard path (e.g. /custom-endpoint/*)
+    should be added to openai_routes so that subpath requests like
+    /custom-endpoint/v1/infer are recognized as LLM API routes.
+
+    Regression test for: non-admin users getting 401 "Only proxy admin" error
+    on pass-through subpath requests.
+    """
+    from litellm.proxy._types import LiteLLMRoutes
+
+    base_path = "/v1/ocr/nvidia/community/nemoretriever-ocr-v1"
+    wildcard_path = base_path + "/*"
+
+    # Simulate what init_pass_through_endpoints does when auth=true + include_subpath=true
+    original_routes = LiteLLMRoutes.openai_routes.value[:]
+    try:
+        LiteLLMRoutes.openai_routes.value.append(base_path)
+        LiteLLMRoutes.openai_routes.value.append(wildcard_path)
+
+        # Exact path should match
+        assert RouteChecks.is_llm_api_route(base_path) is True
+
+        # Subpath should match via wildcard
+        assert RouteChecks.is_llm_api_route(base_path + "/v1/infer") is True
+
+        # Deeper subpath should also match
+        assert RouteChecks.is_llm_api_route(base_path + "/v1/some/deep/path") is True
+
+        # Unrelated route should not match
+        assert RouteChecks.is_llm_api_route("/v1/some-other-endpoint") is False
+    finally:
+        LiteLLMRoutes.openai_routes.value[:] = original_routes


### PR DESCRIPTION
## Relevant issues

Fixes auth failure where non-admin users get 401 "Only proxy admin" error when accessing pass-through endpoints with `auth: true` and `include_subpath: true`.
Fixes LIT-2266

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When a pass-through endpoint is configured with both `auth: true` and `include_subpath: true`, only the base path (e.g. `/v1/ocr/nvidia/community/nemoretriever-ocr-v1`) was added to `LiteLLMRoutes.openai_routes`. Subpath requests (e.g. `.../v1/infer`) failed the exact match in `is_llm_api_route()` and fell through to the admin-only error.

**Fix**: When both flags are set, also register a wildcard path (`/base-path/*`) in `openai_routes`, leveraging the existing `_route_matches_wildcard_pattern` infrastructure.

Also fixes a pre-existing pyright error where `logging_obj` was possibly unbound in the except block of `pass_through_request`.