### PR TITLE
fix: run prisma migration check on PRs to block schema changes without migrations

### DIFF
--- a/.github/workflows/publish-migrations.yml
+++ b/.github/workflows/publish-migrations.yml
@@ -5,6 +5,11 @@ permissions:
   pull-requests: write
 
 on:
+  pull_request:
+    paths:
+      - 'schema.prisma'
+    branches:
+      - main
   push:
     paths:
       - 'schema.prisma'  # Check root schema.prisma
@@ -183,7 +188,7 @@ jobs:
           git status
 
       - name: Create Pull Request
-        if: success()
+        if: success() && github.event_name == 'push'
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Schema changes were merging to main without migrations. The job would then run, detect the drift, auto-generate a migration, and open a PR — but by then the damage was done. Any developer running the proxy off main between the schema merge and the migration PR merge would hit missing columns, 500s on login, and spam errors every 30 seconds.

This PR moves the check to run on PRs, so a schema change without a migration will be blocked from merging entirely.

## Changes

- Added `pull_request` trigger to `publish-migrations.yml`
- Gated `Create Pull Request` step to `push` only (avoids token permission issues on fork PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)