### PR TITLE
fix(ui): guard PriceDataManagementTab TabPanel with admin role check

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -466,7 +466,7 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
                     onAliasUpdate={setModelGroupAlias}
                   />
                 </TabPanel>
-                <PriceDataManagementTab />
+                {all_admin_roles.includes(userRole) && <PriceDataManagementTab />}
               </TabPanels>
             </TabGroup>
           )}


### PR DESCRIPTION
## Summary

Fixes a missing role guard on the `PriceDataManagementTab` TabPanel that causes repeated `401` errors in proxy logs for all non-admin user sessions.

Fixes #24308

## Root Cause

In `ModelsAndEndpointsView.tsx`, the **Tab label** was already correctly guarded:

```tsx
{all_admin_roles.includes(userRole) && <Tab>Price Data Reload</Tab>}  // ✅ guarded
```

But the corresponding **TabPanel** was rendered unconditionally:

```tsx
<PriceDataManagementTab />  // ❌ no role guard — always mounts
```

`PriceDataManagementTab` polls two admin-only endpoints every ~30 seconds:
- `GET /schedule/model_cost_map_reload/status`
- `GET /model/cost_map/source`

For `internal_user` and other non-admin roles, every poll produces a `401 Unauthorized` error in the server logs.

## Change

```diff
- <PriceDataManagementTab />
+ {all_admin_roles.includes(userRole) && <PriceDataManagementTab />}
```

One-line fix. Aligns the TabPanel render condition with the existing Tab label guard.

## Testing

- ✅ `internal_user` sessions no longer trigger 401 errors for `/schedule/model_cost_map_reload/status` or `/model/cost_map/source`
- ✅ Admin users still see and can use the Price Data Reload tab normally
- ✅ No visual regression for admin users

## Impact

- **Minimal**: 1-line change
- **No breaking changes**
- **Affected roles**: `internal_user`, `team`, any non-admin role