### PR TITLE
[Feature] UI - MCP: Team member permissions drawer and CRUD access

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/MemberTable.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/MemberTable.tsx
@@ -1,5 +1,5 @@
 import { Member } from "@/components/networking";
-import { CrownOutlined, InfoCircleOutlined, UserAddOutlined, UserOutlined } from "@ant-design/icons";
+import { CrownOutlined, InfoCircleOutlined, SafetyCertificateOutlined, UserAddOutlined, UserOutlined } from "@ant-design/icons";
 import { Button, Space, Table, Tag, Tooltip, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import React from "react";
@@ -13,6 +13,7 @@ export interface MemberTableProps {
   onEdit: (member: Member) => void;
   onDelete: (member: Member) => void;
   onAddMember?: () => void;
+  onPermissions?: (member: Member) => void;
   roleColumnTitle?: string;
   roleTooltip?: string;
   extraColumns?: ColumnsType<Member>;
@@ -26,6 +27,7 @@ export default function MemberTable({
   onEdit,
   onDelete,
   onAddMember,
+  onPermissions,
   roleColumnTitle = "Role",
   roleTooltip,
   extraColumns = [],
@@ -83,6 +85,17 @@ export default function MemberTable({
       render: (_: unknown, record: Member) =>
         canEdit ? (
           <Space>
+            {onPermissions && (
+              <Tooltip title="Permissions">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<SafetyCertificateOutlined />}
+                  onClick={() => onPermissions(record)}
+                  data-testid="permissions-member"
+                />
+              </Tooltip>
+            )}
             <TableIconActionButton
               variant="Edit"
               tooltipText="Edit member"

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -387,8 +387,8 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         payload.credentials = credentialsPayload;
       }
 
-      // Include team_id for non-admin users
-      if (!isAdmin && teamId) {
+      // Include team_id when a team is selected in the filter
+      if (teamId) {
         payload.team_id = teamId;
       }
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Modal, Tooltip, Form, Select, Input, Switch, Collapse } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
-import { createMCPServer, registerMCPServer } from "../networking";
+import { createMCPServer } from "../networking";
 import { AUTH_TYPE, DiscoverableMCPServer, OAUTH_FLOW, MCPServer, MCPServerCostInfo, TRANSPORT } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import MCPServerCostConfig from "./mcp_server_cost_config";
@@ -30,6 +30,7 @@ interface CreateMCPServerProps {
   availableAccessGroups: string[];
   prefillData?: DiscoverableMCPServer | null;
   onBackToDiscovery?: () => void;
+  teamId?: string | null;
 }
 
 const AUTH_TYPES_REQUIRING_AUTH_VALUE = [AUTH_TYPE.API_KEY, AUTH_TYPE.BEARER_TOKEN, AUTH_TYPE.TOKEN, AUTH_TYPE.BASIC];
@@ -54,6 +55,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   availableAccessGroups,
   prefillData,
   onBackToDiscovery,
+  teamId,
 }) => {
   const [form] = Form.useForm();
   const [isLoading, setIsLoading] = useState(false);
@@ -385,18 +387,17 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         payload.credentials = credentialsPayload;
       }
 
+      // Include team_id for non-admin users
+      if (!isAdmin && teamId) {
+        payload.team_id = teamId;
+      }
+
       console.log(`Payload: ${JSON.stringify(payload)}`);
 
       if (accessToken != null) {
-        const response = isAdmin
-          ? await createMCPServer(accessToken, payload)
-          : await registerMCPServer(accessToken, payload);
+        const response = await createMCPServer(accessToken, payload);
 
-        NotificationsManager.success(
-          isAdmin
-            ? "MCP Server created successfully"
-            : "MCP Server submitted for admin review"
-        );
+        NotificationsManager.success("MCP Server created successfully");
         form.resetFields();
         setCostConfig({});
         clearTools();
@@ -408,9 +409,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       }
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
-      NotificationsManager.fromBackend(
-        isAdmin ? `Error creating MCP Server: ${reason}` : `Error submitting MCP Server: ${reason}`
-      );
+      NotificationsManager.fromBackend(`Error creating MCP Server: ${reason}`);
     } finally {
       setIsLoading(false);
     }
@@ -514,7 +513,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
             }}
           />
           <h2 className="text-xl font-semibold text-gray-900">
-            {isAdmin ? "Add New MCP Server" : "Submit MCP Server for Review"}
+            Add New MCP Server
           </h2>
         </div>
       }
