### PR TITLE
feat(provider): add Rapid-MLX as named provider

### DIFF
--- a/litellm/llms/openai_like/dynamic_config.py
+++ b/litellm/llms/openai_like/dynamic_config.py
@@ -69,7 +69,11 @@ def create_config_class(provider: SimpleProviderConfig):
                 resolved_base = provider.base_url
 
             # Resolve API key
-            resolved_key = api_key or get_secret_str(provider.api_key_env) or provider.default_api_key
+            resolved_key = (
+                api_key
+                or get_secret_str(provider.api_key_env)
+                or provider.default_api_key
+            )
 
             return resolved_base, resolved_key
 

--- a/litellm/llms/openai_like/dynamic_config.py
+++ b/litellm/llms/openai_like/dynamic_config.py
@@ -69,7 +69,7 @@ def create_config_class(provider: SimpleProviderConfig):
                 resolved_base = provider.base_url
 
             # Resolve API key
-            resolved_key = api_key or get_secret_str(provider.api_key_env)
+            resolved_key = api_key or get_secret_str(provider.api_key_env) or provider.default_api_key
 
             return resolved_base, resolved_key
 

--- a/litellm/llms/openai_like/json_loader.py
+++ b/litellm/llms/openai_like/json_loader.py
@@ -17,6 +17,7 @@ class SimpleProviderConfig:
         self.base_url = data["base_url"]
         self.api_key_env = data["api_key_env"]
         self.api_base_env = data.get("api_base_env")
+        self.default_api_key = data.get("default_api_key")
         self.base_class = data.get("base_class", "openai_gpt")
         self.param_mappings = data.get("param_mappings", {})
         self.constraints = data.get("constraints", {})

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -101,5 +101,11 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "rapid_mlx": {
+    "base_url": "http://localhost:8000/v1",
+    "api_key_env": "RAPID_MLX_API_KEY",
+    "default_api_key": "not-needed",
+    "api_base_env": "RAPID_MLX_API_BASE"
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3331,6 +3331,7 @@ class LlmProviders(str, Enum):
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"
+    RAPID_MLX = "rapid_mlx"
 
 
 # Create a set of all provider values for quick lookup

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -471,9 +471,7 @@
         "audio_speech": false,
         "moderations": false,
         "batches": false,
-        "rerank": false,
-        "a2a": false,
-        "interactions": false
+        "rerank": false
       }
     },
     "chutes": {
@@ -2554,9 +2552,9 @@
         "rerank": false
       }
     },
-    "charity_engine": {
-      "display_name": "Charity Engine (`charity_engine`)",
-      "url": "https://docs.litellm.ai/docs/providers/charity_engine",
+    "rapid_mlx": {
+      "display_name": "Rapid-MLX (`rapid_mlx`)",
+      "url": "https://docs.litellm.ai/docs/providers/rapid_mlx",
       "endpoints": {
         "chat_completions": true,
         "messages": true,

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -471,7 +471,9 @@
         "audio_speech": false,
         "moderations": false,
         "batches": false,
-        "rerank": false
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
       }
     },
     "chutes": {
@@ -2557,8 +2559,8 @@
       "url": "https://docs.litellm.ai/docs/providers/rapid_mlx",
       "endpoints": {
         "chat_completions": true,
-        "messages": true,
-        "responses": true,
+        "messages": false,
+        "responses": false,
         "embeddings": false,
         "image_generations": false,
         "audio_transcriptions": false,

--- a/tests/test_litellm/llms/rapid_mlx/test_rapid_mlx_completion.py
+++ b/tests/test_litellm/llms/rapid_mlx/test_rapid_mlx_completion.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import litellm
+
+
+def test_rapid_mlx_provider_routing():
+    """Test that rapid_mlx/ prefix routes correctly as an OpenAI-compatible provider."""
+    with patch(
+        "litellm.main.openai_chat_completions.completion"
+    ) as mock_completion:
+        mock_completion.return_value = {}
+
+        provider = "rapid_mlx"
+        model_name = "default"
+        model = f"{provider}/{model_name}"
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        _ = litellm.completion(
+            model=model,
+            messages=messages,
+            max_tokens=100,
+        )
+
+        mock_completion.assert_called_once()
+        _, call_kwargs = mock_completion.call_args
+        assert call_kwargs.get("custom_llm_provider") == provider
+        assert call_kwargs.get("model") == model_name
+        assert call_kwargs.get("messages") == messages
+        assert call_kwargs.get("api_base") == "http://localhost:8000/v1"
+        assert call_kwargs.get("api_key") == "not-needed"
+
+
+def test_rapid_mlx_custom_api_base():
+    """Test that RAPID_MLX_API_BASE environment variable is respected."""
+    with patch(
+        "litellm.main.openai_chat_completions.completion"
+    ) as mock_completion, patch.dict(
+        "os.environ",
+        {"RAPID_MLX_API_BASE": "http://192.168.1.100:8000/v1"},
+    ):
+        mock_completion.return_value = {}
+
+        _ = litellm.completion(
+            model="rapid_mlx/qwen3.5-9b",
+            messages=[{"role": "user", "content": "test"}],
+        )
+
+        mock_completion.assert_called_once()
+        _, call_kwargs = mock_completion.call_args
+        assert call_kwargs.get("api_base") == "http://192.168.1.100:8000/v1"
+
+
+def test_rapid_mlx_custom_api_key():
+    """Test that RAPID_MLX_API_KEY environment variable is respected."""
+    with patch(
+        "litellm.main.openai_chat_completions.completion"
+    ) as mock_completion, patch.dict(
+        "os.environ",
+        {"RAPID_MLX_API_KEY": "my-secret-key"},
+    ):
+        mock_completion.return_value = {}
+
+        _ = litellm.completion(
+            model="rapid_mlx/default",
+            messages=[{"role": "user", "content": "test"}],
+        )
+
+        mock_completion.assert_called_once()
+        _, call_kwargs = mock_completion.call_args
+        assert call_kwargs.get("api_key") == "my-secret-key"


### PR DESCRIPTION
## Summary

Adds [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) as a named provider via the JSON provider registry.

Rapid-MLX is an OpenAI-compatible inference server optimized for Apple Silicon (MLX), offering 2-4x faster inference than Ollama with full tool calling, reasoning separation, and prompt caching.

### Changes

- **`litellm/llms/openai_like/providers.json`** — add `rapid_mlx` entry with `base_url`, `api_key_env`, and `default_api_key`
- **`litellm/types/utils.py`** — add `RAPID_MLX = "rapid_mlx"` to `LlmProviders` enum
- **`provider_endpoints_support.json`** — add `rapid_mlx` provider with supported endpoints
- **`docs/my-website/docs/providers/rapid_mlx.md`** — provider documentation page (install, SDK usage, proxy config, env vars)
- **`docs/my-website/sidebars.js`** — add `rapid_mlx` to provider docs navigation
- **`tests/test_litellm/llms/rapid_mlx/test_rapid_mlx_completion.py`** — unit tests for provider routing, custom API base, and custom API key

### Usage

```python
from litellm import completion

response = completion(
    model="rapid_mlx/default",
    messages=[{"role": "user", "content": "Hello!"}],
)
```

### Test plan

- [x] Unit tests verify provider routing (`rapid_mlx/` prefix -> correct api_base and api_key)
- [x] Unit tests verify `RAPID_MLX_API_BASE` env var override
- [x] Unit tests verify `RAPID_MLX_API_KEY` env var override
- [ ] CI linting and unit tests pass