### PR TITLE
fix: map 'refusal' finish_reason to 'content_filter' (#24141)

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -98,6 +98,8 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "content_filter": "content_filter",
     # Anthropic Sonnet 4
     "content_filtered": "content_filter",
+    # Azure AI Foundry content filtering
+    "refusal": "content_filter",
 }
 
 

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -123,6 +123,12 @@ class TestMapFinishReasonBedrock:
         assert map_finish_reason("guardrail_intervened") == "content_filter"
 
 
+class TestMapFinishReasonAzureAIFoundry:
+    def test_refusal(self):
+        # GH#24141: Azure AI Foundry returns 'refusal' for content filtering
+        assert map_finish_reason("refusal") == "content_filter"
+
+
 class TestMapFinishReasonOpenAIPassthrough:
     @pytest.mark.parametrize(
         "reason", ["stop", "length", "tool_calls", "function_call", "content_filter"]


### PR DESCRIPTION
Fixes #24141

## Problem

Azure AI Foundry returns `finish_reason='refusal'` when content
filtering rejects a response (e.g. Claude Sonnet 4.6). This was
unmapped in `_FINISH_REASON_MAP`, defaulting to `'stop'` and
hiding the content filter rejection.

## Fix

Add `'refusal': 'content_filter'` to the mapping (1 line in
`core_helpers.py`).

## Test

Added `TestMapFinishReasonAzureAIFoundry::test_refusal`.

- [x] **Sign the Contributor License Agreement (CLA)**
- [x] **Keep scope isolated**
- [x] **Add testing**