### PR TITLE
fix(ollama): properly parse tool_calls with dict arguments

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -377,6 +377,20 @@ class OllamaChatConfig(BaseConfig):
                 response_json_message["reasoning_content"] = reasoning_content
                 response_json_message["content"] = content
 
+        # Handle tool_calls explicitly - ensure they're properly converted
+        # Fixes: https://github.com/BerriAI/litellm/issues/24091
+        tool_calls = response_json_message.get("tool_calls") if response_json_message else None
+        if tool_calls and isinstance(tool_calls, list):
+            converted_tool_calls = []
+            for tc in tool_calls:
+                # Ensure arguments is a string (not a dict) for ChatCompletionMessageToolCall
+                if "function" in tc:
+                    func = tc["function"]
+                    if "arguments" in func and isinstance(func["arguments"], dict):
+                        tc["function"]["arguments"] = json.dumps(func["arguments"])
+                converted_tool_calls.append(tc)
+            response_json_message["tool_calls"] = converted_tool_calls
+
         if (
             request_data.get("format", "") == "json"
             and litellm_params.get("function_name") is not None


### PR DESCRIPTION
## Summary

Ollama returns `tool_calls` with `arguments` as a dict, but `ChatCompletionMessageToolCall` expects `arguments` to be a JSON string. This fix converts dict arguments to JSON strings before passing to the Message constructor.

## Problem

When using LiteLLM to call an Ollama model (e.g., qwen3.5:9b) with tool definitions, the response from Ollama contains a valid `tool_calls` field, but LiteLLM does not expose it in the returned ModelResponse object. The `message.tool_calls` is None, and the model's text response is returned instead.

## Root Cause

The Ollama API returns:
```json
{
  "message": {
    "tool_calls": [{
      "id": "call_xxx",
      "function": {
        "name": "get_weather",
        "arguments": {"location": "Beijing", "date": "tomorrow"}
      }
    }]
  }
}
```

The `arguments` field is a dict, but `ChatCompletionMessageToolCall` expects it to be a string (JSON serialized).

## Fix

Before creating the Message object, check if tool_calls exist and convert any dict arguments to JSON strings:

```python
if tool_calls and isinstance(tool_calls, list):
    converted_tool_calls = []
    for tc in tool_calls:
        if "function" in tc:
            func = tc["function"]
            if "arguments" in func and isinstance(func["arguments"], dict):
                tc["function"]["arguments"] = json.dumps(func["arguments"])
        converted_tool_calls.append(tc)
    response_json_message["tool_calls"] = converted_tool_calls
```

## Testing

Tested with Ollama qwen3.5:9b model with function calling - tool_calls are now properly parsed and returned in the ModelResponse.

Fixes: https://github.com/BerriAI/litellm/issues/24091