### PR TITLE
fix: async task leak in SlackAlerting

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -115,8 +115,9 @@ class SlackAlerting(CustomBatchLogger):
     ):
         if alerting is not None:
             self.alerting = alerting
-            asyncio.create_task(self.periodic_flush())
-            self.periodic_started = True
+            if not self.periodic_started:
+                asyncio.create_task(self.periodic_flush())
+                self.periodic_started = True
         if alerting_threshold is not None:
             self.alerting_threshold = alerting_threshold
         if alert_types is not None:

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -173,6 +173,21 @@ class TestSlackAlerting(unittest.TestCase):
         self.slack_alerting.update_values(alerting_args={"slack_alerting": "True"})
         assert self.slack_alerting.periodic_started == True
         
+    # Repeated calls to update_values should not spawn additional periodic_flush tasks
+    @patch("asyncio.create_task")
+    def test_update_values_does_not_leak_periodic_tasks(self, mock_create_task):
+        mock_create_task.return_value = AsyncMock()
+
+        self.slack_alerting.update_values(alerting=["slack"])
+        assert self.slack_alerting.periodic_started == True
+        assert mock_create_task.call_count == 1
+
+        # Simulate repeated calls from add_deployment scheduler (runs every 30s)
+        self.slack_alerting.update_values(alerting=["slack"])
+        self.slack_alerting.update_values(alerting=["slack"])
+        self.slack_alerting.update_values(alerting_args={"slack_alerting": "True"})
+        assert mock_create_task.call_count == 1
+
     @patch("litellm.integrations.SlackAlerting.slack_alerting.datetime")
     def test_alert_type_in_formatted_message(self, mock_datetime):
         # Setup mocks


### PR DESCRIPTION
## Relevant issues

e.g. #12685 but we're just seeing general instability under any kind of load, and trying to debug it.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Don't leak async tasks from SlackAlerting, by only starting the task when the function is first called; the copies of the function are unnecessary.

`add_deployment` (from scheduler) -> `_update_general_settings` calls this function every 30s. Each call starts a new `while True:` loop.

/debug/asyncio-tasks tells me there's thousands of active tasks with no names, which impacts my ability to work out why the application is hung.

(I don't think it's a big problem, but it's not helping with debuggability.)