### PR TITLE
fix: sanitize surrogate characters in request data to prevent UTF-8 encoding errors

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import ssl
 import sys
 import time
@@ -73,6 +74,29 @@ headers = get_default_headers()
 _DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0, connect=5.0)
 
 
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def _sanitize_surrogates(value: str) -> str:
+    """Replace UTF-16 surrogate characters that cannot be encoded to UTF-8."""
+    return _SURROGATE_RE.sub("\ufffd", value)
+
+
+def _sanitize_data(obj: Any) -> Any:
+    """
+    Recursively walk a request data structure and replace surrogate characters
+    in all string values.  Surrogates (U+D800..U+DFFF) are invalid in UTF-8
+    and cause ``UnicodeEncodeError`` when httpx serialises the request body.
+    """
+    if isinstance(obj, str):
+        return _sanitize_surrogates(obj)
+    if isinstance(obj, dict):
+        return {k: _sanitize_data(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_data(item) for item in obj]
+    return obj
+
+
 def _prepare_request_data_and_content(
     data: Optional[Union[dict, str, bytes]] = None,
     content: Any = None,
@@ -90,6 +114,7 @@ def _prepare_request_data_and_content(
     Solution:
     - Move bytes/str from `data=` to `content=` before calling build_request
     - Keep dicts in `data=` (that's still the correct parameter for dicts)
+    - Sanitize surrogate characters that are invalid in UTF-8
 
     Args:
         data: Request data (can be dict, str, or bytes)
@@ -105,10 +130,10 @@ def _prepare_request_data_and_content(
         if isinstance(data, (bytes, str)):
             # Bytes/strings belong in content= (only if not already provided)
             if content is None:
-                request_content = data
+                request_content = _sanitize_data(data) if isinstance(data, str) else data
         else:
             # dict/Mapping stays in data= parameter
-            request_data = data
+            request_data = _sanitize_data(data)
 
     return request_data, request_content
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -130,7 +130,9 @@ def _prepare_request_data_and_content(
         if isinstance(data, (bytes, str)):
             # Bytes/strings belong in content= (only if not already provided)
             if content is None:
-                request_content = _sanitize_data(data) if isinstance(data, str) else data
+                request_content = (
+                    _sanitize_data(data) if isinstance(data, str) else data
+                )
         else:
             # dict/Mapping stays in data= parameter
             request_data = _sanitize_data(data)


### PR DESCRIPTION
## Summary

Sanitize surrogate characters (`U+D800..U+DFFF`) in HTTP request data before sending to prevent `UnicodeEncodeError` when `httpx` tries to encode the JSON body to UTF-8.

## Problem

When clients send messages containing emoji surrogate pairs (e.g., `\ud83c`), the proxy crashes with:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud83c' in position 19104: surrogates not allowed
```

This happens in `http_handler.py` at `self.client.build_request()` → `httpx._content.encode_json()` → `.encode("utf-8")`.

Surrogate codepoints are valid in Python strings but invalid in UTF-8 encoding. They can appear when clients use languages/libraries that handle Unicode differently (e.g., JavaScript's `String.fromCharCode` with raw surrogates).

## Fix

Added surrogate sanitization in `_prepare_request_data_and_content()` in `http_handler.py`:

- `_sanitize_surrogates(value)`: replaces surrogate codepoints with U+FFFD (Unicode replacement character)
- `_sanitize_data(obj)`: recursively walks dicts/lists/strings to sanitize all surrogates
- Applied before `build_request` for both dict data and string content

This is applied in the common HTTP handler path, so it covers all providers (Azure, OpenAI, Anthropic, etc.).

## Test plan

- [x] Verify strings with surrogate characters are sanitized before HTTP request
- [x] Verify normal UTF-8 content (including valid emoji) is not modified
- [x] Verify the fix covers both sync and async HTTP handlers (9 call sites)