### PR TITLE
fix: upgrade mcp to 1.26.0 and bump version to 1.82.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3473,15 +3473,15 @@ files = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "1.26.0"
 description = "Model Context Protocol SDK"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "python_version >= \"3.10\" and extra == \"proxy\""
 files = [
-    {file = "mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a"},
-    {file = "mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802"},
+    {file = "mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca"},
+    {file = "mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Summary

- Upgrades `mcp` from `1.25.0` to `1.26.0` in `poetry.lock`
- Bumps litellm version from `1.82.4` → `1.82.5` (patch release)

The `pyproject.toml` constraint (`>=1.25.0,<2.0.0`) already allows 1.26.0 — only the lockfile needed updating for the MCP upgrade.

Version bump is required as `1.82.4` is already published to PyPI and cannot be re-uploaded.

## Test plan

- [ ] Verify MCP tests pass
- [ ] Verify PyPI publish succeeds with `1.82.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)