### PR TITLE
feat(proxy): use AZURE_DEFAULT_API_VERSION for proxy --api_version default

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -12,6 +12,7 @@ import click
 import httpx
 from dotenv import load_dotenv
 
+import litellm
 from litellm.constants import DEFAULT_NUM_WORKERS_LITELLM_PROXY
 from litellm.secret_managers.main import get_secret_bool
 
@@ -387,7 +388,7 @@ class ProxyInitializationHelpers:
 @click.option("--api_base", default=None, help="API base URL.")
 @click.option(
     "--api_version",
-    default="2024-07-01-preview",
+    default=litellm.AZURE_DEFAULT_API_VERSION,
     help="For azure - pass in the api version.",
 )
 @click.option(

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -281,6 +281,47 @@ class TestProxyInitializationHelpers:
             mock_uvicorn_run.assert_called_once()
 
     @patch("uvicorn.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False)
+    def test_proxy_default_api_version_uses_azure_default(
+        self, mock_should_update, mock_setup_db, mock_atexit_register, mock_uvicorn_run
+    ):
+        """Proxy default api_version should match litellm.AZURE_DEFAULT_API_VERSION for consistency."""
+        from click.testing import CliRunner
+
+        import litellm
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        clean_env = {k: v for k, v in os.environ.items() if k not in ("DATABASE_URL", "DIRECT_URL")}
+        with patch.dict(os.environ, clean_env, clear=True), patch.dict(
+            "sys.modules",
+            {
+                "proxy_server": mock_proxy_module,
+                "litellm.proxy.proxy_server": mock_proxy_module,
+            },
+        ), patch(
+            "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+        ) as mock_get_args:
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+            result = runner.invoke(run_server, ["--local", "--skip_server_startup"])
+            assert result.exit_code == 0, f"exit_code={result.exit_code}, output={result.output}"
+            mock_proxy_module.save_worker_config.assert_called_once()
+            call_kwargs = mock_proxy_module.save_worker_config.call_args[1]
+            assert call_kwargs["api_version"] == litellm.AZURE_DEFAULT_API_VERSION
+
+    @patch("uvicorn.run")
     @patch("builtins.print")
     def test_keepalive_timeout_flag(self, mock_print, mock_uvicorn_run):
         """Test that the keepalive_timeout flag is properly passed to uvicorn"""


### PR DESCRIPTION
## Summary
Aligns the proxy's default `--api_version` with `litellm.AZURE_DEFAULT_API_VERSION` (2025-02-01-preview) instead of the hardcoded 2024-07-01-preview.

## Motivation
With the old default (2024-07-01-preview), Azure chat completions using `response_format` + `json_schema` fall back to the tools-based approach. For models like gpt-4.1-mini, this returns empty `{}` instead of structured JSON. Native `response_format` requires API version >= 2024-08-01.

## Changes
- Proxy `--api_version` default now uses `litellm.AZURE_DEFAULT_API_VERSION`
- Added `test_proxy_default_api_version_uses_azure_default` to verify the default

