### PR TITLE
fix(bedrock): sanitize tool_use IDs in pass-through messages

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -441,9 +441,9 @@ class AmazonAnthropicClaudeMessagesConfig(
 
         # 1. anthropic_version is required for all claude models
         if "anthropic_version" not in anthropic_messages_request:
-            anthropic_messages_request["anthropic_version"] = (
-                self.DEFAULT_BEDROCK_ANTHROPIC_API_VERSION
-            )
+            anthropic_messages_request[
+                "anthropic_version"
+            ] = self.DEFAULT_BEDROCK_ANTHROPIC_API_VERSION
 
         # 2. `stream` is not allowed in request body for bedrock invoke
         if "stream" in anthropic_messages_request:

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -1,3 +1,4 @@
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -372,6 +373,49 @@ class AmazonAnthropicClaudeMessagesConfig(
         schema_text = {"type": "text", "text": json.dumps(schema)}
         content.append(schema_text)
 
+
+    _VALID_TOOL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+    _INVALID_TOOL_ID_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+    def _sanitize_tool_use_ids(
+        self, anthropic_messages_request: Dict
+    ) -> None:
+        """
+        Sanitize tool_use IDs to match Bedrock's required pattern.
+
+        Bedrock requires tool_use IDs to match ``^[a-zA-Z0-9_-]+$`` but the
+        Anthropic native API allows broader characters. Clients like Claude Code
+        send requests through the pass-through endpoint with IDs that Bedrock
+        rejects with 400 Bad Request.
+
+        Replaces any invalid characters with underscores in both ``tool_use.id``
+        and ``tool_result.tool_use_id`` fields.
+
+        Fixes: https://github.com/BerriAI/litellm/issues/21114
+        """
+        messages = anthropic_messages_request.get("messages")
+        if not isinstance(messages, list):
+            return
+
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                block_type = block.get("type")
+                if block_type == "tool_use" and "id" in block:
+                    tool_id = block["id"]
+                    if isinstance(tool_id, str) and not self._VALID_TOOL_ID_PATTERN.match(tool_id):
+                        block["id"] = self._INVALID_TOOL_ID_CHARS.sub("_", tool_id)
+                elif block_type == "tool_result" and "tool_use_id" in block:
+                    tool_use_id = block["tool_use_id"]
+                    if isinstance(tool_use_id, str) and not self._VALID_TOOL_ID_PATTERN.match(tool_use_id):
+                        block["tool_use_id"] = self._INVALID_TOOL_ID_CHARS.sub("_", tool_use_id)
+
     def transform_anthropic_messages_request(
         self,
         model: str,
@@ -428,6 +472,12 @@ class AmazonAnthropicClaudeMessagesConfig(
         # which causes Bedrock to reject the request with "Extra inputs are not permitted"
         # Ref: https://github.com/BerriAI/litellm/issues/22847
         remove_custom_field_from_tools(anthropic_messages_request)
+
+        # 7. Sanitize tool_use IDs (Bedrock requires ^[a-zA-Z0-9_-]+$)
+        # The Anthropic native API allows broader characters in tool_use IDs,
+        # but Bedrock rejects them with 400 Bad Request.
+        # Fixes: https://github.com/BerriAI/litellm/issues/21114
+        self._sanitize_tool_use_ids(anthropic_messages_request)
 
         # 6. AUTO-INJECT beta headers based on features used
         anthropic_model_info = AnthropicModelInfo()

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -373,13 +373,10 @@ class AmazonAnthropicClaudeMessagesConfig(
         schema_text = {"type": "text", "text": json.dumps(schema)}
         content.append(schema_text)
 
-
     _VALID_TOOL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
     _INVALID_TOOL_ID_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
-    def _sanitize_tool_use_ids(
-        self, anthropic_messages_request: Dict
-    ) -> None:
+    def _sanitize_tool_use_ids(self, anthropic_messages_request: Dict) -> None:
         """
         Sanitize tool_use IDs to match Bedrock's required pattern.
 
@@ -409,12 +406,18 @@ class AmazonAnthropicClaudeMessagesConfig(
                 block_type = block.get("type")
                 if block_type == "tool_use" and "id" in block:
                     tool_id = block["id"]
-                    if isinstance(tool_id, str) and not self._VALID_TOOL_ID_PATTERN.match(tool_id):
+                    if isinstance(
+                        tool_id, str
+                    ) and not self._VALID_TOOL_ID_PATTERN.match(tool_id):
                         block["id"] = self._INVALID_TOOL_ID_CHARS.sub("_", tool_id)
                 elif block_type == "tool_result" and "tool_use_id" in block:
                     tool_use_id = block["tool_use_id"]
-                    if isinstance(tool_use_id, str) and not self._VALID_TOOL_ID_PATTERN.match(tool_use_id):
-                        block["tool_use_id"] = self._INVALID_TOOL_ID_CHARS.sub("_", tool_use_id)
+                    if isinstance(
+                        tool_use_id, str
+                    ) and not self._VALID_TOOL_ID_PATTERN.match(tool_use_id):
+                        block["tool_use_id"] = self._INVALID_TOOL_ID_CHARS.sub(
+                            "_", tool_use_id
+                        )
 
     def transform_anthropic_messages_request(
         self,
@@ -438,9 +441,9 @@ class AmazonAnthropicClaudeMessagesConfig(
 
         # 1. anthropic_version is required for all claude models
         if "anthropic_version" not in anthropic_messages_request:
-            anthropic_messages_request[
-                "anthropic_version"
-            ] = self.DEFAULT_BEDROCK_ANTHROPIC_API_VERSION
+            anthropic_messages_request["anthropic_version"] = (
+                self.DEFAULT_BEDROCK_ANTHROPIC_API_VERSION
+            )
 
         # 2. `stream` is not allowed in request body for bedrock invoke
         if "stream" in anthropic_messages_request:

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -373,7 +373,7 @@ class AmazonAnthropicClaudeMessagesConfig(
         schema_text = {"type": "text", "text": json.dumps(schema)}
         content.append(schema_text)
 
-    _VALID_TOOL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+    _VALID_TOOL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+\Z")
     _INVALID_TOOL_ID_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
     def _sanitize_tool_use_ids(self, anthropic_messages_request: Dict) -> None:
@@ -476,13 +476,13 @@ class AmazonAnthropicClaudeMessagesConfig(
         # Ref: https://github.com/BerriAI/litellm/issues/22847
         remove_custom_field_from_tools(anthropic_messages_request)
 
-        # 7. Sanitize tool_use IDs (Bedrock requires ^[a-zA-Z0-9_-]+$)
+        # 6. Sanitize tool_use IDs (Bedrock requires ^[a-zA-Z0-9_-]+$)
         # The Anthropic native API allows broader characters in tool_use IDs,
         # but Bedrock rejects them with 400 Bad Request.
         # Fixes: https://github.com/BerriAI/litellm/issues/21114
         self._sanitize_tool_use_ids(anthropic_messages_request)
 
-        # 6. AUTO-INJECT beta headers based on features used
+        # 7. AUTO-INJECT beta headers based on features used
         anthropic_model_info = AnthropicModelInfo()
         tools = anthropic_messages_optional_request_params.get("tools")
         messages_typed = cast(List[AllMessageValues], messages)

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -342,3 +342,139 @@ def test_bedrock_messages_strips_output_config_with_output_format():
 
     assert "output_config" not in result
     assert "output_format" not in result
+
+
+class TestSanitizeToolUseIds:
+    """Tests for _sanitize_tool_use_ids in AmazonAnthropicClaudeMessagesConfig.
+
+    Bedrock requires tool_use IDs to match ^[a-zA-Z0-9_-]+$ but the Anthropic
+    native API allows broader characters.
+    Fixes: https://github.com/BerriAI/litellm/issues/21114
+    """
+
+    def test_sanitize_tool_use_id_with_invalid_chars(self):
+        """tool_use.id with invalid characters should be sanitized."""
+        cfg = AmazonAnthropicClaudeMessagesConfig()
+        request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_abc.123+xyz/foo",
+                            "name": "test_tool",
+                            "input": {},
+                        }
+                    ],
+                }
+            ]
+        }
+        cfg._sanitize_tool_use_ids(request)
+        assert request["messages"][0]["content"][0]["id"] == "toolu_abc_123_xyz_foo"
+
+    def test_sanitize_tool_result_id_with_invalid_chars(self):
+        """tool_result.tool_use_id with invalid characters should be sanitized."""
+        cfg = AmazonAnthropicClaudeMessagesConfig()
+        request = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_abc.123+xyz/foo",
+                            "content": "result",
+                        }
+                    ],
+                }
+            ]
+        }
+        cfg._sanitize_tool_use_ids(request)
+        assert (
+            request["messages"][0]["content"][0]["tool_use_id"]
+            == "toolu_abc_123_xyz_foo"
+        )
+
+    def test_valid_ids_unchanged(self):
+        """IDs that already match the Bedrock pattern should not be modified."""
+        cfg = AmazonAnthropicClaudeMessagesConfig()
+        request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_valid-id_123",
+                            "name": "test_tool",
+                            "input": {},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_valid-id_123",
+                            "content": "result",
+                        }
+                    ],
+                },
+            ]
+        }
+        cfg._sanitize_tool_use_ids(request)
+        assert request["messages"][0]["content"][0]["id"] == "toolu_valid-id_123"
+        assert (
+            request["messages"][1]["content"][0]["tool_use_id"] == "toolu_valid-id_123"
+        )
+
+    def test_no_messages_key(self):
+        """Should handle request without messages key gracefully."""
+        cfg = AmazonAnthropicClaudeMessagesConfig()
+        request = {"max_tokens": 1024}
+        cfg._sanitize_tool_use_ids(request)  # Should not raise
+
+    def test_string_content_ignored(self):
+        """Messages with string content (not list) should be skipped."""
+        cfg = AmazonAnthropicClaudeMessagesConfig()
+        request = {
+            "messages": [{"role": "user", "content": "hello"}]
+        }
+        cfg._sanitize_tool_use_ids(request)  # Should not raise
+
+    def test_consistent_sanitization_across_pairs(self):
+        """tool_use.id and matching tool_result.tool_use_id should sanitize identically."""
+        cfg = AmazonAnthropicClaudeMessagesConfig()
+        original_id = "toolu_01A.B+C/D:E"
+        request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": original_id,
+                            "name": "test",
+                            "input": {},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": original_id,
+                            "content": "result",
+                        }
+                    ],
+                },
+            ]
+        }
+        cfg._sanitize_tool_use_ids(request)
+        sanitized_tool_use = request["messages"][0]["content"][0]["id"]
+        sanitized_tool_result = request["messages"][1]["content"][0]["tool_use_id"]
+        assert sanitized_tool_use == sanitized_tool_result
+        assert sanitized_tool_use == "toolu_01A_B_C_D_E"


### PR DESCRIPTION
## Summary

Bedrock requires `tool_use` IDs to match `^[a-zA-Z0-9_-]+$`, but the Anthropic native API allows broader characters. When clients like Claude Code send requests through the `/v1/messages` pass-through endpoint, IDs containing dots, plus signs, slashes, or colons cause Bedrock to return `400 Bad Request`:

```
messages.1.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'
```

This cascades through the entire fallback chain since the invalid ID is in the request payload, not model-specific.

## Changes

Added `_sanitize_tool_use_ids()` to `AmazonAnthropicClaudeMessagesConfig` in the Bedrock invoke transformation pipeline. It replaces invalid characters with underscores in both `tool_use.id` and `tool_result.tool_use_id` fields, applied deterministically so paired IDs stay consistent.

The sanitization runs as step 7 in `transform_anthropic_messages_request()`, alongside existing Bedrock-specific transformations (stream removal, cache_control TTL stripping, custom field removal, etc.).

**Files changed:**
- `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py` — Added `_sanitize_tool_use_ids()` method and call in transform pipeline
- `tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py` — 6 new tests covering invalid chars, valid passthrough, string content, missing messages, and pair consistency

Fixes #21114