### PR TITLE
fix(proxy): pass-through endpoints with auth:false no longer crash wh…

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -90,6 +90,8 @@ class JWTHandler:
 
     @staticmethod
     def is_jwt(token: str):
+        if not token:
+            return False
         parts = token.split(".")
         return len(parts) == 3
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -558,6 +558,15 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         pass_through_endpoints: Optional[List[dict]] = general_settings.get(
             "pass_through_endpoints", None
         )
+        # EARLY BAIL-OUT: if this route is a pass-through endpoint with auth disabled, return immediately before any token parsing that would crash on a None api_key.
+        if pass_through_endpoints is not None:
+            for _endpoint in pass_through_endpoints:
+                if (
+                    isinstance(_endpoint, dict)
+                    and _endpoint.get("path", "") == route
+                    and _endpoint.get("auth") is not True
+                ):
+                    return UserAPIKeyAuth()
         ## CHECK IF X-LITELM-API-KEY IS PASSED IN - supercedes Authorization header
         api_key, passed_in_key = get_api_key(
             custom_litellm_key_header=custom_litellm_key_header,

--- a/tests/proxy_unit_tests/test_jwt.py
+++ b/tests/proxy_unit_tests/test_jwt.py
@@ -1331,6 +1331,9 @@ def test_jwt_handler_is_jwt_static_method():
     # Test with empty string
     assert JWTHandler.is_jwt("") == False
 
+    # Test with None
+    assert JWTHandler.is_jwt(None) == False  # type: ignore
+
 
 @pytest.mark.parametrize(
     "requested_model, should_work",

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -1146,3 +1146,108 @@ async def test_user_api_key_from_query_param():
     valid_token = await user_api_key_auth(request=request, api_key="")
     assert valid_token.token == hash_token(user_key)
 
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_value",
+    [
+        False,       # explicit auth: false
+        None,        # auth key absent (default no-auth)
+    ],
+    ids=["auth_false", "auth_absent"],
+)
+async def test_pass_through_auth_disabled_no_authorization_header(auth_value):
+    """
+    Pass-through endpoints with auth:false (or auth absent) must succeed even
+    when no Authorization header is provided.  Before the fix this crashed with
+    AttributeError: 'NoneType' object has no attribute 'split' (issue #23909).
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm
+    import litellm.proxy.proxy_server
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    endpoint = {"path": "/my/custom/endpoint"}
+    if auth_value is not None:
+        endpoint["auth"] = auth_value
+
+    with patch.object(
+        litellm.proxy.proxy_server,
+        "general_settings",
+        {"pass_through_endpoints": [endpoint]},
+    ):
+        setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+        setattr(litellm.proxy.proxy_server, "prisma_client", "hello-world")
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/my/custom/endpoint")
+
+        # No Authorization header — api_key is empty string (FastAPI default)
+        result = await user_api_key_auth(request=request, api_key="")
+
+    assert isinstance(result, UserAPIKeyAuth)
+
+
+@pytest.mark.asyncio
+async def test_pass_through_auth_enabled_no_key_raises():
+    """
+    Pass-through endpoints with auth:true must still enforce authentication.
+    A missing API key should raise an exception, not silently pass.
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm
+    import litellm.proxy.proxy_server
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    endpoint = {"path": "/my/authed/endpoint", "auth": True}
+
+    with patch.object(
+        litellm.proxy.proxy_server,
+        "general_settings",
+        {"pass_through_endpoints": [endpoint]},
+    ):
+        setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+        setattr(litellm.proxy.proxy_server, "prisma_client", "hello-world")
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/my/authed/endpoint")
+
+        with pytest.raises(Exception):
+            await user_api_key_auth(request=request, api_key="")
+
+
+@pytest.mark.asyncio
+async def test_pass_through_auth_disabled_unmatched_route_still_enforces_auth():
+    """
+    The early bail-out must only fire for the matching route.
+    A request to a different route should go through normal auth enforcement.
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm
+    import litellm.proxy.proxy_server
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    # endpoint registered for /my/custom/endpoint but we request /other/route
+    endpoint = {"path": "/my/custom/endpoint", "auth": False}
+
+    with patch.object(
+        litellm.proxy.proxy_server,
+        "general_settings",
+        {"pass_through_endpoints": [endpoint]},
+    ):
+        setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+        setattr(litellm.proxy.proxy_server, "prisma_client", "hello-world")
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/other/route")
+
+        with pytest.raises(Exception):
+            await user_api_key_auth(request=request, api_key="")
+


### PR DESCRIPTION
fix(proxy): pass-through endpoints with auth:false no longer crash when Authorization header is absent

Adds an early bail-out in _user_api_key_auth_builder for pass-through
endpoints configured with auth:false, returning an empty UserAPIKeyAuth
before any token parsing occurs. Also adds a None guard to
JWTHandler.is_jwt() as defense-in-depth.

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #23909

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
