### PR TITLE
fix(key_rotation): add distributed lock to prevent concurrent rotation across pods

### DIFF
--- a/litellm/proxy/common_utils/key_rotation_manager.py
+++ b/litellm/proxy/common_utils/key_rotation_manager.py
@@ -47,7 +47,10 @@ class KeyRotationManager:
         """
         Main entry point - find and rotate keys that are due for rotation
         """
-        # Acquire distributed lock to prevent concurrent rotation across pods
+        # Acquire distributed lock to prevent concurrent rotation across pods.
+        # Lock TTL is DEFAULT_CRON_JOB_LOCK_TTL_SECONDS (default 60s, configurable
+        # via env var). For large key sets, increase this to avoid lock expiry
+        # mid-rotation.
         lock_acquired = False
         try:
             if self.pod_lock_manager and self.pod_lock_manager.redis_cache:

--- a/litellm/proxy/common_utils/key_rotation_manager.py
+++ b/litellm/proxy/common_utils/key_rotation_manager.py
@@ -103,7 +103,11 @@ class KeyRotationManager:
         except Exception as e:
             verbose_proxy_logger.error(f"Key rotation process failed: {e}")
         finally:
-            if lock_acquired and self.pod_lock_manager and self.pod_lock_manager.redis_cache:
+            if (
+                lock_acquired
+                and self.pod_lock_manager
+                and self.pod_lock_manager.redis_cache
+            ):
                 await self.pod_lock_manager.release_lock(
                     cronjob_id=self.KEY_ROTATION_JOB_NAME,
                 )

--- a/litellm/proxy/common_utils/key_rotation_manager.py
+++ b/litellm/proxy/common_utils/key_rotation_manager.py
@@ -5,7 +5,10 @@ Handles finding keys that need rotation based on their individual schedules.
 """
 
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
 
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import (
@@ -30,14 +33,36 @@ class KeyRotationManager:
     Manages automated key rotation based on individual key rotation schedules.
     """
 
-    def __init__(self, prisma_client: PrismaClient):
+    KEY_ROTATION_JOB_NAME = "key_rotation_job"
+
+    def __init__(
+        self,
+        prisma_client: PrismaClient,
+        pod_lock_manager: Optional["PodLockManager"] = None,
+    ):
         self.prisma_client = prisma_client
+        self.pod_lock_manager = pod_lock_manager
 
     async def process_rotations(self):
         """
         Main entry point - find and rotate keys that are due for rotation
         """
+        # Acquire distributed lock to prevent concurrent rotation across pods
+        lock_acquired = False
         try:
+            if self.pod_lock_manager and self.pod_lock_manager.redis_cache:
+                lock_acquired = (
+                    await self.pod_lock_manager.acquire_lock(
+                        cronjob_id=self.KEY_ROTATION_JOB_NAME,
+                    )
+                    or False
+                )
+                if not lock_acquired:
+                    verbose_proxy_logger.debug(
+                        "Key rotation skipped — another pod holds the lock"
+                    )
+                    return
+
             verbose_proxy_logger.info("Starting scheduled key rotation check...")
 
             # Clean up expired deprecated keys first
@@ -74,6 +99,11 @@ class KeyRotationManager:
 
         except Exception as e:
             verbose_proxy_logger.error(f"Key rotation process failed: {e}")
