### PR TITLE
fix(proxy): add /prompts/list to self_managed_routes (fixes 401 for internal_user)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -657,8 +657,9 @@ class LiteLLMRoutes(enum.Enum):
         "/user/available_roles",  # read-only role metadata; any authenticated user may read
         "/user/list",  # org admins checked in endpoint; non-admins get 403
         "/model/{model_id}/update",
-        "/prompt/list",
-        "/prompt/info",
+         "/prompt/list",
+         "/prompt/info",
+         "/prompts/list",  # plural route alias — endpoint is @router.get("/prompts/list")
         # Invitation routes - org/team admins checked in endpoint via _user_has_admin_privileges
         "/invitation/new",
         "/invitation/delete",


### PR DESCRIPTION
## Summary

Fixes a one-character naming mismatch that causes `GET /prompts/list` to return `401 Unauthorized` for `internal_user` and other non-admin roles.

Fixes #24307

## Root Cause

`self_managed_routes` contained `"/prompt/list"` (singular), but the actual endpoint is registered as `@router.get("/prompts/list")` (plural) in `litellm/proxy/prompts/prompt_endpoints.py`.

Because the route isn't in the whitelist, the proxy's permission checker requires `PROXY_ADMIN` for any request to `/prompts/list`, causing a 401 for non-admin users.

## Change

```diff
# litellm/proxy/_types.py
  "/prompt/list",
  "/prompt/info",
+ "/prompts/list",  # plural route alias — endpoint is @router.get("/prompts/list")
```

## Testing

- ✅ Verified: `internal_user` API key can now successfully call `GET /prompts/list`
- ✅ No change to access control for other routes
- ✅ Existing `/prompt/list` entry preserved for backward compatibility

## Impact

- **Minimal**: 1-line addition to a list constant
- **No breaking changes**
- **Affected roles**: `internal_user`, `team`, any non-`PROXY_ADMIN` role