### PR TITLE
fix(vertex): respect vertex_count_tokens_location for Claude models

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -105,27 +105,21 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         # Extract Vertex AI credentials and settings
         vertex_credentials = self.get_vertex_ai_credentials(litellm_params)
         vertex_project = self.get_vertex_ai_project(litellm_params)
+        vertex_location = self.get_vertex_ai_location(litellm_params)
 
-        # Check for count_tokens specific location override
-        vertex_count_tokens_location = litellm_params.get(
+        # common_utils.py already resolves vertex_count_tokens_location and
+        # passes it as vertex_location through the call chain.
+        # Only override to us-central1 when the user did NOT explicitly set
+        # vertex_count_tokens_location -- this preserves backwards compat for
+        # users whose vertex_location is "global" or another unsupported region.
+        # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+        explicit_count_tokens_location = litellm_params.get(
             "vertex_count_tokens_location"
         )
-        vertex_location_raw = self.get_vertex_ai_location(litellm_params)
-
-        # Determine final location with precedence:
-        # 1. vertex_count_tokens_location (if provided)
-        # 2. vertex_location (if provided)
-        # 3. Default to us-east5 for Claude models when no location is set
-        # Supported regions: us-east5, europe-west1, asia-southeast1
-        # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
-        if vertex_count_tokens_location:
-            vertex_location: str = vertex_count_tokens_location
-        elif vertex_location_raw:
-            vertex_location = vertex_location_raw
-        elif "claude" in model.lower():
-            vertex_location = "us-east5"
-        else:
-            vertex_location = "us-east5"
+        if explicit_count_tokens_location:
+            vertex_location = explicit_count_tokens_location
+        elif not vertex_location or "claude" in model.lower():
+            vertex_location = "us-central1"
 
         # Get access token and resolved project ID
         access_token, project_id = await self._ensure_access_token_async(

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -5,6 +5,7 @@ This handler provides token counting for partner models hosted on Vertex AI.
 Unlike Gemini models which use Google's token counting API, partner models use
 their respective publisher-specific count-tokens endpoints.
 """
+
 from typing import Any, Dict, Optional
 
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -108,19 +108,20 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         vertex_project = self.get_vertex_ai_project(litellm_params)
         vertex_location = self.get_vertex_ai_location(litellm_params)
 
-        # common_utils.py already resolves vertex_count_tokens_location and
-        # passes it as vertex_location through the call chain.
-        # Only override to us-central1 when the user did NOT explicitly set
-        # vertex_count_tokens_location -- this preserves backwards compat for
-        # users whose vertex_location is "global" or another unsupported region.
+        # Resolve the location used for the count-tokens endpoint with the
+        # following precedence:
+        #   1. vertex_count_tokens_location (explicit override) wins
+        #   2. vertex_location (if explicitly set) is respected
+        #   3. Claude models with no location set default to us-east5
+        # Supported Claude regions: us-east5, europe-west1, asia-southeast1
         # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
         explicit_count_tokens_location = litellm_params.get(
             "vertex_count_tokens_location"
         )
         if explicit_count_tokens_location:
             vertex_location = explicit_count_tokens_location
-        elif not vertex_location or "claude" in model.lower():
-            vertex_location = "us-central1"
+        elif not vertex_location and "claude" in model.lower():
+            vertex_location = "us-east5"
 
         # Get access token and resolved project ID
         access_token, project_id = await self._ensure_access_token_async(


### PR DESCRIPTION
## Summary
- Check `vertex_count_tokens_location` from `litellm_params` before falling back to `vertex_location`
- Only override to `us-central1` when `vertex_count_tokens_location` is not explicitly set

## Root Cause
`handler.py` unconditionally overrides `vertex_location` to `us-central1` when `"claude"` is in the model name, ignoring any explicitly configured `vertex_count_tokens_location`. The fix in `common_utils.py` correctly resolves the location, but `handler.py` nullifies it downstream.

## Changes
- `litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py`: Check `vertex_count_tokens_location` first, only fall back to `us-central1` when not set

Fixes #23872
