### PR TITLE
docs: fix duplicate word typos across 6 documentation pages

### DIFF
--- a/docs/my-website/docs/guides/security_settings.md
+++ b/docs/my-website/docs/guides/security_settings.md
@@ -13,7 +13,7 @@ LiteLLM uses HTTPX for network requests, unless otherwise specified.
 
 ## 1. Custom CA Bundle
 
-You can set a custom CA bundle file path using the `SSL_CERT_FILE` environmental variable or passing a string to the the ssl_verify setting.
+You can set a custom CA bundle file path using the `SSL_CERT_FILE` environmental variable or passing a string to the ssl_verify setting.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">

--- a/docs/my-website/docs/providers/lemonade.md
+++ b/docs/my-website/docs/providers/lemonade.md
@@ -185,7 +185,7 @@ print("Available models:", [model['id'] for model in models.get('data', [])])
 
 ## Support
 
-For more information regarding Lemonade please go to to the [Lemonade website](https://lemonade-server.ai/) or [Lemonade repository](https://github.com/lemonade-sdk/lemonade).
+For more information regarding Lemonade please go to the [Lemonade website](https://lemonade-server.ai/) or [Lemonade repository](https://github.com/lemonade-sdk/lemonade).
 
 </TabItem>
 </Tabs>

--- a/docs/my-website/docs/proxy/architecture.md
+++ b/docs/my-website/docs/proxy/architecture.md
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
     - 2.1 Check if the Virtual Key exists in Redis Cache or In Memory Cache
     - 2.2 **If not in Cache**, Lookup Virtual Key in DB
 
-3. **Rate Limiting**: The [MaxParallelRequestsHandler](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/hooks/parallel_request_limiter.py) checks the **rate limit (rpm/tpm)** for the the following components:
+3. **Rate Limiting**: The [MaxParallelRequestsHandler](https://github.com/BerriAI/litellm/blob/main/litellm/proxy/hooks/parallel_request_limiter.py) checks the **rate limit (rpm/tpm)** for the following components:
     - Global Server Rate Limit
     - Virtual Key Rate Limit
     - User Rate Limit

--- a/docs/my-website/docs/proxy/cost_tracking.md
+++ b/docs/my-website/docs/proxy/cost_tracking.md
@@ -169,7 +169,7 @@ Schedule a [meeting with us to get your Enterprise License](https://calendly.com
 
 ##### Create Key
 
-Create Key with with `permissions={"get_spend_routes": true}`
+Create Key with `permissions={"get_spend_routes": true}`
 
 ```shell title="Generate Key with Spend Route Permissions" showLineNumbers
 curl --location 'http://0.0.0.0:4000/key/generate' \

--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -380,7 +380,7 @@ The proxy will log a warning about the UI but API endpoints will work normally.
 
 ## 10. Use a Separate Health Check App
 :::info
-The Separate Health Check App only runs when running via the the LiteLLM Docker Image and using Docker and setting the SEPARATE_HEALTH_APP env var to "1"
+The Separate Health Check App only runs when running via the LiteLLM Docker Image and using Docker and setting the SEPARATE_HEALTH_APP env var to "1"
 :::
 
 Using a separate health check app ensures that your liveness and readiness probes remain responsive even when the main application is under heavy load. 

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -61,7 +61,7 @@ This directory is used by the Prometheus client library to store metric files th
 
 ## Virtual Keys, Teams, Internal Users
 
-Use this for for tracking per [user, key, team, etc.](virtual_keys)
+Use this for tracking per [user, key, team, etc.](virtual_keys)
 
 | Metric Name          | Description                          |
 |----------------------|--------------------------------------|


### PR DESCRIPTION
## Summary

Fixes 6 instances of duplicate/repeated words found across the documentation:

| File | Typo | Fix |
|---|---|---|
| `docs/proxy/prod.md` | "the the LiteLLM Docker Image" | "the LiteLLM Docker Image" |
| `docs/proxy/architecture.md` | "for the the following components" | "for the following components" |
| `docs/guides/security_settings.md` | "to the the ssl_verify setting" | "to the ssl_verify setting" |
| `docs/proxy/prometheus.md` | "Use this for for tracking" | "Use this for tracking" |
| `docs/proxy/cost_tracking.md` | "Create Key with with" | "Create Key with" |
| `docs/providers/lemonade.md` | "please go to to the" | "please go to the" |

## Test plan

- [x] Verified each fix is a genuine typo (not inside code blocks or example output)
- [x] No functional changes, documentation text only
- [x] Excluded false positive in `assembly_ai.md` (duplicate word is part of a transcription prompt example)