### PR TITLE
Update apply_guardrail to allow tool call deletion

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -407,7 +407,15 @@ curl -i  -X POST http://localhost:4000/v1/chat/completions \
 
 ## Handling Tool Calls
 
-By default, guardrails only process messages and responses that contain text. To also receive tool calls, set `guardrail_handles_tool_calls: true` in your guardrail config:
+When the LLM request or response contains tool calls, they are passed to `apply_guardrail` via `inputs["tool_calls"]` as a list of dicts for inspection and validation. You can:
+
+- **Inspect** tool calls and raise an exception to block the request — works by default
+- **Modify** a tool call by changing its fields (e.g. redact arguments) — requires `guardrail_handles_tool_calls: true`
+- **Delete** individual tool calls by setting `"guardrail_deleted": True` on the dict — requires `guardrail_handles_tool_calls: true`
+
+### Deleting Tool Calls
+
+To modify or delete tool calls, set `guardrail_handles_tool_calls: true` in your guardrail config. Without this, tool calls are passed for inspection only — any modifications returned by `apply_guardrail` are not written back.
 
 ```yaml
 guardrails:
@@ -417,22 +425,6 @@ guardrails:
       mode: post_call
       guardrail_handles_tool_calls: true
 ```
-
-Or in Python:
-
-```python
-class ToolFilterGuardrail(CustomGuardrail):
-    def __init__(self, **kwargs):
-        super().__init__(guardrail_handles_tool_calls=True, **kwargs)
-```
-
-When enabled, tool calls are passed to `apply_guardrail` via `inputs["tool_calls"]` as a list of dicts. You can:
-
-- **Modify** a tool call by changing its fields (e.g. redact arguments)
-- **Block** the entire request by raising an exception
-- **Delete** individual tool calls by setting `"guardrail_deleted": True` on the dict
-
-### Deleting Tool Calls
 
 To selectively remove tool calls that violate policy while keeping the rest, set `"guardrail_deleted": True` on the tool call dict:
 

--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -449,6 +449,32 @@ class ToolFilterGuardrail(CustomGuardrail):
   - For **input** messages: the `"tool_calls"` key is removed from the message dict.
   - For **output** responses: the tool calls are removed and the stop/finish reason is updated — OpenAI Chat changes `finish_reason` from `"tool_calls"` to `"stop"`, Anthropic changes `stop_reason` from `"tool_use"` to `"end_turn"`.
 
+### Adding Replacement Text
+
+When deleting tool calls, you can inject replacement text by appending to the `texts` list. This is useful for tool-call-only responses that have no existing text content:
+
+```python
+class ToolFilterGuardrail(CustomGuardrail):
+    async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+        tool_calls = inputs.get("tool_calls", [])
+        blocked = False
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                name = tc.get("function", {}).get("name", "")
+                if name in BLOCKED_TOOLS:
+                    tc["guardrail_deleted"] = True
+                    blocked = True
+
+        if blocked:
+            texts = list(inputs.get("texts", []))
+            texts.append("Some tool calls were blocked by policy.")
+            inputs["texts"] = texts
+
+        return inputs
+```
+
+Extra texts beyond the original count are appended as new content — existing text is not affected.
+
 ## ✨ Pass additional parameters to guardrail
 
 :::info

--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -407,7 +407,26 @@ curl -i  -X POST http://localhost:4000/v1/chat/completions \
 
 ## Handling Tool Calls
 
-When the LLM request or response contains tool calls, they are passed to `apply_guardrail` via `inputs["tool_calls"]` as a list of dicts. You can:
+By default, guardrails only process messages and responses that contain text. To also receive tool calls, set `guardrail_handles_tool_calls: true` in your guardrail config:
+
+```yaml
+guardrails:
+  - guardrail_name: my_tool_filter
+    litellm_params:
+      guardrail: custom_guardrail.ToolFilterGuardrail
+      mode: post_call
+      guardrail_handles_tool_calls: true
+```
+
+Or in Python:
+
+```python
+class ToolFilterGuardrail(CustomGuardrail):
+    def __init__(self, **kwargs):
+        super().__init__(guardrail_handles_tool_calls=True, **kwargs)
+```
+
+When enabled, tool calls are passed to `apply_guardrail` via `inputs["tool_calls"]` as a list of dicts. You can:
 
 - **Modify** a tool call by changing its fields (e.g. redact arguments)
 - **Block** the entire request by raising an exception

--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -447,7 +447,7 @@ class ToolFilterGuardrail(CustomGuardrail):
 - **Partial deletion**: Only the marked tool calls are removed; the rest remain in the request/response.
 - **Full deletion (all tool calls removed)**:
   - For **input** messages: the `"tool_calls"` key is removed from the message dict.
-  - For **output** responses: `tool_calls` is set to `None` and `finish_reason` is changed from `"tool_calls"` to `"stop"`.
+  - For **output** responses: the tool calls are removed and the stop/finish reason is updated — OpenAI Chat changes `finish_reason` from `"tool_calls"` to `"stop"`, Anthropic changes `stop_reason` from `"tool_use"` to `"end_turn"`.
 
 ## ✨ Pass additional parameters to guardrail
 

--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -405,6 +405,50 @@ curl -i  -X POST http://localhost:4000/v1/chat/completions \
 
 </details>
 
+## Handling Tool Calls
+
+When the LLM request or response contains tool calls, they are passed to `apply_guardrail` via `inputs["tool_calls"]` as a list of dicts. You can:
+
+- **Modify** a tool call by changing its fields (e.g. redact arguments)
+- **Block** the entire request by raising an exception
+- **Delete** individual tool calls by setting `"guardrail_deleted": True` on the dict
+
+### Deleting Tool Calls
+
+To selectively remove tool calls that violate policy while keeping the rest, set `"guardrail_deleted": True` on the tool call dict:
+
+```python
+from typing import Any, Literal, Optional
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+BLOCKED_TOOLS = {"run_shell_command", "delete_database"}
+
+class ToolFilterGuardrail(CustomGuardrail):
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                name = tc.get("function", {}).get("name", "")
+                if name in BLOCKED_TOOLS:
+                    tc["guardrail_deleted"] = True
+
+        return inputs
+```
+
+**Behavior when tool calls are deleted:**
+
+- **Partial deletion**: Only the marked tool calls are removed; the rest remain in the request/response.
+- **Full deletion (all tool calls removed)**:
+  - For **input** messages: the `"tool_calls"` key is removed from the message dict.
+  - For **output** responses: `tool_calls` is set to `None` and `finish_reason` is changed from `"tool_calls"` to `"stop"`.
+
 ## ✨ Pass additional parameters to guardrail
 
 :::info

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -14,6 +14,10 @@ from typing import (
 from litellm._logging import verbose_logger
 from litellm.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.llms.base_llm.guardrail_translation.base_translation import (
+    GUARDRAIL_DELETED_KEY as GUARDRAIL_DELETED_KEY,
+)
+
 from litellm.types.guardrails import (
     DynamicGuardrailParams,
     GuardrailEventHooks,

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -95,6 +95,7 @@ class CustomGuardrail(CustomLogger):
         end_session_after_n_fails: Optional[int] = None,
         on_violation: Optional[str] = None,
         realtime_violation_message: Optional[str] = None,
+        guardrail_handles_tool_calls: bool = False,
         **kwargs,
     ):
         """
@@ -110,6 +111,8 @@ class CustomGuardrail(CustomLogger):
             end_session_after_n_fails: For /v1/realtime sessions, end the session after this many violations
             on_violation: For /v1/realtime sessions, 'warn' or 'end_session'
             realtime_violation_message: Message the bot speaks aloud when a /v1/realtime guardrail fires
+            guardrail_handles_tool_calls: If True, this guardrail receives tool calls and processes
+                tool-call-only messages/responses. Required for guardrail_deleted support.
         """
         self.guardrail_name = guardrail_name
         self.supported_event_hooks = supported_event_hooks
@@ -123,6 +126,7 @@ class CustomGuardrail(CustomLogger):
         self.end_session_after_n_fails: Optional[int] = end_session_after_n_fails
         self.on_violation: Optional[str] = on_violation
         self.realtime_violation_message: Optional[str] = realtime_violation_message
+        self.guardrail_handles_tool_calls: bool = guardrail_handles_tool_calls
 
         if supported_event_hooks:
             ## validate event_hook is in supported_event_hooks

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -284,39 +284,17 @@ class AnthropicMessagesHandler(BaseTranslation):
         ] = []  # (content_idx, None) for each text
         tool_call_task_mappings: List[int] = []  # content_idx for each tool call
 
-        # Handle both dict and object responses
-        response_content: List[Any] = []
-        if isinstance(response, dict):
-            response_content = response.get("content", []) or []
-        elif hasattr(response, "content"):
-            content = getattr(response, "content", None)
-            response_content = content or []
-        else:
-            response_content = []
-
+        response_content = self._get_response_content(response) or []
         if not response_content:
             return response
 
         # Step 1: Extract all text content and tool calls from response
         for content_idx, content_block in enumerate(response_content):
-            # Handle both dict and Pydantic object content blocks
-            block_dict: Dict[str, Any] = {}
-            if isinstance(content_block, dict):
-                block_type = content_block.get("type")
-                block_dict = cast(Dict[str, Any], content_block)
-            elif hasattr(content_block, "type"):
-                block_type = getattr(content_block, "type", None)
-                # Convert Pydantic object to dict for processing
-                if hasattr(content_block, "model_dump"):
-                    block_dict = content_block.model_dump()
-                else:
-                    block_dict = {
-                        "type": block_type,
-                        "text": getattr(content_block, "text", None),
-                    }
-            else:
+            block_dict = self._content_block_to_dict(content_block)
+            if block_dict is None:
                 continue
 
+            block_type = block_dict.get("type")
             if block_type in ["text", "tool_use"]:
                 prev_tool_call_count = len(tool_calls_to_check)
                 self._extract_output_text_and_images(
@@ -331,8 +309,19 @@ class AnthropicMessagesHandler(BaseTranslation):
                 for _ in range(len(tool_calls_to_check) - prev_tool_call_count):
                     tool_call_task_mappings.append(content_idx)
 
+        # Gate tool calls behind the guardrail_handles_tool_calls flag
+        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
+        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
+        if tool_calls_to_check and not handles_tool_calls:
+            verbose_proxy_logger.debug(
+                "Anthropic Messages: Skipping %d tool call(s) — "
+                "guardrail_handles_tool_calls is False for '%s'",
+                len(tool_calls_to_check),
+                guardrail_to_apply.guardrail_name,
+            )
+
         # Step 2: Apply guardrail to all texts in batch
-        if texts_to_check or tool_calls_to_check:
+        if texts_to_check or effective_tool_calls:
             # Create a request_data dict with response info and user API key metadata
             request_data: dict = {"response": response}
 
@@ -346,8 +335,8 @@ class AnthropicMessagesHandler(BaseTranslation):
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if tool_calls_to_check:
-                inputs["tool_calls"] = tool_calls_to_check
+            if effective_tool_calls:
+                inputs["tool_calls"] = effective_tool_calls
             # Include model information from the response if available
             response_model = None
             if isinstance(response, dict):
@@ -379,11 +368,11 @@ class AnthropicMessagesHandler(BaseTranslation):
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
-            if tool_calls_to_check:
+            if effective_tool_calls:
                 resolved = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else tool_calls_to_check
+                    else effective_tool_calls
                 )
                 self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,
@@ -679,6 +668,31 @@ class AnthropicMessagesHandler(BaseTranslation):
                 tool_calls_to_check = []
             tool_calls_to_check.append(tool_call)
 
