### PR TITLE
feat: add git-subdir source type to claude-code/plugins API

### DIFF
--- a/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
+++ b/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
@@ -130,6 +130,15 @@ async def get_marketplace():
         )
 
 
+# Allowlist for git-subdir paths: one or more segments separated by '/'.
+# Each segment must start with an alphanumeric character and contain only
+# alphanumeric characters, dots, hyphens, and underscores.
+# This implicitly blocks '..', leading '/', backslashes, and percent-encoded sequences.
+_VALID_GIT_SUBDIR_PATH_RE = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*)*$"
+)
+
+
 @router.post(
     "/claude-code/plugins",
     tags=["Claude Code Marketplace"],
@@ -204,10 +213,34 @@ async def register_plugin(
                         "error": "URL source must include 'url' field (e.g., 'https://github.com/org/repo.git')"
                     },
                 )
+        elif source_type == "git-subdir":
+            if not source.get("url"):
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "git-subdir source must include 'url' field (e.g., 'https://github.com/org/repo.git')"
+                    },
+                )
+            if not source.get("path"):
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "git-subdir source must include 'path' field (e.g., 'plugins/plugin-name')"
+                    },
+                )
+            if not _VALID_GIT_SUBDIR_PATH_RE.match(source["path"]):
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": "git-subdir 'path' must be a relative path of the form 'segment/segment' (alphanumeric, dots, hyphens, underscores only)"
+                    },
+                )
         else:
             raise HTTPException(
                 status_code=400,
-                detail={"error": "source.source must be 'github' or 'url'"},
+                detail={
+                    "error": "source.source must be 'github', 'url', or 'git-subdir'"
+                },
             )
 
         # Build manifest for storage

--- a/litellm/types/proxy/claude_code_endpoints.py
+++ b/litellm/types/proxy/claude_code_endpoints.py
@@ -39,7 +39,8 @@ class RegisterPluginRequest(BaseModel):
         description=(
             "Git source reference. Supported formats:\n"
             "- GitHub: {'source': 'github', 'repo': 'org/repo'}\n"
-            "- Git URL: {'source': 'url', 'url': 'https://github.com/org/repo.git'}"
+            "- Git URL: {'source': 'url', 'url': 'https://github.com/org/repo.git'}\n"
+            "- Git Subdir: {'source': 'git-subdir', 'url': 'https://github.com/org/repo.git', 'path': 'plugins/plugin-name'}"
         ),
     )
     version: Optional[str] = Field("1.0.0", description="Semantic version")

