### PR TITLE
fix(ui): fix /ui/chat 404 — Dockerfile pre-restructure + heuristic false-positive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,19 @@ COPY . .
 # Convert Windows line endings to Unix and make executable
 RUN sed -i 's/\r$//' docker/build_admin_ui.sh && chmod +x docker/build_admin_ui.sh && ./docker/build_admin_ui.sh
 
+# Pre-restructure UI: move root-level {page}.html → {page}/index.html so
+# Starlette StaticFiles can serve extensionless routes (e.g. /ui/chat).
+# Must run before building the wheel since the out/ dir is included in the package.
+RUN cd litellm/proxy/_experimental/out && \
+    for html_file in *.html; do \
+      if [ "$html_file" != "index.html" ] && [ "$html_file" != "404.html" ] && [ -f "$html_file" ]; then \
+        folder_name="${html_file%.html}" && \
+        mkdir -p "$folder_name" && \
+        mv "$html_file" "$folder_name/index.html"; \
+      fi; \
+    done && \
+    touch .litellm_ui_ready
+
 # Build the package
 RUN rm -rf dist/* && python -m build
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1203,7 +1203,27 @@ try:
                 if entry.is_dir() and not entry.name.startswith("_"):
                     index_path = os.path.join(entry.path, "index.html")
                     if os.path.exists(index_path):
-                        # Found at least one restructured route - this proves the pattern
+                        # Found at least one restructured route.
+                        # Also verify no root-level .html files still need restructuring.
+                        # Next.js static export may generate both pre-restructured pages
+                        # (e.g. login/index.html) and new pages as root-level .html files
+                        # (e.g. chat.html), causing the heuristic to fire prematurely.
+                        try:
+                            orphaned = [
+                                e.name
+                                for e in os.scandir(ui_dir)
+                                if e.is_file()
+                                and e.name.endswith(".html")
+                                and e.name not in ("index.html", "404.html")
+                            ]
+                        except (PermissionError, OSError):
+                            orphaned = []
+                        if orphaned:
+                            verbose_proxy_logger.debug(
+                                f"Found un-restructured HTML files at root: {orphaned}. "
+                                f"Restructuring needed despite existing {entry.name}/index.html."
+                            )
+                            return False
                         verbose_proxy_logger.debug(
                             f"Detected restructured UI via pattern: found {entry.name}/index.html"
                         )


### PR DESCRIPTION
## Root Cause

The Chat UI added in #22937 (and routing fixed in #22945) returns **404** in the published Docker images (`main-stable`, `main-latest`).

### Why it breaks

1. **Next.js static export** generates `_experimental/out/chat.html` for the new `/chat` route, but generates `login/index.html`, `playground/index.html` etc. for older routes (mixed output structure).

2. **Starlette `StaticFiles(html=True)`** serves extensionless routes by looking for `{route}/index.html`. It does **not** try `{route}.html`, so `/ui/chat` → 404.

3. **`_restructure_ui_html_files()`** already exists to move `{page}.html → {page}/index.html` at runtime — but it is gated by `_is_ui_pre_restructured()`.

4. **`_is_ui_pre_restructured()` fires a false-positive**: it returns `True` as soon as it finds any `{dir}/index.html` (e.g. `login/index.html`), concluding the UI is fully restructured. This skips the restructure step and leaves `chat.html` in place.

5. **The main `Dockerfile`** (used for published images) never runs the pre-restructure step that `Dockerfile.non_root` does, so no `.litellm_ui_ready` marker is written either.

## Fixes

**`Dockerfile`** — add the same pre-restructure step as `Dockerfile.non_root`:
```dockerfile
RUN cd litellm/proxy/_experimental/out && \
    for html_file in *.html; do \
      if [ "$html_file" != "index.html" ] && [ "$html_file" != "404.html" ] && [ -f "$html_file" ]; then \
        folder_name="${html_file%.html}" && \
        mkdir -p "$folder_name" && \
        mv "$html_file" "$folder_name/index.html"; \
      fi; \
    done && \
    touch .litellm_ui_ready
```
This moves `chat.html → chat/index.html` at image build time and writes the marker, so the proxy skips the heuristic entirely.

**`proxy_server.py`** — tighten the `_is_ui_pre_restructured()` fallback heuristic: when a restructured route is found, also scan for orphaned root-level `.html` files; return `False` if any exist so that `_restructure_ui_html_files()` can run.

## Testing

```bash
# Before fix
curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/ui/chat
# → 404

# After fix
curl -s -o /dev/null -w "%{http_code}" http://localhost:4000/ui/chat
# → 200 (served from chat/index.html)
```

## Related

- #22937 — feat: add Chat UI
- #22945 — fix: /ui/chat routing + Suspense boundary