### PR TITLE
feat(provider): add Runware as a first-class image generation provider

### DIFF
--- a/docs/my-website/docs/providers/runware/images.md
+++ b/docs/my-website/docs/providers/runware/images.md
@@ -1,0 +1,363 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Runware - Image Generation
+
+Runware is an AI inference platform offering fast, scalable access to 1000+ image generation models including FLUX, Qwen Image, Grok Imagine, and more.
+
+## Overview
+
+| Property | Details |
+|----------|---------|
+| Description | Runware provides optimized infrastructure for running image generation models at scale with low latency and competitive pricing. |
+| Provider Route on LiteLLM | `runware/` |
+| Provider Doc | [Runware Documentation ↗](https://docs.runware.ai/) |
+| Supported Operations | [`/images/generations`](#image-generation) |
+
+## Setup
+
+### API Key
+
+```python showLineNumbers
+import os
+
+# Set your Runware API key
+os.environ["RUNWARE_API_KEY"] = "your-runware-api-key"
+```
+
+Get your API key from [runware.ai](https://runware.ai/).
+
+## Supported Models
+
+| Model Name | Description | Cost/Image | Documentation |
+|------------|-------------|------------|---------------|
+| `runware/runware:400@1` | FLUX.2 [dev] - Fast, high-quality generation | $0.009 | [Docs ↗](https://runware.ai/models/bfl-flux-2-dev) |
+| `runware/bfl:7@1` | FLUX.2 [max] - Maximum quality FLUX model | $0.07 | [Docs ↗](https://runware.ai/models/bfl-flux-2-max) |
+| `runware/bfl:5@1` | FLUX.2 [pro] - Professional FLUX model | $0.03 | [Docs ↗](https://runware.ai/models/bfl-flux-2-pro) |
+| `runware/runware:400@3` | FLUX.2 [klein] 9B Base - Lightweight FLUX | $0.0017 | [Docs ↗](https://runware.ai/models/bfl-flux-2-klein-9b-base) |
+| `runware/runware:z-image@turbo` | Z-Image Turbo - Ultra-fast generation | $0.0019 | [Docs ↗](https://runware.ai/models/z-image-turbo) |
+| `runware/google:4@3` | Nano Banana 2 | $0.047 | [Docs ↗](https://runware.ai/models/google-nano-banana-2) |
+| `runware/google:4@2` | Nano Banana Pro | $0.138 | [Docs ↗](https://runware.ai/models/google-nano-banana-pro) |
+| `runware/bytedance:seedream@5.0-lite` | Seedream 5.0 Lite | $0.035 | [Docs ↗](https://runware.ai/models/bytedance-seedream-5-0-lite) |
+| `runware/alibaba:qwen-image@2.0` | Qwen Image 2.0 | $0.035 | [Docs ↗](https://runware.ai/models/alibaba-qwen-image-2-0) |
+| `runware/klingai:kling-image@o3` | Kling Image o3 | $0.028 | [Docs ↗](https://runware.ai/models/klingai-image-o3) |
+| `runware/imagineart:1@5` | ImagineArt 1.5 | $0.03 | [Docs ↗](https://runware.ai/models/imagineart-1-5) |
+| `runware/xai:grok-imagine@image` | Grok Imagine Image | $0.02 | [Docs ↗](https://runware.ai/models/xai-grok-imagine-image) |
+| `runware/xai:grok-imagine@image-pro` | Grok Imagine Image Pro | $0.07 | [Docs ↗](https://runware.ai/models/xai-grok-imagine-image-pro) |
+
+Runware supports 1000+ additional models via CivitAI. Any model can be used by passing its AIR identifier after the `runware/` prefix.
+
+## Image Generation
+
+### Usage - LiteLLM Python SDK
+
+<Tabs>
+<TabItem value="basic" label="Basic Usage">
+
+```python showLineNumbers title="Basic Image Generation"
+import litellm
+import os
+
+# Set your API key
+os.environ["RUNWARE_API_KEY"] = "your-runware-api-key"
+
+# Generate an image
+response = litellm.image_generation(
+    model="runware/runware:400@1",
+    prompt="A serene mountain landscape at sunset with vibrant colors"
+)
+
+print(response.data[0].url)
+```
+
+</TabItem>
+
+<TabItem value="flux-max" label="FLUX.2 Max">
+
+```python showLineNumbers title="FLUX.2 Max - Highest Quality"
+import litellm
+import os
+
+os.environ["RUNWARE_API_KEY"] = "your-runware-api-key"
+
+# Generate with FLUX.2 [max]
+response = litellm.image_generation(
+    model="runware/bfl:7@1",
+    prompt="A photorealistic portrait of a cat wearing a tiny crown",
+    size="1024x1024",
+    n=1
+)
+
+print(response.data[0].url)
+```
+
+</TabItem>
+
+<TabItem value="advanced" label="Advanced Parameters">
+
+```python showLineNumbers title="Advanced Generation with Runware-Specific Parameters"
+import litellm
+import os
+
+os.environ["RUNWARE_API_KEY"] = "your-runware-api-key"
+
+# Generate with advanced parameters
+response = litellm.image_generation(
+    model="runware/runware:400@1",
+    prompt="A majestic dragon soaring over mountains",
+    size="1024x768",
+    n=2,
+    # Runware-specific parameters (passed through directly)
+    negativePrompt="blurry, low quality, distorted",
+    steps=30,
+    CFGScale=7.5,
+    seed=42,
+    scheduler="DPM++ 2M Karras"
+)
+
+for image in response.data:
+    print(f"Generated image: {image.url}")
+```
+
+</TabItem>
+
+<TabItem value="b64" label="Base64 Output">
+
+```python showLineNumbers title="Get Base64 Image Data"
+import litellm
+import os
+
+os.environ["RUNWARE_API_KEY"] = "your-runware-api-key"
+
+# Get image as base64 instead of URL
+response = litellm.image_generation(
+    model="runware/runware:z-image@turbo",
+    prompt="A minimalist logo of a mountain",
+    response_format="b64_json",
+    size="512x512"
+)
+
+# Access base64 data
+b64_data = response.data[0].b64_json
+print(f"Base64 length: {len(b64_data)}")
+```
+
+</TabItem>
+
+<TabItem value="async" label="Async Usage">
+
+```python showLineNumbers title="Async Image Generation"
+import litellm
+import asyncio
+import os
+
+async def generate_image():
+    os.environ["RUNWARE_API_KEY"] = "your-runware-api-key"
+
+    response = await litellm.aimage_generation(
+        model="runware/alibaba:qwen-image@2.0",
+        prompt="A cyberpunk cityscape with neon lights",
+        size="1024x1024"
+    )
+
+    print(response.data[0].url)
+    return response
+
+asyncio.run(generate_image())
+```
+
+</TabItem>
+</Tabs>
+
+### Usage - LiteLLM Proxy Server
+
+#### 1. Configure your config.yaml
+
+```yaml showLineNumbers title="Runware Image Generation Configuration"
+model_list:
+  - model_name: flux-dev
+    litellm_params:
+      model: runware/runware:400@1
+      api_key: os.environ/RUNWARE_API_KEY
+    model_info:
+      mode: image_generation
+
+  - model_name: flux-max
+    litellm_params:
+      model: runware/bfl:7@1
+      api_key: os.environ/RUNWARE_API_KEY
+    model_info:
+      mode: image_generation
+
+  - model_name: z-image-turbo
+    litellm_params:
+      model: runware/runware:z-image@turbo
+      api_key: os.environ/RUNWARE_API_KEY
+    model_info:
+      mode: image_generation
+
+general_settings:
+  master_key: sk-1234
+```
+
+#### 2. Start LiteLLM Proxy Server
+
+```bash showLineNumbers title="Start Proxy Server"
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+#### 3. Make requests
+
+<Tabs>
+<TabItem value="openai-sdk" label="OpenAI SDK">
+
+```python showLineNumbers title="Generate via Proxy - OpenAI SDK"
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:4000",
+    api_key="sk-1234"
+)
+
+response = client.images.generate(
+    model="flux-dev",
+    prompt="A beautiful sunset over the ocean",
+    n=1,
+    size="1024x1024"
+)
+
+print(response.data[0].url)
+```
+
+</TabItem>
+
+<TabItem value="litellm-sdk" label="LiteLLM SDK">
+
+```python showLineNumbers title="Generate via Proxy - LiteLLM SDK"
+import litellm
+
+response = litellm.image_generation(
+    model="litellm_proxy/flux-dev",
+    prompt="A cozy coffee shop interior",
+    api_base="http://localhost:4000",
+    api_key="sk-1234"
+)
+
+print(response.data[0].url)
+```
+
+</TabItem>
+
+<TabItem value="curl" label="cURL">
+
+```bash showLineNumbers title="Generate via Proxy - cURL"
+curl --location 'http://localhost:4000/v1/images/generations' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer sk-1234' \
+--data '{
+    "model": "flux-dev",
+    "prompt": "A serene Japanese garden with cherry blossoms",
+    "n": 1,
+    "size": "1024x1024"
+}'
+```
+
+</TabItem>
+</Tabs>
+
+## Using Model-Specific Parameters
+
+LiteLLM forwards any additional parameters directly to the Runware API. You can pass Runware-specific parameters in your request and they will be sent as-is.
+
+```python showLineNumbers title="Pass Runware-Specific Parameters"
+import litellm
+
+# Any parameters beyond the standard ones are forwarded to Runware
+response = litellm.image_generation(
+    model="runware/runware:400@1",
+    prompt="A beautiful sunset",
+    # Runware-specific parameters
+    negativePrompt="blurry, low quality",
+    steps=30,
+    CFGScale=7.5,
+    seed=42,
+    scheduler="DPM++ 2M Karras",
+    lora=["civitai:12345@67890"],
+)
+```
+
+### Available Runware-Specific Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `negativePrompt` | string | Text describing what to avoid in the image |
+| `steps` | integer | Number of inference steps (higher = more detail) |
+| `CFGScale` | float | Classifier-free guidance scale (1.0-30.0) |
+| `seed` | integer | Seed for reproducible results |
+| `scheduler` | string | Sampling scheduler (e.g., "DPM++ 2M Karras", "Euler a") |
+| `lora` | list | LoRA model identifiers to apply |
+| `controlNet` | list | ControlNet configurations |
+| `refiner` | object | Refiner model configuration |
+
+For the complete list of parameters, see the [Runware API Reference ↗](https://docs.runware.ai/en/image-inference/api-reference).
+
+## Supported OpenAI Parameters
+
+Standard OpenAI-compatible parameters that work across all models:
+
+| Parameter | Type | Description | Runware Mapping |
+|-----------|------|-------------|-----------------|
+| `prompt` | string | Text description of desired image | `positivePrompt` |
+| `model` | string | Runware model AIR identifier | `model` |
+| `n` | integer | Number of images to generate | `numberResults` |
+| `size` | string | Image dimensions (e.g., "1024x1024") | `width` / `height` |
+| `response_format` | string | `"url"` or `"b64_json"` | `outputType` ("URL" or "base64Data") |
+
+## Using Any Runware Model
+
+Runware supports 1000+ models beyond the ones listed above. To use any model, pass its AIR identifier after the `runware/` prefix:
+
+```python showLineNumbers title="Using CivitAI Models"
+import litellm
+
+# Use any CivitAI model via its AIR identifier
+response = litellm.image_generation(
+    model="runware/civitai:36520@76907",
+    prompt="A fantasy landscape",
+    size="512x512"
+)
+
+print(response.data[0].url)
+```
+
+Browse available models at [runware.ai](https://runware.ai/).
+
+## Cost Tracking
+
+Runware reports actual generation costs in API responses. LiteLLM automatically captures these for accurate cost tracking, regardless of whether the model is listed in the pricing table.
+
+```python showLineNumbers title="Access Cost Information"
+response = litellm.image_generation(
+    model="runware/runware:400@1",
+    prompt="A sunset"
+)
+
+# Actual cost reported by Runware
+cost = response._hidden_params.get("response_cost")
+print(f"Generation cost: ${cost}")
+```
+
+## Getting Started
+
+1. Sign up at [runware.ai](https://runware.ai/)
+2. Get your API key from your account dashboard
+3. Set `RUNWARE_API_KEY` environment variable
+4. Choose a model and start generating images with LiteLLM
+
+## Additional Resources
+
+- [Runware Documentation](https://docs.runware.ai/)
+- [API Reference](https://docs.runware.ai/en/image-inference/api-reference)
+- [Model Explorer](https://runware.ai/)

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -981,6 +981,13 @@ const sidebars = {
             "providers/runwayml/videos",
           ]
         },
+        {
+          type: "category",
+          label: "Runware",
+          items: [
+            "providers/runware/images",
+          ]
+        },
         "providers/sambanova",
         "providers/sap",
         "providers/scaleway",

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -539,6 +539,7 @@ xai_models: Set = set()
 zai_models: Set = set()
 deepseek_models: Set = set()
 runwayml_models: Set = set()
+runware_models: Set = set()
 azure_ai_models: Set = set()
 jina_ai_models: Set = set()
 voyage_models: Set = set()
@@ -750,6 +751,8 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             deepseek_models.add(key)
         elif value.get("litellm_provider") == "runwayml":
             runwayml_models.add(key)
+        elif value.get("litellm_provider") == "runware":
+            runware_models.add(key)
         elif value.get("litellm_provider") == "meta_llama":
             llama_models.add(key)
         elif value.get("litellm_provider") == "nscale":
@@ -920,6 +923,7 @@ model_list = list(
     | perplexity_models
     | set(maritalk_models)
     | runwayml_models
+    | runware_models
     | vertex_language_models
     | watsonx_models
     | gemini_models
@@ -1021,6 +1025,7 @@ models_by_provider: dict = {
     "fal_ai": fal_ai_models,
     "deepseek": deepseek_models,
     "runwayml": runwayml_models,
+    "runware": runware_models,
     "mistral": mistral_chat_models,
     "azure_ai": azure_ai_models,
     "voyage": voyage_models,

--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -405,6 +405,7 @@ def image_generation(  # noqa: PLR0915
             litellm.LlmProviders.FAL_AI,
             litellm.LlmProviders.STABILITY,
             litellm.LlmProviders.RUNWAYML,
+            litellm.LlmProviders.RUNWARE,
             litellm.LlmProviders.VERTEX_AI,
             litellm.LlmProviders.OPENROUTER,
         ):

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -969,6 +969,15 @@ class CostCalculatorUtils:
                 model=model,
                 image_response=completion_response,
             )
+        elif custom_llm_provider == litellm.LlmProviders.RUNWARE.value:
+            from litellm.llms.runware.cost_calculator import (
+                cost_calculator as runware_image_cost_calculator,
+            )
+
+            return runware_image_cost_calculator(
+                model=model,
+                image_response=completion_response,
+            )
         elif custom_llm_provider == litellm.LlmProviders.RUNWAYML.value:
             from litellm.llms.runwayml.cost_calculator import (
                 cost_calculator as runwayml_image_cost_calculator,

--- a/litellm/llms/runware/__init__.py
+++ b/litellm/llms/runware/__init__.py
@@ -1,0 +1,11 @@
+from .cost_calculator import cost_calculator
+from .image_generation import (
+    RunwareImageGenerationConfig,
+    get_runware_image_generation_config,
+)
+
+__all__ = [
+    "cost_calculator",
+    "RunwareImageGenerationConfig",
+    "get_runware_image_generation_config",
+]

--- a/litellm/llms/runware/cost_calculator.py
+++ b/litellm/llms/runware/cost_calculator.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+import litellm
+from litellm.types.utils import ImageResponse
+
+
+def cost_calculator(
+    model: str,
+    image_response: Any,
+) -> float:
+    """
+    Runware image generation cost calculator.
+
+    Tries to use Runware's reported cost from the response metadata (via includeCost),
+    then falls back to model_info pricing.
+    """
+    if not isinstance(image_response, ImageResponse):
+        raise ValueError(
+            f"image_response must be of type ImageResponse got type={type(image_response)}"
+        )
+
+    # Try to use Runware's reported cost from response
+    hidden_params = getattr(image_response, "_hidden_params", None)
+    if hidden_params and "runware_cost" in hidden_params:
+        runware_cost = hidden_params["runware_cost"]
+        if runware_cost is not None:
+            return float(runware_cost)
+
+    # Fall back to model_info pricing
+    _model_info = litellm.get_model_info(
+        model=model,
+        custom_llm_provider=litellm.LlmProviders.RUNWARE.value,
+    )
+    output_cost_per_image: float = _model_info.get("output_cost_per_image") or 0.0
+    num_images: int = 0
+    if image_response.data:
+        num_images = len(image_response.data)
+    return output_cost_per_image * num_images

--- a/litellm/llms/runware/image_generation/__init__.py
+++ b/litellm/llms/runware/image_generation/__init__.py
@@ -1,0 +1,19 @@
+from litellm.llms.base_llm.image_generation.transformation import (
+    BaseImageGenerationConfig,
+)
+
+from .transformation import RunwareImageGenerationConfig
+
+__all__ = [
+    "RunwareImageGenerationConfig",
+]
+
+
+def get_runware_image_generation_config(model: str) -> BaseImageGenerationConfig:
+    """
+    Get the Runware image generation configuration.
+
+    All Runware image generation models use the same config since
+    the API has a single endpoint with taskType-based routing.
+    """
+    return RunwareImageGenerationConfig()

--- a/litellm/llms/runware/image_generation/transformation.py
+++ b/litellm/llms/runware/image_generation/transformation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 from uuid import uuid4
 
 import httpx
@@ -102,7 +102,7 @@ class RunwareImageGenerationConfig(BaseImageGenerationConfig):
         optional_params: dict,
         litellm_params: dict,
         headers: dict,
-    ) -> dict:
+    ) -> Union[dict, list]:
         # Parse size into width/height
         width = 1024
         height = 1024
@@ -176,11 +176,15 @@ class RunwareImageGenerationConfig(BaseImageGenerationConfig):
                     )
                 )
 
-        # Store cost metadata from Runware response if available
-        if images and isinstance(images[0], dict):
-            cost = images[0].get("cost", None)
-            if cost is not None:
+        # Store total cost metadata from Runware response if available
+        if images:
+            total_cost = sum(
+                img.get("cost", 0) or 0
+                for img in images
+                if isinstance(img, dict) and img.get("cost") is not None
+            )
+            if total_cost > 0:
                 model_response._hidden_params = model_response._hidden_params or {}
-                model_response._hidden_params["runware_cost"] = cost
+                model_response._hidden_params["runware_cost"] = total_cost
 
         return model_response

--- a/litellm/llms/runware/image_generation/transformation.py
+++ b/litellm/llms/runware/image_generation/transformation.py
@@ -1,0 +1,186 @@
+from typing import TYPE_CHECKING, Any, List, Optional
+from uuid import uuid4
+
+import httpx
+
+from litellm.llms.base_llm.image_generation.transformation import (
+    BaseImageGenerationConfig,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    OpenAIImageGenerationOptionalParams,
+)
+from litellm.types.utils import ImageObject, ImageResponse
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+class RunwareImageGenerationConfig(BaseImageGenerationConfig):
+    """
+    Configuration for Runware image generation.
+
+    Runware API expects:
+    - POST to https://api.runware.ai/v1
+    - Request body is an array: [{taskType: "imageInference", ...}]
+    - Response: {"data": [{imageURL: "...", ...}]}
+    """
+
+    DEFAULT_BASE_URL: str = "https://api.runware.ai/v1"
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        return (
+            api_base or get_secret_str("RUNWARE_API_BASE") or self.DEFAULT_BASE_URL
+        )
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        final_api_key: Optional[str] = api_key or get_secret_str("RUNWARE_API_KEY")
+        if not final_api_key:
+            raise ValueError("RUNWARE_API_KEY is not set")
+
+        headers["Authorization"] = f"Bearer {final_api_key}"
+        headers["Content-Type"] = "application/json"
+        return headers
+
+    def get_supported_openai_params(
+        self, model: str
+    ) -> List[OpenAIImageGenerationOptionalParams]:
+        return [
+            "n",
+            "size",
+            "response_format",
+        ]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+        for k in non_default_params.keys():
+            if k not in optional_params.keys():
+                if k in supported_params:
+                    optional_params[k] = non_default_params[k]
+                elif drop_params:
+                    pass
+                else:
+                    raise ValueError(
+                        f"Parameter {k} is not supported for model {model}. "
+                        f"Supported parameters are {supported_params}. "
+                        f"Set drop_params=True to drop unsupported parameters."
+                    )
+        return optional_params
+
+    def transform_image_generation_request(
+        self,
+        model: str,
+        prompt: str,
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        # Parse size into width/height
+        width = 1024
+        height = 1024
+        if "size" in optional_params:
+            size = optional_params.pop("size")
+            if isinstance(size, str) and "x" in size:
+                parts = size.split("x")
+                width = int(parts[0])
+                height = int(parts[1])
+
+        # Map response_format to outputType
+        output_type = "URL"
+        if "response_format" in optional_params:
+            fmt = optional_params.pop("response_format")
+            if fmt == "b64_json":
+                output_type = "base64Data"
+
+        # Map n to numberResults
+        number_results = 1
+        if "n" in optional_params:
+            number_results = optional_params.pop("n")
+
+        request_body = {
+            "taskType": "imageInference",
+            "taskUUID": str(uuid4()),
+            "positivePrompt": prompt,
+            "model": model,
+            "width": width,
+            "height": height,
+            "numberResults": number_results,
+            "outputType": output_type,
+            "includeCost": True,
+            **optional_params,
+        }
+
+        # Runware expects array request body
+        return [request_body]
+
+    def transform_image_generation_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: ImageResponse,
+        logging_obj: LiteLLMLoggingObj,
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+        encoding: Any,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ImageResponse:
+        try:
+            response_data = raw_response.json()
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=f"Error transforming image generation response: {e}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        if not model_response.data:
+            model_response.data = []
+
+        images = response_data.get("data", [])
+        for image_data in images:
+            if isinstance(image_data, dict):
+                model_response.data.append(
+                    ImageObject(
+                        url=image_data.get("imageURL", None),
+                        b64_json=image_data.get("imageBase64Data", None),
+                    )
+                )
+
+        # Store cost metadata from Runware response if available
+        if images and isinstance(images[0], dict):
+            cost = images[0].get("cost", None)
+            if cost is not None:
+                model_response._hidden_params = model_response._hidden_params or {}
+                model_response._hidden_params["runware_cost"] = cost
+
+        return model_response

--- a/litellm/llms/runware/image_generation/transformation.py
+++ b/litellm/llms/runware/image_generation/transformation.py
@@ -42,9 +42,7 @@ class RunwareImageGenerationConfig(BaseImageGenerationConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ) -> str:
-        return (
-            api_base or get_secret_str("RUNWARE_API_BASE") or self.DEFAULT_BASE_URL
-        )
+        return api_base or get_secret_str("RUNWARE_API_BASE") or self.DEFAULT_BASE_URL
 
     def validate_environment(
         self,

--- a/litellm/llms/runware/image_generation/transformation.py
+++ b/litellm/llms/runware/image_generation/transformation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional
 from uuid import uuid4
 
 import httpx
@@ -86,10 +86,13 @@ class RunwareImageGenerationConfig(BaseImageGenerationConfig):
                 elif drop_params:
                     pass
                 else:
-                    raise ValueError(
-                        f"Parameter {k} is not supported for model {model}. "
+                    from litellm.exceptions import UnsupportedParamsError
+
+                    raise UnsupportedParamsError(
+                        message=f"Parameter {k} is not supported for model {model}. "
                         f"Supported parameters are {supported_params}. "
-                        f"Set drop_params=True to drop unsupported parameters."
+                        f"Set drop_params=True to drop unsupported parameters.",
+                        status_code=400,
                     )
         return optional_params
 
@@ -100,7 +103,7 @@ class RunwareImageGenerationConfig(BaseImageGenerationConfig):
         optional_params: dict,
         litellm_params: dict,
         headers: dict,
-    ) -> Union[dict, list]:
+    ) -> dict:  # type: ignore[override]
         # Parse size into width/height
         width = 1024
         height = 1024
@@ -167,6 +170,11 @@ class RunwareImageGenerationConfig(BaseImageGenerationConfig):
         images = response_data.get("data", [])
         for image_data in images:
             if isinstance(image_data, dict):
+                # Skip error/failed task objects that lack image data
+                if not image_data.get("imageURL") and not image_data.get(
+                    "imageBase64Data"
+                ):
+                    continue
                 model_response.data.append(
                     ImageObject(
                         url=image_data.get("imageURL", None),

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12527,6 +12527,110 @@
             "/v1/images/generations"
         ]
     },
+    "runware/google:4@3": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.047,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/google:4@2": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.138,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/bytedance:seedream@5.0-lite": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.035,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/bfl:7@1": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.07,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/runware:400@1": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.009,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/bfl:5@1": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/runware:z-image@turbo": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0019,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/klingai:kling-image@o3": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.028,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/imagineart:1@5": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/runware:400@3": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0017,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/alibaba:qwen-image@2.0": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.035,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/xai:grok-imagine@image": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.02,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/xai:grok-imagine@image-pro": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.07,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "featherless_ai/featherless-ai/Qwerky-72B": {
         "litellm_provider": "featherless_ai",
         "max_input_tokens": 32768,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3143,6 +3143,7 @@ class LlmProviders(str, Enum):
     BYTEZ = "bytez"
     REPLICATE = "replicate"
     RUNWAYML = "runwayml"
+    RUNWARE = "runware"
     AWS_POLLY = "aws_polly"
     HUGGINGFACE = "huggingface"
     TOGETHER_AI = "together_ai"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8793,6 +8793,12 @@ class ProviderConfigManager:
             )
 
             return get_runwayml_image_generation_config(model)
+        elif LlmProviders.RUNWARE == provider:
+            from litellm.llms.runware.image_generation import (
+                get_runware_image_generation_config,
+            )
+
+            return get_runware_image_generation_config(model)
         elif LlmProviders.BLACK_FOREST_LABS == provider:
             from litellm.llms.black_forest_labs.image_generation import (
                 get_black_forest_labs_image_generation_config,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12527,6 +12527,110 @@
             "/v1/images/generations"
         ]
     },
+    "runware/google:4@3": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.047,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/google:4@2": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.138,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/bytedance:seedream@5.0-lite": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.035,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/bfl:7@1": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.07,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/runware:400@1": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.009,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/bfl:5@1": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/runware:z-image@turbo": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0019,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/klingai:kling-image@o3": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.028,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/imagineart:1@5": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/runware:400@3": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0017,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/alibaba:qwen-image@2.0": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.035,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/xai:grok-imagine@image": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.02,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "runware/xai:grok-imagine@image-pro": {
+        "litellm_provider": "runware",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.07,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "featherless_ai/featherless-ai/Qwerky-72B": {
         "litellm_provider": "featherless_ai",
         "max_input_tokens": 32768,

--- a/tests/image_gen_tests/test_runware_image_generation.py
+++ b/tests/image_gen_tests/test_runware_image_generation.py
@@ -303,6 +303,8 @@ def test_runware_response_transformation_unit():
     assert len(result.data) == 2
     assert result.data[0].url == "https://cdn.runware.ai/image1.png"
     assert result.data[1].url == "https://cdn.runware.ai/image2.png"
+    # Verify multi-image cost is summed
+    assert result._hidden_params["runware_cost"] == 0.004
 
 
 def test_runware_cost_calculator():
@@ -326,6 +328,30 @@ def test_runware_cost_calculator():
     )
 
     assert cost == 0.005
+
+
+def test_runware_cost_calculator_multi_image():
+    """
+    Unit test for Runware cost calculator with multiple images summed.
+    """
+    from litellm.llms.runware.cost_calculator import cost_calculator
+    from litellm.types.utils import ImageObject, ImageResponse
+
+    response = ImageResponse(
+        created=1234567890,
+        data=[
+            ImageObject(url="https://example.com/image1.png"),
+            ImageObject(url="https://example.com/image2.png"),
+        ],
+    )
+    response._hidden_params = {"runware_cost": 0.010}
+
+    cost = cost_calculator(
+        model="runware:400@1",
+        image_response=response,
+    )
+
+    assert cost == 0.010
 
 
 def test_runware_validate_environment():
@@ -359,12 +385,13 @@ def test_runware_validate_environment_missing_key():
     )
 
     config = RunwareImageGenerationConfig()
-    with pytest.raises(ValueError, match="RUNWARE_API_KEY is not set"):
-        config.validate_environment(
-            headers={},
-            model="runware:400@1",
-            messages=[],
-            optional_params={},
-            litellm_params={},
-            api_key=None,
-        )
+    with patch("litellm.llms.runware.image_generation.transformation.get_secret_str", return_value=None):
+        with pytest.raises(ValueError, match="RUNWARE_API_KEY is not set"):
+            config.validate_environment(
+                headers={},
+                model="runware:400@1",
+                messages=[],
+                optional_params={},
+                litellm_params={},
+                api_key=None,
+            )

--- a/tests/image_gen_tests/test_runware_image_generation.py
+++ b/tests/image_gen_tests/test_runware_image_generation.py
@@ -160,8 +160,16 @@ async def test_runware_image_generation_with_n():
         mock_response.headers = {"content-type": "application/json"}
         mock_response.json.return_value = {
             "data": [
-                {"taskType": "imageInference", "taskUUID": "u1", "imageURL": "https://example.com/1.png"},
-                {"taskType": "imageInference", "taskUUID": "u2", "imageURL": "https://example.com/2.png"},
+                {
+                    "taskType": "imageInference",
+                    "taskUUID": "u1",
+                    "imageURL": "https://example.com/1.png",
+                },
+                {
+                    "taskType": "imageInference",
+                    "taskUUID": "u2",
+                    "imageURL": "https://example.com/2.png",
+                },
             ]
         }
         return mock_response
@@ -219,6 +227,54 @@ async def test_runware_image_generation_b64_response_format():
         task = captured_json_data[0]
         assert task["outputType"] == "base64Data"
         assert response.data[0].b64_json is not None
+
+
+@pytest.mark.asyncio
+async def test_runware_image_generation_pass_through_params():
+    """
+    Test that Runware-specific parameters (negativePrompt, steps, CFGScale, seed,
+    scheduler) are forwarded directly to the API request body.
+    """
+    captured_json_data = None
+
+    def capture_post_call(*args, **kwargs):
+        nonlocal captured_json_data
+        captured_json_data = kwargs.get("json")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "taskType": "imageInference",
+                    "taskUUID": "test-uuid",
+                    "imageURL": "https://example.com/image.png",
+                }
+            ]
+        }
+        return mock_response
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
+        mock_post.side_effect = capture_post_call
+
+        await aimage_generation(
+            model="runware/runware:400@1",
+            prompt="A landscape",
+            api_key="test-key",
+            negativePrompt="blurry, low quality",
+            steps=30,
+            CFGScale=7.5,
+            seed=42,
+            scheduler="DPM++ 2M Karras",
+        )
+
+        task = captured_json_data[0]
+        assert task["negativePrompt"] == "blurry, low quality"
+        assert task["steps"] == 30
+        assert task["CFGScale"] == 7.5
+        assert task["seed"] == 42
+        assert task["scheduler"] == "DPM++ 2M Karras"
 
 
 def test_runware_request_transformation_unit():
@@ -385,7 +441,10 @@ def test_runware_validate_environment_missing_key():
     )
 
     config = RunwareImageGenerationConfig()
-    with patch("litellm.llms.runware.image_generation.transformation.get_secret_str", return_value=None):
+    with patch(
+        "litellm.llms.runware.image_generation.transformation.get_secret_str",
+        return_value=None,
+    ):
         with pytest.raises(ValueError, match="RUNWARE_API_KEY is not set"):
             config.validate_environment(
                 headers={},

--- a/tests/image_gen_tests/test_runware_image_generation.py
+++ b/tests/image_gen_tests/test_runware_image_generation.py
@@ -1,0 +1,370 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm import aimage_generation
+
+
+@pytest.mark.parametrize(
+    "model,expected_model_id",
+    [
+        ("runware/runware:400@1", "runware:400@1"),
+        ("runware/bfl:7@1", "bfl:7@1"),
+        ("runware/google:4@3", "google:4@3"),
+        ("runware/alibaba:qwen-image@2.0", "alibaba:qwen-image@2.0"),
+        ("runware/xai:grok-imagine@image", "xai:grok-imagine@image"),
+        ("runware/runware:z-image@turbo", "runware:z-image@turbo"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_runware_image_generation_basic(model, expected_model_id):
+    """
+    Test that runware image generation constructs correct request body and URL.
+
+    Validates:
+    - Correct API endpoint URL
+    - Proper array-wrapped request body format
+    - Correct Authorization header format (Bearer token)
+    - Prompt mapped to positivePrompt
+    - Model ID correctly stripped of runware/ prefix
+    - taskType set to imageInference
+    """
+    captured_url = None
+    captured_json_data = None
+    captured_headers = None
+
+    def capture_post_call(*args, **kwargs):
+        nonlocal captured_url, captured_json_data, captured_headers
+
+        captured_url = args[0] if args else kwargs.get("url")
+        captured_json_data = kwargs.get("json")
+        captured_headers = kwargs.get("headers")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "taskType": "imageInference",
+                    "taskUUID": "test-uuid",
+                    "imageURL": "https://example.com/generated-image.png",
+                    "cost": 0.002,
+                }
+            ]
+        }
+
+        return mock_response
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
+        mock_post.side_effect = capture_post_call
+
+        test_api_key = "test-runware-key-12345"
+        test_prompt = "A cute baby sea otter"
+
+        response = await aimage_generation(
+            model=model,
+            prompt=test_prompt,
+            api_key=test_api_key,
+        )
+
+        # Validate response
+        assert response is not None
+        assert hasattr(response, "data")
+        assert response.data is not None
+        assert len(response.data) > 0
+        assert response.data[0].url == "https://example.com/generated-image.png"
+
+        # Validate URL
+        assert captured_url is not None
+        assert "api.runware.ai" in captured_url
+        print(f"Validated URL: {captured_url}")
+
+        # Validate headers
+        assert captured_headers is not None
+        assert "Authorization" in captured_headers
+        assert captured_headers["Authorization"] == f"Bearer {test_api_key}"
+        print(f"Validated headers: {captured_headers}")
+
+        # Validate request body is array-wrapped
+        assert captured_json_data is not None
+        assert isinstance(captured_json_data, list)
+        assert len(captured_json_data) == 1
+
+        task = captured_json_data[0]
+        assert task["positivePrompt"] == test_prompt
+        assert task["taskType"] == "imageInference"
+        assert task["model"] == expected_model_id
+        assert "taskUUID" in task
+        print(f"Validated request body: {captured_json_data}")
+
+
+@pytest.mark.asyncio
+async def test_runware_image_generation_with_size():
+    """
+    Test that size parameter is correctly parsed into width/height.
+    """
+    captured_json_data = None
+
+    def capture_post_call(*args, **kwargs):
+        nonlocal captured_json_data
+        captured_json_data = kwargs.get("json")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "taskType": "imageInference",
+                    "taskUUID": "test-uuid",
+                    "imageURL": "https://example.com/image.png",
+                }
+            ]
+        }
+        return mock_response
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
+        mock_post.side_effect = capture_post_call
+
+        await aimage_generation(
+            model="runware/runware:400@1",
+            prompt="A landscape",
+            size="512x768",
+            api_key="test-key",
+        )
+
+        task = captured_json_data[0]
+        assert task["width"] == 512
+        assert task["height"] == 768
+
+
+@pytest.mark.asyncio
+async def test_runware_image_generation_with_n():
+    """
+    Test that n parameter maps to numberResults.
+    """
+    captured_json_data = None
+
+    def capture_post_call(*args, **kwargs):
+        nonlocal captured_json_data
+        captured_json_data = kwargs.get("json")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "data": [
+                {"taskType": "imageInference", "taskUUID": "u1", "imageURL": "https://example.com/1.png"},
+                {"taskType": "imageInference", "taskUUID": "u2", "imageURL": "https://example.com/2.png"},
+            ]
+        }
+        return mock_response
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
+        mock_post.side_effect = capture_post_call
+
+        response = await aimage_generation(
+            model="runware/runware:400@1",
+            prompt="Two cats",
+            n=2,
+            api_key="test-key",
+        )
+
+        task = captured_json_data[0]
+        assert task["numberResults"] == 2
+        assert len(response.data) == 2
+
+
+@pytest.mark.asyncio
+async def test_runware_image_generation_b64_response_format():
+    """
+    Test that response_format b64_json maps to outputType base64Data.
+    """
+    captured_json_data = None
+
+    def capture_post_call(*args, **kwargs):
+        nonlocal captured_json_data
+        captured_json_data = kwargs.get("json")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "taskType": "imageInference",
+                    "taskUUID": "test-uuid",
+                    "imageBase64Data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                }
+            ]
+        }
+        return mock_response
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
+        mock_post.side_effect = capture_post_call
+
+        response = await aimage_generation(
+            model="runware/runware:400@1",
+            prompt="A cat",
+            response_format="b64_json",
+            api_key="test-key",
+        )
+
+        task = captured_json_data[0]
+        assert task["outputType"] == "base64Data"
+        assert response.data[0].b64_json is not None
+
+
+def test_runware_request_transformation_unit():
+    """
+    Unit test for RunwareImageGenerationConfig.transform_image_generation_request
+    """
+    from litellm.llms.runware.image_generation.transformation import (
+        RunwareImageGenerationConfig,
+    )
+
+    config = RunwareImageGenerationConfig()
+
+    result = config.transform_image_generation_request(
+        model="runware:400@1",
+        prompt="A beautiful sunset",
+        optional_params={"size": "512x768", "n": 3, "response_format": "b64_json"},
+        litellm_params={},
+        headers={},
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+    task = result[0]
+    assert task["taskType"] == "imageInference"
+    assert task["positivePrompt"] == "A beautiful sunset"
+    assert task["model"] == "runware:400@1"
+    assert task["width"] == 512
+    assert task["height"] == 768
+    assert task["numberResults"] == 3
+    assert task["outputType"] == "base64Data"
+    assert task["includeCost"] is True
+    assert "taskUUID" in task
+
+
+def test_runware_response_transformation_unit():
+    """
+    Unit test for RunwareImageGenerationConfig.transform_image_generation_response
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.llms.runware.image_generation.transformation import (
+        RunwareImageGenerationConfig,
+    )
+    from litellm.types.utils import ImageResponse
+
+    config = RunwareImageGenerationConfig()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "taskType": "imageInference",
+                "taskUUID": "abc-123",
+                "imageURL": "https://cdn.runware.ai/image1.png",
+                "cost": 0.002,
+            },
+            {
+                "taskType": "imageInference",
+                "taskUUID": "abc-456",
+                "imageURL": "https://cdn.runware.ai/image2.png",
+                "cost": 0.002,
+            },
+        ]
+    }
+
+    model_response = ImageResponse(created=1234567890, data=[])
+
+    result = config.transform_image_generation_response(
+        model="runware:400@1",
+        raw_response=mock_response,
+        model_response=model_response,
+        logging_obj=MagicMock(),
+        request_data={},
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert len(result.data) == 2
+    assert result.data[0].url == "https://cdn.runware.ai/image1.png"
+    assert result.data[1].url == "https://cdn.runware.ai/image2.png"
+
+
+def test_runware_cost_calculator():
+    """
+    Unit test for Runware cost calculator with Runware-reported cost.
+    """
+    from litellm.llms.runware.cost_calculator import cost_calculator
+    from litellm.types.utils import ImageObject, ImageResponse
+
+    response = ImageResponse(
+        created=1234567890,
+        data=[
+            ImageObject(url="https://example.com/image.png"),
+        ],
+    )
+    response._hidden_params = {"runware_cost": 0.005}
+
+    cost = cost_calculator(
+        model="runware:400@1",
+        image_response=response,
+    )
+
+    assert cost == 0.005
+
+
+def test_runware_validate_environment():
+    """
+    Test that validate_environment sets correct auth headers.
+    """
+    from litellm.llms.runware.image_generation.transformation import (
+        RunwareImageGenerationConfig,
+    )
+
+    config = RunwareImageGenerationConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="runware:400@1",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="my-test-key",
+    )
+
+    assert headers["Authorization"] == "Bearer my-test-key"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_runware_validate_environment_missing_key():
+    """
+    Test that validate_environment raises when no API key is available.
+    """
+    from litellm.llms.runware.image_generation.transformation import (
+        RunwareImageGenerationConfig,
+    )
+
+    config = RunwareImageGenerationConfig()
+    with pytest.raises(ValueError, match="RUNWARE_API_KEY is not set"):
+        config.validate_environment(
+            headers={},
+            model="runware:400@1",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            api_key=None,
+        )


### PR DESCRIPTION
 ## Relevant issues

  N/A — New provider integration.

  ## Pre-Submission checklist

  - [x] I have Added testing in the [`tests/`](https://github.com/BerriAI/litellm/tree/main/tests) directory, **Adding at least 1 test is a hard requirement** — 14 tests in
  `tests/image_gen_tests/test_runware_image_generation.py`
  - [X ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

  ## Type

  🆕 New Feature

  ## Changes

  Add [Runware](https://runware.ai) (`runware`) as a new image generation provider.

  - **Provider implementation**: `litellm/llms/runware/` — `RunwareImageGenerationConfig` handling request/response transformation, Bearer token auth via `RUNWARE_API_KEY`, array-wrapped request body
  (`[{taskType: "imageInference", ...}]`)
  - **Cost calculator**: `litellm/llms/runware/cost_calculator.py` — uses Runware's `includeCost` response field for real-time cost tracking, falls back to model_info pricing
  - **Enum**: Added `RUNWARE = "runware"` to `LlmProviders` in `litellm/types/utils.py`
  - **Routing**: Added `LlmProviders.RUNWARE` to `llm_http_handler` image generation routing in `litellm/images/main.py`
  - **Registry**: Added `runware_models` set and `models_by_provider` entry in `litellm/__init__.py`; added config getter in `litellm/utils.py`; added cost calculator dispatch in
  `litellm/litellm_core_utils/llm_cost_calc/utils.py`
  - **Model pricing**: Added 13 SOTA models to `model_prices_and_context_window.json` and backup — FLUX.2 [dev/max/pro/klein], Z-Image Turbo, Nano Banana 2/Pro, Seedream 5.0 Lite, Qwen Image 2.0, Kling Image
   o3, ImagineArt 1.5, Grok Imagine/Imagine Pro
  - **OpenAI param mapping**: `prompt` → `positivePrompt`, `n` → `numberResults`, `size` → `width`/`height`, `response_format` → `outputType`
  - **Pass-through params**: Runware-specific parameters (`negativePrompt`, `steps`, `CFGScale`, `seed`, `scheduler`, `lora`, `controlNet`) forwarded directly to the API
  - **Docs**: Added `docs/my-website/docs/providers/runware/images.md` with usage examples (SDK, proxy, cURL), supported model table with docs links, and parameter reference; registered as category in
  `sidebars.js`
  - **Tests**: 14 unit tests in `tests/image_gen_tests/test_runware_image_generation.py` covering request/response transformation, auth, cost calculation, parameter mapping across 6 models
  - **Live verified**: Tested against Runware API with FLUX.2 [dev], FLUX.2 [max], FLUX.2 [pro], Qwen Image 2.0, Grok Imagine, Z-Image Turbo