### PR TITLE
fix : spend tracking for anthropic_messages and allm_passthrough_route

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1066,6 +1066,8 @@ def completion_cost(  # noqa: PLR0915
     """
     try:
         call_type = _infer_call_type(call_type, completion_response) or "completion"
+        if call_type in ("anthropic_messages", "allm_passthrough_route"):
+            call_type = "completion"
 
         if (
             (call_type == "aimage_generation" or call_type == "image_generation")
@@ -1664,6 +1666,8 @@ def response_cost_calculator(
         "aembedding",
         "completion",
         "acompletion",
+        "anthropic_messages",
+        "allm_passthrough_route",
         "atext_completion",
         "text_completion",
         "image_generation",

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1971,6 +1971,8 @@ class Logging(LiteLLMLoggingBaseClass):
             event_type="sync_success"
         ):  # prevent double logging
             return
+        if kwargs.get("response_cost") is not None:
+            self.model_call_details["response_cost"] = kwargs["response_cost"]
         start_time, end_time, result = self._success_handler_helper_fn(
             start_time=start_time,
             end_time=end_time,
@@ -2442,6 +2444,9 @@ class Logging(LiteLLMLoggingBaseClass):
             event_type="async_success"
         ):  # prevent double logging
             return
+
+        if kwargs.get("response_cost") is not None:
+            self.model_call_details["response_cost"] = kwargs["response_cost"]
 
         ## CALCULATE COST FOR BATCH JOBS
         if self.call_type == CallTypes.aretrieve_batch.value and isinstance(

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -148,6 +148,32 @@ def test_cost_calculator_with_usage(monkeypatch):
     assert result == expected_cost, f"Got {result}, Expected {expected_cost}"
 
 
+def test_anthropic_messages_and_passthrough_route_calculate_spend(monkeypatch):
+    """Spend should be calculated for anthropic_messages and allm_passthrough_route."""
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150,
+    )
+    mr = ModelResponse(usage=usage, model="bedrock/eu.anthropic.claude-sonnet-4-6")
+
+    for call_type in ("anthropic_messages", "allm_passthrough_route"):
+        result = response_cost_calculator(
+            response_object=mr,
+            model="bedrock/eu.anthropic.claude-sonnet-4-6",
+            custom_llm_provider="bedrock",
+            call_type=call_type,
+            optional_params={},
+            cache_hit=None,
+            base_model=None,
+        )
+        assert result is not None, f"Spend should be calculated for {call_type}"
+        assert result > 0, f"Spend should be > 0 for {call_type}"
+
+
 def test_transcription_cost_uses_token_pricing():
     from litellm import completion_cost
 


### PR DESCRIPTION
### Changes

 - Fix spend tracking for anthropic_messages and allm_passthrough_route in cost calculation.
 - Preserve precomputed response_cost from passthrough handlers when building spend logs.
- Add unit test to verify spend is calculated (>0) for both affected call types.

fix : #24204

