### PR TITLE
chore: apply black formatting to fix lint CI (batch 3)

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -114,7 +114,9 @@ class LangsmithLogger(CustomBatchLogger):
         self, metadata: dict, credentials: LangsmithCredentialsObject
     ):
         return {
-            "project_name": metadata.get("project_name", credentials["LANGSMITH_PROJECT"]),
+            "project_name": metadata.get(
+                "project_name", credentials["LANGSMITH_PROJECT"]
+            ),
             "run_name": metadata.get("run_name", self.langsmith_default_run_name),
             "run_id": metadata.get("id", metadata.get("run_id", None)),
             "parent_run_id": metadata.get("parent_run_id", None),
@@ -132,7 +134,9 @@ class LangsmithLogger(CustomBatchLogger):
                     extra_metadata[key] = requester_metadata[key]
         return extra_metadata
 
-    def _build_outputs_with_usage(self, payload: StandardLoggingPayload) -> Dict[str, Any]:
+    def _build_outputs_with_usage(
+        self, payload: StandardLoggingPayload
+    ) -> Dict[str, Any]:
         response = payload["response"]
         outputs: Dict[str, Any]
         if isinstance(response, dict):
@@ -171,7 +175,7 @@ class LangsmithLogger(CustomBatchLogger):
         try:
             _litellm_params = kwargs.get("litellm_params", {}) or {}
             metadata = _litellm_params.get("metadata", {}) or {}
-            
+
             fields = self._extract_metadata_fields(metadata, credentials)
             verbose_logger.debug(
                 f"Langsmith Logging - project_name: {fields['project_name']}, run_name {fields['run_name']}"
@@ -202,7 +206,13 @@ class LangsmithLogger(CustomBatchLogger):
             if payload["error_str"] is not None and payload["status"] == "failure":
                 data["error"] = payload["error_str"]
 
-            for key in ("id", "parent_run_id", "trace_id", "session_id", "dotted_order"):
+            for key in (
+                "id",
+                "parent_run_id",
+                "trace_id",
+                "session_id",
+                "dotted_order",
+            ):
                 field_key = "run_id" if key == "id" else key
                 if fields[field_key]:
                     data[key] = fields[field_key]

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3331,7 +3331,10 @@ class Logging(LiteLLMLoggingBaseClass):
             return result
         elif isinstance(result, TextCompletionResponse):
             return result
-        elif isinstance(result, (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent)):
+        elif isinstance(
+            result,
+            (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
+        ):
             ## return unified Usage object
             if isinstance(result.response.usage, ResponseAPIUsage):
                 transformed_usage = (

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -279,7 +279,7 @@ class CustomStreamWrapper:
                 model="",
                 llm_provider="",
             )
-        
+
     def check_special_tokens(self, chunk: str, finish_reason: Optional[str]):
         """
         Output parse <s> / </s> special tokens for sagemaker + hf streaming.

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -578,7 +578,9 @@ class ModelResponseIterator:
             speed=self.speed,
         )
 
-    def _content_block_delta_helper(self, chunk: dict) -> Tuple[
+    def _content_block_delta_helper(
+        self, chunk: dict
+    ) -> Tuple[
         str,
         Optional[ChatCompletionToolCallChunk],
         List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]],
@@ -803,9 +805,9 @@ class ModelResponseIterator:
                         tool_input = content_block_start["content_block"].get(
                             "input", {}
                         )
-                        self._server_tool_inputs[self._current_server_tool_id] = (
-                            tool_input
-                        )
+                        self._server_tool_inputs[
+                            self._current_server_tool_id
+                        ] = tool_input
                     # Include caller information if present (for programmatic tool calling)
                     if "caller" in content_block_start["content_block"]:
                         caller_data = content_block_start["content_block"]["caller"]
@@ -826,9 +828,9 @@ class ModelResponseIterator:
                     # Handle compaction blocks
                     # The full content comes in content_block_start
                     self.compaction_blocks.append(content_block_start["content_block"])
-                    provider_specific_fields["compaction_blocks"] = (
-                        self.compaction_blocks
-                    )
+                    provider_specific_fields[
+                        "compaction_blocks"
+                    ] = self.compaction_blocks
                     provider_specific_fields["compaction_start"] = {
                         "type": "compaction",
                         "content": content_block_start["content_block"].get(
@@ -850,9 +852,9 @@ class ModelResponseIterator:
                         self.web_search_results.append(
                             content_block_start["content_block"]
                         )
-                        provider_specific_fields["web_search_results"] = (
-                            self.web_search_results
-                        )
+                        provider_specific_fields[
+                            "web_search_results"
+                        ] = self.web_search_results
                     elif content_type == "web_fetch_tool_result":
                         # Capture web_fetch_tool_result for multi-turn reconstruction
                         # The full content comes in content_block_start, not in deltas
@@ -860,18 +862,18 @@ class ModelResponseIterator:
                         self.web_search_results.append(
                             content_block_start["content_block"]
                         )
-                        provider_specific_fields["web_search_results"] = (
-                            self.web_search_results
-                        )
+                        provider_specific_fields[
+                            "web_search_results"
+                        ] = self.web_search_results
                     elif content_type != "tool_search_tool_result":
                         # Handle other tool results (code execution, etc.)
                         # Skip tool_search_tool_result as it's internal metadata
                         self.tool_results.append(content_block_start["content_block"])
                         provider_specific_fields["tool_results"] = self.tool_results
                         # Convert to provider-neutral code_interpreter_results
-                        provider_specific_fields["code_interpreter_results"] = (
-                            self._build_code_interpreter_results()
-                        )
+                        provider_specific_fields[
+                            "code_interpreter_results"
+                        ] = self._build_code_interpreter_results()
 
             elif type_chunk == "content_block_stop":
                 ContentBlockStop(**chunk)  # type: ignore
@@ -928,9 +930,9 @@ class ModelResponseIterator:
                     )
                     if container_id and self.tool_results:
                         self._container_id = container_id
-                        provider_specific_fields["code_interpreter_results"] = (
-                            self._build_code_interpreter_results()
-                        )
+                        provider_specific_fields[
+                            "code_interpreter_results"
+                        ] = self._build_code_interpreter_results()
             elif type_chunk == "message_start":
                 """
                 Anthropic

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -964,11 +964,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 if mcp_servers:
                     optional_params["mcp_servers"] = mcp_servers
             elif param == "tool_choice" or param == "parallel_tool_calls":
-                _tool_choice: Optional[AnthropicMessagesToolChoice] = (
-                    self._map_tool_choice(
-                        tool_choice=non_default_params.get("tool_choice"),
-                        parallel_tool_use=non_default_params.get("parallel_tool_calls"),
-                    )
+                _tool_choice: Optional[
+                    AnthropicMessagesToolChoice
+                ] = self._map_tool_choice(
+                    tool_choice=non_default_params.get("tool_choice"),
+                    parallel_tool_use=non_default_params.get("parallel_tool_calls"),
                 )
 
                 if _tool_choice is not None:
@@ -1066,9 +1066,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         self.map_openai_context_management_to_anthropic(value)
                     )
                     if anthropic_context_management is not None:
-                        optional_params["context_management"] = (
-                            anthropic_context_management
-                        )
+                        optional_params[
+                            "context_management"
+                        ] = anthropic_context_management
             elif param == "speed" and isinstance(value, str):
                 # Pass through Anthropic-specific speed parameter for fast mode
                 optional_params["speed"] = value
@@ -1142,9 +1142,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         text=system_message_block["content"],
                     )
                     if "cache_control" in system_message_block:
-                        anthropic_system_message_content["cache_control"] = (
-                            system_message_block["cache_control"]
-                        )
+                        anthropic_system_message_content[
+                            "cache_control"
+                        ] = system_message_block["cache_control"]
                     anthropic_system_message_list.append(
                         anthropic_system_message_content
                     )
@@ -1168,9 +1168,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                             )
                         )
                         if "cache_control" in _content:
