### PR TITLE
refactor: internal users confirm settings modal

### DIFF
--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.test.tsx
@@ -310,6 +310,86 @@ describe("DefaultUserSettings", () => {
     // Should still be in edit mode (Save Changes button visible)
     expect(screen.getByText("Save Changes")).toBeInTheDocument();
   });
+
+  it("should keep modal open when API save fails", async () => {
+    const settingsWithTeams = {
+      ...mockSettings,
+      values: {
+        ...mockSettings.values,
+        teams: [
+          { team_id: "team-alpha", max_budget_in_team: 50, user_role: "user" },
+        ],
+      },
+    };
+    mockGetInternalUserSettings.mockResolvedValue(settingsWithTeams);
+    mockUpdateInternalUserSettings.mockRejectedValue(new Error("Server error"));
+
+    render(<DefaultUserSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+    });
+
+    // Enter edit mode, remove team, click Save → modal opens
+    act(() => {
+      fireEvent.click(screen.getByText("Edit Settings"));
+    });
+    act(() => {
+      fireEvent.click(screen.getAllByText("Remove")[0]);
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("Save Changes"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Review Changes")).toBeInTheDocument();
+    });
+
+    // Click Confirm — API will reject
+    await act(async () => {
+      fireEvent.click(screen.getByText("Confirm Changes"));
+    });
+
+    // Modal should still be open (not cleared on failure)
+    await waitFor(() => {
+      expect(screen.getByText("Review Changes")).toBeInTheDocument();
+      expect(screen.getByText("Confirm Changes")).toBeInTheDocument();
+    });
+  });
+
+  it("should reflect API response values after successful save", async () => {
+    mockGetInternalUserSettings.mockResolvedValue(mockSettings);
+    // API returns different max_budget than what was sent
+    mockUpdateInternalUserSettings.mockResolvedValue({
+      settings: {
+        ...mockSettings.values,
+        max_budget: 2000,
+      },
+    });
+
+    render(<DefaultUserSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("Edit Settings"));
+    });
+
+    const saveButton = screen.getByText("Save Changes");
+    act(() => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateInternalUserSettings).toHaveBeenCalled();
+    });
+
+    // Should exit edit mode and show the API response value
+    expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+    expect(screen.getByText("2000")).toBeInTheDocument();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.test.tsx
@@ -434,9 +434,9 @@ describe("computeSettingsDiff", () => {
     );
   });
 
