### PR TITLE
[Feature] UI - Teams: Modernize Teams Table

### DIFF
--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -9,7 +9,7 @@ import AgentsPanel from "@/components/agents";
 import BudgetPanel from "@/components/budgets/budget_panel";
 import CacheDashboard from "@/components/cache_dashboard";
 import ClaudeCodePluginsPanel from "@/components/claude_code_plugins";
-import { fetchTeams } from "@/components/common_components/fetch_teams";
+import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { CostTrackingSettings } from "@/components/CostTrackingSettings";
 import GeneralSettings from "@/components/general_settings";
@@ -339,7 +339,9 @@ function CreateKeyPageContent() {
       fetchUserModels(userID, userRole, accessToken, setUserModels);
     }
     if (accessToken && userID && userRole) {
-      fetchTeams(accessToken, userID, userRole, null, setTeams);
+      v2TeamListCall(accessToken, 1, 100, {
+        userID: userRole !== "Admin" && userRole !== "Admin Viewer" ? userID : null,
+      }).then((response) => setTeams(response.teams ?? [])).catch(console.error);
     }
     if (accessToken) {
       fetchOrganizations(accessToken, setOrganizations);

--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -18,8 +18,8 @@ vi.mock("./networking", () => ({
   getPoliciesList: vi.fn().mockResolvedValue({ policies: [] }),
 }));
 
-vi.mock("./common_components/fetch_teams", () => ({
-  fetchTeams: vi.fn(),
+vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
+  teamListCall: vi.fn().mockResolvedValue({ teams: [], total: 0, page: 1, page_size: 100, total_pages: 0 }),
 }));
 
 vi.mock("./molecules/notifications_manager", () => ({
@@ -375,6 +375,9 @@ describe("OldTeams - handleCreate organization handling", () => {
         organizations={[]}
       />,
     );
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-team-button")).toBeInTheDocument();
+    });
     const deleteTeamButton = screen.getByTestId("delete-team-button");
     act(() => {
       fireEvent.click(deleteTeamButton);
@@ -389,7 +392,7 @@ describe("OldTeams - empty state", () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
   });
 
-  it("should display empty state message when teams array is empty", () => {
+  it("should display empty state message when teams array is empty", async () => {
     renderWithQueryClient(
       <OldTeams
         teams={[]}
@@ -402,11 +405,13 @@ describe("OldTeams - empty state", () => {
       />,
     );
 
-    expect(screen.getByText("No teams found")).toBeInTheDocument();
-    expect(screen.getByText("Adjust your filters or create a new team")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No teams yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Create your first team to organize members and manage access to models.")).toBeInTheDocument();
   });
 
-  it("should display empty state message when teams is null", () => {
+  it("should display empty state message when teams is null", async () => {
     renderWithQueryClient(
       <OldTeams
         teams={null}
@@ -419,11 +424,13 @@ describe("OldTeams - empty state", () => {
       />,
     );
 
-    expect(screen.getByText("No teams found")).toBeInTheDocument();
-    expect(screen.getByText("Adjust your filters or create a new team")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No teams yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Create your first team to organize members and manage access to models.")).toBeInTheDocument();
   });
 
-  it("should not display empty state when teams array has items", () => {
+  it("should not display empty state when teams array has items", async () => {
     renderWithQueryClient(
       <OldTeams
         teams={[
@@ -451,9 +458,11 @@ describe("OldTeams - empty state", () => {
       />,
     );
 
-    expect(screen.queryByText("No teams found")).not.toBeInTheDocument();
-    expect(screen.queryByText("Adjust your filters or create a new team")).not.toBeInTheDocument();
-    expect(screen.getByText("Test Team")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Test Team")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("No teams yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create your first team to organize members and manage access to models.")).not.toBeInTheDocument();
   });
 });
 
@@ -621,12 +630,9 @@ describe("OldTeams - premium props", () => {
       />,
     );
 
-    const truncatedTeamId = "team-123456789".slice(0, 7);
-    const teamButton = await screen.findByRole("button", {
-      name: new RegExp(`${truncatedTeamId}\\.\\.\\.`),
-    });
+    const teamIdElement = await screen.findByText("team-123456789");
     act(() => {
-      fireEvent.click(teamButton);
+      fireEvent.click(teamIdElement);
     });
 
     await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
@@ -798,7 +804,7 @@ describe("OldTeams - access_group_ids in team create", () => {
       />,
     );
 
-    const createButton = screen.getByRole("button", { name: /create new team/i });
+    const createButton = screen.getAllByRole("button", { name: /create team/i })[0];
     act(() => {
       fireEvent.click(createButton);
     });
@@ -823,7 +829,8 @@ describe("OldTeams - access_group_ids in team create", () => {
     const accessGroupInput = screen.getByTestId("access-group-selector");
     fireEvent.change(accessGroupInput, { target: { value: "ag-1,ag-2" } });
 
-    const createTeamSubmitButton = screen.getByRole("button", { name: /create team/i });
+    const createTeamSubmitButtons = screen.getAllByRole("button", { name: /create team/i });
+    const createTeamSubmitButton = createTeamSubmitButtons[createTeamSubmitButtons.length - 1];
     fireEvent.click(createTeamSubmitButton);
 
     await waitFor(() => {
@@ -865,7 +872,7 @@ describe("OldTeams - models dropdown options", () => {
       expect(fetchAvailableModelsForTeamOrKey).toHaveBeenCalled();
     });
 
-    const createButton = screen.getByRole("button", { name: /create new team/i });
+    const createButton = screen.getAllByRole("button", { name: /create team/i })[0];
     act(() => {
       fireEvent.click(createButton);
     });
@@ -884,7 +891,7 @@ describe("OldTeams - organization alias display", () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
   });
 
-  it("should display organization alias instead of organization id", () => {
+  it("should display organization alias instead of organization id", async () => {
     const mockOrganizations = [
       {
         organization_id: "org-123",
@@ -934,11 +941,13 @@ describe("OldTeams - organization alias display", () => {
       />,
     );
 
-    expect(screen.getByText("Test Organization")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Test Organization")).toBeInTheDocument();
+    });
     expect(screen.queryByText("org-123")).not.toBeInTheDocument();
   });
 
-  it("should display organization id when alias is not found", () => {
+  it("should display organization id when alias is not found", async () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
 
     renderWithQueryClient(
@@ -968,10 +977,12 @@ describe("OldTeams - organization alias display", () => {
       />,
     );
 
-    expect(screen.getByText("org-unknown")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("org-unknown")).toBeInTheDocument();
+    });
   });
 
-  it("should display N/A when organization_id is null", () => {
+  it("should display N/A when organization_id is null", async () => {
     mockUseOrganizations.mockReturnValue({ data: [] });
 
     renderWithQueryClient(
@@ -1001,6 +1012,9 @@ describe("OldTeams - organization alias display", () => {
       />,
     );
 
-    expect(screen.getByText("N/A")).toBeInTheDocument();
+    await waitFor(() => {
+      // When organization_id is null, the table shows "—" in the Organization column
+      expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -3,50 +3,54 @@ import AvailableTeamsPanel from "@/components/team/available_teams";
 import TeamInfoView from "@/components/team/TeamInfo";
 import TeamSSOSettings from "@/components/TeamSSOSettings";
 import { isProxyAdminRole } from "@/utils/roles";
-import { InfoCircleOutlined } from "@ant-design/icons";
-import { ChevronDownIcon, ChevronRightIcon, RefreshIcon } from "@heroicons/react/outline";
-import { FilterInput } from "@/components/common_components/Filters/FilterInput";
-import { FiltersButton } from "@/components/common_components/Filters/FiltersButton";
-import { ResetFiltersButton } from "@/components/common_components/Filters/ResetFiltersButton";
-import { Search, User } from "lucide-react";
+import {
+  InfoCircleOutlined,
+  PlusOutlined,
+  TeamOutlined,
+  ReloadOutlined,
+} from "@ant-design/icons";
 import {
   Accordion,
   AccordionBody,
   AccordionHeader,
-  Badge,
-  Button,
-  Card,
-  Col,
-  Grid,
-  Icon,
-  Select,
-  SelectItem,
-  Tab,
-  TabGroup,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeaderCell,
-  TableRow,
-  Text,
   TextInput,
 } from "@tremor/react";
-import { Button as Button2, Form, Input, Modal, Select as Select2, Switch, Tooltip, Typography } from "antd";
-import React, { useEffect, useState } from "react";
-import { formatNumberWithCommas } from "../utils/dataUtils";
+import {
+  Button,
+  Card,
+  Flex,
+  Form,
+  Input,
+  Layout,
+  Modal,
+  Pagination,
+  Progress,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tabs,
+  Tag,
+  theme,
+  Tooltip,
+  Typography,
+  message,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import type { SorterResult } from "antd/es/table/interface";
+import { KeyIcon, LayersIcon, SearchIcon, UsersIcon } from "lucide-react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { AntDLoadingSpinner } from "@/components/ui/AntDLoadingSpinner";
+import OrganizationDropdown from "./common_components/OrganizationDropdown";
+import TableIconActionButton from "./common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
+import { teamListCall as v2TeamListCall, type TeamsResponse } from "@/app/(dashboard)/hooks/teams/useTeams";
 import AccessGroupSelector from "./common_components/AccessGroupSelector";
 import AgentSelector from "./agent_management/AgentSelector";
-import { fetchTeams } from "./common_components/fetch_teams";
 import ModelAliasManager from "./common_components/ModelAliasManager";
 import PremiumLoggingSettings from "./common_components/PremiumLoggingSettings";
 import RouterSettingsAccordion, { RouterSettingsAccordionValue } from "./common_components/RouterSettingsAccordion";
 import {
   fetchAvailableModelsForTeamOrKey,
-  getModelDisplayName,
   unfurlWildcardModelsInList,
 } from "./key_team_helpers/fetch_available_models_team_key";
 import type { KeyResponse, Team } from "./key_team_helpers/key_list";
@@ -85,8 +89,7 @@ interface EditTeamModalProps {
 
 import { updateExistingKeys } from "@/utils/dataUtils";
 import DeleteResourceModal from "./common_components/DeleteResourceModal";
-import TableIconActionButton from "./common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
-import { Member, teamCreateCall, v2TeamListCall } from "./networking";
+import { Member, teamCreateCall } from "./networking";
 import { ModelSelect } from "./ModelSelect/ModelSelect";
 
 interface TeamInfo {
@@ -182,10 +185,13 @@ const Teams: React.FC<TeamProps> = ({
 }) => {
   console.log(`organizations: ${JSON.stringify(organizations)}`);
   const { data: organizationsData } = useOrganizations();
-  const [lastRefreshed, setLastRefreshed] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [totalTeams, setTotalTeams] = useState(0);
   const [currentOrg, setCurrentOrg] = useState<Organization | null>(null);
   const [currentOrgForCreateTeam, setCurrentOrgForCreateTeam] = useState<Organization | null>(null);
-  const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState<FilterState>({
     team_id: "",
     team_alias: "",
@@ -193,19 +199,55 @@ const Teams: React.FC<TeamProps> = ({
     sort_by: "created_at",
     sort_order: "desc",
   });
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const fetchTeamsV2 = async (opts: {
+    page?: number;
+    size?: number;
+    sortBy?: string;
+    sortOrder?: string;
+    organizationID?: string;
+    teamAlias?: string;
+  } = {}) => {
+    if (!accessToken) return;
+    const page = opts.page ?? currentPage;
+    const size = opts.size ?? pageSize;
+    const sortBy = opts.sortBy ?? filters.sort_by;
+    const sortOrder = opts.sortOrder ?? filters.sort_order;
+    const organizationID = opts.organizationID ?? filters.organization_id;
+    const teamAlias = opts.teamAlias ?? filters.team_alias;
+
+    setIsLoading(true);
+    setFetchError(null);
+    try {
+      const response: TeamsResponse = await v2TeamListCall(
+        accessToken,
+        page,
+        size,
+        {
+          organizationID: organizationID || null,
+          team_alias: teamAlias || null,
+          userID: userRole !== "Admin" && userRole !== "Admin Viewer" ? userID : null,
+          sortBy: sortBy || null,
+          sortOrder: sortOrder || null,
+        },
+      );
+      setTeams(response.teams ?? []);
+      setTotalTeams(response.total ?? 0);
+    } catch (err: any) {
+      setFetchError(err?.message || "Failed to fetch teams");
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   useEffect(() => {
-    console.log(`inside useeffect - ${lastRefreshed}`);
-    if (accessToken) {
-      // Call your function here
-      fetchTeams(accessToken, userID, userRole, currentOrg, setTeams);
-    }
-    handleRefreshClick();
-  }, [lastRefreshed]);
+    fetchTeamsV2();
+  }, [accessToken]);
 
   const [form] = Form.useForm();
   const [memberForm] = Form.useForm();
-  const { Title, Paragraph } = Typography;
   const [value, setValue] = useState("");
   const [editModalVisible, setEditModalVisible] = useState(false);
 
@@ -225,7 +267,6 @@ const Teams: React.FC<TeamProps> = ({
   // Add this state near the other useState declarations
   const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
   const [policiesList, setPoliciesList] = useState<string[]>([]);
-  const [expandedAccordions, setExpandedAccordions] = useState<Record<string, boolean>>({});
   const [loggingSettings, setLoggingSettings] = useState<any[]>([]);
   const [mcpAccessGroups, setMcpAccessGroups] = useState<string[]>([]);
   const [mcpAccessGroupsLoaded, setMcpAccessGroupsLoaded] = useState(false);
@@ -376,7 +417,7 @@ const Teams: React.FC<TeamProps> = ({
     try {
       setIsTeamDeleting(true);
       await teamDeleteCall(accessToken, teamToDelete.team_id);
-      await fetchTeams(accessToken, userID, userRole, currentOrg, setTeams);
+      await fetchTeamsV2();
       NotificationsManager.success("Team deleted successfully");
     } catch (error) {
       NotificationsManager.fromBackend("Error deleting the team: " + error);
@@ -572,467 +613,447 @@ const Teams: React.FC<TeamProps> = ({
     return false;
   };
 
-  const handleRefreshClick = () => {
-    // Update the 'lastRefreshed' state to the current date and time
-    const currentDate = new Date();
-    setLastRefreshed(currentDate.toLocaleString());
+  const handleSearchChange = (value: string) => {
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    setIsSearching(true);
+    searchDebounceRef.current = setTimeout(async () => {
+      try {
+        setFilters((prev) => ({ ...prev, team_alias: value }));
+        setCurrentPage(1);
+        await fetchTeamsV2({ page: 1, teamAlias: value });
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
   };
 
-  const handleFilterChange = (key: keyof FilterState, value: string) => {
+  const handleFilterChange = async (key: keyof FilterState, value: string) => {
     const newFilters = { ...filters, [key]: value };
     setFilters(newFilters);
-    // Call teamListCall with the new filters
-    if (accessToken) {
-      v2TeamListCall(
+    setCurrentPage(1);
+    if (!accessToken) return;
+    try {
+      const response: TeamsResponse = await v2TeamListCall(
         accessToken,
-        newFilters.organization_id || null,
-        null,
-        newFilters.team_id || null,
-        newFilters.team_alias || null,
-      )
-        .then((response) => {
-          if (response && response.teams) {
-            setTeams(response.teams);
-          }
-        })
-        .catch((error) => {
-          console.error("Error fetching teams:", error);
-        });
-    }
-  };
-
-  const handleSortChange = (sortBy: string, sortOrder: "asc" | "desc") => {
-    const newFilters = {
-      ...filters,
-      sort_by: sortBy,
-      sort_order: sortOrder,
-    };
-    setFilters(newFilters);
-    // Call teamListCall with the new sort parameters
-    if (accessToken) {
-      v2TeamListCall(
-        accessToken,
-        filters.organization_id || null,
-        null,
-        filters.team_id || null,
-        filters.team_alias || null,
-      )
-        .then((response) => {
-          if (response && response.teams) {
-            setTeams(response.teams);
-          }
-        })
-        .catch((error) => {
-          console.error("Error fetching teams:", error);
-        });
+        1,
+        pageSize,
+        {
+          organizationID: newFilters.organization_id || null,
+          team_alias: newFilters.team_alias || null,
+          userID: userRole !== "Admin" && userRole !== "Admin Viewer" ? userID : null,
+          sortBy: newFilters.sort_by || null,
+          sortOrder: newFilters.sort_order || null,
+        },
+      );
+      setTeams(response.teams ?? []);
+      setTotalTeams(response.total ?? 0);
+    } catch (error) {
+      console.error("Error fetching teams:", error);
     }
   };
 
   const handleFilterReset = () => {
-    setFilters({
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    setIsSearching(false);
+    const resetFilters: FilterState = {
       team_id: "",
       team_alias: "",
       organization_id: "",
       sort_by: "created_at",
       sort_order: "desc",
-    });
-    // Reset teams list
-    if (accessToken) {
-      v2TeamListCall(accessToken, null, userID || null, null, null)
-        .then((response) => {
-          if (response && response.teams) {
-            setTeams(response.teams);
-          }
-        })
-        .catch((error) => {
-          console.error("Error fetching teams:", error);
-        });
-    }
+    };
+    setFilters(resetFilters);
+    setCurrentPage(1);
+    fetchTeamsV2({ page: 1, organizationID: "", teamAlias: "", sortBy: "created_at", sortOrder: "desc" });
   };
 
+  const { token } = theme.useToken();
+  const { Title, Text } = Typography;
+  const { Content } = Layout;
+
+  const handleRetry = () => {
+    fetchTeamsV2();
+  };
+
+  const handleTableSort = (_pagination: unknown, _filters: unknown, sorter: SorterResult<Team> | SorterResult<Team>[]) => {
+    const s = Array.isArray(sorter) ? sorter[0] : sorter;
+    const sortBy = s.order ? (s.columnKey as string) : "created_at";
+    const sortOrder = s.order === "ascend" ? "asc" : s.order === "descend" ? "desc" : "desc";
+    setFilters((prev) => ({ ...prev, sort_by: sortBy, sort_order: sortOrder }));
+    fetchTeamsV2({ sortBy, sortOrder });
+  };
+
+  const teamColumns: ColumnsType<Team> = useMemo(() => [
+    {
+      title: "Team ID",
+      dataIndex: "team_id",
+      key: "team_id",
+      width: 170,
+      ellipsis: true,
+      render: (id: string, record: Team) => (
+        <Tooltip title={id}>
+          <Text
+            ellipsis
+            className="text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs cursor-pointer"
+            style={{ fontSize: 14, padding: "1px 8px" }}
+            onClick={() => setSelectedTeamId(record.team_id)}
+          >
+            {id}
+          </Text>
+        </Tooltip>
+      ),
+    },
+    {
+      title: "Team Alias",
+      dataIndex: "team_alias",
+      key: "team_alias",
+      ellipsis: true,
+      sorter: true,
+      render: (alias: string | undefined) => (
+        <Text style={{ fontSize: 14 }}>
+          {alias || <Text type="secondary" italic>—</Text>}
+        </Text>
+      ),
+    },
+    {
+      title: "Organization",
+      key: "organization",
+      width: 160,
+      ellipsis: true,
+      render: (_: unknown, record: Team) => {
+        const orgAlias = getOrganizationAlias(record.organization_id, organizationsData || organizations);
+        return record.organization_id ? <Text ellipsis style={{ fontSize: 14 }}>{orgAlias}</Text> : <Text type="secondary">—</Text>;
+      },
+    },
+    {
+      title: "Resources",
+      key: "resources",
+      width: 240,
+      render: (_: unknown, record: Team) => {
+        const memberCount = perTeamInfo?.[record.team_id]?.team_info?.members_with_roles?.length ?? 0;
+        const modelCount = record.models?.length ?? 0;
+        const keyCount = perTeamInfo?.[record.team_id]?.keys?.length ?? 0;
+        return (
+          <Flex gap={12} align="center">
+            <Tooltip title={`${memberCount} Members`}>
+              <Tag color="purple" style={{ fontSize: 14, padding: "2px 8px", margin: 0 }}>
+                <Flex align="center" gap={6}>
+                  <UsersIcon size={14} />
+                  {memberCount}
+                </Flex>
+              </Tag>
+            </Tooltip>
+            <Tooltip title={`${modelCount} Models`}>
+              <Tag color="blue" style={{ fontSize: 14, padding: "2px 8px", margin: 0 }}>
+                <Flex align="center" gap={6}>
+                  <LayersIcon size={14} />
+                  {modelCount}
+                </Flex>
+              </Tag>
+            </Tooltip>
+            <Tooltip title={`${keyCount} Keys`}>
+              <Tag color="cyan" style={{ fontSize: 14, padding: "2px 8px", margin: 0 }}>
+                <Flex align="center" gap={6}>
+                  <KeyIcon size={14} />
+                  {keyCount}
+                </Flex>
+              </Tag>
+            </Tooltip>
+          </Flex>
+        );
+      },
+    },
+    {
+      title: "Spend / Budget",
+      key: "spend",
+      width: 200,
+      sorter: true,
+      render: (_: unknown, record: Team) => {
+        const spendVal = record.spend ?? 0;
+        const budgetVal = record.max_budget;
+        const spendStr = `$${spendVal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        const budgetStr = budgetVal != null
+          ? `$${budgetVal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+          : "Unlimited";
+        const percent = budgetVal != null && budgetVal > 0 ? Math.min((spendVal / budgetVal) * 100, 100) : null;
+        return (
+          <Flex vertical gap={2}>
+            <Text style={{ fontSize: 13 }}>
+              {spendStr}
+              <Text type="secondary" style={{ fontSize: 12 }}>{" / "}{budgetStr}</Text>
+            </Text>
+            {percent != null && (
+              <Progress
+                percent={percent}
+                size="small"
+                showInfo={false}
+                strokeColor={percent >= 90 ? "#ff4d4f" : percent >= 70 ? "#faad14" : "#1677ff"}
+                style={{ marginBottom: 0 }}
+              />
+            )}
+          </Flex>
+        );
+      },
+    },
+    {
+      title: "Created",
+      dataIndex: "created_at",
+      key: "created_at",
+      width: 130,
+      ellipsis: true,
+      sorter: true,
+      render: (date: string | undefined) => (
+        <Text type="secondary" style={{ fontSize: 13 }}>
+          {date ? new Date(date).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }) : "—"}
+        </Text>
+      ),
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      width: 120,
+      align: "right" as const,
+      render: (_: unknown, record: Team) => (
+        <Space size={4}>
+          <TableIconActionButton
+            variant="Copy"
+            tooltipText="Copy Team ID"
+            onClick={() => {
+              navigator.clipboard.writeText(record.team_id)
+                .then(() => message.success("Team ID copied"))
+                .catch(() => message.error("Failed to copy"));
+            }}
+          />
+          {userRole === "Admin" && (
+            <>
+              <TableIconActionButton
+                variant="Edit"
+                tooltipText="Edit team"
+                dataTestId="edit-team-button"
+                onClick={() => {
+                  setSelectedTeamId(record.team_id);
+                  setEditTeam(true);
+                }}
+              />
+              <TableIconActionButton
+                variant="Delete"
+                tooltipText="Delete team"
+                dataTestId="delete-team-button"
+                onClick={() => handleDelete(record)}
+              />
+            </>
+          )}
+        </Space>
+      ),
+    },
+  ], [userRole, perTeamInfo, organizationsData, organizations]);
+
+  const displayTeams = useMemo(() => teams ?? [], [teams]);
+
+  const renderTeamsContent = () => {
+    if (isLoading) {
+      return (
+        <Flex justify="center" align="center" style={{ padding: "80px 0" }}>
+          <AntDLoadingSpinner fontSize={48} />
+        </Flex>
+      );
+    }
+
+    if (fetchError) {
+      return (
+        <Flex vertical align="center" gap={16} style={{ padding: "64px 0" }}>
+          <Text type="danger" style={{ fontSize: 15 }}>
+            Failed to load teams
+          </Text>
+          <Text type="secondary" style={{ fontSize: 13 }}>
+            {fetchError}
+          </Text>
+          <Button icon={<ReloadOutlined />} onClick={handleRetry}>
+            Retry
+          </Button>
+        </Flex>
+      );
+    }
+
+    return (
+      <Table<Team>
+        columns={teamColumns}
+        dataSource={displayTeams}
+        rowKey="team_id"
+        pagination={false}
+        onChange={handleTableSort}
+        locale={{
+          emptyText: (
+            <div style={{ padding: "64px 0", textAlign: "center" }}>
+              <TeamOutlined style={{ fontSize: 40, color: "#d9d9d9", marginBottom: 12 }} />
+              <div>
+                <Text style={{ fontSize: 15, color: "#595959" }}>No teams yet</Text>
+              </div>
+              <div style={{ marginTop: 4 }}>
+                <Text type="secondary" style={{ fontSize: 13 }}>
+                  Create your first team to organize members and manage access to models.
+                </Text>
+              </div>
+              {canCreateOrManageTeams(userRole, userID, organizations) && (
+                <Button
+                  type="primary"
+                  icon={<PlusOutlined />}
+                  onClick={() => setIsTeamModalVisible(true)}
+                  style={{ marginTop: 16 }}
+                >
+                  Create Team
+                </Button>
+              )}
+            </div>
+          ),
+        }}
+        scroll={{ x: 1000 }}
+        size="middle"
+      />
+    );
+  };
+
+  const tabItems = [
+    {
+      key: "your-teams",
+      label: "Your Teams",
+      children: (
+        <>
+          <Card styles={{ body: { padding: 0 } }}>
+            <Flex
+              justify="space-between"
+              align="center"
+              style={{ padding: "12px 16px" }}
+            >
+              <Flex gap={12} align="center">
+                <Input
+                  prefix={<SearchIcon size={16} />}
+                  suffix={isSearching ? <AntDLoadingSpinner size="small" /> : null}
+                  placeholder="Search teams by name..."
+                  onChange={(e) => handleSearchChange(e.target.value)}
+                  allowClear
+                  style={{ maxWidth: 400 }}
+                />
+                <OrganizationDropdown
+                  organizations={organizations}
+                  value={filters.organization_id || undefined}
+                  onChange={(value: string) => handleFilterChange("organization_id", value || "")}
+                  loading={isLoading}
+                />
+              </Flex>
+              <Pagination
+                current={currentPage}
+                total={totalTeams}
+                pageSize={pageSize}
+                onChange={(page, size) => {
+                  setCurrentPage(page);
+                  setPageSize(size);
+                  fetchTeamsV2({ page, size });
+                }}
+                size="small"
+                showTotal={(total) => `${total} teams`}
+                showSizeChanger
+                pageSizeOptions={["10", "20", "50"]}
+              />
+            </Flex>
+
+            {renderTeamsContent()}
+          </Card>
+
+          <DeleteResourceModal
+            isOpen={isDeleteModalOpen}
+            title="Delete Team?"
+            alertMessage={
+              teamToDelete?.keys?.length === 0
+                ? undefined
+                : `Warning: This team has ${teamToDelete?.keys?.length} keys associated with it. Deleting the team will also delete all associated keys. This action is irreversible.`
+            }
+            message="Are you sure you want to delete this team and all its keys? This action cannot be undone."
+            resourceInformationTitle="Team Information"
+            resourceInformation={[
+              { label: "Team ID", value: teamToDelete?.team_id, code: true },
+              { label: "Team Name", value: teamToDelete?.team_alias },
+              { label: "Keys", value: teamToDelete?.keys?.length },
+              { label: "Members", value: teamToDelete?.members_with_roles?.length },
+            ]}
+            requiredConfirmation={teamToDelete?.team_alias}
+            onCancel={cancelDelete}
+            onOk={confirmDelete}
+            confirmLoading={isTeamDeleting}
+          />
+        </>
+      ),
+    },
+    {
+      key: "available-teams",
+      label: "Available Teams",
+      children: <AvailableTeamsPanel accessToken={accessToken} userID={userID} />,
+    },
+    ...(isProxyAdminRole(userRole || "")
+      ? [
+          {
+            key: "default-settings",
+            label: "Default Team Settings",
+            children: <TeamSSOSettings accessToken={accessToken} userID={userID || ""} userRole={userRole || ""} />,
+          },
+        ]
+      : []),
+  ];
+
   return (
-    <div className="w-full mx-4 h-[75vh]">
-      <Grid numItems={1} className="gap-2 p-8 w-full mt-2">
-        <Col numColSpan={1} className="flex flex-col gap-2">
-          {canCreateOrManageTeams(userRole, userID, organizations) && (
-            <Button className="w-fit" onClick={() => setIsTeamModalVisible(true)}>
-              + Create New Team
-            </Button>
-          )}
-          {selectedTeamId ? (
-            <TeamInfoView
-              teamId={selectedTeamId}
-              onUpdate={(data) => {
-                setTeams((teams) => {
-                  if (teams == null) {
-                    return teams;
-                  }
-                  const updated = teams.map((team) => {
-                    if (data.team_id === team.team_id) {
-                      return updateExistingKeys(team, data);
-                    }
-                    return team;
-                  });
-                  // Minimal fix: refresh the full team list after an update
-                  if (accessToken) {
-                    fetchTeams(accessToken, userID, userRole, currentOrg, setTeams);
-                  }
-                  return updated;
-                });
-              }}
-              onClose={() => {
-                setSelectedTeamId(null);
-                setEditTeam(false);
-              }}
-              accessToken={accessToken}
-              is_team_admin={is_team_admin(teams?.find((team) => team.team_id === selectedTeamId))}
-              is_proxy_admin={userRole == "Admin"}
-              userModels={userModels}
-              editTeam={editTeam}
-              premiumUser={premiumUser}
-            />
-          ) : (
-            <TabGroup className="gap-2 h-[75vh] w-full">
-              <TabList className="flex justify-between mt-2 w-full items-center">
-                <div className="flex">
-                  <Tab>Your Teams</Tab>
-                  <Tab>Available Teams</Tab>
-                  {isProxyAdminRole(userRole || "") && <Tab>Default Team Settings</Tab>}
-                </div>
-                <div className="flex items-center space-x-2">
-                  {lastRefreshed && <Text>Last Refreshed: {lastRefreshed}</Text>}
-                  <Icon
-                    icon={RefreshIcon} // Modify as necessary for correct icon name
-                    variant="shadow"
-                    size="xs"
-                    className="self-center"
-                    onClick={handleRefreshClick}
-                  />
-                </div>
-              </TabList>
-              <TabPanels>
-                <TabPanel>
-                  <Text>
-                    Click on &ldquo;Team ID&rdquo; to view team details <b>and</b> manage team members.
-                  </Text>
-                  <Grid numItems={1} className="gap-2 pt-2 pb-2 h-[75vh] w-full mt-2">
-                    <Col numColSpan={1}>
-                      <Card className="w-full mx-auto flex-auto overflow-hidden overflow-y-auto max-h-[50vh]">
-                        <div className="border-b px-6 py-4">
-                          <div className="flex flex-col space-y-4">
-                            {/* Search and Filter Controls */}
-                            <div className="flex flex-wrap items-center gap-3">
-                              {/* Team Alias Search */}
-                              <FilterInput
-                                placeholder="Search by Team Name..."
-                                value={filters.team_alias}
-                                onChange={(value) => handleFilterChange("team_alias", value)}
-                                icon={Search}
-                              />
+    <Content style={{ padding: token.paddingLG, paddingInline: token.paddingLG * 2 }}>
+      {selectedTeamId ? (
+        <TeamInfoView
+          teamId={selectedTeamId}
+          onUpdate={(data) => {
+            setTeams((teams) => {
+              if (teams == null) {
+                return teams;
+              }
+              return teams.map((team) => {
+                if (data.team_id === team.team_id) {
+                  return updateExistingKeys(team, data);
+                }
+                return team;
+              });
+            });
+            fetchTeamsV2();
+          }}
+          onClose={() => {
+            setSelectedTeamId(null);
+            setEditTeam(false);
+          }}
+          accessToken={accessToken}
+          is_team_admin={is_team_admin(teams?.find((team) => team.team_id === selectedTeamId))}
+          is_proxy_admin={userRole == "Admin"}
+          userModels={userModels}
+          editTeam={editTeam}
+          premiumUser={premiumUser}
+        />
+      ) : (
+        <>
+          <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>
+            <Space direction="vertical" size={0}>
+              <Title level={2} style={{ margin: 0 }}>
+                <TeamOutlined style={{ marginRight: 8 }} />
+                Teams
+              </Title>
+              <Text type="secondary">
+                Manage teams, members, and their access to models and budgets
+              </Text>
+            </Space>
+            {canCreateOrManageTeams(userRole, userID, organizations) && (
+              <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsTeamModalVisible(true)}>
+                Create Team
+              </Button>
+            )}
+          </Flex>
 
-                              {/* Filter Button */}
-                              <FiltersButton
-                                onClick={() => setShowFilters(!showFilters)}
-                                active={showFilters}
-                                hasActiveFilters={!!(filters.team_id || filters.team_alias || filters.organization_id)}
-                              />
+          <Tabs items={tabItems} />
+        </>
+      )}
 
-                              {/* Reset Filters Button */}
-                              <ResetFiltersButton onClick={handleFilterReset} />
-                            </div>
-
-                            {/* Additional Filters */}
-                            {showFilters && (
-                              <div className="flex flex-wrap items-center gap-3 mt-3">
-                                {/* Team ID Search */}
-                                <FilterInput
-                                  placeholder="Enter Team ID"
-                                  value={filters.team_id}
-                                  onChange={(value) => handleFilterChange("team_id", value)}
-                                  icon={User}
-                                />
-
-                                {/* Organization Dropdown */}
-                                <div className="w-64">
-                                  <Select
-                                    value={filters.organization_id || ""}
-                                    onValueChange={(value) => handleFilterChange("organization_id", value)}
-                                    placeholder="Select Organization"
-                                  >
-                                    {organizations?.map((org) => (
-                                      <SelectItem key={org.organization_id} value={org.organization_id || ""}>
-                                        {org.organization_alias || org.organization_id}
-                                      </SelectItem>
-                                    ))}
-                                  </Select>
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        <Table>
-                          <TableHead>
-                            <TableRow>
-                              <TableHeaderCell>Team Name</TableHeaderCell>
-                              <TableHeaderCell>Team ID</TableHeaderCell>
-                              <TableHeaderCell>Created</TableHeaderCell>
-                              <TableHeaderCell>Spend (USD)</TableHeaderCell>
-                              <TableHeaderCell>Budget (USD)</TableHeaderCell>
-                              <TableHeaderCell>Models</TableHeaderCell>
-                              <TableHeaderCell>Organization</TableHeaderCell>
-                              <TableHeaderCell>Info</TableHeaderCell>
-                              <TableHeaderCell>Actions</TableHeaderCell>
-                            </TableRow>
-                          </TableHead>
-
-                          <TableBody>
-                            {teams && teams.length > 0 ? (
-                              teams
-                                .filter((team) => {
-                                  if (!currentOrg) return true;
-                                  return team.organization_id === currentOrg.organization_id;
-                                })
-                                .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-                                .map((team: any) => (
-                                  <TableRow key={team.team_id}>
-                                    <TableCell
-                                      style={{
-                                        maxWidth: "4px",
-                                        whiteSpace: "pre-wrap",
-                                        overflow: "hidden",
-                                      }}
-                                    >
-                                      {team["team_alias"]}
-                                    </TableCell>
-                                    <TableCell>
-                                      <div className="overflow-hidden">
-                                        <Tooltip title={team.team_id}>
-                                          <Button
-                                            size="xs"
-                                            variant="light"
-                                            className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left overflow-hidden truncate max-w-[200px]"
-                                            onClick={() => {
-                                              // Add click handler
-                                              setSelectedTeamId(team.team_id);
-                                            }}
-                                          >
-                                            {team.team_id.slice(0, 7)}...
-                                          </Button>
-                                        </Tooltip>
-                                      </div>
-                                    </TableCell>
-                                    <TableCell
-                                      style={{
-                                        maxWidth: "4px",
-                                        whiteSpace: "pre-wrap",
-                                        overflow: "hidden",
-                                      }}
-                                    >
-                                      {team.created_at ? new Date(team.created_at).toLocaleDateString() : "N/A"}
-                                    </TableCell>
-                                    <TableCell
-                                      style={{
-                                        maxWidth: "4px",
-                                        whiteSpace: "pre-wrap",
-                                        overflow: "hidden",
-                                      }}
-                                    >
-                                      {formatNumberWithCommas(team["spend"], 4)}
-                                    </TableCell>
-                                    <TableCell
-                                      style={{
-                                        maxWidth: "4px",
-                                        whiteSpace: "pre-wrap",
-                                        overflow: "hidden",
-                                      }}
-                                    >
-                                      {team["max_budget"] !== null && team["max_budget"] !== undefined
-                                        ? team["max_budget"]
-                                        : "No limit"}
-                                    </TableCell>
-                                    <TableCell
-                                      style={{
-                                        maxWidth: "8-x",
-                                        whiteSpace: "pre-wrap",
-                                        overflow: "hidden",
-                                      }}
-                                      className={team.models.length > 3 ? "px-0" : ""}
-                                    >
-                                      <div className="flex flex-col">
-                                        {Array.isArray(team.models) ? (
-                                          <div className="flex flex-col">
-                                            {team.models.length === 0 ? (
-                                              <Badge size={"xs"} className="mb-1" color="red">
-                                                <Text>All Proxy Models</Text>
-                                              </Badge>
-                                            ) : (
-                                              <>
-                                                <div className="flex items-start">
-                                                  {team.models.length > 3 && (
-                                                    <div>
-                                                      <Icon
-                                                        icon={
-                                                          expandedAccordions[team.team_id]
-                                                            ? ChevronDownIcon
-                                                            : ChevronRightIcon
-                                                        }
-                                                        className="cursor-pointer"
-                                                        size="xs"
-                                                        onClick={() => {
-                                                          setExpandedAccordions((prev) => ({
-                                                            ...prev,
-                                                            [team.team_id]: !prev[team.team_id],
-                                                          }));
-                                                        }}
-                                                      />
-                                                    </div>
-                                                  )}
-                                                  <div className="flex flex-wrap gap-1">
-                                                    {team.models.slice(0, 3).map((model: string, index: number) =>
-                                                      model === "all-proxy-models" ? (
-                                                        <Badge key={index} size={"xs"} color="red">
-                                                          <Text>All Proxy Models</Text>
-                                                        </Badge>
-                                                      ) : (
-                                                        <Badge key={index} size={"xs"} color="blue">
-                                                          <Text>
-                                                            {model.length > 30
-                                                              ? `${getModelDisplayName(model).slice(0, 30)}...`
-                                                              : getModelDisplayName(model)}
-                                                          </Text>
-                                                        </Badge>
-                                                      ),
-                                                    )}
-                                                    {team.models.length > 3 && !expandedAccordions[team.team_id] && (
-                                                      <Badge size={"xs"} color="gray" className="cursor-pointer">
-                                                        <Text>
-                                                          +{team.models.length - 3}{" "}
-                                                          {team.models.length - 3 === 1 ? "more model" : "more models"}
-                                                        </Text>
-                                                      </Badge>
-                                                    )}
-                                                    {expandedAccordions[team.team_id] && (
-                                                      <div className="flex flex-wrap gap-1">
-                                                        {team.models.slice(3).map((model: string, index: number) =>
-                                                          model === "all-proxy-models" ? (
-                                                            <Badge key={index + 3} size={"xs"} color="red">
-                                                              <Text>All Proxy Models</Text>
-                                                            </Badge>
-                                                          ) : (
-                                                            <Badge key={index + 3} size={"xs"} color="blue">
-                                                              <Text>
-                                                                {model.length > 30
-                                                                  ? `${getModelDisplayName(model).slice(0, 30)}...`
-                                                                  : getModelDisplayName(model)}
-                                                              </Text>
-                                                            </Badge>
-                                                          ),
-                                                        )}
-                                                      </div>
-                                                    )}
-                                                  </div>
-                                                </div>
-                                              </>
-                                            )}
-                                          </div>
-                                        ) : null}
-                                      </div>
-                                    </TableCell>
-
-                                    <TableCell>
-                                      {getOrganizationAlias(team.organization_id, organizationsData || organizations)}
-                                    </TableCell>
-                                    <TableCell>
-                                      <Text>
-                                        {perTeamInfo &&
-                                          team.team_id &&
-                                          perTeamInfo[team.team_id] &&
-                                          perTeamInfo[team.team_id].keys &&
-                                          perTeamInfo[team.team_id].keys.length}{" "}
-                                        Keys
-                                      </Text>
-                                      <Text>
-                                        {perTeamInfo &&
-                                          team.team_id &&
-                                          perTeamInfo[team.team_id] &&
-                                          perTeamInfo[team.team_id].team_info &&
-                                          perTeamInfo[team.team_id].team_info.members_with_roles &&
-                                          perTeamInfo[team.team_id].team_info.members_with_roles.length}{" "}
-                                        Members
-                                      </Text>
-                                    </TableCell>
-                                    <TableCell>
-                                      {userRole == "Admin" ? (
-                                        <>
-                                          <TableIconActionButton
-                                            variant="Edit"
-                                            onClick={() => {
-                                              setSelectedTeamId(team.team_id);
-                                              setEditTeam(true);
-                                            }}
-                                            dataTestId="edit-team-button"
-                                            tooltipText="Edit team"
-                                          />
-                                          <TableIconActionButton
-                                            variant="Delete"
-                                            onClick={() => handleDelete(team)}
-                                            dataTestId="delete-team-button"
-                                            tooltipText="Delete team"
-                                          />
-                                        </>
-                                      ) : null}
-                                    </TableCell>
-                                  </TableRow>
-                                ))
-                            ) : (
-                              <TableRow>
-                                <TableCell colSpan={9} className="text-center">
-                                  <div className="flex flex-col items-center justify-center py-4">
-                                    <Text className="text-lg font-medium mb-2">No teams found</Text>
-                                    <Text className="text-sm">Adjust your filters or create a new team</Text>
-                                  </div>
-                                </TableCell>
-                              </TableRow>
-                            )}
-                          </TableBody>
-                        </Table>
-                        <DeleteResourceModal
-                          isOpen={isDeleteModalOpen}
-                          title="Delete Team?"
-                          alertMessage={
-                            teamToDelete?.keys?.length === 0
-                              ? undefined
-                              : `Warning: This team has ${teamToDelete?.keys?.length} keys associated with it. Deleting the team will also delete all associated keys. This action is irreversible.`
-                          }
-                          message="Are you sure you want to delete this team and all its keys? This action cannot be undone."
-                          resourceInformationTitle="Team Information"
-                          resourceInformation={[
-                            { label: "Team ID", value: teamToDelete?.team_id, code: true },
-                            { label: "Team Name", value: teamToDelete?.team_alias },
-                            { label: "Keys", value: teamToDelete?.keys?.length },
-                            { label: "Members", value: teamToDelete?.members_with_roles?.length },
-                          ]}
-                          requiredConfirmation={teamToDelete?.team_alias}
-                          onCancel={cancelDelete}
-                          onOk={confirmDelete}
-                          confirmLoading={isTeamDeleting}
-                        />
-                      </Card>
-                    </Col>
-                  </Grid>
-                </TabPanel>
-                <TabPanel>
-                  <AvailableTeamsPanel accessToken={accessToken} userID={userID} />
-                </TabPanel>
-                {isProxyAdminRole(userRole || "") && (
-                  <TabPanel>
-                    <TeamSSOSettings accessToken={accessToken} userID={userID || ""} userRole={userRole || ""} />
-                  </TabPanel>
-                )}
-              </TabPanels>
-            </TabGroup>
-          )}
-          {canCreateOrManageTeams(userRole, userID, organizations) && (
+      {canCreateOrManageTeams(userRole, userID, organizations) && (
             <Modal
               title="Create Team"
               open={isTeamModalVisible}
@@ -1117,7 +1138,7 @@ const Teams: React.FC<TeamProps> = ({
                                 : ""
                           }
                         >
-                          <Select2
+                          <Select
                             showSearch
                             allowClear={!isOrgAdmin}
                             disabled={isSingleOrg}
@@ -1136,18 +1157,18 @@ const Teams: React.FC<TeamProps> = ({
                             optionFilterProp="children"
                           >
                             {adminOrgs?.map((org) => (
-                              <Select2.Option key={org.organization_id} value={org.organization_id}>
+                              <Select.Option key={org.organization_id} value={org.organization_id}>
                                 <span className="font-medium">{org.organization_alias}</span>{" "}
                                 <span className="text-gray-500">({org.organization_id})</span>
-                              </Select2.Option>
+                              </Select.Option>
                             ))}
-                          </Select2>
+                          </Select>
                         </Form.Item>
 
                         {/* Show message when org admin needs to select organization */}
                         {isOrgAdmin && !isSingleOrg && adminOrgs.length > 1 && (
                           <div className="mb-8 p-4 bg-blue-50 border border-blue-200 rounded-md">
-                            <Text className="text-blue-800 text-sm">
+                            <Text style={{ color: "#1e40af", fontSize: 14 }}>
                               Please select an organization to create a team for. You can only create teams within
                               organizations where you are an admin.
                             </Text>
@@ -1190,11 +1211,11 @@ const Teams: React.FC<TeamProps> = ({
                     <NumericalInput step={0.01} precision={2} width={200} />
                   </Form.Item>
                   <Form.Item className="mt-8" label="Reset Budget" name="budget_duration">
-                    <Select2 defaultValue={null} placeholder="n/a">
-                      <Select2.Option value="24h">daily</Select2.Option>
-                      <Select2.Option value="7d">weekly</Select2.Option>
-                      <Select2.Option value="30d">monthly</Select2.Option>
-                    </Select2>
+                    <Select defaultValue={null} placeholder="n/a">
+                      <Select.Option value="24h">daily</Select.Option>
+                      <Select.Option value="7d">weekly</Select.Option>
+                      <Select.Option value="30d">monthly</Select.Option>
+                    </Select>
                   </Form.Item>
                   <Form.Item label="Tokens per minute Limit (TPM)" name="tpm_limit">
                     <NumericalInput step={1} width={400} />
@@ -1313,7 +1334,7 @@ const Teams: React.FC<TeamProps> = ({
                         className="mt-8"
                         help="Select existing guardrails or enter new ones"
                       >
-                        <Select2
+                        <Select
                           mode="tags"
                           style={{ width: "100%" }}
                           placeholder="Select or enter guardrails"
@@ -1367,7 +1388,7 @@ const Teams: React.FC<TeamProps> = ({
                         className="mt-8"
                         help="Select existing policies or enter new ones"
                       >
-                        <Select2
+                        <Select
                           mode="tags"
                           style={{ width: "100%" }}
                           placeholder="Select or enter policies"
@@ -1533,7 +1554,7 @@ const Teams: React.FC<TeamProps> = ({
                     </AccordionHeader>
                     <AccordionBody>
                       <div className="mt-4">
-                        <Text className="text-sm text-gray-600 mb-4">
+                        <Text type="secondary" style={{ fontSize: 14, marginBottom: 16, display: "block" }}>
                           Create custom aliases for models that can be used by team members in API calls. This allows
                           you to create shortcuts for specific models.
                         </Text>
@@ -1548,14 +1569,12 @@ const Teams: React.FC<TeamProps> = ({
                   </Accordion>
                 </>
                 <div style={{ textAlign: "right", marginTop: "10px" }}>
-                  <Button2 htmlType="submit">Create Team</Button2>
+                  <Button htmlType="submit">Create Team</Button>
                 </div>
               </Form>
             </Modal>
           )}
-        </Col>
-      </Grid>
-    </div>
+    </Content>
   );
 };
 

--- a/ui/litellm-dashboard/src/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton.tsx
@@ -6,6 +6,7 @@ import {
   ChevronUpIcon,
   ChevronDownIcon,
   ExternalLinkIcon,
+  ClipboardCopyIcon,
 } from "@heroicons/react/outline";
 import { Tooltip } from "antd";
 import BaseActionButton from "../BaseActionButton";
@@ -32,6 +33,7 @@ export const TableIconActionButtonMap: Record<string, TableIconActionButtonBaseP
   Up: { icon: ChevronUpIcon, className: "hover:text-blue-600" },
   Down: { icon: ChevronDownIcon, className: "hover:text-blue-600" },
   Open: { icon: ExternalLinkIcon, className: "hover:text-green-600" },
+  Copy: { icon: ClipboardCopyIcon, className: "hover:text-blue-600" },
 };
 
 export default function TableIconActionButton({

--- a/ui/litellm-dashboard/src/components/common_components/OrganizationDropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/OrganizationDropdown.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { Select } from "antd";
+import { Select, Typography } from "antd";
 import { Organization } from "../networking";
+
+const { Text } = Typography;
 
 interface OrganizationDropdownProps {
   organizations?: Organization[] | null;
@@ -8,6 +10,7 @@ interface OrganizationDropdownProps {
   onChange?: (value: string) => void;
   disabled?: boolean;
   loading?: boolean;
+  style?: React.CSSProperties;
 }
 
 const OrganizationDropdown: React.FC<OrganizationDropdownProps> = ({
@@ -16,16 +19,18 @@ const OrganizationDropdown: React.FC<OrganizationDropdownProps> = ({
   onChange,
   disabled,
   loading,
+  style,
 }) => {
   return (
     <Select
       showSearch
-      placeholder="Search or select an organization"
+      placeholder="All Organizations"
       value={value}
       onChange={onChange}
       disabled={disabled}
       loading={loading}
       allowClear
+      style={{ minWidth: 280, ...style }}
       filterOption={(input, option) => {
         if (!option) return false;
         const org = organizations?.find((o) => o.organization_id === option.key);
@@ -37,12 +42,11 @@ const OrganizationDropdown: React.FC<OrganizationDropdownProps> = ({
 
         return orgAlias.includes(searchTerm) || orgId.includes(searchTerm);
       }}
-      optionFilterProp="children"
     >
       {organizations?.map((org) => (
         <Select.Option key={org.organization_id} value={org.organization_id}>
           <span className="font-medium">{org.organization_alias}</span>{" "}
-          <span className="text-gray-500">({org.organization_id})</span>
+          <Text type="secondary">({org.organization_id})</Text>
         </Select.Option>
       ))}
     </Select>

--- a/ui/litellm-dashboard/src/components/ui/AntDLoadingSpinner.tsx
+++ b/ui/litellm-dashboard/src/components/ui/AntDLoadingSpinner.tsx
@@ -1,0 +1,12 @@
+import { Spin } from "antd";
+import { LoadingOutlined } from "@ant-design/icons";
+
+interface AntDLoadingSpinnerProps {
+  size?: "small" | "default" | "large";
+  fontSize?: number;
+}
+
+export function AntDLoadingSpinner({ size, fontSize }: AntDLoadingSpinnerProps) {
+  const indicator = <LoadingOutlined style={fontSize ? { fontSize } : undefined} spin />;
+  return <Spin indicator={indicator} size={size} />;
+}


### PR DESCRIPTION
## Summary

### Problem
The Teams table used legacy Tremor components, client-side pagination with over-fetching (100 teams per request), and the deprecated `/team/list` v1 endpoint.

### Fix
- Migrated the table to Ant Design (`Table`, `Card`, `Flex`, `Tabs`, `Pagination`, `Progress`, `Tag`, `Typography`, `Layout.Content`) matching the Access Groups page pattern
- Switched all data fetching to `/v2/team/list` with server-side pagination, sorting, and filtering
- Added debounced search (300ms) with in-flight loading indicator
- Added reusable `OrganizationDropdown` with searchable options and `AntDLoadingSpinner` component
- Added `Copy` variant to `TableIconActionButton` for copying Team IDs
- Resources column shows members, models, and keys with lucide-react icons matching Access Groups
- Spend/Budget column shows progress bar with color-coded thresholds
- Error state with retry button, proper empty state
- Fixed React anti-patterns: stale closures, side effects in setState updaters, double-fetch on mount

## Testing
- All 30 existing `OldTeams.test.tsx` tests pass
- `next build` passes with no errors

## Type

🆕 New Feature
🧹 Refactoring
✅ Test