### PR TITLE
fix(ui): swap J/K keyboard navigation in log details drawer (#24279)

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts
@@ -15,8 +15,8 @@ interface UseKeyboardNavigationProps {
  * Handles J/K for next/previous and Escape for close.
  *
  * Keyboard shortcuts:
- * - J: Navigate to previous log (up)
- * - K: Navigate to next log (down)
+ * - J: Navigate to next log (down)
+ * - K: Navigate to previous log (up)
  * - Escape: Close drawer
  */
 export function useKeyboardNavigation({
@@ -41,11 +41,11 @@ export function useKeyboardNavigation({
           break;
         case KEY_J_LOWER:
         case KEY_J_UPPER:
-          selectPreviousLog();
+          selectNextLog();
           break;
         case KEY_K_LOWER:
         case KEY_K_UPPER:
-          selectNextLog();
+          selectPreviousLog();
           break;
       }
     };


### PR DESCRIPTION
Fixes #24279

J should navigate down (next) and K should navigate up (previous),
matching vim/standard conventions. They were inverted.

Only 1 file changed: `useKeyboardNavigation.ts` (4 lines swapped).

- [x] **Sign the Contributor License Agreement (CLA)**
- [x] **Keep scope isolated**