### PR TITLE
fix(openrouter): strip 'openrouter/' prefix in chat transform_request

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -158,6 +158,12 @@ class OpenrouterConfig(OpenAIGPTConfig):
         Returns:
             dict: The transformed request. Sent as the body of the API call.
         """
+        # OpenRouter expects the actual model ID (e.g. "mistralai/mistral-7b-instruct"),
+        # not the litellm-internal "openrouter/<model>" form.  Strip the provider
+        # prefix so it is never sent to the API.
+        if model.startswith("openrouter/"):
+            model = model[len("openrouter/"):]
+
         if self._supports_cache_control_in_content(model):
             messages = self._move_cache_control_to_content(messages)
         


### PR DESCRIPTION
## Summary

Fixes #24234

### Problem

OpenRouter chat completions are broken when the model is passed with the `openrouter/` provider prefix (e.g. `openrouter/mistralai/mistral-7b-instruct`). The full string — including `openrouter/` — was being sent to the OpenRouter API, which does not recognise it and returns an error.

### Root cause

`get_llm_provider_logic.py` returns early at L166 when it detects `custom_llm_provider == "openrouter"` and `model.startswith("openrouter/")`, preserving the prefix in the model string. `OpenrouterConfig.transform_request()` then forwarded this unparsed string directly to the upstream API.

### Fix

Strip the `openrouter/` prefix at the start of `OpenrouterConfig.transform_request()` — consistent with the approach already used in `OpenrouterConfig` for **embeddings** (`litellm/llms/openrouter/embedding/transformation.py`, lines 112–113).

```python
# Before (broken)
model = "openrouter/mistralai/mistral-7b-instruct"  # sent as-is

# After (fixed)
model = "mistralai/mistral-7b-instruct"  # prefix stripped
```

## Testing

Manually verified that the transform now produces the correct model string. Unit tests pass.