### PR TITLE
fix: close aiohttp sessions on proxy shutdown to prevent fd leaks

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -244,6 +244,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 await session.close()
         self._loop_sessions.clear()
 
+    async def async_close(self) -> None:
+        """Close resources held by this guardrail (called on proxy shutdown)."""
+        await self._close_http_session()
+
     def __del__(self):
         """Cleanup: we try to close, but doing async cleanup in __del__ is risky."""
         pass

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -976,9 +976,9 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 
     # Shutdown event - close guardrail/callback resources (e.g. presidio aiohttp sessions)
     for callback in litellm.callbacks:
-        if hasattr(callback, "async_close") and callable(callback.async_close):
+        if hasattr(callback, "async_close") and callable(callback.async_close):  # type: ignore[union-attr]
             try:
-                await callback.async_close()
+                await callback.async_close()  # type: ignore[union-attr]
             except Exception as e:
                 verbose_proxy_logger.error(
                     f"Error closing callback {type(callback).__name__}: {e}"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -963,6 +963,27 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
         except Exception as e:
             verbose_proxy_logger.error(f"Error closing shared aiohttp session: {e}")
 
+    # Shutdown event - close cached async HTTP clients (base_llm_aiohttp_handler, etc.)
+    try:
+        from litellm.llms.custom_httpx.async_client_cleanup import (
+            close_litellm_async_clients,
+        )
+
+        await close_litellm_async_clients()
+        verbose_proxy_logger.info("Closed cached async HTTP clients")
+    except Exception as e:
+        verbose_proxy_logger.error(f"Error closing cached async HTTP clients: {e}")
+
+    # Shutdown event - close guardrail/callback resources (e.g. presidio aiohttp sessions)
+    for callback in litellm.callbacks:
+        if hasattr(callback, "async_close") and callable(callback.async_close):
+            try:
+                await callback.async_close()
+            except Exception as e:
+                verbose_proxy_logger.error(
+                    f"Error closing callback {type(callback).__name__}: {e}"
+                )
+
     # Shutdown event - stop RDS IAM token refresh background task
     if (
         prisma_client is not None


### PR DESCRIPTION
## Summary

Close `aiohttp.ClientSession` instances during proxy shutdown to prevent `Unclosed client session` warnings and potential fd leaks in long-running deployments.

## Changes

### 1. Close cached async HTTP clients on shutdown (`proxy_server.py`)
- Call `close_litellm_async_clients()` during the proxy shutdown sequence
- This ensures the global `base_llm_aiohttp_handler` singleton and all cached async HTTP clients are properly closed via the async shutdown path, rather than relying solely on the `atexit` handler which creates a new event loop and is less reliable

### 2. Close guardrail/callback resources on shutdown (`proxy_server.py`)
- Iterate `litellm.callbacks` and call `async_close()` on any callback that implements it
- General-purpose pattern that future guardrails/callbacks can adopt

### 3. Add `async_close()` to Presidio guardrail (`presidio.py`)
- Expose `async_close()` public method that delegates to existing `_close_http_session()`
- Called automatically during proxy shutdown via the callback cleanup loop

## Motivation

When running the LiteLLM proxy in production (long-running K8s pods), we observed repeated `Unclosed client session` warnings at ERROR level during GC:

```
{"message": "Unclosed client session\nclient_session: <aiohttp.client.ClientSession object at 0x7fed181e3210>", "level": "ERROR"}
```

While these don't affect request processing, they indicate sessions that are only cleaned up by GC rather than explicit close, which can lead to fd exhaustion over time.

## Test plan

- [ ] Verify proxy starts and shuts down cleanly without `Unclosed client session` warnings
- [ ] Verify existing guardrail tests pass
- [ ] Verify no regression in proxy functionality