### PR TITLE
fix(prometheus): default to status_code=500 for exceptions without status code

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -974,9 +974,11 @@ class PrometheusLogger(CustomLogger):
             ),
             client_ip=standard_logging_payload["metadata"].get("requester_ip_address"),
             user_agent=standard_logging_payload["metadata"].get("user_agent"),
-            stream=str(standard_logging_payload.get("stream"))
-            if litellm.prometheus_emit_stream_label
-            else None,
+            stream=(
+                str(standard_logging_payload.get("stream"))
+                if litellm.prometheus_emit_stream_label
+                else None
+            ),
         )
 
         if (
@@ -1490,8 +1492,7 @@ class PrometheusLogger(CustomLogger):
         # If an exception was provided (directly or via kwargs) but no status code
         # could be extracted, default to 500 — an unclassified server error is still a 5xx.
         if status_code is None and (
-            exception is not None
-            or (kwargs and kwargs.get("exception") is not None)
+            exception is not None or (kwargs and kwargs.get("exception") is not None)
         ):
             return 500
 
@@ -1638,9 +1639,11 @@ class PrometheusLogger(CustomLogger):
                 client_ip=_metadata.get("requester_ip_address"),
                 user_agent=_metadata.get("user_agent"),
                 model_id=model_id,
-                stream=str(request_data.get("stream"))
-                if litellm.prometheus_emit_stream_label
-                else None,
+                stream=(
+                    str(request_data.get("stream"))
+                    if litellm.prometheus_emit_stream_label
+                    else None
+                ),
             )
             _labels = prometheus_label_factory(
                 supported_enum_labels=self.get_labels_for_metric(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1448,7 +1448,8 @@ class PrometheusLogger(CustomLogger):
             exception: Exception object to extract status code from directly
 
         Returns:
-            Status code as integer if found, None otherwise
+            Status code as integer if found, 500 when an exception is present
+            but carries no status code attribute, or None when no inputs provided
         """
         status_code = None
 
@@ -1485,6 +1486,14 @@ class PrometheusLogger(CustomLogger):
                         status_code = int(status_code)
                     except (ValueError, TypeError):
                         status_code = None
+
+        # If an exception was provided (directly or via kwargs) but no status code
+        # could be extracted, default to 500 — an unclassified server error is still a 5xx.
+        if status_code is None and (
+            exception is not None
+            or (kwargs and kwargs.get("exception") is not None)
+        ):
+            return 500
 
         return status_code
 

--- a/tests/test_litellm/integrations/test_prometheus_status_code_none.py
+++ b/tests/test_litellm/integrations/test_prometheus_status_code_none.py
@@ -39,3 +39,10 @@ def test_extract_status_code_defaults_to_500_for_bare_exception(prometheus_logge
 def test_extract_status_code_returns_none_when_no_exception(prometheus_logger):
     """When no exception is provided at all, should return None."""
     assert prometheus_logger._extract_status_code() is None
+
+
+def test_extract_status_code_defaults_to_500_for_bare_exception_in_kwargs(prometheus_logger):
+    """Bare exception passed through kwargs should also default to 500."""
+    exc = Exception("something broke")
+    result = prometheus_logger._extract_status_code(kwargs={"exception": exc})
+    assert result == 500, f"Expected 500 for bare exception in kwargs, got {result}"

--- a/tests/test_litellm/integrations/test_prometheus_status_code_none.py
+++ b/tests/test_litellm/integrations/test_prometheus_status_code_none.py
@@ -1,0 +1,41 @@
+"""
+Regression tests for #24224 — status_code=None in Prometheus metrics
+"""
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import PrometheusLogger
+
+
+@pytest.fixture(scope="function")
+def prometheus_logger():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        REGISTRY.unregister(collector)
+    return PrometheusLogger()
+
+
+def test_extract_status_code_returns_int_for_exception_with_status_code(prometheus_logger):
+    """Exception with status_code attribute should return that code."""
+    exc = Exception("fail")
+    exc.status_code = 429  # type: ignore
+    assert prometheus_logger._extract_status_code(exception=exc) == 429
+
+
+def test_extract_status_code_returns_int_for_proxy_exception_with_code(prometheus_logger):
+    """ProxyException-style exception with code attribute should return that code."""
+    exc = Exception("fail")
+    exc.code = 403  # type: ignore
+    assert prometheus_logger._extract_status_code(exception=exc) == 403
+
+
+def test_extract_status_code_defaults_to_500_for_bare_exception(prometheus_logger):
+    """Exception with no status_code or code should default to 500, not None."""
+    exc = Exception("something broke")
+    result = prometheus_logger._extract_status_code(exception=exc)
+    assert result == 500, f"Expected 500 for bare exception, got {result}"
+
+
+def test_extract_status_code_returns_none_when_no_exception(prometheus_logger):
+    """When no exception is provided at all, should return None."""
+    assert prometheus_logger._extract_status_code() is None


### PR DESCRIPTION
## Summary

- `_extract_status_code()` returned `None` when an exception lacked `status_code`/`code` attributes
- `str(None)` became the literal `"None"` in Prometheus labels, causing `litellm_proxy_total_requests_metric` 4xx/5xx aggregations to not match `litellm_proxy_failed_requests_metric`
- Now defaults to `500` (unclassified server error) when an exception is present but carries no extractable status code — covers both direct `exception` param and `kwargs["exception"]` paths

## Test plan

- [x] Added 5 regression tests in `tests/test_litellm/integrations/test_prometheus_status_code_none.py`
- [x] Verified no regressions in existing prometheus tests (`test_prometheus_invalid_key_filtering.py` — 2 pre-existing async failures unrelated to this change)

Fixes #24224

🤖 Generated with [Claude Code](https://claude.com/claude-code)