### PR TITLE
chore(deps): add pyroscope-io to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ async_generator==1.10.0 # for async ollama calls
 langfuse==2.59.7 # for langfuse self-hosted logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
 ddtrace==2.19.0      # for advanced DD tracing / profiling
+pyroscope-io==0.8.16 ; sys_platform != "win32" # for Grafana Pyroscope profiling
 orjson==3.11.7 # fast /embedding responses
 polars==1.31.0 # for data processing
 apscheduler==3.10.4 # for resetting budget in background


### PR DESCRIPTION
## Relevant issues
## Pre-Submission checklist
  Please complete all items before asking a LiteLLM maintainer to review your PR

  - [ ] I have Added testing in the tests/test_litellm/ (https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, Adding at least 1 test is a hard requirement - see details
    (https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] My PR passes all unit tests on make test-unit (https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting @greptileai and received a Confidence Score of at least 4/5 before requesting a maintainer review

  ## Delays in PR merge?

  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review) (https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

  ## Type

  🐛 Bug Fix

  ## Changes

  - Added pyroscope-io==0.8.16 ; sys_platform != "win32" to requirements.txt.
  - Kept dependency behavior consistent with pyproject.toml, where pyroscope-io is already included in litellm[proxy] extras.
  - Fixes missing install dependency for environments that install LiteLLM proxy via requirements.txt and use LITELLM_ENABLE_PYROSCOPE=true.