+    @staticmethod
+    def _content_block_to_dict(content_block: Any) -> Optional[Dict[str, Any]]:
+        """Convert a content block (dict or Pydantic object) to a dict, or None."""
+        if isinstance(content_block, dict):
+            return cast(Dict[str, Any], content_block)
+        elif hasattr(content_block, "type"):
+            if hasattr(content_block, "model_dump"):
+                return content_block.model_dump()
+            return {
+                "type": getattr(content_block, "type", None),
+                "text": getattr(content_block, "text", None),
+            }
+        return None
+
+    @staticmethod
+    def _get_response_content(
+        response: "AnthropicMessagesResponse",
+    ) -> Optional[List[Any]]:
+        """Extract the content list from a dict or Pydantic response, or None if unavailable."""
+        if isinstance(response, dict):
+            return response.get("content", []) or []
+        elif hasattr(response, "content"):
+            return getattr(response, "content", None) or []
+        return None
+
     async def _apply_guardrail_responses_to_output(
         self,
         response: "AnthropicMessagesResponse",
@@ -693,12 +707,8 @@ class AnthropicMessagesHandler(BaseTranslation):
         allows guardrails to inject replacement text into tool-call-only
         responses that originally had no text.
         """
-        # Get response content once
-        if isinstance(response, dict):
-            response_content: List[Any] = response.get("content", []) or []
-        elif hasattr(response, "content"):
-            response_content = getattr(response, "content", None) or []
-        else:
+        response_content = self._get_response_content(response)
+        if response_content is None:
             return
 
         # Apply mapped texts back to their original locations
@@ -728,6 +738,60 @@ class AnthropicMessagesHandler(BaseTranslation):
             for extra_text in responses[len(task_mappings) :]:
                 response_content.append({"type": "text", "text": extra_text})
 
+    @staticmethod
+    def _apply_tool_call_to_content_block(
+        content_block: Any,
+        guardrailed_tool_call: Any,
+    ) -> None:
+        """Update a single content block's input/name from a guardrailed tool call."""
+        func = None
+        if (
+            isinstance(guardrailed_tool_call, dict)
+            and "function" in guardrailed_tool_call
+        ):
+            func = guardrailed_tool_call["function"]
+        elif hasattr(guardrailed_tool_call, "function"):
+            func = getattr(guardrailed_tool_call, "function", None)
+
+        if func is None:
+            return
+
+        new_arguments = (
+            func.get("arguments")
+            if isinstance(func, dict)
+            else getattr(func, "arguments", None)
+        )
+        new_name = (
+            func.get("name") if isinstance(func, dict) else getattr(func, "name", None)
+        )
+
+        if isinstance(content_block, dict):
+            if new_arguments is not None:
+                try:
+                    content_block["input"] = (
+                        json.loads(new_arguments)
+                        if isinstance(new_arguments, str)
+                        else new_arguments
+                    )
+                except json.JSONDecodeError:
+                    content_block["input"] = new_arguments
+            if new_name is not None:
+                content_block["name"] = new_name
+        else:
+            if new_arguments is not None:
+                try:
+                    parsed = (
+                        json.loads(new_arguments)
+                        if isinstance(new_arguments, str)
+                        else new_arguments
+                    )
+                except json.JSONDecodeError:
+                    parsed = new_arguments
+                if hasattr(content_block, "input"):
+                    content_block.input = parsed
+            if new_name is not None and hasattr(content_block, "name"):
+                content_block.name = new_name
+
     def _apply_guardrail_responses_to_output_tool_calls(
         self,
         response: "AnthropicMessagesResponse",
@@ -741,16 +805,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         1. Modify pass: update tool_use content blocks with modified arguments/name
         2. Delete pass: remove content blocks marked with guardrail_deleted
         """
-        # Get response content
-        response_content: List[Any] = []
-        if isinstance(response, dict):
-            response_content = response.get("content", []) or []
-        elif hasattr(response, "content"):
-            content = getattr(response, "content", None)
-            response_content = content or []
-        else:
-            return
-
+        response_content = self._get_response_content(response)
         if not response_content:
             return
 
@@ -775,62 +830,10 @@ class AnthropicMessagesHandler(BaseTranslation):
                 indices_to_delete.append(content_idx)
                 continue
 
-            if content_idx >= len(response_content):
-                continue
-
-            content_block = response_content[content_idx]
-
-            # Extract arguments and name from guardrailed tool call
-            func = None
-            if (
-                isinstance(guardrailed_tool_call, dict)
-                and "function" in guardrailed_tool_call
-            ):
-                func = guardrailed_tool_call["function"]
-            elif hasattr(guardrailed_tool_call, "function"):
-                func = getattr(guardrailed_tool_call, "function", None)
-
-            if func is None:
-                continue
-
-            new_arguments = (
-                func.get("arguments")
-                if isinstance(func, dict)
-                else getattr(func, "arguments", None)
-            )
-            new_name = (
-                func.get("name")
-                if isinstance(func, dict)
-                else getattr(func, "name", None)
-            )
-
-            # Update the content block (dict or Pydantic object)
-            if isinstance(content_block, dict):
-                if new_arguments is not None:
-                    try:
-                        content_block["input"] = (
-                            json.loads(new_arguments)
-                            if isinstance(new_arguments, str)
-                            else new_arguments
-                        )
-                    except json.JSONDecodeError:
-                        content_block["input"] = new_arguments
-                if new_name is not None:
-                    content_block["name"] = new_name
-            else:
-                if new_arguments is not None:
-                    try:
-                        parsed = (
-                            json.loads(new_arguments)
-                            if isinstance(new_arguments, str)
-                            else new_arguments
-                        )
-                    except json.JSONDecodeError:
-                        parsed = new_arguments
-                    if hasattr(content_block, "input"):
-                        content_block.input = parsed
-                if new_name is not None and hasattr(content_block, "name"):
-                    content_block.name = new_name
+            if content_idx < len(response_content):
+                self._apply_tool_call_to_content_block(
+                    response_content[content_idx], guardrailed_tool_call
+                )
 
         # Pass 2: Delete marked content blocks
         if indices_to_delete:

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -231,7 +231,8 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         Override this method to customize how responses are applied.
         """
-        for task_idx, guardrail_response in enumerate(responses):
+        for task_idx in range(min(len(responses), len(task_mappings))):
+            guardrail_response = responses[task_idx]
             mapping = task_mappings[task_idx]
             msg_idx = cast(int, mapping[0])
             content_idx_optional = cast(Optional[int], mapping[1])

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -279,9 +279,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
-        task_mappings: List[
-            Tuple[int, Optional[int]]
-        ] = []  # (content_idx, None) for each text
+        task_mappings: List[Tuple[int, Optional[int]]] = []  # (content_idx, None) for each text
         tool_call_task_mappings: List[int] = []  # content_idx for each tool call
 
         # Handle both dict and object responses
@@ -715,7 +713,7 @@ class AnthropicMessagesHandler(BaseTranslation):
             # Verify it's a text block and update the text field
             if isinstance(content_block, dict):
                 if content_block.get("type") == "text":
-                    cast(Dict[str, Any], content_block)["text"] = guardrail_response
+                    content_block["text"] = guardrail_response
             elif (
                 hasattr(content_block, "type")
                 and getattr(content_block, "type", None) == "text"
@@ -725,7 +723,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         # Append extra texts as new content blocks
         if len(responses) > len(task_mappings):
-            for extra_text in responses[len(task_mappings) :]:
+            for extra_text in responses[len(task_mappings):]:
                 response_content.append({"type": "text", "text": extra_text})
 
     def _apply_guardrail_responses_to_output_tool_calls(

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -684,33 +684,31 @@ class AnthropicMessagesHandler(BaseTranslation):
         """
         Apply guardrail responses back to output response.
 
-        Override this method to customize how responses are applied.
+        Mapped texts replace existing content blocks. Extra texts beyond
+        task_mappings length are appended as new text content blocks — this
+        allows guardrails to inject replacement text into tool-call-only
+        responses that originally had no text.
         """
-        for task_idx, guardrail_response in enumerate(responses):
+        # Get response content once
+        if isinstance(response, dict):
+            response_content: List[Any] = response.get("content", []) or []
+        elif hasattr(response, "content"):
+            response_content = getattr(response, "content", None) or []
+        else:
+            return
+
+        # Apply mapped texts back to their original locations
+        for task_idx in range(min(len(responses), len(task_mappings))):
+            guardrail_response = responses[task_idx]
             mapping = task_mappings[task_idx]
             content_idx = cast(int, mapping[0])
 
-            # Handle both dict and object responses
-            response_content: List[Any] = []
-            if isinstance(response, dict):
-                response_content = response.get("content", []) or []
-            elif hasattr(response, "content"):
-                content = getattr(response, "content", None)
-                response_content = content or []
-            else:
-                continue
-
-            if not response_content:
-                continue
-
-            # Get the content block at the index
-            if content_idx >= len(response_content):
+            if not response_content or content_idx >= len(response_content):
                 continue
 
             content_block = response_content[content_idx]
 
             # Verify it's a text block and update the text field
-            # Handle both dict and Pydantic object content blocks
             if isinstance(content_block, dict):
                 if content_block.get("type") == "text":
                     cast(Dict[str, Any], content_block)["text"] = guardrail_response
@@ -718,9 +716,13 @@ class AnthropicMessagesHandler(BaseTranslation):
                 hasattr(content_block, "type")
                 and getattr(content_block, "type", None) == "text"
             ):
-                # Update Pydantic object's text attribute
                 if hasattr(content_block, "text"):
                     content_block.text = guardrail_response
+
+        # Append extra texts as new content blocks
+        if len(responses) > len(task_mappings):
+            for extra_text in responses[len(task_mappings) :]:
+                response_content.append({"type": "text", "text": extra_text})
 
     def _apply_guardrail_responses_to_output_tool_calls(
         self,

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -309,19 +309,8 @@ class AnthropicMessagesHandler(BaseTranslation):
                 for _ in range(len(tool_calls_to_check) - prev_tool_call_count):
                     tool_call_task_mappings.append(content_idx)
 
-        # Gate tool calls behind the guardrail_handles_tool_calls flag
-        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
-        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
-        if tool_calls_to_check and not handles_tool_calls:
-            verbose_proxy_logger.debug(
-                "Anthropic Messages: Skipping %d tool call(s) — "
-                "guardrail_handles_tool_calls is False for '%s'",
-                len(tool_calls_to_check),
-                guardrail_to_apply.guardrail_name,
-            )
-
         # Step 2: Apply guardrail to all texts in batch
-        if texts_to_check or effective_tool_calls:
+        if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
             request_data: dict = {"response": response}
 
@@ -335,8 +324,8 @@ class AnthropicMessagesHandler(BaseTranslation):
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if effective_tool_calls:
-                inputs["tool_calls"] = effective_tool_calls
+            if tool_calls_to_check:
+                inputs["tool_calls"] = tool_calls_to_check
             # Include model information from the response if available
             response_model = None
             if isinstance(response, dict):
@@ -368,11 +357,11 @@ class AnthropicMessagesHandler(BaseTranslation):
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
-            if effective_tool_calls:
+            if tool_calls_to_check and guardrail_to_apply.guardrail_handles_tool_calls:
                 resolved = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else effective_tool_calls
+                    else tool_calls_to_check
                 )
                 self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -16,11 +16,15 @@ import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.core_helpers import remove_items_at_indices
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     LiteLLMAnthropicMessagesAdapter,
 )
-from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
+from litellm.llms.base_llm.guardrail_translation.base_translation import (
+    GUARDRAIL_DELETED_KEY,
+    BaseTranslation,
+)
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
 )
@@ -275,8 +279,10 @@ class AnthropicMessagesHandler(BaseTranslation):
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
-        task_mappings: List[Tuple[int, Optional[int]]] = []
-        # Track (content_index, None) for each text
+        task_mappings: List[
+            Tuple[int, Optional[int]]
+        ] = []  # (content_idx, None) for each text
+        tool_call_task_mappings: List[int] = []  # content_idx for each tool call
 
         # Handle both dict and object responses
         response_content: List[Any] = []
@@ -312,6 +318,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 continue
 
             if block_type in ["text", "tool_use"]:
+                prev_tool_call_count = len(tool_calls_to_check)
                 self._extract_output_text_and_images(
                     content_block=block_dict,
                     content_idx=content_idx,
@@ -320,6 +327,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                     task_mappings=task_mappings,
                     tool_calls_to_check=tool_calls_to_check,
                 )
+                # Track content_idx for any newly added tool calls
+                for _ in range(len(tool_calls_to_check) - prev_tool_call_count):
+                    tool_call_task_mappings.append(content_idx)
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
@@ -362,6 +372,20 @@ class AnthropicMessagesHandler(BaseTranslation):
                 responses=guardrailed_texts,
                 task_mappings=task_mappings,
             )
+
+            # Step 4: Apply guardrailed tool calls back to response
+            guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
+            if tool_calls_to_check:
+                resolved = (
+                    guardrailed_tool_calls
+                    if guardrailed_tool_calls is not None
+                    else tool_calls_to_check
+                )
+                self._apply_guardrail_responses_to_output_tool_calls(
+                    response=response,
+                    tool_calls=resolved,
+                    task_mappings=tool_call_task_mappings,
+                )
 
         verbose_proxy_logger.debug(
             "Anthropic Messages: Processed output response: %s", response
@@ -411,7 +435,8 @@ class AnthropicMessagesHandler(BaseTranslation):
                 if tool_calls_list:
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
-                _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
+                _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
+                    # allow rejecting the response, if invalid
                     inputs=guardrail_inputs,
                     request_data={},
                     input_type="response",
@@ -441,7 +466,8 @@ class AnthropicMessagesHandler(BaseTranslation):
         2. Parsed dict objects (for backwards compatibility)
 
         SSE format example:
-            b'event: content_block_delta\\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" curious"}}\\n\\n'
+            b'event: content_block_delta\\ndata: {"type":"content_block_delta","index":0,"delta":{
+            "type":"text_delta","text":" curious"}}\\n\\n'
 
         Dict format example:
             {
@@ -526,7 +552,8 @@ class AnthropicMessagesHandler(BaseTranslation):
         2. Parsed dict objects (for backwards compatibility)
 
         SSE format example:
-            b'event: message_delta\\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},...}\\n\\n'
+            b'event: message_delta\\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use",
+            "stop_sequence":null},...}\\n\\n'
 
         Dict format example:
             {
@@ -694,3 +721,125 @@ class AnthropicMessagesHandler(BaseTranslation):
                 # Update Pydantic object's text attribute
                 if hasattr(content_block, "text"):
                     content_block.text = guardrail_response
+
+    def _apply_guardrail_responses_to_output_tool_calls(
+        self,
+        response: "AnthropicMessagesResponse",
+        tool_calls: List[Any],
+        task_mappings: List[int],
+    ) -> None:
+        """
+        Apply guardrailed tool calls back to output response content blocks.
+
+        Two-pass approach similar to the OpenAI Chat pattern:
+        1. Modify pass: update tool_use content blocks with modified arguments/name
+        2. Delete pass: remove content blocks marked with guardrail_deleted
+        """
+        # Get response content
+        response_content: List[Any] = []
+        if isinstance(response, dict):
+            response_content = response.get("content", []) or []
+        elif hasattr(response, "content"):
+            content = getattr(response, "content", None)
+            response_content = content or []
+        else:
+            return
+
+        if not response_content:
+            return
+
+        # Pass 1: Modify non-deleted tool calls
+        indices_to_delete: List[int] = []
+        for task_idx, content_idx in enumerate(task_mappings):
+            if task_idx >= len(tool_calls):
+                continue
+
+            guardrailed_tool_call = tool_calls[task_idx]
+
+            # Check for deletion flag
+            is_deleted = False
+            if isinstance(guardrailed_tool_call, dict):
+                is_deleted = guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True
+            elif hasattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY):
+                is_deleted = (
+                    getattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY) is True
+                )
+
+            if is_deleted:
+                indices_to_delete.append(content_idx)
+                continue
+
+            if content_idx >= len(response_content):
+                continue
+
+            content_block = response_content[content_idx]
+
+            # Extract arguments and name from guardrailed tool call
+            func = None
+            if (
+                isinstance(guardrailed_tool_call, dict)
+                and "function" in guardrailed_tool_call
+            ):
+                func = guardrailed_tool_call["function"]
+            elif hasattr(guardrailed_tool_call, "function"):
+                func = getattr(guardrailed_tool_call, "function", None)
+
+            if func is None:
+                continue
+
+            new_arguments = (
+                func.get("arguments")
+                if isinstance(func, dict)
+                else getattr(func, "arguments", None)
+            )
+            new_name = (
+                func.get("name")
+                if isinstance(func, dict)
+                else getattr(func, "name", None)
+            )
+
+            # Update the content block (dict or Pydantic object)
+            if isinstance(content_block, dict):
+                if new_arguments is not None:
+                    try:
+                        content_block["input"] = (
+                            json.loads(new_arguments)
+                            if isinstance(new_arguments, str)
+                            else new_arguments
+                        )
+                    except json.JSONDecodeError:
+                        content_block["input"] = new_arguments
+                if new_name is not None:
+                    content_block["name"] = new_name
+            else:
+                if new_arguments is not None:
+                    try:
+                        parsed = (
+                            json.loads(new_arguments)
+                            if isinstance(new_arguments, str)
+                            else new_arguments
+                        )
+                    except json.JSONDecodeError:
+                        parsed = new_arguments
+                    if hasattr(content_block, "input"):
+                        content_block.input = parsed
+                if new_name is not None and hasattr(content_block, "name"):
+                    content_block.name = new_name
+
+        # Pass 2: Delete marked content blocks
+        if indices_to_delete:
+            remove_items_at_indices(response_content, indices_to_delete)
+
+            # Update stop_reason if no tool_use blocks remain
+            has_tool_use = any(
+                (b.get("type") if isinstance(b, dict) else getattr(b, "type", None))
+                == "tool_use"
+                for b in response_content
+            )
+            if not has_tool_use:
+                if isinstance(response, dict):
+                    if response.get("stop_reason") == "tool_use":
+                        response["stop_reason"] = "end_turn"
+                elif hasattr(response, "stop_reason"):
+                    if getattr(response, "stop_reason", None) == "tool_use":
+                        response.stop_reason = "end_turn"

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -367,11 +367,12 @@ class AnthropicMessagesHandler(BaseTranslation):
             guardrailed_texts = guardrailed_inputs.get("texts", [])
 
             # Step 3: Map guardrail responses back to original response structure
