### PR TITLE
fix(anthropic): skip tools without name key in guardrail tool translation

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -781,6 +781,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 new_tools.append(tool)  # type: ignore[arg-type]
                 continue
 
+            if "name" not in tool:
+                continue
+
             original_name = tool["name"]
             truncated_name = truncate_tool_name(original_name)
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1663,6 +1663,24 @@ def test_translate_anthropic_tools_mixed_names():
     assert len(tool_name_mapping) == 1
 
 
+def test_translate_anthropic_tools_skips_tools_without_name():
+    """Tools without a 'name' key should be skipped instead of raising KeyError."""
+    tools = [
+        {"name": "get_weather", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}},
+        {"type": "custom_tool_without_name", "description": "no name field"},
+        {},
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result, tool_name_mapping = adapter.translate_anthropic_tools_to_openai(
+        tools=tools, model="gpt-4"
+    )
+
+    assert len(result) == 1
+    assert result[0]["function"]["name"] == "get_weather"
+    assert len(tool_name_mapping) == 0
+
+
 def test_translate_openai_response_restores_tool_names():
     """Tool names in responses should be restored to original."""
     original_name = "a_very_long_tool_name_that_needs_truncation_for_openai_api_compatibility"


### PR DESCRIPTION
## Summary
Fixes #23852.

**Root cause:** `translate_anthropic_tools_to_openai()` accesses `tool["name"]` without checking the key exists. When guardrails are configured with `default_on: true` and a request to `/v1/messages` includes tools, the unified guardrail's `async_pre_call_hook` passes `data.copy()` (the full proxy-enriched request dict) to `translate_anthropic_to_openai()`. This dict can contain entries that lack a `"name"` field, causing `KeyError: 'name'` at line 784 of `transformation.py`.

**Fix:** Added a guard to skip tools that don't have a `"name"` key, after the existing Anthropic-hosted tools check. This is consistent with how the method already handles hosted tools (via `continue`).

## Changes
- `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`: Added `if "name" not in tool: continue` guard before accessing `tool["name"]` in `translate_anthropic_tools_to_openai()`.
- `tests/.../test_anthropic_experimental_pass_through_adapters_transformation.py`: Added `test_translate_anthropic_tools_skips_tools_without_name` to verify tools without `"name"` are skipped gracefully.

## Testing
- Added unit test confirming tools without `"name"` are skipped and valid tools are still translated
- Verified fix addresses the reported scenario (guardrail + tools on `/v1/messages`)
- Change is minimal (3 lines) and follows existing skip pattern in the same loop

Made with [Cursor](https://cursor.com)