### PR TITLE
chore: add poetry check --lock to lint CI to prevent stale lockfile merges

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -28,9 +28,12 @@ jobs:
         find . -type d -name "__pycache__" -exec rm -rf {} + || true
         find . -name "*.pyc" -delete || true
 
+    - name: Check poetry.lock is up to date
+      run: |
+        poetry check --lock || (echo "❌ poetry.lock is out of sync with pyproject.toml. Run 'poetry lock' locally and commit the result." && exit 1)
+
     - name: Install dependencies
       run: |
-        poetry lock
         poetry install --with dev
 
     - name: Check Black formatting


### PR DESCRIPTION
## Summary

- Adds `poetry check --lock` step to lint CI that fails loudly if `poetry.lock` is out of sync with `pyproject.toml`
- Removes the silent `poetry lock` from the install step — if the check passes, the lockfile is already in sync

## Why

Previously `poetry lock` ran silently during install, masking drift. This caused a repo-wide CI outage where every PR failed at `poetry install` with no clear error. Now contributors get an explicit, actionable error message:

```
❌ poetry.lock is out of sync with pyproject.toml. Run 'poetry lock' locally and commit the result.
```

## Test plan

- [ ] Verify lint CI passes on this PR
- [ ] Confirm a PR with a stale `poetry.lock` is blocked by this check

🤖 Generated with [Claude Code](https://claude.com/claude-code)