-            await self._apply_guardrail_responses_to_output(
-                response=response,
-                responses=guardrailed_texts,
-                task_mappings=task_mappings,
-            )
+            if guardrailed_texts:
+                await self._apply_guardrail_responses_to_output(
+                    response=response,
+                    responses=guardrailed_texts,
+                    task_mappings=task_mappings,
+                )
 
             # Step 4: Apply guardrailed tool calls back to response
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -375,6 +375,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                 )
 
             # Step 4: Apply guardrailed tool calls back to response
+            # Use guardrailed results if returned, otherwise fall back to originals.
+            # Note: `is not None` (not `or`) so an empty list from the guardrail
+            # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
             if tool_calls_to_check:
                 resolved = (

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -830,6 +830,10 @@ class AnthropicMessagesHandler(BaseTranslation):
                 indices_to_delete.append(content_idx)
                 continue
 
+            # Strip internal metadata before field-level writeback
+            if isinstance(guardrailed_tool_call, dict):
+                guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
+
             if content_idx < len(response_content):
                 self._apply_tool_call_to_content_block(
                     response_content[content_idx], guardrailed_tool_call

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -279,7 +279,9 @@ class AnthropicMessagesHandler(BaseTranslation):
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
-        task_mappings: List[Tuple[int, Optional[int]]] = []  # (content_idx, None) for each text
+        task_mappings: List[
+            Tuple[int, Optional[int]]
+        ] = []  # (content_idx, None) for each text
         tool_call_task_mappings: List[int] = []  # content_idx for each tool call
 
         # Handle both dict and object responses
@@ -723,7 +725,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         # Append extra texts as new content blocks
         if len(responses) > len(task_mappings):
-            for extra_text in responses[len(task_mappings):]:
+            for extra_text in responses[len(task_mappings) :]:
                 response_content.append({"type": "text", "text": extra_text})
 
     def _apply_guardrail_responses_to_output_tool_calls(

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -6,6 +6,8 @@ if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.proxy._types import UserAPIKeyAuth
 
+GUARDRAIL_DELETED_KEY = "guardrail_deleted"
+
 
 class BaseTranslation(ABC):
     @staticmethod

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -772,9 +772,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     )
 
                 if is_deleted:
-                    deletions_by_choice.setdefault(choice_idx, []).append(
-                        tool_call_idx
-                    )
+                    deletions_by_choice.setdefault(choice_idx, []).append(tool_call_idx)
                     continue
 
                 # Strip internal metadata before field-level writeback

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -19,7 +19,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.core_helpers import remove_items_at_indices
-from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
+from litellm.llms.base_llm.guardrail_translation.base_translation import (
+    GUARDRAIL_DELETED_KEY,
+    BaseTranslation,
+)
 from litellm.main import stream_chunk_builder
 from litellm.types.llms.openai import ChatCompletionToolParam
 from litellm.types.utils import (
@@ -32,8 +35,6 @@ from litellm.types.utils import (
 
 if TYPE_CHECKING:
     from litellm.integrations.custom_guardrail import CustomGuardrail
-
-GUARDRAIL_DELETED_KEY = "guardrail_deleted"
 
 
 class OpenAIChatCompletionsHandler(BaseTranslation):
@@ -127,7 +128,11 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             if tool_calls_to_check:
-                resolved_tool_calls = guardrailed_tool_calls if guardrailed_tool_calls is not None else tool_calls_to_check
+                resolved_tool_calls = (
+                    guardrailed_tool_calls
+                    if guardrailed_tool_calls is not None
+                    else tool_calls_to_check
+                )
                 await self._apply_guardrail_responses_to_input_tool_calls(
                     messages=messages,
                     tool_calls=resolved_tool_calls,  # type: ignore
@@ -264,15 +269,14 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     message_tool_calls, list
                 ):
                     if tool_call_idx < len(message_tool_calls):
-                        # Replace the tool call with the guardrailed version
+                        # Strip internal metadata before writing back
+                        guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
 
         # Apply deletions in reverse index order to preserve indices
         for msg_idx, indices_to_delete in deletions_by_msg.items():
             message_tool_calls = messages[msg_idx].get("tool_calls", None)
-            if message_tool_calls is not None and isinstance(
-                message_tool_calls, list
-            ):
+            if message_tool_calls is not None and isinstance(message_tool_calls, list):
                 remove_items_at_indices(message_tool_calls, indices_to_delete)
 
                 if not message_tool_calls:
@@ -374,7 +378,11 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
             if tool_calls_to_check:
-                resolved_tool_calls = guardrailed_tool_calls if guardrailed_tool_calls is not None else tool_calls_to_check
+                resolved_tool_calls = (
+                    guardrailed_tool_calls
+                    if guardrailed_tool_calls is not None
+                    else tool_calls_to_check
+                )
                 await self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,
                     tool_calls=resolved_tool_calls,  # type: ignore
@@ -743,9 +751,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 guardrailed_tool_call = tool_calls[task_idx]
 
                 if guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True:
-                    deletions_by_choice.setdefault(choice_idx, []).append(
-                        tool_call_idx
-                    )
+                    deletions_by_choice.setdefault(choice_idx, []).append(tool_call_idx)
                     continue
 
                 choice = cast(Choices, response.choices[choice_idx])

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -82,24 +82,13 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 tool_call_task_mappings=tool_call_task_mappings,
             )
 
-        # Gate tool calls behind the guardrail_handles_tool_calls flag
-        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
-        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
-        if tool_calls_to_check and not handles_tool_calls:
-            verbose_proxy_logger.debug(
-                "OpenAI Chat: Skipping %d input tool call(s) — "
-                "guardrail_handles_tool_calls is False for '%s'",
-                len(tool_calls_to_check),
-                guardrail_to_apply.guardrail_name,
-            )
-
         # Step 2: Apply guardrail to all texts and tool calls in batch
-        if texts_to_check or effective_tool_calls:
+        if texts_to_check or tool_calls_to_check:
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if effective_tool_calls:
-                inputs["tool_calls"] = effective_tool_calls  # type: ignore
+            if tool_calls_to_check:
+                inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
                 inputs[
                     "structured_messages"
@@ -135,14 +124,14 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 )
 
             # Step 4: Apply guardrailed tool calls back to messages
-            # Use guardrailed results if returned, otherwise fall back to originals.
+            # Only apply modifications/deletions when guardrail_handles_tool_calls is True.
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
-            if effective_tool_calls:
+            if tool_calls_to_check and guardrail_to_apply.guardrail_handles_tool_calls:
                 resolved_tool_calls = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else effective_tool_calls
+                    else tool_calls_to_check
                 )
                 await self._apply_guardrail_responses_to_input_tool_calls(
                     messages=messages,
@@ -339,19 +328,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 tool_call_task_mappings=tool_call_task_mappings,
             )
 
-        # Gate tool calls behind the guardrail_handles_tool_calls flag
-        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
-        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
-        if tool_calls_to_check and not handles_tool_calls:
-            verbose_proxy_logger.debug(
-                "OpenAI Chat: Skipping %d output tool call(s) — "
-                "guardrail_handles_tool_calls is False for '%s'",
-                len(tool_calls_to_check),
-                guardrail_to_apply.guardrail_name,
-            )
-
         # Step 2: Apply guardrail to all texts and tool calls in batch
-        if texts_to_check or effective_tool_calls:
+        if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
             request_data: dict = {"response": response}
 
@@ -365,8 +343,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if effective_tool_calls:
-                inputs["tool_calls"] = effective_tool_calls  # type: ignore
+            if tool_calls_to_check:
+                inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             # Include model information from the response if available
             if hasattr(response, "model") and response.model:
                 inputs["model"] = response.model
@@ -389,15 +367,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 )
 
             # Step 4: Apply guardrailed tool calls back to response
-            # Use guardrailed results if returned, otherwise fall back to originals.
+            # Only apply modifications/deletions when guardrail_handles_tool_calls is True.
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
-            if effective_tool_calls:
+            if tool_calls_to_check and guardrail_to_apply.guardrail_handles_tool_calls:
                 resolved_tool_calls = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else effective_tool_calls
+                    else tool_calls_to_check
                 )
                 await self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -294,6 +294,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
                 if not message_tool_calls:
                     messages[msg_idx].pop("tool_calls", None)
