### PR TITLE
chore: apply black formatting to fix lint CI (batch 2)

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -442,7 +442,9 @@ class DataDogLogger(
         verbose_logger.debug("Datadog: Logger - Logging payload = %s", json_payload)
         dd_payload = DatadogPayload(
             ddsource=get_datadog_source(),
-            ddtags=",".join(get_datadog_tags(standard_logging_object=standard_logging_object)),
+            ddtags=",".join(
+                get_datadog_tags(standard_logging_object=standard_logging_object)
+            ),
             hostname=get_datadog_hostname(),
             message=json_payload,
             service=get_datadog_service(),

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1894,12 +1894,8 @@ class CustomStreamWrapper:
                         getattr(complete_streaming_response, "usage"),
                     )
                     try:
-                        _cache_copy = complete_streaming_response.model_copy(
-                            deep=True
-                        )
-                        _log_copy = complete_streaming_response.model_copy(
-                            deep=True
-                        )
+                        _cache_copy = complete_streaming_response.model_copy(deep=True)
+                        _log_copy = complete_streaming_response.model_copy(deep=True)
                     except RuntimeError:
                         _cache_copy = complete_streaming_response.model_copy()
                         _log_copy = complete_streaming_response.model_copy()
@@ -2122,9 +2118,7 @@ class CustomStreamWrapper:
                         getattr(complete_streaming_response, "usage"),
                     )
                     try:
-                        _copy = complete_streaming_response.model_copy(
-                            deep=True
-                        )
+                        _copy = complete_streaming_response.model_copy(deep=True)
                     except RuntimeError:
                         _copy = complete_streaming_response.model_copy()
                     asyncio.create_task(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -413,7 +413,9 @@ async def common_checks(  # noqa: PLR0915
                 model=_model,
                 team_object=team_object,
                 llm_router=llm_router,
-                team_model_aliases=valid_token.team_model_aliases if valid_token else None,
+                team_model_aliases=valid_token.team_model_aliases
+                if valid_token
+                else None,
             ):
                 raise ProxyException(
                     message=f"Team not allowed to access model. Team={team_object.team_id}, Model={_model}. Allowed team models = {team_object.models}",
@@ -482,7 +484,9 @@ async def common_checks(  # noqa: PLR0915
             )
 
         # 3.1. If organization is in budget
-        with tracer.trace("litellm.proxy.auth.common_checks.organization_max_budget_check"):
+        with tracer.trace(
+            "litellm.proxy.auth.common_checks.organization_max_budget_check"
+        ):
             await _organization_max_budget_check(
                 valid_token=valid_token,
                 team_object=team_object,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1438,10 +1438,12 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             ):  # user set proxy max budget
                 cache_key = "{}:spend".format(litellm_proxy_admin_name)
                 with tracer.trace("litellm.proxy.auth.get_global_proxy_spend"):
-                    global_proxy_spend = await _fetch_global_spend_with_event_coordination(
-                        cache_key=cache_key,
-                        user_api_key_cache=user_api_key_cache,
-                        prisma_client=prisma_client,
+                    global_proxy_spend = (
+                        await _fetch_global_spend_with_event_coordination(
+                            cache_key=cache_key,
+                            user_api_key_cache=user_api_key_cache,
+                            prisma_client=prisma_client,
+                        )
                     )
 
                 if global_proxy_spend is not None:


### PR DESCRIPTION
## Summary

Applies `black` formatting to 4 files causing lint CI to fail:

- `litellm/integrations/datadog/datadog.py`
- `litellm/litellm_core_utils/streaming_handler.py`
- `litellm/proxy/auth/user_api_key_auth.py`
- `litellm/proxy/auth/auth_checks.py`

Follow-up to #24092.