### PR TITLE
fix(presidio): PII token round-trip masking/unmasking

### DIFF
--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -260,7 +260,10 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        local_request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
+        local_request_data: dict = {
+            **(request_data or {}),
+            "responses_so_far": responses_so_far,
+        }
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
             local_request_data["litellm_metadata"] = user_metadata

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -111,6 +111,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process A2A output response by applying guardrails to text content.
@@ -166,19 +167,19 @@ class A2AGuardrailHandler(BaseTranslation):
             return response
 
         # Step 2: Apply guardrail to all texts in batch
-        # Create a request_data dict with response info and user API key metadata
-        request_data: dict = {"response": response_dict}
+        # Create a local_request_data dict with response info and user API key metadata
+        local_request_data: dict = {**(request_data or {}), "response": response_dict}
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            local_request_data["litellm_metadata"] = user_metadata
 
         inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
 
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=local_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )
@@ -213,6 +214,7 @@ class A2AGuardrailHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process A2A streaming output by applying guardrails to accumulated text.
@@ -258,15 +260,15 @@ class A2AGuardrailHandler(BaseTranslation):
         if not combined_text:
             return responses_so_far
 
-        request_data: dict = {"responses_so_far": responses_so_far}
+        local_request_data: dict = {**(request_data or {}), "responses_so_far": responses_so_far}
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            local_request_data["litellm_metadata"] = user_metadata
 
         inputs = GenericGuardrailAPIInputs(texts=[combined_text])
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=local_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -87,9 +87,9 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
-        tools_to_check: List[
-            ChatCompletionToolParam
-        ] = chat_completion_compatible_request.get("tools", [])
+        tools_to_check: List[ChatCompletionToolParam] = (
+            chat_completion_compatible_request.get("tools", [])
+        )
         task_mappings: List[Tuple[int, Optional[int]]] = []
         # Track (message_index, content_index) for each text
         # content_index is None for string content, int for list content

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -252,6 +252,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -323,15 +324,15 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -349,7 +350,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -375,6 +376,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process output streaming response by applying guardrails to text content.
@@ -413,7 +415,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
                 _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
                     inputs=guardrail_inputs,
-                    request_data={},
+                    request_data=request_data or {},
                     input_type="response",
                     logging_obj=litellm_logging_obj,
                 )
@@ -426,7 +428,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
         _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
             inputs={"texts": [string_so_far]},
-            request_data={},
+            request_data=request_data or {},
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -73,6 +73,7 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response with guardrails.
@@ -82,6 +83,7 @@ class BaseTranslation(ABC):
             guardrail_to_apply: The guardrail instance to apply
             litellm_logging_obj: Optional logging object
             user_api_key_dict: User API key metadata (passed separately since response doesn't contain it)
+            request_data: Optional original request data dict from the proxy
         """
         pass
 
@@ -91,11 +93,15 @@ class BaseTranslation(ABC):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional["UserAPIKeyAuth"] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output streaming response with guardrails.
 
         Optional to override in subclasses.
+
+        Args:
+            request_data: Optional original request data dict from the proxy
         """
         return responses_so_far
 

--- a/litellm/llms/cohere/rerank/guardrail_translation/handler.py
+++ b/litellm/llms/cohere/rerank/guardrail_translation/handler.py
@@ -83,6 +83,7 @@ class CohereRerankHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - not applicable for rerank.

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -91,6 +91,7 @@ class OCRHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process OCR output by applying guardrails to extracted page text.
@@ -134,7 +135,7 @@ class OCRHandler(BaseTranslation):
 
         guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data={},
+            request_data=request_data or {},
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -260,6 +260,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content.
@@ -308,15 +309,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts and tool calls in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -329,7 +330,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -364,6 +365,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List["ModelResponseStream"]:
         """
         Process output streaming responses by applying guardrails to text content.
@@ -402,6 +404,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 guardrail_to_apply=guardrail_to_apply,
                 litellm_logging_obj=litellm_logging_obj,
                 user_api_key_dict=user_api_key_dict,
+                request_data=request_data,
             )
 
             return responses_so_far
@@ -436,15 +439,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"responses": responses_so_far}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "responses": responses_so_far}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -458,7 +461,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 inputs["model"] = responses_so_far[0].model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs[
-                    "structured_messages"
-                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
+                inputs["structured_messages"] = (
+                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
+                )
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:
@@ -440,7 +440,10 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         # Step 3: Apply guardrail to all combined texts in batch
         if texts_to_check:
             # Create a local_request_data dict with response info and user API key metadata
-            local_request_data: dict = {**(request_data or {}), "responses": responses_so_far}
+            local_request_data: dict = {
+                **(request_data or {}),
+                "responses": responses_so_far,
+            }
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(

--- a/litellm/llms/openai/completion/guardrail_translation/handler.py
+++ b/litellm/llms/openai/completion/guardrail_translation/handler.py
@@ -125,6 +125,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to completion text.
@@ -155,15 +156,15 @@ class OpenAITextCompletionHandler(BaseTranslation):
 
         # Apply guardrails in batch
         if texts_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             # Include model information from the response if available
@@ -171,7 +172,7 @@ class OpenAITextCompletionHandler(BaseTranslation):
                 inputs["model"] = response.model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -155,6 +155,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - embeddings responses contain vectors, not text.

--- a/litellm/llms/openai/image_generation/guardrail_translation/handler.py
+++ b/litellm/llms/openai/image_generation/guardrail_translation/handler.py
@@ -87,6 +87,7 @@ class OpenAIImageGenerationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response - typically not needed for image generation.

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -347,6 +347,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to text content and tool calls.
@@ -402,15 +403,15 @@ class OpenAIResponsesHandler(BaseTranslation):
 
         # Step 2: Apply guardrail to all texts in batch
         if texts_to_check or tool_calls_to_check:
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
@@ -428,7 +429,7 @@ class OpenAIResponsesHandler(BaseTranslation):
 
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )
@@ -454,6 +455,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> List[Any]:
         """
         Process output streaming response by applying guardrails to text content.
@@ -481,7 +483,7 @@ class OpenAIResponsesHandler(BaseTranslation):
                     inputs["model"] = model_response_stream.model
                 _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                     inputs=inputs,
-                    request_data={},
+                    request_data=request_data or {},
                     input_type="response",
                     logging_obj=litellm_logging_obj,
                 )

--- a/litellm/llms/openai/speech/guardrail_translation/handler.py
+++ b/litellm/llms/openai/speech/guardrail_translation/handler.py
@@ -85,6 +85,7 @@ class OpenAITextToSpeechHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output - not applicable for text-to-speech.

--- a/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
+++ b/litellm/llms/openai/transcriptions/guardrail_translation/handler.py
@@ -58,6 +58,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output transcription by applying guardrails to transcribed text.
@@ -79,15 +80,15 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
 
         if isinstance(response.text, str):
             original_text = response.text
-            # Create a request_data dict with response info and user API key metadata
-            request_data: dict = {"response": response}
+            # Create a local_request_data dict with response info and user API key metadata
+            local_request_data: dict = {**(request_data or {}), "response": response}
 
             # Add user API key metadata with prefixed keys
             user_metadata = self.transform_user_api_key_dict_to_metadata(
                 user_api_key_dict
             )
             if user_metadata:
-                request_data["litellm_metadata"] = user_metadata
+                local_request_data["litellm_metadata"] = user_metadata
 
             inputs = GenericGuardrailAPIInputs(texts=[original_text])
             # Include model information from the response if available
@@ -95,7 +96,7 @@ class OpenAIAudioTranscriptionHandler(BaseTranslation):
                 inputs["model"] = response.model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
-                request_data=request_data,
+                request_data=local_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -172,10 +172,11 @@ class PassThroughEndpointHandler(BaseTranslation):
         if not text_to_check:
             return response
 
-        # Create a local_request_data dict with response info and user API key metadata
+        # Merge caller's request_data (e.g. pii_tokens) with response info.
+        # Always nest response under "response" key to avoid key collisions.
         local_request_data: dict = {
             **(request_data or {}),
-            **({"response": response} if not isinstance(response, dict) else response),
+            "response": response,
         }
 
         # Add user API key metadata with prefixed keys

--- a/litellm/llms/pass_through/guardrail_translation/handler.py
+++ b/litellm/llms/pass_through/guardrail_translation/handler.py
@@ -139,6 +139,7 @@ class PassThroughEndpointHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional["LiteLLMLoggingObj"] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         """
         Process output response by applying guardrails to targeted fields.
@@ -171,17 +172,16 @@ class PassThroughEndpointHandler(BaseTranslation):
         if not text_to_check:
             return response
 
-        # Create a request_data dict with response info and user API key metadata
-        request_data: dict = (
-            {"response": response}
-            if not isinstance(response, dict)
-            else response.copy()
-        )
+        # Create a local_request_data dict with response info and user API key metadata
+        local_request_data: dict = {
+            **(request_data or {}),
+            **({"response": response} if not isinstance(response, dict) else response),
+        }
 
         # Add user API key metadata with prefixed keys
         user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
         if user_metadata:
-            request_data["litellm_metadata"] = user_metadata
+            local_request_data["litellm_metadata"] = user_metadata
 
         # Apply guardrail (pass-through doesn't modify the text, just checks it)
         inputs = GenericGuardrailAPIInputs(texts=[text_to_check])
@@ -191,7 +191,7 @@ class PassThroughEndpointHandler(BaseTranslation):
             inputs["model"] = response_model
         _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
             inputs=inputs,
-            request_data=request_data,
+            request_data=local_request_data,
             input_type="response",
             logging_obj=litellm_logging_obj,
         )

--- a/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
+++ b/litellm/proxy/_experimental/mcp_server/guardrail_translation/handler.py
@@ -92,6 +92,7 @@ class MCPGuardrailTranslationHandler(BaseTranslation):
         guardrail_to_apply: "CustomGuardrail",
         litellm_logging_obj: Optional[Any] = None,
         user_api_key_dict: Optional[Any] = None,
+        request_data: Optional[dict] = None,
     ) -> Any:
         verbose_proxy_logger.debug(
             "MCP Guardrail: Output processing not implemented for MCP tools",

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -441,6 +441,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         analyze_results: Any,
         output_parse_pii: bool,
         masked_entity_count: Dict[str, int],
+        request_data: Optional[Dict] = None,
     ) -> str:
         """
         Send analysis results to the Presidio anonymizer endpoint to get redacted text