+        finally:
+            if lock_acquired and self.pod_lock_manager and self.pod_lock_manager.redis_cache:
+                await self.pod_lock_manager.release_lock(
+                    cronjob_id=self.KEY_ROTATION_JOB_NAME,
+                )
 
     async def _find_keys_needing_rotation(self) -> List[LiteLLM_VerificationToken]:
         """

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1523,7 +1523,9 @@ master_key: Optional[str] = None
 config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
-key_rotation_pod_lock_manager: Optional[Any] = None  # PodLockManager for key rotation distributed lock
+key_rotation_pod_lock_manager: Optional[
+    Any
+] = None  # PodLockManager for key rotation distributed lock
 shared_aiohttp_session: Optional[
     "ClientSession"
 ] = None  # Global shared session for connection reuse
@@ -6237,9 +6239,15 @@ class ProxyStartupEvent:
                 # Get prisma_client from global scope
                 global prisma_client, key_rotation_pod_lock_manager
                 if prisma_client is not None:
-                    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+                    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import (
+                        PodLockManager,
+                    )
+
                     key_rotation_pod_lock_manager = PodLockManager(
-                        redis_cache=litellm.cache.cache if litellm.cache is not None and isinstance(litellm.cache.cache, RedisCache) else None
+                        redis_cache=litellm.cache.cache
+                        if litellm.cache is not None
+                        and isinstance(litellm.cache.cache, RedisCache)
+                        else None
                     )
                     key_rotation_manager = KeyRotationManager(
                         prisma_client,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6236,7 +6236,14 @@ class ProxyStartupEvent:
                 # Get prisma_client from global scope
                 global prisma_client
                 if prisma_client is not None:
-                    key_rotation_manager = KeyRotationManager(prisma_client)
+                    from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+                    key_rotation_pod_lock_manager = PodLockManager(
+                        redis_cache=litellm.cache.cache if litellm.cache is not None and isinstance(litellm.cache.cache, RedisCache) else None
+                    )
+                    key_rotation_manager = KeyRotationManager(
+                        prisma_client,
+                        pod_lock_manager=key_rotation_pod_lock_manager,
+                    )
                     verbose_proxy_logger.debug(
                         f"Key rotation background job scheduled every {LITELLM_KEY_ROTATION_CHECK_INTERVAL_SECONDS} seconds (LITELLM_KEY_ROTATION_ENABLED=true)"
                     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1523,6 +1523,7 @@ master_key: Optional[str] = None
 config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
+key_rotation_pod_lock_manager: Optional[Any] = None  # PodLockManager for key rotation distributed lock
 shared_aiohttp_session: Optional[
     "ClientSession"
 ] = None  # Global shared session for connection reuse
@@ -6234,7 +6235,7 @@ class ProxyStartupEvent:
                 )
 
                 # Get prisma_client from global scope
-                global prisma_client
+                global prisma_client, key_rotation_pod_lock_manager
                 if prisma_client is not None:
                     from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
                     key_rotation_pod_lock_manager = PodLockManager(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -445,6 +445,9 @@ class ProxyLogging:
             self.internal_usage_cache.dual_cache.redis_cache = redis_cache
             self.db_spend_update_writer.redis_update_buffer.redis_cache = redis_cache
             self.db_spend_update_writer.pod_lock_manager.redis_cache = redis_cache
+            from litellm.proxy.proxy_server import key_rotation_pod_lock_manager
+            if key_rotation_pod_lock_manager is not None:
+                key_rotation_pod_lock_manager.redis_cache = redis_cache
 
     def _add_proxy_hooks(self, llm_router: Optional[Router] = None):
         """

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -446,6 +446,7 @@ class ProxyLogging:
             self.db_spend_update_writer.redis_update_buffer.redis_cache = redis_cache
             self.db_spend_update_writer.pod_lock_manager.redis_cache = redis_cache
             from litellm.proxy.proxy_server import key_rotation_pod_lock_manager
+
             if key_rotation_pod_lock_manager is not None:
                 key_rotation_pod_lock_manager.redis_cache = redis_cache
 

--- a/tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py
+++ b/tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py
@@ -290,3 +290,101 @@ class TestKeyRotationManager:
             call_args = mock_regenerate.call_args
             regenerate_request = call_args[1]["data"]
             assert regenerate_request.grace_period == "48h"