+                    # Ensure message remains valid for the API
+                    if messages[msg_idx].get("content") is None:
+                        messages[msg_idx]["content"] = ""
 
     async def process_output_response(
         self,
@@ -732,10 +735,13 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Note: for n>1 responses, extras always target choices[0].
         if len(responses) > len(task_mappings) and response.choices:
             choice = response.choices[0]
-            for extra_text in responses[len(task_mappings) :]:
-                if choice.message.content is None:
-                    choice.message.content = extra_text
-                elif isinstance(choice.message.content, str):
+            extra_texts = responses[len(task_mappings) :]
+            if choice.message.content is None:
+                # Set the first extra as the content, then append the rest
+                choice.message.content = extra_texts[0]
+                extra_texts = extra_texts[1:]
+            for extra_text in extra_texts:
+                if isinstance(choice.message.content, str):
                     choice.message.content += "\n" + extra_text
                 elif isinstance(choice.message.content, list):
                     choice.message.content.append({"type": "text", "text": extra_text})

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -306,13 +306,6 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             - List content: choice.message.content = [{"type": "text", "text": "text here"}, ...]
         """
 
-        # Step 0: Check if response has any text content to process
-        if not self._has_text_content(response):
-            verbose_proxy_logger.warning(
-                "OpenAI Chat Completions: No text content in response, skipping guardrail"
-            )
-            return response
-
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[Dict[str, Any]] = []
@@ -365,7 +358,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             guardrailed_texts = guardrailed_inputs.get("texts", [])
 
             # Step 3: Map guardrail responses back to original response structure
-            if guardrailed_texts and texts_to_check:
+            if guardrailed_texts:
                 await self._apply_guardrail_responses_to_output_texts(
                     response=response,
                     responses=guardrailed_texts,
@@ -707,9 +700,14 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         """
         Apply guardrail text responses back to output response.
 
-        Override this method to customize how text responses are applied.
+        Mapped texts (indices within task_mappings) replace existing content.
+        Extra texts (beyond task_mappings length) are appended as new content
+        on the first choice — this allows guardrails to inject replacement text
+        into tool-call-only responses that originally had no text.
         """
-        for task_idx, guardrail_response in enumerate(responses):
+        # Apply mapped texts back to their original locations
+        for task_idx in range(min(len(responses), len(task_mappings))):
+            guardrail_response = responses[task_idx]
             mapping = task_mappings[task_idx]
             choice_idx = cast(int, mapping[0])
             content_idx_optional = cast(Optional[int], mapping[1])
@@ -728,6 +726,17 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
                 choice.message.content[content_idx_optional]["text"] = guardrail_response  # type: ignore
+
+        # Append extra texts as new content on the first choice
+        if len(responses) > len(task_mappings) and response.choices:
+            choice = cast(Choices, response.choices[0])
+            for extra_text in responses[len(task_mappings) :]:
+                if choice.message.content is None:
+                    choice.message.content = extra_text
+                elif isinstance(choice.message.content, str):
+                    choice.message.content += "\n" + extra_text
+                elif isinstance(choice.message.content, list):
+                    choice.message.content.append({"type": "text", "text": extra_text})
 
     async def _apply_guardrail_responses_to_output_tool_calls(
         self,

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -729,8 +729,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Append extra texts as new content on the first choice
         if len(responses) > len(task_mappings) and response.choices:
-            choice = cast(Choices, response.choices[0])
-            for extra_text in responses[len(task_mappings) :]:
+            choice = response.choices[0]
+            for extra_text in responses[len(task_mappings):]:
                 if choice.message.content is None:
                     choice.message.content = extra_text
                 elif isinstance(choice.message.content, str):
@@ -784,7 +784,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Apply deletions in reverse index order to preserve indices
         for choice_idx, indices_to_delete in deletions_by_choice.items():
-            choice = cast(Choices, response.choices[choice_idx])
+            choice = response.choices[choice_idx]
             choice_tool_calls = choice.message.tool_calls
             if choice_tool_calls is not None and isinstance(choice_tool_calls, list):
                 remove_items_at_indices(choice_tool_calls, indices_to_delete)

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -587,40 +587,28 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         self, response: Union["ModelResponse", "ModelResponseStream"]
     ) -> bool:
         """
-        Check if response has any text content or tool calls to process.
+        Check if response has any text content to process.
 
-        Override this method to customize text content detection.
+        Note: this is only used in the streaming path. Tool calls are NOT
+        checked here — they are gated by guardrail_handles_tool_calls in the
+        non-streaming process_output_response path instead.
         """
         from litellm.types.utils import ModelResponse, ModelResponseStream
 
         if isinstance(response, ModelResponse):
             for choice in response.choices:
                 if isinstance(choice, litellm.Choices):
-                    # Check for text content
                     if choice.message.content and isinstance(
                         choice.message.content, str
                     ):
                         return True
-                    # Check for tool calls
-                    if choice.message.tool_calls and isinstance(
-                        choice.message.tool_calls, list
-                    ):
-                        if len(choice.message.tool_calls) > 0:
-                            return True
         elif isinstance(response, ModelResponseStream):
             for streaming_choice in response.choices:
                 if isinstance(streaming_choice, litellm.StreamingChoices):
-                    # Check for text content
                     if streaming_choice.delta.content and isinstance(
                         streaming_choice.delta.content, str
                     ):
                         return True
-                    # Check for tool calls
-                    if streaming_choice.delta.tool_calls and isinstance(
-                        streaming_choice.delta.tool_calls, list
-                    ):
-                        if len(streaming_choice.delta.tool_calls) > 0:
-                            return True
         return False
 
     def _extract_output_text_images_and_tool_calls(
@@ -786,6 +774,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     deletions_by_choice.setdefault(choice_idx, []).append(tool_call_idx)
                     continue
 
+                # Strip internal metadata before field-level writeback
+                guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
+
                 choice = cast(Choices, response.choices[choice_idx])
                 choice_tool_calls = choice.message.tool_calls
 
@@ -793,9 +784,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     choice_tool_calls, list
                 ):
                     if tool_call_idx < len(choice_tool_calls):
-                        # Update the tool call with guardrailed version
                         existing_tool_call = choice_tool_calls[tool_call_idx]
-                        # Update object attributes (output responses always have typed objects)
                         if "function" in guardrailed_tool_call:
                             func_dict = guardrailed_tool_call["function"]
                             if "arguments" in func_dict:

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.core_helpers import remove_items_at_indices
 from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
 from litellm.main import stream_chunk_builder
 from litellm.types.llms.openai import ChatCompletionToolParam
@@ -31,6 +32,8 @@ from litellm.types.utils import (
 
 if TYPE_CHECKING:
     from litellm.integrations.custom_guardrail import CustomGuardrail
+
+GUARDRAIL_DELETED_KEY = "guardrail_deleted"
 
 
 class OpenAIChatCompletionsHandler(BaseTranslation):
@@ -106,7 +109,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             )
 
             guardrailed_texts = guardrailed_inputs.get("texts", [])
-            guardrailed_tool_calls = guardrailed_inputs.get("tool_calls", [])
+            guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
             guardrailed_tools = guardrailed_inputs.get("tools")
             if guardrailed_tools is not None:
                 data["tools"] = guardrailed_tools
@@ -120,12 +123,14 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 )
 
             # Step 4: Apply guardrailed tool calls back to messages
-            if guardrailed_tool_calls:
-                # Note: The guardrail may modify tool_calls_to_check in place
-                # or we may need to handle returned tool calls differently
+            # Use guardrailed results if returned, otherwise fall back to originals.
+            # Note: `is not None` (not `or`) so an empty list from the guardrail
+            # correctly signals "all tool calls deleted" rather than falling back.
+            if tool_calls_to_check:
+                resolved_tool_calls = guardrailed_tool_calls if guardrailed_tool_calls is not None else tool_calls_to_check
                 await self._apply_guardrail_responses_to_input_tool_calls(
                     messages=messages,
-                    tool_calls=guardrailed_tool_calls,  # type: ignore
+                    tool_calls=resolved_tool_calls,  # type: ignore
                     task_mappings=tool_call_task_mappings,
                 )
 
@@ -243,9 +248,17 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         Override this method to customize how tool call responses are applied.
         """
+        # Collect indices to delete, grouped by msg_idx
+        deletions_by_msg: Dict[int, List[int]] = {}
+
         for task_idx, (msg_idx, tool_call_idx) in enumerate(task_mappings):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
+
+                if guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True:
+                    deletions_by_msg.setdefault(msg_idx, []).append(tool_call_idx)
+                    continue
+
                 message_tool_calls = messages[msg_idx].get("tool_calls", None)
                 if message_tool_calls is not None and isinstance(
                     message_tool_calls, list
@@ -253,6 +266,17 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     if tool_call_idx < len(message_tool_calls):
                         # Replace the tool call with the guardrailed version
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
+
+        # Apply deletions in reverse index order to preserve indices
+        for msg_idx, indices_to_delete in deletions_by_msg.items():
+            message_tool_calls = messages[msg_idx].get("tool_calls", None)
+            if message_tool_calls is not None and isinstance(
+                message_tool_calls, list
+            ):
+                remove_items_at_indices(message_tool_calls, indices_to_delete)
+
+                if not message_tool_calls:
+                    messages[msg_idx].pop("tool_calls", None)
 
     async def process_output_response(
         self,
@@ -345,10 +369,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 )
 
             # Step 4: Apply guardrailed tool calls back to response
+            # Use guardrailed results if returned, otherwise fall back to originals.
+            # Note: `is not None` (not `or`) so an empty list from the guardrail
+            # correctly signals "all tool calls deleted" rather than falling back.
+            guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
             if tool_calls_to_check:
+                resolved_tool_calls = guardrailed_tool_calls if guardrailed_tool_calls is not None else tool_calls_to_check
                 await self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,
-                    tool_calls=tool_calls_to_check,
+                    tool_calls=resolved_tool_calls,  # type: ignore
                     task_mappings=tool_call_task_mappings,
                 )
 
@@ -706,9 +735,19 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         Override this method to customize how tool call responses are applied.
         """
+        # Collect indices to delete, grouped by choice_idx
+        deletions_by_choice: Dict[int, List[int]] = {}
+
         for task_idx, (choice_idx, tool_call_idx) in enumerate(task_mappings):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
+
+                if guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True:
+                    deletions_by_choice.setdefault(choice_idx, []).append(
+                        tool_call_idx
+                    )
+                    continue
+
                 choice = cast(Choices, response.choices[choice_idx])
                 choice_tool_calls = choice.message.tool_calls
 
@@ -727,6 +766,18 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                                 ]
                             if "name" in func_dict:
                                 existing_tool_call.function.name = func_dict["name"]
+
+        # Apply deletions in reverse index order to preserve indices
+        for choice_idx, indices_to_delete in deletions_by_choice.items():
+            choice = cast(Choices, response.choices[choice_idx])
+            choice_tool_calls = choice.message.tool_calls
+            if choice_tool_calls is not None and isinstance(choice_tool_calls, list):
+                remove_items_at_indices(choice_tool_calls, indices_to_delete)
+
+                if not choice_tool_calls:
+                    choice.message.tool_calls = None
+                    if choice.finish_reason == "tool_calls":
+                        choice.finish_reason = "stop"
 
     async def _apply_guardrail_responses_to_output_streaming(
         self,

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -730,7 +730,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Append extra texts as new content on the first choice
         if len(responses) > len(task_mappings) and response.choices:
             choice = response.choices[0]
-            for extra_text in responses[len(task_mappings):]:
+            for extra_text in responses[len(task_mappings) :]:
                 if choice.message.content is None:
                     choice.message.content = extra_text
                 elif isinstance(choice.message.content, str):

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -747,10 +747,10 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         """
         Apply guardrailed tool calls back to output response.
 
-        The guardrail may have modified the tool_calls list in place,
-        so we apply the modified tool calls back to the original response.
-
-        Override this method to customize how tool call responses are applied.
+        Two-pass approach:
+        1. Modify pass: update tool calls with modified arguments/name
+        2. Delete pass: remove tool calls marked with guardrail_deleted,
+           set tool_calls to None and finish_reason to "stop" if all removed
         """
         # Collect indices to delete, grouped by choice_idx
         deletions_by_choice: Dict[int, List[int]] = {}

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -261,17 +261,29 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
 
-                if guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True:
+                is_deleted = False
+                if isinstance(guardrailed_tool_call, dict):
+                    is_deleted = (
+                        guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True
+                    )
+                elif hasattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY):
+                    is_deleted = (
+                        getattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY) is True
+                    )
+
+                if is_deleted:
                     deletions_by_msg.setdefault(msg_idx, []).append(tool_call_idx)
                     continue
+
+                # Strip internal metadata before writing back
+                if isinstance(guardrailed_tool_call, dict):
+                    guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
 
                 message_tool_calls = messages[msg_idx].get("tool_calls", None)
                 if message_tool_calls is not None and isinstance(
                     message_tool_calls, list
                 ):
                     if tool_call_idx < len(message_tool_calls):
-                        # Strip internal metadata before writing back
-                        guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
 
         # Apply deletions in reverse index order to preserve indices
@@ -716,7 +728,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 # Replace specific text item in list content
                 choice.message.content[content_idx_optional]["text"] = guardrail_response  # type: ignore
 
-        # Append extra texts as new content on the first choice
+        # Append extra texts as new content on the first choice.
+        # Note: for n>1 responses, extras always target choices[0].
         if len(responses) > len(task_mappings) and response.choices:
             choice = response.choices[0]
             for extra_text in responses[len(task_mappings) :]:
@@ -748,12 +761,25 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
 
-                if guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True:
-                    deletions_by_choice.setdefault(choice_idx, []).append(tool_call_idx)
+                is_deleted = False
+                if isinstance(guardrailed_tool_call, dict):
+                    is_deleted = (
+                        guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True
+                    )
+                elif hasattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY):
+                    is_deleted = (
+                        getattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY) is True
+                    )
+
+                if is_deleted:
+                    deletions_by_choice.setdefault(choice_idx, []).append(
+                        tool_call_idx
+                    )
                     continue
 
                 # Strip internal metadata before field-level writeback
-                guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
+                if isinstance(guardrailed_tool_call, dict):
+                    guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
 
                 choice = cast(Choices, response.choices[choice_idx])
                 choice_tool_calls = choice.message.tool_calls

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -82,13 +82,24 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 tool_call_task_mappings=tool_call_task_mappings,
             )
 
+        # Gate tool calls behind the guardrail_handles_tool_calls flag
+        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
+        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
+        if tool_calls_to_check and not handles_tool_calls:
+            verbose_proxy_logger.debug(
+                "OpenAI Chat: Skipping %d input tool call(s) — "
+                "guardrail_handles_tool_calls is False for '%s'",
+                len(tool_calls_to_check),
+                guardrail_to_apply.guardrail_name,
+            )
+
         # Step 2: Apply guardrail to all texts and tool calls in batch
-        if texts_to_check or tool_calls_to_check:
+        if texts_to_check or effective_tool_calls:
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if tool_calls_to_check:
-                inputs["tool_calls"] = tool_calls_to_check  # type: ignore
+            if effective_tool_calls:
+                inputs["tool_calls"] = effective_tool_calls  # type: ignore
             if messages:
                 inputs[
                     "structured_messages"
@@ -127,11 +138,11 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # Use guardrailed results if returned, otherwise fall back to originals.
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
-            if tool_calls_to_check:
+            if effective_tool_calls:
                 resolved_tool_calls = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else tool_calls_to_check
+                    else effective_tool_calls
                 )
                 await self._apply_guardrail_responses_to_input_tool_calls(
                     messages=messages,
@@ -219,7 +230,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         Override this method to customize how text responses are applied.
         """
-        for task_idx, guardrail_response in enumerate(responses):
+        for task_idx in range(min(len(responses), len(task_mappings))):
+            guardrail_response = responses[task_idx]
             mapping = task_mappings[task_idx]
             msg_idx = cast(int, mapping[0])
             content_idx_optional = cast(Optional[int], mapping[1])
@@ -327,8 +339,19 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 tool_call_task_mappings=tool_call_task_mappings,
             )
 
+        # Gate tool calls behind the guardrail_handles_tool_calls flag
+        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
+        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
+        if tool_calls_to_check and not handles_tool_calls:
+            verbose_proxy_logger.debug(
+                "OpenAI Chat: Skipping %d output tool call(s) — "
+                "guardrail_handles_tool_calls is False for '%s'",
+                len(tool_calls_to_check),
+                guardrail_to_apply.guardrail_name,
+            )
+
         # Step 2: Apply guardrail to all texts and tool calls in batch
-        if texts_to_check or tool_calls_to_check:
+        if texts_to_check or effective_tool_calls:
             # Create a request_data dict with response info and user API key metadata
             request_data: dict = {"response": response}
 
@@ -342,8 +365,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if tool_calls_to_check:
-                inputs["tool_calls"] = tool_calls_to_check  # type: ignore
+            if effective_tool_calls:
+                inputs["tool_calls"] = effective_tool_calls  # type: ignore
             # Include model information from the response if available
             if hasattr(response, "model") and response.model:
                 inputs["model"] = response.model
@@ -370,11 +393,11 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
-            if tool_calls_to_check:
+            if effective_tool_calls:
                 resolved_tool_calls = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else tool_calls_to_check
+                    else effective_tool_calls
                 )
                 await self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -797,7 +797,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Append extra texts as new message output items
         if len(responses) > len(task_mappings):
             for i, extra_text in enumerate(responses[len(task_mappings) :]):