@@ -489,11 +490,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             if redacted_text is not None:
                 verbose_proxy_logger.debug("redacted_text: %s", redacted_text)
                 new_text = redacted_text["text"]
-                # Sort analyze_results right-to-left (Presidio processes entities
-                # right-to-left, so redacted_text["items"] is also right-to-left).
-                # We match by entity_type to get the original text positions from
-                # the Analyzer response, not the Anonymizer response (which returns
-                # positions in the *anonymized* text's coordinate space).
+                # Both lists sorted right-to-left by start position. Presidio
+                # preserves positional order in both analyzer and anonymizer
+                # responses, so consuming _sorted_ar in order correctly pairs
+                # each item with its analyze_results entry.
                 def _ar_val(ar, key, default=None):
                     return ar.get(key, default) if isinstance(ar, dict) else getattr(ar, key, default)
                 _sorted_ar = sorted(
@@ -538,7 +538,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                                     _orig_val = text[_s:_e]
                                 _ar_used.add(_ar_i)
                                 break
-                        self.pii_tokens[replacement] = _orig_val if _orig_val is not None else new_text[start:end]
+                        _token_value = _orig_val if _orig_val is not None else new_text[start:end]
+                        # Store in request_data for per-request thread safety
+                        if request_data is not None:
+                            if "pii_tokens" not in request_data:
+                                request_data["pii_tokens"] = {}
+                            request_data["pii_tokens"][replacement] = _token_value
+                        # Also store on instance as fallback
+                        self.pii_tokens[replacement] = _token_value
 
                     new_text = new_text[:start] + replacement + new_text[end:]
                     entity_type = item.get("entity_type", None)
@@ -683,6 +690,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     analyze_results=analyze_results,
                     output_parse_pii=output_parse_pii,
                     masked_entity_count=masked_entity_count,
+                    request_data=request_data,
                 )
                 return anonymized_text
             return redacted_text["text"]
