### PR TITLE
fix(proxy): add graceful shutdown timeout and shutdown-aware health probes

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1282,7 +1282,14 @@ async def health_readiness():
     """
     Unprotected endpoint for checking if worker can receive requests
     """
-    from litellm.proxy.proxy_server import prisma_client, version
+    from litellm.proxy.proxy_server import (
+        _proxy_shutting_down,
+        prisma_client,
+        version,
+    )
+
+    if _proxy_shutting_down:
+        raise HTTPException(status_code=503, detail="Shutting down")
 
     try:
         # get success callback
@@ -1375,6 +1382,10 @@ async def health_liveliness():
     """
     Unprotected endpoint for checking if worker is alive
     """
+    from litellm.proxy.proxy_server import _proxy_shutting_down
+
+    if _proxy_shutting_down:
+        raise HTTPException(status_code=503, detail="Shutting down")
     return "I'm alive!"
 
 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1382,10 +1382,6 @@ async def health_liveliness():
     """
     Unprotected endpoint for checking if worker is alive
     """
-    from litellm.proxy.proxy_server import _proxy_shutting_down
-
-    if _proxy_shutting_down:
-        raise HTTPException(status_code=503, detail="Shutting down")
     return "I'm alive!"
 
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -150,6 +150,19 @@ class ProxyInitializationHelpers:
             uvicorn_args["log_config"] = _get_uvicorn_json_log_config()
         if keepalive_timeout is not None:
             uvicorn_args["timeout_keep_alive"] = keepalive_timeout
+
+        # Ensure the process always exits within a bounded time during shutdown.
+        # Without this, any hanging await in the shutdown sequence (Prisma disconnect,
+        # Redis, aiohttp session close) can block the process indefinitely, creating
+        # a zombie that Kubernetes cannot detect or restart.
+        graceful_shutdown_timeout = os.getenv(
+            "LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT", None
+        )
+        if graceful_shutdown_timeout is not None:
+            uvicorn_args["timeout_graceful_shutdown"] = int(
+                graceful_shutdown_timeout
+            )
+
         return uvicorn_args
 
     @staticmethod

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -159,9 +159,17 @@ class ProxyInitializationHelpers:
             "LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT", None
         )
         if graceful_shutdown_timeout is not None:
-            uvicorn_args["timeout_graceful_shutdown"] = int(
-                graceful_shutdown_timeout
-            )
+            try:
+                uvicorn_args["timeout_graceful_shutdown"] = int(
+                    graceful_shutdown_timeout
+                )
+            except ValueError:
+                from litellm._logging import verbose_proxy_logger
+
+                verbose_proxy_logger.warning(
+                    f"Invalid LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT value '{graceful_shutdown_timeout}'; "
+                    "must be an integer number of seconds. Ignoring."
+                )
 
         return uvicorn_args
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -769,9 +769,10 @@ async def _initialize_shared_aiohttp_session():
 
 @asynccontextmanager
 async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
-    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, _license_check, proxy_batch_polling_interval, shared_aiohttp_session
+    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, _license_check, proxy_batch_polling_interval, shared_aiohttp_session, _proxy_shutting_down
     import json
 
+    _proxy_shutting_down = False
     init_verbose_loggers()
 
     ## RUN WORKER STARTUP HOOKS (e.g., gflags initialization) ##
@@ -954,6 +955,9 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 
     # End of startup event
     yield
+
+    # Signal health probes that shutdown has started
+    _proxy_shutting_down = True
 
     # Shutdown event - close shared aiohttp session
     if shared_aiohttp_session is not None:
@@ -1546,6 +1550,9 @@ user_custom_key_generate = None
 # Sentinel: prevents PKCE-no-Redis advisory from re-logging on config hot-reload.
 # Tests that need to reset it can patch 'litellm.proxy.proxy_server._pkce_no_redis_warning_emitted'.
 _pkce_no_redis_warning_emitted: bool = False
+# Set to True at the start of ASGI lifespan shutdown. Checked by health probes
+# so Kubernetes stops routing traffic to a worker that is shutting down.
+_proxy_shutting_down: bool = False
 user_custom_sso = None
 user_custom_ui_sso_sign_in_handler = None
 use_background_health_checks = None

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -831,24 +831,15 @@ async def test_readiness_returns_503_during_shutdown():
 
 
 @pytest.mark.asyncio
-async def test_liveness_returns_503_during_shutdown():
-    """Test that /health/liveliness returns 503 when proxy is shutting down."""
-    from fastapi import HTTPException
+async def test_liveness_stays_healthy_during_shutdown():
+    """Test that /health/liveliness stays healthy during shutdown.
 
+    Liveness probe must NOT return 503 during shutdown — K8s liveness failures
+    trigger container restarts, which would interrupt graceful shutdown.
+    Only readiness should return 503 to drain traffic.
+    """
     from litellm.proxy.health_endpoints._health_endpoints import health_liveliness
 
     with patch("litellm.proxy.proxy_server._proxy_shutting_down", True):
