### PR TITLE
chore: apply black formatting to fix lint CI

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1460,9 +1460,7 @@ class Logging(LiteLLMLoggingBaseClass):
         # streaming) don't carry _hidden_params["model_id"] like ModelResponse does.
         if router_model_id is None and hasattr(self, "litellm_params"):
             for metadata_key in ("litellm_metadata", "metadata"):
-                _metadata: dict = (
-                    self.litellm_params.get(metadata_key, {}) or {}
-                )
+                _metadata: dict = self.litellm_params.get(metadata_key, {}) or {}
                 _model_info: dict = _metadata.get("model_info", {}) or {}
                 _model_id = _model_info.get("id")
                 if _model_id is not None:
@@ -2972,8 +2970,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if (
                         isinstance(callback, CustomLogger)
                         and is_sync_request
-                        and self.call_type
-                        != CallTypes.pass_through.value
+                        and self.call_type != CallTypes.pass_through.value
                     ):  # custom logger class
                         callback.log_failure_event(
                             start_time=start_time,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3334,7 +3334,9 @@ def _convert_teams_to_response_models(
     use_deleted_table: bool,
 ) -> List[Union[TeamListItem, LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]]:
     """Convert raw Prisma team rows to response models."""
-    team_list: List[Union[TeamListItem, LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]] = []
+    team_list: List[
+        Union[TeamListItem, LiteLLM_TeamTable, LiteLLM_DeletedTeamTable]
+    ] = []
     for team in teams:
         try:
             team_dict = team.model_dump()


### PR DESCRIPTION
## Summary

- Applies `black` formatting to 2 files that were causing the lint CI job to fail
- `litellm/litellm_core_utils/litellm_logging.py`
- `litellm/proxy/management_endpoints/team_endpoints.py`

## Test plan

- [ ] Verify lint CI passes