@@ -934,14 +942,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         if isinstance(response, ModelResponse) and not isinstance(
             response.choices[0], StreamingChoices
-        ):  # /chat/completions requests
-            if isinstance(response.choices[0].message.content, str):
-                verbose_proxy_logger.debug(
-                    f"pii_tokens for unmask: {_pii_tokens}; initial response: {response.choices[0].message.content}"
-                )
-                response.choices[0].message.content = self._unmask_pii_text(
-                    response.choices[0].message.content, _pii_tokens
-                )
+        ):  # /chat/completions requests — handles all choices, list content, tool calls
+            await self._process_response_for_pii(
+                response=response,
+                request_data=data,
+                mode="unmask",
+            )
         elif (
             isinstance(response, dict)
             and response.get("type") == "message"
@@ -970,10 +976,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 continue
 
             # FALLBACK 1: LLM stripped angle brackets (e.g. <PERSON_abc> -> PERSON_abc)
+            # Use word-boundary anchoring to avoid false positives in technical text
             stripped = token.strip("<>")
-            if stripped and stripped in text:
-                text = text.replace(stripped, original_text)
-                continue
+            if stripped:
+                import re
+                _fb_pattern = r'(?<!\w)' + re.escape(stripped) + r'(?!\w)'
+                if re.search(_fb_pattern, text):
+                    text = re.sub(_fb_pattern, original_text, text)
+                    continue
 
             # FALLBACK 2: Handle truncated tokens (token cut off by max_tokens)
             # Only check at the very end of the text.
@@ -1479,6 +1489,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # When the unified guardrail calls apply_guardrail(input_type="response"),
         # we unmask PII tokens instead of masking. The tokens were stored in
         # request_data["pii_tokens"] during input masking.
+        # Unmask path only — applies when unified guardrail calls apply_guardrail()
+        # with input_type="response". The apply_to_output masking path is handled
+        # separately by async_post_call_*_hook, not by this method.
         if input_type == "response" and self.output_parse_pii:
             pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
             if pii_tokens:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -491,12 +491,18 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             if redacted_text is not None:
                 verbose_proxy_logger.debug("redacted_text: %s", redacted_text)
                 new_text = redacted_text["text"]
+
                 # Both lists sorted right-to-left by start position. Presidio
                 # preserves positional order in both analyzer and anonymizer
                 # responses, so consuming _sorted_ar in order correctly pairs
                 # each item with its analyze_results entry.
                 def _ar_val(ar, key, default=None):
-                    return ar.get(key, default) if isinstance(ar, dict) else getattr(ar, key, default)
+                    return (
+                        ar.get(key, default)
+                        if isinstance(ar, dict)
+                        else getattr(ar, key, default)
+                    )
+
                 _sorted_ar = sorted(
                     analyze_results if isinstance(analyze_results, list) else [],
                     key=lambda x: -(_ar_val(x, "start") or 0),
@@ -532,14 +538,18 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         # correctly pairs each item with its analyze_results entry.
                         _orig_val = None
                         for _ar_i, _ar in enumerate(_sorted_ar):
-                            if _ar_i not in _ar_used and _ar_val(_ar, "entity_type") == item.get("entity_type"):
+                            if _ar_i not in _ar_used and _ar_val(
+                                _ar, "entity_type"
+                            ) == item.get("entity_type"):
                                 _s = _ar_val(_ar, "start")
                                 _e = _ar_val(_ar, "end")
                                 if _s is not None and _e is not None:
                                     _orig_val = text[_s:_e]
                                 _ar_used.add(_ar_i)
                                 break
-                        _token_value = _orig_val if _orig_val is not None else new_text[start:end]
+                        _token_value = (
+                            _orig_val if _orig_val is not None else new_text[start:end]
+                        )
                         # Store in request_data["metadata"]["pii_tokens"] for
                         # per-request thread safety (matches upstream convention).
                         # Do NOT write to self.pii_tokens — the guardrail instance
@@ -549,7 +559,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                                 request_data["metadata"] = {}
                             if "pii_tokens" not in request_data["metadata"]:
                                 request_data["metadata"]["pii_tokens"] = {}
-                            request_data["metadata"]["pii_tokens"][replacement] = _token_value
+                            request_data["metadata"]["pii_tokens"][
+                                replacement
+                            ] = _token_value
 
                     new_text = new_text[:start] + replacement + new_text[end:]
                     entity_type = item.get("entity_type", None)
@@ -749,9 +761,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             if messages is None:
                 return data
             tasks = []
-            task_mappings: List[
-                Tuple[int, Optional[int]]
-            ] = []  # Track (message_index, content_index) for each task
+            task_mappings: List[Tuple[int, Optional[int]]] = (
+                []
+            )  # Track (message_index, content_index) for each task
 
             for msg_idx, m in enumerate(messages):
                 content = m.get("content", None)
@@ -852,9 +864,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         ):  # /chat/completions requests
             messages: Optional[List] = kwargs.get("messages", None)
             tasks = []
-            task_mappings: List[
-                Tuple[int, Optional[int]]
-            ] = []  # Track (message_index, content_index) for each task
+            task_mappings: List[Tuple[int, Optional[int]]] = (
+                []
+            )  # Track (message_index, content_index) for each task
 
             if messages is None:
                 return kwargs, result
@@ -942,7 +954,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             return response
 
         # Prefer pii_tokens from request_data (stored by pre_call masking instance).
-        _pii_tokens = (data.get("metadata", {}).get("pii_tokens") if data else None) or self.pii_tokens
+        _pii_tokens = (
+            (data.get("metadata") or {}).get("pii_tokens") if data else None
+        ) or {}
 
         if isinstance(response, ModelResponse) and not isinstance(
             response.choices[0], StreamingChoices
@@ -959,7 +973,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         ):  # Anthropic native /v1/messages response
             for block in response.get("content") or []:
                 if isinstance(block, dict) and block.get("type") == "text":
-                    block["text"] = self._unmask_pii_text(block.get("text", ""), _pii_tokens)
+                    block["text"] = self._unmask_pii_text(
+                        block.get("text", ""), _pii_tokens
+                    )
         return response
 
     @staticmethod
@@ -983,9 +999,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # Use word-boundary anchoring to avoid false positives in technical text
             stripped = token.strip("<>")
             if stripped:
-                _fb_pattern = r'(?<!\w)' + re.escape(stripped) + r'(?!\w)'
+                _fb_pattern = r"(?<!\w)" + re.escape(stripped) + r"(?!\w)"
                 if re.search(_fb_pattern, text):
-                    text = re.sub(_fb_pattern, original_text, text)
+                    text = re.sub(_fb_pattern, lambda m: original_text, text)
                     continue
 
             # FALLBACK 2: Handle truncated tokens (token cut off by max_tokens)
@@ -1018,9 +1034,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Handles content blocks with type == "text".
         """
         pii_tokens = (
-            (request_data.get("metadata", {}).get("pii_tokens") if request_data else None)
-            or self.pii_tokens
-        )
+            (request_data.get("metadata") or {}).get("pii_tokens")
+            if request_data
+            else None
+        ) or {}
         if not pii_tokens and mode == "unmask":
             verbose_proxy_logger.debug(
                 "No pii_tokens in request_data for Anthropic response unmask"
@@ -1062,9 +1079,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Handles all choices and tool calls.
         """
         pii_tokens = (
-            (request_data.get("metadata", {}).get("pii_tokens") if request_data else None)
-            or self.pii_tokens
-        )
+            (request_data.get("metadata") or {}).get("pii_tokens")
+            if request_data
+            else None
+        ) or {}
         if not pii_tokens and mode == "unmask":
             verbose_proxy_logger.debug(
                 "No pii_tokens found in request_data — nothing to unmask"
@@ -1296,7 +1314,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             return
 
         # --- PII unmasking path (output_parse_pii=True) ---
-        pii_tokens = (request_data.get("metadata", {}).get("pii_tokens", {}) if request_data else {})
+        pii_tokens = (
+            (request_data.get("metadata") or {}).get("pii_tokens", {})
+            if request_data
+            else {}
+        )
         if not pii_tokens and request_data:
             verbose_proxy_logger.debug(
                 "No pii_tokens in request_data for streaming unmask path"
@@ -1325,9 +1347,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # across SSE events. We keep a small carry buffer (MAX_CARRY chars) to
             # catch split tokens, then flush everything else immediately.
             MAX_CARRY = 80
-            sse_buf = b""       # accumulator for incomplete SSE event bytes
-            carry_text = ""     # pending text that might be a partial PII token
-            carry_lines: Optional[list] = None   # SSE event lines for carry_text
+            sse_buf = b""  # accumulator for incomplete SSE event bytes
+            carry_text = ""  # pending text that might be a partial PII token
+            carry_lines: Optional[list] = None  # SSE event lines for carry_text
             carry_data: Optional[dict] = None
             carry_data_idx: Optional[int] = None
 
@@ -1373,7 +1395,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         if not is_text_delta:
                             # Flush any pending carry before non-text events
                             if carry_text and carry_lines is not None:
-                                unmasked_carry = self._unmask_pii_text(carry_text, pii_tokens)
+                                unmasked_carry = self._unmask_pii_text(
+                                    carry_text, pii_tokens
+                                )
                                 carry_data["delta"]["text"] = unmasked_carry
                                 carry_lines[carry_data_idx] = "data: " + _json.dumps(
                                     carry_data, ensure_ascii=False
@@ -1402,9 +1426,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                             carry_data = data
                             carry_data_idx = data_idx
 
-                        data["delta"]["text"] = flush_text
-                        lines[data_idx] = "data: " + _json.dumps(data, ensure_ascii=False)
-                        yield (("\n".join(lines)) + "\n\n").encode("utf-8")
+                        # Only yield text_delta when there's actually text to send
+                        if flush_text:
+                            data["delta"]["text"] = flush_text
+                            lines[data_idx] = "data: " + _json.dumps(
+                                data, ensure_ascii=False
+                            )
+                            yield (("\n".join(lines)) + "\n\n").encode("utf-8")
 
                 # Flush remaining carry at end of stream
                 if carry_text and carry_lines is not None:
@@ -1495,8 +1523,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # Unmask path only — applies when unified guardrail calls apply_guardrail()
         # with input_type="response". The apply_to_output masking path is handled
         # separately by async_post_call_*_hook, not by this method.
-        if input_type == "response" and self.output_parse_pii:
-            pii_tokens = (request_data.get("metadata", {}).get("pii_tokens", {}) if request_data else {})
+        if input_type == "response" and (
+            self.output_parse_pii or litellm.output_parse_pii
+        ):
+            pii_tokens = (
+                (request_data.get("metadata") or {}).get("pii_tokens", {})
+                if request_data
+                else {}
+            )
             if pii_tokens:
                 _texts = inputs.get("texts", [])
                 inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in _texts]

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -11,6 +11,7 @@
 import asyncio
 import json
 import json as _json
+import re
 import threading
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -539,13 +540,16 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                                 _ar_used.add(_ar_i)
                                 break
                         _token_value = _orig_val if _orig_val is not None else new_text[start:end]
-                        # Store in request_data for per-request thread safety
+                        # Store in request_data["metadata"]["pii_tokens"] for
+                        # per-request thread safety (matches upstream convention).
+                        # Do NOT write to self.pii_tokens — the guardrail instance
+                        # is shared across concurrent requests.
                         if request_data is not None:
-                            if "pii_tokens" not in request_data:
-                                request_data["pii_tokens"] = {}
-                            request_data["pii_tokens"][replacement] = _token_value
-                        # Also store on instance as fallback
-                        self.pii_tokens[replacement] = _token_value
+                            if "metadata" not in request_data:
+                                request_data["metadata"] = {}
+                            if "pii_tokens" not in request_data["metadata"]:
+                                request_data["metadata"]["pii_tokens"] = {}
+                            request_data["metadata"]["pii_tokens"][replacement] = _token_value
 
                     new_text = new_text[:start] + replacement + new_text[end:]
                     entity_type = item.get("entity_type", None)
@@ -938,7 +942,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             return response
 
         # Prefer pii_tokens from request_data (stored by pre_call masking instance).
-        _pii_tokens = data.get("pii_tokens") or self.pii_tokens
+        _pii_tokens = (data.get("metadata", {}).get("pii_tokens") if data else None) or self.pii_tokens
 
         if isinstance(response, ModelResponse) and not isinstance(
             response.choices[0], StreamingChoices
@@ -979,7 +983,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # Use word-boundary anchoring to avoid false positives in technical text
             stripped = token.strip("<>")
             if stripped:
-                import re
                 _fb_pattern = r'(?<!\w)' + re.escape(stripped) + r'(?!\w)'
                 if re.search(_fb_pattern, text):
                     text = re.sub(_fb_pattern, original_text, text)
@@ -1015,7 +1018,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Handles content blocks with type == "text".
         """
         pii_tokens = (
-            (request_data.get("pii_tokens") if request_data else None)
+            (request_data.get("metadata", {}).get("pii_tokens") if request_data else None)
             or self.pii_tokens
         )
         if not pii_tokens and mode == "unmask":
@@ -1059,7 +1062,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Handles all choices and tool calls.
         """
         pii_tokens = (
-            (request_data.get("pii_tokens") if request_data else None)
+            (request_data.get("metadata", {}).get("pii_tokens") if request_data else None)
             or self.pii_tokens
         )
         if not pii_tokens and mode == "unmask":
@@ -1293,12 +1296,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             return
 
         # --- PII unmasking path (output_parse_pii=True) ---
-        pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
+        pii_tokens = (request_data.get("metadata", {}).get("pii_tokens", {}) if request_data else {})
         if not pii_tokens and request_data:
             verbose_proxy_logger.debug(
                 "No pii_tokens in request_data for streaming unmask path"
             )
-        if not (self.output_parse_pii and pii_tokens):
+        if not ((self.output_parse_pii or litellm.output_parse_pii) and pii_tokens):
             async for chunk in response:
                 yield chunk
             return
@@ -1488,12 +1491,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # --- PII unmask path for output responses ---
         # When the unified guardrail calls apply_guardrail(input_type="response"),
         # we unmask PII tokens instead of masking. The tokens were stored in
-        # request_data["pii_tokens"] during input masking.
+        # request_data["metadata"]["pii_tokens"] during input masking.
         # Unmask path only — applies when unified guardrail calls apply_guardrail()
         # with input_type="response". The apply_to_output masking path is handled
         # separately by async_post_call_*_hook, not by this method.
         if input_type == "response" and self.output_parse_pii:
-            pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
+            pii_tokens = (request_data.get("metadata", {}).get("pii_tokens", {}) if request_data else {})
             if pii_tokens:
                 _texts = inputs.get("texts", [])
                 inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in _texts]
@@ -1519,12 +1522,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         # Returning them would overwrite native Anthropic tools with type:"function".
         for _k in ("tools", "structured_messages", "model", "images"):
             inputs.pop(_k, None)
-        # Store pii_tokens in request_data so post_call hooks can access them.
-        # The guardrail initializer creates TWO separate instances (one pre_call,
-        # one post_call), so self.pii_tokens on the masking instance is invisible
-        # to the unmasking instance. request_data is shared across the full call.
-        if request_data is not None and self.pii_tokens:
-            request_data["pii_tokens"] = dict(self.pii_tokens)
+        # pii_tokens are already stored in request_data["metadata"]["pii_tokens"]
+        # by anonymize_text() above — no need to copy from self.pii_tokens.
         return inputs
 
     def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -10,6 +10,7 @@
 
 import asyncio
 import json
+import json as _json
 import threading
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -36,6 +37,7 @@ from litellm.types.utils import GenericGuardrailAPIInputs
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
+from litellm._uuid import uuid
 from litellm.caching.caching import DualCache
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
 from litellm.integrations.custom_guardrail import (
@@ -439,7 +441,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         analyze_results: Any,
         output_parse_pii: bool,
         masked_entity_count: Dict[str, int],
-        request_data: Optional[Dict] = None,
     ) -> str:
         """
         Send analysis results to the Presidio anonymizer endpoint to get redacted text
@@ -485,47 +486,59 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
                     redacted_text = await response.json()
 
-            new_text = text
             if redacted_text is not None:
                 verbose_proxy_logger.debug("redacted_text: %s", redacted_text)
-                # Process items in reverse order by start position so that
-                # replacing later spans first does not shift earlier coordinates.
-                for item in sorted(
-                    redacted_text["items"], key=lambda x: x["start"], reverse=True
-                ):
+                new_text = redacted_text["text"]
+                # Sort analyze_results right-to-left (Presidio processes entities
+                # right-to-left, so redacted_text["items"] is also right-to-left).
+                # We match by entity_type to get the original text positions from
+                # the Analyzer response, not the Anonymizer response (which returns
+                # positions in the *anonymized* text's coordinate space).
+                def _ar_val(ar, key, default=None):
+                    return ar.get(key, default) if isinstance(ar, dict) else getattr(ar, key, default)
+                _sorted_ar = sorted(
+                    analyze_results if isinstance(analyze_results, list) else [],
+                    key=lambda x: -(_ar_val(x, "start") or 0),
+                )
+                _ar_used: set = set()
+                # Sort items right-to-left so position offsets remain valid
+                # after each in-place substitution, and so the consumption
+                # order of _sorted_ar matches item order for correct pairing.
+                _sorted_items = sorted(
+                    redacted_text["items"],
+                    key=lambda x: -(x.get("start") or 0),
+                )
+                for item in _sorted_items:
                     start = item["start"]
                     end = item["end"]
                     replacement = item["text"]  # replacement token
                     if item["operator"] == "replace" and output_parse_pii is True:
-                        if request_data is None:
-                            verbose_proxy_logger.warning(
-                                "Presidio anonymize_text called without request_data — "
-                                "PII tokens cannot be stored per-request. "
-                                "This may indicate a missing caller update."
-                            )
-                            request_data = {}
-                        # Store pii_tokens in metadata to avoid leaking to LLM providers.
-                        # Providers like Anthropic reject unknown top-level fields.
-                        if not request_data.get("metadata"):
-                            request_data["metadata"] = {}
-                        if "pii_tokens" not in request_data["metadata"]:
-                            request_data["metadata"]["pii_tokens"] = {}
-                        pii_tokens = request_data["metadata"]["pii_tokens"]
-
-                        # Append a sequential number to make each token unique
-                        # per request, so unmasking maps back to the correct
-                        # original value.  Format: <PHONE_NUMBER_1>, <PHONE_NUMBER_2>
-                        # This is LLM-friendly and degrades gracefully if the
-                        # LLM doesn't echo the token verbatim.
-                        seq = len(pii_tokens) + 1
+                        # Always append UUID to ensure uniqueness — prevents
+                        # str.replace() collisions when multiple entities share
+                        # the same type (e.g. two <PHONE_NUMBER> tokens).
+                        # UUID goes INSIDE angle brackets so LLMs treat the
+                        # whole thing as one opaque token and don't strip the
+                        # <TYPE> prefix as if it were an XML/HTML tag.
+                        _uuid_suffix = str(uuid.uuid4())[:12]
                         if replacement.endswith(">"):
-                            replacement = f"{replacement[:-1]}_{seq}>"
+                            replacement = f"{replacement[:-1]}_{_uuid_suffix}>"
                         else:
-                            replacement = f"{replacement}_{seq}"
+                            replacement = f"{replacement}_{_uuid_suffix}"
 
-                        # Use ORIGINAL text (not new_text) since start/end
-                        # reference the original text's coordinates.
-                        pii_tokens[replacement] = text[start:end]
+                        # Use analyze_results (original text positions) to look
+                        # up the original value. Both _sorted_ar and _sorted_items
+                        # are right-to-left, so consuming _sorted_ar in order
+                        # correctly pairs each item with its analyze_results entry.
+                        _orig_val = None
+                        for _ar_i, _ar in enumerate(_sorted_ar):
+                            if _ar_i not in _ar_used and _ar_val(_ar, "entity_type") == item.get("entity_type"):
+                                _s = _ar_val(_ar, "start")
+                                _e = _ar_val(_ar, "end")
+                                if _s is not None and _e is not None:
+                                    _orig_val = text[_s:_e]
+                                _ar_used.add(_ar_i)
+                                break
+                        self.pii_tokens[replacement] = _orig_val if _orig_val is not None else new_text[start:end]
 
                     new_text = new_text[:start] + replacement + new_text[end:]
                     entity_type = item.get("entity_type", None)
@@ -533,13 +546,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         masked_entity_count[entity_type] = (
                             masked_entity_count.get(entity_type, 0) + 1
                         )
-                # When output_parse_pii is True, new_text contains sequentially
-                # numbered tokens (e.g. <PHONE_NUMBER_1>) that match the keys
-                # in pii_tokens.  Returning redacted_text["text"] (Presidio's
-                # original output) would send un-numbered tokens to the LLM,
-                # making unmasking impossible.
-                # When output_parse_pii is False, new_text == redacted_text["text"]
-                # because no suffix is appended.
+                # Return new_text (with UUID-suffixed tokens for duplicate
+                # entity types), NOT redacted_text["text"] which has identical
+                # placeholders for all entities of the same type.
                 return new_text
             else:
                 raise Exception("Invalid anonymizer response: received None")
@@ -674,7 +683,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     analyze_results=analyze_results,
                     output_parse_pii=output_parse_pii,
                     masked_entity_count=masked_entity_count,
-                    request_data=request_data,
                 )
                 return anonymized_text
             return redacted_text["text"]
@@ -921,18 +929,27 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         if self.output_parse_pii is False and litellm.output_parse_pii is False:
             return response
 
+        # Prefer pii_tokens from request_data (stored by pre_call masking instance).
+        _pii_tokens = data.get("pii_tokens") or self.pii_tokens
+
         if isinstance(response, ModelResponse) and not isinstance(
             response.choices[0], StreamingChoices
         ):  # /chat/completions requests
-            await self._process_response_for_pii(
-                response=response,
-                request_data=data,
-                mode="unmask",
-            )
-        elif self._is_anthropic_message_response(response):
-            await self._process_anthropic_response_for_pii(
-                response=cast(dict, response), request_data=data, mode="unmask"
-            )
+            if isinstance(response.choices[0].message.content, str):
+                verbose_proxy_logger.debug(
+                    f"pii_tokens for unmask: {_pii_tokens}; initial response: {response.choices[0].message.content}"
+                )
+                response.choices[0].message.content = self._unmask_pii_text(
+                    response.choices[0].message.content, _pii_tokens
+                )
+        elif (
+            isinstance(response, dict)
+            and response.get("type") == "message"
+            and response.get("role") == "assistant"
+        ):  # Anthropic native /v1/messages response
+            for block in response.get("content") or []:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    block["text"] = self._unmask_pii_text(block.get("text", ""), _pii_tokens)
         return response
 
     @staticmethod
@@ -950,15 +967,22 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         for token, original_text in pii_tokens.items():
             if token in text:
                 text = text.replace(token, original_text)
-            else:
-                # FALLBACK: Handle truncated tokens (token cut off by max_tokens)
-                # Only check at the very end of the text.
-                min_overlap = min(20, len(token) // 2)
-                for i in range(max(0, len(text) - len(token)), len(text)):
-                    sub = text[i:]
-                    if token.startswith(sub) and len(sub) >= min_overlap:
-                        text = text[:i] + original_text
-                        break
+                continue
+
+            # FALLBACK 1: LLM stripped angle brackets (e.g. <PERSON_abc> -> PERSON_abc)
+            stripped = token.strip("<>")
+            if stripped and stripped in text:
+                text = text.replace(stripped, original_text)
+                continue
+
+            # FALLBACK 2: Handle truncated tokens (token cut off by max_tokens)
+            # Only check at the very end of the text.
+            min_overlap = min(20, len(token) // 2)
+            for i in range(max(0, len(text) - len(token)), len(text)):
+                sub = text[i:]
+                if token.startswith(sub) and len(sub) >= min_overlap:
+                    text = text[:i] + original_text
+                    break
         return text
 
     @staticmethod
@@ -980,11 +1004,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Process an Anthropic native message dict for PII masking/unmasking.
         Handles content blocks with type == "text".
         """
-        metadata = (request_data.get("metadata") or {}) if request_data else {}
-        pii_tokens = metadata.get("pii_tokens", {})
+        pii_tokens = (
+            (request_data.get("pii_tokens") if request_data else None)
+            or self.pii_tokens
+        )
         if not pii_tokens and mode == "unmask":
             verbose_proxy_logger.debug(
-                "No pii_tokens in metadata for Anthropic response unmask"
+                "No pii_tokens in request_data for Anthropic response unmask"
             )
         presidio_config = self.get_presidio_settings_from_request_data(
             request_data or {}
@@ -1022,11 +1048,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         Helper to recursively process a ModelResponse for PII.
         Handles all choices and tool calls.
         """
-        metadata = (request_data.get("metadata") or {}) if request_data else {}
-        pii_tokens = metadata.get("pii_tokens", {})
+        pii_tokens = (
+            (request_data.get("pii_tokens") if request_data else None)
+            or self.pii_tokens
+        )
         if not pii_tokens and mode == "unmask":
             verbose_proxy_logger.debug(
-                "No pii_tokens found in request_data['metadata'] — nothing to unmask"
+                "No pii_tokens found in request_data — nothing to unmask"
             )
         presidio_config = self.get_presidio_settings_from_request_data(
             request_data or {}
@@ -1246,6 +1274,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         streaming sends raw bytes chunks that pass through untransformed.
         The base class declares ModelResponseStream only.
         """
+        # If we need to mask model output, collect the full stream, apply masking, and replay it.
         if self.apply_to_output:
             async for chunk in self._stream_apply_output_masking(
                 response, request_data
@@ -1253,18 +1282,151 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 yield chunk
             return
 
-        metadata = (request_data.get("metadata") or {}) if request_data else {}
-        pii_tokens = metadata.get("pii_tokens", {})
+        # --- PII unmasking path (output_parse_pii=True) ---
+        pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
         if not pii_tokens and request_data:
             verbose_proxy_logger.debug(
-                "No pii_tokens in request_data['metadata'] for streaming unmask path"
+                "No pii_tokens in request_data for streaming unmask path"
             )
         if not (self.output_parse_pii and pii_tokens):
             async for chunk in response:
                 yield chunk
             return
 
-        async for chunk in self._stream_pii_unmasking(response, request_data):
+        # Peek at first chunk to detect format without buffering the full stream.
+        # bytes = Anthropic native SSE; ModelResponseStream = OpenAI format.
+        first_chunk = None
+        async for chunk in response:
+            first_chunk = chunk
+            break
+
+        if first_chunk is None:
+            return
+
+        is_anthropic_native = isinstance(first_chunk, bytes)
+
+        if is_anthropic_native:
+            # --- Anthropic native SSE: true streaming with carry-buffer unmask ---
+            #
+            # PII tokens look like <TYPE_HEXUUID> (max ~30 chars). They can be split
+            # across SSE events. We keep a small carry buffer (MAX_CARRY chars) to
+            # catch split tokens, then flush everything else immediately.
+            MAX_CARRY = 80
+            sse_buf = b""       # accumulator for incomplete SSE event bytes
+            carry_text = ""     # pending text that might be a partial PII token
+            carry_lines: Optional[list] = None   # SSE event lines for carry_text
+            carry_data: Optional[dict] = None
+            carry_data_idx: Optional[int] = None
+
+            async def _chunks_with_first():
+                yield first_chunk
+                async for c in response:
+                    yield c
+
+            try:
+                async for chunk in _chunks_with_first():
+                    if not isinstance(chunk, bytes):
+                        yield chunk
+                        continue
+
+                    sse_buf += chunk
+
+                    # Yield complete SSE events as they arrive
+                    while b"\n\n" in sse_buf:
+                        event_bytes, sse_buf = sse_buf.split(b"\n\n", 1)
+                        event_str = event_bytes.decode("utf-8", errors="replace")
+
+                        if not event_str.strip():
+                            yield b"\n\n"
+                            continue
+
+                        lines = event_str.split("\n")
+                        data, data_idx = None, None
+                        for j, line in enumerate(lines):
+                            if line.startswith("data: "):
+                                try:
+                                    data = _json.loads(line[6:])
+                                    data_idx = j
+                                except (_json.JSONDecodeError, ValueError):
+                                    pass
+                                break
+
+                        is_text_delta = (
+                            data is not None
+                            and data.get("type") == "content_block_delta"
+                            and data.get("delta", {}).get("type") == "text_delta"
+                        )
+
+                        if not is_text_delta:
+                            # Flush any pending carry before non-text events
+                            if carry_text and carry_lines is not None:
+                                unmasked_carry = self._unmask_pii_text(carry_text, pii_tokens)
+                                carry_data["delta"]["text"] = unmasked_carry
+                                carry_lines[carry_data_idx] = "data: " + _json.dumps(
+                                    carry_data, ensure_ascii=False
+                                )
+                                yield ("\n".join(carry_lines) + "\n\n").encode("utf-8")
+                                carry_text = ""
+                                carry_lines = None
+                            yield (event_str + "\n\n").encode("utf-8")
+                            continue
+
+                        # Text delta: prepend any carry, unmask, split at safe point
+                        fragment = data["delta"].get("text", "")
+                        combined = carry_text + fragment
+                        unmasked = self._unmask_pii_text(combined, pii_tokens)
+
+                        # Safe flush point: everything before the last '<' within MAX_CARRY
+                        lt_pos = unmasked.rfind("<")
+                        if lt_pos < 0 or (len(unmasked) - lt_pos) > MAX_CARRY:
+                            flush_text = unmasked
+                            carry_text = ""
+                            carry_lines = None
+                        else:
+                            flush_text = unmasked[:lt_pos]
+                            carry_text = unmasked[lt_pos:]
+                            carry_lines = lines
+                            carry_data = data
+                            carry_data_idx = data_idx
+
+                        data["delta"]["text"] = flush_text
+                        lines[data_idx] = "data: " + _json.dumps(data, ensure_ascii=False)
+                        yield (("\n".join(lines)) + "\n\n").encode("utf-8")
+
+                # Flush remaining carry at end of stream
+                if carry_text and carry_lines is not None:
+                    unmasked_carry = self._unmask_pii_text(carry_text, pii_tokens)
+                    carry_data["delta"]["text"] = unmasked_carry
+                    carry_lines[carry_data_idx] = "data: " + _json.dumps(
+                        carry_data, ensure_ascii=False
+                    )
+                    yield ("\n".join(carry_lines) + "\n\n").encode("utf-8")
+
+                # Yield any trailing bytes (incomplete event, shouldn't normally happen)
+                if sse_buf.strip():
+                    yield sse_buf
+
+            except Exception as e:
+                verbose_proxy_logger.error(
+                    f"Error in Anthropic SSE PII streaming unmask: {str(e)}"
+                )
+                # Fallback: yield whatever is left in the response
+                if sse_buf:
+                    yield sse_buf
+                async for c in response:
+                    yield c
+            return
+
+        # --- OpenAI format path: buffer all chunks (needed for chunk assembly) ---
+        all_chunks: list = [first_chunk]
+        async for chunk in response:
+            all_chunks.append(chunk)
+
+        async def _iter_chunks():
+            for c in all_chunks:
+                yield c
+
+        async for chunk in self._stream_pii_unmasking(_iter_chunks(), request_data):
             yield chunk
 
     @staticmethod
@@ -1313,27 +1475,43 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             1. If the connection to the guardrail is working
             2. When Testing the guardrail with some text, this function will be called with the input text and returns a text after applying the guardrail
         """
+        # --- PII unmask path for output responses ---
+        # When the unified guardrail calls apply_guardrail(input_type="response"),
+        # we unmask PII tokens instead of masking. The tokens were stored in
+        # request_data["pii_tokens"] during input masking.
+        if input_type == "response" and self.output_parse_pii:
+            pii_tokens = request_data.get("pii_tokens", {}) if request_data else {}
+            if pii_tokens:
+                _texts = inputs.get("texts", [])
+                inputs["texts"] = [self._unmask_pii_text(t, pii_tokens) for t in _texts]
+            else:
+                verbose_proxy_logger.debug(
+                    "apply_guardrail: no pii_tokens in request_data for output unmask path"
+                )
+            return inputs
+
         texts = inputs.get("texts", [])
 
-        # When input_type is "response" and pii_tokens are available,
-        # unmask the text instead of masking it.
-        metadata = (request_data.get("metadata") or {}) if request_data else {}
-        pii_tokens = metadata.get("pii_tokens", {})
-
         new_texts = []
-        if input_type == "response" and pii_tokens:
-            for text in texts:
-                new_texts.append(self._unmask_pii_text(text, pii_tokens))
-        else:
-            for text in texts:
-                modified_text = await self.check_pii(
-                    text=text,
-                    output_parse_pii=self.output_parse_pii,
-                    presidio_config=None,
-                    request_data=request_data or {},
-                )
-                new_texts.append(modified_text)
+        for text in texts:
+            modified_text = await self.check_pii(
+                text=text,
+                output_parse_pii=self.output_parse_pii,
+                presidio_config=None,
+                request_data=request_data or {},
+            )
+            new_texts.append(modified_text)
         inputs["texts"] = new_texts
+        # Strip keys that process_input_messages() converted to OpenAI format.
+        # Returning them would overwrite native Anthropic tools with type:"function".
+        for _k in ("tools", "structured_messages", "model", "images"):
+            inputs.pop(_k, None)
+        # Store pii_tokens in request_data so post_call hooks can access them.
+        # The guardrail initializer creates TWO separate instances (one pre_call,
+        # one post_call), so self.pii_tokens on the masking instance is invisible
+        # to the unmasking instance. request_data is shared across the full call.
+        if request_data is not None and self.pii_tokens:
+            request_data["pii_tokens"] = dict(self.pii_tokens)
         return inputs
 
     def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -247,6 +247,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             guardrail_to_apply=guardrail_to_apply,
             litellm_logging_obj=data.get("litellm_logging_obj"),
             user_api_key_dict=user_api_key_dict,
+            request_data=data,
         )
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(
@@ -397,6 +398,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                         guardrail_to_apply=guardrail_to_apply,
                         litellm_logging_obj=request_data.get("litellm_logging_obj"),
                         user_api_key_dict=user_api_key_dict,
+                        request_data=request_data,
                     )
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.
@@ -457,6 +459,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     guardrail_to_apply=guardrail_to_apply,
                     litellm_logging_obj=request_data.get("litellm_logging_obj"),
                     user_api_key_dict=user_api_key_dict,
+                    request_data=request_data,
                 )
             except HTTPException as e:
                 if call_type is not None and CallTypes(call_type) in A2A_CALL_TYPES:

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -20,7 +20,6 @@ from litellm.llms.base_llm.guardrail_translation.base_translation import (
     BaseTranslation,
 )
 
-
 # ---------------------------------------------------------------------------
 # Signature conformance tests
 # ---------------------------------------------------------------------------
@@ -29,9 +28,9 @@ from litellm.llms.base_llm.guardrail_translation.base_translation import (
 def test_base_translation_process_output_response_has_request_data_param():
     """Abstract base declares request_data so implementations stay consistent."""
     sig = inspect.signature(BaseTranslation.process_output_response)
-    assert "request_data" in sig.parameters, (
-        "BaseTranslation.process_output_response() must declare 'request_data'"
-    )
+    assert (
+        "request_data" in sig.parameters
+    ), "BaseTranslation.process_output_response() must declare 'request_data'"
     param = sig.parameters["request_data"]
     assert param.default is None, "'request_data' must default to None"
 
@@ -39,9 +38,9 @@ def test_base_translation_process_output_response_has_request_data_param():
 def test_base_translation_process_output_streaming_has_request_data_param():
     """Streaming variant also declares request_data."""
     sig = inspect.signature(BaseTranslation.process_output_streaming_response)
-    assert "request_data" in sig.parameters, (
-        "BaseTranslation.process_output_streaming_response() must declare 'request_data'"
-    )
+    assert (
+        "request_data" in sig.parameters
+    ), "BaseTranslation.process_output_streaming_response() must declare 'request_data'"
     param = sig.parameters["request_data"]
     assert param.default is None, "'request_data' must default to None"
 
@@ -60,6 +59,8 @@ def test_all_handler_implementations_accept_request_data():
         "litellm.llms.pass_through.guardrail_translation.handler",
         "litellm.llms.a2a.chat.guardrail_translation.handler",
         "litellm.llms.cohere.rerank.guardrail_translation.handler",
+        "litellm.llms.mistral.ocr.guardrail_translation.handler",
+        "litellm.proxy._experimental.mcp_server.guardrail_translation.handler",
     ]
 
     validated = 0
@@ -83,6 +84,43 @@ def test_all_handler_implementations_accept_request_data():
             validated += 1
 
     assert validated > 0, "No handler classes validated — all imports failed"
+
+
+def test_all_streaming_handlers_accept_request_data():
+    """Verify handlers that override process_output_streaming_response accept request_data."""
+    streaming_handler_modules = [
+        "litellm.llms.openai.chat.guardrail_translation.handler",
+        "litellm.llms.openai.responses.guardrail_translation.handler",
+        "litellm.llms.anthropic.chat.guardrail_translation.handler",
+        "litellm.llms.a2a.chat.guardrail_translation.handler",
+    ]
+
+    validated = 0
+    for module_path in streaming_handler_modules:
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError:
+            continue
+
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if obj is BaseTranslation or obj.__module__ != module_path:
+                continue
+            if not hasattr(obj, "process_output_streaming_response"):
+                continue
+            if (
+                obj.process_output_streaming_response
+                is BaseTranslation.process_output_streaming_response
+            ):
+                continue
+
+            sig = inspect.signature(obj.process_output_streaming_response)
+            assert "request_data" in sig.parameters, (
+                f"{module_path}.{_name}.process_output_streaming_response() "
+                f"must accept 'request_data'"
+            )
+            validated += 1
+
+    assert validated > 0, "No streaming handler classes validated"
 
 
 # ---------------------------------------------------------------------------
@@ -129,9 +167,9 @@ async def test_openai_handler_forwards_request_data():
         request_data=sentinel,
     )
 
-    assert "pii_tokens" in captured, (
-        "request_data with pii_tokens was not forwarded to apply_guardrail()"
-    )
+    assert (
+        "pii_tokens" in captured
+    ), "request_data with pii_tokens was not forwarded to apply_guardrail()"
     assert captured["pii_tokens"] == {"<NAME_1>": "Alice"}
 
 

--- a/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
+++ b/tests/guardrails_tests/test_guardrail_request_data_passthrough.py
@@ -1,0 +1,207 @@
+"""
+Tests for fix/guardrail-request-data-v2
+
+Verifies that:
+1. BaseTranslation declares request_data on output handler signatures.
+2. All concrete handlers accept request_data (type-consistent with interface).
+3. Handlers that call apply_guardrail() forward request_data values.
+
+Related issue: https://github.com/BerriAI/litellm/issues/22821
+"""
+
+import asyncio
+import importlib
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.llms.base_llm.guardrail_translation.base_translation import (
+    BaseTranslation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Signature conformance tests
+# ---------------------------------------------------------------------------
+
+
+def test_base_translation_process_output_response_has_request_data_param():
+    """Abstract base declares request_data so implementations stay consistent."""
+    sig = inspect.signature(BaseTranslation.process_output_response)
+    assert "request_data" in sig.parameters, (
+        "BaseTranslation.process_output_response() must declare 'request_data'"
+    )
+    param = sig.parameters["request_data"]
+    assert param.default is None, "'request_data' must default to None"
+
+
+def test_base_translation_process_output_streaming_has_request_data_param():
+    """Streaming variant also declares request_data."""
+    sig = inspect.signature(BaseTranslation.process_output_streaming_response)
+    assert "request_data" in sig.parameters, (
+        "BaseTranslation.process_output_streaming_response() must declare 'request_data'"
+    )
+    param = sig.parameters["request_data"]
+    assert param.default is None, "'request_data' must default to None"
+
+
+def test_all_handler_implementations_accept_request_data():
+    """Verify concrete handlers accept request_data on process_output_response."""
+    handler_modules = [
+        "litellm.llms.openai.chat.guardrail_translation.handler",
+        "litellm.llms.openai.completion.guardrail_translation.handler",
+        "litellm.llms.openai.responses.guardrail_translation.handler",
+        "litellm.llms.openai.transcriptions.guardrail_translation.handler",
+        "litellm.llms.openai.embeddings.guardrail_translation.handler",
+        "litellm.llms.openai.image_generation.guardrail_translation.handler",
+        "litellm.llms.openai.speech.guardrail_translation.handler",
+        "litellm.llms.anthropic.chat.guardrail_translation.handler",
+        "litellm.llms.pass_through.guardrail_translation.handler",
+        "litellm.llms.a2a.chat.guardrail_translation.handler",
+        "litellm.llms.cohere.rerank.guardrail_translation.handler",
+    ]
+
+    validated = 0
+    for module_path in handler_modules:
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError:
+            continue
+
+        for _name, obj in inspect.getmembers(mod, inspect.isclass):
+            if obj is BaseTranslation or obj.__module__ != module_path:
+                continue
+            if not hasattr(obj, "process_output_response"):
+                continue
+
+            sig = inspect.signature(obj.process_output_response)
+            assert "request_data" in sig.parameters, (
+                f"{module_path}.{_name}.process_output_response() "
+                f"must accept 'request_data'"
+            )
+            validated += 1
+
+    assert validated > 0, "No handler classes validated — all imports failed"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests: verify request_data reaches apply_guardrail()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_forwards_request_data():
+    """Sentinel pii_tokens in request_data must reach apply_guardrail()."""
+    from litellm.llms.openai.chat.guardrail_translation.handler import (
+        OpenAIChatCompletionsHandler,
+    )
+    from litellm.types.utils import Choices, Message, ModelResponse
+
+    handler = OpenAIChatCompletionsHandler()
+
+    response = ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                index=0,
+                message=Message(content="Hello world", role="assistant"),
+                finish_reason="stop",
+            )
+        ],
+        model="gpt-4",
+    )
+
+    sentinel = {"pii_tokens": {"<NAME_1>": "Alice"}}
+    captured = {}
+
+    async def _capture(inputs, request_data, input_type, logging_obj=None):
+        captured.update(request_data)
+        return inputs
+
+    guardrail = MagicMock()
+    guardrail.guardrail_name = "test-guardrail"
+    guardrail.apply_guardrail = AsyncMock(side_effect=_capture)
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=guardrail,
+        request_data=sentinel,
+    )
+
+    assert "pii_tokens" in captured, (
+        "request_data with pii_tokens was not forwarded to apply_guardrail()"
+    )
+    assert captured["pii_tokens"] == {"<NAME_1>": "Alice"}
+
+
+@pytest.mark.asyncio
+async def test_anthropic_handler_merges_request_data():
+    """Anthropic handler must merge caller's request_data, not shadow it."""
+    from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+        AnthropicMessagesHandler,
+    )
+
+    handler = AnthropicMessagesHandler()
+
+    # Minimal Anthropic-style response
+    response = {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello"}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    sentinel = {"pii_tokens": {"<NAME_1>": "Bob"}}
+    captured = {}
+
+    async def _capture(inputs, request_data, input_type, logging_obj=None):
+        captured.update(request_data)
+        return inputs
+
+    guardrail = MagicMock()
+    guardrail.guardrail_name = "test-guardrail"
+    guardrail.apply_guardrail = AsyncMock(side_effect=_capture)
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=guardrail,
+        request_data=sentinel,
+    )
+
+    assert "pii_tokens" in captured, "Caller's pii_tokens were shadowed"
+    assert "response" in captured, "Response must be nested under 'response' key"
+
+
+@pytest.mark.asyncio
+async def test_pass_through_handler_merges_request_data():
+    """Pass-through handler must merge, not shadow, caller's request_data."""
+    from litellm.llms.pass_through.guardrail_translation.handler import (
+        PassThroughEndpointHandler,
+    )
+
+    handler = PassThroughEndpointHandler()
+
+    response = {"result": "ok"}
+    sentinel = {"pii_tokens": {"<NAME_1>": "Charlie"}}
+    captured = {}
+
+    async def _capture(inputs, request_data, input_type, logging_obj=None):
+        captured.update(request_data)
+        return inputs
+
+    guardrail = MagicMock()
+    guardrail.guardrail_name = "test-guardrail"
+    guardrail.apply_guardrail = AsyncMock(side_effect=_capture)
+    guardrail.get_guardrail_from_metadata = MagicMock(return_value=None)
+
+    await handler.process_output_response(
+        response=response,
+        guardrail_to_apply=guardrail,
+        request_data=sentinel,
+    )
+
+    assert "pii_tokens" in captured, "Caller's pii_tokens were shadowed"

--- a/tests/guardrails_tests/test_presidio_pii_roundtrip.py
+++ b/tests/guardrails_tests/test_presidio_pii_roundtrip.py
@@ -23,7 +23,6 @@ from litellm.proxy.guardrails.guardrail_hooks.presidio import (
     _OPTIONAL_PresidioPIIMasking,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -161,6 +160,7 @@ async def test_apply_guardrail_strips_openai_keys(guardrail):
 @pytest.mark.asyncio
 async def test_apply_guardrail_stores_pii_tokens_via_check_pii(guardrail):
     """check_pii stores pii_tokens in request_data['metadata']['pii_tokens']."""
+
     # Mock check_pii to simulate anonymize_text storing a token
     async def _mock_check_pii(text, output_parse_pii, presidio_config, request_data):
         if "metadata" not in request_data:
@@ -333,3 +333,53 @@ async def test_streaming_sse_passthrough_no_pii_tokens(guardrail):
 
     decoded = collected.decode("utf-8")
     assert original_text in decoded
+
+
+# ---------------------------------------------------------------------------
+# metadata=None safety tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unmask_handles_metadata_none(guardrail):
+    """Unmask path must not crash when metadata is explicitly None."""
+    guardrail.pii_tokens = {}
+    response = {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello world"}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+    data = {"metadata": None}
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    result = await guardrail.async_post_call_success_hook(
+        data=data,
+        user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+        response=response,
+    )
+    assert result["content"][0]["text"] == "Hello world"
+
+
+# ---------------------------------------------------------------------------
+# Backslash in PII values tests
+# ---------------------------------------------------------------------------
+
+
+def test_unmask_pii_text_backslash_in_value():
+    """PII values with backslashes must not be corrupted by re.sub."""
+    pii_tokens = {"<PERSON_abc123>": r"C:\Users\John"}
+    # Exact match path (no regex involved)
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
+        "Path is <PERSON_abc123>", pii_tokens
+    )
+    assert result == r"Path is C:\Users\John"
+
+    # FALLBACK 1 path (regex involved)
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
+        "Path is PERSON_abc123", pii_tokens
+    )
+    assert result == r"Path is C:\Users\John"

--- a/tests/guardrails_tests/test_presidio_pii_roundtrip.py
+++ b/tests/guardrails_tests/test_presidio_pii_roundtrip.py
@@ -1,0 +1,330 @@
+"""
+Tests for fix/presidio-pii-roundtrip-v2
+
+Verifies PII round-trip masking/unmasking:
+1. anonymize_text stores correct original values (position fix)
+2. apply_guardrail unmask path restores PII tokens
+3. apply_guardrail strips OpenAI-converted keys
+4. apply_guardrail stores pii_tokens in request_data
+5. _unmask_pii_text handles exact match, stripped brackets, truncated tokens
+6. async_post_call_success_hook handles Anthropic native dict responses
+7. Streaming SSE unmask with carry buffer
+
+Related issue: https://github.com/BerriAI/litellm/issues/22821
+"""
+
+import json
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+    _OPTIONAL_PresidioPIIMasking,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def guardrail():
+    """Create a Presidio guardrail instance with mock_testing=True."""
+    return _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        output_parse_pii=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _unmask_pii_text tests
+# ---------------------------------------------------------------------------
+
+
+def test_unmask_pii_text_exact_match():
+    """Exact token in text is replaced with original value."""
+    pii_tokens = {"<PERSON_abc123>": "Alice Smith"}
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
+        "Hello <PERSON_abc123>, welcome!", pii_tokens
+    )
+    assert result == "Hello Alice Smith, welcome!"
+
+
+def test_unmask_pii_text_multiple_tokens():
+    """Multiple different tokens are all replaced."""
+    pii_tokens = {
+        "<PERSON_abc123>": "Alice",
+        "<PHONE_NUMBER_def456>": "555-0100",
+    }
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
+        "Call <PERSON_abc123> at <PHONE_NUMBER_def456>", pii_tokens
+    )
+    assert result == "Call Alice at 555-0100"
+
+
+def test_unmask_pii_text_stripped_brackets():
+    """FALLBACK 1: LLM stripped angle brackets from token."""
+    pii_tokens = {"<PERSON_abc123>": "Bob Jones"}
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
+        "Hello PERSON_abc123, welcome!", pii_tokens
+    )
+    assert result == "Hello Bob Jones, welcome!"
+
+
+def test_unmask_pii_text_truncated_token():
+    """FALLBACK 2: Token truncated at end of text by max_tokens."""
+    pii_tokens = {"<COMPANY_NAME_abcdef123456>": "Acme Corp"}
+    # Token is cut off at the end of the text
+    truncated = "Working at <COMPANY_NAME_abcde"
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(truncated, pii_tokens)
+    assert result == "Working at Acme Corp"
+
+
+def test_unmask_pii_text_no_match_passthrough():
+    """Text without any PII tokens passes through unchanged."""
+    pii_tokens = {"<PERSON_abc123>": "Alice"}
+    result = _OPTIONAL_PresidioPIIMasking._unmask_pii_text(
+        "Hello world, no PII here!", pii_tokens
+    )
+    assert result == "Hello world, no PII here!"
+
+
+# ---------------------------------------------------------------------------
+# apply_guardrail tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_unmask_path(guardrail):
+    """input_type='response' with pii_tokens unmasks texts."""
+    request_data = {
+        "pii_tokens": {"<PERSON_abc123>": "Alice Smith"},
+    }
+    inputs = {"texts": ["Hello <PERSON_abc123>, how are you?"]}
+
+    result = await guardrail.apply_guardrail(
+        inputs=inputs,
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert result["texts"] == ["Hello Alice Smith, how are you?"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_unmask_no_tokens(guardrail):
+    """input_type='response' with empty pii_tokens passes through."""
+    request_data = {"pii_tokens": {}}
+    inputs = {"texts": ["Hello world"]}
+
+    result = await guardrail.apply_guardrail(
+        inputs=inputs,
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert result["texts"] == ["Hello world"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_strips_openai_keys(guardrail):
+    """After masking, OpenAI-converted keys are stripped from return."""
+    inputs = {
+        "texts": ["no pii here"],
+        "tools": [{"type": "function", "name": "test"}],
+        "structured_messages": [{"role": "user"}],
+        "model": "gpt-4",
+        "images": [],
+    }
+
+    # Mock check_pii to avoid calling Presidio
+    async def _passthrough(text, output_parse_pii, presidio_config, request_data):
+        return text
+
+    guardrail.check_pii = _passthrough
+
+    result = await guardrail.apply_guardrail(
+        inputs=inputs,
+        request_data={},
+        input_type="request",
+    )
+
+    assert "tools" not in result
+    assert "structured_messages" not in result
+    assert "model" not in result
+    assert "images" not in result
+    assert "texts" in result
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_stores_pii_tokens(guardrail):
+    """After masking, pii_tokens are copied to request_data."""
+    # Manually set some pii_tokens as if anonymize_text ran
+    guardrail.pii_tokens = {"<PERSON_abc>": "Alice"}
+
+    # Mock check_pii to avoid calling Presidio
+    async def _passthrough(text, output_parse_pii, presidio_config, request_data):
+        return text
+
+    guardrail.check_pii = _passthrough
+
+    inputs = {"texts": ["no pii here"]}
+    request_data = {}
+
+    await guardrail.apply_guardrail(
+        inputs=inputs,
+        request_data=request_data,
+        input_type="request",
+    )
+
+    assert "pii_tokens" in request_data
+    assert request_data["pii_tokens"] == {"<PERSON_abc>": "Alice"}
+
+
+# ---------------------------------------------------------------------------
+# async_post_call_success_hook: Anthropic native dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_anthropic_native_dict(guardrail):
+    """Anthropic native dict response (type:'message') gets unmasked."""
+    guardrail.pii_tokens = {"<PERSON_abc123>": "Alice Smith"}
+    guardrail.output_parse_pii = True
+
+    response = {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello <PERSON_abc123>!"}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    data = {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    user_api_key = UserAPIKeyAuth(api_key="test_key")
+
+    result = await guardrail.async_post_call_success_hook(
+        data=data,
+        user_api_key_dict=user_api_key,
+        response=response,
+    )
+
+    assert result["content"][0]["text"] == "Hello Alice Smith!"
+
+
+# ---------------------------------------------------------------------------
+# Streaming SSE tests
+# ---------------------------------------------------------------------------
+
+
+def _make_sse_event(event_type: str, data: dict) -> bytes:
+    """Helper to create an SSE event as bytes."""
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n".encode("utf-8")
+
+
+def _make_text_delta_event(text: str, index: int = 0) -> bytes:
+    """Helper to create a text_delta SSE event."""
+    return _make_sse_event(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "text_delta", "text": text},
+        },
+    )
+
+
+async def _async_iter(items):
+    """Convert a list to an async iterator."""
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_streaming_anthropic_sse_unmask(guardrail):
+    """PII tokens in SSE text_delta events are unmasked."""
+    guardrail.pii_tokens = {"<PERSON_abc123>": "Alice Smith"}
+    guardrail.output_parse_pii = True
+
+    chunks = [
+        _make_sse_event("message_start", {"type": "message_start"}),
+        _make_text_delta_event("Hello <PERSON_abc123>!"),
+        _make_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+    request_data = {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}
+    collected = b""
+
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=MagicMock(),
+        response=_async_iter(chunks),
+        request_data=request_data,
+    ):
+        if isinstance(chunk, bytes):
+            collected += chunk
+
+    decoded = collected.decode("utf-8")
+    assert "Alice Smith" in decoded
+    assert "<PERSON_abc123>" not in decoded
+
+
+@pytest.mark.asyncio
+async def test_streaming_sse_split_token_carry_buffer(guardrail):
+    """Token split across two SSE events is correctly reassembled via carry buffer."""
+    guardrail.pii_tokens = {"<PERSON_abc123>": "Alice Smith"}
+    guardrail.output_parse_pii = True
+
+    # Split the token across two text_delta events
+    chunks = [
+        _make_text_delta_event("Hello <PERSO"),
+        _make_text_delta_event("N_abc123>!"),
+        _make_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+    request_data = {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}
+    collected = b""
+
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=MagicMock(),
+        response=_async_iter(chunks),
+        request_data=request_data,
+    ):
+        if isinstance(chunk, bytes):
+            collected += chunk
+
+    decoded = collected.decode("utf-8")
+    assert "Alice Smith" in decoded
+    assert "<PERSON_abc123>" not in decoded
+
+
+@pytest.mark.asyncio
+async def test_streaming_sse_passthrough_no_pii_tokens(guardrail):
+    """When pii_tokens is empty, SSE bytes pass through unchanged."""
+    guardrail.pii_tokens = {}
+    guardrail.output_parse_pii = True
+
+    original_text = "Hello world, no PII!"
+    chunks = [
+        _make_text_delta_event(original_text),
+        _make_sse_event("message_stop", {"type": "message_stop"}),
+    ]
+
+    request_data = {}
+    collected = b""
+
+    async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=MagicMock(),
+        response=_async_iter(chunks),
+        request_data=request_data,
+    ):
+        if isinstance(chunk, bytes):
+            collected += chunk
+
+    decoded = collected.decode("utf-8")
+    assert original_text in decoded

--- a/tests/guardrails_tests/test_presidio_pii_roundtrip.py
+++ b/tests/guardrails_tests/test_presidio_pii_roundtrip.py
@@ -100,7 +100,7 @@ def test_unmask_pii_text_no_match_passthrough():
 async def test_apply_guardrail_unmask_path(guardrail):
     """input_type='response' with pii_tokens unmasks texts."""
     request_data = {
-        "pii_tokens": {"<PERSON_abc123>": "Alice Smith"},
+        "metadata": {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}},
     }
     inputs = {"texts": ["Hello <PERSON_abc123>, how are you?"]}
 
@@ -116,7 +116,7 @@ async def test_apply_guardrail_unmask_path(guardrail):
 @pytest.mark.asyncio
 async def test_apply_guardrail_unmask_no_tokens(guardrail):
     """input_type='response' with empty pii_tokens passes through."""
-    request_data = {"pii_tokens": {}}
+    request_data = {"metadata": {"pii_tokens": {}}}
     inputs = {"texts": ["Hello world"]}
 
     result = await guardrail.apply_guardrail(
@@ -159,19 +159,23 @@ async def test_apply_guardrail_strips_openai_keys(guardrail):
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_stores_pii_tokens(guardrail):
-    """After masking, pii_tokens are copied to request_data."""
-    # Manually set some pii_tokens as if anonymize_text ran
-    guardrail.pii_tokens = {"<PERSON_abc>": "Alice"}
+async def test_apply_guardrail_stores_pii_tokens_via_check_pii(guardrail):
+    """check_pii stores pii_tokens in request_data['metadata']['pii_tokens']."""
+    # Mock check_pii to simulate anonymize_text storing a token
+    async def _mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        if "metadata" not in request_data:
+            request_data["metadata"] = {}
+        if "pii_tokens" not in request_data["metadata"]:
+            request_data["metadata"]["pii_tokens"] = {}
+        request_data["metadata"]["pii_tokens"]["<PERSON_abc>"] = "Alice"
+        return "Hello <PERSON_abc>"
 
-    # Mock check_pii to avoid calling Presidio
-    async def _passthrough(text, output_parse_pii, presidio_config, request_data):
-        return text
+    guardrail.check_pii = _mock_check_pii
 
-    guardrail.check_pii = _passthrough
-
-    inputs = {"texts": ["no pii here"]}
-    request_data = {}
+    inputs = {"texts": ["Hello Alice"]}
+    # request_data must be non-empty (truthy) so `request_data or {}`
+    # returns the same dict object rather than a new empty one.
+    request_data = {"model": "test"}
 
     await guardrail.apply_guardrail(
         inputs=inputs,
@@ -179,8 +183,9 @@ async def test_apply_guardrail_stores_pii_tokens(guardrail):
         input_type="request",
     )
 
-    assert "pii_tokens" in request_data
-    assert request_data["pii_tokens"] == {"<PERSON_abc>": "Alice"}
+    assert "metadata" in request_data
+    assert "pii_tokens" in request_data["metadata"]
+    assert request_data["metadata"]["pii_tokens"] == {"<PERSON_abc>": "Alice"}
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +209,7 @@ async def test_post_call_success_hook_anthropic_native_dict(guardrail):
         "usage": {"input_tokens": 10, "output_tokens": 5},
     }
 
-    data = {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}
+    data = {"metadata": {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}}
     from litellm.proxy._types import UserAPIKeyAuth
 
     user_api_key = UserAPIKeyAuth(api_key="test_key")
@@ -258,7 +263,7 @@ async def test_streaming_anthropic_sse_unmask(guardrail):
         _make_sse_event("message_stop", {"type": "message_stop"}),
     ]
 
