### PR TITLE
Modified the aiohttp transport to derive a `total` deadline from the …

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -265,12 +265,18 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         # overriding the session/connector defaults with None (which is
         # not a valid value for aiohttp's ssl parameter).
         
-        # Derive a `total` deadline from the per-phase values so that
-        # aiohttp doesn't leave it as None.  Without this, long-running
-        # reasoning models (e.g. GPT-5-PRO) can hit infrastructure idle
-        # timeouts (~60s) before the model responds.
-        _phase_values = [v for v in timeout.values() if v is not None]
-        _total = max(_phase_values) if _phase_values else None
+        # Set total = max(pool, connect) + read so aiohttp has a finite overall
+        # deadline.  Per the aiohttp docs, `connect` (pool acquisition) already
+        # encompasses `sock_connect` (TCP handshake) for new connections, so
+        # they are not additive.  `write` is excluded — aiohttp has no
+        # corresponding ClientTimeout field.
+        _sock_connect = timeout.get("connect")
+        _sock_read = timeout.get("read")
+        _pool = timeout.get("pool")
+        _conn_phase_values = [v for v in (_sock_connect, _pool) if v is not None]
+        _conn_phase = max(_conn_phase_values) if _conn_phase_values else None
+        _total_values = [v for v in (_conn_phase, _sock_read) if v is not None]
+        _total = sum(_total_values) if _total_values else None
 
         request_kwargs: Dict[str, Any] = {
             "method": request.method,
@@ -281,9 +287,9 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             "auto_decompress": False,
             "timeout": ClientTimeout(
                 total=_total,
-                sock_connect=timeout.get("connect"),
-                sock_read=timeout.get("read"),
-                connect=timeout.get("pool"),
+                sock_connect=_sock_connect,
+                sock_read=_sock_read,
+                connect=_pool,
             ),
             "proxy": proxy,
             "server_hostname": sni_hostname,

--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -264,6 +264,14 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         # Only pass ssl kwarg when explicitly configured, to avoid
         # overriding the session/connector defaults with None (which is
         # not a valid value for aiohttp's ssl parameter).
+        
+        # Derive a `total` deadline from the per-phase values so that
+        # aiohttp doesn't leave it as None.  Without this, long-running
+        # reasoning models (e.g. GPT-5-PRO) can hit infrastructure idle
+        # timeouts (~60s) before the model responds.
+        _phase_values = [v for v in timeout.values() if v is not None]
+        _total = max(_phase_values) if _phase_values else None
+
         request_kwargs: Dict[str, Any] = {
             "method": request.method,
             "url": YarlURL(str(request.url), encoded=True),
@@ -272,6 +280,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             "allow_redirects": False,
             "auto_decompress": False,
             "timeout": ClientTimeout(
+                total=_total,
                 sock_connect=timeout.get("connect"),
                 sock_read=timeout.get("read"),
                 connect=timeout.get("pool"),

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -5,6 +5,7 @@ import sys
 import aiohttp
 import aiohttp.client_exceptions
 import aiohttp.http_exceptions
+from aiohttp import ClientTimeout
 import httpx
 import pytest
 
@@ -556,19 +557,56 @@ async def test_handle_closed_session_before_request():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_client_timeout_total_set_to_max_phase_value():
+def test_aiohttp_client_timeout_total_none_is_the_bug():
     """
-    Regression test for issue #22747: ClientTimeout.total must be set to the
-    maximum phase timeout so aiohttp has an overall deadline.
+    Directly demonstrates the bug from issue #22747 using aiohttp's API.
+
+    Building a ClientTimeout without ``total=...`` leaves ``total`` as None,
+    giving aiohttp no overall request deadline.  This is exactly what the old
+    transport produced for every user request, regardless of their configured
+    timeout value.
+
+    The fix derives ``total`` from the three phases that aiohttp uses
+    (sock_connect, sock_read, connect/pool) using sum(), which is the safe
+    upper bound.  max() would prematurely abort requests where multiple phases
+    each approach their individual limits.
+    """
+    # What the OLD transport code produced for timeout=300 (the bug):
+    old_timeout = ClientTimeout(
+        sock_connect=300.0,
+        sock_read=300.0,
+        connect=300.0,
+        # total was never set — this is the bug
+    )
+    assert old_timeout.total is None  # no overall deadline!
+
+    # What the NEW transport code produces for timeout=300 (the fix):
+    # connection phase = max(sock_connect=300, connect=300) = 300
+    # total = connection_phase + sock_read = 300 + 300 = 600 s
+    new_timeout = ClientTimeout(
+        total=600.0,
+        sock_connect=300.0,
+        sock_read=300.0,
+        connect=300.0,
+    )
+    assert new_timeout.total == 600.0  # finite, safe upper-bound deadline
+
+
+@pytest.mark.asyncio
+async def test_client_timeout_total_derived_from_connection_and_read_phases():
+    """
+    Regression test for issue #22747: ClientTimeout.total must be set so that
+    aiohttp has a finite overall request deadline.
 
     Without this fix, total=None caused aiohttp to have no overall deadline,
-    allowing infrastructure idle timeouts (~60s) to kill connections before
+    allowing infrastructure idle-timeouts (~60 s) to kill connections before
     long-running reasoning models (e.g. GPT-5-PRO) responded.
 
     httpx converts ``timeout=300`` into all four phase keys set to 300.
-    The ``write`` key is included in ``_phase_values`` via ``.values()`` but is
-    not mapped to any aiohttp ``ClientTimeout`` field — that's expected and fine.
+    Per the aiohttp docs, sock_connect is nested inside connect (they are not
+    additive for new connections), so total = max(pool, connect) + read.
+    ``write`` is excluded — it has no corresponding aiohttp field.
+    Expected total = max(300, 300) + 300 = 600.
     """
     captured: dict = {}
     transport = LiteLLMAiohttpTransport(client=lambda: _make_capturing_session(captured))  # type: ignore
@@ -576,33 +614,44 @@ async def test_client_timeout_total_set_to_max_phase_value():
     request.extensions["timeout"] = {
         "connect": 300.0,
         "read": 300.0,
-        "write": 300.0,
+        "write": 300.0,  # excluded — not mapped to any aiohttp field
         "pool": 300.0,
     }
     await transport.handle_async_request(request)
 
     timeout = captured["timeout"]
     assert timeout is not None
-    assert timeout.total == 300.0, f"Expected total=300.0, got total={timeout.total}"
+    assert timeout.total == 600.0, f"Expected total=600.0, got total={timeout.total}"
     assert timeout.sock_connect == 300.0
     assert timeout.sock_read == 300.0
 
 
 @pytest.mark.asyncio
-async def test_client_timeout_total_uses_max_when_phases_differ():
-    """total should be the max of all provided phase timeouts."""
+async def test_client_timeout_total_no_false_timeout_when_phases_differ():
+    """
+    total must not prematurely abort a request where multiple phases each
+    approach their individual limits.
+
+    With connect=10 s (TCP) and pool=5 s (pool acquisition), the effective
+    connection limit is max(10, 5) = 10 s, because sock_connect is nested
+    inside connect per the aiohttp docs.  Then read=600 s follows.
+    Expected total = max(10, 5) + 600 = 610 s.
+
+    Using plain max() of all phases would give total=600 s, which would
+    false-timeout a request that takes 9 s to connect + 602 s to read.
+    """
     captured: dict = {}
     transport = LiteLLMAiohttpTransport(client=lambda: _make_capturing_session(captured))  # type: ignore
     request = httpx.Request("GET", "http://example.com")
     request.extensions["timeout"] = {
         "connect": 10.0,
-        "read": 600.0,  # Longest — should become total
+        "read": 600.0,
         "pool": 5.0,
     }
     await transport.handle_async_request(request)
 
     timeout = captured["timeout"]
-    assert timeout.total == 600.0, f"Expected total=600.0, got total={timeout.total}"
+    assert timeout.total == 610.0, f"Expected total=610.0, got total={timeout.total}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -500,6 +500,46 @@ def _make_mock_session(closed=False):
     return MockSession()
 
 
+def _make_capturing_session(captured: dict):
+    """
+    Helper to create a fake session that records the kwargs passed to request().
+    Use ``captured["<key>"]`` after the transport call to inspect what was sent.
+    """
+
+    class CapturingSession:
+        def __init__(self):
+            self.closed = False
+            try:
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = None
+
+        def request(self, *args, **kwargs):
+            captured.update(kwargs)
+
+            class Resp:
+                status = 200
+                headers = {}
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, exc_type, exc, tb):
+                    pass
+
+                @property
+                def content(self):
+                    class C:
+                        async def iter_chunked(self, size):
+                            yield b""
+
+                    return C()
+
+            return Resp()
+
+    return CapturingSession()
+
+
 @pytest.mark.asyncio
 async def test_handle_closed_session_before_request():
     """Test that closed sessions are detected and recreated"""
@@ -514,6 +554,69 @@ async def test_handle_closed_session_before_request():
 
     assert counts["sessions"] == 2  # Created 2 sessions: closed one, then open one
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_client_timeout_total_set_to_max_phase_value():
+    """
+    Regression test for issue #22747: ClientTimeout.total must be set to the
+    maximum phase timeout so aiohttp has an overall deadline.
+
+    Without this fix, total=None caused aiohttp to have no overall deadline,
+    allowing infrastructure idle timeouts (~60s) to kill connections before
+    long-running reasoning models (e.g. GPT-5-PRO) responded.
+
+    httpx converts ``timeout=300`` into all four phase keys set to 300.
+    The ``write`` key is included in ``_phase_values`` via ``.values()`` but is
+    not mapped to any aiohttp ``ClientTimeout`` field — that's expected and fine.
+    """
+    captured: dict = {}
+    transport = LiteLLMAiohttpTransport(client=lambda: _make_capturing_session(captured))  # type: ignore
+    request = httpx.Request("GET", "http://example.com")
+    request.extensions["timeout"] = {
+        "connect": 300.0,
+        "read": 300.0,
+        "write": 300.0,
+        "pool": 300.0,
+    }
+    await transport.handle_async_request(request)
+
+    timeout = captured["timeout"]
+    assert timeout is not None
+    assert timeout.total == 300.0, f"Expected total=300.0, got total={timeout.total}"
+    assert timeout.sock_connect == 300.0
+    assert timeout.sock_read == 300.0
+
+
+@pytest.mark.asyncio
+async def test_client_timeout_total_uses_max_when_phases_differ():
+    """total should be the max of all provided phase timeouts."""
+    captured: dict = {}
+    transport = LiteLLMAiohttpTransport(client=lambda: _make_capturing_session(captured))  # type: ignore
+    request = httpx.Request("GET", "http://example.com")
+    request.extensions["timeout"] = {
+        "connect": 10.0,
+        "read": 600.0,  # Longest — should become total
+        "pool": 5.0,
+    }
+    await transport.handle_async_request(request)
+
+    timeout = captured["timeout"]
+    assert timeout.total == 600.0, f"Expected total=600.0, got total={timeout.total}"
+
+
+@pytest.mark.asyncio
+async def test_client_timeout_total_is_none_when_no_phases_set():
+    """When no phase timeouts are provided, total should remain None."""
+    captured: dict = {}
+    transport = LiteLLMAiohttpTransport(client=lambda: _make_capturing_session(captured))  # type: ignore
+    request = httpx.Request("GET", "http://example.com")
+    # Empty timeout dict — simulates a request with no timeout configured
+    request.extensions["timeout"] = {}
+    await transport.handle_async_request(request)
+
+    timeout = captured["timeout"]
+    assert timeout.total is None, f"Expected total=None, got total={timeout.total}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Modified the aiohttp transport to derive a `total` deadline from the per-phase timeout values, ensuring that long-running reasoning models don't hit infrastructure idle timeouts before responding. This change allows for better handling of models like GPT-5-PRO that may require more time to generate responses.

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #22747

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
