### PR TITLE
Fix: missing fields in model LiteLLM_MCPServerTable in schema.prisma

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -320,6 +320,13 @@ model LiteLLM_MCPServerTable {
   is_byok               Boolean  @default(false)
   byok_description      String[] @default([])
   byok_api_key_help_url String?
+  source_url            String?
+  // BYOM submission lifecycle
+  approval_status  String?   @default("active")
+  submitted_by     String?
+  submitted_at     DateTime?
+  reviewed_at      DateTime?
+  review_notes     String?
 }
 
 // Per-user BYOK credentials for MCP servers


### PR DESCRIPTION
## Relevant issues

Fixes #23869 

## Type

🐛 Bug Fix

## Changes

- The schema.prisma file in root was out of sync from other prisma file and that was causing mcp server create to fail because of the missing fields
- Added all missing fields in the schema.prisma 