### PR TITLE
docs: add git-subdir source type to claude-code plugin marketplace docs

### DIFF
--- a/docs/my-website/docs/tutorials/claude_code_plugin_marketplace.md
+++ b/docs/my-website/docs/tutorials/claude_code_plugin_marketplace.md
@@ -37,7 +37,7 @@ Click **+ Add New Plugin** to register a plugin in your marketplace.
 Enter the plugin information:
 
 - **Name**: Plugin identifier (kebab-case, e.g., `my-plugin`)
-- **Source Type**: Choose GitHub or URL
+- **Source Type**: Choose GitHub, Git URL, or Git Subdir
 - **Repository/URL**: The git source (e.g., `org/repo` for GitHub)
 - **Version**: Semantic version (optional)
 - **Description**: What the plugin does
@@ -215,6 +215,22 @@ curl -X DELETE http://localhost:4000/claude-code/plugins/my-plugin \
 ```
 
 Use this format for GitLab, Bitbucket, or self-hosted git repositories.
+
+</TabItem>
+<TabItem value="git-subdir" label="Git Subdir">
+
+```json
+{
+  "name": "my-plugin",
+  "source": {
+    "source": "git-subdir",
+    "url": "https://github.com/org/repo.git",
+    "path": "plugins/my-plugin"
+  }
+}
+```
+
+Use this format when your plugin lives in a subdirectory of a git repository. The `path` field must be a relative path of slash-separated segments (alphanumeric, dots, hyphens, underscores only).
 
 </TabItem>
 </Tabs>

--- a/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
+++ b/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
@@ -157,7 +157,7 @@ async def register_plugin(
 
     Parameters:
         - name: Plugin name (kebab-case)
-        - source: Git source reference (github or url format)
+        - source: Git source reference (github, url, or git-subdir format)
         - version: Semantic version (optional)
         - description: Plugin description (optional)
         - author: Author information (optional)


### PR DESCRIPTION
## Summary

Documentation update for the `git-subdir` plugin source type added in #24223. Closes part of #24228.

## Changes

- **`docs/my-website/docs/tutorials/claude_code_plugin_marketplace.md`**: added a "Git Subdir" tab to the _Plugin Source Formats_ section showing the `git-subdir` payload format and `path` field constraints; updated the Source Type field description in the admin guide
- **`litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py`**: updated the endpoint docstring (shown in Swagger UI) from `"github or url format"` to `"github, url, or git-subdir format"`

## Type

📝 Documentation