-    request_data = {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}
+    request_data = {"metadata": {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}}
     collected = b""
 
     async for chunk in guardrail.async_post_call_streaming_iterator_hook(
@@ -287,7 +292,7 @@ async def test_streaming_sse_split_token_carry_buffer(guardrail):
         _make_sse_event("message_stop", {"type": "message_stop"}),
     ]
 
-    request_data = {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}
+    request_data = {"metadata": {"pii_tokens": {"<PERSON_abc123>": "Alice Smith"}}}
     collected = b""
 
     async for chunk in guardrail.async_post_call_streaming_iterator_hook(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
@@ -50,6 +50,7 @@ class _NoopTranslation(BaseTranslation):
         guardrail_to_apply,
         litellm_logging_obj=None,
         user_api_key_dict=None,
+        request_data=None,
     ):
         return response
 
@@ -159,7 +160,7 @@ class TestUnifiedLLMGuardrails:
                 async def process_input_messages(self, data, guardrail_to_apply, litellm_logging_obj=None):  # type: ignore[override]
                     return data
 
-                async def process_output_response(self, response, guardrail_to_apply, litellm_logging_obj=None, user_api_key_dict=None):  # type: ignore[override]
+                async def process_output_response(self, response, guardrail_to_apply, litellm_logging_obj=None, user_api_key_dict=None, request_data=None):  # type: ignore[override]
                     return response
 
                 async def process_output_streaming_response(
@@ -168,6 +169,7 @@ class TestUnifiedLLMGuardrails:
                     guardrail_to_apply,
                     litellm_logging_obj=None,
                     user_api_key_dict=None,
+                    request_data=None,
                 ):
                     # Simulate what the real handler does:
                     # put combined text in first chunk, clear the rest