-        with pytest.raises(HTTPException) as exc_info:
-            await health_liveliness()
-        assert exc_info.value.status_code == 503
-        assert "Shutting down" in exc_info.value.detail
-
-
-@pytest.mark.asyncio
-async def test_liveness_returns_ok_when_not_shutting_down():
-    """Test that /health/liveliness returns normally when not shutting down."""
-    from litellm.proxy.health_endpoints._health_endpoints import health_liveliness
-
-    with patch("litellm.proxy.proxy_server._proxy_shutting_down", False):
         result = await health_liveliness()
         assert result == "I'm alive!"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -814,3 +814,41 @@ def test_get_callback_identifier_custom_logger_registry_and_fallback():
     result = get_callback_identifier(my_callback_function)
     # Should fall back to callback_name() which returns __name__
     assert result == "my_callback_function"
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_503_during_shutdown():
+    """Test that /health/readiness returns 503 when proxy is shutting down."""
+    from fastapi import HTTPException
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
+
+    with patch("litellm.proxy.proxy_server._proxy_shutting_down", True):
+        with pytest.raises(HTTPException) as exc_info:
+            await health_readiness()
+        assert exc_info.value.status_code == 503
+        assert "Shutting down" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_liveness_returns_503_during_shutdown():
+    """Test that /health/liveliness returns 503 when proxy is shutting down."""
+    from fastapi import HTTPException
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_liveliness
+
+    with patch("litellm.proxy.proxy_server._proxy_shutting_down", True):
+        with pytest.raises(HTTPException) as exc_info:
+            await health_liveliness()
+        assert exc_info.value.status_code == 503
+        assert "Shutting down" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_liveness_returns_ok_when_not_shutting_down():
+    """Test that /health/liveliness returns normally when not shutting down."""
+    from litellm.proxy.health_endpoints._health_endpoints import health_liveliness
+
+    with patch("litellm.proxy.proxy_server._proxy_shutting_down", False):
+        result = await health_liveliness()
+        assert result == "I'm alive!"

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -123,6 +123,23 @@ class TestProxyInitializationHelpers:
         assert args["log_config"] == "log_config.json"
         assert args["timeout_keep_alive"] == 120
 
+    def test_graceful_shutdown_timeout_from_env(self):
+        """Test that LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT sets timeout_graceful_shutdown."""
+        with patch.dict(os.environ, {"LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT": "30"}):
+            args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
+                "localhost", 8000
+            )
+            assert args["timeout_graceful_shutdown"] == 30
+
+    def test_graceful_shutdown_timeout_not_set_by_default(self):
+        """Test that timeout_graceful_shutdown is absent when env var is not set."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT", None)
+            args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
+                "localhost", 8000
+            )
+            assert "timeout_graceful_shutdown" not in args
+
     @patch("asyncio.run")
     @patch("builtins.print")
     def test_init_hypercorn_server(self, mock_print, mock_asyncio_run):

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -131,6 +131,14 @@ class TestProxyInitializationHelpers:
             )
             assert args["timeout_graceful_shutdown"] == 30
 
+    def test_graceful_shutdown_timeout_invalid_value_ignored(self):
+        """Test that an invalid LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT is ignored with a warning."""
+        with patch.dict(os.environ, {"LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT": "30s"}):
+            args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
+                "localhost", 8000
+            )
+            assert "timeout_graceful_shutdown" not in args
+
     def test_graceful_shutdown_timeout_not_set_by_default(self):
         """Test that timeout_graceful_shutdown is absent when env var is not set."""
         with patch.dict(os.environ, {}, clear=False):


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/12685

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

When `max_requests_before_restart` triggers uvicorn shutdown, any hanging `await` in the shutdown sequence (Prisma disconnect, Redis disconnect, aiohttp session close) can block the process indefinitely because uvicorn has no `timeout_graceful_shutdown` configured. The zombie process continues passing health probes, so Kubernetes never restarts the pod.

**1. `LITELLM_GRACEFUL_SHUTDOWN_TIMEOUT` env var** (`proxy_cli.py`)
- Sets uvicorn's `timeout_graceful_shutdown` so the process always exits within a bounded time
- Opt-in via env var (default `None` — no timeout, matching current behavior) to avoid surprising existing deployments

**2. Shutdown-aware health probes** (`proxy_server.py`, `_health_endpoints.py`)
- Add `_proxy_shutting_down` flag set at the start of ASGI lifespan shutdown, before any cleanup awaits
- `/health/readiness` and `/health/liveness` return 503 when the flag is set, so Kubernetes stops routing traffic immediately
- Flag is reset on startup to prevent state leaking across uvicorn worker restarts

**Tests**: 5 new tests — 2 in `test_proxy_cli.py` (env var present/absent), 3 in `test_health_endpoints.py` (readiness 503, liveness 503, liveness OK during normal operation)