-                            anthropic_system_message_content["cache_control"] = (
-                                _content["cache_control"]
-                            )
+                            anthropic_system_message_content[
+                                "cache_control"
+                            ] = _content["cache_control"]
 
                         anthropic_system_message_list.append(
                             anthropic_system_message_content
@@ -1467,7 +1467,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 )
         return _message
 
-    def extract_response_content(self, completion_response: dict) -> Tuple[
+    def extract_response_content(
+        self, completion_response: dict
+    ) -> Tuple[
         str,
         Optional[List[Any]],
         Optional[
@@ -1684,7 +1686,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         )
         return usage
 
-    def _build_code_by_id_map(self, tool_calls: List[ChatCompletionToolCallChunk]) -> Dict[str, str]:
+    def _build_code_by_id_map(
+        self, tool_calls: List[ChatCompletionToolCallChunk]
+    ) -> Dict[str, str]:
         code_by_id: Dict[str, str] = {}
         for tc in tool_calls:
             try:
@@ -1698,7 +1702,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         return code_by_id
 
     def _build_code_interpreter_results(
-        self, tool_results: List[Any], code_by_id: Dict[str, str], container_id: Optional[str]
+        self,
+        tool_results: List[Any],
+        code_by_id: Dict[str, str],
+        container_id: Optional[str],
     ) -> List[OutputCodeInterpreterCall]:
         code_interpreter_results = []
         for tr in tool_results:
@@ -1723,7 +1730,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         self,
         completion_response: dict,
         citations: Optional[List[Any]],
-        thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]],
+        thinking_blocks: Optional[
+            List[
+                Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
+            ]
+        ],
         web_search_results: Optional[List[Any]],
         tool_results: Optional[List[Any]],
         compaction_blocks: Optional[List[Any]],
