### PR TITLE
include meta data in mcp resource response

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -629,11 +629,25 @@ if MCP_AVAILABLE:
             oauth2_headers=oauth2_headers,
             raw_headers=raw_headers,
         )
+        return _normalize_read_resource_contents(read_resource_result)
 
+    ########################################################
+    ############ End of MCP Server Routes ##################
+    ########################################################
+
+    ########################################################
+    ############ Helper Functions ##########################
+    ########################################################
+
+    def _normalize_read_resource_contents(
+        read_resource_result: ReadResourceResult,
+    ) -> List[ReadResourceContents]:
+        """Normalize upstream resource contents to ReadResourceContents, preserving _meta."""
         normalized_contents: List[ReadResourceContents] = []
         for content in read_resource_result.contents:
-            # Preserve _meta from upstream (MCP spec: JSON key _meta, Python attr meta)
-            meta = getattr(content, "_meta", None) or getattr(content, "meta", None)
+            meta = getattr(content, "_meta", None)
+            if meta is None:
+                meta = getattr(content, "meta", None)
             if isinstance(content, TextResourceContents):
                 text_content: TextResourceContents = content
                 rc_kwargs: Dict[str, Any] = {
@@ -645,7 +659,6 @@ if MCP_AVAILABLE:
                 try:
                     normalized_contents.append(ReadResourceContents(**rc_kwargs))
                 except TypeError:
-                    # Older MCP SDK may not support meta in ReadResourceContents
                     rc_kwargs.pop("meta", None)
                     normalized_contents.append(ReadResourceContents(**rc_kwargs))
             elif isinstance(content, BlobResourceContents):
@@ -658,16 +671,7 @@ if MCP_AVAILABLE:
                 except TypeError:
                     rc_kwargs.pop("meta", None)
                     normalized_contents.append(ReadResourceContents(**rc_kwargs))
-
         return normalized_contents
-
-    ########################################################
-    ############ End of MCP Server Routes ##################
-    ########################################################
-
-    ########################################################
-    ############ Helper Functions ##########################
-    ########################################################
 
     async def _get_allowed_mcp_servers_from_mcp_server_names(
         mcp_servers: Optional[List[str]],

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -632,22 +632,32 @@ if MCP_AVAILABLE:
 
         normalized_contents: List[ReadResourceContents] = []
         for content in read_resource_result.contents:
+            # Preserve _meta from upstream (MCP spec: JSON key _meta, Python attr meta)
+            meta = getattr(content, "_meta", None) or getattr(content, "meta", None)
             if isinstance(content, TextResourceContents):
                 text_content: TextResourceContents = content
-                normalized_contents.append(
-                    ReadResourceContents(
-                        content=text_content.text,
-                        mime_type=text_content.mimeType,
-                    )
-                )
+                rc_kwargs: Dict[str, Any] = {
+                    "content": text_content.text,
+                    "mime_type": text_content.mimeType,
+                }
+                if meta is not None:
+                    rc_kwargs["meta"] = meta
+                try:
+                    normalized_contents.append(ReadResourceContents(**rc_kwargs))
+                except TypeError:
+                    # Older MCP SDK may not support meta in ReadResourceContents
+                    rc_kwargs.pop("meta", None)
+                    normalized_contents.append(ReadResourceContents(**rc_kwargs))
             elif isinstance(content, BlobResourceContents):
                 blob_content: BlobResourceContents = content
-                normalized_contents.append(
-                    ReadResourceContents(
-                        content=blob_content.blob,
-                        mime_type=None,
-                    )
-                )
+                rc_kwargs = {"content": blob_content.blob, "mime_type": None}
+                if meta is not None:
+                    rc_kwargs["meta"] = meta
+                try:
+                    normalized_contents.append(ReadResourceContents(**rc_kwargs))
+                except TypeError:
+                    rc_kwargs.pop("meta", None)
+                    normalized_contents.append(ReadResourceContents(**rc_kwargs))
 
         return normalized_contents
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -414,6 +414,64 @@ async def test_mcp_read_resource_success():
 
 
 @pytest.mark.asyncio
+async def test_read_resource_preserves_meta():
+    """Test that _meta from upstream MCP resource contents is preserved when normalizing.
+
+    The read_resource handler normalizes upstream TextResourceContents/BlobResourceContents
+    into ReadResourceContents. This test verifies meta is passed through (fix for _meta
+    being dropped when accessing resources through LiteLLM proxy).
+    """
+    try:
+        from mcp.server.lowlevel.helper_types import ReadResourceContents
+        from mcp.types import BlobResourceContents
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    meta_value = {"ui": {"prefersBorder": False, "domain": "https://example.com"}}
+    read_result = ReadResourceResult(
+        contents=[
+            TextResourceContents(
+                uri="ui://widget/product-search",
+                text="<html>content</html>",
+                mimeType="text/html",
+                meta=meta_value,
+            )
+        ]
+    )
+
+    # Replicate the normalization logic from read_resource handler to verify meta flow
+    normalized_contents: list = []
+    for content in read_result.contents:
+        meta = getattr(content, "_meta", None) or getattr(content, "meta", None)
+        if isinstance(content, TextResourceContents):
+            rc_kwargs = {"content": content.text, "mime_type": content.mimeType}
+            if meta is not None:
+                rc_kwargs["meta"] = meta
+            try:
+                normalized_contents.append(ReadResourceContents(**rc_kwargs))
+            except TypeError:
+                rc_kwargs.pop("meta", None)
+                normalized_contents.append(ReadResourceContents(**rc_kwargs))
+        elif isinstance(content, BlobResourceContents):
+            rc_kwargs = {"content": content.blob, "mime_type": None}
+            if meta is not None:
+                rc_kwargs["meta"] = meta
+            try:
+                normalized_contents.append(ReadResourceContents(**rc_kwargs))
+            except TypeError:
+                rc_kwargs.pop("meta", None)
+                normalized_contents.append(ReadResourceContents(**rc_kwargs))
+
+    assert len(normalized_contents) == 1
+    out = normalized_contents[0]
+    assert out.content == "<html>content</html>"
+    assert out.mime_type == "text/html"
+    # meta is preserved when ReadResourceContents supports it (MCP SDK >= 1.26)
+    if hasattr(out, "meta"):
+        assert out.meta == meta_value
+
+
+@pytest.mark.asyncio
 async def test_mcp_read_resource_multiple_servers_error():
     try:
         from litellm.proxy._experimental.mcp_server.server import mcp_read_resource

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -417,13 +417,13 @@ async def test_mcp_read_resource_success():
 async def test_read_resource_preserves_meta():
     """Test that _meta from upstream MCP resource contents is preserved when normalizing.
 
-    The read_resource handler normalizes upstream TextResourceContents/BlobResourceContents
-    into ReadResourceContents. This test verifies meta is passed through (fix for _meta
+    Exercises the production _normalize_read_resource_contents helper (fix for _meta
     being dropped when accessing resources through LiteLLM proxy).
     """
     try:
-        from mcp.server.lowlevel.helper_types import ReadResourceContents
-        from mcp.types import BlobResourceContents
+        from litellm.proxy._experimental.mcp_server.server import (
+            _normalize_read_resource_contents,
+        )
     except ImportError:
         pytest.skip("MCP server not available")
 
@@ -439,34 +439,12 @@ async def test_read_resource_preserves_meta():
         ]
     )
 
