### PR TITLE
fix(openai): filter None values from embedding optional_params (encoding_format=null)

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1324,7 +1324,14 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     ) -> EmbeddingResponse:
         super().embedding()
         try:
-            data = {"model": model, "input": input, **optional_params}
+            # Filter out None and empty string values from optional_params.
+            # This prevents sending e.g. encoding_format=null to strict
+            # OpenAI-compatible servers (llama.cpp, vLLM, TEI) that reject
+            # null values in JSON. Matches the pattern used in openai_like handler.
+            filtered_optional_params = {
+                k: v for k, v in optional_params.items() if v not in (None, "")
+            }
+            data = {"model": model, "input": input, **filtered_optional_params}
             max_retries = max_retries or litellm.DEFAULT_MAX_RETRIES
             if not isinstance(max_retries, int):
                 raise OpenAIError(status_code=422, message="max retries must be an int")

--- a/tests/test_litellm/llms/openai/embedding/test_openai_embedding_encoding_format.py
+++ b/tests/test_litellm/llms/openai/embedding/test_openai_embedding_encoding_format.py
@@ -14,7 +14,6 @@ Refs:
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from litellm.llms.openai.openai import OpenAIChatCompletion
 

--- a/tests/test_litellm/llms/openai/embedding/test_openai_embedding_encoding_format.py
+++ b/tests/test_litellm/llms/openai/embedding/test_openai_embedding_encoding_format.py
@@ -1,0 +1,109 @@
+"""
+Test that the generic OpenAI embedding handler filters None/empty values
+from optional_params before constructing the request payload.
+
+This mirrors the filtering already present in the openai_like handler
+(litellm/llms/openai_like/embedding/handler.py L108-110) and prevents
+sending encoding_format=null to strict OpenAI-compatible servers
+(llama.cpp, vLLM, TEI) that reject null JSON values.
+
+Refs:
+  - https://docs.litellm.ai/blog/vllm-embeddings-incident
+  - https://github.com/BerriAI/litellm/issues/19174
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.llms.openai.openai import OpenAIChatCompletion
+
+
+def _make_handler_and_call(optional_params: dict) -> dict:
+    """
+    Helper: call OpenAIChatCompletion.embedding() with the given optional_params,
+    intercepting the `data` dict before it reaches the OpenAI SDK.
+
+    Returns the `data` dict that would have been sent.
+    """
+    handler = OpenAIChatCompletion()
+
+    captured_data = {}
+
+    def fake_make_sync(openai_client, data, timeout, logging_obj):
+        captured_data.update(data)
+        # Return a mock that looks like an EmbeddingResponse
+        mock_resp = MagicMock()
+        mock_resp.model_dump.return_value = {
+            "object": "list",
+            "data": [{"object": "embedding", "embedding": [0.1, 0.2], "index": 0}],
+            "model": "test-model",
+            "usage": {"prompt_tokens": 3, "total_tokens": 3},
+        }
+        return {}, mock_resp
+
+    mock_logging = MagicMock()
+
+    with patch.object(handler, "make_sync_openai_embedding_request", side_effect=fake_make_sync):
+        with patch.object(handler, "_get_openai_client", return_value=MagicMock()):
+            handler.embedding(
+                model="test-model",
+                input=["test input"],
+                timeout=60.0,
+                logging_obj=mock_logging,
+                model_response=MagicMock(),
+                optional_params=optional_params,
+                api_key="test-key",
+                api_base="http://localhost:8099",
+            )
+
+    return captured_data
+
+
+class TestOpenAIEmbeddingEncodingFormatFiltering:
+    """Verify that None/empty optional_params are filtered in the openai handler."""
+
+    def test_encoding_format_none_filtered_out(self):
+        """encoding_format=None must NOT appear in the request payload."""
+        data = _make_handler_and_call({"encoding_format": None})
+        assert "encoding_format" not in data, (
+            "encoding_format=None should be filtered out"
+        )
+        assert data["model"] == "test-model"
+        assert data["input"] == ["test input"]
+
+    def test_encoding_format_empty_string_filtered_out(self):
+        """encoding_format='' must NOT appear in the request payload."""
+        data = _make_handler_and_call({"encoding_format": ""})
+        assert "encoding_format" not in data, (
+            "encoding_format='' should be filtered out"
+        )
+
+    def test_encoding_format_float_preserved(self):
+        """encoding_format='float' must be preserved in the request payload."""
+        data = _make_handler_and_call({"encoding_format": "float"})
+        assert data["encoding_format"] == "float"
+
+    def test_encoding_format_base64_preserved(self):
+        """encoding_format='base64' must be preserved in the request payload."""
+        data = _make_handler_and_call({"encoding_format": "base64"})
+        assert data["encoding_format"] == "base64"
+
+    def test_other_optional_params_preserved(self):
+        """Other params (dimensions, user) must survive when encoding_format=None is dropped."""
+        data = _make_handler_and_call({
+            "encoding_format": None,
+            "dimensions": 4096,
+            "user": "test-user",
+        })
+        assert "encoding_format" not in data
+        assert data["dimensions"] == 4096
+        assert data["user"] == "test-user"
+        assert data["model"] == "test-model"
+
+    def test_no_optional_params(self):
+        """Empty optional_params should work without errors."""
+        data = _make_handler_and_call({})
+        assert data["model"] == "test-model"
+        assert data["input"] == ["test input"]
+        assert "encoding_format" not in data

--- a/tests/test_litellm/llms/openai/embedding/test_openai_embedding_encoding_format.py
+++ b/tests/test_litellm/llms/openai/embedding/test_openai_embedding_encoding_format.py
@@ -45,16 +45,17 @@ def _make_handler_and_call(optional_params: dict) -> dict:
 
     with patch.object(handler, "make_sync_openai_embedding_request", side_effect=fake_make_sync):
         with patch.object(handler, "_get_openai_client", return_value=MagicMock()):
-            handler.embedding(
-                model="test-model",
-                input=["test input"],
-                timeout=60.0,
-                logging_obj=mock_logging,
-                model_response=MagicMock(),
-                optional_params=optional_params,
-                api_key="test-key",
-                api_base="http://localhost:8099",
-            )
+            with patch("litellm.llms.openai.openai.convert_to_model_response_object", return_value=MagicMock()):
+                handler.embedding(
+                    model="test-model",
+                    input=["test input"],
+                    timeout=60.0,
+                    logging_obj=mock_logging,
+                    model_response=MagicMock(),
+                    optional_params=optional_params,
+                    api_key="test-key",
+                    api_base="http://localhost:8099",
+                )
 
     return captured_data
 


### PR DESCRIPTION
## Summary

Filter out `None` and empty string values from `optional_params` in the generic OpenAI embedding handler before constructing the request, preventing `encoding_format: null` from being sent to custom endpoints.

## Problem

When using `litellm.embedding()` with the `openai` provider and a custom `api_base` pointing to a local embedding server (llama.cpp, vLLM, TEI, etc.), the request includes `encoding_format: null` in the JSON body. Strict JSON parsers reject this:

```
[json.exception.type_error.302] type must be string, but is null
```

This was already fixed for the `openai_like` handler (L108-110 in `litellm/llms/openai_like/embedding/handler.py`) after the [vLLM embeddings incident](https://docs.litellm.ai/blog/vllm-embeddings-incident), but the same filter was not applied to the generic `openai` handler in `litellm/llms/openai/openai.py`.

Users hitting this issue use the `openai` provider with `api_base` to point to local servers — a common pattern for llama.cpp, TEI, LocalAI, etc.

## Fix

Apply the exact same filtering pattern from `openai_like` handler to the generic `openai` handler:

```python
# Before (L1327):
data = {"model": model, "input": input, **optional_params}

# After:
filtered_optional_params = {
    k: v for k, v in optional_params.items() if v not in (None, "")
}
data = {"model": model, "input": input, **filtered_optional_params}
```

## Impact

- **No behavioral change** for standard OpenAI API calls (they don't send None values)
- **Fixes** all custom `api_base` endpoints that reject null JSON values
- **Consistent** with the `openai_like` handler's existing approach

## Refs

- vLLM incident report: https://docs.litellm.ai/blog/vllm-embeddings-incident
- Related issue: https://github.com/BerriAI/litellm/issues/19174
- openai_like fix (reference): `litellm/llms/openai_like/embedding/handler.py` L108-110