### PR TITLE
fix(secret_managers): check vault rotation error return and mask raw API keys in logs

### DIFF
--- a/litellm/proxy/hooks/key_management_event_hooks.py
+++ b/litellm/proxy/hooks/key_management_event_hooks.py
@@ -322,7 +322,7 @@ class KeyManagementEventHooks:
                     optional_params = await KeyManagementEventHooks._get_secret_manager_optional_params(
                         team_id
                     )
-                    await litellm.secret_manager_client.async_rotate_secret(
+                    result = await litellm.secret_manager_client.async_rotate_secret(
                         current_secret_name=KeyManagementEventHooks._get_secret_name(
                             current_secret_name
                         ),
@@ -332,6 +332,13 @@ class KeyManagementEventHooks:
                         new_secret_value=new_secret_value,
                         optional_params=optional_params,
                     )
+                    if (
+                        isinstance(result, dict)
+                        and result.get("status") == "error"
+                    ):
+                        raise ValueError(
+                            f"Secret manager rotation failed: {result.get('message', 'unknown error')}"
+                        )
 
     @staticmethod
     def _get_secret_name(secret_name: str) -> str:

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -538,8 +538,8 @@ class HashicorpSecretManager(BaseSecretManager):
                 )
                 if new_secret_value_from_vault != new_secret_value:
                     # Mask key values to avoid logging raw API keys
-                    masked_expected = f"...{new_secret_value[-4:]}" if new_secret_value else "<empty>"
-                    masked_got = f"...{new_secret_value_from_vault[-4:]}" if new_secret_value_from_vault else "<empty>"
+                    masked_expected = f"...{new_secret_value[-4:]}" if new_secret_value and len(new_secret_value) > 4 else "<redacted>"
+                    masked_got = f"...{new_secret_value_from_vault[-4:]}" if new_secret_value_from_vault and len(new_secret_value_from_vault) > 4 else "<redacted>"
                     verbose_logger.error(
                         "New secret value mismatch. Expected: %s, Got: %s",
                         masked_expected,

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -537,12 +537,17 @@ class HashicorpSecretManager(BaseSecretManager):
                     json_resp.get("data", {}).get("data", {}).get(data_key, None)
                 )
                 if new_secret_value_from_vault != new_secret_value:
