### PR TITLE
fix: [Bug]: reasoning_content not parsed from raw <think> tags for nvidia_nim/minimax-m2.5 via LiteLLM Proxy

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1206,9 +1206,9 @@ def _extract_reasoning_content(message: dict) -> Tuple[Optional[str], Optional[s
         tuple[Optional[str], Optional[str]]: A tuple of (reasoning_content, content)
     """
     message_content = message.get("content")
-    if "reasoning_content" in message:
+    if "reasoning_content" in message and message["reasoning_content"] is not None:
         return message["reasoning_content"], message_content
-    elif "reasoning" in message:
+    elif "reasoning" in message and message["reasoning"] is not None:
         return message["reasoning"], message_content
     elif isinstance(message_content, str):
         return _parse_content_for_reasoning(message_content)

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -108,6 +108,7 @@ class CustomStreamWrapper:
         self.sent_first_thinking_block = False
         self.sent_last_thinking_block = False
         self.thinking_content = ""
+        self._in_think_content_block: bool = False
 
         self.system_fingerprint: Optional[str] = None
         self.received_finish_reason: Optional[str] = None
@@ -994,6 +995,9 @@ class CustomStreamWrapper:
                 self._optional_combine_thinking_block_in_choices(
                     model_response=model_response
                 )
+                self._maybe_extract_think_tags_from_streaming_content(
+                    model_response=model_response
+                )
 
                 return model_response
             else:
@@ -1092,6 +1096,67 @@ class CustomStreamWrapper:
             if hasattr(model_response.choices[0].delta, "reasoning_content"):
                 del model_response.choices[0].delta.reasoning_content
         return
+
+    def _maybe_extract_think_tags_from_streaming_content(
+        self, model_response: ModelResponseStream
+    ) -> None:
+        """
+        For providers that embed <think>...</think> tags directly in streaming
+        content (e.g. nvidia_nim with minimax reasoning models), extract the
+        thinking content from delta.content and set delta.reasoning_content.
+
+        This is the streaming counterpart to _parse_content_for_reasoning used
+        for non-streaming responses.
+
+        Only runs when:
+        - merge_reasoning_content_in_choices is False (the default), and
+        - reasoning_content is not already set by the provider on the delta.
+        """
+        if self.merge_reasoning_content_in_choices:
+            return
+
+        choice = model_response.choices[0]
+        if not isinstance(choice, StreamingChoices):
+            return
+
+        delta = choice.delta
+        if getattr(delta, "reasoning_content", None) is not None:
+            return
+
+        content = delta.content
+
+        if not self._in_think_content_block:
+            if not content or "<think>" not in content:
+                return
+
+            idx = content.index("<think>")
+            pre_think = content[:idx]
+            after_start = content[idx + len("<think>") :]
+
+            if "</think>" in after_start:
+                end_idx = after_start.index("</think>")
+                think_text = after_start[:end_idx]
+                post_think = after_start[end_idx + len("</think>") :]
+                if think_text:
+                    delta.reasoning_content = think_text
+                delta.content = (pre_think + post_think) or None
+            else:
+                self._in_think_content_block = True
+                if after_start:
+                    delta.reasoning_content = after_start
+                delta.content = pre_think or None
+        else:
+            if content and "</think>" in content:
+                end_idx = content.index("</think>")
+                think_text = content[:end_idx]
+                post_think = content[end_idx + len("</think>") :]
+                self._in_think_content_block = False
+                if think_text:
+                    delta.reasoning_content = think_text
+                delta.content = post_think or None
+            elif content:
+                delta.reasoning_content = content
+                delta.content = None
 
     def chunk_creator(self, chunk: Any):  # type: ignore  # noqa: PLR0915
         if hasattr(chunk, "id"):

--- a/tests/llm_translation/test_nvidia_nim.py
+++ b/tests/llm_translation/test_nvidia_nim.py
@@ -247,6 +247,240 @@ async def test_nvidia_nim_rerank_ranking_endpoint():
         assert request_data["model"] == "nvidia/llama-3.2-nv-rerankqa-1b-v2"
 
 
+def test_nvidia_nim_non_streaming_think_tags_parsed_when_reasoning_content_null():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/24253
+
+    When nvidia_nim (e.g. minimax-m1) returns a response where:
+      - content contains raw <think>...</think> tags, AND
+      - reasoning_content is explicitly null in the message dict
+
+    _extract_reasoning_content must still parse the tags out of content and
+    populate reasoning_content, rather than returning (None, content_with_tags).
+    """
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _extract_reasoning_content,
+    )
+
+    # Simulates what model_dump() produces when the API returns reasoning_content: null
+    message = {
+        "role": "assistant",
+        "content": "<think>The user sent ping</think>\n\npong",
+        "reasoning_content": None,
+    }
+    reasoning_content, content = _extract_reasoning_content(message)
+
+    assert reasoning_content == "The user sent ping"
+    assert content == "\n\npong"
+
+
+def test_nvidia_nim_non_streaming_think_tags_parsed_without_reasoning_content_field():
+    """
+    When the API response does not include a reasoning_content field at all,
+    _extract_reasoning_content should still parse <think> tags from content.
+    """
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _extract_reasoning_content,
+    )
+
+    message = {
+        "role": "assistant",
+        "content": "<think>internal reasoning here</think>final answer",
+    }
+    reasoning_content, content = _extract_reasoning_content(message)
+
+    assert reasoning_content == "internal reasoning here"
+    assert content == "final answer"
+
+
+def test_nvidia_nim_non_streaming_explicit_reasoning_content_not_overwritten():
+    """
+    When reasoning_content is already populated by the provider (non-null),
+    it should take precedence over any <think> tags that might appear in content.
+    """
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _extract_reasoning_content,
+    )
+
+    message = {
+        "role": "assistant",
+        "content": "final answer",
+        "reasoning_content": "provider supplied reasoning",
+    }
+    reasoning_content, content = _extract_reasoning_content(message)
+
+    assert reasoning_content == "provider supplied reasoning"
+    assert content == "final answer"
+
+
+def test_nvidia_nim_streaming_think_tags_extracted_single_chunk():
+    """
+    When a streaming chunk contains a complete <think>...</think> block inside
+    delta.content, the block should be moved to delta.reasoning_content and
+    stripped from delta.content.
+    """
+    from unittest.mock import MagicMock
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="nvidia_nim/minimax/minimax-m1",
+        logging_obj=MagicMock(),
+        custom_llm_provider="nvidia_nim",
+    )
+
+    model_response = ModelResponseStream(
+        id="test-id",
+        object="chat.completion.chunk",
+        created=1234567890,
+        model="nvidia_nim/minimax/minimax-m1",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="<think>thinking step</think>pong"),
+            )
+        ],
+    )
+
+    wrapper._maybe_extract_think_tags_from_streaming_content(model_response)
+
+    assert model_response.choices[0].delta.reasoning_content == "thinking step"
+    assert model_response.choices[0].delta.content == "pong"
+
+
+def test_nvidia_nim_streaming_think_tags_extracted_across_chunks():
+    """
+    When <think> and </think> span multiple streaming chunks, the state is
+    tracked across calls and reasoning_content is populated correctly.
+    """
+    from unittest.mock import MagicMock
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="nvidia_nim/minimax/minimax-m1",
+        logging_obj=MagicMock(),
+        custom_llm_provider="nvidia_nim",
+    )
+
+    def make_chunk(content):
+        return ModelResponseStream(
+            id="test-id",
+            object="chat.completion.chunk",
+            created=1234567890,
+            model="nvidia_nim/minimax/minimax-m1",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(content=content),
+                )
+            ],
+        )
+
+    chunk1 = make_chunk("<think>")
+    chunk2 = make_chunk("step one")
+    chunk3 = make_chunk("</think>")
+    chunk4 = make_chunk("pong")
+
+    wrapper._maybe_extract_think_tags_from_streaming_content(chunk1)
+    wrapper._maybe_extract_think_tags_from_streaming_content(chunk2)
+    wrapper._maybe_extract_think_tags_from_streaming_content(chunk3)
+    wrapper._maybe_extract_think_tags_from_streaming_content(chunk4)
+
+    # chunk1: <think> with no text → no reasoning_content, content cleared
+    assert getattr(chunk1.choices[0].delta, "reasoning_content", None) is None
+    assert chunk1.choices[0].delta.content is None
+
+    # chunk2: inside think block → becomes reasoning_content
+    assert chunk2.choices[0].delta.reasoning_content == "step one"
+    assert chunk2.choices[0].delta.content is None
+
+    # chunk3: </think> with no remaining text → closes block
+    assert getattr(chunk3.choices[0].delta, "reasoning_content", None) is None
+    assert chunk3.choices[0].delta.content is None
+
+    # chunk4: after think block → regular content
+    assert getattr(chunk4.choices[0].delta, "reasoning_content", None) is None
+    assert chunk4.choices[0].delta.content == "pong"
+
+
+def test_nvidia_nim_streaming_no_think_tags_unaffected():
+    """
+    Regular streaming chunks without <think> tags must not be modified.
+    """
+    from unittest.mock import MagicMock
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="nvidia_nim/minimax/minimax-m1",
+        logging_obj=MagicMock(),
+        custom_llm_provider="nvidia_nim",
+    )
+
+    model_response = ModelResponseStream(
+        id="test-id",
+        object="chat.completion.chunk",
+        created=1234567890,
+        model="nvidia_nim/minimax/minimax-m1",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="Hello, world!"),
+            )
+        ],
+    )
+
+    wrapper._maybe_extract_think_tags_from_streaming_content(model_response)
+
+    assert getattr(model_response.choices[0].delta, "reasoning_content", None) is None
+    assert model_response.choices[0].delta.content == "Hello, world!"
+
+
+def test_nvidia_nim_streaming_skipped_when_merge_reasoning_content_in_choices():
+    """
+    When merge_reasoning_content_in_choices=True, think-tag extraction must be
+    skipped (the merge path owns the think-tag lifecycle).
+    """
+    from unittest.mock import MagicMock
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="nvidia_nim/minimax/minimax-m1",
+        logging_obj=MagicMock(),
+        custom_llm_provider="nvidia_nim",
+    )
+    wrapper.merge_reasoning_content_in_choices = True
+
+    model_response = ModelResponseStream(
+        id="test-id",
+        object="chat.completion.chunk",
+        created=1234567890,
+        model="nvidia_nim/minimax/minimax-m1",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="<think>thinking</think>answer"),
+            )
+        ],
+    )
+
+    wrapper._maybe_extract_think_tags_from_streaming_content(model_response)
+
+    # Content must be untouched when merge path is active
+    assert getattr(model_response.choices[0].delta, "reasoning_content", None) is None
+    assert model_response.choices[0].delta.content == "<think>thinking</think>answer"
+
+
 class TestNvidiaNim(BaseLLMRerankTest):
     def get_custom_llm_provider(self) -> litellm.LlmProviders:
         return litellm.LlmProviders.NVIDIA_NIM


### PR DESCRIPTION
## Summary
Fixes #24253

## Changes
<!-- Edit this description as needed -->

## Test plan
- [x] Unit tests added
- [x] `make test-unit` passes
- [x] `make lint` passes