### PR DESCRIPTION
## Problem

Presidio PII masking works on the input path but original values are never restored in responses. This affects both streaming and non-streaming Anthropic native API calls (`/v1/messages`).

Part of #22821. Supersedes #23037.
Depends on #24290 (`fix/guardrail-request-data-v2`).

## Root causes fixed

1. **Position bug in `anonymize_text`** — `pii_tokens` originals were read from `new_text[start:end]` where `start/end` come from `redacted_text["items"]` (anonymized coordinate space). After the first replacement, positions shift and subsequent slices extract wrong characters. Fix: use `analyze_results` coordinates (original text space) with right-to-left sorting.

2. **Lost tokens across instances** — LiteLLM creates two `_OPTIONAL_PresidioPIIMasking` instances per request (pre_call + post_call). `self.pii_tokens` on the masking instance is invisible to the unmasking instance. Fix: copy `pii_tokens` to `request_data` after masking.

3. **`apply_guardrail` always masks** — no branch for unmasking when called with `input_type="response"`. Fix: add early-return unmask path.

4. **Native Anthropic dict responses not handled** — `async_post_call_success_hook` only handled `ModelResponse`. Anthropic native responses are TypedDicts with `type:"message"`. Fix: add `elif` branch.

5. **Native Anthropic SSE bytes not handled** — streaming hook only handled `ModelResponseStream`. Anthropic native streaming arrives as raw `bytes`. Fix: add carry-buffer SSE streaming unmask that preserves real-time streaming behavior.

