### PR TITLE
fix(anthropic): pass output_config parameter through to Messages API

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -210,6 +210,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             params.append("thinking")
             params.append("reasoning_effort")
 
+        # output_config is supported for all Anthropic models (effort, schema settings)
+        params.append("output_config")
+
         return params
 
     @staticmethod

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3321,3 +3321,34 @@ def test_map_tool_helper_empty_parameters_get_default():
     assert result is not None
     assert result["input_schema"]["type"] == "object"
     assert result["input_schema"].get("properties") == {}
+
+
+def test_output_config_in_supported_params():
+    """
+    Test that output_config is listed in get_supported_openai_params for all
+    Anthropic models. This ensures the parameter is not silently dropped before
+    reaching transform_request().
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23380
+    """
+    config = AnthropicConfig()
+
+    # Standard model — must include output_config
+    params = config.get_supported_openai_params(model="claude-3-5-sonnet-20241022")
+    assert "output_config" in params, (
+        "output_config must be in supported params for standard claude models"
+    )
+
+    # Claude 4.6 model — must also include output_config
+    params_46 = config.get_supported_openai_params(model="claude-opus-4-6-20251101")
+    assert "output_config" in params_46, (
+        "output_config must be in supported params for claude-4.6 models"
+    )
+
+    # Reasoning model — must also include output_config
+    params_reasoning = config.get_supported_openai_params(
+        model="claude-3-7-sonnet-20250219"
+    )
+    assert "output_config" in params_reasoning, (
+        "output_config must be in supported params for reasoning models"
+    )


### PR DESCRIPTION
Fixes #23380

## Problem

`output_config` parameter is silently dropped when calling Anthropic Messages API through LiteLLM. The transformation logic in `transform_request()` already handles `output_config` correctly (lines 1429–1442), but the parameter never reaches it because it was not included in `get_supported_openai_params()`. LiteLLM filters out any parameter not on the supported list before calling `transform_request()`.

## Root Cause

`get_supported_openai_params()` in `litellm/llms/anthropic/chat/transformation.py` was missing `output_config`, so users who passed `output_config` (for effort/schema settings) would either get an `UnsupportedParamsError` or have the parameter silently dropped when `drop_params=True`.

## Fix

Added `output_config` to the list returned by `get_supported_openai_params()` for all Anthropic models. This allows the parameter to flow through to the existing transformation code.

```python
# litellm/llms/anthropic/chat/transformation.py
params.append("output_config")
```

## Tests

Added `test_output_config_in_supported_params` to verify `output_config` appears in supported params for standard, Claude 4.6, and reasoning models.