-                response_output.append(
+                response_output.append(  # type: ignore[arg-type]
                     GenericResponseOutputItem(
                         type="message",
                         id=f"guardrail_msg_{uuid.uuid4().hex[:12]}",

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -454,6 +454,9 @@ class OpenAIResponsesHandler(BaseTranslation):
                 )
 
             # Step 4: Apply guardrailed tool calls back to response
+            # Use guardrailed results if returned, otherwise fall back to originals.
+            # Note: `is not None` (not `or`) so an empty list from the guardrail
+            # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
             if tool_calls_to_check:
                 resolved = (

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -446,11 +446,12 @@ class OpenAIResponsesHandler(BaseTranslation):
             guardrailed_texts = guardrailed_inputs.get("texts", [])
 
             # Step 3: Map guardrail responses back to original response structure
-            await self._apply_guardrail_responses_to_output(
-                response=response,
-                responses=guardrailed_texts,
-                task_mappings=task_mappings,
-            )
+            if guardrailed_texts:
+                await self._apply_guardrail_responses_to_output(
+                    response=response,
+                    responses=guardrailed_texts,
+                    task_mappings=task_mappings,
+                )
 
             # Step 4: Apply guardrailed tool calls back to response
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -730,7 +730,10 @@ class OpenAIResponsesHandler(BaseTranslation):
         """
         Apply guardrail responses back to output response.
 
-        Override this method to customize how responses are applied.
+        Mapped texts replace existing content items. Extra texts beyond
+        task_mappings length are appended as new message output items — this
+        allows guardrails to inject replacement text into tool-call-only
+        responses that originally had no text.
         """
         # Handle both dict and Pydantic object responses
         if isinstance(response, dict):
@@ -740,7 +743,9 @@ class OpenAIResponsesHandler(BaseTranslation):
         else:
             return
 
-        for task_idx, guardrail_response in enumerate(responses):
+        # Apply mapped texts back to their original locations
+        for task_idx in range(min(len(responses), len(task_mappings))):
+            guardrail_response = responses[task_idx]
             mapping = task_mappings[task_idx]
             output_idx = cast(int, mapping[0])
             content_idx = cast(int, mapping[1])
@@ -782,6 +787,21 @@ class OpenAIResponsesHandler(BaseTranslation):
                         content[content_idx]["text"] = guardrail_response
                     elif hasattr(content[content_idx], "text"):
                         content[content_idx].text = guardrail_response
+
+        # Append extra texts as new message output items
+        if len(responses) > len(task_mappings):
+            for i, extra_text in enumerate(responses[len(task_mappings) :]):
+                response_output.append(
+                    {
+                        "type": "message",
+                        "id": f"guardrail_msg_{i}",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": extra_text},
+                        ],
+                    }
+                )
 
     def _apply_guardrail_responses_to_output_tool_calls(
         self,

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -797,15 +797,17 @@ class OpenAIResponsesHandler(BaseTranslation):
         if len(responses) > len(task_mappings):
             for i, extra_text in enumerate(responses[len(task_mappings) :]):
                 response_output.append(
-                    {
-                        "type": "message",
-                        "id": f"guardrail_msg_{i}",
-                        "status": "completed",
-                        "role": "assistant",
-                        "content": [
-                            {"type": "output_text", "text": extra_text},
+                    GenericResponseOutputItem(
+                        type="message",
+                        id=f"guardrail_msg_{i}",
+                        status="completed",
+                        role="assistant",
+                        content=[
+                            OutputText(
+                                type="output_text", text=extra_text, annotations=None
+                            ),
                         ],
-                    }
+                    )
                 )
 
     def _apply_guardrail_responses_to_output_tool_calls(

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -410,8 +410,19 @@ class OpenAIResponsesHandler(BaseTranslation):
             for _ in range(len(tool_calls_to_check) - prev_tool_call_count):
                 tool_call_task_mappings.append(output_idx)
 
+        # Gate tool calls behind the guardrail_handles_tool_calls flag
+        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
+        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
+        if tool_calls_to_check and not handles_tool_calls:
+            verbose_proxy_logger.debug(
+                "OpenAI Responses: Skipping %d tool call(s) — "
+                "guardrail_handles_tool_calls is False for '%s'",
+                len(tool_calls_to_check),
+                guardrail_to_apply.guardrail_name,
+            )
+
         # Step 2: Apply guardrail to all texts in batch
-        if texts_to_check or tool_calls_to_check:
+        if texts_to_check or effective_tool_calls:
             # Create a request_data dict with response info and user API key metadata
             request_data: dict = {"response": response}
 
@@ -425,8 +436,8 @@ class OpenAIResponsesHandler(BaseTranslation):
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if tool_calls_to_check:
-                inputs["tool_calls"] = tool_calls_to_check
+            if effective_tool_calls:
+                inputs["tool_calls"] = effective_tool_calls
             # Include model information from the response if available
             response_model = None
             if isinstance(response, dict):
@@ -458,11 +469,11 @@ class OpenAIResponsesHandler(BaseTranslation):
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
-            if tool_calls_to_check:
+            if effective_tool_calls:
                 resolved = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else tool_calls_to_check
+                    else effective_tool_calls
                 )
                 self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -28,6 +28,7 @@ Output: response.output is List[GenericResponseOutputItem] where each has:
     - text: str
 """
 
+import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
@@ -799,7 +800,7 @@ class OpenAIResponsesHandler(BaseTranslation):
                 response_output.append(
                     GenericResponseOutputItem(
                         type="message",
-                        id=f"guardrail_msg_{i}",
+                        id=f"guardrail_msg_{uuid.uuid4().hex[:12]}",
                         status="completed",
                         role="assistant",
                         content=[

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -253,8 +253,8 @@ class OpenAIResponsesHandler(BaseTranslation):
         j = 0
         for tool in original_tools:
             if isinstance(tool, dict) and tool.get("type") in (
-                    "web_search",
-                    "web_search_preview",
+                "web_search",
+                "web_search_preview",
             ):
                 result.append(tool)
             else:
@@ -375,7 +375,9 @@ class OpenAIResponsesHandler(BaseTranslation):
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
-        task_mappings: List[Tuple[int, int]] = []  # (output_idx, content_idx) for each text
+        task_mappings: List[
+            Tuple[int, int]
+        ] = []  # (output_idx, content_idx) for each text
         tool_call_task_mappings: List[int] = []  # output_idx for each tool call
 
         # Handle both dict and Pydantic object responses
@@ -489,10 +491,9 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         if final_chunk.get("type") == "response.output_item.done":
             # convert openai response to model response
-            model_response_stream = (
-                OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+            model_response_stream = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
                 final_chunk
-            ))
+            )
 
             tool_calls = model_response_stream.choices[0].delta.tool_calls
             if tool_calls:
@@ -642,11 +643,10 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Check if this is a tool call (OutputFunctionToolCall)
         if isinstance(output_item, OutputFunctionToolCall):
             if tool_calls_to_check is not None:
-                tool_call_dict = (
-                    LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+                tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                     tool_call_item=output_item,
                     index=output_idx,
-                ))
+                )
                 tool_calls_to_check.append(
                     cast(ChatCompletionToolCallChunk, tool_call_dict)
                 )
@@ -657,11 +657,10 @@ class OpenAIResponsesHandler(BaseTranslation):
             and getattr(output_item, "type") == "function_call"
         ):
             if tool_calls_to_check is not None:
-                tool_call_dict = (
-                    LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+                tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                     tool_call_item=output_item,
                     index=output_idx,
-                ))
+                )
                 tool_calls_to_check.append(
                     cast(ChatCompletionToolCallChunk, tool_call_dict)
                 )
@@ -674,11 +673,10 @@ class OpenAIResponsesHandler(BaseTranslation):
                 # Convert dict to ResponseFunctionToolCall for processing
                 try:
                     tool_call_obj = ResponseFunctionToolCall(**output_item)
-                    tool_call_dict = (
-                        LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+                    tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                         tool_call_item=tool_call_obj,
                         index=output_idx,
-                    ))
+                    )
                     tool_calls_to_check.append(
                         cast(ChatCompletionToolCallChunk, tool_call_dict)
                     )
@@ -797,7 +795,7 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Append extra texts as new message output items
         if len(responses) > len(task_mappings):
-            for i, extra_text in enumerate(responses[len(task_mappings):]):
+            for i, extra_text in enumerate(responses[len(task_mappings) :]):
                 response_output.append(
                     {
                         "type": "message",

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -34,11 +34,15 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.core_helpers import remove_items_at_indices
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,
     OpenAiResponsesToChatCompletionStreamIterator,
 )
-from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
+from litellm.llms.base_llm.guardrail_translation.base_translation import (
+    GUARDRAIL_DELETED_KEY,
+    BaseTranslation,
+)
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
@@ -371,8 +375,10 @@ class OpenAIResponsesHandler(BaseTranslation):
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
-        task_mappings: List[Tuple[int, int]] = []
-        # Track (output_item_index, content_index) for each text
+        task_mappings: List[
+            Tuple[int, int]
+        ] = []  # (output_idx, content_idx) for each text
+        tool_call_task_mappings: List[int] = []  # output_idx for each tool call
 
         # Handle both dict and Pydantic object responses
         if isinstance(response, dict):
@@ -391,6 +397,7 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Step 1: Extract all text content and tool calls from response output
         for output_idx, output_item in enumerate(response_output):
+            prev_tool_call_count = len(tool_calls_to_check)
             self._extract_output_text_and_images(
                 output_item=output_item,
                 output_idx=output_idx,
@@ -399,6 +406,9 @@ class OpenAIResponsesHandler(BaseTranslation):
                 task_mappings=task_mappings,
                 tool_calls_to_check=tool_calls_to_check,
             )
+            # Track output_idx for any newly added tool calls
+            for _ in range(len(tool_calls_to_check) - prev_tool_call_count):
+                tool_call_task_mappings.append(output_idx)
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
@@ -441,6 +451,20 @@ class OpenAIResponsesHandler(BaseTranslation):
                 responses=guardrailed_texts,
                 task_mappings=task_mappings,
             )
+
+            # Step 4: Apply guardrailed tool calls back to response
+            guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
+            if tool_calls_to_check:
+                resolved = (
+                    guardrailed_tool_calls
+                    if guardrailed_tool_calls is not None
+                    else tool_calls_to_check
+                )
+                self._apply_guardrail_responses_to_output_tool_calls(
+                    response=response,
+                    tool_calls=resolved,
+                    task_mappings=tool_call_task_mappings,
+                )
 
         verbose_proxy_logger.debug(
             "OpenAI Responses API: Processed output response: %s", response
@@ -758,3 +782,95 @@ class OpenAIResponsesHandler(BaseTranslation):
                         content[content_idx]["text"] = guardrail_response
                     elif hasattr(content[content_idx], "text"):
                         content[content_idx].text = guardrail_response
+
+    def _apply_guardrail_responses_to_output_tool_calls(
+        self,
+        response: "ResponsesAPIResponse",
+        tool_calls: List[Any],
+        task_mappings: List[int],
+    ) -> None:
+        """
+        Apply guardrailed tool calls back to output response items.
+
+        Two-pass approach similar to the OpenAI Chat pattern:
+        1. Modify pass: update function_call output items with modified arguments/name
+        2. Delete pass: remove output items marked with guardrail_deleted
+        """
+        # Get response output
+        if isinstance(response, dict):
+            response_output = response.get("output", [])
+        elif hasattr(response, "output"):
+            response_output = response.output or []
+        else:
+            return
+
+        if not response_output:
+            return
+
+        # Pass 1: Modify non-deleted tool calls
+        indices_to_delete: List[int] = []
+        for task_idx, output_idx in enumerate(task_mappings):
+            if task_idx >= len(tool_calls):
+                continue
+
+            guardrailed_tool_call = tool_calls[task_idx]
+
+            # Check for deletion flag
+            is_deleted = False
+            if isinstance(guardrailed_tool_call, dict):
+                is_deleted = guardrailed_tool_call.get(GUARDRAIL_DELETED_KEY) is True
+            elif hasattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY):
+                is_deleted = (
+                    getattr(guardrailed_tool_call, GUARDRAIL_DELETED_KEY) is True
+                )
+
+            if is_deleted:
+                indices_to_delete.append(output_idx)
+                continue
+
+            if output_idx >= len(response_output):
+                continue
+
+            output_item = response_output[output_idx]
+
+            # Extract arguments and name from guardrailed tool call
+            func = None
+            if (
+                isinstance(guardrailed_tool_call, dict)
+                and "function" in guardrailed_tool_call
+            ):
+                func = guardrailed_tool_call["function"]
+            elif hasattr(guardrailed_tool_call, "function"):
+                func = getattr(guardrailed_tool_call, "function", None)
+
+            if func is None:
+                continue
+
+            new_arguments = (
+                func.get("arguments")
+                if isinstance(func, dict)
+                else getattr(func, "arguments", None)
+            )
+            new_name = (
+                func.get("name")
+                if isinstance(func, dict)
+                else getattr(func, "name", None)
+            )
+
+            # Update the output item (Pydantic object or dict)
+            if isinstance(output_item, dict):
+                if new_arguments is not None:
+                    output_item["arguments"] = new_arguments
+                if new_name is not None:
+                    output_item["name"] = new_name
+            else:
+                if new_arguments is not None and hasattr(output_item, "arguments"):
+                    output_item.arguments = new_arguments
+                if new_name is not None and hasattr(output_item, "name"):
+                    output_item.name = new_name
+
+        # Pass 2: Delete marked output items
+        # Note: Unlike OpenAI Chat (finish_reason) and Anthropic (stop_reason),
+        # the Responses API status field does not change based on tool call presence.
+        if indices_to_delete:
+            remove_items_at_indices(response_output, indices_to_delete)

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -253,8 +253,8 @@ class OpenAIResponsesHandler(BaseTranslation):
         j = 0
         for tool in original_tools:
             if isinstance(tool, dict) and tool.get("type") in (
-                "web_search",
-                "web_search_preview",
+                    "web_search",
+                    "web_search_preview",
             ):
                 result.append(tool)
             else:
@@ -375,9 +375,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
         tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
-        task_mappings: List[
-            Tuple[int, int]
-        ] = []  # (output_idx, content_idx) for each text
+        task_mappings: List[Tuple[int, int]] = []  # (output_idx, content_idx) for each text
         tool_call_task_mappings: List[int] = []  # output_idx for each tool call
 
         # Handle both dict and Pydantic object responses
@@ -491,9 +489,10 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         if final_chunk.get("type") == "response.output_item.done":
             # convert openai response to model response
-            model_response_stream = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+            model_response_stream = (
+                OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
                 final_chunk
-            )
+            ))
 
             tool_calls = model_response_stream.choices[0].delta.tool_calls
             if tool_calls:
@@ -549,7 +548,8 @@ class OpenAIResponsesHandler(BaseTranslation):
                 verbose_proxy_logger.debug(
                     "Skipping output guardrail - model response has no choices"
                 )
-        # model_response_stream = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(final_chunk)
+        # model_response_stream =
+        # OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(final_chunk)
         # tool_calls = model_response_stream.choices[0].tool_calls
         # convert openai response to model response
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
@@ -642,10 +642,11 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Check if this is a tool call (OutputFunctionToolCall)
         if isinstance(output_item, OutputFunctionToolCall):
             if tool_calls_to_check is not None:
-                tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+                tool_call_dict = (
+                    LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                     tool_call_item=output_item,
                     index=output_idx,
-                )
+                ))
                 tool_calls_to_check.append(
                     cast(ChatCompletionToolCallChunk, tool_call_dict)
                 )
@@ -656,10 +657,11 @@ class OpenAIResponsesHandler(BaseTranslation):
             and getattr(output_item, "type") == "function_call"
         ):
             if tool_calls_to_check is not None:
-                tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+                tool_call_dict = (
+                    LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                     tool_call_item=output_item,
                     index=output_idx,
-                )
+                ))
                 tool_calls_to_check.append(
                     cast(ChatCompletionToolCallChunk, tool_call_dict)
                 )
@@ -672,10 +674,11 @@ class OpenAIResponsesHandler(BaseTranslation):
                 # Convert dict to ResponseFunctionToolCall for processing
                 try:
                     tool_call_obj = ResponseFunctionToolCall(**output_item)
-                    tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
+                    tool_call_dict = (
+                        LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                         tool_call_item=tool_call_obj,
                         index=output_idx,
-                    )
+                    ))
                     tool_calls_to_check.append(
                         cast(ChatCompletionToolCallChunk, tool_call_dict)
                     )
@@ -794,7 +797,7 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Append extra texts as new message output items
         if len(responses) > len(task_mappings):
-            for i, extra_text in enumerate(responses[len(task_mappings) :]):
+            for i, extra_text in enumerate(responses[len(task_mappings):]):
                 response_output.append(
                     {
                         "type": "message",

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -867,9 +867,12 @@ class OpenAIResponsesHandler(BaseTranslation):
             if output_idx >= len(response_output):
                 continue
 
+            # Strip internal metadata before field-level writeback
+            if isinstance(guardrailed_tool_call, dict):
+                guardrailed_tool_call.pop(GUARDRAIL_DELETED_KEY, None)
+
             output_item = response_output[output_idx]
 
-            # Extract arguments and name from guardrailed tool call
             func = None
             if (
                 isinstance(guardrailed_tool_call, dict)

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -796,9 +796,9 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Append extra texts as new message output items
         if len(responses) > len(task_mappings):
-            for i, extra_text in enumerate(responses[len(task_mappings) :]):
-                response_output.append(  # type: ignore[arg-type]
-                    GenericResponseOutputItem(
+            for extra_text in responses[len(task_mappings) :]:
+                response_output.append(
+                    GenericResponseOutputItem(  # type: ignore[arg-type]
                         type="message",
                         id=f"guardrail_msg_{uuid.uuid4().hex[:12]}",
                         status="completed",

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -410,19 +410,8 @@ class OpenAIResponsesHandler(BaseTranslation):
             for _ in range(len(tool_calls_to_check) - prev_tool_call_count):
                 tool_call_task_mappings.append(output_idx)
 
-        # Gate tool calls behind the guardrail_handles_tool_calls flag
-        handles_tool_calls = guardrail_to_apply.guardrail_handles_tool_calls
-        effective_tool_calls = tool_calls_to_check if handles_tool_calls else []
-        if tool_calls_to_check and not handles_tool_calls:
-            verbose_proxy_logger.debug(
-                "OpenAI Responses: Skipping %d tool call(s) — "
-                "guardrail_handles_tool_calls is False for '%s'",
-                len(tool_calls_to_check),
-                guardrail_to_apply.guardrail_name,
-            )
-
         # Step 2: Apply guardrail to all texts in batch
-        if texts_to_check or effective_tool_calls:
+        if texts_to_check or tool_calls_to_check:
             # Create a request_data dict with response info and user API key metadata
             request_data: dict = {"response": response}
 
@@ -436,8 +425,8 @@ class OpenAIResponsesHandler(BaseTranslation):
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
-            if effective_tool_calls:
-                inputs["tool_calls"] = effective_tool_calls
+            if tool_calls_to_check:
+                inputs["tool_calls"] = tool_calls_to_check
             # Include model information from the response if available
             response_model = None
             if isinstance(response, dict):
@@ -469,11 +458,11 @@ class OpenAIResponsesHandler(BaseTranslation):
             # Note: `is not None` (not `or`) so an empty list from the guardrail
             # correctly signals "all tool calls deleted" rather than falling back.
             guardrailed_tool_calls = guardrailed_inputs.get("tool_calls")
-            if effective_tool_calls:
+            if tool_calls_to_check and guardrail_to_apply.guardrail_handles_tool_calls:
                 resolved = (
                     guardrailed_tool_calls
                     if guardrailed_tool_calls is not None
-                    else effective_tool_calls
+                    else tool_calls_to_check
                 )
                 self._apply_guardrail_responses_to_output_tool_calls(
                     response=response,

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -606,10 +606,10 @@ class BaseLitellmParams(
     guardrail_handles_tool_calls: Optional[bool] = Field(
         default=False,
         description=(
-            "When True, this guardrail will receive tool calls in inputs and "
-            "responses that contain only tool calls (no text). When False "
-            "(default), tool-call-only messages/responses skip this guardrail. "
-            "Enable this to use guardrail_deleted or to inspect tool call arguments."
+            "When True, modifications and deletions to tool calls returned by "
+            "apply_guardrail are written back to the response. When False "
+            "(default), tool calls are still passed to apply_guardrail for "
+            "inspection/validation but returned changes are not applied."
         ),
     )
 

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -603,6 +603,16 @@ class BaseLitellmParams(
         description="When True, guardrails only receive the latest message for the relevant role (e.g., newest user input pre-call, newest assistant output post-call)",
     )
 
+    guardrail_handles_tool_calls: Optional[bool] = Field(
+        default=False,
+        description=(
+            "When True, this guardrail will receive tool calls in inputs and "
+            "responses that contain only tool calls (no text). When False "
+            "(default), tool-call-only messages/responses skip this guardrail. "
+            "Enable this to use guardrail_deleted or to inspect tool call arguments."
+        ),
+    )
+
     # Lakera specific params
     category_thresholds: Optional[LakeraCategoryThresholds] = Field(
         default=None,

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -298,7 +298,10 @@ class MockToolCallDeletionGuardrail(CustomGuardrail):
     """Mock guardrail that marks specific tool calls for deletion via guardrail_deleted flag."""
 
     def __init__(self, guardrail_name: str, indices_to_delete: Optional[List[int]] = None):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(
+            guardrail_name=guardrail_name,
+            guardrail_handles_tool_calls=True,
+        )
         self.indices_to_delete = indices_to_delete or []
 
     async def apply_guardrail(
@@ -500,7 +503,10 @@ class MockMixedModifyDeleteGuardrail(CustomGuardrail):
         names_to_delete: List[str],
         names_to_modify: Optional[List[str]] = None,
     ):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(
+            guardrail_name=guardrail_name,
+            guardrail_handles_tool_calls=True,
+        )
         self.names_to_delete = names_to_delete
         self.names_to_modify = names_to_modify or []
 
@@ -576,7 +582,10 @@ class MockDeletionWithReplacementGuardrail(CustomGuardrail):
     """Mock guardrail that deletes all tool calls and adds replacement text."""
 
     def __init__(self, guardrail_name: str, replacement_text: str):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(
+            guardrail_name=guardrail_name,
+            guardrail_handles_tool_calls=True,
+        )
         self.replacement_text = replacement_text
 
     async def apply_guardrail(

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -294,6 +294,154 @@ class TestAnthropicMessagesHandlerInputProcessing:
         assert "input_schema" in tools[1]
 
 
+class MockToolCallDeletionGuardrail(CustomGuardrail):
+    """Mock guardrail that marks specific tool calls for deletion via guardrail_deleted flag."""
+
+    def __init__(self, guardrail_name: str, indices_to_delete: Optional[List[int]] = None):
+        super().__init__(guardrail_name=guardrail_name)
+        self.indices_to_delete = indices_to_delete or []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for idx in self.indices_to_delete:
+            if idx < len(tool_calls):
+                if isinstance(tool_calls[idx], dict):
+                    tool_calls[idx]["guardrail_deleted"] = True
+        return inputs
+
+
+class TestAnthropicOutputToolCallDeletion:
+    """Test guardrail_deleted support for Anthropic output tool calls."""
+
+    @pytest.mark.asyncio
+    async def test_partial_tool_call_deletion(self):
+        """One tool_use block deleted, text and other tool_use remain."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockToolCallDeletionGuardrail(
+            guardrail_name="test", indices_to_delete=[0]
+        )
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {"type": "text", "text": "Let me help you."},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "dangerous_tool",
+                    "input": {"action": "delete"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_2",
+                    "name": "safe_tool",
+                    "input": {"query": "hello"},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # Text block should remain, first tool_use deleted, second remains
+        assert len(result["content"]) == 2
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "Let me help you."
+        assert result["content"][1]["type"] == "tool_use"
+        assert result["content"][1]["name"] == "safe_tool"
+        # stop_reason should stay tool_use since one tool_use remains
+        assert result["stop_reason"] == "tool_use"
+
+    @pytest.mark.asyncio
+    async def test_full_tool_call_deletion(self):
+        """All tool_use blocks deleted, stop_reason changes to end_turn."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockToolCallDeletionGuardrail(
+            guardrail_name="test", indices_to_delete=[0, 1]
+        )
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {"type": "text", "text": "I will run two tools."},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "tool_a",
+                    "input": {"x": 1},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_2",
+                    "name": "tool_b",
+                    "input": {"y": 2},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # Only text block should remain
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "I will run two tools."
+        # stop_reason should change since no tool_use blocks remain
+        assert result["stop_reason"] == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_no_deletion_regression(self):
+        """No deletion flag set — tool calls should pass through unchanged."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockPassThroughGuardrail(guardrail_name="test")
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {"type": "text", "text": "Running tool."},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "my_tool",
+                    "input": {"a": "b"},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        assert len(result["content"]) == 2
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "tool_use"
+        assert result["content"][1]["name"] == "my_tool"
+        assert result["stop_reason"] == "tool_use"
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -442,6 +442,105 @@ class TestAnthropicOutputToolCallDeletion:
         assert result["stop_reason"] == "tool_use"
 
 
+class MockDeletionWithReplacementGuardrail(CustomGuardrail):
+    """Mock guardrail that deletes all tool calls and adds replacement text."""
+
+    def __init__(self, guardrail_name: str, replacement_text: str):
+        super().__init__(guardrail_name=guardrail_name)
+        self.replacement_text = replacement_text
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                tc["guardrail_deleted"] = True
+
+        texts = list(inputs.get("texts", []))
+        texts.append(self.replacement_text)
+
+        result: GenericGuardrailAPIInputs = {"texts": texts}
+        if tool_calls:
+            result["tool_calls"] = tool_calls  # type: ignore
+        return result
+
+
+class TestAnthropicReplacementText:
+    """Test adding replacement text when deleting tool calls."""
+
+    @pytest.mark.asyncio
+    async def test_tool_only_response_deletion_with_replacement_text(self):
+        """Tool-call-only response: delete all and inject replacement text."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockDeletionWithReplacementGuardrail(
+            guardrail_name="test",
+            replacement_text="Tool call blocked by policy.",
+        )
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "dangerous_tool",
+                    "input": {"action": "delete"},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # Tool use deleted, replacement text injected
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "Tool call blocked by policy."
+        assert result["stop_reason"] == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_tool_only_response_no_deletion_no_replacement(self):
+        """Tool-call-only response with passthrough: no text added."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockPassThroughGuardrail(guardrail_name="test")
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "my_tool",
+                    "input": {"a": "b"},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "tool_use"
+        assert result["stop_reason"] == "tool_use"
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -441,6 +441,136 @@ class TestAnthropicOutputToolCallDeletion:
         assert result["content"][1]["name"] == "my_tool"
         assert result["stop_reason"] == "tool_use"
 
+    @pytest.mark.asyncio
+    async def test_non_contiguous_deletion(self):
+        """Delete indices 0 and 2, keep index 1."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockToolCallDeletionGuardrail(
+            guardrail_name="test", indices_to_delete=[0, 2]
+        )
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {"type": "text", "text": "Here are results."},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "tool_a",
+                    "input": {"x": 1},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_2",
+                    "name": "tool_b",
+                    "input": {"y": 2},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_3",
+                    "name": "tool_c",
+                    "input": {"z": 3},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # tool_a (index 0) and tool_c (index 2) deleted, text and tool_b remain
+        assert len(result["content"]) == 2
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "tool_use"
+        assert result["content"][1]["name"] == "tool_b"
+        assert result["stop_reason"] == "tool_use"
+
+
+class MockMixedModifyDeleteGuardrail(CustomGuardrail):
+    """Mock guardrail that deletes some tool calls by name and modifies others."""
+
+    def __init__(
+        self,
+        guardrail_name: str,
+        names_to_delete: List[str],
+        names_to_modify: Optional[List[str]] = None,
+    ):
+        super().__init__(guardrail_name=guardrail_name)
+        self.names_to_delete = names_to_delete
+        self.names_to_modify = names_to_modify or []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                name = tc.get("function", {}).get("name", "")
+                if name in self.names_to_delete:
+                    tc["guardrail_deleted"] = True
+                elif name in self.names_to_modify:
+                    tc["function"]["arguments"] = '{"modified": true}'
+        return inputs
+
+
+class TestAnthropicMixedModifyAndDelete:
+    """Test mixed modification and deletion of tool calls."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_modify_and_delete(self):
+        """One tool_use modified, another deleted."""
+        handler = AnthropicMessagesHandler()
+        guardrail = MockMixedModifyDeleteGuardrail(
+            guardrail_name="test",
+            names_to_delete=["dangerous_tool"],
+            names_to_modify=["safe_tool"],
+        )
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "stop_reason": "tool_use",
+            "content": [
+                {"type": "text", "text": "Running tools."},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "dangerous_tool",
+                    "input": {"action": "delete"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "tu_2",
+                    "name": "safe_tool",
+                    "input": {"query": "hello"},
+                },
+            ],
+        }
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # dangerous_tool deleted, safe_tool modified
+        assert len(result["content"]) == 2
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "tool_use"
+        assert result["content"][1]["name"] == "safe_tool"
+        assert result["content"][1]["input"] == {"modified": True}
+        assert result["stop_reason"] == "tool_use"
+
 
 class MockDeletionWithReplacementGuardrail(CustomGuardrail):
     """Mock guardrail that deletes all tool calls and adds replacement text."""

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -1463,25 +1463,25 @@ class TestGuardrailReplacementText:
 
 
 class TestGuardrailHandlesToolCallsFlag:
-    """Test that guardrail_handles_tool_calls=False (default) skips tool-call-only responses."""
+    """Test guardrail_handles_tool_calls flag controls apply-back, not inspection."""
 
     @pytest.mark.asyncio
-    async def test_default_flag_skips_tool_only_output(self):
-        """Default guardrail (flag=False) should not process tool-call-only responses."""
+    async def test_default_flag_passes_tool_calls_for_inspection(self):
+        """Default guardrail (flag=False) still receives tool calls for inspection."""
         handler = OpenAIChatCompletionsHandler()
 
-        class DefaultGuardrail(CustomGuardrail):
+        class InspectingGuardrail(CustomGuardrail):
             def __init__(self):
-                super().__init__(guardrail_name="default")
-                self.was_called = False
+                super().__init__(guardrail_name="inspector")
+                self.received_tool_calls = None
 
             async def apply_guardrail(
                 self, inputs, request_data, input_type, logging_obj=None
             ):
-                self.was_called = True
+                self.received_tool_calls = inputs.get("tool_calls")
                 return inputs
 
-        guardrail = DefaultGuardrail()
+        guardrail = InspectingGuardrail()
         assert guardrail.guardrail_handles_tool_calls is False
 
         response = ModelResponse(
@@ -1510,32 +1510,22 @@ class TestGuardrailHandlesToolCallsFlag:
 
         await handler.process_output_response(response, guardrail)
 
-        # Guardrail should NOT have been called
-        assert guardrail.was_called is False
-        # Response should be unchanged
+        # Guardrail SHOULD be called and receive tool calls for inspection
+        assert guardrail.received_tool_calls is not None
+        assert len(guardrail.received_tool_calls) == 1
+        # But apply-back should NOT happen — tool calls unchanged
         assert response.choices[0].message.tool_calls is not None
         assert len(response.choices[0].message.tool_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_flag_true_processes_tool_only_output(self):
-        """Guardrail with flag=True should process tool-call-only responses."""
+    async def test_flag_true_enables_apply_back(self):
+        """Guardrail with flag=True enables tool call deletion."""
         handler = OpenAIChatCompletionsHandler()
-
-        class OptInGuardrail(CustomGuardrail):
-            def __init__(self):
-                super().__init__(
-                    guardrail_name="opt-in",
-                    guardrail_handles_tool_calls=True,
-                )
-                self.was_called = False
-
-            async def apply_guardrail(
-                self, inputs, request_data, input_type, logging_obj=None
-            ):
-                self.was_called = True
-                return inputs
-
-        guardrail = OptInGuardrail()
+        guardrail = MockDeletionWithReplacementGuardrail(
+            guardrail_name="test",
+            replacement_text="Blocked.",
+        )
+        assert guardrail.guardrail_handles_tool_calls is True
 
         response = ModelResponse(
             id="chatcmpl-2",
@@ -1563,12 +1553,13 @@ class TestGuardrailHandlesToolCallsFlag:
 
         await handler.process_output_response(response, guardrail)
 
-        # Guardrail SHOULD have been called
-        assert guardrail.was_called is True
+        # Tool calls should be deleted and replacement text injected
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].message.content == "Blocked."
 
     @pytest.mark.asyncio
     async def test_default_flag_still_processes_text_responses(self):
-        """Default guardrail (flag=False) should still process responses with text."""
+        """Default guardrail (flag=False) still processes text responses normally."""
         handler = OpenAIChatCompletionsHandler()
 
         class DefaultGuardrail(CustomGuardrail):

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -35,7 +35,7 @@ class MockGuardrail(CustomGuardrail):
     """Mock guardrail for testing that transforms text and tool calls"""
 
     def __init__(self, guardrail_name: str = "test"):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(guardrail_name=guardrail_name, guardrail_handles_tool_calls=True)
         self.last_inputs = None
         self.last_request_data = None
         self.tool_calls_modified = False
@@ -890,7 +890,7 @@ class MockDeletingGuardrail(CustomGuardrail):
         names_to_modify: Optional[List[str]] = None,
         guardrail_name: str = "test-deleter",
     ):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(guardrail_name=guardrail_name, guardrail_handles_tool_calls=True)
         self.names_to_delete = names_to_delete
         self.names_to_modify = names_to_modify or []
 
@@ -1303,7 +1303,7 @@ class MockDeletionWithReplacementGuardrail(CustomGuardrail):
     """Mock guardrail that deletes all tool calls and adds replacement text."""
 
     def __init__(self, guardrail_name: str, replacement_text: str):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(guardrail_name=guardrail_name, guardrail_handles_tool_calls=True)
         self.replacement_text = replacement_text
 
     async def apply_guardrail(
@@ -1460,6 +1460,149 @@ class TestGuardrailReplacementText:
         # Tool calls deleted, text preserved with replacement appended
         assert response.choices[0].message.tool_calls is None
         assert response.choices[0].message.content == "Let me help.\nTool removed."
+
+
+class TestGuardrailHandlesToolCallsFlag:
+    """Test that guardrail_handles_tool_calls=False (default) skips tool-call-only responses."""
+
+    @pytest.mark.asyncio
+    async def test_default_flag_skips_tool_only_output(self):
+        """Default guardrail (flag=False) should not process tool-call-only responses."""
+        handler = OpenAIChatCompletionsHandler()
+
+        class DefaultGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(guardrail_name="default")
+                self.was_called = False
+
+            async def apply_guardrail(
+                self, inputs, request_data, input_type, logging_obj=None
+            ):
+                self.was_called = True
+                return inputs
+
+        guardrail = DefaultGuardrail()
+        assert guardrail.guardrail_handles_tool_calls is False
+
+        response = ModelResponse(
+            id="chatcmpl-1",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(name="my_tool", arguments="{}"),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        # Guardrail should NOT have been called
+        assert guardrail.was_called is False
+        # Response should be unchanged
+        assert response.choices[0].message.tool_calls is not None
+        assert len(response.choices[0].message.tool_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_flag_true_processes_tool_only_output(self):
+        """Guardrail with flag=True should process tool-call-only responses."""
+        handler = OpenAIChatCompletionsHandler()
+
+        class OptInGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(
+                    guardrail_name="opt-in",
+                    guardrail_handles_tool_calls=True,
+                )
+                self.was_called = False
+
+            async def apply_guardrail(
+                self, inputs, request_data, input_type, logging_obj=None
+            ):
+                self.was_called = True
+                return inputs
+
+        guardrail = OptInGuardrail()
+
+        response = ModelResponse(
+            id="chatcmpl-2",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(name="my_tool", arguments="{}"),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        # Guardrail SHOULD have been called
+        assert guardrail.was_called is True
+
+    @pytest.mark.asyncio
+    async def test_default_flag_still_processes_text_responses(self):
+        """Default guardrail (flag=False) should still process responses with text."""
+        handler = OpenAIChatCompletionsHandler()
+
+        class DefaultGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(guardrail_name="default")
+                self.was_called = False
+
+            async def apply_guardrail(
+                self, inputs, request_data, input_type, logging_obj=None
+            ):
+                self.was_called = True
+                return inputs
+
+        guardrail = DefaultGuardrail()
+
+        response = ModelResponse(
+            id="chatcmpl-3",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hello!", role="assistant"),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        # Text-only response should still be processed
+        assert guardrail.was_called is True
+
 
 if __name__ == "__main__":
     # Run the tests

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -1299,6 +1299,168 @@ class TestGuardrailDeletedEdgeCases:
         assert response.choices[0].finish_reason == "tool_calls"
 
 
+class MockDeletionWithReplacementGuardrail(CustomGuardrail):
+    """Mock guardrail that deletes all tool calls and adds replacement text."""
+
+    def __init__(self, guardrail_name: str, replacement_text: str):
+        super().__init__(guardrail_name=guardrail_name)
+        self.replacement_text = replacement_text
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                tc["guardrail_deleted"] = True
+
+        texts = list(inputs.get("texts", []))
+        texts.append(self.replacement_text)
+
+        result: GenericGuardrailAPIInputs = {"texts": texts}
+        if tool_calls:
+            result["tool_calls"] = tool_calls  # type: ignore
+        return result
+
+
+class TestGuardrailReplacementText:
+    """Test adding replacement text when deleting tool calls from tool-call-only responses."""
+
+    @pytest.mark.asyncio
+    async def test_tool_only_response_deletion_with_replacement_text(self):
+        """Tool-call-only response: delete all tool calls and inject replacement text."""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletionWithReplacementGuardrail(
+            guardrail_name="test",
+            replacement_text="Tool call blocked by policy.",
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-1",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="dangerous_tool",
+                                    arguments='{"action":"delete"}',
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        # Tool calls should be deleted
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].finish_reason == "stop"
+        # Replacement text should be injected
+        assert response.choices[0].message.content == "Tool call blocked by policy."
+
+    @pytest.mark.asyncio
+    async def test_tool_only_response_no_deletion_no_replacement(self):
+        """Tool-call-only response with passthrough guardrail: no text added."""
+        handler = OpenAIChatCompletionsHandler()
+
+        class PassThrough(CustomGuardrail):
+            async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+                return inputs
+
+        guardrail = PassThrough(guardrail_name="test")
+
+        response = ModelResponse(
+            id="chatcmpl-2",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="my_tool",
+                                    arguments="{}",
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        # Tool calls should remain, no text added
+        assert response.choices[0].message.tool_calls is not None
+        assert len(response.choices[0].message.tool_calls) == 1
+        assert response.choices[0].message.content is None
+
+    @pytest.mark.asyncio
+    async def test_mixed_text_and_tool_calls_with_replacement(self):
+        """Response with both text and tool calls: existing text preserved, extra appended."""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletionWithReplacementGuardrail(
+            guardrail_name="test",
+            replacement_text="Tool removed.",
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-3",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content="Let me help.",
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="bad_tool",
+                                    arguments="{}",
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        # Tool calls deleted, text preserved with replacement appended
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].message.content == "Let me help.\nTool removed."
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -881,6 +881,424 @@ class TestOpenAIChatCompletionsHandlerStreamingOutput:
         assert result == responses_so_far
 
 
+class MockDeletingGuardrail(CustomGuardrail):
+    """Mock guardrail that deletes tool calls based on function name"""
+
+    def __init__(
+        self,
+        names_to_delete: List[str],
+        names_to_modify: Optional[List[str]] = None,
+        guardrail_name: str = "test-deleter",
+    ):
+        super().__init__(guardrail_name=guardrail_name)
+        self.names_to_delete = names_to_delete
+        self.names_to_modify = names_to_modify or []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                name = tc.get("function", {}).get("name", "")
+                if name in self.names_to_delete:
+                    tc["guardrail_deleted"] = True
+                elif name in self.names_to_modify:
+                    tc["function"]["arguments"] = '{"modified": true}'
+
+        result: GenericGuardrailAPIInputs = {"texts": inputs.get("texts", [])}
+        if tool_calls:
+            result["tool_calls"] = tool_calls  # type: ignore
+        return result
+
+
+class TestGuardrailDeletedOutputToolCalls:
+    """Test guardrail_deleted support for output (response) tool calls"""
+
+    @pytest.mark.asyncio
+    async def test_partial_deletion_output(self):
+        """One of two tool calls is deleted; the other remains"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(names_to_delete=["dangerous_func"])
+
+        response = ModelResponse(
+            id="chatcmpl-1",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_safe",
+                                type="function",
+                                function=Function(
+                                    name="safe_func",
+                                    arguments='{"x": 1}',
+                                ),
+                            ),
+                            ChatCompletionMessageToolCall(
+                                id="call_bad",
+                                type="function",
+                                function=Function(
+                                    name="dangerous_func",
+                                    arguments='{"y": 2}',
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        assert len(response.choices[0].message.tool_calls) == 1
+        assert response.choices[0].message.tool_calls[0].function.name == "safe_func"
+        assert response.choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_full_deletion_output(self):
+        """All tool calls deleted → tool_calls=None, finish_reason='stop'"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(
+            names_to_delete=["func_a", "func_b"]
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-2",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_a",
+                                type="function",
+                                function=Function(
+                                    name="func_a",
+                                    arguments="{}",
+                                ),
+                            ),
+                            ChatCompletionMessageToolCall(
+                                id="call_b",
+                                type="function",
+                                function=Function(
+                                    name="func_b",
+                                    arguments="{}",
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_no_deletion_regression(self):
+        """No guardrail_deleted field → existing behavior unchanged"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(names_to_delete=[])  # deletes nothing
+
+        response = ModelResponse(
+            id="chatcmpl-3",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="get_weather",
+                                    arguments='{"loc": "NYC"}',
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        assert len(response.choices[0].message.tool_calls) == 1
+        assert response.choices[0].message.tool_calls[0].function.name == "get_weather"
+        assert response.choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_mixed_modify_and_delete_output(self):
+        """Some tool calls modified, some deleted"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(
+            names_to_delete=["bad_func"],
+            names_to_modify=["good_func"],
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-4",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_good",
+                                type="function",
+                                function=Function(
+                                    name="good_func",
+                                    arguments='{"original": true}',
+                                ),
+                            ),
+                            ChatCompletionMessageToolCall(
+                                id="call_bad",
+                                type="function",
+                                function=Function(
+                                    name="bad_func",
+                                    arguments='{"secret": "data"}',
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        assert len(response.choices[0].message.tool_calls) == 1
+        remaining = response.choices[0].message.tool_calls[0]
+        assert remaining.function.name == "good_func"
+        assert remaining.function.arguments == '{"modified": true}'
+        assert response.choices[0].finish_reason == "tool_calls"
+
+
+class TestGuardrailDeletedInputToolCalls:
+    """Test guardrail_deleted support for input (request) tool calls"""
+
+    @pytest.mark.asyncio
+    async def test_partial_deletion_input(self):
+        """One of two input tool calls is deleted"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(names_to_delete=["banned_tool"])
+
+        data = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_ok",
+                            "type": "function",
+                            "function": {
+                                "name": "allowed_tool",
+                                "arguments": '{"a": 1}',
+                            },
+                        },
+                        {
+                            "id": "call_ban",
+                            "type": "function",
+                            "function": {
+                                "name": "banned_tool",
+                                "arguments": '{"b": 2}',
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+        await handler.process_input_messages(data, guardrail)
+
+        tool_calls = data["messages"][0]["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "allowed_tool"
+
+    @pytest.mark.asyncio
+    async def test_full_deletion_input(self):
+        """All input tool calls deleted → tool_calls key removed from message"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(names_to_delete=["func_x"])
+
+        data = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_x",
+                            "type": "function",
+                            "function": {
+                                "name": "func_x",
+                                "arguments": "{}",
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+        await handler.process_input_messages(data, guardrail)
+
+        assert "tool_calls" not in data["messages"][0]
+
+
+class MockFalseDeleteGuardrail(CustomGuardrail):
+    """Mock guardrail that sets guardrail_deleted to False (should NOT delete)"""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                tc["guardrail_deleted"] = False
+        result: GenericGuardrailAPIInputs = {"texts": inputs.get("texts", [])}
+        if tool_calls:
+            result["tool_calls"] = tool_calls  # type: ignore
+        return result
+
+
+class TestGuardrailDeletedEdgeCases:
+    """Edge case tests for guardrail_deleted behavior"""
+
+    @pytest.mark.asyncio
+    async def test_guardrail_deleted_false_does_not_delete(self):
+        """guardrail_deleted: False should NOT delete tool calls"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockFalseDeleteGuardrail(guardrail_name="test-false")
+
+        response = ModelResponse(
+            id="chatcmpl-false",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="some_func",
+                                    arguments='{"a": 1}',
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        assert len(response.choices[0].message.tool_calls) == 1
+        assert response.choices[0].message.tool_calls[0].function.name == "some_func"
+        assert response.choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_non_contiguous_deletion_output(self):
+        """Delete indices 0 and 2, keep index 1"""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockDeletingGuardrail(
+            names_to_delete=["func_a", "func_c"]
+        )
+
+        response = ModelResponse(
+            id="chatcmpl-noncontig",
+            created=1,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_a",
+                                type="function",
+                                function=Function(
+                                    name="func_a",
+                                    arguments="{}",
+                                ),
+                            ),
+                            ChatCompletionMessageToolCall(
+                                id="call_b",
+                                type="function",
+                                function=Function(
+                                    name="func_b",
+                                    arguments="{}",
+                                ),
+                            ),
+                            ChatCompletionMessageToolCall(
+                                id="call_c",
+                                type="function",
+                                function=Function(
+                                    name="func_c",
+                                    arguments="{}",
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        await handler.process_output_response(response, guardrail)
+
+        assert len(response.choices[0].message.tool_calls) == 1
+        assert response.choices[0].message.tool_calls[0].function.name == "func_b"
+        assert response.choices[0].message.tool_calls[0].id == "call_b"
+        assert response.choices[0].finish_reason == "tool_calls"
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -833,6 +833,190 @@ class MockPassThroughGuardrail(CustomGuardrail):
         return inputs
 
 
+class MockToolCallDeletionGuardrail(CustomGuardrail):
+    """Mock guardrail that marks specific tool calls for deletion via guardrail_deleted flag."""
+
+    def __init__(self, guardrail_name: str, indices_to_delete: Optional[List[int]] = None):
+        super().__init__(guardrail_name=guardrail_name)
+        self.indices_to_delete = indices_to_delete or []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for idx in self.indices_to_delete:
+            if idx < len(tool_calls):
+                if isinstance(tool_calls[idx], dict):
+                    tool_calls[idx]["guardrail_deleted"] = True
+        return inputs
+
+
+class TestOpenAIResponsesOutputToolCallDeletion:
+    """Test guardrail_deleted support for OpenAI Responses output tool calls."""
+
+    @pytest.mark.asyncio
+    async def test_partial_tool_call_deletion(self):
+        """One function_call output item deleted, message output remains."""
+        handler = OpenAIResponsesHandler()
+        guardrail = MockToolCallDeletionGuardrail(
+            guardrail_name="test", indices_to_delete=[0]
+        )
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            model="gpt-4",
+            object="response",
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_123",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Let me help."},
+                    ],
+                },
+                ResponseFunctionToolCall(
+                    arguments='{"action":"delete"}',
+                    call_id="call_1",
+                    name="dangerous_tool",
+                    type="function_call",
+                    id="fc_1",
+                    status="completed",
+                ),
+                ResponseFunctionToolCall(
+                    arguments='{"query":"hello"}',
+                    call_id="call_2",
+                    name="safe_tool",
+                    type="function_call",
+                    id="fc_2",
+                    status="completed",
+                ),
+            ],
+        )
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # First tool call deleted, message and second tool call remain
+        assert len(result.output) == 2
+        # Message output
+        msg = result.output[0]
+        if isinstance(msg, dict):
+            assert msg["type"] == "message"
+        else:
+            assert msg.type == "message"
+        # Remaining tool call
+        remaining_tc = result.output[1]
+        assert remaining_tc.name == "safe_tool"
+
+    @pytest.mark.asyncio
+    async def test_full_tool_call_deletion(self):
+        """All function_call items deleted."""
+        handler = OpenAIResponsesHandler()
+        guardrail = MockToolCallDeletionGuardrail(
+            guardrail_name="test", indices_to_delete=[0, 1]
+        )
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            model="gpt-4",
+            object="response",
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_123",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Running tools."},
+                    ],
+                },
+                ResponseFunctionToolCall(
+                    arguments='{"x":1}',
+                    call_id="call_1",
+                    name="tool_a",
+                    type="function_call",
+                    id="fc_1",
+                    status="completed",
+                ),
+                ResponseFunctionToolCall(
+                    arguments='{"y":2}',
+                    call_id="call_2",
+                    name="tool_b",
+                    type="function_call",
+                    id="fc_2",
+                    status="completed",
+                ),
+            ],
+        )
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # Only message output should remain
+        assert len(result.output) == 1
+        msg = result.output[0]
+        if isinstance(msg, dict):
+            assert msg["type"] == "message"
+        else:
+            assert msg.type == "message"
+
+    @pytest.mark.asyncio
+    async def test_no_deletion_regression(self):
+        """No deletion flag set — tool calls pass through unchanged."""
+        handler = OpenAIResponsesHandler()
+        guardrail = MockPassThroughGuardrail(guardrail_name="test")
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            model="gpt-4",
+            object="response",
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_123",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Running tool."},
+                    ],
+                },
+                ResponseFunctionToolCall(
+                    arguments='{"a":"b"}',
+                    call_id="call_1",
+                    name="my_tool",
+                    type="function_call",
+                    id="fc_1",
+                    status="completed",
+                ),
+            ],
+        )
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        assert len(result.output) == 2
+        tc = result.output[1]
+        assert tc.name == "my_tool"
+
+
 class TestOpenAIResponsesHandlerStreamingOutputProcessing:
     """Test streaming output processing functionality"""
 

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -16,7 +16,6 @@ sys.path.insert(
     0, os.path.abspath("../../../../../..")
 )  # Adds the parent directory to the system path
 
-from fastapi import HTTPException
 from openai.types.responses import ResponseFunctionToolCall
 
 from litellm.integrations.custom_guardrail import CustomGuardrail
@@ -41,14 +40,12 @@ class MockGuardrail(CustomGuardrail):
     ) -> GenericGuardrailAPIInputs:
         """
         For requests: Append [GUARDRAILED] to text
-        For responses: Block by raising HTTPException (masking responses is no longer supported)
+        For responses: Block by raising ValueError
         """
         texts = inputs.get("texts", [])
         if input_type == "response":
-            # Responses should be blocked, not masked
-            raise HTTPException(
-                status_code=400,
-                detail={"error": "Response blocked by guardrail", "texts": texts},
+            raise ValueError(
+                f"Response blocked by guardrail: {texts}"
             )
         # For requests, we can still mask/transform
         inputs["texts"] = [f"{text} [GUARDRAILED]" for text in texts]
@@ -217,11 +214,8 @@ class TestOpenAIResponsesHandlerOutputProcessing:
         )
 
         # Response should be blocked, not masked
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(ValueError, match="Response blocked by guardrail"):
             await handler.process_output_response(response, guardrail)
-
-        assert exc_info.value.status_code == 400
-        assert "Response blocked by guardrail" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_process_output_response_multiple_items(self):
@@ -263,11 +257,8 @@ class TestOpenAIResponsesHandlerOutputProcessing:
         )
 
         # Response should be blocked, not masked
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(ValueError, match="Response blocked by guardrail"):
             await handler.process_output_response(response, guardrail)
-
-        assert exc_info.value.status_code == 400
-        assert "Response blocked by guardrail" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_process_output_response_multiple_content_items(self):
@@ -301,11 +292,8 @@ class TestOpenAIResponsesHandlerOutputProcessing:
         )
 
         # Response should be blocked, not masked
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(ValueError, match="Response blocked by guardrail"):
             await handler.process_output_response(response, guardrail)
-
-        assert exc_info.value.status_code == 400
-        assert "Response blocked by guardrail" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_process_output_response_with_dict_format(self):
@@ -338,11 +326,8 @@ class TestOpenAIResponsesHandlerOutputProcessing:
         )
 
         # Response should be blocked, not masked
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(ValueError, match="Response blocked by guardrail"):
             await handler.process_output_response(response, guardrail)
-
-        assert exc_info.value.status_code == 400
-        assert "Response blocked by guardrail" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_process_output_response_no_text_content(self):

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -1017,6 +1017,111 @@ class TestOpenAIResponsesOutputToolCallDeletion:
         assert tc.name == "my_tool"
 
 
+class MockDeletionWithReplacementGuardrail(CustomGuardrail):
+    """Mock guardrail that deletes all tool calls and adds replacement text."""
+
+    def __init__(self, guardrail_name: str, replacement_text: str):
+        super().__init__(guardrail_name=guardrail_name)
+        self.replacement_text = replacement_text
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        tool_calls = inputs.get("tool_calls", [])
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                tc["guardrail_deleted"] = True
+
+        texts = list(inputs.get("texts", []))
+        texts.append(self.replacement_text)
+
+        result: GenericGuardrailAPIInputs = {"texts": texts}
+        if tool_calls:
+            result["tool_calls"] = tool_calls  # type: ignore
+        return result
+
+
+class TestOpenAIResponsesReplacementText:
+    """Test adding replacement text when deleting tool calls."""
+
+    @pytest.mark.asyncio
+    async def test_tool_only_response_deletion_with_replacement_text(self):
+        """Tool-call-only response: delete all and inject replacement text."""
+        handler = OpenAIResponsesHandler()
+        guardrail = MockDeletionWithReplacementGuardrail(
+            guardrail_name="test",
+            replacement_text="Tool call blocked by policy.",
+        )
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            model="gpt-4",
+            object="response",
+            status="completed",
+            output=[
+                ResponseFunctionToolCall(
+                    arguments='{"action":"delete"}',
+                    call_id="call_1",
+                    name="dangerous_tool",
+                    type="function_call",
+                    id="fc_1",
+                    status="completed",
+                ),
+            ],
+        )
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        # Tool call deleted, replacement message output injected
+        assert len(result.output) == 1
+        msg = result.output[0]
+        if isinstance(msg, dict):
+            assert msg["type"] == "message"
+            assert msg["content"][0]["text"] == "Tool call blocked by policy."
+        else:
+            assert msg.type == "message"
+
+    @pytest.mark.asyncio
+    async def test_tool_only_response_no_deletion_no_replacement(self):
+        """Tool-call-only response with passthrough: no text added."""
+        handler = OpenAIResponsesHandler()
+        guardrail = MockPassThroughGuardrail(guardrail_name="test")
+
+        response = ResponsesAPIResponse(
+            id="resp_123",
+            created_at=1234567890,
+            model="gpt-4",
+            object="response",
+            status="completed",
+            output=[
+                ResponseFunctionToolCall(
+                    arguments='{"a":"b"}',
+                    call_id="call_1",
+                    name="my_tool",
+                    type="function_call",
+                    id="fc_1",
+                    status="completed",
+                ),
+            ],
+        )
+
+        result = await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+        )
+
+        assert len(result.output) == 1
+        assert result.output[0].name == "my_tool"
+
+
 class TestOpenAIResponsesHandlerStreamingOutputProcessing:
     """Test streaming output processing functionality"""
 

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -627,14 +627,13 @@ class TestOpenAIResponsesHandlerToolCallExtraction:
         )
 
     @pytest.mark.asyncio
-    async def test_process_output_response_with_tool_calls(self):
-        """Test processing output response containing function tool calls"""
+    async def test_process_output_response_with_tool_calls_skipped_by_default(self):
+        """Tool-call-only response skipped when guardrail_handles_tool_calls is False (default)"""
         handler = OpenAIResponsesHandler()
         guardrail = MockGuardrail(guardrail_name="test")
 
-        # Create a full response matching user's provided structure
         response = ResponsesAPIResponse(
-            id="resp_zlasw86v56zobnneYprKIagz33tpQeh7arqL9mrI1oec47HNQLGz0VL0PpM9z67EADHExs7UjtyGqpoBKcM9oR6icMGx826UsXnlvu3ZvIyrVA1CaMgeaMo9H5DdQMhvmXtriqXpikuyYbIsko97x8GvtBIoSCcovM9s5KCwJ4eWSjfr51d6-GwLIMkCNbQI6AN11uYyIKrIfCt_9j7FZdBnRHhZ0_zE7E1LYWQPm9G9_nPmTyh9FXNLUZ9Uib1SejrCetPargnpQeBibaXqPoj_pXFKvgc-_-znG5IWEsM8WH9Pjbm6uWEwpUiCxt8yfjQGEADqaluLAts1mnzQVEhCtZbU67QG3ebSG-rXtBw511f2pJPzZ8kI4hPISmZL8Co3LmIrdpmzzb02sQRoH3v4HCwzVGXgtRwRYkdpffebYElQWzvYDhqIHFHKNavfF8mC5AVPvPRA5h1Pf3utTf26",
+            id="resp_123",
             created_at=1764901066,
             model="gpt-4.1-mini-2025-04-14",
             object="response",
@@ -651,12 +650,11 @@ class TestOpenAIResponsesHandlerToolCallExtraction:
             ],
         )
 
-        # Response should be blocked since MockGuardrail blocks responses
-        with pytest.raises(HTTPException) as exc_info:
-            await handler.process_output_response(response, guardrail)
-
-        assert exc_info.value.status_code == 400
-        assert "Response blocked by guardrail" in str(exc_info.value.detail)
+        # Default guardrail does not handle tool calls, so tool-call-only
+        # response should pass through unchanged
+        result = await handler.process_output_response(response, guardrail)
+        assert len(result.output) == 1
+        assert result.output[0].name == "get_current_weather"
 
     def test_extract_mixed_content_with_text_and_tool_calls(self):
         """Test extracting both text and tool calls from response"""
@@ -837,7 +835,10 @@ class MockToolCallDeletionGuardrail(CustomGuardrail):
     """Mock guardrail that marks specific tool calls for deletion via guardrail_deleted flag."""
 
     def __init__(self, guardrail_name: str, indices_to_delete: Optional[List[int]] = None):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(
+            guardrail_name=guardrail_name,
+            guardrail_handles_tool_calls=True,
+        )
         self.indices_to_delete = indices_to_delete or []
 
     async def apply_guardrail(
@@ -1021,7 +1022,10 @@ class MockDeletionWithReplacementGuardrail(CustomGuardrail):
     """Mock guardrail that deletes all tool calls and adds replacement text."""
 
     def __init__(self, guardrail_name: str, replacement_text: str):
-        super().__init__(guardrail_name=guardrail_name)
+        super().__init__(
+            guardrail_name=guardrail_name,
+            guardrail_handles_tool_calls=True,
+        )
         self.replacement_text = replacement_text
 
     async def apply_guardrail(

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -612,8 +612,8 @@ class TestOpenAIResponsesHandlerToolCallExtraction:
         )
 
     @pytest.mark.asyncio
-    async def test_process_output_response_with_tool_calls_skipped_by_default(self):
-        """Tool-call-only response skipped when guardrail_handles_tool_calls is False (default)"""
+    async def test_process_output_response_with_tool_calls(self):
+        """Tool-call-only response reaches guardrail for inspection"""
         handler = OpenAIResponsesHandler()
         guardrail = MockGuardrail(guardrail_name="test")
 
@@ -635,11 +635,9 @@ class TestOpenAIResponsesHandlerToolCallExtraction:
             ],
         )
 
-        # Default guardrail does not handle tool calls, so tool-call-only
-        # response should pass through unchanged
-        result = await handler.process_output_response(response, guardrail)
-        assert len(result.output) == 1
-        assert result.output[0].name == "get_current_weather"
+        # MockGuardrail blocks responses — tool-call-only response should reach it
+        with pytest.raises(ValueError, match="Response blocked by guardrail"):
+            await handler.process_output_response(response, guardrail)
 
     def test_extract_mixed_content_with_text_and_tool_calls(self):
         """Test extracting both text and tool calls from response"""


### PR DESCRIPTION
Adds guardrail_deleted support so custom guardrails can selectively delete individual tool calls from LLM responses across three API formats (OpenAI Chat Completions, Anthropic Messages, OpenAI Responses). Also enables guardrails to run on tool-call-only responses and inject replacement text, as these are both useful for tool-deletion use cases

Changes

- guardrail_deleted flag: Guardrails set tc["guardrail_deleted"] = True on individual tool call dicts to remove them. Defined as GUARDRAIL_DELETED_KEY in base_translation.py, implemented with a two-pass modify/delete approach in all three output handlers.
- Tool-call-only responses now reach guardrails — removed the _has_text_content early return in OpenAI Chat that skipped responses with no text.
- Replacement text injection — guardrails can append extra entries to the texts list to inject text into responses that originally had none. Each handler creates text blocks in its native format.
- Empty-text guard — text writeback skipped when guardrail returns empty texts (prevents spurious empty text blocks on passthrough guardrails).
- Docs: new "Handling Tool Calls" and "Adding Replacement Text" sections with examples.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type


🆕 New Feature

## Changes
