### PR TITLE
fix(gemini-embeddings): convert task_type to camelCase taskType for Gemini API

### DIFF
--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -152,6 +152,8 @@ def transform_openai_input_gemini_content(
     gemini_params = optional_params.copy()
     if "dimensions" in gemini_params:
         gemini_params["outputDimensionality"] = gemini_params.pop("dimensions")
+    if "task_type" in gemini_params:
+        gemini_params["taskType"] = gemini_params.pop("task_type")
 
     requests: List[EmbedContentRequest] = []
     if isinstance(input, str):
@@ -196,6 +198,8 @@ def transform_openai_input_gemini_embed_content(
     gemini_params = optional_params.copy()
     if "dimensions" in gemini_params:
         gemini_params["outputDimensionality"] = gemini_params.pop("dimensions")
+    if "task_type" in gemini_params:
+        gemini_params["taskType"] = gemini_params.pop("task_type")
 
     input_list = [input] if isinstance(input, str) else input
     parts: List[PartType] = []

--- a/tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py
+++ b/tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py
@@ -22,6 +22,7 @@ from litellm.llms.vertex_ai.gemini_embeddings.batch_embed_content_transformation
     _is_multimodal_input,
     _parse_data_url,
     process_embed_content_response,
+    transform_openai_input_gemini_content,
     transform_openai_input_gemini_embed_content,
 )
 from litellm.types.utils import EmbeddingResponse
@@ -394,6 +395,44 @@ def test_transform_with_optional_params():
     
     assert result["outputDimensionality"] == 768
     assert result["taskType"] == "SEMANTIC_SIMILARITY"
+
+
+def test_task_type_mapped_to_camel_case_batch():
+    """Test that snake_case task_type is converted to camelCase taskType for batchEmbedContents."""
+    result = transform_openai_input_gemini_content(
+        input="test text",
+        model="text-embedding-004",
+        optional_params={"task_type": "RETRIEVAL_DOCUMENT"},
+    )
+    for request in result["requests"]:
+        assert "taskType" in request
+        assert request["taskType"] == "RETRIEVAL_DOCUMENT"
+        assert "task_type" not in request
+
+
+def test_task_type_mapped_to_camel_case_embed_content():
+    """Test that snake_case task_type is converted to camelCase taskType for embedContent."""
+    result = transform_openai_input_gemini_embed_content(
+        input=["test text"],
+        model="gemini-embedding-2-preview",
+        optional_params={"task_type": "RETRIEVAL_DOCUMENT"},
+        resolved_files=None,
+    )
+    assert "taskType" in result
+    assert result["taskType"] == "RETRIEVAL_DOCUMENT"
+    assert "task_type" not in result
+
+
+def test_task_type_camel_case_passthrough():
+    """Test that camelCase taskType passed directly is preserved."""
+    result = transform_openai_input_gemini_embed_content(
+        input=["test text"],
+        model="gemini-embedding-2-preview",
+        optional_params={"taskType": "SEMANTIC_SIMILARITY"},
+        resolved_files=None,
+    )
+    assert result["taskType"] == "SEMANTIC_SIMILARITY"
+    assert "task_type" not in result
 
 
 def test_dimensions_mapped_to_output_dimensionality():


### PR DESCRIPTION
Fixes #24190

### What

- Gemini REST API documents the field as camelCase `taskType` ([ref](https://ai.google.dev/api/embeddings#method:-models.embedcontent))
- LiteLLM sends it as snake_case `task_type`
- LiteLLM's own TypedDicts (`GeminiEmbedContentRequestBody`) define it as camelCase `taskType`

The existing code converts `dimensions` → `outputDimensionality` but misses the parallel `task_type` → `taskType` conversion.

### Fix

Adds `task_type` → `taskType` conversion to both transformation functions in `batch_embed_content_transformation.py`, following the existing `dimensions` pattern:

```python
if "task_type" in gemini_params:
    gemini_params["taskType"] = gemini_params.pop("task_type")
```

### Tests added

- `test_task_type_mapped_to_camel_case_batch` — snake_case conversion for batchEmbedContents path
- `test_task_type_mapped_to_camel_case_embed_content` — snake_case conversion for embedContent path
- `test_task_type_camel_case_passthrough` — camelCase `taskType` passed directly is preserved

All 23 tests in `test_gemini_batch_embeddings.py` pass.