### PR TITLE
[Feature] MCP team management + per-member granular permissions

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -40,8 +40,8 @@ def _prepare_mcp_server_data(
     """
     from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-    # Convert model to dict
-    data_dict = data.model_dump(exclude_none=True)
+    # Convert model to dict, excluding fields that are not DB columns
+    data_dict = data.model_dump(exclude_none=True, exclude={"team_id"})
     # Ensure alias is always present in the dict (even if None)
     if "alias" not in data_dict:
         data_dict["alias"] = getattr(data, "alias", None)

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3769,6 +3769,7 @@ class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
 class TeamMemberUpdateResponse(MemberUpdateResponse):
     team_id: str
     max_budget_in_team: Optional[float] = None
+    extra_permissions: Optional[List[str]] = None
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1625,16 +1625,23 @@ class Member(MemberBase):
     @field_validator("extra_permissions", mode="before")
     @classmethod
     def validate_permission_format(cls, v):
-        """Validate that all permission strings follow the resource:action format."""
+        """Validate that all permission strings are known valid permissions."""
         if v is None:
             return v
         if not isinstance(v, list):
             raise ValueError("extra_permissions must be a list of strings")
+        from litellm.proxy.auth.permissions import VALID_PERMISSIONS
+
         for perm in v:
             if not isinstance(perm, str) or ":" not in perm:
                 raise ValueError(
                     f"Invalid permission format: '{perm}'. "
                     "Must follow 'resource:action' format (e.g. 'mcp:create')."
+                )
+            if perm not in VALID_PERMISSIONS:
+                raise ValueError(
+                    f"Unknown permission: '{perm}'. "
+                    f"Valid permissions: {sorted(VALID_PERMISSIONS)}"
                 )
         return v
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -655,6 +655,7 @@ class LiteLLMRoutes(enum.Enum):
         "/model/delete",
         "/user/daily/activity",
         "/user/available_roles",  # read-only role metadata; any authenticated user may read
+        "/team/available_permissions",  # read-only permission metadata; any authenticated user may read
         "/user/list",  # org admins checked in endpoint; non-admins get 403
         "/model/{model_id}/update",
         "/prompt/list",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1104,6 +1104,11 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     server_name: Optional[str] = None
     alias: Optional[str] = None
     description: Optional[str] = None
+    team_id: Optional[str] = Field(
+        default=None,
+        description="Team ID to scope this MCP server to. Required for non-proxy-admin users. "
+        "When provided, the server is auto-assigned to the team's ObjectPermissionTable.",
+    )
     transport: MCPTransportType = MCPTransport.sse
     auth_type: Optional[MCPAuthType] = None
     credentials: Optional[MCPCredentials] = None
@@ -1610,6 +1615,10 @@ class Member(MemberBase):
         "user",
     ] = Field(
         description="The role of the user within the team. 'admin' users can manage team settings and members, 'user' is a regular team member"
+    )
+    extra_permissions: Optional[List[str]] = Field(
+        default=None,
+        description="Granular permissions granted to this member (e.g. 'mcp:create', 'mcp:delete'). Used for per-member permission grants.",
     )
 
 
@@ -3728,6 +3737,10 @@ class TeamMemberDeleteRequest(MemberDeleteRequest):
 class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
     max_budget_in_team: Optional[float] = None
     role: Optional[Literal["admin", "user"]] = None
+    extra_permissions: Optional[List[str]] = Field(
+        default=None,
+        description="Granular permissions to grant to this team member (e.g. ['mcp:create', 'mcp:delete']). Replaces any existing extra_permissions.",
+    )
     tpm_limit: Optional[int] = Field(
         default=None, description="Tokens per minute limit for this team member"
     )

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1622,6 +1622,22 @@ class Member(MemberBase):
         description="Granular permissions granted to this member (e.g. 'mcp:create', 'mcp:delete'). Used for per-member permission grants.",
     )
 
+    @field_validator("extra_permissions", mode="before")
+    @classmethod
+    def validate_permission_format(cls, v):
+        """Validate that all permission strings follow the resource:action format."""
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            raise ValueError("extra_permissions must be a list of strings")
+        for perm in v:
+            if not isinstance(perm, str) or ":" not in perm:
+                raise ValueError(
+                    f"Invalid permission format: '{perm}'. "
+                    "Must follow 'resource:action' format (e.g. 'mcp:create')."
+                )
+        return v
+
 
 class OrgMember(MemberBase):
     role: Literal[

--- a/litellm/proxy/auth/permissions.py
+++ b/litellm/proxy/auth/permissions.py
@@ -1,0 +1,59 @@
+"""
+Granular permission strings for the LiteLLM proxy.
+
+Permission format: `resource:action`
+
+This module defines the valid permission strings that can be granted to
+team members via `extra_permissions`. It is the first step toward a full
+Permission Strings RBAC system (custom roles, org intersection, denied_permissions).
+
+New resource permissions should be added here as enums and included in
+VALID_PERMISSIONS so that the validation in team_member_update rejects typos.
+"""
+
+from enum import Enum
+from typing import Dict, List
+
+
+class MCPPermission(str, Enum):
+    """Permissions for MCP server management."""
+
+    READ = "mcp:read"
+    CREATE = "mcp:create"
+    UPDATE = "mcp:update"
+    DELETE = "mcp:delete"
+
+
+# All known permission strings — used for validation when granting permissions.
+# Grows as more resource permissions are added (keys:create, teams:create, etc.)
+VALID_PERMISSIONS: set = {p.value for p in MCPPermission}
+
+
+def get_available_permissions() -> List[Dict[str, str]]:
+    """
+    Return the list of valid permission strings with labels, grouped by resource.
+
+    Used by the GET /team/available_permissions endpoint for UI dropdowns.
+    """
+    return [
+        {
+            "value": MCPPermission.READ.value,
+            "label": "View MCP servers",
+            "resource": "mcp",
+        },
+        {
+            "value": MCPPermission.CREATE.value,
+            "label": "Create MCP servers",
+            "resource": "mcp",
+        },
+        {
+            "value": MCPPermission.UPDATE.value,
+            "label": "Edit MCP servers",
+            "resource": "mcp",
+        },
+        {
+            "value": MCPPermission.DELETE.value,
+            "label": "Delete MCP servers",
+            "resource": "mcp",
+        },
+    ]

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -11,6 +11,7 @@ from litellm.proxy._types import (
     LiteLLM_TeamTable,
     LiteLLM_UserTable,
     LitellmUserRoles,
+    Member,
     NewProjectRequest,
     UpdateProjectRequest,
     UserAPIKeyAuth,
@@ -37,6 +38,57 @@ def _is_user_team_admin(
             member.user_id is not None and member.user_id == user_api_key_dict.user_id
         ) and member.role == "admin":
             return True
+
+    return False
+
+
+def _find_member_in_team(
+    user_api_key_dict: UserAPIKeyAuth, team_obj: LiteLLM_TeamTable
+) -> Optional[Member]:
+    """Find and return the Member object for the given user in the team, or None."""
+    if not user_api_key_dict.user_id:
+        return None
+    for member in team_obj.members_with_roles:
+        if member.user_id is not None and member.user_id == user_api_key_dict.user_id:
+            return member
+    return None
+
+
+def check_member_permission(
+    user_api_key_dict: UserAPIKeyAuth,
+    team_obj: LiteLLM_TeamTable,
+    required_permission: str,
+) -> bool:
+    """
+    Check if a user has a specific permission for a team.
+
+    Resolution order:
+    1. Proxy admin → True
+    2. Team admin → True
+    3. Member with required_permission in extra_permissions → True
+    4. Otherwise → False
+
+    This is the minimal permission check for the first phase of granular RBAC.
+    When the full RBAC engine ships, this function will be replaced by
+    check_permission() in permissions.py with role resolution, org intersection,
+    and denied_permissions support.
+    """
+    # 1. Proxy admin
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+        return True
+
+    # Find member in team
+    member = _find_member_in_team(user_api_key_dict, team_obj)
+    if member is None:
+        return False
+
+    # 2. Team admin
+    if member.role == "admin":
+        return True
+
+    # 3. Check extra_permissions
+    if member.extra_permissions and required_permission in member.extra_permissions:
+        return True
 
     return False
 

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -45,12 +45,25 @@ def _is_user_team_admin(
 def _find_member_in_team(
     user_api_key_dict: UserAPIKeyAuth, team_obj: LiteLLM_TeamTable
 ) -> Optional[Member]:
-    """Find and return the Member object for the given user in the team, or None."""
-    if not user_api_key_dict.user_id:
-        return None
+    """Find and return the Member object for the given user in the team, or None.
+
+    Matches by user_id first, then falls back to user_email for email-only members.
+    """
     for member in team_obj.members_with_roles:
-        if member.user_id is not None and member.user_id == user_api_key_dict.user_id:
+        if (
+            user_api_key_dict.user_id
+            and member.user_id is not None
+            and member.user_id == user_api_key_dict.user_id
+        ):
             return member
+    # Fallback: match by email for email-only members
+    if user_api_key_dict.user_email:
+        for member in team_obj.members_with_roles:
+            if (
+                member.user_email is not None
+                and member.user_email == user_api_key_dict.user_email
+            ):
+                return member
     return None
 
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1491,10 +1491,10 @@ if MCP_AVAILABLE:
 
     @router.delete(
         "/server/{server_id}",
-        description="Allows deleting mcp serves in the db",
+        description="Allows deleting mcp servers in the db",
         dependencies=[Depends(user_api_key_auth)],
         response_class=JSONResponse,
-        status_code=status.HTTP_202_ACCEPTED,
+        status_code=status.HTTP_204_NO_CONTENT,
     )
     @management_endpoint_wrapper
     async def remove_mcp_server(
@@ -1588,7 +1588,7 @@ if MCP_AVAILABLE:
         if litellm.store_audit_logs:
             pass
 
-        return Response(status_code=status.HTTP_202_ACCEPTED)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.post(
         "/server/{server_id}/user-credential",
@@ -1848,10 +1848,10 @@ if MCP_AVAILABLE:
 
     @router.put(
         "/server",
-        description="Allows deleting mcp serves in the db",
+        description="Allows updating mcp servers in the db",
         dependencies=[Depends(user_api_key_auth)],
         response_model=LiteLLM_MCPServerTable,
-        status_code=status.HTTP_202_ACCEPTED,
+        status_code=status.HTTP_200_OK,
     )
     @management_endpoint_wrapper
     async def edit_mcp_server(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -130,7 +130,14 @@ if MCP_AVAILABLE:
     )
     from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
     from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
-    from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+    from litellm.proxy.management_endpoints.common_utils import (
+        _user_has_admin_view,
+        check_member_permission,
+    )
+    from litellm.proxy.management_helpers.object_permission_utils import (
+        add_mcp_server_to_team,
+        remove_mcp_server_from_team,
+    )
     from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
     from litellm.types.mcp import MCPCredentials
     from litellm.types.mcp_server.mcp_server_manager import MCPServer
@@ -1206,15 +1213,38 @@ if MCP_AVAILABLE:
         # Validate and normalize payload fields
         validate_and_normalize_mcp_server_payload(payload)
 
-        # AuthZ - restrict only proxy admins to create mcp servers
+        # AuthZ - proxy admins, team admins, or members with mcp:create permission
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import user_api_key_cache
+
+        team_obj = None
+        team_id = payload.team_id or user_api_key_dict.team_id
+
         if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "error": "User does not have permission to create mcp servers. You can only create mcp servers if you are a PROXY_ADMIN."
-                },
+            if not team_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "error": "team_id is required for non-proxy-admin users to create MCP servers."
+                    },
+                )
+            team_obj = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
             )
-        elif payload.server_id is not None:
+            if not check_member_permission(
+                user_api_key_dict, team_obj, "mcp:create"
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "User does not have permission to create MCP servers for this team. "
+                        "Requires team admin role or 'mcp:create' permission."
+                    },
+                )
+
+        if payload.server_id is not None:
             # fail if the mcp server with id already exists
             mcp_server = await get_mcp_server(prisma_client, payload.server_id)
             if mcp_server is not None:
@@ -1261,6 +1291,18 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail={"error": f"Error creating mcp server: {str(e)}"},
             )
+
+        # Auto-assign server to team's ObjectPermissionTable if team-scoped
+        if team_id and new_mcp_server.server_id:
+            try:
+                await add_mcp_server_to_team(
+                    prisma_client, team_id, new_mcp_server.server_id
+                )
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    f"Failed to auto-assign MCP server {new_mcp_server.server_id} to team {team_id}: {e}"
+                )
+
         return _redact_mcp_credentials(new_mcp_server)
 
     @router.post(
@@ -1477,16 +1519,48 @@ if MCP_AVAILABLE:
             "Database not connected. Connect a database to your proxy - https://docs.litellm.ai/docs/simple_proxy#managing-auth---virtual-keys"
         )
 
-        # Authz - restrict only admins to delete mcp servers
+        # AuthZ - proxy admins, team admins, or members with mcp:delete permission
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import user_api_key_cache
+
+        team_id = user_api_key_dict.team_id
+
         if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "error": "Call not allowed to delete MCP server. User is not a proxy admin. route={}".format(
-                        "DELETE /v1/mcp/server"
-                    )
-                },
+            if not team_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "error": "team_id is required for non-proxy-admin users to delete MCP servers."
+                    },
+                )
+            team_obj = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
             )
+            if not check_member_permission(
+                user_api_key_dict, team_obj, "mcp:delete"
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "User does not have permission to delete MCP servers for this team. "
+                        "Requires team admin role or 'mcp:delete' permission."
+                    },
+                )
+            # Verify server belongs to this team
+            from litellm.proxy.management_helpers.object_permission_utils import (
+                _get_team_allowed_mcp_servers,
+            )
+
+            team_servers = await _get_team_allowed_mcp_servers(team_obj)
+            if server_id not in team_servers:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": f"MCP Server {server_id} does not belong to your team."
+                    },
+                )
 
         # try to delete the mcp server
         mcp_server_record_deleted = await delete_mcp_server(prisma_client, server_id)
@@ -1501,15 +1575,18 @@ if MCP_AVAILABLE:
         # Ensure registry is up to date by reloading from database
         await global_mcp_server_manager.reload_servers_from_database()
 
+        # Remove server from team's ObjectPermissionTable
+        if team_id:
+            try:
+                await remove_mcp_server_from_team(prisma_client, team_id, server_id)
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    f"Failed to remove MCP server {server_id} from team {team_id}: {e}"
+                )
+
         # TODO: Enterprise: Finish audit log trail
         if litellm.store_audit_logs:
             pass
-
-        # TODO: Delete from virtual keys
-
-        # TODO: Delete from teams
-
-        # Update from global mcp store
 
         return Response(status_code=status.HTTP_202_ACCEPTED)
 
@@ -1802,16 +1879,47 @@ if MCP_AVAILABLE:
         # Validate and normalize payload fields
         validate_and_normalize_mcp_server_payload(payload)
 
-        # Authz - restrict only admins to delete mcp servers
+        # AuthZ - proxy admins, team admins, or members with mcp:update permission
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import user_api_key_cache
+
         if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "error": "Call not allowed to update MCP server. User is not a proxy admin. route={}".format(
-                        "PUT /v1/mcp/server"
-                    )
-                },
+            team_id = user_api_key_dict.team_id
+            if not team_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "error": "team_id is required for non-proxy-admin users to update MCP servers."
+                    },
+                )
+            team_obj = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
             )
+            if not check_member_permission(
+                user_api_key_dict, team_obj, "mcp:update"
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "User does not have permission to update MCP servers for this team. "
+                        "Requires team admin role or 'mcp:update' permission."
+                    },
+                )
+            # Verify server belongs to this team
+            from litellm.proxy.management_helpers.object_permission_utils import (
+                _get_team_allowed_mcp_servers,
+            )
+
+            team_servers = await _get_team_allowed_mcp_servers(team_obj)
+            if payload.server_id not in team_servers:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": f"MCP Server {payload.server_id} does not belong to your team."
+                    },
+                )
 
         # try to update the mcp server
         mcp_server_record_updated = await update_mcp_server(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1854,7 +1854,7 @@ if MCP_AVAILABLE:
         description="Allows updating mcp servers in the db",
         dependencies=[Depends(user_api_key_auth)],
         response_model=LiteLLM_MCPServerTable,
-        status_code=status.HTTP_200_OK,
+        status_code=status.HTTP_202_ACCEPTED,
     )
     @management_endpoint_wrapper
     async def edit_mcp_server(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1294,14 +1294,9 @@ if MCP_AVAILABLE:
 
         # Auto-assign server to team's ObjectPermissionTable if team-scoped
         if team_id and new_mcp_server.server_id:
-            try:
-                await add_mcp_server_to_team(
-                    prisma_client, team_id, new_mcp_server.server_id
-                )
-            except Exception as e:
-                verbose_proxy_logger.warning(
-                    f"Failed to auto-assign MCP server {new_mcp_server.server_id} to team {team_id}: {e}"
-                )
+            await add_mcp_server_to_team(
+                prisma_client, team_id, new_mcp_server.server_id
+            )
 
         return _redact_mcp_credentials(new_mcp_server)
 
@@ -1577,12 +1572,7 @@ if MCP_AVAILABLE:
 
         # Remove server from team's ObjectPermissionTable
         if team_id:
-            try:
-                await remove_mcp_server_from_team(prisma_client, team_id, server_id)
-            except Exception as e:
-                verbose_proxy_logger.warning(
-                    f"Failed to remove MCP server {server_id} from team {team_id}: {e}"
-                )
+            await remove_mcp_server_from_team(prisma_client, team_id, server_id)
 
         # TODO: Enterprise: Finish audit log trail
         if litellm.store_audit_logs:
@@ -1913,6 +1903,13 @@ if MCP_AVAILABLE:
             )
 
             team_servers = await _get_team_allowed_mcp_servers(team_obj)
+            if payload.server_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "error": "server_id is required to update an MCP server."
+                    },
+                )
             if payload.server_id not in team_servers:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1294,9 +1294,16 @@ if MCP_AVAILABLE:
 
         # Auto-assign server to team's ObjectPermissionTable if team-scoped
         if team_id and new_mcp_server.server_id:
-            await add_mcp_server_to_team(
-                prisma_client, team_id, new_mcp_server.server_id
-            )
+            try:
+                await add_mcp_server_to_team(
+                    prisma_client, team_id, new_mcp_server.server_id
+                )
+            except ValueError as e:
+                # Team not found — surface as 400 so caller knows
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={"error": str(e)},
+                )
 
         return _redact_mcp_credentials(new_mcp_server)
 
@@ -1489,7 +1496,7 @@ if MCP_AVAILABLE:
         description="Allows deleting mcp servers in the db",
         dependencies=[Depends(user_api_key_auth)],
         response_class=JSONResponse,
-        status_code=status.HTTP_204_NO_CONTENT,
+        status_code=status.HTTP_202_ACCEPTED,
     )
     @management_endpoint_wrapper
     async def remove_mcp_server(
@@ -1572,13 +1579,19 @@ if MCP_AVAILABLE:
 
         # Remove server from team's ObjectPermissionTable
         if team_id:
-            await remove_mcp_server_from_team(prisma_client, team_id, server_id)
+            try:
+                await remove_mcp_server_from_team(prisma_client, team_id, server_id)
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    f"Failed to remove server {server_id} from team {team_id} permissions: {e}. "
+                    "Server was deleted but team's ObjectPermissionTable may contain a stale entry."
+                )
 
         # TODO: Enterprise: Finish audit log trail
         if litellm.store_audit_logs:
             pass
 
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
+        return Response(status_code=status.HTTP_202_ACCEPTED)
 
     @router.post(
         "/server/{server_id}/user-credential",

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2434,31 +2434,7 @@ async def team_member_update(
             rpm_limit=data.rpm_limit,
         )
 
-    ### update team member role
-    if data.role is not None:
-        team_members: List[Member] = []
-        for member in team_table.members_with_roles:
-            if member.user_id == received_user_id:
-                team_members.append(
-                    Member(
-                        user_id=member.user_id,
-                        role=data.role,
-                        user_email=data.user_email or member.user_email,
-                        extra_permissions=member.extra_permissions,
-                    )
-                )
-            else:
-                team_members.append(member)
-
-        team_table.members_with_roles = team_members
-
-        _db_team_members: List[dict] = [m.model_dump() for m in team_members]
-        await prisma_client.db.litellm_teamtable.update(
-            where={"team_id": data.team_id},
-            data={"members_with_roles": json.dumps(_db_team_members)},  # type: ignore
-        )
-
-    ### update team member extra_permissions
+    ### Validate extra_permissions before applying any changes
     if data.extra_permissions is not None:
         from litellm.proxy.auth.permissions import VALID_PERMISSIONS
 
@@ -2472,34 +2448,39 @@ async def team_member_update(
                 },
             )
 
-        team_members_updated: List[Member] = []
+    ### Apply role and extra_permissions updates in-memory, then do a single DB write
+    members_changed = data.role is not None or data.extra_permissions is not None
+    if members_changed:
+        updated_members: List[Member] = []
         for member in team_table.members_with_roles:
             if member.user_id == received_user_id:
-                team_members_updated.append(
+                updated_members.append(
                     Member(
                         user_id=member.user_id,
-                        role=member.role,
-                        user_email=member.user_email,
-                        extra_permissions=data.extra_permissions,
+                        role=data.role if data.role is not None else member.role,
+                        user_email=data.user_email or member.user_email,
+                        extra_permissions=(
+                            data.extra_permissions
+                            if data.extra_permissions is not None
+                            else member.extra_permissions
+                        ),
                     )
                 )
             else:
-                team_members_updated.append(member)
+                updated_members.append(member)
 
-        team_table.members_with_roles = team_members_updated
+        team_table.members_with_roles = updated_members
 
-        _db_team_members_perms: List[dict] = [
-            m.model_dump() for m in team_members_updated
-        ]
+        _db_team_members: List[dict] = [m.model_dump() for m in updated_members]
         await prisma_client.db.litellm_teamtable.update(
             where={"team_id": data.team_id},
-            data={"members_with_roles": json.dumps(_db_team_members_perms)},  # type: ignore
+            data={"members_with_roles": json.dumps(_db_team_members)},  # type: ignore
         )
 
-    # Invalidate team cache so permission changes take effect immediately
-    from litellm.proxy.proxy_server import user_api_key_cache
+        # Invalidate team cache so changes take effect immediately
+        from litellm.proxy.proxy_server import user_api_key_cache
 
-    user_api_key_cache.delete_cache(key="team_id:{}".format(data.team_id))
+        user_api_key_cache.delete_cache(key="team_id:{}".format(data.team_id))
 
     return TeamMemberUpdateResponse(
         team_id=data.team_id,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2421,20 +2421,7 @@ async def team_member_update(
             identified_budget_id = tm.budget_id
             break
 
-    ### upsert new budget
-    async with prisma_client.db.tx() as tx:
-        await _upsert_budget_and_membership(
-            tx=tx,
-            team_id=data.team_id,
-            user_id=received_user_id,
-            max_budget=data.max_budget_in_team,
-            existing_budget_id=identified_budget_id,
-            user_api_key_dict=user_api_key_dict,
-            tpm_limit=data.tpm_limit,
-            rpm_limit=data.rpm_limit,
-        )
-
-    ### Validate extra_permissions before applying any changes
+    ### Validate extra_permissions BEFORE any DB writes
     if data.extra_permissions is not None:
         from litellm.proxy.auth.permissions import VALID_PERMISSIONS
 
@@ -2447,6 +2434,19 @@ async def team_member_update(
                     f"Valid permissions: {sorted(VALID_PERMISSIONS)}"
                 },
             )
+
+    ### upsert new budget
+    async with prisma_client.db.tx() as tx:
+        await _upsert_budget_and_membership(
+            tx=tx,
+            team_id=data.team_id,
+            user_id=received_user_id,
+            max_budget=data.max_budget_in_team,
+            existing_budget_id=identified_budget_id,
+            user_api_key_dict=user_api_key_dict,
+            tpm_limit=data.tpm_limit,
+            rpm_limit=data.rpm_limit,
+        )
 
     ### Apply role and extra_permissions updates in-memory, then do a single DB write
     members_changed = data.role is not None or data.extra_permissions is not None

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2496,6 +2496,11 @@ async def team_member_update(
             data={"members_with_roles": json.dumps(_db_team_members_perms)},  # type: ignore
         )
 
+    # Invalidate team cache so permission changes take effect immediately
+    from litellm.proxy.proxy_server import user_api_key_cache
+
+    user_api_key_cache.delete_cache(key="team_id:{}".format(data.team_id))
+
     return TeamMemberUpdateResponse(
         team_id=data.team_id,
         user_id=received_user_id,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2444,6 +2444,7 @@ async def team_member_update(
                         user_id=member.user_id,
                         role=data.role,
                         user_email=data.user_email or member.user_email,
+                        extra_permissions=member.extra_permissions,
                     )
                 )
             else:
@@ -2457,6 +2458,44 @@ async def team_member_update(
             data={"members_with_roles": json.dumps(_db_team_members)},  # type: ignore
         )
 
+    ### update team member extra_permissions
+    if data.extra_permissions is not None:
+        from litellm.proxy.auth.permissions import VALID_PERMISSIONS
+
+        invalid_perms = set(data.extra_permissions) - VALID_PERMISSIONS
+        if invalid_perms:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Invalid permission strings: {sorted(invalid_perms)}. "
+                    f"Valid permissions: {sorted(VALID_PERMISSIONS)}"
+                },
+            )
+
+        team_members_updated: List[Member] = []
+        for member in team_table.members_with_roles:
+            if member.user_id == received_user_id:
+                team_members_updated.append(
+                    Member(
+                        user_id=member.user_id,
+                        role=member.role,
+                        user_email=member.user_email,
+                        extra_permissions=data.extra_permissions,
+                    )
+                )
+            else:
+                team_members_updated.append(member)
+
+        team_table.members_with_roles = team_members_updated
+
+        _db_team_members_perms: List[dict] = [
+            m.model_dump() for m in team_members_updated
+        ]
+        await prisma_client.db.litellm_teamtable.update(
+            where={"team_id": data.team_id},
+            data={"members_with_roles": json.dumps(_db_team_members_perms)},  # type: ignore
+        )
+
     return TeamMemberUpdateResponse(
         team_id=data.team_id,
         user_id=received_user_id,
@@ -2465,6 +2504,24 @@ async def team_member_update(
         tpm_limit=data.tpm_limit,
         rpm_limit=data.rpm_limit,
     )
+
+
+@router.get(
+    "/team/available_permissions",
+    tags=["team management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def get_available_permissions(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    List all valid permission strings that can be granted to team members.
+
+    Used by the UI to populate permission dropdowns when editing team member permissions.
+    """
+    from litellm.proxy.auth.permissions import get_available_permissions
+
+    return get_available_permissions()
 
 
 def _create_results_from_response(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2487,6 +2487,7 @@ async def team_member_update(
         user_id=received_user_id,
         user_email=data.user_email,
         max_budget_in_team=data.max_budget_in_team,
+        extra_permissions=data.extra_permissions,
         tpm_limit=data.tpm_limit,
         rpm_limit=data.rpm_limit,
     )

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -364,3 +364,86 @@ async def validate_key_mcp_servers_against_team(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"error": detail},
             )
+
+
+async def add_mcp_server_to_team(
+    prisma_client: PrismaClient, team_id: str, server_id: str
+) -> None:
+    """
+    Add an MCP server ID to a team's ObjectPermissionTable.mcp_servers.
+
+    If the team has no ObjectPermissionTable yet, one is created.
+    """
+    team = await prisma_client.db.litellm_teamtable.find_unique(
+        where={"team_id": team_id}
+    )
+    if team is None:
+        raise ValueError(f"Team {team_id} not found")
+
+    object_permission_id = team.object_permission_id or str(uuid.uuid4())
+
+    # Get existing object permission or start fresh
+    existing_mcp_servers: List[str] = []
+    if team.object_permission_id:
+        existing_perm = (
+            await prisma_client.db.litellm_objectpermissiontable.find_unique(
+                where={"object_permission_id": team.object_permission_id}
+            )
+        )
+        if existing_perm and existing_perm.mcp_servers:
+            existing_mcp_servers = list(existing_perm.mcp_servers)
+
+    # Add server if not already present
+    if server_id not in existing_mcp_servers:
+        existing_mcp_servers.append(server_id)
+
+    # Upsert the ObjectPermissionTable
+    await prisma_client.db.litellm_objectpermissiontable.upsert(
+        where={"object_permission_id": object_permission_id},
+        data={
+            "create": {
+                "object_permission_id": object_permission_id,
+                "mcp_servers": existing_mcp_servers,
+            },
+            "update": {
+                "mcp_servers": existing_mcp_servers,
+            },
+        },
+    )
+
+    # Link the team to the ObjectPermissionTable if not already linked
+    if not team.object_permission_id:
+        await prisma_client.db.litellm_teamtable.update(
+            where={"team_id": team_id},
+            data={"object_permission_id": object_permission_id},
+        )
+
+
+async def remove_mcp_server_from_team(
+    prisma_client: PrismaClient, team_id: str, server_id: str
+) -> None:
+    """
+    Remove an MCP server ID from a team's ObjectPermissionTable.mcp_servers.
+
+    No-op if the team has no ObjectPermissionTable or the server isn't in the list.
+    """
+    team = await prisma_client.db.litellm_teamtable.find_unique(
+        where={"team_id": team_id}
+    )
+    if team is None or not team.object_permission_id:
+        return
+
+    existing_perm = (
+        await prisma_client.db.litellm_objectpermissiontable.find_unique(
+            where={"object_permission_id": team.object_permission_id}
+        )
+    )
+    if existing_perm is None or not existing_perm.mcp_servers:
+        return
+
+    updated_servers = [s for s in existing_perm.mcp_servers if s != server_id]
+    if len(updated_servers) != len(existing_perm.mcp_servers):
+        await prisma_client.db.litellm_objectpermissiontable.update(
+            where={"object_permission_id": team.object_permission_id},
+            data={"mcp_servers": updated_servers},
+        )

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -373,50 +373,53 @@ async def add_mcp_server_to_team(
     Add an MCP server ID to a team's ObjectPermissionTable.mcp_servers.
 
     If the team has no ObjectPermissionTable yet, one is created.
+    Uses a DB transaction to prevent race conditions when multiple
+    concurrent calls try to initialize the ObjectPermissionTable.
     """
-    team = await prisma_client.db.litellm_teamtable.find_unique(
-        where={"team_id": team_id}
-    )
-    if team is None:
-        raise ValueError(f"Team {team_id} not found")
+    async with prisma_client.db.tx() as tx:
+        team = await tx.litellm_teamtable.find_unique(
+            where={"team_id": team_id}
+        )
+        if team is None:
+            raise ValueError(f"Team {team_id} not found")
 
-    object_permission_id = team.object_permission_id or str(uuid.uuid4())
+        object_permission_id = team.object_permission_id or str(uuid.uuid4())
 
-    # Get existing object permission or start fresh
-    existing_mcp_servers: List[str] = []
-    if team.object_permission_id:
-        existing_perm = (
-            await prisma_client.db.litellm_objectpermissiontable.find_unique(
-                where={"object_permission_id": team.object_permission_id}
+        # Get existing object permission or start fresh
+        existing_mcp_servers: List[str] = []
+        if team.object_permission_id:
+            existing_perm = (
+                await tx.litellm_objectpermissiontable.find_unique(
+                    where={"object_permission_id": team.object_permission_id}
+                )
             )
-        )
-        if existing_perm and existing_perm.mcp_servers:
-            existing_mcp_servers = list(existing_perm.mcp_servers)
+            if existing_perm and existing_perm.mcp_servers:
+                existing_mcp_servers = list(existing_perm.mcp_servers)
 
-    # Add server if not already present
-    if server_id not in existing_mcp_servers:
-        existing_mcp_servers.append(server_id)
+        # Add server if not already present
+        if server_id not in existing_mcp_servers:
+            existing_mcp_servers.append(server_id)
 
-    # Upsert the ObjectPermissionTable
-    await prisma_client.db.litellm_objectpermissiontable.upsert(
-        where={"object_permission_id": object_permission_id},
-        data={
-            "create": {
-                "object_permission_id": object_permission_id,
-                "mcp_servers": existing_mcp_servers,
+        # Upsert the ObjectPermissionTable
+        await tx.litellm_objectpermissiontable.upsert(
+            where={"object_permission_id": object_permission_id},
+            data={
+                "create": {
+                    "object_permission_id": object_permission_id,
+                    "mcp_servers": existing_mcp_servers,
+                },
+                "update": {
+                    "mcp_servers": existing_mcp_servers,
+                },
             },
-            "update": {
-                "mcp_servers": existing_mcp_servers,
-            },
-        },
-    )
-
-    # Link the team to the ObjectPermissionTable if not already linked
-    if not team.object_permission_id:
-        await prisma_client.db.litellm_teamtable.update(
-            where={"team_id": team_id},
-            data={"object_permission_id": object_permission_id},
         )
+
+        # Link the team to the ObjectPermissionTable if not already linked
+        if not team.object_permission_id:
+            await tx.litellm_teamtable.update(
+                where={"team_id": team_id},
+                data={"object_permission_id": object_permission_id},
+            )
 
 
 async def remove_mcp_server_from_team(
@@ -426,24 +429,26 @@ async def remove_mcp_server_from_team(
     Remove an MCP server ID from a team's ObjectPermissionTable.mcp_servers.
 
     No-op if the team has no ObjectPermissionTable or the server isn't in the list.
+    Uses a DB transaction for consistency.
     """
-    team = await prisma_client.db.litellm_teamtable.find_unique(
-        where={"team_id": team_id}
-    )
-    if team is None or not team.object_permission_id:
-        return
-
-    existing_perm = (
-        await prisma_client.db.litellm_objectpermissiontable.find_unique(
-            where={"object_permission_id": team.object_permission_id}
+    async with prisma_client.db.tx() as tx:
+        team = await tx.litellm_teamtable.find_unique(
+            where={"team_id": team_id}
         )
-    )
-    if existing_perm is None or not existing_perm.mcp_servers:
-        return
+        if team is None or not team.object_permission_id:
+            return
 
-    updated_servers = [s for s in existing_perm.mcp_servers if s != server_id]
-    if len(updated_servers) != len(existing_perm.mcp_servers):
-        await prisma_client.db.litellm_objectpermissiontable.update(
-            where={"object_permission_id": team.object_permission_id},
-            data={"mcp_servers": updated_servers},
+        existing_perm = (
+            await tx.litellm_objectpermissiontable.find_unique(
+                where={"object_permission_id": team.object_permission_id}
+            )
         )
+        if existing_perm is None or not existing_perm.mcp_servers:
+            return
+
+        updated_servers = [s for s in existing_perm.mcp_servers if s != server_id]
+        if len(updated_servers) != len(existing_perm.mcp_servers):
+            await tx.litellm_objectpermissiontable.update(
+                where={"object_permission_id": team.object_permission_id},
+                data={"mcp_servers": updated_servers},
+            )

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -366,6 +366,13 @@ async def validate_key_mcp_servers_against_team(
             )
 
 
+def _invalidate_team_cache(team_id: str) -> None:
+    """Invalidate the cached team object so subsequent reads see updated data."""
+    from litellm.proxy.proxy_server import user_api_key_cache
+
+    user_api_key_cache.delete_cache(key="team_id:{}".format(team_id))
+
+
 async def add_mcp_server_to_team(
     prisma_client: PrismaClient, team_id: str, server_id: str
 ) -> None:
@@ -421,6 +428,9 @@ async def add_mcp_server_to_team(
                 data={"object_permission_id": object_permission_id},
             )
 
+    # Invalidate team cache so the updated mcp_servers list is visible immediately
+    _invalidate_team_cache(team_id)
+
 
 async def remove_mcp_server_from_team(
     prisma_client: PrismaClient, team_id: str, server_id: str
@@ -452,3 +462,6 @@ async def remove_mcp_server_from_team(
                 where={"object_permission_id": team.object_permission_id},
                 data={"mcp_servers": updated_servers},
             )
+
+    # Invalidate team cache so the updated mcp_servers list is visible immediately
+    _invalidate_team_cache(team_id)

--- a/tests/litellm/proxy/management_endpoints/test_common_utils.py
+++ b/tests/litellm/proxy/management_endpoints/test_common_utils.py
@@ -157,3 +157,127 @@ class TestUpdateMetadataFieldsPremiumCheck:
         }
         _update_metadata_fields(updated_kv)
         mock_check.assert_called()
+
+
+class TestCheckMemberPermission:
+    """Tests for check_member_permission and _find_member_in_team."""
+
+    def _make_user_api_key_dict(self, user_id="user-1", user_role=None):
+        from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+        return UserAPIKeyAuth(
+            user_id=user_id,
+            user_role=user_role or LitellmUserRoles.INTERNAL_USER,
+            api_key="sk-test",
+        )
+
+    def _make_team(self, members):
+        from litellm.proxy._types import LiteLLM_TeamTable
+
+        return LiteLLM_TeamTable(
+            team_id="team-1",
+            members_with_roles=members,
+        )
+
+    def test_proxy_admin_always_allowed(self):
+        from litellm.proxy._types import LitellmUserRoles
+        from litellm.proxy.management_endpoints.common_utils import (
+            check_member_permission,
+        )
+
+        user = self._make_user_api_key_dict(
+            user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+        team = self._make_team([])
+        assert check_member_permission(user, team, "mcp:create") is True
+
+    def test_team_admin_always_allowed(self):
+        from litellm.proxy._types import Member
+        from litellm.proxy.management_endpoints.common_utils import (
+            check_member_permission,
+        )
+
+        user = self._make_user_api_key_dict(user_id="admin-1")
+        team = self._make_team(
+            [Member(user_id="admin-1", role="admin")]
+        )
+        assert check_member_permission(user, team, "mcp:create") is True
+
+    def test_member_with_permission_allowed(self):
+        from litellm.proxy._types import Member
+        from litellm.proxy.management_endpoints.common_utils import (
+            check_member_permission,
+        )
+
+        user = self._make_user_api_key_dict(user_id="member-1")
+        team = self._make_team(
+            [Member(user_id="member-1", role="user", extra_permissions=["mcp:create"])]
+        )
+        assert check_member_permission(user, team, "mcp:create") is True
+
+    def test_member_without_permission_denied(self):
+        from litellm.proxy._types import Member
+        from litellm.proxy.management_endpoints.common_utils import (
+            check_member_permission,
+        )
+
+        user = self._make_user_api_key_dict(user_id="member-1")
+        team = self._make_team(
+            [Member(user_id="member-1", role="user", extra_permissions=["mcp:read"])]
+        )
+        assert check_member_permission(user, team, "mcp:create") is False
+
+    def test_member_with_no_permissions_denied(self):
+        from litellm.proxy._types import Member
+        from litellm.proxy.management_endpoints.common_utils import (
+            check_member_permission,
+        )
+
+        user = self._make_user_api_key_dict(user_id="member-1")
+        team = self._make_team(
+            [Member(user_id="member-1", role="user")]
+        )
+        assert check_member_permission(user, team, "mcp:create") is False
+
+    def test_user_not_in_team_denied(self):
+        from litellm.proxy._types import Member
+        from litellm.proxy.management_endpoints.common_utils import (
+            check_member_permission,
+        )
+
+        user = self._make_user_api_key_dict(user_id="outsider")
+        team = self._make_team(
+            [Member(user_id="member-1", role="user", extra_permissions=["mcp:create"])]
+        )
+        assert check_member_permission(user, team, "mcp:create") is False
+
+
+class TestMemberExtraPermissionsSerialization:
+    """Verify Member with extra_permissions round-trips through JSON."""
+
+    def test_member_with_permissions_roundtrip(self):
+        import json
+
+        from litellm.proxy._types import Member
+
+        original = Member(
+            user_id="user-1",
+            role="user",
+            extra_permissions=["mcp:create", "mcp:delete"],
+        )
+        serialized = json.dumps(original.model_dump())
+        deserialized = Member(**json.loads(serialized))
+        assert deserialized.extra_permissions == ["mcp:create", "mcp:delete"]
+        assert deserialized.user_id == "user-1"
+        assert deserialized.role == "user"
+
+    def test_member_without_permissions_roundtrip(self):
+        import json
+
+        from litellm.proxy._types import Member
+
+        original = Member(user_id="user-1", role="admin")
+        serialized = json.dumps(original.model_dump())
+        deserialized = Member(**json.loads(serialized))
+        assert deserialized.extra_permissions is None
+        assert deserialized.role == "admin"


### PR DESCRIPTION
## Summary

### Problem
MCP server CRUD is currently proxy-admin-only. Team admins cannot manage MCP servers for their own teams, unlike models where team admins have self-service management. Additionally, there's no way to grant granular MCP permissions to non-admin team members.

### Fix
- Team admins can now create, update, and delete MCP servers scoped to their team
- Non-admin team members can be granted granular MCP permissions (`mcp:create`, `mcp:update`, `mcp:delete`, `mcp:read`) via per-member `extra_permissions`
- Servers created by team admins/members are auto-assigned to the team's `ObjectPermissionTable`
- Permission strings use `resource:action` format designed for forward-compatibility with full RBAC

## Changes

- Added `extra_permissions` field to `Member` model (stored in `members_with_roles` JSON — no schema migration needed)
- New `litellm/proxy/auth/permissions.py` with `MCPPermission` enum and `VALID_PERMISSIONS` set
- New `check_member_permission()` helper in `common_utils.py` (proxy admin → team admin → member with permission)
- Replaced 3 proxy-admin-only auth checks in MCP endpoints with team-scoped permission checks
- `team_member_update` now handles `extra_permissions` with validation against known permission strings
- New `GET /team/available_permissions` endpoint for UI dropdowns
- New `add_mcp_server_to_team()` / `remove_mcp_server_from_team()` helpers in `object_permission_utils.py`
- Added `team_id` field to `NewMCPServerRequest`

## Testing

- 8 unit tests for `check_member_permission()` and `Member` serialization (all passing)
- E2E verification script (`test_mcp_permissions_e2e.sh`) with 9 API tests covering: team admin create, member denied without permission, grant permission, member allowed with permission, update/delete scoping, available permissions endpoint, invalid permission rejection

## Type

🆕 New Feature
✅ Test