### PR TITLE
fix(vertex-ai): align partner model pricing with Vertex AI

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30678,28 +30678,38 @@
         ]
     },
     "vertex_ai/claude-3-5-haiku": {
-        "input_cost_per_token": 1e-06,
+        "cache_creation_input_token_cost": 1e-06,
+        "cache_read_input_token_cost": 8e-08,
+        "input_cost_per_token": 8e-07,
+        "input_cost_per_token_batches": 4e-07,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 5e-06,
+        "output_cost_per_token": 4e-06,
+        "output_cost_per_token_batches": 2e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "vertex_ai/claude-3-5-haiku@20241022": {
-        "input_cost_per_token": 1e-06,
+        "cache_creation_input_token_cost": 1e-06,
+        "cache_read_input_token_cost": 8e-08,
+        "input_cost_per_token": 8e-07,
+        "input_cost_per_token_batches": 4e-07,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 5e-06,
+        "output_cost_per_token": 4e-06,
+        "output_cost_per_token_batches": 2e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_pdf_input": true,
         "supports_tool_choice": true
     },
@@ -30806,6 +30816,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-3-haiku": {
+        "cache_creation_input_token_cost": 3e-07,
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -30819,6 +30831,8 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-haiku@20240307": {
+        "cache_creation_input_token_cost": 3e-07,
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -31303,13 +31317,16 @@
         "supports_tool_choice": true
     },
     "vertex_ai/deepseek-ai/deepseek-v3.1-maas": {
-        "input_cost_per_token": 1.35e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_token": 6e-07,
+        "input_cost_per_token_batches": 3e-07,
         "litellm_provider": "vertex_ai-deepseek_models",
         "max_input_tokens": 163840,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 5.4e-06,
+        "output_cost_per_token": 1.7e-06,
+        "output_cost_per_token_batches": 8.5e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supported_regions": [
             "us-west2"
@@ -31321,6 +31338,7 @@
         "supports_tool_choice": true
     },
     "vertex_ai/deepseek-ai/deepseek-v3.2-maas": {
+        "cache_read_input_token_cost": 5.6e-08,
         "input_cost_per_token": 5.6e-07,
         "input_cost_per_token_batches": 2.8e-07,
         "litellm_provider": "vertex_ai-deepseek_models",
@@ -31705,6 +31723,7 @@
         "supports_tool_choice": true
     },
     "vertex_ai/minimaxai/minimax-m2-maas": {
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-minimax_models",
         "max_input_tokens": 196608,
@@ -31717,6 +31736,7 @@
         "supports_tool_choice": true
     },
     "vertex_ai/moonshotai/kimi-k2-thinking-maas": {
+        "cache_read_input_token_cost": 6e-08,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "vertex_ai-moonshot_models",
         "max_input_tokens": 256000,
@@ -31868,25 +31888,25 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-small-2503": {
-        "input_cost_per_token": 1e-06,
+        "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 3e-06,
+        "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
     "vertex_ai/mistral-small-2503@001": {
-        "input_cost_per_token": 1e-06,
+        "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
-        "output_cost_per_token": 3e-06,
+        "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -31908,35 +31928,42 @@
         "source": "https://cloud.google.com/vertex-ai/pricing"
     },
     "vertex_ai/openai/gpt-oss-120b-maas": {
-        "input_cost_per_token": 1.5e-07,
+        "input_cost_per_token": 9e-08,
+        "input_cost_per_token_batches": 4.5e-08,
         "litellm_provider": "vertex_ai-openai_models",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 6e-07,
+        "output_cost_per_token": 3.6e-07,
+        "output_cost_per_token_batches": 1.8e-07,
         "source": "https://console.cloud.google.com/vertex-ai/publishers/openai/model-garden/gpt-oss-120b-maas",
         "supports_reasoning": true
     },
     "vertex_ai/openai/gpt-oss-20b-maas": {
+        "cache_read_input_token_cost": 7e-09,
         "input_cost_per_token": 7.5e-08,
+        "input_cost_per_token_batches": 3.5e-08,
         "litellm_provider": "vertex_ai-openai_models",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.5e-07,
+        "output_cost_per_token_batches": 1.25e-07,
         "source": "https://console.cloud.google.com/vertex-ai/publishers/openai/model-garden/gpt-oss-120b-maas",
         "supports_reasoning": true
     },
     "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
-        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_batches": 1.1e-07,
         "litellm_provider": "vertex_ai-qwen_models",
         "max_input_tokens": 262144,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
-        "output_cost_per_token": 1e-06,
+        "output_cost_per_token": 8.8e-07,
+        "output_cost_per_token_batches": 4.4e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_regions": [
             "global"
@@ -31945,13 +31972,16 @@
         "supports_tool_choice": true
     },
     "vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas": {
-        "input_cost_per_token": 1e-06,
+        "cache_read_input_token_cost": 2.2e-08,
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_batches": 1.1e-07,
         "litellm_provider": "vertex_ai-qwen_models",
         "max_input_tokens": 262144,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 4e-06,
+        "output_cost_per_token": 1.8e-06,
+        "output_cost_per_token_batches": 9e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_regions": [
             "global"

--- a/tests/test_litellm/test_vertex_ai_pricing_config.py
+++ b/tests/test_litellm/test_vertex_ai_pricing_config.py
@@ -1,0 +1,140 @@
+import json
+import os
+
+import pytest
+
+
+def _load_model_data():
+    json_path = os.path.join(
+        os.path.dirname(__file__), "../../model_prices_and_context_window.json"
+    )
+    with open(json_path) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        (
+            "vertex_ai/claude-3-5-haiku",
+            {
+                "input_cost_per_token": 8e-07,
+                "output_cost_per_token": 4e-06,
+                "cache_creation_input_token_cost": 1e-06,
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token_batches": 4e-07,
+                "output_cost_per_token_batches": 2e-06,
+            },
+        ),
+        (
+            "vertex_ai/claude-3-5-haiku@20241022",
+            {
+                "input_cost_per_token": 8e-07,
+                "output_cost_per_token": 4e-06,
+                "cache_creation_input_token_cost": 1e-06,
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token_batches": 4e-07,
+                "output_cost_per_token_batches": 2e-06,
+            },
+        ),
+        (
+            "vertex_ai/claude-3-haiku",
+            {
+                "cache_creation_input_token_cost": 3e-07,
+                "cache_read_input_token_cost": 3e-08,
+            },
+        ),
+        (
+            "vertex_ai/claude-3-haiku@20240307",
+            {
+                "cache_creation_input_token_cost": 3e-07,
+                "cache_read_input_token_cost": 3e-08,
+            },
+        ),
+        (
+            "vertex_ai/deepseek-ai/deepseek-v3.1-maas",
+            {
+                "input_cost_per_token": 6e-07,
+                "output_cost_per_token": 1.7e-06,
+                "cache_read_input_token_cost": 6e-08,
+                "input_cost_per_token_batches": 3e-07,
+                "output_cost_per_token_batches": 8.5e-07,
+            },
+        ),
+        (
+            "vertex_ai/deepseek-ai/deepseek-v3.2-maas",
+            {
+                "cache_read_input_token_cost": 5.6e-08,
+            },
+        ),
+        (
+            "vertex_ai/minimaxai/minimax-m2-maas",
+            {
+                "cache_read_input_token_cost": 3e-08,
+            },
+        ),
+        (
+            "vertex_ai/moonshotai/kimi-k2-thinking-maas",
+            {
+                "cache_read_input_token_cost": 6e-08,
+            },
+        ),
+        (
+            "vertex_ai/mistral-small-2503",
+            {
+                "input_cost_per_token": 1e-07,
+                "output_cost_per_token": 3e-07,
+            },
+        ),
+        (
+            "vertex_ai/mistral-small-2503@001",
+            {
+                "input_cost_per_token": 1e-07,
+                "output_cost_per_token": 3e-07,
+            },
+        ),
+        (
+            "vertex_ai/openai/gpt-oss-120b-maas",
+            {
+                "input_cost_per_token": 9e-08,
+                "output_cost_per_token": 3.6e-07,
+                "input_cost_per_token_batches": 4.5e-08,
+                "output_cost_per_token_batches": 1.8e-07,
+            },
+        ),
+        (
+            "vertex_ai/openai/gpt-oss-20b-maas",
+            {
+                "output_cost_per_token": 2.5e-07,
+                "cache_read_input_token_cost": 7e-09,
+                "input_cost_per_token_batches": 3.5e-08,
+                "output_cost_per_token_batches": 1.25e-07,
+            },
+        ),
+        (
+            "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas",
+            {
+                "input_cost_per_token": 2.2e-07,
+                "output_cost_per_token": 8.8e-07,
+                "input_cost_per_token_batches": 1.1e-07,
+                "output_cost_per_token_batches": 4.4e-07,
+            },
+        ),
+        (
+            "vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas",
+            {
+                "input_cost_per_token": 2.2e-07,
+                "output_cost_per_token": 1.8e-06,
+                "cache_read_input_token_cost": 2.2e-08,
+                "input_cost_per_token_batches": 1.1e-07,
+                "output_cost_per_token_batches": 9e-07,
+            },
+        ),
+    ],
+)
+def test_vertex_ai_pricing_config_matches_vertex_ai_pricing_page(model_name, expected):
+    model_data = _load_model_data()
+
+    assert model_name in model_data, f"Missing model entry: {model_name}"
+    for key, value in expected.items():
+        assert model_data[model_name][key] == value


### PR DESCRIPTION
## Summary
- align several Vertex AI partner model prices with the current Vertex AI pricing page
- add missing cache hit and batch pricing metadata where Vertex AI publishes it
- add a regression test covering the corrected Vertex AI entries

## What changed
- corrected pricing for `vertex_ai/claude-3-5-haiku` and its dated alias
- added missing cache pricing for `vertex_ai/claude-3-haiku` and its dated alias
- corrected `vertex_ai/deepseek-ai/deepseek-v3.1-maas`
- added missing cache pricing for `vertex_ai/deepseek-ai/deepseek-v3.2-maas`
- added missing cache pricing for `vertex_ai/minimaxai/minimax-m2-maas`
- added missing cache pricing for `vertex_ai/moonshotai/kimi-k2-thinking-maas`
- corrected `vertex_ai/mistral-small-2503` and `vertex_ai/mistral-small-2503@001`
- corrected `vertex_ai/openai/gpt-oss-120b-maas` and `vertex_ai/openai/gpt-oss-20b-maas`
- corrected `vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas`
- corrected `vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas`

## Testing
- `pytest -q tests/test_litellm/test_vertex_ai_pricing_config.py`
