### PR TITLE
fix(redis-semantic-cache): support custom embedding api_base and api_key

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -99,6 +99,8 @@ class Cache:
         gcs_path_service_account: Optional[str] = None,
         gcs_path: Optional[str] = None,
         redis_semantic_cache_embedding_model: str = "text-embedding-ada-002",
+        redis_semantic_cache_embedding_api_base: Optional[str] = None,
+        redis_semantic_cache_embedding_api_key: Optional[str] = None,
         redis_semantic_cache_index_name: Optional[str] = None,
         redis_flush_size: Optional[int] = None,
         redis_startup_nodes: Optional[List] = None,
@@ -205,6 +207,8 @@ class Cache:
                 password=password,
                 similarity_threshold=similarity_threshold,
                 embedding_model=redis_semantic_cache_embedding_model,
+                embedding_api_base=redis_semantic_cache_embedding_api_base,
+                embedding_api_key=redis_semantic_cache_embedding_api_key,
                 index_name=redis_semantic_cache_index_name,
                 **kwargs,
             )

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -44,6 +44,8 @@ class RedisSemanticCache(BaseCache):
         redis_url: Optional[str] = None,
         similarity_threshold: Optional[float] = None,
         embedding_model: str = "text-embedding-ada-002",
+        embedding_api_base: Optional[str] = None,
+        embedding_api_key: Optional[str] = None,
         index_name: Optional[str] = None,
         **kwargs,
     ):
@@ -86,6 +88,8 @@ class RedisSemanticCache(BaseCache):
         # While similarity: 1 = most similar, 0 = least similar
         self.distance_threshold = 1 - similarity_threshold
         self.embedding_model = embedding_model
+        self.embedding_api_base = embedding_api_base
+        self.embedding_api_key = embedding_api_key
 
         # Set up Redis connection
         if redis_url is None:
@@ -143,13 +147,18 @@ class RedisSemanticCache(BaseCache):
             List[float]: The embedding vector
         """
         # Create an embedding from prompt
+        embed_kwargs: dict = {
+            "model": self.embedding_model,
+            "input": prompt,
+            "cache": {"no-store": True, "no-cache": True},
+        }
+        if self.embedding_api_base is not None:
+            embed_kwargs["api_base"] = self.embedding_api_base
+        if self.embedding_api_key is not None:
+            embed_kwargs["api_key"] = self.embedding_api_key
         embedding_response = cast(
             EmbeddingResponse,
-            litellm.embedding(
-                model=self.embedding_model,
-                input=prompt,
-                cache={"no-store": True, "no-cache": True},
-            ),
+            litellm.embedding(**embed_kwargs),
         )
         embedding = embedding_response["data"][0]["embedding"]
         return embedding

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -313,11 +313,16 @@ class RedisSemanticCache(BaseCache):
                 )
             else:
                 # Generate embedding directly
-                embedding_response = await litellm.aembedding(
-                    model=self.embedding_model,
-                    input=prompt,
-                    cache={"no-store": True, "no-cache": True},
-                )
+                async_embed_kwargs: dict = {
+                    "model": self.embedding_model,
+                    "input": prompt,
+                    "cache": {"no-store": True, "no-cache": True},
+                }
+                if self.embedding_api_base is not None:
+                    async_embed_kwargs["api_base"] = self.embedding_api_base
+                if self.embedding_api_key is not None:
+                    async_embed_kwargs["api_key"] = self.embedding_api_key
+                embedding_response = await litellm.aembedding(**async_embed_kwargs)
 
             # Extract and return the embedding vector
             return embedding_response["data"][0]["embedding"]


### PR DESCRIPTION
## Problem

`RedisSemanticCache` hardcodes the embedding call to always use the default OpenAI endpoint. This causes a startup crash when using a self-hosted or alternative embedding provider (LM Studio, Ollama, Azure OpenAI, etc.) because `CustomTextVectorizer.__init__` validates the embedding synchronously at init time.

**Error:**
```
litellm.NotFoundError: OpenAIException - Error code: 404 - 
{'error': {'message': 'The model `<your-model>` does not exist or you do not have access to it.'}}
ValueError: Invalid embedding method: ...
ERROR: Application startup failed. Exiting.
```

## Root Cause

`_get_embedding()` calls `litellm.embedding(model=self.embedding_model, ...)` with no `api_base` or `api_key`, so it always routes to OpenAI regardless of what provider is actually serving the embedding model.

## Fix

- Add `embedding_api_base` and `embedding_api_key` optional params to `RedisSemanticCache.__init__()`
- Pass them through to `litellm.embedding()` in `_get_embedding()` when set
- Expose as `redis_semantic_cache_embedding_api_base` / `redis_semantic_cache_embedding_api_key` on the `Cache` factory

## Usage After Fix

```yaml
# config.yaml
litellm_settings:
  cache: true
  cache_params:
    type: redis-semantic
    redis_url: redis://localhost:6379
    similarity_threshold: 0.85
    redis_semantic_cache_embedding_model: openai/text-embedding-nomic-embed-text-v1.5
    redis_semantic_cache_embedding_api_base: http://localhost:11434/v1  # Ollama
    redis_semantic_cache_embedding_api_key: ollama
```

## Backward Compatibility

Both new params default to `None`. Existing deployments using `text-embedding-ada-002` via OpenAI are completely unaffected.

## Testing

Verified working with LM Studio serving `text-embedding-snowflake-arctic-embed-l-v2.0` against a Redis Stack instance. Semantic similarity hits confirmed at 0.85 threshold across paraphrased queries.