@@ -537,10 +536,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
           layout="vertical"
           className="space-y-6"
         >
-          {!isAdmin && (
-            <div className="rounded-md bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-800">
-              Your submission will be sent for admin review before it becomes active.
-              {" "}Note: the request must be made with a team-scoped API key.
+          {!isAdmin && !teamId && (
+            <div className="rounded-md bg-yellow-50 border border-yellow-200 px-4 py-3 text-sm text-yellow-800">
+              Select a team from the filter to create an MCP server for your team.
             </div>
           )}
           <div className="grid grid-cols-1 gap-6">

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -296,6 +296,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           setPrefillData(null);
           setDiscoveryVisible(true);
         }}
+        teamId={selectedTeam !== "all" && selectedTeam !== "personal" ? selectedTeam : null}
       />
       <div className="flex items-center justify-between">
         <div>
@@ -310,23 +311,9 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           <Text className="text-tremor-content mt-1">Configure and manage your MCP servers</Text>
         </div>
         <div className="flex items-center gap-2">
-          {isAdminRole(userRole) && (
-            <Button className="flex-shrink-0" onClick={() => setDiscoveryVisible(true)}>
-              + Add New MCP Server
-            </Button>
-          )}
-          {!isAdminRole(userRole) && (
-            <Button
-              className="flex-shrink-0"
-              onClick={() => {
-                setPrefillData(null);
-                setModalVisible(true);
-              }}
-              variant="secondary"
-            >
-              + Submit MCP Server
-            </Button>
-          )}
+          <Button className="flex-shrink-0" onClick={() => setDiscoveryVisible(true)}>
+            + Add New MCP Server
+          </Button>
         </div>
       </div>
       <MCPDiscovery

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -311,9 +311,17 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
           <Text className="text-tremor-content mt-1">Configure and manage your MCP servers</Text>
         </div>
         <div className="flex items-center gap-2">
