### PR TITLE
fix(test): mock get_auth_header instead of get_api_key in anthropic file content test

### DIFF
--- a/tests/test_litellm/llms/anthropic/test_anthropic_files_and_batches.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_files_and_batches.py
@@ -336,7 +336,7 @@ class TestAnthropicFilesHandler:
             "extra_body": None
         }
 
-        with patch.object(handler.anthropic_model_info, "get_api_key", return_value=None):
+        with patch.object(handler.anthropic_model_info, "get_auth_header", return_value=None):
             with pytest.raises(ValueError, match="Missing Anthropic API Key"):
                 await handler.afile_content(
                     file_content_request=file_content_request,


### PR DESCRIPTION
## Summary

Fixes a regression introduced by f415b72b which added `get_auth_header` to the handler. The test was mocking `get_api_key` but the handler now calls `get_auth_header` directly, causing the mock to be bypassed — resulting in a real HTTP request to Anthropic and a 400 instead of the expected `ValueError`.

## Root Cause

- Test added Dec 2025 mocking `get_api_key`
- Mar 18 2026: `f415b72b` changed handler to call `get_auth_header` instead
- Mock stopped working, real HTTP request made to `api.anthropic.com`, got 400

## Fix

Mock `get_auth_header` directly since that's what the handler calls to gate on missing credentials.