### PR TITLE
feat(redis): add circuit breaker to RedisCache to fast-fail when Redis is down

### DIFF
--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -393,15 +393,16 @@ class DualCache(BaseCache):
         parent_otel_span: Optional[Span] = None,
         local_only: bool = False,
         **kwargs,
-    ) -> float:
+    ) -> Optional[float]:
         """
         Key - the key in cache
 
         Value - float - the value you want to increment by
 
-        Returns - float - the incremented value
+        Returns - the incremented value, or None if no cache backend is
+        available (in_memory_cache is None and Redis failed/is absent).
         """
-        result: float = value
+        result: Optional[float] = None
         try:
             if self.in_memory_cache is not None:
                 result = await self.in_memory_cache.async_increment(

--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -401,8 +401,8 @@ class DualCache(BaseCache):
 
         Returns - float - the incremented value
         """
+        result: float = value
         try:
-            result: float = value
             if self.in_memory_cache is not None:
                 result = await self.in_memory_cache.async_increment(
                     key, value, **kwargs
@@ -418,7 +418,11 @@ class DualCache(BaseCache):
 
             return result
         except Exception as e:
-            raise e  # don't log if exception is raised
+            verbose_logger.warning(
+                "Redis async_increment_cache failed, falling back to in-memory result: %s",
+                e,
+            )
+            return result
 
     async def async_increment_cache_pipeline(
         self,
@@ -427,8 +431,8 @@ class DualCache(BaseCache):
         parent_otel_span: Optional[Span] = None,
         **kwargs,
     ) -> Optional[List[float]]:
+        result: Optional[List[float]] = None
         try:
-            result: Optional[List[float]] = None
             if self.in_memory_cache is not None:
                 result = await self.in_memory_cache.async_increment_pipeline(
                     increment_list=increment_list,
@@ -443,7 +447,11 @@ class DualCache(BaseCache):
 
             return result
         except Exception as e:
-            raise e  # don't log if exception is raised
+            verbose_logger.warning(
+                "Redis async_increment_cache_pipeline failed, falling back to in-memory result: %s",
+                e,
+            )
+            return result
 
     async def async_set_cache_sadd(
         self, key, value: List, local_only: bool = False, **kwargs

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -123,10 +123,15 @@ class RedisCircuitBreaker:
 
     def is_open(self) -> bool:
         """Returns True if Redis calls should be skipped."""
+        if self._state == self.HALF_OPEN:
+            # Probe already in flight — fast-fail all concurrent requests.
+            # Only the one call that caused the OPEN→HALF_OPEN transition
+            # (which returned False) is the designated probe.
+            return True
         if self._state == self.OPEN:
             if time.time() - (self._opened_at or 0) > self.recovery_timeout:
                 self._state = self.HALF_OPEN
-                return False  # allow probe through
+                return False  # this caller is the designated probe
             return True
         return False
 

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -10,6 +10,7 @@ Has 4 primary methods:
 
 import ast
 import asyncio
+import functools
 import hashlib
 import inspect
 import json
@@ -19,7 +20,11 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
-from litellm.constants import DEFAULT_REDIS_MAJOR_VERSION
+from litellm.constants import (
+    DEFAULT_REDIS_MAJOR_VERSION,
+    REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+    REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
+)
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
 from litellm.types.caching import (
@@ -89,6 +94,86 @@ def _get_call_stack_info(num_frames: int = 2) -> str:
         return "unknown"
 
 
+class RedisCircuitBreaker:
+    """
+    Tracks Redis health for a RedisCache instance.
+
+    States:
+      CLOSED    - normal, Redis is called
+      OPEN      - Redis is down, raise immediately (no network call)
+      HALF_OPEN - recovery probe: allow one request through
+
+    Transitions:
+      CLOSED    -> OPEN      after failure_threshold consecutive failures
+      OPEN      -> HALF_OPEN after recovery_timeout seconds
+      HALF_OPEN -> CLOSED    on success
+      HALF_OPEN -> OPEN      on failure (resets timer)
+    """
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+    def __init__(self, failure_threshold: int, recovery_timeout: int) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self._failure_count = 0
+        self._opened_at: Optional[float] = None
+        self._state = self.CLOSED
+
+    def is_open(self) -> bool:
+        """Returns True if Redis calls should be skipped."""
+        if self._state == self.OPEN:
+            if time.time() - (self._opened_at or 0) > self.recovery_timeout:
+                self._state = self.HALF_OPEN
+                return False  # allow probe through
+            return True
+        return False
+
+    def record_failure(self) -> None:
+        self._failure_count += 1
+        self._opened_at = time.time()
+        if self._failure_count >= self.failure_threshold:
+            if self._state != self.OPEN:
+                verbose_logger.warning(
+                    "Redis circuit breaker OPENED after %d consecutive failures — "
+                    "fast-failing Redis calls for %ds",
+                    self._failure_count,
+                    self.recovery_timeout,
+                )
+            self._state = self.OPEN
+
+    def record_success(self) -> None:
+        if self._state == self.HALF_OPEN:
+            verbose_logger.info("Redis circuit breaker CLOSED — Redis recovered")
+        self._failure_count = 0
+        self._state = self.CLOSED
+
+
+def _redis_circuit_breaker_guard(method):  # type: ignore
+    """
+    Decorator for RedisCache async methods.
+    Checks the circuit breaker before each call; records success/failure after.
+    Does not apply to ping/disconnect/test_connection (health/teardown must always run).
+    """
+
+    @functools.wraps(method)
+    async def wrapper(self, *args, **kwargs):  # type: ignore
+        if self._circuit_breaker.is_open():
+            raise Exception(
+                f"Redis circuit breaker is open — skipping {method.__name__}"
+            )
+        try:
+            result = await method(self, *args, **kwargs)
+            self._circuit_breaker.record_success()
+            return result
+        except Exception as e:
+            self._circuit_breaker.record_failure()
+            raise
+
+    return wrapper
+
+
 class RedisCache(BaseCache):
     # if users don't provider one, use the default litellm cache
 
@@ -149,6 +234,11 @@ class RedisCache(BaseCache):
                 self.redis_version = self.redis_client.info()["redis_version"]  # type: ignore
         except Exception:
             pass
+
+        self._circuit_breaker = RedisCircuitBreaker(
+            failure_threshold=REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+            recovery_timeout=REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
+        )
 
         self._setup_health_pings()
 
@@ -375,6 +465,7 @@ class RedisCache(BaseCache):
             )
             raise e
 
+    @_redis_circuit_breaker_guard
     async def async_scan_iter(self, pattern: str, count: int = 100) -> list:
         start_time = time.time()
         try:
@@ -451,6 +542,7 @@ class RedisCache(BaseCache):
             verbose_logger.error(f"Error registering Redis script: {str(e)}")
             raise e
 
+    @_redis_circuit_breaker_guard
     async def async_set_cache(self, key, value, **kwargs):
         from redis.asyncio import Redis
 
@@ -560,6 +652,7 @@ class RedisCache(BaseCache):
         results = await pipe.execute()
         return results
 
+    @_redis_circuit_breaker_guard
     async def async_set_cache_pipeline(
         self, cache_list: List[Tuple[Any, Any]], ttl: Optional[float] = None, **kwargs
     ):
@@ -636,6 +729,7 @@ class RedisCache(BaseCache):
         except Exception:
             raise
 
+    @_redis_circuit_breaker_guard
     async def async_set_cache_sadd(
         self, key, value: List, ttl: Optional[float], **kwargs
     ):
@@ -708,6 +802,7 @@ class RedisCache(BaseCache):
                 value,
             )
 
+    @_redis_circuit_breaker_guard
     async def batch_cache_write(self, key, value, **kwargs):
         print_verbose(
             f"in batch cache writing for redis buffer size={len(self.redis_batch_writing_buffer)}",
@@ -717,6 +812,7 @@ class RedisCache(BaseCache):
         if len(self.redis_batch_writing_buffer) >= self.redis_flush_size:
             await self.flush_cache_buffer()  # logging done in here
 
+    @_redis_circuit_breaker_guard
     async def async_increment(
         self,
         key,
@@ -894,6 +990,7 @@ class RedisCache(BaseCache):
             verbose_logger.error(f"Error occurred in batch get cache - {str(e)}")
             return key_value_dict
 
+    @_redis_circuit_breaker_guard
     async def async_get_cache(
         self, key, parent_otel_span: Optional[Span] = None, **kwargs
     ):
@@ -944,6 +1041,7 @@ class RedisCache(BaseCache):
                 f"litellm.caching.caching: async get() - Got exception from REDIS: {str(e)}"
             )
 
+    @_redis_circuit_breaker_guard
     async def async_batch_get_cache(
         self,
         key_list: Union[List[str], List[Optional[str]]],
@@ -1087,6 +1185,7 @@ class RedisCache(BaseCache):
             )
             raise e
 
+    @_redis_circuit_breaker_guard
     async def delete_cache_keys(self, keys):
         # typed as Any, redis python lib has incomplete type stubs for RedisCluster and does not include `delete`
         _redis_client: Any = self.init_async_client()
@@ -1151,6 +1250,7 @@ class RedisCache(BaseCache):
                 "error": str(e),
             }
 
+    @_redis_circuit_breaker_guard
     async def async_delete_cache(self, key: str):
         # typed as Any, redis python lib has incomplete type stubs for RedisCluster and does not include `delete`
         _redis_client: Any = self.init_async_client()
@@ -1184,6 +1284,7 @@ class RedisCache(BaseCache):
         )
         return [r for r in results if isinstance(r, float)]
 
+    @_redis_circuit_breaker_guard
     async def async_increment_pipeline(
         self, increment_list: List[RedisPipelineIncrementOperation], **kwargs
     ) -> Optional[List[float]]:
@@ -1247,6 +1348,7 @@ class RedisCache(BaseCache):
             )
             raise e
 
+    @_redis_circuit_breaker_guard
     async def async_get_ttl(self, key: str) -> Optional[int]:
         """
         Get the remaining TTL of a key in Redis
@@ -1270,6 +1372,7 @@ class RedisCache(BaseCache):
             verbose_logger.debug(f"Redis TTL Error: {e}")
             return None
 
+    @_redis_circuit_breaker_guard
     async def async_rpush(
         self,
         key: str,
@@ -1336,6 +1439,7 @@ class RedisCache(BaseCache):
                 raise r
         return results
 
+    @_redis_circuit_breaker_guard
     async def async_rpush_pipeline(
         self,
         rpush_list: List[RedisPipelineRpushOperation],
@@ -1405,6 +1509,7 @@ class RedisCache(BaseCache):
 
         return result
 
+    @_redis_circuit_breaker_guard
     async def async_lpop(
         self,
         key: str,
@@ -1534,6 +1639,7 @@ class RedisCache(BaseCache):
                 decoded_results.append(None)
         return decoded_results
 
+    @_redis_circuit_breaker_guard
     async def async_lpop_pipeline(
         self,
         lpop_list: List[RedisPipelineLpopOperation],

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -350,6 +350,12 @@ AZURE_DOCUMENT_INTELLIGENCE_DEFAULT_DPI = int(
 )
 REDIS_SOCKET_TIMEOUT = float(os.getenv("REDIS_SOCKET_TIMEOUT", 0.1))
 REDIS_CONNECTION_POOL_TIMEOUT = int(os.getenv("REDIS_CONNECTION_POOL_TIMEOUT", 5))
+REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD = int(
+    os.getenv("REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5)
+)
+REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT = int(
+    os.getenv("REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", 60)
+)
 # Default Redis major version to assume when version cannot be determined
 # Using 7 as it's the modern version that supports LPOP with count parameter
 DEFAULT_REDIS_MAJOR_VERSION = int(os.getenv("DEFAULT_REDIS_MAJOR_VERSION", 7))

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -216,3 +216,45 @@ def test_circuit_breaker_closes_on_recovery():
     # Successful probe closes the circuit
     cb.record_success()
     assert cb._state == "closed"
+
+
+def test_circuit_breaker_half_open_concurrent_calls_are_fast_failed():
+    """
+    Regression test: only ONE probe gets through when the circuit transitions
+    OPEN → HALF_OPEN. All concurrent callers that check is_open() while the
+    state is already HALF_OPEN must be fast-failed (return True), not allowed
+    through as additional probes.
+    """
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    cb = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+    cb._state = "open"
+    cb._opened_at = time.time() - 9999  # recovery timeout long expired
+
+    # First caller: OPEN + expired → transitions to HALF_OPEN, returns False (probe)
+    assert cb.is_open() is False
+    assert cb._state == "half_open"
+
+    # All subsequent concurrent callers: HALF_OPEN → fast-fail (return True)
+    for _ in range(10):
+        assert cb.is_open() is True, "concurrent callers should be fast-failed in HALF_OPEN"
+
+
+@pytest.mark.asyncio
+async def test_async_increment_cache_returns_none_when_no_in_memory_cache_and_redis_fails():
+    """
+    Regression test: when in_memory_cache is None and Redis fails, async_increment_cache
+    must return None — not the raw increment delta — to avoid silently miscalculating
+    rate-limit counters.
+    """
+    dc = DualCache()
+    dc.in_memory_cache = None  # type: ignore[assignment]  # constructor always creates InMemoryCache, so null it manually
+    dc.redis_cache = MagicMock()
+    dc.redis_cache.async_increment = AsyncMock(side_effect=Exception("redis down"))
+
+    result = await dc.async_increment_cache("rpm:model:14-05", 1.0, ttl=60)
+
+    assert result is None, (
+        f"Expected None when in_memory_cache is absent and Redis fails, got {result!r}. "
+        "Returning the delta (1.0) would silently miscalculate rate-limit counters."
+    )

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -159,3 +159,60 @@ async def test_dual_cache_sync_and_async_set_cache_use_same_ttl():
     # Both should use default_in_memory_ttl=60, so their expiry times
     # should be within a small tolerance of each other
     assert abs(sync_expiry - async_expiry) < 1.0
+
+
+def test_circuit_breaker_opens_after_threshold():
+    """Circuit opens after N consecutive Redis failures."""
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    cb = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+    for _ in range(3):
+        cb.record_failure()
+
+    assert cb._state == "open"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_open_skips_redis():
+    """When circuit is open, the guard decorator raises immediately without calling the method."""
+    from litellm.caching.redis_cache import (
+        RedisCircuitBreaker,
+        _redis_circuit_breaker_guard,
+    )
+
+    class FakeRedis:
+        def __init__(self):
+            self._circuit_breaker = RedisCircuitBreaker(
+                failure_threshold=3, recovery_timeout=60
+            )
+            self._circuit_breaker._state = "open"
+            self._circuit_breaker._opened_at = time.time()
+            self.call_count = 0
+
+        @_redis_circuit_breaker_guard
+        async def do_thing(self):
+            self.call_count += 1
+            return "result"
+
+    fr = FakeRedis()
+    with pytest.raises(Exception, match="circuit breaker is open"):
+        await fr.do_thing()
+
+    assert fr.call_count == 0  # method body never executed
+
+
+def test_circuit_breaker_closes_on_recovery():
+    """After recovery_timeout expires, probe is allowed and success closes the circuit."""
+    from litellm.caching.redis_cache import RedisCircuitBreaker
+
+    cb = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+    cb._state = "open"
+    cb._opened_at = time.time() - 9999  # recovery timeout long expired
+
+    # is_open() should return False to allow a probe through, and transition to HALF_OPEN
+    assert cb.is_open() is False
+    assert cb._state == "half_open"
+
+    # Successful probe closes the circuit
+    cb.record_success()
+    assert cb._state == "closed"


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Problem

When ElastiCache is slow/unresponsive, every `async_increment` call (rate-limit counters, TPM/RPM tracking) blocks for the full `socket_timeout` — ~8s per call in production. There was no mechanism to stop hammering a dead Redis after repeated failures.

Two separate issues:
1. `RedisCache` had no circuit breaker — kept retrying Redis on every request even after repeated timeouts
2. `DualCache.async_increment_cache` and `async_increment_cache_pipeline` re-raised Redis exceptions (`raise e`) instead of falling back to the L1 in-memory cache

## Changes

**`litellm/caching/redis_cache.py`**
- Added `RedisCircuitBreaker` class (CLOSED → OPEN → HALF_OPEN state machine)
- Added `_redis_circuit_breaker_guard` decorator that wraps all public async Redis methods — checks if circuit is open before making a network call, records success/failure after
- After `REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD` (default 5) consecutive failures, circuit opens and all subsequent calls raise immediately without touching the network
- After `REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` (default 60s), circuit allows one probe through; success closes it, failure resets the timer
- Both thresholds configurable via env vars

**`litellm/caching/dual_cache.py`**
- Changed `raise e` → `return result` (with warning log) in `async_increment_cache` and `async_increment_cache_pipeline` — when Redis fails (including circuit-breaker fast-fail), falls back to the L1 in-memory value instead of crashing the caller

**`litellm/constants.py`**
- Added `REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD` and `REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT` constants

## Behavior

```
Normal:        Redis ok  → success recorded, result returned
Redis fails:   exception → failure recorded, DualCache returns L1 value
After 5 fails: circuit OPEN → decorator raises immediately (0ms, no network)
               DualCache catches, returns L1 value instantly
After 60s:     circuit HALF_OPEN → one probe allowed through
  Probe ok  →  circuit CLOSED, normal resumes
  Probe fail → circuit OPEN again, timer resets
```

## Type

🐛 Bug Fix / ⚡ Performance Improvement