### PR TITLE
fix(proxy): sync model_call_details call_type after normalization in …

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1885,16 +1885,19 @@ class ProxyLogging:
                 litellm_logging_obj.model_call_details["messages"] = input
                 if litellm_logging_obj.call_type != CallTypes.pass_through.value:
                     litellm_logging_obj.call_type = CallTypes.acompletion.value
+                    litellm_logging_obj.model_call_details["call_type"] = litellm_logging_obj.call_type
             elif "prompt" in request_data and isinstance(request_data["prompt"], str):
                 input = request_data["prompt"]
                 litellm_logging_obj.model_call_details["prompt"] = input
                 if litellm_logging_obj.call_type != CallTypes.pass_through.value:
                     litellm_logging_obj.call_type = CallTypes.atext_completion.value
+                    litellm_logging_obj.model_call_details["call_type"] = litellm_logging_obj.call_type
             elif "input" in request_data and isinstance(request_data["input"], list):
                 input = request_data["input"]
                 litellm_logging_obj.model_call_details["input"] = input
                 if litellm_logging_obj.call_type != CallTypes.pass_through.value:
                     litellm_logging_obj.call_type = CallTypes.aembedding.value
+                    litellm_logging_obj.model_call_details["call_type"] = litellm_logging_obj.call_type
             # Pass-through endpoints are logged via the callback loop's
             # async_post_call_failure_hook — skip pre_call and failure handlers.
             if litellm_logging_obj.call_type == CallTypes.pass_through.value:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1885,19 +1885,25 @@ class ProxyLogging:
                 litellm_logging_obj.model_call_details["messages"] = input
                 if litellm_logging_obj.call_type != CallTypes.pass_through.value:
                     litellm_logging_obj.call_type = CallTypes.acompletion.value
-                    litellm_logging_obj.model_call_details["call_type"] = litellm_logging_obj.call_type
+                    litellm_logging_obj.model_call_details["call_type"] = (
+                        litellm_logging_obj.call_type
+                    )
             elif "prompt" in request_data and isinstance(request_data["prompt"], str):
                 input = request_data["prompt"]
                 litellm_logging_obj.model_call_details["prompt"] = input
                 if litellm_logging_obj.call_type != CallTypes.pass_through.value:
                     litellm_logging_obj.call_type = CallTypes.atext_completion.value
-                    litellm_logging_obj.model_call_details["call_type"] = litellm_logging_obj.call_type
+                    litellm_logging_obj.model_call_details["call_type"] = (
+                        litellm_logging_obj.call_type
+                    )
             elif "input" in request_data and isinstance(request_data["input"], list):
                 input = request_data["input"]
                 litellm_logging_obj.model_call_details["input"] = input
                 if litellm_logging_obj.call_type != CallTypes.pass_through.value:
                     litellm_logging_obj.call_type = CallTypes.aembedding.value
-                    litellm_logging_obj.model_call_details["call_type"] = litellm_logging_obj.call_type
+                    litellm_logging_obj.model_call_details["call_type"] = (
+                        litellm_logging_obj.call_type
+                    )
             # Pass-through endpoints are logged via the callback loop's
             # async_post_call_failure_hook — skip pre_call and failure handlers.
             if litellm_logging_obj.call_type == CallTypes.pass_through.value:


### PR DESCRIPTION
## Summary
- Sync `model_call_details["call_type"]` after normalizing `litellm_logging_obj.call_type` in `_handle_logging_proxy_only_error`

## Root Cause
The method updates `logging_obj.call_type` to the normalized value (e.g. `acompletion`) but never syncs `logging_obj.model_call_details["call_type"]`. Standard logging payloads are built from `model_call_details`, so downstream callbacks receive the stale route-based value (e.g. `/v1/completions`).

## Changes
- `litellm/proxy/utils.py`: Add `model_call_details["call_type"]` sync after each `call_type` assignment in the three request-type branches

Fixes #24049