@@ -1733,14 +1744,14 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "citations": citations,
             "thinking_blocks": thinking_blocks,
         }
-        
+
         context_management = completion_response.get("context_management")
         if context_management is not None:
             provider_specific_fields["context_management"] = context_management
-        
+
         if web_search_results is not None:
             provider_specific_fields["web_search_results"] = web_search_results
-        
+
         if tool_results is not None:
             provider_specific_fields["tool_results"] = tool_results
             container_id = (
@@ -1752,15 +1763,17 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             code_interpreter_results = self._build_code_interpreter_results(
                 tool_results, code_by_id, container_id
             )
-            provider_specific_fields["code_interpreter_results"] = code_interpreter_results
-        
+            provider_specific_fields[
+                "code_interpreter_results"
+            ] = code_interpreter_results
+
         container = completion_response.get("container")
         if container is not None:
             provider_specific_fields["container"] = container
-        
+
         if compaction_blocks is not None:
             provider_specific_fields["compaction_blocks"] = compaction_blocks
-        
+
         return provider_specific_fields
 
     def transform_parsed_response(
@@ -1830,7 +1843,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             _message = json_mode_message
 
         model_response.choices[0].message = _message
-        model_response._hidden_params["original_response"] = completion_response["content"]
+        model_response._hidden_params["original_response"] = completion_response[
+            "content"
+        ]
         model_response.choices[0].finish_reason = cast(
             OpenAIChatCompletionFinishReason,
             map_finish_reason(completion_response["stop_reason"]),

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -6,23 +6,21 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.litellm_core_utils.litellm_logging import \
-    Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.litellm_logging import \
-    use_custom_pricing_for_model
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
 from litellm.llms.anthropic import get_anthropic_config
-from litellm.llms.anthropic.chat.handler import \
-    ModelResponseIterator as AnthropicModelResponseIterator
+from litellm.llms.anthropic.chat.handler import (
+    ModelResponseIterator as AnthropicModelResponseIterator,
+)
 from litellm.proxy._types import PassThroughEndpointLoggingTypedDict
 from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
-from litellm.types.passthrough_endpoints.pass_through_endpoints import \
-    PassthroughStandardLoggingPayload
-from litellm.types.utils import (LiteLLMBatch, ModelResponse,
-                                 TextCompletionResponse)
+from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+    PassthroughStandardLoggingPayload,
+)
+from litellm.types.utils import LiteLLMBatch, ModelResponse, TextCompletionResponse
 
 if TYPE_CHECKING:
-    from litellm.types.passthrough_endpoints.pass_through_endpoints import \
-        EndpointType
+    from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
 
     from ..success_handler import PassThroughEndpointLogging
 else:
@@ -333,8 +331,7 @@ class AnthropicPassthroughLoggingHandler:
         import base64
 
         from litellm._uuid import uuid
-        from litellm.llms.anthropic.batches.transformation import \
-            AnthropicBatchesConfig
+        from litellm.llms.anthropic.batches.transformation import AnthropicBatchesConfig
         from litellm.types.utils import Choices, SpecialEnums
 
         try:
@@ -550,8 +547,7 @@ class AnthropicPassthroughLoggingHandler:
                 managed_files_hook, "store_unified_object_id"
             ):
                 # Create a mock user API key dict for the managed object storage
-                from litellm.proxy._types import (LitellmUserRoles,
-                                                  UserAPIKeyAuth)
+                from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 
                 user_api_key_dict = UserAPIKeyAuth(
                     user_id=kwargs.get("user_id", "default-user"),

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1898,9 +1898,9 @@ class ProxyLogging:
                     normalized_call_type = CallTypes.aembedding.value
             if normalized_call_type is not None:
                 litellm_logging_obj.call_type = normalized_call_type
-                litellm_logging_obj.model_call_details["call_type"] = (
-                    normalized_call_type
-                )
+                litellm_logging_obj.model_call_details[
+                    "call_type"
+                ] = normalized_call_type
             # Pass-through endpoints are logged via the callback loop's
             # async_post_call_failure_hook — skip pre_call and failure handlers.
             if litellm_logging_obj.call_type == CallTypes.pass_through.value:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2113,9 +2113,9 @@ class LiteLLMCompletionResponsesConfig:
                 hasattr(completion_details, "reasoning_tokens")
                 and completion_details.reasoning_tokens is not None
             ):
-                output_details_dict["reasoning_tokens"] = (
-                    completion_details.reasoning_tokens
-                )
+                output_details_dict[
+                    "reasoning_tokens"
+                ] = completion_details.reasoning_tokens
             else:
                 output_details_dict["reasoning_tokens"] = 0
 

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -168,14 +168,10 @@ class BaseResponsesAPIStreamingIterator:
 
                 # Store the completed response (also for incomplete/failed so logging still fires)
                 _chunk_type = getattr(openai_responses_api_chunk, "type", None)
-                if (
-                    openai_responses_api_chunk
-                    and _chunk_type
-                    in (
-                        ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
-                        ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
-                        ResponsesAPIStreamEvents.RESPONSE_FAILED,
-                    )
+                if openai_responses_api_chunk and _chunk_type in (
+                    ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+                    ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
+                    ResponsesAPIStreamEvents.RESPONSE_FAILED,
                 ):
                     self.completed_response = openai_responses_api_chunk
                     # Add cost to usage object if include_cost_in_streaming_usage is True

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -970,12 +970,12 @@ class OpenAIChatCompletionChunk(ChatCompletionChunk):
 
 class Hyperparameters(BaseModel):
     batch_size: Optional[Union[str, int]] = None  # "Number of examples in each batch."
-    learning_rate_multiplier: Optional[Union[str, float]] = (
-        None  # Scaling factor for the learning rate
-    )
-    n_epochs: Optional[Union[str, int]] = (
-        None  # "The number of epochs to train the model for"
-    )
+    learning_rate_multiplier: Optional[
+        Union[str, float]
+    ] = None  # Scaling factor for the learning rate
+    n_epochs: Optional[
+        Union[str, int]
+    ] = None  # "The number of epochs to train the model for"
 
     model_config = {"extra": "allow"}
 
@@ -1004,18 +1004,18 @@ class FineTuningJobCreate(BaseModel):
 
     model: str  # "The name of the model to fine-tune."
     training_file: str  # "The ID of an uploaded file that contains training data."
-    hyperparameters: Optional[Hyperparameters] = (
-        None  # "The hyperparameters used for the fine-tuning job."
-    )
-    suffix: Optional[str] = (
-        None  # "A string of up to 18 characters that will be added to your fine-tuned model name."
-    )
-    validation_file: Optional[str] = (
-        None  # "The ID of an uploaded file that contains validation data."
-    )
-    integrations: Optional[List[str]] = (
-        None  # "A list of integrations to enable for your fine-tuning job."
-    )
+    hyperparameters: Optional[
+        Hyperparameters
+    ] = None  # "The hyperparameters used for the fine-tuning job."
+    suffix: Optional[
+        str
+    ] = None  # "A string of up to 18 characters that will be added to your fine-tuned model name."
+    validation_file: Optional[
+        str
+    ] = None  # "The ID of an uploaded file that contains validation data."
+    integrations: Optional[
+        List[str]
+    ] = None  # "A list of integrations to enable for your fine-tuning job."
     seed: Optional[int] = None  # "The seed controls the reproducibility of the job."
 
 


### PR DESCRIPTION
## Summary

Applies `black` formatting to 10 files that were merged before required lint checks were enabled:

- `litellm/integrations/langsmith.py`
- `litellm/llms/anthropic/chat/handler.py`
- `litellm/litellm_core_utils/streaming_handler.py`
- `litellm/llms/anthropic/chat/transformation.py`
- `litellm/litellm_core_utils/litellm_logging.py`
- `litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py`
- `litellm/responses/litellm_completion_transformation/transformation.py`
- `litellm/responses/streaming_iterator.py`
- `litellm/proxy/utils.py`
- `litellm/types/llms/openai.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)