### PR TITLE
chore: regenerate poetry.lock to unblock CI (pyproject.toml content hash drift)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8018,4 +8018,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "eda34dfd8b35474beffee18893d6782c7b3d0d3d2c610f66237eb97176f43527"
+content-hash = "2cf958f1a04fd5f1ab0e5cfc33bdbf441b518ed6c82d0f2546bf64cd3d2f89be"


### PR DESCRIPTION
## Summary

- `pyproject.toml` content hash changed but `poetry.lock` was not updated, causing **all PR builds to fail at `poetry install`** with Poetry 2.3.2
- Only 1 line changed in `poetry.lock` (the `content-hash` field)

## Impact

Every open PR is failing CI at the dependency install step — no tests are running. This unblocks all of them.

## Test plan

- [ ] Verify CI passes `poetry install` step on this PR
- [ ] Confirm other PRs unblock after merging