### PR TITLE
fix(ui): disable /config/list fetch for non-admin users in useProxyConfig hook

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxyConfig/useProxyConfig.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, UseMutationResult } from "@tanstack/react-query";
 import { createQueryKeys } from "../common/queryKeysFactory";
 import useAuthorized from "../useAuthorized";
+import { isProxyAdminRole } from "@/utils/roles";
 import { proxyBaseUrl, getGlobalLitellmHeaderName, deriveErrorMessage, handleError } from "@/components/networking";
 
 /**
@@ -146,7 +147,7 @@ export const deleteProxyConfigFieldCall = async (
  * @returns React Query result with the config list data
  */
 export const useProxyConfig = (configType: ConfigType) => {
-  const { accessToken } = useAuthorized();
+  const { accessToken, userRole } = useAuthorized();
   return useQuery<ProxyConfigResponse>({
     queryKey: proxyConfigKeys.list({
       filters: {
@@ -154,7 +155,7 @@ export const useProxyConfig = (configType: ConfigType) => {
       },
     }),
     queryFn: async () => await getProxyConfigCall(accessToken!, configType),
-    enabled: Boolean(accessToken),
+    enabled: Boolean(accessToken) && isProxyAdminRole(userRole ?? ""),
   });
 };
 


### PR DESCRIPTION
## Summary

Fixes `useProxyConfig` hook to skip the `GET /config/list` request for non-admin users, eliminating repeated `400` errors in proxy logs on every page load.

Fixes #24309

## Root Cause

`useProxyConfig` calls `GET /config/list` unconditionally on component mount. Since `/config/list` is restricted to `PROXY_ADMIN` (returns `400 Bad Request` for other roles), every page load for `internal_user` sessions triggers:

```
400 {"error": "Not allowed access, your role=internal_user"}
```

Components using `useProxyConfig` (`ModelSettingsModal`, `SpendLogsSettingsModal`) are rendered during initial page load, so this fires immediately and on every navigation.

## Change

```diff
+ import { isProxyAdminRole } from "@/utils/roles";

  export const useProxyConfig = (configType: ConfigType) => {
-   const { accessToken } = useAuthorized();
+   const { accessToken, userRole } = useAuthorized();
    return useQuery<ProxyConfigResponse>({
      ...
-     enabled: Boolean(accessToken),
+     enabled: Boolean(accessToken) && isProxyAdminRole(userRole ?? ""),
    });
  };
```

The `isProxyAdminRole` utility already exists in `@/utils/roles` — no new dependencies.

## Testing

- ✅ `internal_user` sessions no longer produce `400` errors on page load
- ✅ Admin users still fetch and display proxy config normally
- ✅ Components that consume `useProxyConfig` handle the `undefined` data state (they already do via optional chaining)

## Impact

- **Minimal**: 3-line change to one hook
- **No breaking changes**
- **Affected components**: any consumer of `useProxyConfig` (`ModelSettingsModal`, `SpendLogsSettingsModal`, and future consumers)