+
+
+class TestKeyRotationManagerDistributedLock:
+    """Tests for distributed lock behavior in process_rotations."""
+
+    @pytest.mark.asyncio
+    async def test_process_rotations_acquires_lock(self):
+        """Test that process_rotations acquires distributed lock before processing."""
+        from unittest.mock import patch, MagicMock
+
+        mock_prisma_client = AsyncMock()
+        mock_prisma_client.db.litellm_verificationtoken.find_many.return_value = []
+        mock_prisma_client.db.litellm_deprecatedverificationtoken.delete_many.return_value = 0
+
+        mock_pod_lock_manager = MagicMock()
+        mock_pod_lock_manager.redis_cache = MagicMock()
+        mock_pod_lock_manager.acquire_lock = AsyncMock(return_value=True)
+        mock_pod_lock_manager.release_lock = AsyncMock()
+
+        manager = KeyRotationManager(mock_prisma_client, pod_lock_manager=mock_pod_lock_manager)
+        await manager.process_rotations()
+
+        mock_pod_lock_manager.acquire_lock.assert_called_once_with(
+            cronjob_id=KeyRotationManager.KEY_ROTATION_JOB_NAME,
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_rotations_skips_when_lock_held(self):
+        """Test that process_rotations skips when another pod holds the lock."""
+        from unittest.mock import MagicMock
+
+        mock_prisma_client = AsyncMock()
+        mock_pod_lock_manager = MagicMock()
+        mock_pod_lock_manager.redis_cache = MagicMock()
+        mock_pod_lock_manager.acquire_lock = AsyncMock(return_value=False)
+        mock_pod_lock_manager.release_lock = AsyncMock()
+
+        manager = KeyRotationManager(mock_prisma_client, pod_lock_manager=mock_pod_lock_manager)
+        await manager.process_rotations()
+
+        # Should not attempt any DB queries since lock was not acquired
+        mock_prisma_client.db.litellm_verificationtoken.find_many.assert_not_called()
+        mock_pod_lock_manager.release_lock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_rotations_releases_lock_on_success(self):
+        """Test that lock is released after successful rotation."""
+        from unittest.mock import MagicMock
+
+        mock_prisma_client = AsyncMock()
+        mock_prisma_client.db.litellm_verificationtoken.find_many.return_value = []
+        mock_prisma_client.db.litellm_deprecatedverificationtoken.delete_many.return_value = 0
+
+        mock_pod_lock_manager = MagicMock()
+        mock_pod_lock_manager.redis_cache = MagicMock()
+        mock_pod_lock_manager.acquire_lock = AsyncMock(return_value=True)
+        mock_pod_lock_manager.release_lock = AsyncMock()
+
+        manager = KeyRotationManager(mock_prisma_client, pod_lock_manager=mock_pod_lock_manager)
+        await manager.process_rotations()
+
+        mock_pod_lock_manager.release_lock.assert_called_once_with(
+            cronjob_id=KeyRotationManager.KEY_ROTATION_JOB_NAME,
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_rotations_releases_lock_on_failure(self):
+        """Test that lock is released even when rotation fails."""
+        from unittest.mock import MagicMock
+
+        mock_prisma_client = AsyncMock()
+        mock_prisma_client.db.litellm_deprecatedverificationtoken.delete_many.side_effect = Exception("DB error")
+
+        mock_pod_lock_manager = MagicMock()
+        mock_pod_lock_manager.redis_cache = MagicMock()
+        mock_pod_lock_manager.acquire_lock = AsyncMock(return_value=True)
+        mock_pod_lock_manager.release_lock = AsyncMock()
+
+        manager = KeyRotationManager(mock_prisma_client, pod_lock_manager=mock_pod_lock_manager)
+        await manager.process_rotations()
+
+        # Lock should still be released via finally block
+        mock_pod_lock_manager.release_lock.assert_called_once_with(
+            cronjob_id=KeyRotationManager.KEY_ROTATION_JOB_NAME,
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_rotations_works_without_lock_manager(self):
+        """Test that process_rotations works when pod_lock_manager is None (single instance)."""
+        mock_prisma_client = AsyncMock()
+        mock_prisma_client.db.litellm_verificationtoken.find_many.return_value = []
+        mock_prisma_client.db.litellm_deprecatedverificationtoken.delete_many.return_value = 0
+
+        manager = KeyRotationManager(mock_prisma_client, pod_lock_manager=None)
+        await manager.process_rotations()
+
+        # Should still execute normally without lock
+        mock_prisma_client.db.litellm_deprecatedverificationtoken.delete_many.assert_called_once()

--- a/tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py
+++ b/tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py
@@ -298,7 +298,7 @@ class TestKeyRotationManagerDistributedLock:
     @pytest.mark.asyncio
     async def test_process_rotations_acquires_lock(self):
         """Test that process_rotations acquires distributed lock before processing."""
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock
 
         mock_prisma_client = AsyncMock()
         mock_prisma_client.db.litellm_verificationtoken.find_many.return_value = []


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

In multi-instance deployments, every proxy instance runs `process_rotations` concurrently via APScheduler, querying the same keys and rotating them simultaneously. Two concurrent rotations write different values to the same Vault path, causing secret value mismatches.

This adds a `PodLockManager` distributed lock (Redis-based `SET NX EX`) to `KeyRotationManager.process_rotations`, following the same pattern already used by `spend_log_cleanup.py` and `db_spend_update_writer.py`. Only one pod processes rotations at a time. Without Redis, the lock is a no-op (single-instance deployments unaffected).

### Files changed
- `litellm/proxy/common_utils/key_rotation_manager.py` — added `PodLockManager` acquire/release in try/finally around `process_rotations`
- `litellm/proxy/proxy_server.py` — inject `PodLockManager` with `RedisCache` into `KeyRotationManager` at startup
- `tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py` — added `TestKeyRotationManagerDistributedLock` (5 tests: acquire, skip when held, release on success, release on failure, works without lock manager)