--- a/tests/pass_through_unit_tests/test_claude_code_marketplace.py
+++ b/tests/pass_through_unit_tests/test_claude_code_marketplace.py
@@ -236,3 +236,49 @@ async def test_get_marketplace(mock_prisma_client):
     await mock_prisma_client.db.litellm_claudecodeplugintable.delete(
         where={"name": plugin_name}
     )
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir(mock_prisma_client):
+    """Test registering a plugin with git-subdir source type."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", mock_prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    await litellm.proxy.proxy_server.prisma_client.connect()
+
+    plugin_name = f"test-subdir-plugin-{int(time.time())}"
+
+    request = RegisterPluginRequest(
+        name=plugin_name,
+        source={
+            "source": "git-subdir",
+            "url": "https://github.com/test-org/monorepo.git",
+            "path": "plugins/my-plugin",
+        },
+        version="1.0.0",
+        description="Test git-subdir plugin",
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-1234",
+        user_id="test-user",
+    )
+
+    response = await register_plugin(
+        request=request,
+        user_api_key_dict=user_api_key_dict,
+    )
+
+    assert response["status"] == "success"
+    assert response["action"] == "created"
+    assert response["plugin"]["name"] == plugin_name
+    assert response["plugin"]["source"]["source"] == "git-subdir"
+    assert response["plugin"]["source"]["url"] == "https://github.com/test-org/monorepo.git"
+    assert response["plugin"]["source"]["path"] == "plugins/my-plugin"
+    assert response["plugin"]["enabled"] is True
+
+    # Cleanup
+    await mock_prisma_client.db.litellm_claudecodeplugintable.delete(
+        where={"name": plugin_name}
+    )

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for claude_code_marketplace.py source validation.
+
+Covers the git-subdir source type added alongside the existing github and url types.
+"""
+
+import pytest
+from fastapi import HTTPException
+from unittest.mock import AsyncMock, MagicMock
+
+import litellm
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.proxy_server import LitellmUserRoles
+from litellm.types.proxy.claude_code_endpoints import RegisterPluginRequest
+from litellm.proxy.anthropic_endpoints.claude_code_endpoints.claude_code_marketplace import (
+    register_plugin,
+)
+
+
+def _make_mock_prisma():
+    """Stateful prisma mock that supports find_unique, create, and update."""
+    store: dict = {}
+
+    mock_client = MagicMock()
+    mock_client.proxy_logging_obj = MagicMock()
+    mock_table = MagicMock()
+
+    async def _find_unique(where):
+        return store.get(where.get("name"))
+
+    async def _create(data):
+        record = MagicMock()
+        record.id = "test-id"
+        record.name = data["name"]
+        record.version = data.get("version")
+        record.description = data.get("description")
+        record.manifest_json = data.get("manifest_json", "{}")
+        record.enabled = data.get("enabled", True)
+        store[data["name"]] = record
+        return record
+
+    async def _update(where, data):
+        record = store[where["name"]]
+        for k, v in data.items():
+            setattr(record, k, v)
+        return record
+
+    mock_table.find_unique = AsyncMock(side_effect=_find_unique)
+    mock_table.create = AsyncMock(side_effect=_create)
+    mock_table.update = AsyncMock(side_effect=_update)
+    mock_client.db.litellm_claudecodeplugintable = mock_table
+    return mock_client
+
+
+_USER = UserAPIKeyAuth(
+    user_role=LitellmUserRoles.PROXY_ADMIN,
+    api_key="sk-1234",
+    user_id="test-user",
+)
+
+_GIT_SUBDIR_SOURCE = {
+    "source": "git-subdir",
+    "url": "https://github.com/org/monorepo.git",
+    "path": "plugins/my-plugin",
+}
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_success():
+    """git-subdir with both url and path fields registers successfully."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(name="my-monorepo-plugin", source=_GIT_SUBDIR_SOURCE)
+
+    response = await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert response["status"] == "success"
+    assert response["action"] == "created"
+    assert response["plugin"]["source"]["source"] == "git-subdir"
+    assert response["plugin"]["source"]["path"] == "plugins/my-plugin"
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_update():
+    """Registering the same git-subdir plugin twice returns action=updated."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(
+        name="my-monorepo-plugin", source=_GIT_SUBDIR_SOURCE, version="1.0.0"
+    )
+    await register_plugin(request=request, user_api_key_dict=_USER)
+
+    request2 = RegisterPluginRequest(
+        name="my-monorepo-plugin", source=_GIT_SUBDIR_SOURCE, version="2.0.0"
+    )
+    response = await register_plugin(request=request2, user_api_key_dict=_USER)
+
+    assert response["status"] == "success"
+    assert response["action"] == "updated"
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_missing_url():
+    """git-subdir without url field raises HTTP 400."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(
+        name="bad-plugin",
+        source={"source": "git-subdir", "path": "plugins/my-plugin"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert exc_info.value.status_code == 400
+    assert "url" in exc_info.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_empty_url():
+    """git-subdir with empty url raises HTTP 400."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(
+        name="bad-plugin",
+        source={"source": "git-subdir", "url": "", "path": "plugins/my-plugin"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert exc_info.value.status_code == 400
+    assert "url" in exc_info.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_missing_path():
+    """git-subdir without path field raises HTTP 400."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(
+        name="bad-plugin",
+        source={"source": "git-subdir", "url": "https://github.com/org/monorepo.git"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert exc_info.value.status_code == 400
+    assert "path" in exc_info.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_empty_path():
+    """git-subdir with empty path raises HTTP 400."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(
+        name="bad-plugin",
+        source={"source": "git-subdir", "url": "https://github.com/org/monorepo.git", "path": ""},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert exc_info.value.status_code == 400
+    assert "path" in exc_info.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_path_traversal():
+    """git-subdir with path traversal segments raises HTTP 400."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    for bad_path in [
+        "../../etc/passwd",
+        "../secrets",
+        "/absolute/path",
+        "plugins\\..\\..\\secrets",  # backslash traversal
+        "plugins/%2e%2e/secrets",   # percent-encoded traversal
+        "plugins/%2E%2E/secrets",   # uppercase percent-encoded traversal
+        "plugins/%252e%252e/secrets",  # double-encoded traversal
+    ]:
+        request = RegisterPluginRequest(
+            name="bad-plugin",
+            source={
+                "source": "git-subdir",
+                "url": "https://github.com/org/monorepo.git",
+                "path": bad_path,
+            },
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await register_plugin(request=request, user_api_key_dict=_USER)
+
+        assert exc_info.value.status_code == 400
+        assert "relative" in exc_info.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_unknown_source_type():
+    """Unknown source type raises HTTP 400 listing all valid types."""
+    setattr(litellm.proxy.proxy_server, "prisma_client", _make_mock_prisma())
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+
+    request = RegisterPluginRequest(
+        name="bad-plugin",
+        source={"source": "ftp", "url": "ftp://example.com/repo"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert exc_info.value.status_code == 400
+    assert "git-subdir" in exc_info.value.detail["error"]

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/add_plugin_form.test.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/add_plugin_form.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders } from "../../../tests/test-utils";
+import AddPluginForm from "./add_plugin_form";
+
+vi.mock("../networking", () => ({
+  registerClaudeCodePlugin: vi.fn().mockResolvedValue({ status: "success" }),
+}));
+
+const DEFAULT_PROPS = {
+  visible: true,
+  onClose: vi.fn(),
+  accessToken: "sk-test",
+  onSuccess: vi.fn(),
+};
+
+describe("AddPluginForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the source type select with GitHub as default", () => {
+    renderWithProviders(<AddPluginForm {...DEFAULT_PROPS} />);
+
+    // The default value "GitHub" is displayed in the collapsed select
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    // The form label is present
+    expect(screen.getByText("Source Type")).toBeInTheDocument();
+  });
+
+  it("shows URL and Path fields when git-subdir is selected", async () => {
+    renderWithProviders(<AddPluginForm {...DEFAULT_PROPS} />);
+
+    const sourceSelect = screen.getByLabelText("Source Type");
+    await act(async () => {
+      fireEvent.mouseDown(sourceSelect);
+    });
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("Git Subdir"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("https://github.com/org/repo.git")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("plugins/plugin-name")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show Path field for url source type", async () => {
+    renderWithProviders(<AddPluginForm {...DEFAULT_PROPS} />);
+
+    const sourceSelect = screen.getByLabelText("Source Type");
+    await act(async () => {
+      fireEvent.mouseDown(sourceSelect);
+    });
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("Git URL"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("https://github.com/org/repo.git")).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText("plugins/plugin-name")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows path format error when pattern does not match", async () => {
+    renderWithProviders(<AddPluginForm {...DEFAULT_PROPS} />);
+
+    // Switch to git-subdir
+    const sourceSelect = screen.getByLabelText("Source Type");
+    await act(async () => {
+      fireEvent.mouseDown(sourceSelect);
+    });
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("Git Subdir"));
+    });
+
+    // Fill required fields
+    fireEvent.change(screen.getByPlaceholderText("my-awesome-plugin"), {
+      target: { value: "my-plugin" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("https://github.com/org/repo.git"), {
+      target: { value: "https://github.com/org/repo.git" },
+    });
+    // Enter a path that violates the allowlist
+    fireEvent.change(screen.getByPlaceholderText("plugins/plugin-name"), {
+      target: { value: "../../etc/passwd" },
+    });
+
+    // Submit — triggers Antd form validation
+    await act(async () => {
+      fireEvent.click(screen.getByText("Register Plugin"));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Path must be relative segments (alphanumeric, dots, hyphens, underscores), e.g. plugins/plugin-name"
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clears path field when switching away from git-subdir", async () => {
+    renderWithProviders(<AddPluginForm {...DEFAULT_PROPS} />);
+
+    // Switch to git-subdir
+    const sourceSelect = screen.getByLabelText("Source Type");
+    await act(async () => {
+      fireEvent.mouseDown(sourceSelect);
+    });
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("Git Subdir"));
+    });
+
+    // Switch back to GitHub
+    await act(async () => {
+      fireEvent.mouseDown(sourceSelect);
+    });
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("GitHub"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("plugins/plugin-name")).not.toBeInTheDocument();
+      expect(screen.getByPlaceholderText("anthropics/claude-code")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/add_plugin_form.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/add_plugin_form.tsx
@@ -39,7 +39,7 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
 }) => {
   const [form] = Form.useForm();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [sourceType, setSourceType] = useState<"github" | "url">("github");
+  const [sourceType, setSourceType] = useState<"github" | "url" | "git-subdir">("github");
 
   const handleSubmit = async (values: any) => {
     if (!accessToken) {
@@ -75,6 +75,12 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
       return;
     }
 
+    // Validate git URL for url/git-subdir source types
+    if ((sourceType === "url" || sourceType === "git-subdir") && values.url && !isValidUrl(values.url)) {
+      message.error("Invalid git URL format");
+      return;
+    }
+
     setIsSubmitting(true);
     try {
       // Build plugin data
@@ -85,6 +91,12 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
             ? {
                 source: "github",
                 repo: values.repo.trim(),
+              }
+            : sourceType === "git-subdir"
+            ? {
+                source: "git-subdir",
+                url: values.url.trim(),
+                path: values.path.trim(),
               }
             : {
                 source: "url",
@@ -138,10 +150,10 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
     onClose();
   };
 
-  const handleSourceTypeChange = (value: "github" | "url") => {
+  const handleSourceTypeChange = (value: "github" | "url" | "git-subdir") => {
     setSourceType(value);
-    // Clear repo/url fields when switching
-    form.setFieldsValue({ repo: undefined, url: undefined });
+    // Clear repo/url/path fields when switching
+    form.setFieldsValue({ repo: undefined, url: undefined, path: undefined });
   };
 
   return (
@@ -185,7 +197,8 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
         >
           <Select onChange={handleSourceTypeChange} className="rounded-lg">
             <Option value="github">GitHub</Option>
-            <Option value="url">URL</Option>
+            <Option value="url">Git URL</Option>
+            <Option value="git-subdir">Git Subdir</Option>
           </Select>
         </Form.Item>
 
@@ -208,7 +221,7 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
         )}
 
         {/* Git URL */}
-        {sourceType === "url" && (
+        {(sourceType === "url" || sourceType === "git-subdir") && (
           <Form.Item
             label="Git URL"
             name="url"
@@ -218,6 +231,28 @@ const AddPluginForm: React.FC<AddPluginFormProps> = ({
             <Input
               type="url"
               placeholder="https://github.com/org/repo.git"
+              className="rounded-lg"
+            />
+          </Form.Item>
+        )}
+
+        {/* Git Subdir Path */}
+        {sourceType === "git-subdir" && (
+          <Form.Item
+            label="Subdirectory Path"
+            name="path"
+            rules={[
+              { required: true, message: "Please enter subdirectory path" },
+              {
+                pattern: /^[a-zA-Z0-9][a-zA-Z0-9._-]*(\/[a-zA-Z0-9][a-zA-Z0-9._-]*)*$/,
+                message:
+                  "Path must be relative segments (alphanumeric, dots, hyphens, underscores), e.g. plugins/plugin-name",
+              },
+            ]}
+            tooltip="Path to the plugin directory within the repository (e.g., plugins/plugin-name)"
+          >
+            <Input
+              placeholder="plugins/plugin-name"
               className="rounded-lg"
             />
           </Form.Item>


### PR DESCRIPTION
## Relevant issues

Fixes #24228 

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✨ New Feature

## Changes

Add support for the git-subdir plugin source type in the POST /claude-code/plugins API, as documented in the [official Claude Code plugin marketplaces spec](https://code.claude.com/docs/en/plugin-marketplaces#git-subdirectories).

**New source format:**
```json
{
  "source": "git-subdir",
  "url": "https://github.com/org/monorepo.git",
  "path": "plugins/plugin-name"
}
```

**Path validation** uses a simple allowlist regex that only permits alphanumeric characters, dots, hyphens, and underscores — one or more `/`-separated segments. This blocks path traversal (`..`), absolute paths (`/`), backslashes, percent-encoded sequences, and any other unsafe characters without needing URL decoding.

**Changes:**
- `litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py`: add `git-subdir` branch with allowlist regex validation
- `litellm/types/proxy/claude_code_endpoints.py`: document all three source types in `RegisterPluginRequest.source`
- `tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py`: 8 unit tests (success, update, missing url, empty url, missing path, empty path, path traversal × 7 variants, unknown source type)
- `ui/litellm-dashboard/src/components/claude_code_plugins/add_plugin_form.tsx`: add "Git Subdir" option with URL + path fields
- `ui/litellm-dashboard/src/components/claude_code_plugins/add_plugin_form.test.tsx`: 4 UI tests