-  it("treats empty string same as null for scalars", () => {
-    const original = { max_budget: "" };
-    const edited = { max_budget: null };
+  it("treats null and undefined as equal for scalars", () => {
+    const original = { max_budget: null };
+    const edited = { max_budget: undefined };
 
     const { changes } = computeSettingsDiff(original, edited);
     expect(changes).toHaveLength(0);

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import DefaultUserSettings from "./DefaultUserSettings";
+import DefaultUserSettings, { computeSettingsDiff } from "./DefaultUserSettings";
 import * as networking from "./networking";
 
 vi.mock("./networking", () => ({
@@ -18,6 +18,10 @@ vi.mock("./common_components/budget_duration_dropdown", () => ({
     </select>
   ),
   getBudgetDurationLabel: (value: string) => value,
+}));
+
+vi.mock("@/utils/dataUtils", () => ({
+  formatNumberWithCommas: (n: number) => String(n),
 }));
 
 vi.mock("./key_team_helpers/fetch_available_models_team_key", () => ({
@@ -115,13 +119,11 @@ describe("DefaultUserSettings", () => {
     expect(screen.queryByText("Edit Settings")).not.toBeInTheDocument();
   });
 
-  it("should save settings when save button is clicked", async () => {
+  it("should save settings directly when no destructive changes", async () => {
+    // No changes at all → direct save (no modal)
     mockGetInternalUserSettings.mockResolvedValue(mockSettings);
     mockUpdateInternalUserSettings.mockResolvedValue({
-      settings: {
-        ...mockSettings.values,
-        max_budget: 2000,
-      },
+      settings: mockSettings.values,
     });
 
     render(<DefaultUserSettings {...defaultProps} />);
@@ -148,6 +150,295 @@ describe("DefaultUserSettings", () => {
       expect(mockUpdateInternalUserSettings).toHaveBeenCalled();
     });
 
+    // No modal should appear
+    expect(screen.queryByText("Review Changes")).not.toBeInTheDocument();
     expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+  });
+
+  it("should show confirmation modal when a team is removed", async () => {
+    const settingsWithTeams = {
+      ...mockSettings,
+      values: {
+        ...mockSettings.values,
+        teams: [
+          { team_id: "team-alpha", max_budget_in_team: 50, user_role: "user" },
+          { team_id: "team-beta", max_budget_in_team: 25, user_role: "admin" },
+        ],
+      },
+    };
+    mockGetInternalUserSettings.mockResolvedValue(settingsWithTeams);
+
+    render(<DefaultUserSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+    });
+
+    // Enter edit mode
+    act(() => {
+      fireEvent.click(screen.getByText("Edit Settings"));
+    });
+
+    // Remove the first team
+    const removeButtons = screen.getAllByText("Remove");
+    act(() => {
+      fireEvent.click(removeButtons[0]);
+    });
+
+    // Click Save Changes
+    act(() => {
+      fireEvent.click(screen.getByText("Save Changes"));
+    });
+
+    // Modal should appear
+    await waitFor(() => {
+      expect(screen.getByText("Review Changes")).toBeInTheDocument();
+    });
+
+    // Should mention the removed team
+    expect(screen.getByText(/team-alpha/)).toBeInTheDocument();
+
+    // Save should NOT have been called yet
+    expect(mockUpdateInternalUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("should save after confirming in the modal", async () => {
+    const settingsWithTeams = {
+      ...mockSettings,
+      values: {
+        ...mockSettings.values,
+        teams: [
+          { team_id: "team-alpha", max_budget_in_team: 50, user_role: "user" },
+          { team_id: "team-beta", max_budget_in_team: 25, user_role: "admin" },
+        ],
+      },
+    };
+    mockGetInternalUserSettings.mockResolvedValue(settingsWithTeams);
+    mockUpdateInternalUserSettings.mockResolvedValue({
+      settings: {
+        ...settingsWithTeams.values,
+        teams: [{ team_id: "team-beta", max_budget_in_team: 25, user_role: "admin" }],
+      },
+    });
+
+    render(<DefaultUserSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+    });
+
+    // Enter edit mode, remove first team, click Save
+    act(() => {
+      fireEvent.click(screen.getByText("Edit Settings"));
+    });
+    const removeButtons = screen.getAllByText("Remove");
+    act(() => {
+      fireEvent.click(removeButtons[0]);
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("Save Changes"));
+    });
+
+    // Wait for modal
+    await waitFor(() => {
+      expect(screen.getByText("Review Changes")).toBeInTheDocument();
+    });
+
+    // Click Confirm
+    await act(async () => {
+      fireEvent.click(screen.getByText("Confirm Changes"));
+    });
+
+    // Save should have been called
+    await waitFor(() => {
+      expect(mockUpdateInternalUserSettings).toHaveBeenCalledTimes(1);
+    });
+
+    // The saved teams should not include team-alpha
+    const sentValues = mockUpdateInternalUserSettings.mock.calls[0][1];
+    const sentTeamIds = sentValues.teams.map((t: any) => t.team_id);
+    expect(sentTeamIds).not.toContain("team-alpha");
+    expect(sentTeamIds).toContain("team-beta");
+  });
+
+  it("should NOT save when modal is cancelled", async () => {
+    const settingsWithTeams = {
+      ...mockSettings,
+      values: {
+        ...mockSettings.values,
+        teams: [
+          { team_id: "team-alpha", max_budget_in_team: 50, user_role: "user" },
+        ],
+      },
+    };
+    mockGetInternalUserSettings.mockResolvedValue(settingsWithTeams);
+
+    render(<DefaultUserSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+    });
+
+    // Enter edit mode, remove team, click Save
+    act(() => {
+      fireEvent.click(screen.getByText("Edit Settings"));
+    });
+    const removeButtons = screen.getAllByText("Remove");
+    act(() => {
+      fireEvent.click(removeButtons[0]);
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("Save Changes"));
+    });
+
+    // Wait for modal
+    await waitFor(() => {
+      expect(screen.getByText("Review Changes")).toBeInTheDocument();
+    });
+
+    // Click Cancel inside the modal (there are two Cancel buttons: one in the
+    // edit header and one in the modal footer). The modal's Cancel is the last
+    // one rendered.
+    const cancelButtons = screen.getAllByText("Cancel");
+    await act(async () => {
+      fireEvent.click(cancelButtons[cancelButtons.length - 1]);
+    });
+
+    // Save should NOT have been called
+    expect(mockUpdateInternalUserSettings).not.toHaveBeenCalled();
+
+    // Should still be in edit mode (Save Changes button visible)
+    expect(screen.getByText("Save Changes")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: computeSettingsDiff (pure function)
+// ---------------------------------------------------------------------------
+
+describe("computeSettingsDiff", () => {
+  it("returns no changes when values are identical", () => {
+    const values = { max_budget: 100, models: ["gpt-4"], teams: [] };
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(values, { ...values });
+    expect(changes).toHaveLength(0);
+    expect(hasDestructiveChanges).toBe(false);
+  });
+
+  it("detects team removal as destructive", () => {
+    const original = {
+      teams: [
+        { team_id: "team-alpha", user_role: "user" },
+        { team_id: "team-beta", user_role: "admin" },
+      ],
+    };
+    const edited = {
+      teams: [{ team_id: "team-alpha", user_role: "user" }],
+    };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(true);
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "removed",
+          details: expect.stringContaining("team-beta"),
+        }),
+      ]),
+    );
+  });
+
+  it("detects team addition as non-destructive", () => {
+    const original = { teams: [] };
+    const edited = { teams: [{ team_id: "new-team", user_role: "user" }] };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(false);
+    expect(changes).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "added" })]),
+    );
+  });
+
+  it("detects team budget change as destructive", () => {
+    const original = { teams: [{ team_id: "t1", max_budget_in_team: 100, user_role: "user" }] };
+    const edited = { teams: [{ team_id: "t1", max_budget_in_team: 50, user_role: "user" }] };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(true);
+    expect(changes[0].type).toBe("changed");
+    expect(changes[0].details).toContain("$100");
+    expect(changes[0].details).toContain("$50");
+  });
+
+  it("detects model removal as destructive", () => {
+    const original = { models: ["gpt-4", "gpt-3.5-turbo"] };
+    const edited = { models: ["gpt-4"] };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(true);
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "removed", details: expect.stringContaining("gpt-3.5-turbo") }),
+      ]),
+    );
+  });
+
+  it("detects model addition as non-destructive", () => {
+    const original = { models: ["gpt-4"] };
+    const edited = { models: ["gpt-4", "claude-3"] };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(false);
+    expect(changes).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "added" })]),
+    );
+  });
+
+  it("detects scalar field cleared as destructive", () => {
+    const original = { max_budget: 100 };
+    const edited = { max_budget: null };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(true);
+    expect(changes[0].type).toBe("removed");
+    expect(changes[0].details).toContain("Cleared");
+  });
+
+  it("detects scalar field set as non-destructive", () => {
+    const original = { max_budget: null };
+    const edited = { max_budget: 200 };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(false);
+    expect(changes[0].type).toBe("added");
+  });
+
+  it("detects scalar value change as destructive", () => {
+    const original = { user_role: "internal_user" };
+    const edited = { user_role: "internal_user_view_only" };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(true);
+    expect(changes[0].type).toBe("changed");
+  });
+
+  it("handles string team_ids in original", () => {
+    const original = { teams: ["team-alpha", "team-beta"] };
+    const edited = { teams: [{ team_id: "team-alpha", user_role: "user" }] };
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(original, edited);
+    expect(hasDestructiveChanges).toBe(true);
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "removed", details: expect.stringContaining("team-beta") }),
+      ]),
+    );
+  });
+
+  it("treats empty string same as null for scalars", () => {
+    const original = { max_budget: "" };
+    const edited = { max_budget: null };
+
+    const { changes } = computeSettingsDiff(original, edited);
+    expect(changes).toHaveLength(0);
   });
 });

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
@@ -22,22 +22,30 @@ interface TeamEntry {
   user_role: "user" | "admin";
 }
 