-                    verbose_logger.exception(
-                        f"New secret value mismatch. Expected: {new_secret_value}, Got: {new_secret_value_from_vault}"
+                    # Mask key values to avoid logging raw API keys
+                    masked_expected = f"...{new_secret_value[-4:]}" if new_secret_value else "<empty>"
+                    masked_got = f"...{new_secret_value_from_vault[-4:]}" if new_secret_value_from_vault else "<empty>"
+                    verbose_logger.error(
+                        "New secret value mismatch. Expected: %s, Got: %s",
+                        masked_expected,
+                        masked_got,
                     )
                     return {
                         "status": "error",
-                        "message": f"New secret value mismatch. Expected: {new_secret_value}, Got: {new_secret_value_from_vault}",
+                        "message": f"New secret value mismatch. Expected: {masked_expected}, Got: {masked_got}",
                     }
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 404:

--- a/tests/litellm_utils_tests/test_hashicorp.py
+++ b/tests/litellm_utils_tests/test_hashicorp.py
@@ -759,4 +759,7 @@ async def test_hashicorp_secret_manager_rotate_secret_value_mismatch(hashicorp_s
         # Verify error response
         assert response["status"] == "error"
         assert "mismatch" in response["message"].lower()
-        assert "expected-value" in response["message"]
+        # Raw key values should be masked — only last 4 chars shown
+        assert "expected-value" not in response["message"]
+        assert "...alue" in response["message"]  # last 4 of "expected-value"
+        assert "...alue" in response["message"]  # last 4 of "different-value"

--- a/tests/litellm_utils_tests/test_hashicorp.py
+++ b/tests/litellm_utils_tests/test_hashicorp.py
@@ -737,7 +737,7 @@ async def test_hashicorp_secret_manager_rotate_secret_value_mismatch(hashicorp_s
         mock_get_response_new = MagicMock()
         mock_get_response_new.json.return_value = {
             "data": {
-                "data": {"key": "different-value"},  # Different from expected
+                "data": {"key": "different-ABCD"},  # Different from expected
             }
         }
         mock_get_response_new.raise_for_status.return_value = None
@@ -748,18 +748,18 @@ async def test_hashicorp_secret_manager_rotate_secret_value_mismatch(hashicorp_s
         
         current_secret_name = f"old-secret-{uuid.uuid4()}"
         new_secret_name = f"new-secret-{uuid.uuid4()}"
-        new_secret_value = "expected-value"
-        
+        new_secret_value = "expected-XYZW"
+
         response = await hashicorp_secret_manager.async_rotate_secret(
             current_secret_name=current_secret_name,
             new_secret_name=new_secret_name,
             new_secret_value=new_secret_value,
         )
-        
+
         # Verify error response
         assert response["status"] == "error"
         assert "mismatch" in response["message"].lower()
         # Raw key values should be masked — only last 4 chars shown
-        assert "expected-value" not in response["message"]
-        assert "...alue" in response["message"]  # last 4 of "expected-value"
-        assert "...alue" in response["message"]  # last 4 of "different-value"
+        assert "expected-XYZW" not in response["message"]
+        assert "...XYZW" in response["message"]  # last 4 of "expected-XYZW"
+        assert "...ABCD" in response["message"]  # last 4 of "different-ABCD"

--- a/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
+++ b/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
@@ -385,6 +385,96 @@ class TestRotateVirtualKeyInSecretManager:
             new_secret_value="sk-new-value",
             team_id="team-123",
         )
-        
+
         # Verify async_rotate_secret was NOT called
         mock_secret_manager.async_rotate_secret.assert_not_called()
+
+
+class TestRotateVirtualKeyErrorHandling:
+    """Tests that _rotate_virtual_key_in_secret_manager propagates error dicts as exceptions."""
+
+    @pytest.mark.asyncio
+    async def test_rotate_raises_on_error_dict(self):
+        """Test that error dict from async_rotate_secret is raised as ValueError."""
+        from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
+        from litellm.secret_managers.base_secret_manager import BaseSecretManager
+        import litellm
+
+        mock_secret_manager = MagicMock(spec=BaseSecretManager)
+        mock_secret_manager.async_rotate_secret = AsyncMock(
+            return_value={"status": "error", "message": "New secret value mismatch. Expected: ...3lcA, Got: ...zt4w"}
+        )
+
+        litellm.secret_manager_client = mock_secret_manager
+        litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
+        litellm._key_management_settings = KeyManagementSettings(
+            store_virtual_keys=True,
+            prefix_for_stored_virtual_keys="litellm/",
+        )
+
+        import builtins
+        original_isinstance = builtins.isinstance
+
+        def mock_isinstance(obj, cls):
+            if cls == BaseSecretManager and obj == mock_secret_manager:
+                return True
+            return original_isinstance(obj, cls)
+
+        with patch.object(
+            KeyManagementEventHooks,
+            "_get_secret_manager_optional_params",
+            return_value=None,
+        ), patch(
+            "litellm.proxy.hooks.key_management_event_hooks.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            with pytest.raises(ValueError, match="Secret manager rotation failed"):
+                await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
+                    current_secret_name="old-key",
+                    new_secret_name="new-key",
+                    new_secret_value="sk-new-value",
+                    team_id=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_rotate_success_dict_does_not_raise(self):
+        """Test that a success response from async_rotate_secret does not raise."""
+        from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
+        from litellm.secret_managers.base_secret_manager import BaseSecretManager
+        import litellm
+
+        mock_secret_manager = MagicMock(spec=BaseSecretManager)
+        mock_secret_manager.async_rotate_secret = AsyncMock(
+            return_value={"request_id": "abc", "data": {}}
+        )
+
+        litellm.secret_manager_client = mock_secret_manager
+        litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
+        litellm._key_management_settings = KeyManagementSettings(
+            store_virtual_keys=True,
+            prefix_for_stored_virtual_keys="litellm/",
+        )
+
+        import builtins
+        original_isinstance = builtins.isinstance
+
+        def mock_isinstance(obj, cls):
+            if cls == BaseSecretManager and obj == mock_secret_manager:
+                return True
+            return original_isinstance(obj, cls)
+
+        with patch.object(
+            KeyManagementEventHooks,
+            "_get_secret_manager_optional_params",
+            return_value=None,
+        ), patch(
+            "litellm.proxy.hooks.key_management_event_hooks.isinstance",
+            side_effect=mock_isinstance,
+        ):
+            # Should not raise
+            await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
+                current_secret_name="old-key",
+                new_secret_name="new-key",
+                new_secret_value="sk-new-value",
+                team_id=None,
+            )

--- a/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
+++ b/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../../.."))
 
 from litellm.proxy.hooks.key_management_event_hooks import KeyManagementEventHooks
+from litellm.secret_managers.base_secret_manager import BaseSecretManager
 
 
 class TestKeyManagementEventHooksIndependentOperations:
@@ -390,6 +391,28 @@ class TestRotateVirtualKeyInSecretManager:
         mock_secret_manager.async_rotate_secret.assert_not_called()
 
 
+class _StubSecretManager(BaseSecretManager):
+    """Minimal concrete BaseSecretManager for testing — passes isinstance checks naturally."""
+
+    def __init__(self):
+        pass
+
+    async def async_read_secret(self, secret_name, optional_params=None, timeout=None):
+        raise NotImplementedError
+
+    def sync_read_secret(self, secret_name, optional_params=None):
+        raise NotImplementedError
+
+    async def async_write_secret(self, secret_name, secret_value, description=None, optional_params=None):
+        raise NotImplementedError
+
+    async def async_delete_secret(self, secret_name, optional_params=None):
+        raise NotImplementedError
+
+    async def async_rotate_secret(self, current_secret_name, new_secret_name, new_secret_value, optional_params=None):
+        raise NotImplementedError
+
+
 class TestRotateVirtualKeyErrorHandling:
     """Tests that _rotate_virtual_key_in_secret_manager propagates error dicts as exceptions."""
 
@@ -397,36 +420,24 @@ class TestRotateVirtualKeyErrorHandling:
     async def test_rotate_raises_on_error_dict(self):
         """Test that error dict from async_rotate_secret is raised as ValueError."""
         from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
-        from litellm.secret_managers.base_secret_manager import BaseSecretManager
         import litellm
 
-        mock_secret_manager = MagicMock(spec=BaseSecretManager)
-        mock_secret_manager.async_rotate_secret = AsyncMock(
+        stub = _StubSecretManager()
+        stub.async_rotate_secret = AsyncMock(
             return_value={"status": "error", "message": "New secret value mismatch. Expected: ...3lcA, Got: ...zt4w"}
         )
 
-        litellm.secret_manager_client = mock_secret_manager
+        litellm.secret_manager_client = stub
         litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=True,
             prefix_for_stored_virtual_keys="litellm/",
         )
 
-        import builtins
-        original_isinstance = builtins.isinstance
-
-        def mock_isinstance(obj, cls):
-            if cls == BaseSecretManager and obj == mock_secret_manager:
-                return True
-            return original_isinstance(obj, cls)
-
         with patch.object(
             KeyManagementEventHooks,
             "_get_secret_manager_optional_params",
             return_value=None,
-        ), patch(
-            "litellm.proxy.hooks.key_management_event_hooks.isinstance",
-            side_effect=mock_isinstance,
         ):
             with pytest.raises(ValueError, match="Secret manager rotation failed"):
                 await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(
@@ -440,36 +451,24 @@ class TestRotateVirtualKeyErrorHandling:
     async def test_rotate_success_dict_does_not_raise(self):
         """Test that a success response from async_rotate_secret does not raise."""
         from litellm.types.secret_managers.main import KeyManagementSystem, KeyManagementSettings
-        from litellm.secret_managers.base_secret_manager import BaseSecretManager
         import litellm
 
-        mock_secret_manager = MagicMock(spec=BaseSecretManager)
-        mock_secret_manager.async_rotate_secret = AsyncMock(
+        stub = _StubSecretManager()
+        stub.async_rotate_secret = AsyncMock(
             return_value={"request_id": "abc", "data": {}}
         )
 
-        litellm.secret_manager_client = mock_secret_manager
+        litellm.secret_manager_client = stub
         litellm._key_management_system = KeyManagementSystem.HASHICORP_VAULT
         litellm._key_management_settings = KeyManagementSettings(
             store_virtual_keys=True,
             prefix_for_stored_virtual_keys="litellm/",
         )
 
-        import builtins
-        original_isinstance = builtins.isinstance
-
-        def mock_isinstance(obj, cls):
-            if cls == BaseSecretManager and obj == mock_secret_manager:
-                return True
-            return original_isinstance(obj, cls)
-
         with patch.object(
             KeyManagementEventHooks,
             "_get_secret_manager_optional_params",
             return_value=None,
-        ), patch(
-            "litellm.proxy.hooks.key_management_event_hooks.isinstance",
-            side_effect=mock_isinstance,
         ):
             # Should not raise
             await KeyManagementEventHooks._rotate_virtual_key_in_secret_manager(


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Two bugs in HashiCorp Vault key rotation:

1. **Error return silently discarded**: `async_rotate_secret` returns `{"status": "error", ...}` on failure, but `_rotate_virtual_key_in_secret_manager` discarded the return value. The caller then unconditionally logged "Secret updated in secret manager" — misleading operators. Now the return value is checked and a `ValueError` is raised on error, which the existing `try/except` in `async_key_rotated_hook` handles correctly.

2. **Raw API keys in logs**: The mismatch error log at `hashicorp_secret_manager.py` interpolated full raw API key values (`Expected: sk-xxx, Got: sk-yyy`). Now masked to last 4 characters only (e.g., `...3lcA`). Also changed `verbose_logger.exception` to `verbose_logger.error` — `.exception` was generating a misleading traceback on a non-exception code path.

### Files changed
- `litellm/secret_managers/hashicorp_secret_manager.py` — mask key values in mismatch log, use `.error()` instead of `.exception()`
- `litellm/proxy/hooks/key_management_event_hooks.py` — capture return value of `async_rotate_secret`, raise `ValueError` on error dict
- `tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py` — added `TestRotateVirtualKeyErrorHandling` (2 tests)
- `tests/litellm_utils_tests/test_hashicorp.py` — updated mismatch test to assert masked values