### PR TITLE
fix: use files_settings credentials in file and batch operation fallback paths

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -35,6 +35,9 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     resolve_output_file_ids_to_unified,
     update_batch_in_database,
 )
+from litellm.proxy.openai_files_endpoints.files_endpoints import (
+    get_files_provider_config,
+)
 from litellm.proxy.utils import handle_exception_on_proxy, is_known_model
 from litellm.types.llms.openai import LiteLLMBatchCreateRequest
 
@@ -277,7 +280,16 @@ async def create_batch(  # noqa: PLR0915
 
                 verbose_proxy_logger.debug(f"Created batch using model: {model_param}")
             else:
-                # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
+                # SCENARIO 3: Fallback to custom_llm_provider with files_settings credentials
+                # get configs for custom_llm_provider
+                llm_provider_config = get_files_provider_config(
+                    custom_llm_provider=custom_llm_provider
+                )
+                if llm_provider_config is not None:
+                    # add llm_provider_config to data
+                    _create_batch_data.update(llm_provider_config)
+                _create_batch_data.pop("custom_llm_provider", None)
+
                 response = await litellm.acreate_batch(
                     custom_llm_provider=custom_llm_provider, **_create_batch_data  # type: ignore
                 )
@@ -507,7 +519,7 @@ async def retrieve_batch(  # noqa: PLR0915
                 if model_id_from_batch:
                     response._hidden_params["model_id"] = model_id_from_batch
 
-        # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
+        # SCENARIO 3: Fallback to custom_llm_provider with files_settings credentials
         else:
             custom_llm_provider = (
                 provider
@@ -515,6 +527,15 @@ async def retrieve_batch(  # noqa: PLR0915
                 or get_custom_llm_provider_from_request_query(request=request)
                 or "openai"
             )
+            # get configs for custom_llm_provider
+            llm_provider_config = get_files_provider_config(
+                custom_llm_provider=custom_llm_provider
+            )
+            if llm_provider_config is not None:
+                # add llm_provider_config to data
+                data.update(llm_provider_config)
+            data.pop("custom_llm_provider", None)
+
             response = await litellm.aretrieve_batch(
                 custom_llm_provider=custom_llm_provider, **data  # type: ignore
             )
@@ -710,7 +731,7 @@ async def list_batches(
                 **data,
             )
 
-        # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
+        # SCENARIO 3: Fallback to custom_llm_provider with files_settings credentials
         else:
             custom_llm_provider = (
                 provider
@@ -718,6 +739,15 @@ async def list_batches(
                 or get_custom_llm_provider_from_request_query(request=request)
                 or "openai"
             )
+            # get configs for custom_llm_provider
+            llm_provider_config = get_files_provider_config(
+                custom_llm_provider=custom_llm_provider
+            )
+            if llm_provider_config is not None:
+                # add llm_provider_config to data
+                data.update(llm_provider_config)
+            data.pop("custom_llm_provider", None)
+
             response = await litellm.alist_batches(
                 custom_llm_provider=custom_llm_provider,  # type: ignore
                 after=after,
@@ -894,11 +924,20 @@ async def cancel_batch(
             if not response._hidden_params.get("model_id") and data.get("model"):
                 response._hidden_params["model_id"] = data["model"]
 
-        # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
+        # SCENARIO 3: Fallback to custom_llm_provider with files_settings credentials
         else:
             custom_llm_provider = (
                 provider or data.pop("custom_llm_provider", None) or "openai"
             )
+            # get configs for custom_llm_provider
+            llm_provider_config = get_files_provider_config(
+                custom_llm_provider=custom_llm_provider
+            )
+            if llm_provider_config is not None:
+                # add llm_provider_config to data
+                data.update(llm_provider_config)
+            data.pop("custom_llm_provider", None)
+
             # Extract batch_id from data to avoid "multiple values for keyword argument" error
             # data was cast from CancelBatchRequest which already contains batch_id
             data.pop("batch_id", None)

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -753,7 +753,16 @@ async def get_file_content(  # noqa: PLR0915
                     )
                 )
             else:
-                # Fallback to default behavior (uses env variables or provider-based routing)
+                # Fallback with files_settings credentials
+                # get configs for custom_llm_provider
+                llm_provider_config = get_files_provider_config(
+                    custom_llm_provider=custom_llm_provider
+                )
+                if llm_provider_config is not None:
+                    # add llm_provider_config to data
+                    data.update(llm_provider_config)
+                data.pop("custom_llm_provider", None)
+
                 response = await litellm.afile_content(
                     **{
                         "custom_llm_provider": custom_llm_provider,
@@ -954,6 +963,14 @@ async def get_file(
                 llm_router=llm_router,
             )
         else:
+            # get configs for custom_llm_provider
+            llm_provider_config = get_files_provider_config(
+                custom_llm_provider=custom_llm_provider
+            )
+            if llm_provider_config is not None:
+                # add llm_provider_config to data
+                data.update(llm_provider_config)
+            data.pop("custom_llm_provider", None)
             # Remove file_id from data to avoid "multiple values for keyword argument" error
             # data was initialized with {"file_id": file_id}
             data.pop("file_id", None)
@@ -1156,6 +1173,14 @@ async def delete_file(
                 **data_without_file_id,
             )
         else:
+            # get configs for custom_llm_provider
+            llm_provider_config = get_files_provider_config(
+                custom_llm_provider=custom_llm_provider
+            )
+            if llm_provider_config is not None:
+                # add llm_provider_config to data
+                data.update(llm_provider_config)
+            data.pop("custom_llm_provider", None)
             data.pop("file_id", None)
             response = await litellm.afile_delete(
                 custom_llm_provider=custom_llm_provider, file_id=file_id, **data  # type: ignore
@@ -1320,6 +1345,15 @@ async def list_files(
                 or await get_custom_llm_provider_from_request_body(request=request)
                 or "openai"
             )
+
+            # get configs for custom_llm_provider
+            llm_provider_config = get_files_provider_config(
+                custom_llm_provider=custom_llm_provider
+            )
+            if llm_provider_config is not None:
+                # add llm_provider_config to data
+                data.update(llm_provider_config)
+            data.pop("custom_llm_provider", None)
 
             response = await litellm.afile_list(
                 custom_llm_provider=custom_llm_provider, purpose=purpose, **data  # type: ignore


### PR DESCRIPTION
## Problem

File and batch operations were failing with "api_key client option must be set" error even when `files_settings` was properly configured in config.yaml. This occurred because the fallback code paths (when model-based routing wasn't used) weren't using the `get_files_provider_config()` function to fetch credentials from `files_settings`.

## Root Cause

Only the file upload endpoint called `get_files_provider_config()` to fetch credentials from `files_settings`. All other file and batch endpoints had fallback paths that passed no credentials to the underlying litellm functions, causing them to fail unless:
1. Users passed provider info via `extra_body`/`extra_query` on every call, OR
2. Environment variables (OPENAI_API_KEY, etc.) were set

## Files Fixed

**litellm/proxy/openai_files_endpoints/files_endpoints.py**
- File retrieval (GET /files/{file_id})
- File deletion (DELETE /files/{file_id})
- File listing (GET /files)
- File content download (GET /files/{file_id}/content)

**litellm/proxy/batches_endpoints/endpoints.py**
- Batch creation (POST /batches)
- Batch retrieval (GET /batches/{batch_id})
- Batch listing (GET /batches)
- Batch cancellation (POST /batches/{batch_id}/cancel)

## Solution

Added `get_files_provider_config()` calls in all fallback paths to properly fetch and inject credentials from `files_settings` configuration:

```python
llm_provider_config = get_files_provider_config(
    custom_llm_provider=custom_llm_provider
)
if llm_provider_config is not None:
    data.update(llm_provider_config)
data.pop("custom_llm_provider", None)
```

## Testing

Verified end-to-end with:
- File upload, retrieval, and deletion operations
- Complete batch lifecycle: file upload → batch creation → polling → output file download → cleanup
- All operations successful using only `files_settings` configuration without environment variables or per-call provider specification

## Impact

Users can now configure file and batch credentials once in `files_settings` and have them work across all operations, improving usability and reducing configuration burden.

## Related Issues

- Addresses similar symptoms as #14940 but fixes the root cause
- Complements PR #14997's `extra_query` approach by making `files_settings` work automatically without requiring per-call provider specification

## Type

🐛 Bug Fix