-/** Normalize heterogeneous team arrays (strings or objects) to TeamEntry[]. */
-function normalizeTeams(teams: any[]): TeamEntry[] {
-  if (!teams || !Array.isArray(teams)) return [];
+/** Shape returned by the GET endpoint and sent back on PATCH. */
+interface DefaultUserSettingsValues {
+  user_role?: string | null;
+  max_budget?: number | null;
+  budget_duration?: string | null;
+  models?: string[] | null;
+  teams?: (string | TeamEntry)[] | null;
+}
 
-  return teams.map((team) => {
-    if (typeof team === "string") {
-      return { team_id: team, user_role: "user" as const };
-    } else if (typeof team === "object" && team.team_id) {
-      return {
-        team_id: team.team_id,
-        max_budget_in_team: team.max_budget_in_team,
-        user_role: team.user_role || "user",
-      };
-    }
-    return { team_id: "", user_role: "user" as const };
-  });
+interface SettingsResponse {
+  values: DefaultUserSettingsValues;
+  field_schema: {
+    description?: string;
+    properties: Record<string, { type: string; description?: string; enum?: string[]; items?: { enum?: string[] } }>;
+  };
+}
+
+/** Normalize the backend's union type (string | TeamEntry) to TeamEntry[]. */
+function normalizeTeams(teams: (string | TeamEntry)[]): TeamEntry[] {
+  return teams.map((team) =>
+    typeof team === "string"
+      ? { team_id: team, user_role: "user" as const }
+      : { team_id: team.team_id, max_budget_in_team: team.max_budget_in_team, user_role: team.user_role || "user" },
+  );
 }
 
 /**
@@ -46,136 +54,64 @@ function normalizeTeams(teams: any[]): TeamEntry[] {
  * cleared, or reduced.
  */
 export function computeSettingsDiff(
-  original: Record<string, any>,
-  edited: Record<string, any>,
+  original: DefaultUserSettingsValues,
+  edited: DefaultUserSettingsValues,
 ): { changes: SettingsChange[]; hasDestructiveChanges: boolean } {
   const changes: SettingsChange[] = [];
 
-  const allKeys = new Set([...Object.keys(original), ...Object.keys(edited)]);
+  // --- Teams ---
+  const oldTeams = normalizeTeams(original.teams || []);
+  const newTeams = normalizeTeams(edited.teams || []);
+  const oldTeamMap = new Map(oldTeams.map((t) => [t.team_id, t]));
+  const newTeamIds = new Set(newTeams.map((t) => t.team_id));
 
-  for (const key of allKeys) {
-    const oldVal = original[key];
-    const newVal = edited[key];
-
-    const displayName = key.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
-
-    if (key === "teams") {
-      const oldTeams = normalizeTeams(oldVal || []);
-      const newTeams = normalizeTeams(newVal || []);
-
-      const oldIds = new Set(oldTeams.map((t) => t.team_id));
-      const newIds = new Set(newTeams.map((t) => t.team_id));
-
-      // Removed teams
-      for (const t of oldTeams) {
-        if (!newIds.has(t.team_id)) {
-          changes.push({
-            field: displayName,
-            type: "removed",
-            details: `Team "${t.team_id}" removed`,
-          });
-        }
-      }
-
-      // Added teams
-      for (const t of newTeams) {
-        if (t.team_id && !oldIds.has(t.team_id)) {
-          changes.push({
-            field: displayName,
-            type: "added",
-            details: `Team "${t.team_id}" added`,
-          });
-        }
-      }
-
-      // Budget/role changes for teams that still exist
-      for (const newTeam of newTeams) {
-        if (!oldIds.has(newTeam.team_id)) continue;
-        const oldTeam = oldTeams.find((t) => t.team_id === newTeam.team_id);
-        if (!oldTeam) continue;
-
-        if (oldTeam.max_budget_in_team !== newTeam.max_budget_in_team) {
-          const oldBudget = oldTeam.max_budget_in_team !== undefined ? `$${oldTeam.max_budget_in_team}` : "No limit";
-          const newBudget = newTeam.max_budget_in_team !== undefined ? `$${newTeam.max_budget_in_team}` : "No limit";
-          changes.push({
-            field: displayName,
-            type: "changed",
-            details: `Team "${newTeam.team_id}" budget: ${oldBudget} → ${newBudget}`,
-          });
-        }
-
-        if (oldTeam.user_role !== newTeam.user_role) {
-          changes.push({
-            field: displayName,
-            type: "changed",
-            details: `Team "${newTeam.team_id}" role: ${oldTeam.user_role} → ${newTeam.user_role}`,
-          });
-        }
-      }
-
+  for (const t of oldTeams) {
+    if (!newTeamIds.has(t.team_id)) {
+      changes.push({ field: "Teams", type: "removed", details: `Team "${t.team_id}" removed` });
+    }
+  }
+  for (const t of newTeams) {
+    if (!t.team_id) continue;
+    const old = oldTeamMap.get(t.team_id);
+    if (!old) {
+      changes.push({ field: "Teams", type: "added", details: `Team "${t.team_id}" added` });
       continue;
     }
-
-    if (key === "models") {
-      const oldModels: string[] = Array.isArray(oldVal) ? oldVal : [];
-      const newModels: string[] = Array.isArray(newVal) ? newVal : [];
-      const oldSet = new Set(oldModels);
-      const newSet = new Set(newModels);
-
-      const removed = oldModels.filter((m) => !newSet.has(m));
-      const added = newModels.filter((m) => !oldSet.has(m));
-
-      if (removed.length > 0) {
-        changes.push({
-          field: displayName,
-          type: "removed",
-          details: `${removed.join(", ")} removed`,
-        });
-      }
-      if (added.length > 0) {
-        changes.push({
-          field: displayName,
-          type: "added",
-          details: `${added.join(", ")} added`,
-        });
-      }
-      continue;
+    if (old.max_budget_in_team !== t.max_budget_in_team) {
+      const fmt = (v?: number) => (v !== undefined ? `$${v}` : "No limit");
+      changes.push({ field: "Teams", type: "changed", details: `Team "${t.team_id}" budget: ${fmt(old.max_budget_in_team)} → ${fmt(t.max_budget_in_team)}` });
     }
-
-    // Scalar fields
-    const oldNorm = oldVal === "" ? null : oldVal;
-    const newNorm = newVal === "" ? null : newVal;
-
-    if (oldNorm === newNorm) continue;
-    // Both null/undefined — no change
-    if (oldNorm == null && newNorm == null) continue;
-
-    if (oldNorm != null && newNorm == null) {
-      // Value cleared
-      changes.push({
-        field: displayName,
-        type: "removed",
-        details: `Cleared (was "${oldNorm}")`,
-      });
-    } else if (oldNorm == null && newNorm != null) {
-      // Value set
-      changes.push({
-        field: displayName,
-        type: "added",
-        details: `Set to "${newNorm}"`,
-      });
-    } else if (oldNorm !== newNorm) {
-      changes.push({
-        field: displayName,
-        type: "changed",
-        details: `"${oldNorm}" → "${newNorm}"`,
-      });
+    if (old.user_role !== t.user_role) {
+      changes.push({ field: "Teams", type: "changed", details: `Team "${t.team_id}" role: ${old.user_role} → ${t.user_role}` });
     }
   }
 
-  const hasDestructiveChanges = changes.some((c) => c.type === "removed" || c.type === "changed");
+  // --- Models ---
+  const oldModels = new Set(original.models || []);
+  const newModels = new Set(edited.models || []);
+  const removedModels = [...oldModels].filter((m) => !newModels.has(m));
+  const addedModels = [...newModels].filter((m) => !oldModels.has(m));
+  if (removedModels.length) changes.push({ field: "Models", type: "removed", details: `${removedModels.join(", ")} removed` });
+  if (addedModels.length) changes.push({ field: "Models", type: "added", details: `${addedModels.join(", ")} added` });
 
-  return { changes, hasDestructiveChanges };
+  // --- Scalars ---
+  const scalarKeys = ["user_role", "max_budget", "budget_duration"] as const;
+  for (const key of scalarKeys) {
+    const oldVal = original[key] ?? null;
+    const newVal = edited[key] ?? null;
+    if (oldVal === newVal) continue;
+
+    const displayName = key.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+    if (oldVal != null && newVal == null) {
+      changes.push({ field: displayName, type: "removed", details: `Cleared (was "${oldVal}")` });
+    } else if (oldVal == null && newVal != null) {
+      changes.push({ field: displayName, type: "added", details: `Set to "${newVal}"` });
+    } else {
+      changes.push({ field: displayName, type: "changed", details: `"${oldVal}" → "${newVal}"` });
+    }
+  }
+
+  return { changes, hasDestructiveChanges: changes.some((c) => c.type === "removed" || c.type === "changed") };
 }
 
 const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
@@ -185,14 +121,14 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
   userRole,
 }) => {
   const [loading, setLoading] = useState<boolean>(true);
-  const [settings, setSettings] = useState<any>(null);
+  const [settings, setSettings] = useState<SettingsResponse | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [editedValues, setEditedValues] = useState<any>({});
+  const [editedValues, setEditedValues] = useState<DefaultUserSettingsValues>({});
   const [saving, setSaving] = useState<boolean>(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
   const [pendingChanges, setPendingChanges] = useState<SettingsChange[]>([]);
-  const [pendingProcessedValues, setPendingProcessedValues] = useState<Record<string, any> | null>(null);
+  const [pendingProcessedValues, setPendingProcessedValues] = useState<DefaultUserSettingsValues | null>(null);
   const { Paragraph } = Typography;
   const { Option } = Select;
 
@@ -232,7 +168,7 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
   }, [accessToken]);
 
   /** Perform the actual API save with the given processed values. */
-  const executeSave = async (processedValues: Record<string, any>) => {
+  const executeSave = async (processedValues: DefaultUserSettingsValues) => {
     if (!accessToken) return;
 
     setSaving(true);
@@ -253,13 +189,9 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     if (!accessToken) return;
 
     // Convert empty strings to null
-    const processedValues = Object.entries(editedValues).reduce(
-      (acc, [key, value]) => {
-        acc[key] = value === "" ? null : value;
-        return acc;
-      },
-      {} as Record<string, any>,
-    );
+    const processedValues = Object.fromEntries(
+      Object.entries(editedValues).map(([key, value]) => [key, value === "" ? null : value]),
+    ) as DefaultUserSettingsValues;
 
     const { changes, hasDestructiveChanges } = computeSettingsDiff(
       settings?.values || {},
@@ -286,11 +218,8 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     setPendingProcessedValues(null);
   };
 
-  const handleTextInputChange = (key: string, value: any) => {
-    setEditedValues((prev: Record<string, any>) => ({
-      ...prev,
-      [key]: value,
-    }));
+  const handleTextInputChange = (key: keyof DefaultUserSettingsValues, value: DefaultUserSettingsValues[typeof key]) => {
+    setEditedValues((prev) => ({ ...prev, [key]: value }));
   };
 
   // Teams editor component

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
@@ -174,7 +174,7 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     setSaving(true);
     try {
       const updatedSettings = await updateInternalUserSettings(accessToken, processedValues);
-      setSettings({ ...settings, values: updatedSettings.settings });
+      setSettings((prev) => prev ? { ...prev, values: updatedSettings.settings } : null);
       setIsEditing(false);
       return true;
     } catch (error) {
@@ -222,7 +222,7 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     }
   };
 
-  const handleTextInputChange = (key: keyof DefaultUserSettingsValues, value: DefaultUserSettingsValues[typeof key]) => {
+  const handleTextInputChange = (key: string, value: any) => {
     setEditedValues((prev) => ({ ...prev, [key]: value }));
   };
 

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
@@ -4,6 +4,7 @@ import { Button, Typography, Spin, Switch, Select, InputNumber } from "antd";
 import { PlusOutlined, DeleteOutlined } from "@ant-design/icons";
 import { getInternalUserSettings, updateInternalUserSettings, modelAvailableCall } from "./networking";
 import BudgetDurationDropdown, { getBudgetDurationLabel } from "./common_components/budget_duration_dropdown";
+import ConfirmSettingsChangeModal, { SettingsChange } from "./common_components/ConfirmSettingsChangeModal";
 import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import NotificationManager from "./molecules/notifications_manager";
@@ -21,6 +22,162 @@ interface TeamEntry {
   user_role: "user" | "admin";
 }
 
+/** Normalize heterogeneous team arrays (strings or objects) to TeamEntry[]. */
+function normalizeTeams(teams: any[]): TeamEntry[] {
+  if (!teams || !Array.isArray(teams)) return [];
+
+  return teams.map((team) => {
+    if (typeof team === "string") {
+      return { team_id: team, user_role: "user" as const };
+    } else if (typeof team === "object" && team.team_id) {
+      return {
+        team_id: team.team_id,
+        max_budget_in_team: team.max_budget_in_team,
+        user_role: team.user_role || "user",
+      };
+    }
+    return { team_id: "", user_role: "user" as const };
+  });
+}
+
+/**
+ * Compare original settings values against edited values and return a list of
+ * human-readable changes. A change is "destructive" if something was removed,
+ * cleared, or reduced.
+ */
+export function computeSettingsDiff(
+  original: Record<string, any>,
+  edited: Record<string, any>,
+): { changes: SettingsChange[]; hasDestructiveChanges: boolean } {
+  const changes: SettingsChange[] = [];
+
+  const allKeys = new Set([...Object.keys(original), ...Object.keys(edited)]);
+
+  for (const key of allKeys) {
+    const oldVal = original[key];
+    const newVal = edited[key];
+
+    const displayName = key.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+
+    if (key === "teams") {
+      const oldTeams = normalizeTeams(oldVal || []);
+      const newTeams = normalizeTeams(newVal || []);
+
+      const oldIds = new Set(oldTeams.map((t) => t.team_id));
+      const newIds = new Set(newTeams.map((t) => t.team_id));
+
+      // Removed teams
+      for (const t of oldTeams) {
+        if (!newIds.has(t.team_id)) {
+          changes.push({
+            field: displayName,
+            type: "removed",
+            details: `Team "${t.team_id}" removed`,
+          });
+        }
+      }
+
+      // Added teams
+      for (const t of newTeams) {
+        if (t.team_id && !oldIds.has(t.team_id)) {
+          changes.push({
+            field: displayName,
+            type: "added",
+            details: `Team "${t.team_id}" added`,
+          });
+        }
+      }
+
+      // Budget/role changes for teams that still exist
+      for (const newTeam of newTeams) {
+        if (!oldIds.has(newTeam.team_id)) continue;
+        const oldTeam = oldTeams.find((t) => t.team_id === newTeam.team_id);
+        if (!oldTeam) continue;
+
+        if (oldTeam.max_budget_in_team !== newTeam.max_budget_in_team) {
+          const oldBudget = oldTeam.max_budget_in_team !== undefined ? `$${oldTeam.max_budget_in_team}` : "No limit";
+          const newBudget = newTeam.max_budget_in_team !== undefined ? `$${newTeam.max_budget_in_team}` : "No limit";
+          changes.push({
+            field: displayName,
+            type: "changed",
+            details: `Team "${newTeam.team_id}" budget: ${oldBudget} → ${newBudget}`,
+          });
+        }
+
+        if (oldTeam.user_role !== newTeam.user_role) {
+          changes.push({
+            field: displayName,
+            type: "changed",
+            details: `Team "${newTeam.team_id}" role: ${oldTeam.user_role} → ${newTeam.user_role}`,
+          });
+        }
+      }
+
+      continue;
+    }
+
+    if (key === "models") {
+      const oldModels: string[] = Array.isArray(oldVal) ? oldVal : [];
+      const newModels: string[] = Array.isArray(newVal) ? newVal : [];
+      const oldSet = new Set(oldModels);
+      const newSet = new Set(newModels);
+
+      const removed = oldModels.filter((m) => !newSet.has(m));
+      const added = newModels.filter((m) => !oldSet.has(m));
+
+      if (removed.length > 0) {
+        changes.push({
+          field: displayName,
+          type: "removed",
+          details: `${removed.join(", ")} removed`,
+        });
+      }
+      if (added.length > 0) {
+        changes.push({
+          field: displayName,
+          type: "added",
+          details: `${added.join(", ")} added`,
+        });
+      }
+      continue;
+    }
+
+    // Scalar fields
+    const oldNorm = oldVal === "" ? null : oldVal;
+    const newNorm = newVal === "" ? null : newVal;
+
+    if (oldNorm === newNorm) continue;
+    // Both null/undefined — no change
+    if (oldNorm == null && newNorm == null) continue;
+
+    if (oldNorm != null && newNorm == null) {
+      // Value cleared
+      changes.push({
+        field: displayName,
+        type: "removed",
+        details: `Cleared (was "${oldNorm}")`,
+      });
+    } else if (oldNorm == null && newNorm != null) {
+      // Value set
+      changes.push({
+        field: displayName,
+        type: "added",
+        details: `Set to "${newNorm}"`,
+      });
+    } else if (oldNorm !== newNorm) {
+      changes.push({
+        field: displayName,
+        type: "changed",
+        details: `"${oldNorm}" → "${newNorm}"`,
+      });
+    }
+  }
+
+  const hasDestructiveChanges = changes.some((c) => c.type === "removed" || c.type === "changed");
+
+  return { changes, hasDestructiveChanges };
+}
+
 const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
   accessToken,
   possibleUIRoles,
@@ -33,6 +190,9 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
   const [editedValues, setEditedValues] = useState<any>({});
   const [saving, setSaving] = useState<boolean>(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
+  const [pendingChanges, setPendingChanges] = useState<SettingsChange[]>([]);
+  const [pendingProcessedValues, setPendingProcessedValues] = useState<Record<string, any> | null>(null);
   const { Paragraph } = Typography;
   const { Option } = Select;
 
@@ -71,20 +231,12 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     fetchSSOSettings();
   }, [accessToken]);
 
-  const handleSaveSettings = async () => {
+  /** Perform the actual API save with the given processed values. */
+  const executeSave = async (processedValues: Record<string, any>) => {
     if (!accessToken) return;
 
     setSaving(true);
     try {
-      // Convert empty strings to null
-      const processedValues = Object.entries(editedValues).reduce(
-        (acc, [key, value]) => {
-          acc[key] = value === "" ? null : value;
-          return acc;
-        },
-        {} as Record<string, any>,
-      );
-
       const updatedSettings = await updateInternalUserSettings(accessToken, processedValues);
       setSettings({ ...settings, values: updatedSettings.settings });
       setIsEditing(false);
@@ -96,35 +248,49 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     }
   };
 
+  /** Called when user clicks "Save Changes". Shows modal if destructive. */
+  const handleSaveSettings = async () => {
+    if (!accessToken) return;
+
+    // Convert empty strings to null
+    const processedValues = Object.entries(editedValues).reduce(
+      (acc, [key, value]) => {
+        acc[key] = value === "" ? null : value;
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
+
+    const { changes, hasDestructiveChanges } = computeSettingsDiff(
+      settings?.values || {},
+      processedValues,
+    );
+
+    if (hasDestructiveChanges) {
+      setPendingChanges(changes);
+      setPendingProcessedValues(processedValues);
+      setShowConfirmModal(true);
+      return;
+    }
+
+    // No destructive changes — save directly
+    await executeSave(processedValues);
+  };
+
+  /** Called when user confirms changes in the modal. */
+  const handleConfirmSave = async () => {
+    if (!pendingProcessedValues) return;
+    await executeSave(pendingProcessedValues);
+    setShowConfirmModal(false);
+    setPendingChanges([]);
+    setPendingProcessedValues(null);
+  };
+
   const handleTextInputChange = (key: string, value: any) => {
     setEditedValues((prev: Record<string, any>) => ({
       ...prev,
       [key]: value,
     }));
-  };
-
-  // Helper function to normalize teams array to consistent format
-  const normalizeTeams = (teams: any[]): TeamEntry[] => {
-    if (!teams || !Array.isArray(teams)) return [];
-
-    return teams.map((team) => {
-      if (typeof team === "string") {
-        return {
-          team_id: team,
-          user_role: "user" as const,
-        };
-      } else if (typeof team === "object" && team.team_id) {
-        return {
-          team_id: team.team_id,
-          max_budget_in_team: team.max_budget_in_team,
-          user_role: team.user_role || "user",
-        };
-      }
-      return {
-        team_id: "",
-        user_role: "user" as const,
-      };
-    });
   };
 
   // Teams editor component
@@ -484,6 +650,18 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
       <Divider />
 
       <div className="mt-4 space-y-4">{renderSettings()}</div>
+
+      <ConfirmSettingsChangeModal
+        isOpen={showConfirmModal}
+        changes={pendingChanges}
+        onConfirm={handleConfirmSave}
+        onCancel={() => {
+          setShowConfirmModal(false);
+          setPendingChanges([]);
+          setPendingProcessedValues(null);
+        }}
+        confirmLoading={saving}
+      />
     </Card>
   );
 };

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
@@ -167,18 +167,20 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     fetchSSOSettings();
   }, [accessToken]);
 
-  /** Perform the actual API save with the given processed values. */
-  const executeSave = async (processedValues: DefaultUserSettingsValues) => {
-    if (!accessToken) return;
+  /** Perform the actual API save. Returns true on success, false on failure. */
+  const executeSave = async (processedValues: DefaultUserSettingsValues): Promise<boolean> => {
+    if (!accessToken) return false;
 
     setSaving(true);
     try {
       const updatedSettings = await updateInternalUserSettings(accessToken, processedValues);
       setSettings({ ...settings, values: updatedSettings.settings });
       setIsEditing(false);
+      return true;
     } catch (error) {
       console.error("Error updating SSO settings:", error);
       NotificationManager.fromBackend("Failed to update settings: " + error);
+      return false;
     } finally {
       setSaving(false);
     }
@@ -209,13 +211,15 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
     await executeSave(processedValues);
   };
 
-  /** Called when user confirms changes in the modal. */
+  /** Called when user confirms changes in the modal. Only clears modal on success. */
   const handleConfirmSave = async () => {
     if (!pendingProcessedValues) return;
-    await executeSave(pendingProcessedValues);
-    setShowConfirmModal(false);
-    setPendingChanges([]);
-    setPendingProcessedValues(null);
+    const success = await executeSave(pendingProcessedValues);
+    if (success) {
+      setShowConfirmModal(false);
+      setPendingChanges([]);
+      setPendingProcessedValues(null);
+    }
   };
 
   const handleTextInputChange = (key: keyof DefaultUserSettingsValues, value: DefaultUserSettingsValues[typeof key]) => {

--- a/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
+++ b/ui/litellm-dashboard/src/components/DefaultUserSettings.tsx
@@ -386,6 +386,19 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
           ))}
         </Select>
       );
+    } else if (type === "number") {
+      return (
+        <InputNumber
+          style={{ width: "100%" }}
+          value={editedValues[key] as number | undefined}
+          onChange={(value) => handleTextInputChange(key, value)}
+          placeholder={property.description || ""}
+          className="mt-2"
+          min={0}
+          step={0.01}
+          precision={2}
+        />
+      );
     } else if (type === "string" && property.enum) {
       return (
         <Select

--- a/ui/litellm-dashboard/src/components/common_components/ConfirmSettingsChangeModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/ConfirmSettingsChangeModal.tsx
@@ -55,12 +55,14 @@ export default function ConfirmSettingsChangeModal({
       title="Review Changes"
       open={isOpen}
       onOk={onConfirm}
-      onCancel={onCancel}
+      onCancel={() => { if (!confirmLoading) onCancel(); }}
       confirmLoading={confirmLoading}
       okText={confirmLoading ? "Saving..." : "Confirm Changes"}
       cancelText="Cancel"
       okButtonProps={{ disabled: confirmLoading }}
       cancelButtonProps={{ disabled: confirmLoading }}
+      keyboard={!confirmLoading}
+      maskClosable={!confirmLoading}
     >
       <div className="space-y-4">
         <div className="space-y-2">

--- a/ui/litellm-dashboard/src/components/common_components/ConfirmSettingsChangeModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/ConfirmSettingsChangeModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Alert, Modal, Typography } from "antd";
+import { Modal, Typography } from "antd";
 import {
   MinusCircleOutlined,
   PlusCircleOutlined,
@@ -63,13 +63,7 @@ export default function ConfirmSettingsChangeModal({
       cancelButtonProps={{ disabled: confirmLoading }}
     >
       <div className="space-y-4">
-        <Alert
-          message="These defaults apply to all future users created via SSO, API, or SCIM."
-          type="warning"
-          showIcon
-        />
-
-        <div className="mt-4 space-y-2">
+        <div className="space-y-2">
           {changes.map((change, index) => {
             const config = CHANGE_CONFIG[change.type];
             return (

--- a/ui/litellm-dashboard/src/components/common_components/ConfirmSettingsChangeModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/ConfirmSettingsChangeModal.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { Alert, Modal, Typography } from "antd";
+import {
+  MinusCircleOutlined,
+  PlusCircleOutlined,
+  EditOutlined,
+} from "@ant-design/icons";
+
+export interface SettingsChange {
+  field: string;
+  type: "removed" | "added" | "changed";
+  details: string;
+}
+
+interface ConfirmSettingsChangeModalProps {
+  isOpen: boolean;
+  changes: SettingsChange[];
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmLoading: boolean;
+}
+
+const CHANGE_CONFIG: Record<
+  SettingsChange["type"],
+  { color: string; icon: React.ReactNode; label: string }
+> = {
+  removed: {
+    color: "#cf1322",
+    icon: <MinusCircleOutlined style={{ color: "#cf1322" }} />,
+    label: "Removed",
+  },
+  added: {
+    color: "#389e0d",
+    icon: <PlusCircleOutlined style={{ color: "#389e0d" }} />,
+    label: "Added",
+  },
+  changed: {
+    color: "#d48806",
+    icon: <EditOutlined style={{ color: "#d48806" }} />,
+    label: "Changed",
+  },
+};
+
+export default function ConfirmSettingsChangeModal({
+  isOpen,
+  changes,
+  onConfirm,
+  onCancel,
+  confirmLoading,
+}: ConfirmSettingsChangeModalProps) {
+  const { Text } = Typography;
+
+  return (
+    <Modal
+      title="Review Changes"
+      open={isOpen}
+      onOk={onConfirm}
+      onCancel={onCancel}
+      confirmLoading={confirmLoading}
+      okText={confirmLoading ? "Saving..." : "Confirm Changes"}
+      cancelText="Cancel"
+      okButtonProps={{ disabled: confirmLoading }}
+      cancelButtonProps={{ disabled: confirmLoading }}
+    >
+      <div className="space-y-4">
+        <Alert
+          message="These defaults apply to all future users created via SSO, API, or SCIM."
+          type="warning"
+          showIcon
+        />
+
+        <div className="mt-4 space-y-2">
+          {changes.map((change, index) => {
+            const config = CHANGE_CONFIG[change.type];
+            return (
+              <div
+                key={index}
+                className="flex items-start gap-2 p-2 rounded"
+                style={{ backgroundColor: `${config.color}08` }}
+              >
+                <span className="mt-0.5 flex-shrink-0">{config.icon}</span>
+                <div>
+                  <Text strong style={{ color: config.color }}>
+                    {change.field}
+                  </Text>
+                  <Text className="ml-1" style={{ color: config.color }}>
+                    — {change.details}
+                  </Text>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

When removing teams, clearing budgets, or changing roles in Default User Settings, a "Review Changes" modal now appears summarizing what will change before persisting. Non-destructive changes (additions only) save directly.

<img width="1050" height="907" alt="Screenshot 2026-03-21 at 11 20 16 AM" src="https://github.com/user-attachments/assets/15c302f6-4215-4404-9862-9b11e417ee0e" />
