### PR TITLE
chore: apply black formatting to proxy/_types.py to fix lint CI

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2955,7 +2955,9 @@ class LiteLLM_ErrorLogs(LiteLLMPydanticObjectBase):
     endTime: Union[str, datetime, None]
 
 
-AUDIT_ACTIONS = Literal["created", "updated", "deleted", "blocked", "unblocked", "rotated"]
+AUDIT_ACTIONS = Literal[
+    "created", "updated", "deleted", "blocked", "unblocked", "rotated"
+]
 
 
 class LiteLLM_AuditLogs(LiteLLMPydanticObjectBase):


### PR DESCRIPTION
## Summary

- Applies `black` formatting to `litellm/proxy/_types.py` to fix lint CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)