-    # Replicate the normalization logic from read_resource handler to verify meta flow
-    normalized_contents: list = []
-    for content in read_result.contents:
-        meta = getattr(content, "_meta", None) or getattr(content, "meta", None)
-        if isinstance(content, TextResourceContents):
-            rc_kwargs = {"content": content.text, "mime_type": content.mimeType}
-            if meta is not None:
-                rc_kwargs["meta"] = meta
-            try:
-                normalized_contents.append(ReadResourceContents(**rc_kwargs))
-            except TypeError:
-                rc_kwargs.pop("meta", None)
-                normalized_contents.append(ReadResourceContents(**rc_kwargs))
-        elif isinstance(content, BlobResourceContents):
-            rc_kwargs = {"content": content.blob, "mime_type": None}
-            if meta is not None:
-                rc_kwargs["meta"] = meta
-            try:
-                normalized_contents.append(ReadResourceContents(**rc_kwargs))
-            except TypeError:
-                rc_kwargs.pop("meta", None)
-                normalized_contents.append(ReadResourceContents(**rc_kwargs))
+    normalized_contents = _normalize_read_resource_contents(read_result)
 
     assert len(normalized_contents) == 1
     out = normalized_contents[0]
     assert out.content == "<html>content</html>"
     assert out.mime_type == "text/html"
-    # meta is preserved when ReadResourceContents supports it (MCP SDK >= 1.26)
     if hasattr(out, "meta"):
         assert out.meta == meta_value
 


### PR DESCRIPTION
## Relevant issues
Cause: The read_resource handler rebuilt ReadResourceContents from upstream TextResourceContents/BlobResourceContents and only copied content and mime_type, so _meta was dropped.
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes
Fix: When building ReadResourceContents, pass through _meta (or meta) from the upstream content. Add a try/except TypeError so older MCP SDK versions without a meta field still work.
