### PR TITLE
fix: populate team_member_rpm/tpm_limit for Virtual Key auth flow

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1169,9 +1169,16 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 valid_token
             )  # updating it here, allows all downstream reporting / checks to use the updated budget
 
-            # Populate team_member_rpm_limit / team_member_tpm_limit for Virtual Key auth.
-            # JWT auth flow already gets this from JWTAuthManager.auth_builder(),
-            # but Virtual Key flow never queries team membership. Fix that here.
+            # Bug fix: Populate team_member_rpm_limit / team_member_tpm_limit for Virtual Key auth.
+            #
+            # This is a pure bug fix, not a behaviour change. The JWT auth flow already
+            # enforces per-member rate limits via JWTAuthManager.auth_builder() (see #13601).
+            # The Virtual Key flow was simply missing the equivalent query, causing
+            # team_member_rpm_limit / team_member_tpm_limit to be silently ignored for
+            # all virtual-key requests. Operators who configured per-member limits
+            # always expected them to be enforced; this restores parity between the
+            # two auth paths. No flag is needed because the previous behaviour
+            # (limits not enforced) was unintentional.
             if (
                 valid_token.user_id is not None
                 and valid_token.team_id is not None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -39,6 +39,7 @@ from litellm.proxy.auth.auth_checks import (
     get_jwt_key_mapping_object,
     get_key_object,
     get_project_object,
+    get_team_membership,
     get_team_object,
     get_user_object,
     is_valid_fallback_model,
@@ -1167,6 +1168,39 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             valid_token = _update_key_budget_with_temp_budget_increase(
                 valid_token
             )  # updating it here, allows all downstream reporting / checks to use the updated budget
+
+            # Populate team_member_rpm_limit / team_member_tpm_limit for Virtual Key auth.
+            # JWT auth flow already gets this from JWTAuthManager.auth_builder(),
+            # but Virtual Key flow never queries team membership. Fix that here.
+            if (
+                valid_token.user_id is not None
+                and valid_token.team_id is not None
+                and valid_token.team_member_rpm_limit is None
+                and valid_token.team_member_tpm_limit is None
+            ):
+                try:
+                    _team_membership = await get_team_membership(
+                        user_id=valid_token.user_id,
+                        team_id=valid_token.team_id,
+                        prisma_client=prisma_client,
+                        user_api_key_cache=user_api_key_cache,
+                        parent_otel_span=parent_otel_span,
+                        proxy_logging_obj=proxy_logging_obj,
+                    )
+                    if _team_membership is not None:
+                        valid_token.team_member_rpm_limit = (
+                            _team_membership.safe_get_team_member_rpm_limit()
+                        )
+                        valid_token.team_member_tpm_limit = (
+                            _team_membership.safe_get_team_member_tpm_limit()
+                        )
+                except Exception as e:
+                    verbose_logger.debug(
+                        "user_api_key_auth: Unable to get team membership for "
+                        "user_id={}, team_id={}. Error={}".format(
+                            valid_token.user_id, valid_token.team_id, str(e)
+                        )
+                    )
 
         user_obj: Optional[LiteLLM_UserTable] = None
         valid_token_dict: dict = {}

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1182,8 +1182,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             if (
                 valid_token.user_id is not None
                 and valid_token.team_id is not None
-                and valid_token.team_member_rpm_limit is None
-                and valid_token.team_member_tpm_limit is None
+                and (
+                    valid_token.team_member_rpm_limit is None
+                    or valid_token.team_member_tpm_limit is None
+                )
             ):
                 try:
                     _team_membership = await get_team_membership(


### PR DESCRIPTION
## What does this PR do?

Fixes a gap where `team_member_rpm_limit` and `team_member_tpm_limit` were not being applied for users authenticating via **Virtual Keys**.

## Root Cause

The JWT auth flow already populates `team_member_rpm_limit` / `team_member_tpm_limit` via `JWTAuthManager.auth_builder()`, but the Virtual Key auth flow in `_user_api_key_auth_builder()` never queried team membership. This meant per-member rate limits set on a team were silently ignored for Virtual Key users.

## Fix

After token validation in the Virtual Key path, query team membership and apply `safe_get_team_member_rpm_limit()` / `safe_get_team_member_tpm_limit()` — the same logic already used in the JWT auth path.

```python
# JWT auth already does this (JWTAuthManager.auth_builder)
team_member_rpm_limit=team_membership.safe_get_team_member_rpm_limit()
team_member_tpm_limit=team_membership.safe_get_team_member_tpm_limit()

# Virtual Key auth now also does this (this PR)
_team_membership = await get_team_membership(...)
valid_token.team_member_rpm_limit = _team_membership.safe_get_team_member_rpm_limit()
valid_token.team_member_tpm_limit = _team_membership.safe_get_team_member_tpm_limit()
```

## Testing

- [ ] Set a `team_member_rpm_limit` on a team member
- [ ] Authenticate using a Virtual Key belonging to that user/team
- [ ] Verify the rate limit is enforced

## Related

- Companion to #13601 ([Feat] Team Member Rate Limits + Support for using with JWT Auth) which only fixed the JWT path