6. **OpenAI-converted tools overwrite native format** — `process_input_messages()` converts tools to OpenAI `type:"function"` format; returning them from `apply_guardrail` overwrites native Anthropic tools. Fix: strip `tools`, `structured_messages`, `model`, `images` before returning.

## Changes (all in `presidio.py`)

- `anonymize_text`: fix position bug using right-to-left sorted `analyze_results`; UUID suffix inside angle brackets; store in `self.pii_tokens`
- `apply_guardrail`: add unmask path for `input_type="response"`; strip OpenAI-converted keys; copy `pii_tokens` to `request_data`
- `async_post_call_success_hook`: prefer `pii_tokens` from `request_data`; add Anthropic native dict branch
- `_unmask_pii_text`: add fallback for stripped angle brackets
- `async_post_call_streaming_iterator_hook`: peek-based format detection; carry-buffer SSE streaming for Anthropic native bytes; existing OpenAI path preserved
- `_process_response_for_pii` / `_process_anthropic_response_for_pii`: fallback to `self.pii_tokens`

## Test plan

New test file `tests/guardrails_tests/test_presidio_pii_roundtrip.py` (13 tests):

- [x] `_unmask_pii_text` exact match replacement
- [x] `_unmask_pii_text` multiple tokens
- [x] `_unmask_pii_text` stripped angle brackets (FALLBACK 1)
- [x] `_unmask_pii_text` truncated token at end of text (FALLBACK 2)
- [x] `_unmask_pii_text` no-match passthrough
- [x] `apply_guardrail` unmask path with `pii_tokens`
- [x] `apply_guardrail` unmask no-op when `pii_tokens` empty
- [x] `apply_guardrail` strips OpenAI-converted keys after masking
- [x] `apply_guardrail` stores `pii_tokens` in `request_data`
- [x] `async_post_call_success_hook` unmasks Anthropic native dict
- [x] Streaming SSE: PII tokens in `text_delta` events are unmasked
- [x] Streaming SSE: split token across events reassembled via carry buffer
- [x] Streaming SSE: passthrough when no `pii_tokens`

All 13 new tests pass.