-          <Button className="flex-shrink-0" onClick={() => setDiscoveryVisible(true)}>
-            + Add New MCP Server
-          </Button>
+          {!isAdminRole(userRole) && (selectedTeam === "all" || selectedTeam === "personal") ? (
+            <Tooltip title="Select a team first to add an MCP server">
+              <Button className="flex-shrink-0 opacity-50 cursor-not-allowed" onClick={() => {}}>
+                + Add New MCP Server
+              </Button>
+            </Tooltip>
+          ) : (
+            <Button className="flex-shrink-0" onClick={() => setDiscoveryVisible(true)}>
+              + Add New MCP Server
+            </Button>
+          )}
         </div>
       </div>
       <MCPDiscovery

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -3695,6 +3695,7 @@ export interface Member {
   max_budget_in_team?: number | null;
   tpm_limit?: number | null;
   rpm_limit?: number | null;
+  extra_permissions?: string[] | null;
 }
 
 export const teamMemberAddCall = async (accessToken: string, teamId: string, formValues: Member) => {
@@ -3833,6 +3834,9 @@ export const teamMemberUpdateCall = async (
     }
     if (formValues.rpm_limit !== undefined && formValues.rpm_limit !== null) {
       requestBody.rpm_limit = formValues.rpm_limit;
+    }
+    if (formValues.extra_permissions !== undefined) {
+      requestBody.extra_permissions = formValues.extra_permissions;
     }
 
     console.log("Final request body:", requestBody);
@@ -6509,6 +6513,41 @@ export const fetchMCPClientIp = async (accessToken: string): Promise<string | nu
     return data.ip || null;
   } catch {
     return null;
+  }
+};
+
+export interface AvailablePermission {
+  value: string;
+  label: string;
+  resource: string;
+}
+
+export const fetchAvailableTeamMemberPermissions = async (accessToken: string): Promise<AvailablePermission[]> => {
+  try {
+    const url = proxyBaseUrl
+      ? `${proxyBaseUrl}/team/available_permissions`
+      : `/team/available_permissions`;
+
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.GET,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+    return data || [];
+  } catch (error) {
+    console.error("Failed to fetch available permissions:", error);
+    throw error;
   }
 };
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -7269,12 +7269,11 @@ export const getTeamPermissionsCall = async (accessToken: string, teamId: string
     if (!response.ok) {
       const errorData = await response.json();
       const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
-      throw new Error(errorMessage);
+      console.error("Available permissions fetch failed:", errorMessage);
+      return { all_available_permissions: [], team_member_permissions: [] };
     }
 
     const data = await response.json();
-    console.log("Team permissions response:", data);
     return data;
   } catch (error) {
     console.error("Failed to get team permissions:", error);

--- a/ui/litellm-dashboard/src/components/team/EditMembership.tsx
+++ b/ui/litellm-dashboard/src/components/team/EditMembership.tsx
@@ -21,7 +21,7 @@ interface ModalConfig {
   additionalFields?: Array<{
     name: string;
     label: string | React.ReactNode;
-    type: "input" | "select" | "numerical";
+    type: "input" | "select" | "numerical" | "multi_select";
     options?: Array<{ label: string; value: string }>;
     rules?: any[];
     step?: number;
@@ -65,6 +65,7 @@ const MemberModal = <T extends BaseMember>({
           max_budget_in_team: (initialData as any).max_budget_in_team || null,
           tpm_limit: (initialData as any).tpm_limit || null,
           rpm_limit: (initialData as any).rpm_limit || null,
+          extra_permissions: (initialData as any).extra_permissions || [],
         };
         console.log("Setting form values:", formValues);
         form.setFieldsValue(formValues);
@@ -115,7 +116,7 @@ const MemberModal = <T extends BaseMember>({
   const renderField = (field: {
     name: string;
     label: string | React.ReactNode;
-    type: "input" | "select" | "numerical";
+    type: "input" | "select" | "numerical" | "multi_select";
     options?: Array<{ label: string; value: string }>;
     rules?: any[];
     step?: number;
@@ -143,6 +144,17 @@ const MemberModal = <T extends BaseMember>({
               </Select.Option>
             ))}
           </Select>
+        );
+      case "multi_select":
+        return (
+          <Select
+            mode="multiple"
+            allowClear
+            placeholder={field.placeholder || "Select permissions"}
+            style={{ width: "100%" }}
+            optionFilterProp="label"
+            options={field.options}
+          />
         );
       default:
         return null;

--- a/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
@@ -1,0 +1,206 @@
+import { AvailablePermission, Member, teamMemberUpdateCall } from "@/components/networking";
+import { CloudServerOutlined, SaveOutlined, UserOutlined } from "@ant-design/icons";
+import { Alert, Button, Drawer, Switch, Tag, Typography } from "antd";
+import React, { useEffect, useMemo, useState } from "react";
+import NotificationsManager from "../molecules/notifications_manager";
+
+const { Text, Title: AntTitle } = Typography;
+
+interface MemberPermissionsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  member: Member | null;
+  availablePermissions: AvailablePermission[];
+  accessToken: string | null;
+  teamId: string;
+  onUpdate: () => void;
+}
+
+const MemberPermissionsDrawer: React.FC<MemberPermissionsDrawerProps> = ({
+  open,
+  onClose,
+  member,
+  availablePermissions,
+  accessToken,
+  teamId,
+  onUpdate,
+}) => {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  // Sync state when member changes or drawer opens
+  useEffect(() => {
+    if (open && member) {
+      setSelected(new Set(member.extra_permissions || []));
+    }
+  }, [open, member]);
+
+  const initial = useMemo(
+    () => new Set(member?.extra_permissions || []),
+    [member],
+  );
+
+  const isDirty = useMemo(() => {
+    if (selected.size !== initial.size) return true;
+    for (const p of selected) {
+      if (!initial.has(p)) return true;
+    }
+    return false;
+  }, [selected, initial]);
+
+  const allSelected = availablePermissions.length > 0 && availablePermissions.every((p) => selected.has(p.value));
+
+  const handleToggle = (value: string, checked: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(value);
+      } else {
+        next.delete(value);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleAll = (checked: boolean) => {
+    if (checked) {
+      setSelected(new Set(availablePermissions.map((p) => p.value)));
+    } else {
+      setSelected(new Set());
+    }
+  };
+
+  const handleSave = async () => {
+    if (!accessToken || !member) return;
+    setSaving(true);
+    try {
+      const updatedMember: Member = {
+        ...member,
+        extra_permissions: Array.from(selected),
+      };
+      await teamMemberUpdateCall(accessToken, teamId, updatedMember);
+      NotificationsManager.success("Permissions updated successfully");
+      onUpdate();
+      onClose();
+    } catch (error: any) {
+      const errMsg = error?.message || "Failed to update permissions";
+      NotificationsManager.fromBackend(errMsg);
+      console.error("Error updating permissions:", error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const memberDisplay = member?.user_email || member?.user_id || "Unknown";
+  const isAdmin = member?.role?.toLowerCase() === "admin";
+
+  return (
+    <Drawer
+      title={
+        <div className="flex items-center gap-3">
+          <div className="flex items-center justify-center w-8 h-8 bg-blue-50 text-blue-600 rounded-full shrink-0">
+            <UserOutlined />
+          </div>
+          <div className="flex flex-col overflow-hidden">
+            <Text strong className="text-base leading-tight truncate">
+              {memberDisplay}
+            </Text>
+            <Text type="secondary" className="text-xs truncate">
+              {member?.user_id || ""}
+            </Text>
+          </div>
+          <Tag color={isAdmin ? "gold" : "default"} className="ml-auto shrink-0">
+            {member?.role || "user"}
+          </Tag>
+        </div>
+      }
+      placement="right"
+      width={480}
+      open={open}
+      onClose={onClose}
+      closable={!saving}
+      maskClosable={!saving}
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button onClick={onClose} disabled={saving}>Cancel</Button>
+          <Button
+            type="primary"
+            icon={<SaveOutlined />}
+            onClick={handleSave}
+            loading={saving}
+            disabled={!isDirty}
+          >
+            Save Changes
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-6">
+        {isAdmin ? (
+          <Alert
+            message="Team admins have all permissions by default. Extra permissions only apply to non-admin members."
+            type="info"
+            showIcon
+          />
+        ) : (
+          <Alert
+            message="Permissions allow this member to manage MCP servers for this team."
+            type="info"
+            showIcon
+          />
+        )}
+
+        {/* MCP Server Permissions */}
+        <div>
+          <div className="flex items-center gap-2 mb-4">
+            <CloudServerOutlined className="text-lg text-gray-600" />
+            <AntTitle level={5} className="!m-0">
+              MCP Server Permissions
+            </AntTitle>
+          </div>
+
+          <div className="bg-gray-50 p-3 rounded-lg border border-gray-200 mb-4 flex items-center justify-between">
+            <Text strong>{allSelected ? "Deselect All" : "Select All"}</Text>
+            <Switch
+              checked={allSelected}
+              onChange={handleToggleAll}
+              disabled={isAdmin}
+            />
+          </div>
+
+          <div className="flex flex-col">
+            {availablePermissions.map((perm) => (
+              <div
+                key={perm.value}
+                className="flex items-center justify-between py-3 border-b border-gray-100 last:border-0"
+              >
+                <div className="flex flex-col gap-1">
+                  <Text>{perm.label}</Text>
+                  <Text
+                    type="secondary"
+                    className="font-mono text-xs bg-gray-100 px-1.5 py-0.5 rounded w-fit border border-gray-200"
+                  >
+                    {perm.value}
+                  </Text>
+                </div>
+                <Switch
+                  checked={selected.has(perm.value)}
+                  onChange={(checked) => handleToggle(perm.value, checked)}
+                  disabled={isAdmin}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {availablePermissions.length === 0 && (
+          <div className="text-center py-8 text-gray-400 text-sm">
+            No permissions available.
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+};
+
+export default MemberPermissionsDrawer;

--- a/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
@@ -28,16 +28,21 @@ const MemberPermissionsDrawer: React.FC<MemberPermissionsDrawerProps> = ({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
 
-  // Sync state when member changes or drawer opens
+  // Sync state when member changes or drawer opens — only seed with known permissions
+  // so that unknown permissions are preserved separately on save without duplication
   useEffect(() => {
     if (open && member) {
-      setSelected(new Set(member.extra_permissions || []));
+      const knownValues = new Set(availablePermissions.map((p) => p.value));
+      setSelected(new Set((member.extra_permissions || []).filter((p) => knownValues.has(p))));
     }
-  }, [open, member]);
+  }, [open, member, availablePermissions]);
 
   const initial = useMemo(
-    () => new Set(member?.extra_permissions || []),
-    [member],
+    () => {
+      const knownValues = new Set(availablePermissions.map((p) => p.value));
+      return new Set((member?.extra_permissions || []).filter((p) => knownValues.has(p)));
+    },
+    [member, availablePermissions],
   );
 
   const isDirty = useMemo(() => {

--- a/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
@@ -13,7 +13,7 @@ interface MemberPermissionsDrawerProps {
   availablePermissions: AvailablePermission[];
   accessToken: string | null;
   teamId: string;
-  onUpdate: () => void;
+  onUpdate: () => Promise<void>;
 }
 
 const MemberPermissionsDrawer: React.FC<MemberPermissionsDrawerProps> = ({
@@ -80,7 +80,7 @@ const MemberPermissionsDrawer: React.FC<MemberPermissionsDrawerProps> = ({
       };
       await teamMemberUpdateCall(accessToken, teamId, updatedMember);
       NotificationsManager.success("Permissions updated successfully");
-      onUpdate();
+      await onUpdate();
       onClose();
     } catch (error: any) {
       const errMsg = error?.message || "Failed to update permissions";

--- a/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/team/MemberPermissionsDrawer.tsx
@@ -74,14 +74,23 @@ const MemberPermissionsDrawer: React.FC<MemberPermissionsDrawerProps> = ({
     if (!accessToken || !member) return;
     setSaving(true);
     try {
+      // Preserve unknown permissions not present in the available set
+      const availableValues = new Set(availablePermissions.map((p) => p.value));
+      const existingUnknown = (member.extra_permissions || []).filter(
+        (p) => !availableValues.has(p),
+      );
       const updatedMember: Member = {
         ...member,
-        extra_permissions: Array.from(selected),
+        extra_permissions: [...existingUnknown, ...Array.from(selected)],
       };
       await teamMemberUpdateCall(accessToken, teamId, updatedMember);
       NotificationsManager.success("Permissions updated successfully");
-      await onUpdate();
       onClose();
+      try {
+        await onUpdate();
+      } catch (refreshError) {
+        console.error("Failed to refresh team data after permission update:", refreshError);
+      }
     } catch (error: any) {
       const errMsg = error?.message || "Failed to update permissions";
       NotificationsManager.fromBackend(errMsg);

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -2,6 +2,8 @@ import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import UserSearchModal from "@/components/common_components/user_search_modal";
 import {
+  AvailablePermission,
+  fetchAvailableTeamMemberPermissions,
   getGuardrailsList,
   getPoliciesList,
   getPolicyInfoWithGuardrails,
@@ -48,6 +50,7 @@ import {
   TEAM_INFO_TAB_KEYS,
   TEAM_INFO_TAB_LABELS,
 } from "./tabVisibilityUtils";
+import MemberPermissionsDrawer from "./MemberPermissionsDrawer";
 import TeamMembersComponent from "./TeamMemberTab";
 import { TeamVirtualKeysTable } from "./TeamVirtualKeysTable";
 
@@ -183,6 +186,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isTeamSaving, setIsTeamSaving] = useState(false);
   const [organization, setOrganization] = useState<Organization | null>(null);
+  const [availablePermissions, setAvailablePermissions] = useState<AvailablePermission[]>([]);
+  const [permissionsDrawerMember, setPermissionsDrawerMember] = useState<Member | null>(null);
   const { userRole, userId } = useAuthorized();
   const { data: userOrganizations = [] } = useOrganizations();
 
@@ -218,6 +223,20 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   useEffect(() => {
     fetchTeamInfo();
   }, [teamId, accessToken]);
+
+  // Fetch available permissions for team member editing
+  useEffect(() => {
+    const fetchPermissions = async () => {
+      if (!accessToken) return;
+      try {
+        const permissions = await fetchAvailableTeamMemberPermissions(accessToken);
+        setAvailablePermissions(permissions);
+      } catch (error) {
+        console.error("Error fetching available permissions:", error);
+      }
+    };
+    fetchPermissions();
+  }, [accessToken]);
 
   // Fetch organization data when team has organization_id
   useEffect(() => {
@@ -365,6 +384,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         max_budget_in_team: values.max_budget_in_team,
         tpm_limit: values.tpm_limit,
         rpm_limit: values.rpm_limit,
+        extra_permissions: values.extra_permissions,
       };
       message.destroy(); // Remove all existing toasts
 
@@ -761,6 +781,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                 setSelectedEditMember={setSelectedEditMember}
                 setIsEditMemberModalVisible={setIsEditMemberModalVisible}
                 setIsAddMemberModalVisible={setIsAddMemberModalVisible}
+                onPermissions={(member) => setPermissionsDrawerMember(member)}
               />
             ),
           },
@@ -1333,6 +1354,20 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         onCancel={handleDeleteCancel}
         onOk={handleDeleteConfirm}
         confirmLoading={isDeleting}
+      />
+
+      <MemberPermissionsDrawer
+        open={!!permissionsDrawerMember}
+        onClose={() => setPermissionsDrawerMember(null)}
+        member={permissionsDrawerMember}
+        availablePermissions={availablePermissions}
+        accessToken={accessToken}
+        teamId={teamId}
+        onUpdate={async () => {
+          const updatedTeamData = await teamInfoCall(accessToken!, teamId);
+          setTeamData(updatedTeamData);
+          onUpdate(updatedTeamData);
+        }}
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -224,8 +224,9 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
     fetchTeamInfo();
   }, [teamId, accessToken]);
 
-  // Fetch available permissions for team member editing
+  // Fetch available permissions for team member editing (only for users who can edit the team)
   useEffect(() => {
+    if (!canEditTeam) return;
     const fetchPermissions = async () => {
       if (!accessToken) return;
       try {
@@ -236,7 +237,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       }
     };
     fetchPermissions();
-  }, [accessToken]);
+  }, [accessToken, canEditTeam]);
 
   // Fetch organization data when team has organization_id
   useEffect(() => {
@@ -1364,7 +1365,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         accessToken={accessToken}
         teamId={teamId}
         onUpdate={async () => {
-          const updatedTeamData = await teamInfoCall(accessToken!, teamId);
+          if (!accessToken) return;
+          const updatedTeamData = await teamInfoCall(accessToken, teamId);
           setTeamData(updatedTeamData);
           onUpdate(updatedTeamData);
         }}

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -16,6 +16,7 @@ interface TeamMemberTabProps {
   setSelectedEditMember: (member: Member) => void;
   setIsEditMemberModalVisible: (visible: boolean) => void;
   setIsAddMemberModalVisible: (visible: boolean) => void;
+  onPermissions?: (member: Member) => void;
 }
 
 export default function TeamMemberTab({
@@ -25,6 +26,7 @@ export default function TeamMemberTab({
   setSelectedEditMember,
   setIsEditMemberModalVisible,
   setIsAddMemberModalVisible,
+  onPermissions,
 }: TeamMemberTabProps) {
   const formatNumber = (value: number | null): string => {
     if (value === null || value === undefined) return "0";
@@ -144,6 +146,7 @@ export default function TeamMemberTab({
       }}
       onDelete={handleMemberDelete}
       onAddMember={() => setIsAddMemberModalVisible(true)}
+      onPermissions={onPermissions}
       roleColumnTitle="Team Role"
       roleTooltip="This role applies only to this team and is independent from the user's proxy-level role."
       extraColumns={extraColumns}


### PR DESCRIPTION
## Summary

### Problem
PR #24266 added backend support for team-scoped MCP server CRUD with per-member granular permissions (`mcp:read`, `mcp:create`, `mcp:update`, `mcp:delete`). The UI had no way to grant these permissions to team members, and non-admin users could only submit MCP servers for review rather than creating them directly.

### Fix
- Added a **MemberPermissionsDrawer** (Ant Design Drawer) that opens from the team members table, allowing team admins to toggle MCP permissions per member
- Updated the MCP Servers page so all users see "+ Add New MCP Server" (backend enforces permissions)
- Non-admin users now pass `team_id` when creating MCP servers
- Added `extra_permissions` to the `Member` interface and API calls

## Changes

- New `MemberPermissionsDrawer.tsx` component with Switch toggles for each MCP permission, Select All, save/cancel flow
- Added shield icon button to `MemberTable` actions column to open the drawer
- `networking.tsx`: Added `fetchAvailableTeamMemberPermissions()` API call and `extra_permissions` field to `Member`
- `create_mcp_server.tsx`: Always uses direct create (not submit-for-review), passes `team_id` for non-admins
- `mcp_servers.tsx`: Removed admin-only gate on "+ Add New MCP Server" button

## Testing

- [ ] Open Team Info → Members tab, verify shield icon appears in actions column
- [ ] Click shield icon → drawer opens with MCP permission toggles
- [ ] Toggle permissions, save → verify `extra_permissions` persisted
- [ ] As non-admin with `mcp:create`, verify can create MCP server directly
- [ ] As non-admin without permissions, verify backend returns appropriate error

## Type

🆕 New Feature