### PR TITLE
feat(mcp): MCP Toolsets — curated tool subsets from one or more MCP servers

### DIFF
--- a/docs/my-website/docs/mcp_toolsets.md
+++ b/docs/my-website/docs/mcp_toolsets.md
@@ -1,0 +1,231 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# MCP Toolsets
+
+A **Toolset** is a named collection of specific tools drawn from one or more MCP servers. Instead of giving an agent access to every tool on every server, you pick exactly which tools it needs — from whichever servers they live on — and bundle them under a single name.
+
+## How it works
+
+```
+                    ┌─────────────────────────────────┐
+                    │         MCP Toolset              │
+                    │      "devtooling-prod"           │
+                    └────────────┬────────────────────┘
+                                 │
+              ┌──────────────────┴──────────────────┐
+              │                                     │
+     ┌────────▼────────┐                  ┌────────▼────────┐
+     │  CircleCI MCP   │                  │  DeepWiki MCP   │
+     │  (10+ tools)    │                  │  (3 tools)      │
+     └────────┬────────┘                  └────────┬────────┘
+              │                                    │
+    ┌─────────┴──────────┐              ┌──────────┴──────────┐
+    │ ✓ get_build_logs   │              │ ✓ read_wiki_structure│
+    │ ✓ find_flaky_tests │              │ ✓ read_wiki_contents │
+    │ ✓ get_pipeline_    │              │ ✗ ask_question       │
+    │   status           │              └─────────────────────┘
+    │ ✓ run_pipeline     │
+    │ ✗ list_followed_   │
+    │   projects         │
+    └────────────────────┘
+
+        Agent sees exactly 6 tools, nothing more.
+```
+
+Instead of 13+ tools across two servers, the agent gets 6 — the ones it actually needs.
+
+**Why this matters:**
+- Smaller tool lists → fewer tokens, faster responses, less hallucination
+- Combine tools from GitHub + Linear + CircleCI into one named grant
+- Assign to keys and teams the same way you assign MCP servers today
+
+---
+
+## Create a toolset
+
+### 1. Go to the MCP page
+
+Navigate to **MCP** in the left sidebar.
+
+![Navigate to MCP](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/1a96c713-6a37-4f96-92f1-07bd58c1973c/ascreenshot_23515f386ccc4597b0633987667fe01f_text_export.jpeg)
+
+### 2. Open the Toolsets tab
+
+Click the **Toolsets** tab on the MCP page.
+
+![Click Toolsets tab](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/65b6986b-595a-4b28-8fdc-a7b36bc76e59/ascreenshot_ca70c18fe7ec415486f96a6b405bf550_text_export.jpeg)
+
+### 3. Click "New Toolset"
+
+![New Toolset button](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/798c55c4-5d6b-4815-a642-70ac9f34f102/ascreenshot_3f144f54a1a944e28454239c837b4e6d_text_export.jpeg)
+
+### 4. Enter a name
+
+Type a name for the toolset. Pick something descriptive — this is what agents will reference.
+
+![Enter toolset name](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/62b412e0-d38f-44c3-99e4-3693f1512f6a/ascreenshot_b678c7c988a04f8b887b0f54c4dd95a7_text_export.jpeg)
+
+![Toolset name field](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/ba5ebc95-cab7-470b-a7c9-21f12b9b01a3/ascreenshot_a602e982a2a44890a83dca64d61c38eb_text_export.jpeg)
+
+### 5. Add the first tool
+
+Select an MCP server from the dropdown, then choose the tool you want to include from that server.
+
+![Select MCP server](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/2aa5bcba-6414-42e3-9813-efb0a9078e32/ascreenshot_58fbff35ba654210a1b4dc5452aa6bd9_text_export.jpeg)
+
+![Choose server from dropdown](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/4fd9cffb-d3ba-461a-8679-89f278bf67ad/ascreenshot_b61e9e85a51b494a8d09fe61198d63e1_text_export.jpeg)
+
+![Select tool from server](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/60718e72-2062-494b-9a23-456992c88cbd/ascreenshot_7a1f8eeab30a4a05ba39c450e5458b78_text_export.jpeg)
+
+### 6. Add tools from a second server
+
+Click **Add Tool**, pick a different MCP server, and select another tool. Repeat for as many tools as you need — they can come from any number of servers.
+
+![Add tool from second server](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/f34e0600-cc74-4b18-8794-88d45f326144/ascreenshot_98834b14ab9343e39fb503e458d72b7c_text_export.jpeg)
+
+![Select second server](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/75150368-2202-4da1-99f1-6f0620e9b133/ascreenshot_f94d0bc08ea147348a9cf021cce7d854_text_export.jpeg)
+
+![Select tool from second server](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/ed2cdf6e-025d-4d50-8b12-ed68745d5c51/ascreenshot_0c1c7f76524b46c5a056fda5e6956e2b_text_export.jpeg)
+
+### 7. Create the toolset
+
+Click **Create Toolset** to save.
+
+![Create Toolset](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/021ca7b3-2d9a-49a0-8758-dae3dc3bcb4d/ascreenshot_14c6434e71114a6091e359a996f20e12_text_export.jpeg)
+
+---
+
+## Use a toolset in the Playground
+
+Once created, your toolset appears alongside MCP servers in the **MCP Servers** dropdown in the Playground — it's selectable the same way.
+
+### 1. Go to the Playground
+
+![Navigate to Playground](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/f9d4aa4c-d98e-4767-b98e-aad2890e97ca/ascreenshot_d84239c441bb4e828f229d0c9e079e3f_text_export.jpeg)
+
+![Click Playground](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/d8a07563-97fe-453a-b974-88da46c87294/ascreenshot_ea494300a536400abb2ea6bf3bdfd5ab_text_export.jpeg)
+
+### 2. Select your toolset from MCP Servers
+
+In the left panel under **MCP Servers**, open the dropdown and pick your toolset. The model will only see the tools you included in it.
+
+![Select MCP servers dropdown](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/ee8cb38c-c4ff-4b4b-844c-22f2e40832ae/ascreenshot_e300fb39cea0434fb5e3986e912a2b8d_text_export.jpeg)
+
+![Open MCP server picker](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/8672070c-5d07-4f63-878c-6fc7dcbc9b65/ascreenshot_326ddd0868224c99a6fa5dab2d144f1f_text_export.jpeg)
+
+![Select toolset](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/955826ad-2bbb-403e-ab26-c1ac03ec2675/ascreenshot_13f837ad53574535986ca7ca5998d34a_text_export.jpeg)
+
+![Toolset selected and active](https://colony-recorder.s3.amazonaws.com/files/2026-03-22/9a59c3b9-1563-4731-838f-1c35d636ddc9/ascreenshot_c05d8fa5f37a4b3093fc46e26f293b4d_text_export.jpeg)
+
+The model now has access to exactly the tools in your toolset and nothing else.
+
+---
+
+## Use a toolset via API
+
+Pass the toolset's route as the `server_url` in your tools list. LiteLLM resolves it server-side — no public URL needed.
+
+<Tabs>
+<TabItem value="responses" label="Responses API">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="your-litellm-key",
+    base_url="http://your-proxy/v1",
+)
+
+response = client.responses.create(
+    model="gpt-4o",
+    input="What CI/CD tools do you have?",
+    tools=[
+        {
+            "type": "mcp",
+            "server_label": "devtooling-prod",
+            "server_url": "litellm_proxy/mcp/devtooling-prod",
+            "require_approval": "never",
+        }
+    ],
+)
+print(response.output_text)
+```
+
+</TabItem>
+<TabItem value="chat" label="Chat Completions API">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="your-litellm-key",
+    base_url="http://your-proxy/v1",
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "What CI/CD tools do you have?"}],
+    tools=[
+        {
+            "type": "mcp",
+            "server_label": "devtooling-prod",
+            "server_url": "litellm_proxy/mcp/devtooling-prod",
+            "require_approval": "never",
+        }
+    ],
+)
+print(response.choices[0].message.content)
+```
+
+</TabItem>
+<TabItem value="rest" label="REST">
+
+```bash
+curl http://your-proxy/v1/responses \
+  -H "Authorization: Bearer your-litellm-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "input": "What CI/CD tools do you have?",
+    "tools": [
+      {
+        "type": "mcp",
+        "server_label": "devtooling-prod",
+        "server_url": "litellm_proxy/mcp/devtooling-prod",
+        "require_approval": "never"
+      }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+## Manage toolsets via API
+
+```bash
+# List all toolsets
+curl http://your-proxy/v1/mcp/toolset \
+  -H "Authorization: Bearer your-litellm-key"
+
+# Create a toolset
+curl -X POST http://your-proxy/v1/mcp/toolset \
+  -H "Authorization: Bearer your-litellm-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "toolset_name": "devtooling-prod",
+    "description": "CircleCI + DeepWiki tools for the dev team",
+    "tools": [
+      {"server_id": "<circleci-server-id>", "tool_name": "get_build_failure_logs"},
+      {"server_id": "<circleci-server-id>", "tool_name": "run_pipeline"},
+      {"server_id": "<deepwiki-server-id>", "tool_name": "read_wiki_structure"}
+    ]
+  }'
+
+# Delete a toolset
+curl -X DELETE http://your-proxy/v1/mcp/toolset/<toolset_id> \
+  -H "Authorization: Bearer your-litellm-key"
+```

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -325,6 +325,7 @@ const sidebars = {
                 "mcp_control",
                 "mcp_cost",
                 "mcp_guardrail",
+                "mcp_toolsets",
                 {
                   type: "link",
                   label: "MCP Troubleshooting Guide",

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260321000000_add_mcp_toolsets/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260321000000_add_mcp_toolsets/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable: LiteLLM_MCPToolsetTable
+CREATE TABLE IF NOT EXISTS "LiteLLM_MCPToolsetTable" (
+    "toolset_id" TEXT NOT NULL,
+    "toolset_name" TEXT NOT NULL,
+    "description" TEXT,
+    "tools" JSONB NOT NULL DEFAULT '[]',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_by" TEXT,
+
+    CONSTRAINT "LiteLLM_MCPToolsetTable_pkey" PRIMARY KEY ("toolset_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_MCPToolsetTable_toolset_name_key" ON "LiteLLM_MCPToolsetTable"("toolset_name");
+
+-- AlterTable: add mcp_toolsets to ObjectPermissionTable
+ALTER TABLE "LiteLLM_ObjectPermissionTable" ADD COLUMN IF NOT EXISTS "mcp_toolsets" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -336,7 +336,7 @@ model LiteLLM_MCPToolsetTable {
   tools        Json     @default("[]") // [{server_id: string, tool_name: string}]
   created_at   DateTime @default(now())
   created_by   String?
-  updated_at   DateTime @updatedAt
+  updated_at   DateTime @default(now()) @updatedAt
   updated_by   String?
 }
 

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -273,6 +273,7 @@ model LiteLLM_ObjectPermissionTable {
   agent_access_groups   String[]       @default([])
   models                String[]       @default([])
   blocked_tools         String[]       @default([]) // Tool names blocked for any key/team/user with this permission
+  mcp_toolsets          String[]       @default([]) // Toolset IDs granted to this key/team/user
   teams                 LiteLLM_TeamTable[]
   projects              LiteLLM_ProjectTable[]
   verification_tokens   LiteLLM_VerificationToken[]
@@ -325,6 +326,18 @@ model LiteLLM_MCPServerTable {
   submitted_at          DateTime?
   reviewed_at           DateTime?
   review_notes          String?
+}
+
+// Named collection of {server_id, tool_name} pairs that can be granted to keys/teams
+model LiteLLM_MCPToolsetTable {
+  toolset_id   String   @id @default(uuid())
+  toolset_name String   @unique
+  description  String?
+  tools        Json     @default("[]") // [{server_id: string, tool_name: string}]
+  created_at   DateTime @default(now())
+  created_by   String?
+  updated_at   DateTime @updatedAt
+  updated_by   String?
 }
 
 // Per-user BYOK credentials for MCP servers

--- a/litellm/proxy/_experimental/mcp_server/mcp_context.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_context.py
@@ -1,0 +1,16 @@
+"""
+Shared ContextVars for the MCP server layer.
+
+Lives in its own module to avoid circular imports between
+mcp_server_manager.py and server.py.
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
+# Set server-side in proxy_server.py route handlers when a request arrives via
+# /toolset/{name}/mcp or the toolset fallback in dynamic_mcp_route.
+# Never populated from client-supplied headers.
+_mcp_active_toolset_id: ContextVar[Optional[str]] = ContextVar(
+    "_mcp_active_toolset_id", default=None
+)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -182,12 +182,6 @@ class MCPServerManager:
         }
         """
 
-        # Toolset caches are now stored in user_api_key_cache (Redis-backed DualCache
-        # in production) so entries are shared across workers.  These attributes are
-        # kept as empty stubs so existing callers don't AttributeError during tests.
-        self._toolset_perm_cache: Dict[str, Tuple[Dict[str, List[str]], float]] = {}
-        self._toolset_name_cache: Dict[str, Tuple[Optional[Any], float]] = {}
-
     def get_registry(self) -> Dict[str, MCPServer]:
         """
         Get the registered MCP Servers from the registry and union with the config MCP Servers
@@ -885,8 +879,10 @@ class MCPServerManager:
                 ]
             for k in keys_to_remove:
                 cache_dict.pop(k, None)
-        except Exception:
-            pass
+        except Exception as e:
+            verbose_logger.warning(
+                f"invalidate_toolset_cache: failed to evict in-memory entries: {e}"
+            )
 
     async def get_toolset_by_name_cached(
         self,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -793,14 +793,15 @@ class MCPServerManager:
             )
             combined_servers = set(allowed_mcp_servers)
             # Only skip allow_all_keys servers when the request is inside a toolset
-            # scope.  _apply_toolset_scope marks this by setting mcp_toolsets=[].
-            # For regular keys (mcp_toolsets=None) or keys with configured toolsets
-            # (mcp_toolsets=[...non-empty...]), allow_all_keys servers must still be
-            # included to preserve backward-compatible behavior.
-            op = user_api_key_auth.object_permission if user_api_key_auth else None
-            in_toolset_scope = (
-                op is not None and op.mcp_servers is not None and op.mcp_toolsets == []
+            # scope.  toolset_mcp_route / dynamic_mcp_route set _mcp_active_toolset_id
+            # before calling the handler — that ContextVar is the reliable signal.
+            # Using op.mcp_toolsets==[] would false-positive on DB-default rows where
+            # Postgres initialises the column to ARRAY[]::TEXT[].
+            from litellm.proxy._experimental.mcp_server.mcp_context import (  # noqa: PLC0415
+                _mcp_active_toolset_id,
             )
+
+            in_toolset_scope = _mcp_active_toolset_id.get() is not None
             if not in_toolset_scope:
                 combined_servers.update(allow_all_server_ids)
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -501,12 +501,12 @@ class MCPServerManager:
                     )
 
                     # Update tool name to server name mapping (for both prefixed and base names)
-                    self.tool_name_to_mcp_server_name_mapping[
-                        base_tool_name
-                    ] = server_prefix
-                    self.tool_name_to_mcp_server_name_mapping[
-                        prefixed_tool_name
-                    ] = server_prefix
+                    self.tool_name_to_mcp_server_name_mapping[base_tool_name] = (
+                        server_prefix
+                    )
+                    self.tool_name_to_mcp_server_name_mapping[prefixed_tool_name] = (
+                        server_prefix
+                    )
 
                     registered_count += 1
                     verbose_logger.debug(
@@ -786,7 +786,12 @@ class MCPServerManager:
                 f"Allowed MCP Servers for user api key auth: {allowed_mcp_servers}"
             )
             combined_servers = set(allowed_mcp_servers)
-            combined_servers.update(allow_all_server_ids)
+            # Only add allow_all_keys servers when there is no explicit server
+            # restriction on the key/object_permission.  When mcp_servers is
+            # explicitly set (e.g. by a toolset scope), the explicit list IS
+            # the permission boundary — allow_all_keys servers must not bleed in.
+            if not has_explicit_object_permission:
+                combined_servers.update(allow_all_server_ids)
 
             if len(combined_servers) == 0:
                 verbose_logger.debug(
@@ -796,6 +801,41 @@ class MCPServerManager:
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed MCP servers: {str(e)}.")
             return allow_all_server_ids
+
+    async def resolve_toolset_tool_permissions(
+        self,
+        toolset_ids: List[str],
+    ) -> Dict[str, List[str]]:
+        """
+        Resolve a list of toolset IDs into a mcp_tool_permissions dict.
+
+        Returns: {server_id: [tool_name, ...]} — the union of all tools across
+        the given toolsets. This is merged (union semantics) into the key's
+        existing mcp_tool_permissions before access-control filtering runs.
+        """
+        from litellm.proxy._experimental.mcp_server.toolset_db import list_mcp_toolsets
+        from litellm.proxy.proxy_server import prisma_client
+
+        if not toolset_ids or prisma_client is None:
+            return {}
+
+        try:
+            toolsets = await list_mcp_toolsets(prisma_client, toolset_ids=toolset_ids)
+            tool_permissions: Dict[str, List[str]] = {}
+            for toolset in toolsets:
+                for tool in toolset.tools:
+                    # Stored tool_names may include the server prefix (e.g.
+                    # "server_alias__tool_name"). filter_tools_by_key_team_permissions
+                    # compares against the unprefixed name, so strip it here.
+                    raw_name = tool["tool_name"]
+                    unprefixed, _ = split_server_prefix_from_name(raw_name)
+                    tool_permissions.setdefault(tool["server_id"], [])
+                    if unprefixed not in tool_permissions[tool["server_id"]]:
+                        tool_permissions[tool["server_id"]].append(unprefixed)
+            return tool_permissions
+        except Exception as e:
+            verbose_logger.warning(f"Failed to resolve toolset permissions: {str(e)}")
+            return {}
 
     def filter_server_ids_by_ip(
         self, server_ids: List[str], client_ip: Optional[str]
@@ -1071,6 +1111,17 @@ class MCPServerManager:
                 tools = global_mcp_tool_registry.convert_tools_to_mcp_sdk_tool_type(
                     _tools
                 )
+                # OpenAPI tools are stored in the registry with their prefix already
+                # applied (e.g. "test_petstore-getinventory").  Do NOT pass them
+                # through _create_prefixed_tools — that would add the prefix a second
+                # time producing "test_petstore-test_petstore-getinventory".
+                if not add_prefix:
+                    prefix = get_server_prefix(server)
+                    sep = MCP_TOOL_PREFIX_SEPARATOR
+                    for t in tools:
+                        if t.name.startswith(f"{prefix}{sep}"):
+                            t.name = t.name[len(prefix) + len(sep) :]
+                return tools
             else:
                 tools = await self._fetch_tools_with_timeout(client, server.name)
 
@@ -2421,9 +2472,18 @@ class MCPServerManager:
         prisma_client = get_prisma_client_or_throw(
             "Database not connected. Connect a database to your proxy"
         )
-        db_mcp_servers = await get_all_mcp_servers(
-            prisma_client, approval_status="active"
+        _all_db_mcp_servers = await get_all_mcp_servers(
+            prisma_client, approval_status=None
         )
+        # Load servers that are "active" (explicit approval) or "approved"
+        # (legacy default value pre-dating the approval workflow).
+        # Exclude "pending_review" and "rejected".
+        _load_statuses = {"active", "approved"}
+        db_mcp_servers = [
+            s
+            for s in _all_db_mcp_servers
+            if s.approval_status in _load_statuses or s.approval_status is None
+        ]
         verbose_logger.info(f"Found {len(db_mcp_servers)} MCP servers in database")
 
         previous_registry = self.registry

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -792,11 +792,16 @@ class MCPServerManager:
                 f"Allowed MCP Servers for user api key auth: {allowed_mcp_servers}"
             )
             combined_servers = set(allowed_mcp_servers)
-            # Only add allow_all_keys servers when there is no explicit server
-            # restriction on the key/object_permission.  When mcp_servers is
-            # explicitly set (e.g. by a toolset scope), the explicit list IS
-            # the permission boundary — allow_all_keys servers must not bleed in.
-            if not has_explicit_object_permission:
+            # Only skip allow_all_keys servers when the request is inside a toolset
+            # scope.  _apply_toolset_scope marks this by setting mcp_toolsets=[].
+            # For regular keys (mcp_toolsets=None) or keys with configured toolsets
+            # (mcp_toolsets=[...non-empty...]), allow_all_keys servers must still be
+            # included to preserve backward-compatible behavior.
+            op = user_api_key_auth.object_permission if user_api_key_auth else None
+            in_toolset_scope = (
+                op is not None and op.mcp_servers is not None and op.mcp_toolsets == []
+            )
+            if not in_toolset_scope:
                 combined_servers.update(allow_all_server_ids)
 
             if len(combined_servers) == 0:
@@ -2554,18 +2559,19 @@ class MCPServerManager:
         prisma_client = get_prisma_client_or_throw(
             "Database not connected. Connect a database to your proxy"
         )
-        _all_db_mcp_servers = await get_all_mcp_servers(
-            prisma_client, approval_status=None
+        # Load only "active", legacy "approved", and NULL (no approval workflow) rows.
+        # Pending/rejected servers are excluded at the DB level so we never load them.
+        from litellm.proxy._experimental.mcp_server.db import LiteLLM_MCPServerTable
+
+        raw_rows = await prisma_client.db.litellm_mcpservertable.find_many(
+            where={
+                "OR": [
+                    {"approval_status": None},
+                    {"approval_status": {"in": ["active", "approved"]}},
+                ]
+            }
         )
-        # Load servers that are "active" (explicit approval) or "approved"
-        # (legacy default value pre-dating the approval workflow).
-        # Exclude "pending_review" and "rejected".
-        _load_statuses = {"active", "approved"}
-        db_mcp_servers = [
-            s
-            for s in _all_db_mcp_servers
-            if s.approval_status in _load_statuses or s.approval_status is None
-        ]
+        db_mcp_servers = [LiteLLM_MCPServerTable(**r.model_dump()) for r in raw_rows]
         verbose_logger.info(f"Found {len(db_mcp_servers)} MCP servers in database")
 
         previous_registry = self.registry

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -11,6 +11,7 @@ import datetime
 import hashlib
 import json
 import re
+import time
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 from urllib.parse import urlparse
 
@@ -181,6 +182,8 @@ class MCPServerManager:
             "gmail_send_email": "zapier_mcp_server",
         }
         """
+
+        self._toolset_perm_cache: Dict[str, Tuple[Dict[str, List[str]], float]] = {}
 
     def get_registry(self) -> Dict[str, MCPServer]:
         """
@@ -810,8 +813,7 @@ class MCPServerManager:
         Resolve a list of toolset IDs into a mcp_tool_permissions dict.
 
         Returns: {server_id: [tool_name, ...]} — the union of all tools across
-        the given toolsets. This is merged (union semantics) into the key's
-        existing mcp_tool_permissions before access-control filtering runs.
+        the given toolsets. Results are cached for 60 s to avoid per-request DB queries.
         """
         from litellm.proxy._experimental.mcp_server.toolset_db import list_mcp_toolsets
         from litellm.proxy.proxy_server import prisma_client
@@ -819,23 +821,43 @@ class MCPServerManager:
         if not toolset_ids or prisma_client is None:
             return {}
 
+        cache_key = ",".join(sorted(toolset_ids))
+        cached_entry = self._toolset_perm_cache.get(cache_key)
+        if cached_entry is not None:
+            result, cached_at = cached_entry
+            if time.time() - cached_at < 60:
+                return result
+
         try:
             toolsets = await list_mcp_toolsets(prisma_client, toolset_ids=toolset_ids)
             tool_permissions: Dict[str, List[str]] = {}
             for toolset in toolsets:
                 for tool in toolset.tools:
-                    # Stored tool_names may include the server prefix (e.g.
-                    # "server_alias__tool_name"). filter_tools_by_key_team_permissions
-                    # compares against the unprefixed name, so strip it here.
                     raw_name = tool["tool_name"]
                     unprefixed, _ = split_server_prefix_from_name(raw_name)
                     tool_permissions.setdefault(tool["server_id"], [])
                     if unprefixed not in tool_permissions[tool["server_id"]]:
                         tool_permissions[tool["server_id"]].append(unprefixed)
+            self._toolset_perm_cache[cache_key] = (tool_permissions, time.time())
             return tool_permissions
         except Exception as e:
             verbose_logger.warning(f"Failed to resolve toolset permissions: {str(e)}")
             return {}
+
+    def invalidate_toolset_cache(self, toolset_id: Optional[str] = None) -> None:
+        """Evict cached toolset permission entries.
+
+        Called after create/update/delete of a toolset so stale data is not served.
+        Pass toolset_id to evict only entries containing that ID, or None to clear all.
+        """
+        if toolset_id is None:
+            self._toolset_perm_cache.clear()
+            return
+        keys_to_remove = [
+            k for k in self._toolset_perm_cache if toolset_id in k.split(",")
+        ]
+        for k in keys_to_remove:
+            del self._toolset_perm_cache[k]
 
     def filter_server_ids_by_ip(
         self, server_ids: List[str], client_ip: Optional[str]

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -891,16 +891,27 @@ class MCPServerManager:
     ) -> Optional[Any]:
         """Return a toolset by name, cached in ``user_api_key_cache`` (Redis-backed
         ``DualCache`` in production) to avoid a DB hit on every routed request.
+
+        Serialisation note: the cache value is stored as a plain JSON-safe dict via
+        ``model_dump(mode="json")`` so that Redis round-trips correctly in multi-worker
+        deployments.  On a cache hit we reconstruct the ``MCPToolset`` Pydantic object
+        so callers can always use attribute access (e.g. ``toolset.toolset_id``).
         """
         from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
         from litellm.proxy.proxy_server import user_api_key_cache
+        from litellm.types.mcp_server.mcp_toolset import MCPToolset
 
         cache_key = f"toolset_name:{toolset_name}"
         cached = await user_api_key_cache.async_get_cache(key=cache_key)
         if cached is not None:
             # Sentinel value used to cache "not found" so we don't re-query for
             # names that don't exist.
-            return None if cached == "__not_found__" else cached
+            if cached == "__not_found__":
+                return None
+            # Redis deserialises JSON back as a plain dict — reconstruct the model.
+            if isinstance(cached, dict):
+                return MCPToolset(**cached)
+            return cached
 
         from litellm.proxy._experimental.mcp_server.toolset_db import (
             get_mcp_toolset_by_name,
@@ -909,7 +920,11 @@ class MCPServerManager:
         toolset = await get_mcp_toolset_by_name(prisma_client, toolset_name)
         await user_api_key_cache.async_set_cache(
             key=cache_key,
-            value=toolset if toolset is not None else "__not_found__",
+            value=(
+                toolset.model_dump(mode="json")
+                if toolset is not None
+                else "__not_found__"
+            ),
             ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
         )
         return toolset

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -11,7 +11,6 @@ import datetime
 import hashlib
 import json
 import re
-import time
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 from urllib.parse import urlparse
 
@@ -183,8 +182,10 @@ class MCPServerManager:
         }
         """
 
+        # Toolset caches are now stored in user_api_key_cache (Redis-backed DualCache
+        # in production) so entries are shared across workers.  These attributes are
+        # kept as empty stubs so existing callers don't AttributeError during tests.
         self._toolset_perm_cache: Dict[str, Tuple[Dict[str, List[str]], float]] = {}
-        # name → (toolset | None, cached_at)  — 60 s TTL
         self._toolset_name_cache: Dict[str, Tuple[Optional[Any], float]] = {}
 
     def get_registry(self) -> Dict[str, MCPServer]:
@@ -815,20 +816,21 @@ class MCPServerManager:
         Resolve a list of toolset IDs into a mcp_tool_permissions dict.
 
         Returns: {server_id: [tool_name, ...]} — the union of all tools across
-        the given toolsets. Results are cached for 60 s to avoid per-request DB queries.
+        the given toolsets.  Results are cached via ``user_api_key_cache`` (a
+        Redis-backed ``DualCache`` in production) so that cache entries are
+        shared across workers and cold-cache DB hits are minimised.
         """
+        from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
         from litellm.proxy._experimental.mcp_server.toolset_db import list_mcp_toolsets
-        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
         if not toolset_ids or prisma_client is None:
             return {}
 
-        cache_key = ",".join(sorted(toolset_ids))
-        cached_entry = self._toolset_perm_cache.get(cache_key)
-        if cached_entry is not None:
-            result, cached_at = cached_entry
-            if time.time() - cached_at < 60:
-                return result
+        cache_key = "toolset_perms:" + ",".join(sorted(toolset_ids))
+        cached = await user_api_key_cache.async_get_cache(key=cache_key)
+        if cached is not None:
+            return cached
 
         try:
             toolsets = await list_mcp_toolsets(prisma_client, toolset_ids=toolset_ids)
@@ -840,7 +842,11 @@ class MCPServerManager:
                     tool_permissions.setdefault(tool["server_id"], [])
                     if unprefixed not in tool_permissions[tool["server_id"]]:
                         tool_permissions[tool["server_id"]].append(unprefixed)
-            self._toolset_perm_cache[cache_key] = (tool_permissions, time.time())
+            await user_api_key_cache.async_set_cache(
+                key=cache_key,
+                value=tool_permissions,
+                ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+            )
             return tool_permissions
         except Exception as e:
             verbose_logger.warning(f"Failed to resolve toolset permissions: {str(e)}")
@@ -850,47 +856,60 @@ class MCPServerManager:
         """Evict cached toolset permission entries.
 
         Called after create/update/delete of a toolset so stale data is not served.
+        The in-memory layer of ``user_api_key_cache`` is cleared immediately;
+        Redis entries expire naturally after the configured TTL.
         Pass toolset_id to evict only entries containing that ID, or None to clear all.
         """
-        if toolset_id is None:
-            self._toolset_perm_cache.clear()
-            self._toolset_name_cache.clear()
-            return
-        keys_to_remove = [
-            k for k in self._toolset_perm_cache if toolset_id in k.split(",")
-        ]
-        for k in keys_to_remove:
-            del self._toolset_perm_cache[k]
-        # Also evict any name cache entry that refers to this toolset_id
-        name_keys_to_remove = [
-            name
-            for name, (ts, _) in self._toolset_name_cache.items()
-            if ts is not None and getattr(ts, "toolset_id", None) == toolset_id
-        ]
-        for k in name_keys_to_remove:
-            del self._toolset_name_cache[k]
+        # Clear the in-memory layer of the shared DualCache for affected keys.
+        # We can't enumerate Redis keys by pattern, so Redis entries expire via TTL.
+        try:
+            from litellm.proxy.proxy_server import user_api_key_cache
+
+            in_mem = getattr(user_api_key_cache, "in_memory_cache", None)
+            if in_mem is None:
+                return
+            cache_dict = getattr(in_mem, "cache_dict", {})
+            if toolset_id is None:
+                keys_to_remove = [k for k in cache_dict if k.startswith("toolset_")]
+            else:
+                keys_to_remove = [
+                    k
+                    for k in cache_dict
+                    if k.startswith("toolset_") and toolset_id in k
+                ]
+            for k in keys_to_remove:
+                cache_dict.pop(k, None)
+        except Exception:
+            pass
 
     async def get_toolset_by_name_cached(
         self,
         prisma_client: Any,
         toolset_name: str,
     ) -> Optional[Any]:
-        """Return a toolset by name, using a 60 s in-memory TTL cache.
-
-        Avoids a DB hit on every MCP request routed through a named toolset.
+        """Return a toolset by name, cached in ``user_api_key_cache`` (Redis-backed
+        ``DualCache`` in production) to avoid a DB hit on every routed request.
         """
-        cached_entry = self._toolset_name_cache.get(toolset_name)
-        if cached_entry is not None:
-            toolset, cached_at = cached_entry
-            if time.time() - cached_at < 60:
-                return toolset
+        from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+        from litellm.proxy.proxy_server import user_api_key_cache
+
+        cache_key = f"toolset_name:{toolset_name}"
+        cached = await user_api_key_cache.async_get_cache(key=cache_key)
+        if cached is not None:
+            # Sentinel value used to cache "not found" so we don't re-query for
+            # names that don't exist.
+            return None if cached == "__not_found__" else cached
 
         from litellm.proxy._experimental.mcp_server.toolset_db import (
             get_mcp_toolset_by_name,
         )
 
         toolset = await get_mcp_toolset_by_name(prisma_client, toolset_name)
-        self._toolset_name_cache[toolset_name] = (toolset, time.time())
+        await user_api_key_cache.async_set_cache(
+            key=cache_key,
+            value=toolset if toolset is not None else "__not_found__",
+            ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        )
         return toolset
 
     def filter_server_ids_by_ip(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -184,6 +184,8 @@ class MCPServerManager:
         """
 
         self._toolset_perm_cache: Dict[str, Tuple[Dict[str, List[str]], float]] = {}
+        # name → (toolset | None, cached_at)  — 60 s TTL
+        self._toolset_name_cache: Dict[str, Tuple[Optional[Any], float]] = {}
 
     def get_registry(self) -> Dict[str, MCPServer]:
         """
@@ -852,12 +854,44 @@ class MCPServerManager:
         """
         if toolset_id is None:
             self._toolset_perm_cache.clear()
+            self._toolset_name_cache.clear()
             return
         keys_to_remove = [
             k for k in self._toolset_perm_cache if toolset_id in k.split(",")
         ]
         for k in keys_to_remove:
             del self._toolset_perm_cache[k]
+        # Also evict any name cache entry that refers to this toolset_id
+        name_keys_to_remove = [
+            name
+            for name, (ts, _) in self._toolset_name_cache.items()
+            if ts is not None and getattr(ts, "toolset_id", None) == toolset_id
+        ]
+        for k in name_keys_to_remove:
+            del self._toolset_name_cache[k]
+
+    async def get_toolset_by_name_cached(
+        self,
+        prisma_client: Any,
+        toolset_name: str,
+    ) -> Optional[Any]:
+        """Return a toolset by name, using a 60 s in-memory TTL cache.
+
+        Avoids a DB hit on every MCP request routed through a named toolset.
+        """
+        cached_entry = self._toolset_name_cache.get(toolset_name)
+        if cached_entry is not None:
+            toolset, cached_at = cached_entry
+            if time.time() - cached_at < 60:
+                return toolset
+
+        from litellm.proxy._experimental.mcp_server.toolset_db import (
+            get_mcp_toolset_by_name,
+        )
+
+        toolset = await get_mcp_toolset_by_name(prisma_client, toolset_name)
+        self._toolset_name_cache[toolset_name] = (toolset, time.time())
+        return toolset
 
     def filter_server_ids_by_ip(
         self, server_ids: List[str], client_ip: Optional[str]

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -872,10 +872,15 @@ class MCPServerManager:
             if toolset_id is None:
                 keys_to_remove = [k for k in cache_dict if k.startswith("toolset_")]
             else:
+                # Evict permission-cache entries that reference this toolset ID.
+                # Also evict ALL name-cache entries (toolset_name:*): we can't map
+                # toolset_id → toolset_name without a DB call, and the name may have
+                # changed in an update anyway.
                 keys_to_remove = [
                     k
                     for k in cache_dict
-                    if k.startswith("toolset_") and toolset_id in k
+                    if (k.startswith("toolset_perms:") and toolset_id in k)
+                    or k.startswith("toolset_name:")
                 ]
             for k in keys_to_remove:
                 cache_dict.pop(k, None)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1193,9 +1193,16 @@ class MCPServerManager:
                 if not add_prefix:
                     prefix = get_server_prefix(server)
                     sep = MCP_TOOL_PREFIX_SEPARATOR
-                    for t in tools:
-                        if t.name.startswith(f"{prefix}{sep}"):
-                            t.name = t.name[len(prefix) + len(sep) :]
+                    tools = [
+                        (
+                            t.model_copy(
+                                update={"name": t.name[len(prefix) + len(sep) :]}
+                            )
+                            if t.name.startswith(f"{prefix}{sep}")
+                            else t
+                        )
+                        for t in tools
+                    ]
                 return tools
             else:
                 tools = await self._fetch_tools_with_timeout(client, server.name)

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1497,8 +1497,14 @@ if MCP_AVAILABLE:
             merged = list(set(existing_tools) | set(tool_names))
             existing[server_id] = merged
 
-        # Build updated object_permission with merged tool permissions
-        updated_op = op.model_copy(update={"mcp_tool_permissions": existing})
+        # Build updated object_permission with merged tool permissions and server IDs.
+        # Union the toolset's server IDs into mcp_servers so downstream server-level
+        # filtering doesn't silently drop servers that the toolset references but that
+        # aren't already in the key's explicit mcp_servers list.
+        merged_servers = list(set(op.mcp_servers or []) | set(existing.keys()))
+        updated_op = op.model_copy(
+            update={"mcp_servers": merged_servers, "mcp_tool_permissions": existing}
+        )
         return user_api_key_auth.model_copy(update={"object_permission": updated_op})
 
     async def _list_mcp_tools(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2417,10 +2417,25 @@ if MCP_AVAILABLE:
         Restrict a key's MCP permissions to a single toolset.
 
         When a request arrives via /toolset/{name}/mcp we override the key's
-        object_permission so that only the toolset's tools are visible,
-        regardless of what the key's normal permissions are.
+        object_permission so that only the toolset's tools are visible.
+
+        Raises HTTPException(403) if the key has an explicit toolset grant list
+        that does not include toolset_id (i.e. mcp_toolsets is set but empty,
+        or set to a list that omits this toolset).  Admin keys always pass.
         """
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        # Access control: non-admin keys must have this toolset in their grant list.
+        is_admin = getattr(user_api_key_auth, "user_role", None) == "proxy_admin"
+        if not is_admin:
+            op = user_api_key_auth.object_permission
+            granted = getattr(op, "mcp_toolsets", None) if op else None
+            # granted=None → no restriction (allow); granted=[] or list without toolset_id → deny
+            if granted is not None and toolset_id not in granted:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"API key does not have access to toolset '{toolset_id}'.",
+                )
 
         tool_permissions = (
             await global_mcp_server_manager.resolve_toolset_tool_permissions(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1,6 +1,7 @@
 """
 LiteLLM MCP Server Routes
 """
+
 # pyright: reportInvalidTypeForm=false, reportArgumentType=false, reportOptionalCall=false
 
 import asyncio
@@ -1455,6 +1456,43 @@ if MCP_AVAILABLE:
 
         return filtered_tools
 
+    async def _merge_toolset_permissions(
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+    ) -> Optional[UserAPIKeyAuth]:
+        """
+        Resolve mcp_toolsets on the key's object_permission into tool-level permissions
+        and merge them (union) into object_permission.mcp_tool_permissions.
+
+        Returns the (possibly mutated copy of) user_api_key_auth.
+        """
+        if user_api_key_auth is None:
+            return None
+        op = user_api_key_auth.object_permission
+        if op is None:
+            return user_api_key_auth
+        toolset_ids = getattr(op, "mcp_toolsets", None) or []
+        if not toolset_ids:
+            return user_api_key_auth
+
+        toolset_perms = (
+            await global_mcp_server_manager.resolve_toolset_tool_permissions(
+                toolset_ids=toolset_ids
+            )
+        )
+        if not toolset_perms:
+            return user_api_key_auth
+
+        # Merge toolset_perms into existing mcp_tool_permissions (union)
+        existing = dict(op.mcp_tool_permissions or {})
+        for server_id, tool_names in toolset_perms.items():
+            existing_tools = existing.get(server_id, [])
+            merged = list(set(existing_tools) | set(tool_names))
+            existing[server_id] = merged
+
+        # Build updated object_permission with merged tool permissions
+        updated_op = op.model_copy(update={"mcp_tool_permissions": existing})
+        return user_api_key_auth.model_copy(update={"object_permission": updated_op})
+
     async def _list_mcp_tools(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
         mcp_auth_header: Optional[str] = None,
@@ -1479,6 +1517,11 @@ if MCP_AVAILABLE:
         """
         if not MCP_AVAILABLE:
             return []
+
+        # Resolve toolset permissions and merge into the key's object_permission
+        # so that the existing filter_tools_by_key_team_permissions logic picks them up.
+        user_api_key_auth = await _merge_toolset_permissions(user_api_key_auth)
+
         # Get tools from managed MCP servers with error handling
         managed_tools = []
         try:
@@ -1822,9 +1865,9 @@ if MCP_AVAILABLE:
             "litellm_logging_obj", None
         )
         if litellm_logging_obj:
-            litellm_logging_obj.model_call_details[
-                "mcp_tool_call_metadata"
-            ] = standard_logging_mcp_tool_call
+            litellm_logging_obj.model_call_details["mcp_tool_call_metadata"] = (
+                standard_logging_mcp_tool_call
+            )
             litellm_logging_obj.model = f"MCP: {name}"
         # Resolve the MCP server early so BYOK checks and credential injection
         # apply to ALL dispatch paths (local tool registry AND managed MCP server).
@@ -1836,9 +1879,9 @@ if MCP_AVAILABLE:
                 mcp_server.mcp_info or {}
             ).get("mcp_server_cost_info")
             if litellm_logging_obj:
-                litellm_logging_obj.model_call_details[
-                    "mcp_tool_call_metadata"
-                ] = standard_logging_mcp_tool_call
+                litellm_logging_obj.model_call_details["mcp_tool_call_metadata"] = (
+                    standard_logging_mcp_tool_call
+                )
 
             # BYOK: retrieve the stored per-user credential.  A single DB call
             # both checks existence and fetches the value, avoiding a double query.
@@ -2358,6 +2401,43 @@ if MCP_AVAILABLE:
         ]
         return False
 
+    async def _apply_toolset_scope(
+        user_api_key_auth: UserAPIKeyAuth,
+        toolset_id: str,
+    ) -> UserAPIKeyAuth:
+        """
+        Restrict a key's MCP permissions to a single toolset.
+
+        When a request arrives via /toolset/{name}/mcp we override the key's
+        object_permission so that only the toolset's tools are visible,
+        regardless of what the key's normal permissions are.
+        """
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        tool_permissions = (
+            await global_mcp_server_manager.resolve_toolset_tool_permissions(
+                toolset_ids=[toolset_id]
+            )
+        )
+        server_ids = list(tool_permissions.keys())
+        existing_op = user_api_key_auth.object_permission
+        if existing_op is not None:
+            updated_op = existing_op.model_copy(
+                update={
+                    "mcp_servers": server_ids,
+                    "mcp_tool_permissions": tool_permissions,
+                    "mcp_toolsets": [],
+                    "mcp_access_groups": [],
+                }
+            )
+        else:
+            updated_op = LiteLLM_ObjectPermissionTable(
+                object_permission_id="toolset-scope",
+                mcp_servers=server_ids,
+                mcp_tool_permissions=tool_permissions,
+            )
+        return user_api_key_auth.model_copy(update={"object_permission": updated_op})
+
     async def handle_streamable_http_mcp(
         scope: Scope, receive: Receive, send: Send
     ) -> None:
@@ -2401,6 +2481,21 @@ if MCP_AVAILABLE:
                         detail="Unauthorized",
                         headers={"www-authenticate": authorization_uri},
                     )
+
+            # If the request came via /toolset/{name}/mcp, scope the auth context
+            # to that toolset so the key only sees that toolset's tools.
+            toolset_id_header = next(
+                (
+                    v.decode()
+                    for k, v in scope.get("headers", [])
+                    if k == b"x-mcp-toolset-id"
+                ),
+                None,
+            )
+            if toolset_id_header and user_api_key_auth is not None:
+                user_api_key_auth = await _apply_toolset_scope(
+                    user_api_key_auth, toolset_id_header
+                )
 
             # Inject masked debug headers when client sends x-litellm-mcp-debug: true
             _debug_headers = MCPDebug.maybe_build_debug_headers(
@@ -2580,17 +2675,15 @@ if MCP_AVAILABLE:
         )
         auth_context_var.set(auth_user)
 
-    def get_auth_context() -> (
-        Tuple[
-            Optional[UserAPIKeyAuth],
-            Optional[str],
-            Optional[List[str]],
-            Optional[Dict[str, Dict[str, str]]],
-            Optional[Dict[str, str]],
-            Optional[Dict[str, str]],
-            Optional[str],
-        ]
-    ):
+    def get_auth_context() -> Tuple[
+        Optional[UserAPIKeyAuth],
+        Optional[str],
+        Optional[List[str]],
+        Optional[Dict[str, Dict[str, str]]],
+        Optional[Dict[str, str]],
+        Optional[Dict[str, str]],
+        Optional[str],
+    ]:
         """
         Get the UserAPIKeyAuth from the auth context variable.
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -9,6 +9,7 @@ import contextlib
 import time
 import traceback
 import uuid
+from contextvars import ContextVar
 from datetime import datetime
 from typing import (
     Any,
@@ -55,6 +56,13 @@ from litellm.types.mcp import MCPAuth
 from litellm.types.mcp_server.mcp_server_manager import MCPInfo, MCPServer
 from litellm.types.utils import CallTypes, StandardLoggingMCPToolCall
 from litellm.utils import Rules, client, function_setup
+
+# ContextVar holding the active toolset ID when a request arrives via
+# /toolset/{name}/mcp or /{name}/mcp (toolset fallback).  Set server-side
+# in proxy_server.py route handlers; never read from client-supplied headers.
+_mcp_active_toolset_id: ContextVar[Optional[str]] = ContextVar(
+    "_mcp_active_toolset_id", default=None
+)
 
 # Short-lived in-memory cache for BYOK credentials.
 # Keyed by (user_id, server_id); value is (credential_or_None, monotonic_timestamp).
@@ -2482,19 +2490,19 @@ if MCP_AVAILABLE:
                         headers={"www-authenticate": authorization_uri},
                     )
 
-            # If the request came via /toolset/{name}/mcp, scope the auth context
-            # to that toolset so the key only sees that toolset's tools.
-            toolset_id_header = next(
-                (
-                    v.decode()
-                    for k, v in scope.get("headers", [])
-                    if k == b"x-mcp-toolset-id"
-                ),
-                None,
-            )
-            if toolset_id_header and user_api_key_auth is not None:
+            # Strip any client-supplied x-mcp-toolset-id to prevent forgery.
+            scope["headers"] = [
+                (k, v)
+                for k, v in scope.get("headers", [])
+                if k.lower() != b"x-mcp-toolset-id"
+            ]
+
+            # Apply toolset scope if set server-side via ContextVar (set by
+            # /toolset/{name}/mcp and /{name}/mcp route handlers in proxy_server.py).
+            active_toolset_id = _mcp_active_toolset_id.get()
+            if active_toolset_id and user_api_key_auth is not None:
                 user_api_key_auth = await _apply_toolset_scope(
-                    user_api_key_auth, toolset_id_header
+                    user_api_key_auth, active_toolset_id
                 )
 
             # Inject masked debug headers when client sends x-litellm-mcp-debug: true

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2460,7 +2460,8 @@ if MCP_AVAILABLE:
                     "mcp_servers": server_ids,
                     "mcp_tool_permissions": tool_permissions,
                     "mcp_toolsets": [],
-                    "mcp_access_groups": [],
+                    # mcp_access_groups is preserved: a key's access-group grants
+                    # remain valid even when the request is scoped to a single toolset.
                 }
             )
         else:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -9,7 +9,6 @@ import contextlib
 import time
 import traceback
 import uuid
-from contextvars import ContextVar
 from datetime import datetime
 from typing import (
     Any,
@@ -38,6 +37,7 @@ from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
 from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
     get_request_base_url,
 )
+from litellm.proxy._experimental.mcp_server.mcp_context import _mcp_active_toolset_id
 from litellm.proxy._experimental.mcp_server.mcp_debug import MCPDebug
 from litellm.proxy._experimental.mcp_server.utils import (
     LITELLM_MCP_SERVER_DESCRIPTION,
@@ -56,13 +56,6 @@ from litellm.types.mcp import MCPAuth
 from litellm.types.mcp_server.mcp_server_manager import MCPInfo, MCPServer
 from litellm.types.utils import CallTypes, StandardLoggingMCPToolCall
 from litellm.utils import Rules, client, function_setup
-
-# ContextVar holding the active toolset ID when a request arrives via
-# /toolset/{name}/mcp or /{name}/mcp (toolset fallback).  Set server-side
-# in proxy_server.py route handlers; never read from client-supplied headers.
-_mcp_active_toolset_id: ContextVar[Optional[str]] = ContextVar(
-    "_mcp_active_toolset_id", default=None
-)
 
 # Short-lived in-memory cache for BYOK credentials.
 # Keyed by (user_id, server_id); value is (credential_or_None, monotonic_timestamp).

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2430,14 +2430,18 @@ if MCP_AVAILABLE:
         or set to a list that omits this toolset).  Admin keys always pass.
         """
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+        from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
 
         # Access control: non-admin keys must have this toolset in their grant list.
-        is_admin = getattr(user_api_key_auth, "user_role", None) == "proxy_admin"
+        # Use _user_has_admin_view so that PROXY_ADMIN_VIEW_ONLY is also treated as admin.
+        is_admin = _user_has_admin_view(user_api_key_auth)
         if not is_admin:
             op = user_api_key_auth.object_permission
             granted = getattr(op, "mcp_toolsets", None) if op else None
-            # granted=None → no restriction (allow); granted=[] or list without toolset_id → deny
-            if granted is not None and toolset_id not in granted:
+            # granted=None → key has no explicit toolset grants → deny (same semantics as
+            # fetch_mcp_toolsets which returns [] for non-admin keys with no grants configured).
+            # granted=[] or list without toolset_id → also deny.
+            if granted is None or toolset_id not in granted:
                 raise HTTPException(
                     status_code=403,
                     detail=f"API key does not have access to toolset '{toolset_id}'.",

--- a/litellm/proxy/_experimental/mcp_server/toolset_db.py
+++ b/litellm/proxy/_experimental/mcp_server/toolset_db.py
@@ -81,15 +81,23 @@ async def update_mcp_toolset(
     prisma_client: PrismaClient,
     data: UpdateMCPToolsetRequest,
     touched_by: str,
-) -> MCPToolset:
+) -> Optional[MCPToolset]:
     data_dict = data.model_dump(exclude_none=True, exclude={"toolset_id"})
     if "tools" in data_dict:
         data_dict["tools"] = json.dumps(data_dict["tools"])
     data_dict["updated_by"] = touched_by
-    row = await prisma_client.db.litellm_mcptoolsettable.update(
-        where={"toolset_id": data.toolset_id},
-        data=data_dict,
-    )
+    try:
+        row = await prisma_client.db.litellm_mcptoolsettable.update(
+            where={"toolset_id": data.toolset_id},
+            data=data_dict,
+        )
+    except Exception as e:
+        if (
+            "RecordNotFoundError" in type(e).__name__
+            or "record was not found" in str(e).lower()
+        ):
+            return None
+        raise
     return _toolset_from_row(row)
 
 

--- a/litellm/proxy/_experimental/mcp_server/toolset_db.py
+++ b/litellm/proxy/_experimental/mcp_server/toolset_db.py
@@ -1,6 +1,8 @@
 import json
 from typing import List, Optional
 
+from prisma.errors import RecordNotFoundError
+
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.proxy.utils import PrismaClient
@@ -91,13 +93,8 @@ async def update_mcp_toolset(
             where={"toolset_id": data.toolset_id},
             data=data_dict,
         )
-    except Exception as e:
-        if (
-            "RecordNotFoundError" in type(e).__name__
-            or "record was not found" in str(e).lower()
-        ):
-            return None
-        raise
+    except RecordNotFoundError:
+        return None
     return _toolset_from_row(row)
 
 
@@ -109,11 +106,6 @@ async def delete_mcp_toolset(
         row = await prisma_client.db.litellm_mcptoolsettable.delete(
             where={"toolset_id": toolset_id}
         )
-    except Exception as e:
-        if (
-            "RecordNotFoundError" in type(e).__name__
-            or "record was not found" in str(e).lower()
-        ):
-            return None
-        raise
+    except RecordNotFoundError:
+        return None
     return _toolset_from_row(row)

--- a/litellm/proxy/_experimental/mcp_server/toolset_db.py
+++ b/litellm/proxy/_experimental/mcp_server/toolset_db.py
@@ -97,9 +97,15 @@ async def delete_mcp_toolset(
     prisma_client: PrismaClient,
     toolset_id: str,
 ) -> Optional[MCPToolset]:
-    row = await prisma_client.db.litellm_mcptoolsettable.delete(
-        where={"toolset_id": toolset_id}
-    )
-    if row is None:
-        return None
+    try:
+        row = await prisma_client.db.litellm_mcptoolsettable.delete(
+            where={"toolset_id": toolset_id}
+        )
+    except Exception as e:
+        if (
+            "RecordNotFoundError" in type(e).__name__
+            or "record was not found" in str(e).lower()
+        ):
+            return None
+        raise
     return _toolset_from_row(row)

--- a/litellm/proxy/_experimental/mcp_server/toolset_db.py
+++ b/litellm/proxy/_experimental/mcp_server/toolset_db.py
@@ -59,7 +59,7 @@ async def list_mcp_toolsets(
         rows = await prisma_client.db.litellm_mcptoolsettable.find_many(where=where)
         return [_toolset_from_row(r) for r in rows]
     except Exception as e:
-        verbose_proxy_logger.debug(
+        verbose_proxy_logger.warning(
             "litellm.proxy._experimental.mcp_server.toolset_db::list_mcp_toolsets - {}".format(
                 str(e)
             )

--- a/litellm/proxy/_experimental/mcp_server/toolset_db.py
+++ b/litellm/proxy/_experimental/mcp_server/toolset_db.py
@@ -1,0 +1,105 @@
+import json
+from typing import List, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm._uuid import uuid
+from litellm.proxy.utils import PrismaClient
+from litellm.types.mcp_server.mcp_toolset import (
+    MCPToolset,
+    NewMCPToolsetRequest,
+    UpdateMCPToolsetRequest,
+)
+
+
+def _toolset_from_row(row) -> MCPToolset:
+    data = row.model_dump()
+    tools = data.get("tools") or []
+    if isinstance(tools, str):
+        tools = json.loads(tools)
+    data["tools"] = tools
+    return MCPToolset(**data)
+
+
+async def create_mcp_toolset(
+    prisma_client: PrismaClient,
+    data: NewMCPToolsetRequest,
+    touched_by: str,
+) -> MCPToolset:
+    data_dict = data.model_dump(exclude_none=True)
+    data_dict["toolset_id"] = str(uuid.uuid4())
+    data_dict["tools"] = json.dumps(data_dict.get("tools", []))
+    data_dict["created_by"] = touched_by
+    data_dict["updated_by"] = touched_by
+    row = await prisma_client.db.litellm_mcptoolsettable.create(data=data_dict)
+    return _toolset_from_row(row)
+
+
+async def get_mcp_toolset(
+    prisma_client: PrismaClient,
+    toolset_id: str,
+) -> Optional[MCPToolset]:
+    row = await prisma_client.db.litellm_mcptoolsettable.find_unique(
+        where={"toolset_id": toolset_id}
+    )
+    if row is None:
+        return None
+    return _toolset_from_row(row)
+
+
+async def list_mcp_toolsets(
+    prisma_client: PrismaClient,
+    toolset_ids: Optional[List[str]] = None,
+) -> List[MCPToolset]:
+    try:
+        where = {}
+        if toolset_ids is not None:
+            where = {"toolset_id": {"in": toolset_ids}}
+        rows = await prisma_client.db.litellm_mcptoolsettable.find_many(where=where)
+        return [_toolset_from_row(r) for r in rows]
+    except Exception as e:
+        verbose_proxy_logger.debug(
+            "litellm.proxy._experimental.mcp_server.toolset_db::list_mcp_toolsets - {}".format(
+                str(e)
+            )
+        )
+        return []
+
+
+async def get_mcp_toolset_by_name(
+    prisma_client: PrismaClient,
+    toolset_name: str,
+) -> Optional[MCPToolset]:
+    row = await prisma_client.db.litellm_mcptoolsettable.find_first(
+        where={"toolset_name": toolset_name}
+    )
+    if row is None:
+        return None
+    return _toolset_from_row(row)
+
+
+async def update_mcp_toolset(
+    prisma_client: PrismaClient,
+    data: UpdateMCPToolsetRequest,
+    touched_by: str,
+) -> MCPToolset:
+    data_dict = data.model_dump(exclude_none=True, exclude={"toolset_id"})
+    if "tools" in data_dict:
+        data_dict["tools"] = json.dumps(data_dict["tools"])
+    data_dict["updated_by"] = touched_by
+    row = await prisma_client.db.litellm_mcptoolsettable.update(
+        where={"toolset_id": data.toolset_id},
+        data=data_dict,
+    )
+    return _toolset_from_row(row)
+
+
+async def delete_mcp_toolset(
+    prisma_client: PrismaClient,
+    toolset_id: str,
+) -> Optional[MCPToolset]:
+    row = await prisma_client.db.litellm_mcptoolsettable.delete(
+        where={"toolset_id": toolset_id}
+    )
+    if row is None:
+        return None
+    return _toolset_from_row(row)

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -883,9 +883,9 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     allowed_cache_controls: Optional[list] = []
     config: Optional[dict] = {}
     permissions: Optional[dict] = {}
-    model_max_budget: Optional[
-        dict
-    ] = {}  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
+    model_max_budget: Optional[dict] = (
+        {}
+    )  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
 
     model_config = ConfigDict(protected_namespaces=())
     model_rpm_limit: Optional[dict] = None
@@ -1027,9 +1027,9 @@ class RegenerateKeyRequest(GenerateKeyRequest):
     spend: Optional[float] = None
     metadata: Optional[dict] = None
     new_master_key: Optional[str] = None
-    grace_period: Optional[
-        str
-    ] = None  # Duration to keep old key valid (e.g. "24h", "2d"); None = immediate revoke
+    grace_period: Optional[str] = (
+        None  # Duration to keep old key valid (e.g. "24h", "2d"); None = immediate revoke
+    )
 
 
 class ResetSpendRequest(LiteLLMPydanticObjectBase):
@@ -1539,12 +1539,12 @@ class NewCustomerRequest(BudgetNewRequest):
     blocked: bool = False  # allow/disallow requests for this end-user
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
     spend: Optional[float] = None
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = (
+        None  # if no equivalent model in allowed region - default all requests to this model
+    )
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
     @model_validator(mode="before")
@@ -1567,12 +1567,12 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = (
+        None  # if no equivalent model in allowed region - default all requests to this model
+    )
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
 
@@ -1662,15 +1662,15 @@ class NewTeamRequest(TeamBase):
     ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
 
     model_tpm_limit: Optional[Dict[str, int]] = None
-    team_member_budget: Optional[
-        float
-    ] = None  # allow user to set a budget for all team members
-    team_member_rpm_limit: Optional[
-        int
-    ] = None  # allow user to set RPM limit for all team members
-    team_member_tpm_limit: Optional[
-        int
-    ] = None  # allow user to set TPM limit for all team members
+    team_member_budget: Optional[float] = (
+        None  # allow user to set a budget for all team members
+    )
+    team_member_rpm_limit: Optional[int] = (
+        None  # allow user to set RPM limit for all team members
+    )
+    team_member_tpm_limit: Optional[int] = (
+        None  # allow user to set TPM limit for all team members
+    )
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     team_member_budget_duration: Optional[str] = None  # e.g. "30d", "1mo"
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
@@ -1767,9 +1767,9 @@ class BlockKeyRequest(LiteLLMPydanticObjectBase):
 
 class AddTeamCallback(LiteLLMPydanticObjectBase):
     callback_name: str
-    callback_type: Optional[
-        Literal["success", "failure", "success_and_failure"]
-    ] = "success_and_failure"
+    callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = (
+        "success_and_failure"
+    )
     callback_vars: Dict[str, str]
 
     @model_validator(mode="before")
@@ -1846,6 +1846,8 @@ class LiteLLM_ObjectPermissionTable(LiteLLMPydanticObjectBase):
     vector_stores: Optional[List[str]] = []
     agents: Optional[List[str]] = []
     agent_access_groups: Optional[List[str]] = []
+    mcp_toolsets: Optional[List[str]] = []
+    blocked_tools: Optional[List[str]] = []
 
 
 class LiteLLM_TeamTable(TeamBase):
@@ -2109,9 +2111,9 @@ class ConfigList(LiteLLMPydanticObjectBase):
     stored_in_db: Optional[bool]
     field_default_value: Any
     premium_field: bool = False
-    nested_fields: Optional[
-        List[FieldDetail]
-    ] = None  # For nested dictionary or Pydantic fields
+    nested_fields: Optional[List[FieldDetail]] = (
+        None  # For nested dictionary or Pydantic fields
+    )
 
 
 class UserHeaderMapping(LiteLLMPydanticObjectBase):
@@ -2468,9 +2470,9 @@ class UserAPIKeyAuth(
     user_max_budget: Optional[float] = None
     request_route: Optional[str] = None
     user: Optional[Any] = None  # Expanded user object when expand=user is used
-    created_by_user: Optional[
-        Any
-    ] = None  # Expanded created_by user when expand=user is used
+    created_by_user: Optional[Any] = (
+        None  # Expanded created_by user when expand=user is used
+    )
     end_user_object_permission: Optional[LiteLLM_ObjectPermissionTable] = None
     # Decoded upstream IdP claims (groups, roles, etc.) propagated by JWT auth machinery
     # and forwarded into outbound tokens by guardrails such as MCPJWTSigner.
@@ -2609,9 +2611,9 @@ class LiteLLM_OrganizationMembershipTable(LiteLLMPydanticObjectBase):
     budget_id: Optional[str] = None
     created_at: datetime
     updated_at: datetime
-    user: Optional[
-        Any
-    ] = None  # You might want to replace 'Any' with a more specific type if available
+    user: Optional[Any] = (
+        None  # You might want to replace 'Any' with a more specific type if available
+    )
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
     user_email: Optional[str] = None
 
@@ -3761,9 +3763,9 @@ class TeamModelDeleteRequest(BaseModel):
 # Organization Member Requests
 class OrganizationMemberAddRequest(OrgMemberAddRequest):
     organization_id: str
-    max_budget_in_organization: Optional[
-        float
-    ] = None  # Users max budget within the organization
+    max_budget_in_organization: Optional[float] = (
+        None  # Users max budget within the organization
+    )
 
 
 class OrganizationMemberDeleteRequest(MemberDeleteRequest):
@@ -4014,9 +4016,9 @@ class ProviderBudgetResponse(LiteLLMPydanticObjectBase):
     Maps provider names to their budget configs.
     """
 
-    providers: Dict[
-        str, ProviderBudgetResponseObject
-    ] = {}  # Dictionary mapping provider names to their budget configurations
+    providers: Dict[str, ProviderBudgetResponseObject] = (
+        {}
+    )  # Dictionary mapping provider names to their budget configurations
 
 
 class ProxyStateVariables(TypedDict):
@@ -4160,9 +4162,9 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     enforce_rbac: bool = False
     roles_jwt_field: Optional[str] = None  # v2 on role mappings
     role_mappings: Optional[List[RoleMapping]] = None
-    object_id_jwt_field: Optional[
-        str
-    ] = None  # can be either user / team, inferred from the role mapping
+    object_id_jwt_field: Optional[str] = (
+        None  # can be either user / team, inferred from the role mapping
+    )
     scope_mappings: Optional[List[ScopeMapping]] = None
     enforce_scope_based_access: bool = False
     enforce_team_based_model_access: bool = False

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -856,6 +856,7 @@ class LiteLLM_ObjectPermissionBase(LiteLLMPydanticObjectBase):
     mcp_access_groups: Optional[List[str]] = None
     mcp_tool_permissions: Optional[Dict[str, List[str]]] = None
     mcp_toolsets: Optional[List[str]] = None
+    blocked_tools: Optional[List[str]] = None
     vector_stores: Optional[List[str]] = None
     agents: Optional[List[str]] = None
     agent_access_groups: Optional[List[str]] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1847,7 +1847,7 @@ class LiteLLM_ObjectPermissionTable(LiteLLMPydanticObjectBase):
     vector_stores: Optional[List[str]] = []
     agents: Optional[List[str]] = []
     agent_access_groups: Optional[List[str]] = []
-    mcp_toolsets: Optional[List[str]] = []
+    mcp_toolsets: Optional[List[str]] = None
     blocked_tools: Optional[List[str]] = []
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -855,6 +855,7 @@ class LiteLLM_ObjectPermissionBase(LiteLLMPydanticObjectBase):
     mcp_servers: Optional[List[str]] = None
     mcp_access_groups: Optional[List[str]] = None
     mcp_tool_permissions: Optional[Dict[str, List[str]]] = None
+    mcp_toolsets: Optional[List[str]] = None
     vector_stores: Optional[List[str]] = None
     agents: Optional[List[str]] = None
     agent_access_groups: Optional[List[str]] = None

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -387,7 +387,13 @@ class PrismaManager:
                 else:
                     # Use prisma db push with increased timeout
                     subprocess.run(
-                        ["prisma", "db", "push", "--accept-data-loss"],
+                        [
+                            "prisma",
+                            "db",
+                            "push",
+                            "--accept-data-loss",
+                            "--skip-generate",
+                        ],
                         timeout=60,
                         check=True,
                     )

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -37,9 +37,10 @@ from fastapi import (
 from fastapi.responses import JSONResponse
 
 try:
-    from prisma.errors import RecordNotFoundError
+    from prisma.errors import RecordNotFoundError, UniqueViolationError
 except ImportError:
     RecordNotFoundError = Exception  # type: ignore
+    UniqueViolationError = Exception  # type: ignore
 
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
@@ -2074,15 +2075,13 @@ if MCP_AVAILABLE:
         )
         try:
             result = await create_mcp_toolset(prisma_client, payload, touched_by)
-        except Exception as e:
-            if "UniqueViolationError" in type(e).__name__ or "unique" in str(e).lower():
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail={
-                        "error": f"A toolset named '{payload.toolset_name}' already exists."
-                    },
-                )
-            raise
+        except UniqueViolationError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": f"A toolset named '{payload.toolset_name}' already exists."
+                },
+            )
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2166,6 +2166,11 @@ if MCP_AVAILABLE:
             litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
         )
         result = await update_mcp_toolset(prisma_client, payload, touched_by)
+        if result is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": f"Toolset '{payload.toolset_id}' not found."},
+            )
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2164,7 +2164,19 @@ if MCP_AVAILABLE:
         touched_by = (
             litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
         )
-        result = await update_mcp_toolset(prisma_client, payload, touched_by)
+        try:
+            result = await update_mcp_toolset(prisma_client, payload, touched_by)
+        except UniqueViolationError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": (
+                        f"A toolset named '{payload.toolset_name}' already exists."
+                        if payload.toolset_name
+                        else "A toolset with that name already exists."
+                    )
+                },
+            )
         if result is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -424,17 +424,17 @@ if MCP_AVAILABLE:
             inherited_credentials["scopes"] = existing_server.scopes
         # AWS SigV4 fields
         if existing_server.aws_access_key_id:
-            inherited_credentials[
-                "aws_access_key_id"
-            ] = existing_server.aws_access_key_id
+            inherited_credentials["aws_access_key_id"] = (
+                existing_server.aws_access_key_id
+            )
         if existing_server.aws_secret_access_key:
-            inherited_credentials[
-                "aws_secret_access_key"
-            ] = existing_server.aws_secret_access_key
+            inherited_credentials["aws_secret_access_key"] = (
+                existing_server.aws_secret_access_key
+            )
         if existing_server.aws_session_token:
-            inherited_credentials[
-                "aws_session_token"
-            ] = existing_server.aws_session_token
+            inherited_credentials["aws_session_token"] = (
+                existing_server.aws_session_token
+            )
         if existing_server.aws_region_name:
             inherited_credentials["aws_region_name"] = existing_server.aws_region_name
         if existing_server.aws_service_name:
@@ -2031,3 +2031,139 @@ if MCP_AVAILABLE:
                 f"Failed to load OpenAPI registry from {_OPENAPI_REGISTRY_PATH}: {e}"
             )
             return {"apis": []}
+
+    # ---------------------------------------------------------------------------
+    # MCP Toolset endpoints
+    # ---------------------------------------------------------------------------
+
+    from litellm.proxy._experimental.mcp_server.toolset_db import (
+        create_mcp_toolset,
+        delete_mcp_toolset,
+        get_mcp_toolset,
+        list_mcp_toolsets,
+        update_mcp_toolset,
+    )
+    from litellm.types.mcp_server.mcp_toolset import (
+        MCPToolset,
+        NewMCPToolsetRequest,
+        UpdateMCPToolsetRequest,
+    )
+
+    @router.post(
+        "/toolset",
+        description="Create a new MCP toolset (admin only)",
+        status_code=status.HTTP_201_CREATED,
+    )
+    @management_endpoint_wrapper
+    async def add_mcp_toolset(
+        payload: NewMCPToolsetRequest,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+        litellm_changed_by: Optional[str] = Header(None),
+    ):
+        """Create a named toolset — a curated selection of {server_id, tool_name} pairs."""
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "Only proxy admins can create MCP toolsets."},
+            )
+        touched_by = (
+            litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
+        )
+        return await create_mcp_toolset(prisma_client, payload, touched_by)
+
+    @router.get(
+        "/toolset",
+        description="List MCP toolsets accessible to the calling key",
+    )
+    @management_endpoint_wrapper
+    async def fetch_mcp_toolsets(
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        """Return toolsets the calling key is allowed to access."""
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+        # Admins with no explicit restriction see all toolsets
+        if _user_has_admin_view(user_api_key_dict):
+            op = user_api_key_dict.object_permission
+            if op is None or getattr(op, "mcp_toolsets", None) is None:
+                return await list_mcp_toolsets(prisma_client)
+
+        op = user_api_key_dict.object_permission
+        allowed_ids = (getattr(op, "mcp_toolsets", None) or []) if op else []
+        return await list_mcp_toolsets(
+            prisma_client, toolset_ids=allowed_ids if allowed_ids else None
+        )
+
+    @router.get(
+        "/toolset/{toolset_id}",
+        description="Get a specific MCP toolset by ID",
+    )
+    @management_endpoint_wrapper
+    async def fetch_mcp_toolset(
+        toolset_id: str,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+        toolset = await get_mcp_toolset(prisma_client, toolset_id)
+        if toolset is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": f"Toolset '{toolset_id}' not found."},
+            )
+        return toolset
+
+    @router.put(
+        "/toolset",
+        description="Update an existing MCP toolset (admin only)",
+    )
+    @management_endpoint_wrapper
+    async def edit_mcp_toolset(
+        payload: UpdateMCPToolsetRequest,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+        litellm_changed_by: Optional[str] = Header(None),
+    ):
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "Only proxy admins can update MCP toolsets."},
+            )
+        touched_by = (
+            litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
+        )
+        return await update_mcp_toolset(prisma_client, payload, touched_by)
+
+    @router.delete(
+        "/toolset/{toolset_id}",
+        description="Delete an MCP toolset (admin only)",
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+    @management_endpoint_wrapper
+    async def remove_mcp_toolset(
+        toolset_id: str,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+        litellm_changed_by: Optional[str] = Header(None),
+    ):
+        prisma_client = get_prisma_client_or_throw(
+            "Database not connected. Connect a database to your proxy"
+        )
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "Only proxy admins can delete MCP toolsets."},
+            )
+        deleted = await delete_mcp_toolset(prisma_client, toolset_id)
+        if deleted is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": f"Toolset '{toolset_id}' not found."},
+            )
+        return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2072,7 +2072,17 @@ if MCP_AVAILABLE:
         touched_by = (
             litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
         )
-        result = await create_mcp_toolset(prisma_client, payload, touched_by)
+        try:
+            result = await create_mcp_toolset(prisma_client, payload, touched_by)
+        except Exception as e:
+            if "UniqueViolationError" in type(e).__name__ or "unique" in str(e).lower():
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "error": f"A toolset named '{payload.toolset_name}' already exists."
+                    },
+                )
+            raise
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )
@@ -2092,20 +2102,16 @@ if MCP_AVAILABLE:
         prisma_client = get_prisma_client_or_throw(
             "Database not connected. Connect a database to your proxy"
         )
-        # Admins with no explicit restriction see all toolsets
-        if _user_has_admin_view(user_api_key_dict):
-            op = user_api_key_dict.object_permission
-            if op is None or getattr(op, "mcp_toolsets", None) is None:
-                return await list_mcp_toolsets(prisma_client)
-
+        is_admin = _user_has_admin_view(user_api_key_dict)
         op = user_api_key_dict.object_permission
-        # Distinguish None (field absent = no restriction) from [] (explicitly empty = zero allowed).
+        # mcp_toolsets=None means the field was never set.
+        # For admins: None → no restriction → return all.
+        # For non-admins: None → no toolsets explicitly granted → return nothing.
         raw_toolsets = getattr(op, "mcp_toolsets", None) if op else None
-        # raw_toolsets is None  → field not set → no restriction, return all
-        # raw_toolsets is []    → explicitly empty → return nothing
-        # raw_toolsets is [ids] → return only those
         if raw_toolsets is None:
-            return await list_mcp_toolsets(prisma_client)
+            if is_admin:
+                return await list_mcp_toolsets(prisma_client)
+            return []
         if not raw_toolsets:
             return []
         return await list_mcp_toolsets(prisma_client, toolset_ids=raw_toolsets)
@@ -2122,6 +2128,15 @@ if MCP_AVAILABLE:
         prisma_client = get_prisma_client_or_throw(
             "Database not connected. Connect a database to your proxy"
         )
+        # Non-admin keys may only fetch toolsets they've been explicitly granted.
+        if not _user_has_admin_view(user_api_key_dict):
+            op = user_api_key_dict.object_permission
+            granted = getattr(op, "mcp_toolsets", None) if op else None
+            if granted is None or toolset_id not in granted:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={"error": "API key does not have access to this toolset."},
+                )
         toolset = await get_mcp_toolset(prisma_client, toolset_id)
         if toolset is None:
             raise HTTPException(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2103,15 +2103,14 @@ if MCP_AVAILABLE:
         )
         is_admin = _user_has_admin_view(user_api_key_dict)
         op = user_api_key_dict.object_permission
-        # mcp_toolsets=None means the field was never set.
-        # For admins: None → no restriction → return all.
-        # For non-admins: None → no toolsets explicitly granted → return nothing.
+        # mcp_toolsets=None or [] both mean "not restricted by toolsets".
+        # For admins: either value → no restriction → return all.
+        # For non-admins: either value → no toolsets explicitly granted → return nothing.
+        # (An admin whose DB row has mcp_toolsets=[] should still see all toolsets.)
         raw_toolsets = getattr(op, "mcp_toolsets", None) if op else None
-        if raw_toolsets is None:
+        if not raw_toolsets:
             if is_admin:
                 return await list_mcp_toolsets(prisma_client)
-            return []
-        if not raw_toolsets:
             return []
         return await list_mcp_toolsets(prisma_client, toolset_ids=raw_toolsets)
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2072,7 +2072,13 @@ if MCP_AVAILABLE:
         touched_by = (
             litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
         )
-        return await create_mcp_toolset(prisma_client, payload, touched_by)
+        result = await create_mcp_toolset(prisma_client, payload, touched_by)
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        global_mcp_server_manager.invalidate_toolset_cache()
+        return result
 
     @router.get(
         "/toolset",
@@ -2093,10 +2099,16 @@ if MCP_AVAILABLE:
                 return await list_mcp_toolsets(prisma_client)
 
         op = user_api_key_dict.object_permission
-        allowed_ids = (getattr(op, "mcp_toolsets", None) or []) if op else []
-        return await list_mcp_toolsets(
-            prisma_client, toolset_ids=allowed_ids if allowed_ids else None
-        )
+        # Distinguish None (field absent = no restriction) from [] (explicitly empty = zero allowed).
+        raw_toolsets = getattr(op, "mcp_toolsets", None) if op else None
+        # raw_toolsets is None  → field not set → no restriction, return all
+        # raw_toolsets is []    → explicitly empty → return nothing
+        # raw_toolsets is [ids] → return only those
+        if raw_toolsets is None:
+            return await list_mcp_toolsets(prisma_client)
+        if not raw_toolsets:
+            return []
+        return await list_mcp_toolsets(prisma_client, toolset_ids=raw_toolsets)
 
     @router.get(
         "/toolset/{toolset_id}",
@@ -2139,7 +2151,15 @@ if MCP_AVAILABLE:
         touched_by = (
             litellm_changed_by or user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME
         )
-        return await update_mcp_toolset(prisma_client, payload, touched_by)
+        result = await update_mcp_toolset(prisma_client, payload, touched_by)
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        global_mcp_server_manager.invalidate_toolset_cache(
+            getattr(payload, "toolset_id", None)
+        )
+        return result
 
     @router.delete(
         "/toolset/{toolset_id}",
@@ -2166,4 +2186,9 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": f"Toolset '{toolset_id}' not found."},
             )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        global_mcp_server_manager.invalidate_toolset_cache(toolset_id)
         return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -380,30 +380,26 @@ async def validate_key_mcp_servers_against_team(
                 detail={"error": detail},
             )
 
-    # Validate requested toolsets (must be subset of team's toolsets)
-    if requested_toolsets:
+    # Validate requested toolsets against team's allowed toolsets.
+    # Only enforce the team-based restriction when a team is present — standalone
+    # keys (no team) can freely be granted any toolset by an admin.
+    if requested_toolsets and team_obj is not None:
         team_toolsets: Set[str] = set()
         if (
-            team_obj is not None
-            and team_obj.object_permission is not None
+            team_obj.object_permission is not None
             and team_obj.object_permission.mcp_toolsets
         ):
             team_toolsets = set(team_obj.object_permission.mcp_toolsets)
 
         disallowed_toolsets = requested_toolsets - team_toolsets
         if disallowed_toolsets:
-            if team_obj is not None:
-                detail = (
-                    f"Key requests MCP toolsets not allowed by team '{team_obj.team_id}': "
-                    f"{sorted(disallowed_toolsets)}. "
-                    f"Team allows: {sorted(team_toolsets)}."
-                )
-            else:
-                detail = (
-                    f"Key is not in a team. MCP toolsets cannot be assigned to "
-                    f"keys outside of a team. Disallowed toolsets: {sorted(disallowed_toolsets)}."
-                )
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail={"error": detail},
+                detail={
+                    "error": (
+                        f"Key requests MCP toolsets not allowed by team '{team_obj.team_id}': "
+                        f"{sorted(disallowed_toolsets)}. "
+                        f"Team allows: {sorted(team_toolsets)}."
+                    )
+                },
             )

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -384,22 +384,19 @@ async def validate_key_mcp_servers_against_team(
     # Only enforce the team-based restriction when a team is present — standalone
     # keys (no team) can freely be granted any toolset by an admin.
     if requested_toolsets and team_obj is not None:
-        team_toolsets: Set[str] = set()
-        if (
-            team_obj.object_permission is not None
-            and team_obj.object_permission.mcp_toolsets
-        ):
-            team_toolsets = set(team_obj.object_permission.mcp_toolsets)
-
-        disallowed_toolsets = requested_toolsets - team_toolsets
-        if disallowed_toolsets:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "error": (
-                        f"Key requests MCP toolsets not allowed by team '{team_obj.team_id}': "
-                        f"{sorted(disallowed_toolsets)}. "
-                        f"Team allows: {sorted(team_toolsets)}."
-                    )
-                },
-            )
+        team_op = team_obj.object_permission
+        team_mcp_toolsets = team_op.mcp_toolsets if team_op is not None else None
+        # None or [] means the team has no toolset restriction — allow any toolsets.
+        if team_mcp_toolsets:
+            disallowed_toolsets = requested_toolsets - set(team_mcp_toolsets)
+            if disallowed_toolsets:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": (
+                            f"Key requests MCP toolsets not allowed by team '{team_obj.team_id}': "
+                            f"{sorted(disallowed_toolsets)}. "
+                            f"Team allows: {sorted(team_mcp_toolsets)}."
+                        )
+                    },
+                )

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -208,10 +208,10 @@ async def _resolve_team_allowed_mcp_servers(
     )
 
     direct_servers: List[str] = team_object_permission.mcp_servers or []
-    access_group_servers: List[
-        str
-    ] = await MCPRequestHandler._get_mcp_servers_from_access_groups(
-        team_object_permission.mcp_access_groups or []
+    access_group_servers: List[str] = (
+        await MCPRequestHandler._get_mcp_servers_from_access_groups(
+            team_object_permission.mcp_access_groups or []
+        )
     )
     raw_tool_perms = team_object_permission.mcp_tool_permissions or {}
     if isinstance(raw_tool_perms, str):
@@ -286,6 +286,19 @@ def _extract_requested_mcp_access_groups(
     return set()
 
 
+def _extract_requested_mcp_toolsets(
+    object_permission: Optional[dict],
+) -> Set[str]:
+    """Extract MCP toolset IDs from a key's object_permission dict."""
+    if not object_permission or not isinstance(object_permission, dict):
+        return set()
+
+    toolsets = object_permission.get("mcp_toolsets")
+    if isinstance(toolsets, list):
+        return set(toolsets)
+    return set()
+
+
 async def validate_key_mcp_servers_against_team(
     object_permission: Optional[dict],
     team_obj: Optional["LiteLLM_TeamTableCachedObj"],
@@ -305,8 +318,10 @@ async def validate_key_mcp_servers_against_team(
     requested_servers = _extract_requested_mcp_server_ids(object_permission)
     requested_access_groups = _extract_requested_mcp_access_groups(object_permission)
 
+    requested_toolsets = _extract_requested_mcp_toolsets(object_permission)
+
     # Nothing to validate
-    if not requested_servers and not requested_access_groups:
+    if not requested_servers and not requested_access_groups and not requested_toolsets:
         return
 
     allow_all_keys_servers = _get_allow_all_keys_server_ids()
@@ -359,6 +374,34 @@ async def validate_key_mcp_servers_against_team(
                 detail = (
                     f"Key is not in a team. MCP access groups cannot be assigned to "
                     f"keys outside of a team. Disallowed groups: {sorted(disallowed_groups)}."
+                )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": detail},
+            )
+
+    # Validate requested toolsets (must be subset of team's toolsets)
+    if requested_toolsets:
+        team_toolsets: Set[str] = set()
+        if (
+            team_obj is not None
+            and team_obj.object_permission is not None
+            and team_obj.object_permission.mcp_toolsets
+        ):
+            team_toolsets = set(team_obj.object_permission.mcp_toolsets)
+
+        disallowed_toolsets = requested_toolsets - team_toolsets
+        if disallowed_toolsets:
+            if team_obj is not None:
+                detail = (
+                    f"Key requests MCP toolsets not allowed by team '{team_obj.team_id}': "
+                    f"{sorted(disallowed_toolsets)}. "
+                    f"Team allows: {sorted(team_toolsets)}."
+                )
+            else:
+                detail = (
+                    f"Key is not in a team. MCP toolsets cannot be assigned to "
+                    f"keys outside of a team. Disallowed toolsets: {sorted(disallowed_toolsets)}."
                 )
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -194,6 +194,7 @@ def generate_feedback_box():
     print()  # noqa
 
 
+import contextlib
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from functools import lru_cache
@@ -13500,6 +13501,70 @@ app.include_router(agent_endpoints_router)
 app.include_router(compliance_router)
 app.include_router(a2a_router)
 app.include_router(access_group_router)
+
+
+async def _stream_mcp_asgi_response(
+    handle_fn, scope: dict, receive
+) -> "StreamingResponse":
+    """
+    Call an ASGI MCP handler and return a StreamingResponse so SSE/streaming works.
+
+    asyncio.create_task copies the current context, so any ContextVar set before
+    this call (e.g. _mcp_active_toolset_id) is visible inside the handler task.
+    """
+    from starlette.responses import StreamingResponse
+
+    headers_ready: asyncio.Future = asyncio.get_event_loop().create_future()
+    body_queue: asyncio.Queue = asyncio.Queue()
+
+    async def bridging_send(message):
+        if message["type"] == "http.response.start":
+            if not headers_ready.done():
+                headers_ready.set_result(
+                    (message.get("status", 200), message.get("headers", []))
+                )
+        elif message["type"] == "http.response.body":
+            chunk = message.get("body", b"")
+            if chunk:
+                await body_queue.put(chunk)
+            if not message.get("more_body", False):
+                await body_queue.put(None)  # EOF sentinel
+
+    handler_task = asyncio.create_task(handle_fn(scope, receive, bridging_send))
+
+    try:
+        status, raw_headers = await asyncio.wait_for(
+            asyncio.shield(headers_ready), timeout=30.0
+        )
+    except asyncio.TimeoutError:
+        handler_task.cancel()
+        raise HTTPException(
+            status_code=504, detail="MCP handler did not respond in time"
+        )
+
+    headers_dict = {k.decode("latin-1"): v.decode("latin-1") for k, v in raw_headers}
+
+    async def body_iter():
+        try:
+            while True:
+                chunk = await body_queue.get()
+                if chunk is None:
+                    break
+                yield chunk
+        finally:
+            if not handler_task.done():
+                handler_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await handler_task
+
+    return StreamingResponse(
+        body_iter(),
+        status_code=status,
+        headers=headers_dict,
+        media_type=headers_dict.get("content-type"),
+    )
+
+
 ########################################################
 # MCP Server
 ########################################################
@@ -13537,39 +13602,20 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
                 detail=f"Toolset '{toolset_name}' not found",
             )
 
-        # Inject the resolved toolset_id as a header so handle_streamable_http_mcp
-        # can apply toolset-scoped permissions regardless of the key's own permissions.
         scope = dict(request.scope)
-        scope["headers"] = list(scope.get("headers", [])) + [
-            (b"x-mcp-toolset-id", toolset.toolset_id.encode()),
-        ]
         scope["path"] = "/mcp"
 
-        response_status = 200
-        response_headers: list = []
-        response_body = b""
-
-        async def custom_send(message):
-            nonlocal response_status, response_headers, response_body
-            if message["type"] == "http.response.start":
-                response_status = message["status"]
-                response_headers = message.get("headers", [])
-            elif message["type"] == "http.response.body":
-                response_body += message.get("body", b"")
-
-        await handle_streamable_http_mcp(
-            scope, receive=request.receive, send=custom_send
+        from litellm.proxy._experimental.mcp_server.server import (
+            _mcp_active_toolset_id,
         )
 
-        from starlette.responses import Response
-
-        headers_dict = {k.decode(): v.decode() for k, v in response_headers}
-        return Response(
-            content=response_body,
-            status_code=response_status,
-            headers=headers_dict,
-            media_type=headers_dict.get("content-type", "application/json"),
-        )
+        token = _mcp_active_toolset_id.set(toolset.toolset_id)
+        try:
+            return await _stream_mcp_asgi_response(
+                handle_streamable_http_mcp, scope, request.receive
+            )
+        finally:
+            _mcp_active_toolset_id.reset(token)
 
     except HTTPException as e:
         raise e
@@ -13613,34 +13659,19 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
                 toolset = await get_mcp_toolset_by_name(prisma_client, mcp_server_name)
                 if toolset is not None:
                     scope = dict(request.scope)
-                    scope["headers"] = list(scope.get("headers", [])) + [
-                        (b"x-mcp-toolset-id", toolset.toolset_id.encode()),
-                    ]
                     scope["path"] = "/mcp"
-                    response_status = 200
-                    response_headers: list = []
-                    response_body = b""
 
-                    async def toolset_send(message):
-                        nonlocal response_status, response_headers, response_body
-                        if message["type"] == "http.response.start":
-                            response_status = message["status"]
-                            response_headers = message.get("headers", [])
-                        elif message["type"] == "http.response.body":
-                            response_body += message.get("body", b"")
-
-                    await handle_streamable_http_mcp(
-                        scope, receive=request.receive, send=toolset_send
+                    from litellm.proxy._experimental.mcp_server.server import (
+                        _mcp_active_toolset_id,
                     )
-                    from starlette.responses import Response
 
-                    headers_dict = {k.decode(): v.decode() for k, v in response_headers}
-                    return Response(
-                        content=response_body,
-                        status_code=response_status,
-                        headers=headers_dict,
-                        media_type=headers_dict.get("content-type", "application/json"),
-                    )
+                    token = _mcp_active_toolset_id.set(toolset.toolset_id)
+                    try:
+                        return await _stream_mcp_asgi_response(
+                            handle_streamable_http_mcp, scope, request.receive
+                        )
+                    finally:
+                        _mcp_active_toolset_id.reset(token)
 
             raise HTTPException(
                 status_code=404, detail=f"MCP server '{mcp_server_name}' not found"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -480,11 +480,11 @@ from litellm.proxy.search_endpoints.search_tool_management import (
     router as search_tool_management_router,
 )
 from litellm.proxy.spend_tracking.cloudzero_endpoints import router as cloudzero_router
-from litellm.proxy.spend_tracking.vantage_endpoints import router as vantage_router
 from litellm.proxy.spend_tracking.spend_management_endpoints import (
     router as spend_management_router,
 )
 from litellm.proxy.spend_tracking.spend_tracking_utils import get_logging_payload
+from litellm.proxy.spend_tracking.vantage_endpoints import router as vantage_router
 from litellm.proxy.types_utils.utils import get_instance_fn
 from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
     router as ui_crud_endpoints_router,
@@ -639,9 +639,9 @@ except ImportError:
 server_root_path = get_server_root_path()
 _license_check = LicenseCheck()
 premium_user: bool = _license_check.is_premium()
-premium_user_data: Optional[
-    "EnterpriseLicenseData"
-] = _license_check.airgapped_license_data
+premium_user_data: Optional["EnterpriseLicenseData"] = (
+    _license_check.airgapped_license_data
+)
 global_max_parallel_request_retries_env: Optional[str] = os.getenv(
     "LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRIES"
 )
@@ -1524,9 +1524,9 @@ master_key: Optional[str] = None
 config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
-shared_aiohttp_session: Optional[
-    "ClientSession"
-] = None  # Global shared session for connection reuse
+shared_aiohttp_session: Optional["ClientSession"] = (
+    None  # Global shared session for connection reuse
+)
 user_api_key_cache = DualCache(
     default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value
 )
@@ -1534,13 +1534,13 @@ model_max_budget_limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(
     dual_cache=user_api_key_cache
 )
 litellm.logging_callback_manager.add_litellm_callback(model_max_budget_limiter)
-redis_usage_cache: Optional[
-    RedisCache
-] = None  # redis cache used for tracking spend, tpm/rpm limits
+redis_usage_cache: Optional[RedisCache] = (
+    None  # redis cache used for tracking spend, tpm/rpm limits
+)
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
-native_background_mode: List[
-    str
-] = []  # Models that should use native provider background mode instead of polling
+native_background_mode: List[str] = (
+    []
+)  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -1900,9 +1900,9 @@ async def update_cache(  # noqa: PLR0915
         _id = "team_id:{}".format(team_id)
         try:
             # Fetch the existing cost for the given user
-            existing_spend_obj: Optional[
-                LiteLLM_TeamTable
-            ] = await user_api_key_cache.async_get_cache(key=_id)
+            existing_spend_obj: Optional[LiteLLM_TeamTable] = (
+                await user_api_key_cache.async_get_cache(key=_id)
+            )
             if existing_spend_obj is None:
                 # do nothing if team not in api key cache
                 return
@@ -2023,11 +2023,9 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(
-            f"""
+        verbose_proxy_logger.debug(f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """
-        )
+        """)
 
 
 def _get_process_rss_mb() -> Optional[float]:
@@ -3321,7 +3319,7 @@ class ProxyConfig:
                 async_only_mode=True  # only init async clients
             ),
             ignore_invalid_deployments=True,  # don't raise an error if a deployment is invalid
-        )  # type:ignore
+        )  # type: ignore
 
         if redis_usage_cache is not None and router.cache.redis_cache is None:
             router._update_redis_cache(cache=redis_usage_cache)
@@ -4978,10 +4976,10 @@ class ProxyConfig:
         )
 
         try:
-            guardrails_in_db: List[
-                Guardrail
-            ] = await GuardrailRegistry.get_all_guardrails_from_db(
-                prisma_client=prisma_client
+            guardrails_in_db: List[Guardrail] = (
+                await GuardrailRegistry.get_all_guardrails_from_db(
+                    prisma_client=prisma_client
+                )
             )
             verbose_proxy_logger.debug(
                 "guardrails from the DB %s", str(guardrails_in_db)
@@ -5363,9 +5361,9 @@ async def initialize(  # noqa: PLR0915
         user_api_base = api_base
         dynamic_config[user_model]["api_base"] = api_base
     if api_version:
-        os.environ[
-            "AZURE_API_VERSION"
-        ] = api_version  # set this for azure - litellm can read this from the env
+        os.environ["AZURE_API_VERSION"] = (
+            api_version  # set this for azure - litellm can read this from the env
+        )
     if max_tokens:  # model-specific param
         dynamic_config[user_model]["max_tokens"] = max_tokens
     if temperature:  # model-specific param
@@ -5702,9 +5700,9 @@ class ProxyStartupEvent:
         """
         from litellm.secret_managers.main import str_to_bool
 
-        _use_redis_transaction_buffer: Optional[
-            Union[bool, str]
-        ] = general_settings.get("use_redis_transaction_buffer", False)
+        _use_redis_transaction_buffer: Optional[Union[bool, str]] = (
+            general_settings.get("use_redis_transaction_buffer", False)
+        )
         if isinstance(_use_redis_transaction_buffer, str):
             _use_redis_transaction_buffer = str_to_bool(_use_redis_transaction_buffer)
 
@@ -12299,9 +12297,9 @@ async def get_config_list(
                             hasattr(sub_field_info, "description")
                             and sub_field_info.description is not None
                         ):
-                            nested_fields[
-                                idx
-                            ].field_description = sub_field_info.description
+                            nested_fields[idx].field_description = (
+                                sub_field_info.description
+                            )
                         idx += 1
 
                     _stored_in_db = None
@@ -13507,13 +13505,88 @@ app.include_router(access_group_router)
 ########################################################
 
 
+# Toolset-namespaced MCP routes - handle /toolset/{toolset_name}/mcp
+# Must be declared BEFORE /{mcp_server_name}/mcp to avoid being swallowed by the catchall.
+@app.api_route(
+    "/toolset/{toolset_name}/mcp",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+)
+async def toolset_mcp_route(toolset_name: str, request: Request):
+    """
+    Namespace a toolset as its own MCP endpoint.
+
+    Connecting to /toolset/<name>/mcp exposes exactly the tools defined in
+    the toolset, regardless of what other permissions the API key has.
+    Any valid API key can discover and call the toolset's tools here.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+        )
+        from litellm.proxy._experimental.mcp_server.toolset_db import (
+            get_mcp_toolset_by_name,
+        )
+
+        if prisma_client is None:
+            raise HTTPException(status_code=503, detail="Database not available")
+
+        toolset = await get_mcp_toolset_by_name(prisma_client, toolset_name)
+        if toolset is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Toolset '{toolset_name}' not found",
+            )
+
+        # Inject the resolved toolset_id as a header so handle_streamable_http_mcp
+        # can apply toolset-scoped permissions regardless of the key's own permissions.
+        scope = dict(request.scope)
+        scope["headers"] = list(scope.get("headers", [])) + [
+            (b"x-mcp-toolset-id", toolset.toolset_id.encode()),
+        ]
+        scope["path"] = "/mcp"
+
+        response_status = 200
+        response_headers: list = []
+        response_body = b""
+
+        async def custom_send(message):
+            nonlocal response_status, response_headers, response_body
+            if message["type"] == "http.response.start":
+                response_status = message["status"]
+                response_headers = message.get("headers", [])
+            elif message["type"] == "http.response.body":
+                response_body += message.get("body", b"")
+
+        await handle_streamable_http_mcp(
+            scope, receive=request.receive, send=custom_send
+        )
+
+        from starlette.responses import Response
+
+        headers_dict = {k.decode(): v.decode() for k, v in response_headers}
+        return Response(
+            content=response_body,
+            status_code=response_status,
+            headers=headers_dict,
+            media_type=headers_dict.get("content-type", "application/json"),
+        )
+
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        verbose_proxy_logger.error(
+            f"Error handling toolset MCP route for {toolset_name}: {str(e)}"
+        )
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
 # Dynamic MCP server routes - handle /{mcp_server_name}/mcp
 @app.api_route(
     "/{mcp_server_name}/mcp",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
 )
 async def dynamic_mcp_route(mcp_server_name: str, request: Request):
-    """Handle dynamic MCP server routes like /github_mcp/mcp"""
+    """Handle dynamic MCP server routes like /github_mcp/mcp and toolset routes like /devtooling-prod/mcp"""
     try:
         # Validate that the MCP server exists
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
@@ -13527,6 +13600,48 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
             mcp_server_name, client_ip=client_ip
         )
         if mcp_server is None:
+            # Check if this is a toolset name — toolsets are accessible at /{name}/mcp
+            # the same way individual servers are, no separate /toolset/ prefix needed.
+            if prisma_client is not None:
+                from litellm.proxy._experimental.mcp_server.server import (
+                    handle_streamable_http_mcp,
+                )
+                from litellm.proxy._experimental.mcp_server.toolset_db import (
+                    get_mcp_toolset_by_name,
+                )
+
+                toolset = await get_mcp_toolset_by_name(prisma_client, mcp_server_name)
+                if toolset is not None:
+                    scope = dict(request.scope)
+                    scope["headers"] = list(scope.get("headers", [])) + [
+                        (b"x-mcp-toolset-id", toolset.toolset_id.encode()),
+                    ]
+                    scope["path"] = "/mcp"
+                    response_status = 200
+                    response_headers: list = []
+                    response_body = b""
+
+                    async def toolset_send(message):
+                        nonlocal response_status, response_headers, response_body
+                        if message["type"] == "http.response.start":
+                            response_status = message["status"]
+                            response_headers = message.get("headers", [])
+                        elif message["type"] == "http.response.body":
+                            response_body += message.get("body", b"")
+
+                    await handle_streamable_http_mcp(
+                        scope, receive=request.receive, send=toolset_send
+                    )
+                    from starlette.responses import Response
+
+                    headers_dict = {k.decode(): v.decode() for k, v in response_headers}
+                    return Response(
+                        content=response_body,
+                        status_code=response_status,
+                        headers=headers_dict,
+                        media_type=headers_dict.get("content-type", "application/json"),
+                    )
+
             raise HTTPException(
                 status_code=404, detail=f"MCP server '{mcp_server_name}' not found"
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13532,6 +13532,14 @@ async def _stream_mcp_asgi_response(
 
     handler_task = asyncio.create_task(handle_fn(scope, receive, bridging_send))
 
+    # If the handler task dies (exception or cancellation) without sending the EOF
+    # sentinel, body_iter() would block forever on body_queue.get().  The callback
+    # below guarantees the queue gets unblocked regardless of how the task ends.
+    def _ensure_eof(task: asyncio.Task) -> None:
+        body_queue.put_nowait(None)
+
+    handler_task.add_done_callback(_ensure_eof)
+
     try:
         status, raw_headers = await asyncio.wait_for(
             asyncio.shield(headers_ready), timeout=30.0

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13585,17 +13585,20 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
     Any valid API key can discover and call the toolset's tools here.
     """
     try:
-        from litellm.proxy._experimental.mcp_server.server import (
-            handle_streamable_http_mcp,
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
         )
-        from litellm.proxy._experimental.mcp_server.toolset_db import (
-            get_mcp_toolset_by_name,
+        from litellm.proxy._experimental.mcp_server.server import (
+            _mcp_active_toolset_id,
+            handle_streamable_http_mcp,
         )
 
         if prisma_client is None:
             raise HTTPException(status_code=503, detail="Database not available")
 
-        toolset = await get_mcp_toolset_by_name(prisma_client, toolset_name)
+        toolset = await global_mcp_server_manager.get_toolset_by_name_cached(
+            prisma_client, toolset_name
+        )
         if toolset is None:
             raise HTTPException(
                 status_code=404,
@@ -13604,10 +13607,6 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
 
         scope = dict(request.scope)
         scope["path"] = "/mcp"
-
-        from litellm.proxy._experimental.mcp_server.server import (
-            _mcp_active_toolset_id,
-        )
 
         token = _mcp_active_toolset_id.set(toolset.toolset_id)
         try:
@@ -13649,21 +13648,20 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
             # Check if this is a toolset name — toolsets are accessible at /{name}/mcp
             # the same way individual servers are, no separate /toolset/ prefix needed.
             if prisma_client is not None:
+                from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                    global_mcp_server_manager,
+                )
                 from litellm.proxy._experimental.mcp_server.server import (
+                    _mcp_active_toolset_id,
                     handle_streamable_http_mcp,
                 )
-                from litellm.proxy._experimental.mcp_server.toolset_db import (
-                    get_mcp_toolset_by_name,
-                )
 
-                toolset = await get_mcp_toolset_by_name(prisma_client, mcp_server_name)
+                toolset = await global_mcp_server_manager.get_toolset_by_name_cached(
+                    prisma_client, mcp_server_name
+                )
                 if toolset is not None:
                     scope = dict(request.scope)
                     scope["path"] = "/mcp"
-
-                    from litellm.proxy._experimental.mcp_server.server import (
-                        _mcp_active_toolset_id,
-                    )
 
                     token = _mcp_active_toolset_id.set(toolset.toolset_id)
                     try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13589,8 +13589,9 @@ async def toolset_mcp_route(toolset_name: str, request: Request):
     Namespace a toolset as its own MCP endpoint.
 
     Connecting to /toolset/<name>/mcp exposes exactly the tools defined in
-    the toolset, regardless of what other permissions the API key has.
-    Any valid API key can discover and call the toolset's tools here.
+    the toolset. Access is enforced: non-admin API keys must have the toolset
+    listed in their object_permission.mcp_toolsets grant list, or the request
+    will be rejected with a 403.
     """
     try:
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13536,7 +13536,8 @@ async def _stream_mcp_asgi_response(
     # sentinel, body_iter() would block forever on body_queue.get().  The callback
     # below guarantees the queue gets unblocked regardless of how the task ends.
     def _ensure_eof(task: asyncio.Task) -> None:
-        body_queue.put_nowait(None)
+        if task.cancelled() or task.exception() is not None:
+            body_queue.put_nowait(None)
 
     handler_task.add_done_callback(_ensure_eof)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13514,7 +13514,7 @@ async def _stream_mcp_asgi_response(
     """
     from starlette.responses import StreamingResponse
 
-    headers_ready: asyncio.Future = asyncio.get_event_loop().create_future()
+    headers_ready: asyncio.Future = asyncio.get_running_loop().create_future()
     body_queue: asyncio.Queue = asyncio.Queue()
 
     async def bridging_send(message):

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -340,7 +340,7 @@ model LiteLLM_MCPToolsetTable {
   tools        Json     @default("[]") // [{server_id: string, tool_name: string}]
   created_at   DateTime @default(now())
   created_by   String?
-  updated_at   DateTime @updatedAt
+  updated_at   DateTime @default(now()) @updatedAt
   updated_by   String?
 }
 

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -273,6 +273,7 @@ model LiteLLM_ObjectPermissionTable {
   agent_access_groups   String[]       @default([])
   models                String[]       @default([])
   blocked_tools         String[]       @default([]) // Tool names blocked for any key/team/user with this permission
+  mcp_toolsets          String[]       @default([]) // Toolset IDs granted to this key/team/user
   teams                 LiteLLM_TeamTable[]
   projects              LiteLLM_ProjectTable[]
   verification_tokens   LiteLLM_VerificationToken[]
@@ -329,6 +330,18 @@ model LiteLLM_MCPServerTable {
   review_notes     String?
 
   @@index([approval_status])
+}
+
+// Named collection of {server_id, tool_name} pairs that can be granted to keys/teams
+model LiteLLM_MCPToolsetTable {
+  toolset_id   String   @id @default(uuid())
+  toolset_name String   @unique
+  description  String?
+  tools        Json     @default("[]") // [{server_id: string, tool_name: string}]
+  created_at   DateTime @default(now())
+  created_by   String?
+  updated_at   DateTime @updatedAt
+  updated_by   String?
 }
 
 // Per-user BYOK credentials for MCP servers

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -160,10 +160,38 @@ class LiteLLM_Proxy_MCP_Handler:
                 ):
                     mcp_servers.append(server_url.split("/")[-1])
 
+        # Resolve toolset names: if any name in mcp_servers is a toolset (not a real
+        # server name), apply toolset scope to user_api_key_auth so that only the
+        # toolset's servers and tools are visible. Non-toolset names are kept as-is.
+        resolved_mcp_servers: List[str] = []
+        for name in mcp_servers:
+            if not global_mcp_server_manager.get_mcp_server_by_name(name):
+                try:
+                    from litellm.proxy._experimental.mcp_server.server import (
+                        _apply_toolset_scope,
+                    )
+                    from litellm.proxy._experimental.mcp_server.toolset_db import (
+                        get_mcp_toolset_by_name,
+                    )
+                    from litellm.proxy.proxy_server import prisma_client
+
+                    if prisma_client is not None and user_api_key_auth is not None:
+                        toolset = await get_mcp_toolset_by_name(prisma_client, name)
+                        if toolset is not None:
+                            user_api_key_auth = await _apply_toolset_scope(
+                                user_api_key_auth, toolset.toolset_id
+                            )
+                            # Don't add to resolved_mcp_servers — toolset scope
+                            # restricts via object_permission, not server name filter.
+                            continue
+                except Exception as _e:
+                    verbose_logger.debug(f"Could not resolve '{name}' as toolset: {_e}")
+            resolved_mcp_servers.append(name)
+
         tools = await _get_tools_from_mcp_servers(
             user_api_key_auth=user_api_key_auth,
             mcp_auth_header=mcp_auth_header,
-            mcp_servers=mcp_servers,
+            mcp_servers=resolved_mcp_servers if resolved_mcp_servers else None,
             mcp_server_auth_headers=mcp_server_auth_headers,
             log_list_tools_to_spendlogs=True,
             list_tools_log_source="responses",
@@ -178,7 +206,7 @@ class LiteLLM_Proxy_MCP_Handler:
         )
 
         allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(
-            mcp_servers=mcp_servers,
+            mcp_servers=resolved_mcp_servers if resolved_mcp_servers else None,
             allowed_mcp_servers=allowed_mcp_servers,
         )
 
@@ -682,14 +710,14 @@ class LiteLLM_Proxy_MCP_Handler:
                         standard_logging_mcp_tool_call["mcp_server_logo_url"] = logo_url
                     cost_info = mcp_info.get("mcp_server_cost_info")
                     if cost_info:
-                        standard_logging_mcp_tool_call[
-                            "mcp_server_cost_info"
-                        ] = cost_info
+                        standard_logging_mcp_tool_call["mcp_server_cost_info"] = (
+                            cost_info
+                        )
 
                 if litellm_logging_obj:
-                    litellm_logging_obj.model_call_details[
-                        "mcp_tool_call_metadata"
-                    ] = standard_logging_mcp_tool_call
+                    litellm_logging_obj.model_call_details["mcp_tool_call_metadata"] = (
+                        standard_logging_mcp_tool_call
+                    )
                     litellm_logging_obj.model = f"MCP: {tool_name}"
                     litellm_logging_obj.call_type = CallTypes.call_mcp_tool.value
 

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -160,34 +160,63 @@ class LiteLLM_Proxy_MCP_Handler:
                 ):
                     mcp_servers.append(server_url.split("/")[-1])
 
-        # Resolve toolset names: if any name in mcp_servers is a toolset (not a real
-        # server name), apply toolset scope to user_api_key_auth so that only the
-        # toolset's servers and tools are visible. Non-toolset names are kept as-is.
+        # Resolve toolset names: collect all toolset IDs first, then apply their
+        # combined permissions in a single pass so multiple toolsets are unioned
+        # rather than the last one overwriting the others.
         resolved_mcp_servers: List[str] = []
+        resolved_toolset_ids: List[str] = []
         for name in mcp_servers:
             if not global_mcp_server_manager.get_mcp_server_by_name(name):
                 try:
-                    from litellm.proxy._experimental.mcp_server.server import (
-                        _apply_toolset_scope,
-                    )
                     from litellm.proxy.proxy_server import prisma_client
 
-                    if prisma_client is not None and user_api_key_auth is not None:
+                    if prisma_client is not None:
                         toolset = (
                             await global_mcp_server_manager.get_toolset_by_name_cached(
                                 prisma_client, name
                             )
                         )
                         if toolset is not None:
-                            user_api_key_auth = await _apply_toolset_scope(
-                                user_api_key_auth, toolset.toolset_id
-                            )
+                            resolved_toolset_ids.append(toolset.toolset_id)
                             # Don't add to resolved_mcp_servers — toolset scope
                             # restricts via object_permission, not server name filter.
                             continue
                 except Exception as _e:
                     verbose_logger.debug(f"Could not resolve '{name}' as toolset: {_e}")
             resolved_mcp_servers.append(name)
+
+        # Apply all resolved toolsets at once (union), avoiding permission overwrite.
+        if resolved_toolset_ids and user_api_key_auth is not None:
+            try:
+                from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+                tool_permissions = (
+                    await global_mcp_server_manager.resolve_toolset_tool_permissions(
+                        toolset_ids=resolved_toolset_ids
+                    )
+                )
+                server_ids = list(tool_permissions.keys())
+                existing_op = user_api_key_auth.object_permission
+                if existing_op is not None:
+                    updated_op = existing_op.model_copy(
+                        update={
+                            "mcp_servers": server_ids,
+                            "mcp_tool_permissions": tool_permissions,
+                            "mcp_toolsets": [],
+                            "mcp_access_groups": [],
+                        }
+                    )
+                else:
+                    updated_op = LiteLLM_ObjectPermissionTable(
+                        object_permission_id="toolset-scope",
+                        mcp_servers=server_ids,
+                        mcp_tool_permissions=tool_permissions,
+                    )
+                user_api_key_auth = user_api_key_auth.model_copy(
+                    update={"object_permission": updated_op}
+                )
+            except Exception as _e:
+                verbose_logger.debug(f"Could not apply toolset permissions: {_e}")
 
         tools = await _get_tools_from_mcp_servers(
             user_api_key_auth=user_api_key_auth,

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -226,12 +226,21 @@ class LiteLLM_Proxy_MCP_Handler:
                 )
                 existing_op = user_api_key_auth.object_permission
                 if existing_op is not None:
+                    # Merge toolset tool permissions with existing ones (union),
+                    # so direct-server tool restrictions are not overwritten.
+                    merged_tool_perms = dict(existing_op.mcp_tool_permissions or {})
+                    for server_id, tool_names in tool_permissions.items():
+                        existing_tools = merged_tool_perms.get(server_id, [])
+                        merged_tool_perms[server_id] = list(
+                            set(existing_tools) | set(tool_names)
+                        )
                     updated_op = existing_op.model_copy(
                         update={
                             "mcp_servers": all_server_ids,
-                            "mcp_tool_permissions": tool_permissions,
+                            "mcp_tool_permissions": merged_tool_perms,
                             "mcp_toolsets": [],
-                            "mcp_access_groups": [],
+                            # mcp_access_groups preserved: existing access-group
+                            # grants remain valid alongside toolset grants.
                         }
                     )
                 else:
@@ -246,10 +255,18 @@ class LiteLLM_Proxy_MCP_Handler:
             except Exception as _e:
                 verbose_logger.debug(f"Could not apply toolset permissions: {_e}")
 
+        # When toolsets were resolved we updated object_permission.mcp_servers to the
+        # full union (toolset server IDs + direct server names).  Passing a name-based
+        # filter here would exclude those toolset server IDs (which are UUIDs, not
+        # names), so use None and let the auth object's mcp_servers do the filtering.
+        effective_server_filter = (
+            None if resolved_toolset_ids else (resolved_mcp_servers or None)
+        )
+
         tools = await _get_tools_from_mcp_servers(
             user_api_key_auth=user_api_key_auth,
             mcp_auth_header=mcp_auth_header,
-            mcp_servers=resolved_mcp_servers if resolved_mcp_servers else None,
+            mcp_servers=effective_server_filter,
             mcp_server_auth_headers=mcp_server_auth_headers,
             log_list_tools_to_spendlogs=True,
             list_tools_log_source="responses",
@@ -264,7 +281,7 @@ class LiteLLM_Proxy_MCP_Handler:
         )
 
         allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(
-            mcp_servers=resolved_mcp_servers if resolved_mcp_servers else None,
+            mcp_servers=effective_server_filter,
             allowed_mcp_servers=allowed_mcp_servers,
         )
 

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -177,6 +177,27 @@ class LiteLLM_Proxy_MCP_Handler:
                             )
                         )
                         if toolset is not None:
+                            # Access control: only allow if the key explicitly grants this toolset.
+                            if user_api_key_auth is not None:
+                                is_admin = (
+                                    getattr(user_api_key_auth, "user_role", None)
+                                    == "proxy_admin"
+                                )
+                                if not is_admin:
+                                    op = user_api_key_auth.object_permission
+                                    granted = (
+                                        getattr(op, "mcp_toolsets", None)
+                                        if op
+                                        else None
+                                    )
+                                    if (
+                                        granted is not None
+                                        and toolset.toolset_id not in granted
+                                    ):
+                                        verbose_logger.debug(
+                                            f"Key does not have access to toolset '{name}', skipping."
+                                        )
+                                        continue
                             resolved_toolset_ids.append(toolset.toolset_id)
                             # Don't add to resolved_mcp_servers — toolset scope
                             # restricts via object_permission, not server name filter.

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -170,13 +170,14 @@ class LiteLLM_Proxy_MCP_Handler:
                     from litellm.proxy._experimental.mcp_server.server import (
                         _apply_toolset_scope,
                     )
-                    from litellm.proxy._experimental.mcp_server.toolset_db import (
-                        get_mcp_toolset_by_name,
-                    )
                     from litellm.proxy.proxy_server import prisma_client
 
                     if prisma_client is not None and user_api_key_auth is not None:
-                        toolset = await get_mcp_toolset_by_name(prisma_client, name)
+                        toolset = (
+                            await global_mcp_server_manager.get_toolset_by_name_cached(
+                                prisma_client, name
+                            )
+                        )
                         if toolset is not None:
                             user_api_key_auth = await _apply_toolset_scope(
                                 user_api_key_auth, toolset.toolset_id

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -216,12 +216,16 @@ class LiteLLM_Proxy_MCP_Handler:
                         toolset_ids=resolved_toolset_ids
                     )
                 )
-                server_ids = list(tool_permissions.keys())
+                # Union toolset server IDs with direct servers the user also requested,
+                # so explicitly-selected servers aren't dropped by downstream permission filtering.
+                all_server_ids = list(
+                    set(tool_permissions.keys()) | set(resolved_mcp_servers)
+                )
                 existing_op = user_api_key_auth.object_permission
                 if existing_op is not None:
                     updated_op = existing_op.model_copy(
                         update={
-                            "mcp_servers": server_ids,
+                            "mcp_servers": all_server_ids,
                             "mcp_tool_permissions": tool_permissions,
                             "mcp_toolsets": [],
                             "mcp_access_groups": [],
@@ -230,7 +234,7 @@ class LiteLLM_Proxy_MCP_Handler:
                 else:
                     updated_op = LiteLLM_ObjectPermissionTable(
                         object_permission_id="toolset-scope",
-                        mcp_servers=server_ids,
+                        mcp_servers=all_server_ids,
                         mcp_tool_permissions=tool_permissions,
                     )
                 user_api_key_auth = user_api_key_auth.model_copy(

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -179,10 +179,11 @@ class LiteLLM_Proxy_MCP_Handler:
                         if toolset is not None:
                             # Access control: only allow if the key explicitly grants this toolset.
                             if user_api_key_auth is not None:
-                                is_admin = (
-                                    getattr(user_api_key_auth, "user_role", None)
-                                    == "proxy_admin"
+                                from litellm.proxy.management_endpoints.common_utils import (
+                                    _user_has_admin_view,
                                 )
+
+                                is_admin = _user_has_admin_view(user_api_key_auth)
                                 if not is_admin:
                                     op = user_api_key_auth.object_permission
                                     granted = (
@@ -190,9 +191,11 @@ class LiteLLM_Proxy_MCP_Handler:
                                         if op
                                         else None
                                     )
+                                    # None means no grants configured → deny (consistent with
+                                    # fetch_mcp_toolsets which returns [] for unconfigured keys)
                                     if (
-                                        granted is not None
-                                        and toolset.toolset_id not in granted
+                                        granted is None
+                                        or toolset.toolset_id not in granted
                                     ):
                                         verbose_logger.debug(
                                             f"Key does not have access to toolset '{name}', skipping."

--- a/litellm/types/mcp_server/mcp_toolset.py
+++ b/litellm/types/mcp_server/mcp_toolset.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+
+class MCPToolsetTool(TypedDict):
+    server_id: str
+    tool_name: str
+
+
+class MCPToolset(BaseModel):
+    toolset_id: str
+    toolset_name: str
+    description: Optional[str] = None
+    tools: List[MCPToolsetTool] = []
+    created_at: Optional[datetime] = None
+    created_by: Optional[str] = None
+    updated_at: Optional[datetime] = None
+    updated_by: Optional[str] = None
+
+
+class NewMCPToolsetRequest(BaseModel):
+    toolset_name: str
+    description: Optional[str] = None
+    tools: List[MCPToolsetTool] = []
+
+
+class UpdateMCPToolsetRequest(BaseModel):
+    toolset_id: str
+    toolset_name: Optional[str] = None
+    description: Optional[str] = None
+    tools: Optional[List[MCPToolsetTool]] = None

--- a/schema.prisma
+++ b/schema.prisma
@@ -331,7 +331,7 @@ model LiteLLM_MCPToolsetTable {
   tools        Json     @default("[]") // [{server_id: string, tool_name: string}]
   created_at   DateTime @default(now())
   created_by   String?
-  updated_at   DateTime @updatedAt
+  updated_at   DateTime @default(now()) @updatedAt
   updated_by   String?
 }
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -273,6 +273,7 @@ model LiteLLM_ObjectPermissionTable {
   agent_access_groups   String[]       @default([])
   models                String[]       @default([])
   blocked_tools         String[]       @default([]) // Tool names blocked for any key/team/user with this permission
+  mcp_toolsets          String[]       @default([]) // Toolset IDs granted to this key/team/user
   teams                 LiteLLM_TeamTable[]
   projects              LiteLLM_ProjectTable[]
   verification_tokens   LiteLLM_VerificationToken[]
@@ -320,6 +321,18 @@ model LiteLLM_MCPServerTable {
   is_byok               Boolean  @default(false)
   byok_description      String[] @default([])
   byok_api_key_help_url String?
+}
+
+// Named collection of {server_id, tool_name} pairs that can be granted to keys/teams
+model LiteLLM_MCPToolsetTable {
+  toolset_id   String   @id @default(uuid())
+  toolset_name String   @unique
+  description  String?
+  tools        Json     @default("[]") // [{server_id: string, tool_name: string}]
+  created_at   DateTime @default(now())
+  created_by   String?
+  updated_at   DateTime @updatedAt
+  updated_by   String?
 }
 
 // Per-user BYOK credentials for MCP servers

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -84,7 +84,7 @@ class TestApplyToolsetScope:
     @pytest.mark.asyncio
     async def test_non_admin_no_object_permission_raises_403(self):
         """Non-admin key with object_permission=None is denied (no grants configured)."""
-        from fastapi import HTTPException
+        from starlette.exceptions import HTTPException
 
         from litellm.proxy._experimental.mcp_server.server import _apply_toolset_scope
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -59,7 +59,8 @@ class TestApplyToolsetScope:
         assert op.mcp_tool_permissions == toolset_perms
 
     @pytest.mark.asyncio
-    async def test_creates_object_permission_when_none(self):
+    async def test_admin_creates_object_permission_when_none(self):
+        """Admin key with object_permission=None can access any toolset."""
         from litellm.proxy._experimental.mcp_server.server import _apply_toolset_scope
 
         toolset_perms = {"server-a": ["tool1"]}
@@ -68,13 +69,29 @@ class TestApplyToolsetScope:
             "global_mcp_server_manager.resolve_toolset_tool_permissions",
             new=AsyncMock(return_value=toolset_perms),
         ):
-            auth = UserAPIKeyAuth(api_key="sk-test", object_permission=None)
+            auth = UserAPIKeyAuth(
+                api_key="sk-test",
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                object_permission=None,
+            )
             result = await _apply_toolset_scope(auth, "toolset-123")
 
         op = result.object_permission
         assert op is not None
         assert op.mcp_servers == ["server-a"]
         assert op.mcp_tool_permissions == toolset_perms
+
+    @pytest.mark.asyncio
+    async def test_non_admin_no_object_permission_raises_403(self):
+        """Non-admin key with object_permission=None is denied (no grants configured)."""
+        from fastapi import HTTPException
+
+        from litellm.proxy._experimental.mcp_server.server import _apply_toolset_scope
+
+        auth = UserAPIKeyAuth(api_key="sk-test", object_permission=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await _apply_toolset_scope(auth, "toolset-123")
+        assert exc_info.value.status_code == 403
 
 
 class TestFetchMCPToolsetsAccess:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -22,7 +22,7 @@ def _make_auth(
         object_permission_id="test",
         mcp_servers=mcp_servers,
         mcp_tool_permissions=mcp_tool_permissions or {},
-        mcp_toolsets=mcp_toolsets or [],
+        mcp_toolsets=mcp_toolsets,
     )
     return UserAPIKeyAuth(
         api_key="sk-test",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -1,0 +1,122 @@
+"""Tests for MCP toolset scope enforcement."""
+
+import asyncio
+from typing import Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
+
+
+def _make_auth(
+    mcp_servers: Optional[List[str]] = None,
+    mcp_tool_permissions: Optional[Dict[str, List[str]]] = None,
+    mcp_toolsets: Optional[List[str]] = None,
+) -> UserAPIKeyAuth:
+    op = LiteLLM_ObjectPermissionTable(
+        object_permission_id="test",
+        mcp_servers=mcp_servers,
+        mcp_tool_permissions=mcp_tool_permissions or {},
+        mcp_toolsets=mcp_toolsets or [],
+    )
+    return UserAPIKeyAuth(
+        api_key="sk-test",
+        object_permission=op,
+    )
+
+
+class TestApplyToolsetScope:
+    """Tests for _apply_toolset_scope helper."""
+
+    @pytest.mark.asyncio
+    async def test_restricts_to_toolset_servers_and_tools(self):
+        from litellm.proxy._experimental.mcp_server.server import _apply_toolset_scope
+
+        toolset_perms = {
+            "server-a": ["tool1", "tool2"],
+            "server-b": ["tool3"],
+        }
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server."
+            "global_mcp_server_manager.resolve_toolset_tool_permissions",
+            new=AsyncMock(return_value=toolset_perms),
+        ):
+            auth = _make_auth(mcp_servers=["server-a", "server-b", "server-c"])
+            result = await _apply_toolset_scope(auth, "toolset-123")
+
+        op = result.object_permission
+        assert op is not None
+        assert set(op.mcp_servers or []) == {"server-a", "server-b"}
+        assert op.mcp_tool_permissions == toolset_perms
+
+    @pytest.mark.asyncio
+    async def test_creates_object_permission_when_none(self):
+        from litellm.proxy._experimental.mcp_server.server import _apply_toolset_scope
+
+        toolset_perms = {"server-a": ["tool1"]}
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server."
+            "global_mcp_server_manager.resolve_toolset_tool_permissions",
+            new=AsyncMock(return_value=toolset_perms),
+        ):
+            auth = UserAPIKeyAuth(api_key="sk-test", object_permission=None)
+            result = await _apply_toolset_scope(auth, "toolset-123")
+
+        op = result.object_permission
+        assert op is not None
+        assert op.mcp_servers == ["server-a"]
+        assert op.mcp_tool_permissions == toolset_perms
+
+
+class TestFetchMCPToolsetsAccess:
+    """Tests for GET /v1/mcp/toolset access control."""
+
+    def test_empty_toolsets_returns_empty(self):
+        """Non-admin key with mcp_toolsets=[] must not see any toolsets."""
+        # Simulate what fetch_mcp_toolsets does with raw_toolsets=[]
+        raw_toolsets: Optional[List[str]] = []
+        # raw_toolsets is [] → return nothing
+        assert raw_toolsets is not None
+        assert not raw_toolsets  # empty list → return []
+
+    def test_none_toolsets_returns_all(self):
+        """Key where mcp_toolsets is absent (None) should return all toolsets."""
+        raw_toolsets: Optional[List[str]] = None
+        # raw_toolsets is None → no restriction → return all
+        assert raw_toolsets is None
+
+    def test_populated_toolsets_filters(self):
+        """Key with explicit toolset IDs should only see those."""
+        raw_toolsets: Optional[List[str]] = ["ts-1", "ts-2"]
+        assert raw_toolsets is not None
+        assert len(raw_toolsets) == 2
+
+
+class TestMCPActiveToolsetContextVar:
+    """Tests for _mcp_active_toolset_id ContextVar — clients cannot inject it."""
+
+    def test_contextvar_default_is_none(self):
+        from litellm.proxy._experimental.mcp_server.server import _mcp_active_toolset_id
+
+        assert _mcp_active_toolset_id.get() is None
+
+    def test_contextvar_set_and_reset(self):
+        from litellm.proxy._experimental.mcp_server.server import _mcp_active_toolset_id
+
+        token = _mcp_active_toolset_id.set("toolset-abc")
+        assert _mcp_active_toolset_id.get() == "toolset-abc"
+        _mcp_active_toolset_id.reset(token)
+        assert _mcp_active_toolset_id.get() is None
+
+    def test_client_header_is_stripped(self):
+        """x-mcp-toolset-id header is removed from scope headers before auth runs."""
+        # Simulate the stripping logic from handle_streamable_http_mcp
+        headers = [
+            (b"authorization", b"Bearer sk-test"),
+            (b"x-mcp-toolset-id", b"evil-toolset"),
+            (b"content-type", b"application/json"),
+        ]
+        stripped = [(k, v) for k, v in headers if k.lower() != b"x-mcp-toolset-id"]
+        assert (b"x-mcp-toolset-id", b"evil-toolset") not in stripped
+        assert len(stripped) == 2

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
+from litellm.proxy._types import (
+    LiteLLM_ObjectPermissionTable,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
 
 
 def _make_auth(
@@ -42,7 +46,11 @@ class TestApplyToolsetScope:
             "global_mcp_server_manager.resolve_toolset_tool_permissions",
             new=AsyncMock(return_value=toolset_perms),
         ):
-            auth = _make_auth(mcp_servers=["server-a", "server-b", "server-c"])
+            # Key has been explicitly granted toolset-123 — access check passes.
+            auth = _make_auth(
+                mcp_servers=["server-a", "server-b", "server-c"],
+                mcp_toolsets=["toolset-123"],
+            )
             result = await _apply_toolset_scope(auth, "toolset-123")
 
         op = result.object_permission
@@ -72,25 +80,111 @@ class TestApplyToolsetScope:
 class TestFetchMCPToolsetsAccess:
     """Tests for GET /v1/mcp/toolset access control."""
 
-    def test_empty_toolsets_returns_empty(self):
+    @pytest.mark.asyncio
+    async def test_non_admin_empty_grants_returns_empty(self):
         """Non-admin key with mcp_toolsets=[] must not see any toolsets."""
-        # Simulate what fetch_mcp_toolsets does with raw_toolsets=[]
-        raw_toolsets: Optional[List[str]] = []
-        # raw_toolsets is [] → return nothing
-        assert raw_toolsets is not None
-        assert not raw_toolsets  # empty list → return []
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            fetch_mcp_toolsets,
+        )
 
-    def test_none_toolsets_returns_all(self):
-        """Key where mcp_toolsets is absent (None) should return all toolsets."""
-        raw_toolsets: Optional[List[str]] = None
-        # raw_toolsets is None → no restriction → return all
-        assert raw_toolsets is None
+        auth = _make_auth(mcp_toolsets=[])
+        mock_client = MagicMock()
 
-    def test_populated_toolsets_filters(self):
-        """Key with explicit toolset IDs should only see those."""
-        raw_toolsets: Optional[List[str]] = ["ts-1", "ts-2"]
-        assert raw_toolsets is not None
-        assert len(raw_toolsets) == 2
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.list_mcp_toolsets",
+                new=AsyncMock(return_value=[]),
+            ) as mock_list,
+        ):
+            result = await fetch_mcp_toolsets(user_api_key_dict=auth)
+
+        assert result == []
+        mock_list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_admin_unrestricted_returns_all(self):
+        """Admin key with mcp_toolsets absent (None) gets all toolsets."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            fetch_mcp_toolsets,
+        )
+
+        auth = UserAPIKeyAuth(
+            api_key="sk-test",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            object_permission=None,
+        )
+        fake_toolsets = [MagicMock(), MagicMock()]
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.list_mcp_toolsets",
+                new=AsyncMock(return_value=fake_toolsets),
+            ) as mock_list,
+        ):
+            result = await fetch_mcp_toolsets(user_api_key_dict=auth)
+
+        assert result == fake_toolsets
+        mock_list.assert_called_once_with(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_none_grants_returns_empty(self):
+        """Non-admin key with no object_permission (field absent) gets no toolsets."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            fetch_mcp_toolsets,
+        )
+
+        auth = UserAPIKeyAuth(api_key="sk-test", object_permission=None)
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.list_mcp_toolsets",
+                new=AsyncMock(return_value=[]),
+            ) as mock_list,
+        ):
+            result = await fetch_mcp_toolsets(user_api_key_dict=auth)
+
+        assert result == []
+        mock_list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_populated_grants_filters_toolsets(self):
+        """Key with explicit toolset IDs fetches only those IDs from the DB."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            fetch_mcp_toolsets,
+        )
+
+        auth = _make_auth(mcp_toolsets=["ts-1", "ts-2"])
+        fake_toolsets = [MagicMock(toolset_id="ts-1"), MagicMock(toolset_id="ts-2")]
+        mock_client = MagicMock()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=mock_client,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.list_mcp_toolsets",
+                new=AsyncMock(return_value=fake_toolsets),
+            ) as mock_list,
+        ):
+            result = await fetch_mcp_toolsets(user_api_key_dict=auth)
+
+        assert len(result) == 2
+        mock_list.assert_called_once_with(mock_client, toolset_ids=["ts-1", "ts-2"])
 
 
 class TestMCPActiveToolsetContextVar:
@@ -109,14 +203,69 @@ class TestMCPActiveToolsetContextVar:
         _mcp_active_toolset_id.reset(token)
         assert _mcp_active_toolset_id.get() is None
 
-    def test_client_header_is_stripped(self):
-        """x-mcp-toolset-id header is removed from scope headers before auth runs."""
-        # Simulate the stripping logic from handle_streamable_http_mcp
-        headers = [
-            (b"authorization", b"Bearer sk-test"),
-            (b"x-mcp-toolset-id", b"evil-toolset"),
-            (b"content-type", b"application/json"),
-        ]
-        stripped = [(k, v) for k, v in headers if k.lower() != b"x-mcp-toolset-id"]
-        assert (b"x-mcp-toolset-id", b"evil-toolset") not in stripped
-        assert len(stripped) == 2
+    @pytest.mark.asyncio
+    async def test_client_header_is_stripped_in_scope(self):
+        """handle_streamable_http_mcp strips x-mcp-toolset-id from scope before passing to session manager."""
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+        )
+
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "method": "GET",
+            "query_string": b"",
+            "headers": [
+                (b"authorization", b"Bearer sk-test"),
+                (b"x-mcp-toolset-id", b"evil-toolset"),
+                (b"content-type", b"application/json"),
+            ],
+        }
+        mock_auth = UserAPIKeyAuth(api_key="sk-test")
+
+        async def fake_receive():
+            return {"type": "http.disconnect"}
+
+        async def fake_send(msg):
+            pass
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+                new=AsyncMock(
+                    return_value=(mock_auth, None, [], {}, {}, scope["headers"])
+                ),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server.IPAddressUtils",
+                MagicMock(get_mcp_client_ip=MagicMock(return_value="127.0.0.1")),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+                MagicMock(get_mcp_server_by_name=MagicMock(return_value=None)),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server.MCPDebug",
+                MagicMock(
+                    maybe_build_debug_headers=MagicMock(return_value=None),
+                ),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server.set_auth_context",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+                True,
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server._handle_stale_mcp_session",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            await handle_streamable_http_mcp(scope, fake_receive, fake_send)
+
+        header_keys = [k for k, _ in scope["headers"]]
+        assert b"x-mcp-toolset-id" not in header_keys
+        assert b"authorization" in header_keys
+        assert b"content-type" in header_keys

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/mcpServers/useMCPToolsets.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/mcpServers/useMCPToolsets.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+import { fetchMCPToolsets } from "@/components/networking";
+import { MCPToolset } from "@/components/mcp_tools/types";
+import useAuthorized from "../useAuthorized";
+
+const mcpToolsetKeys = createQueryKeys("mcpToolsets");
+
+export const useMCPToolsets = () => {
+  const { accessToken } = useAuthorized();
+  return useQuery<MCPToolset[]>({
+    queryKey: mcpToolsetKeys.list(),
+    queryFn: async () => await fetchMCPToolsets(accessToken!),
+    enabled: !!accessToken,
+  });
+};

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -1,13 +1,15 @@
 import { useMCPAccessGroups } from "@/app/(dashboard)/hooks/mcpServers/useMCPAccessGroups";
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
 import { Select } from "antd";
 import React from "react";
 
 interface MCPServerSelectorProps {
-  onChange: (selected: { servers: string[]; accessGroups: string[] }) => void;
+  onChange: (selected: { servers: string[]; accessGroups: string[]; toolsets: string[] }) => void;
   value?: {
     servers: string[];
     accessGroups: string[];
+    toolsets?: string[];
   };
   className?: string;
   accessToken: string;
@@ -15,6 +17,8 @@ interface MCPServerSelectorProps {
   disabled?: boolean;
   teamId?: string | null;
 }
+
+const TOOLSET_PREFIX = "toolset:";
 
 const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
   onChange,
@@ -27,33 +31,61 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
 }) => {
   const { data: mcpServers = [], isLoading: serversLoading } = useMCPServers(teamId);
   const { data: accessGroups = [], isLoading: groupsLoading } = useMCPAccessGroups();
+  const { data: toolsets = [], isLoading: toolsetsLoading } = useMCPToolsets();
 
-  const loading = serversLoading || groupsLoading;
+  const loading = serversLoading || groupsLoading || toolsetsLoading;
 
-  // Combine options, access groups first
+  const accessGroupSet = new Set(accessGroups);
+
+  // Combine options: access groups (green) + servers (blue) + toolsets (purple)
   const options = [
     ...accessGroups.map((group) => ({
       label: group,
       value: group,
-      isAccessGroup: true,
+      type: "accessGroup" as const,
       searchText: `${group} Access Group`,
     })),
     ...mcpServers.map((server) => ({
       label: `${server.server_name || server.server_id} (${server.server_id})`,
       value: server.server_id,
-      isAccessGroup: false,
+      type: "server" as const,
       searchText: `${server.server_name || server.server_id} ${server.server_id} MCP Server`,
+    })),
+    ...toolsets.map((toolset) => ({
+      label: toolset.toolset_name,
+      value: `${TOOLSET_PREFIX}${toolset.toolset_id}`,
+      type: "toolset" as const,
+      searchText: `${toolset.toolset_name} ${toolset.toolset_id} Toolset`,
     })),
   ];
 
-  // Flatten value for Select
-  const selectedValues = [...(value?.servers || []), ...(value?.accessGroups || [])];
+  const colorByType: Record<string, string> = {
+    accessGroup: "#52c41a",
+    server: "#1890ff",
+    toolset: "#722ed1",
+  };
+  const labelByType: Record<string, string> = {
+    accessGroup: "Access Group",
+    server: "MCP Server",
+    toolset: "Toolset",
+  };
+
+  // Flatten value for Select — prefix toolset IDs
+  const selectedValues = [
+    ...(value?.servers || []),
+    ...(value?.accessGroups || []),
+    ...(value?.toolsets || []).map((id) => `${TOOLSET_PREFIX}${id}`),
+  ];
 
   // Handle selection
   const handleChange = (selected: string[]) => {
-    const servers = selected.filter((v) => !accessGroups.includes(v));
-    const accessGroupsSelected = selected.filter((v) => accessGroups.includes(v));
-    onChange({ servers, accessGroups: accessGroupsSelected });
+    const toolsetsSelected = selected
+      .filter((v) => v.startsWith(TOOLSET_PREFIX))
+      .map((v) => v.slice(TOOLSET_PREFIX.length));
+    const rest = selected.filter((v) => !v.startsWith(TOOLSET_PREFIX));
+    const servers = rest.filter((v) => !accessGroupSet.has(v));
+    const accessGroupsSelected = rest.filter((v) => accessGroupSet.has(v));
+    onChange({ servers, accessGroups: accessGroupsSelected, toolsets: toolsetsSelected });
   };
 
   return (
@@ -83,20 +115,20 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
                   width: 8,
                   height: 8,
                   borderRadius: "50%",
-                  background: opt.isAccessGroup ? "#52c41a" : "#1890ff",
+                  background: colorByType[opt.type],
                   flexShrink: 0,
                 }}
               />
               <span style={{ flex: 1 }}>{opt.label}</span>
               <span
                 style={{
-                  color: opt.isAccessGroup ? "#52c41a" : "#1890ff",
+                  color: colorByType[opt.type],
                   fontSize: "12px",
                   fontWeight: 500,
                   opacity: 0.8,
                 }}
               >
-                {opt.isAccessGroup ? "Access Group" : "MCP Server"}
+                {labelByType[opt.type]}
               </span>
             </div>
           </Select.Option>

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolsetsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolsetsTab.tsx
@@ -1,0 +1,524 @@
+import React, { useState, useCallback } from "react";
+import { Button, Text, Title } from "@tremor/react";
+import { Modal, Form, Input, message, Spin, Card, Typography, Space } from "antd";
+import { PlusIcon, PencilIcon, TrashIcon } from "@heroicons/react/outline";
+import { ColumnDef } from "@tanstack/react-table";
+import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
+import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { useQueryClient } from "@tanstack/react-query";
+import { DataTable } from "../view_logs/table";
+import {
+  createMCPToolset,
+  updateMCPToolset,
+  deleteMCPToolset,
+  listMCPTools,
+  getProxyBaseUrl,
+} from "../networking";
+import { MCPToolset, MCPToolsetTool } from "./types";
+
+const { Text: AntdText } = Typography;
+
+interface MCPToolsetsTabProps {
+  accessToken: string | null;
+  userRole: string | null;
+}
+
+interface ToolsetFormValues {
+  toolset_name: string;
+  description?: string;
+}
+
+interface MCPToolListProps {
+  serverId: string;
+  serverName: string;
+  accessToken: string | null;
+  selectedTools: MCPToolsetTool[];
+  onToggle: (tool: MCPToolsetTool) => void;
+}
+
+interface ToolEntry {
+  name: string;
+  description?: string;
+}
+
+function MCPToolList({ serverId, serverName, accessToken, selectedTools, onToggle }: MCPToolListProps) {
+  const [tools, setTools] = useState<ToolEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const selectedSet = new Set(selectedTools.filter((t) => t.server_id === serverId).map((t) => t.tool_name));
+
+  const fetchTools = useCallback(async () => {
+    if (!accessToken || tools.length > 0) return;
+    setLoading(true);
+    try {
+      const result = await listMCPTools(accessToken, serverId);
+      const toolList = Array.isArray(result) ? result : result?.tools ?? [];
+      setTools(toolList.map((t: any) => ({ name: t.name ?? t.tool_name ?? t, description: t.description ?? "" })));
+    } catch {
+      setTools([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, serverId, tools.length]);
+
+  const handleToggle = () => {
+    if (!expanded) fetchTools();
+    setExpanded(!expanded);
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors"
+        onClick={handleToggle}
+      >
+        <span className="text-sm font-medium text-gray-700 flex items-center gap-2">
+          <span className="inline-block w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+          {serverName}
+          {selectedSet.size > 0 && (
+            <span className="ml-1 text-xs text-purple-600 font-semibold">{selectedSet.size} selected</span>
+          )}
+        </span>
+        <span className="text-gray-400 text-xs">{expanded ? "▲" : "▼"}</span>
+      </button>
+      {expanded && (
+        <div className="p-2">
+          {loading ? (
+            <div className="flex justify-center py-3"><Spin size="small" /></div>
+          ) : tools.length === 0 ? (
+            <p className="text-xs text-gray-400 px-2 py-2">No tools found for this server.</p>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {tools.map((tool) => {
+                const selected = selectedSet.has(tool.name);
+                return (
+                  <button
+                    key={tool.name}
+                    type="button"
+                    onClick={() => onToggle({ server_id: serverId, tool_name: tool.name })}
+                    className={`flex items-start justify-between px-3 py-2 rounded-lg text-left transition-colors ${
+                      selected
+                        ? "bg-purple-50 border border-purple-300"
+                        : "bg-white border border-gray-100 hover:bg-gray-50"
+                    }`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className={`text-sm font-medium leading-tight ${selected ? "text-purple-800" : "text-gray-800"}`}>
+                        {tool.name}
+                      </p>
+                      {tool.description && (
+                        <p className="text-xs text-gray-400 mt-0.5 leading-tight line-clamp-2">{tool.description}</p>
+                      )}
+                    </div>
+                    {selected && <span className="text-purple-500 text-xs font-semibold ml-2 flex-shrink-0 mt-0.5">✓</span>}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CreateToolsetModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (name: string, description: string | undefined, tools: MCPToolsetTool[]) => Promise<void>;
+  accessToken: string | null;
+  initialToolset?: MCPToolset;
+}
+
+function CreateToolsetModal({ open, onClose, onSave, accessToken, initialToolset }: CreateToolsetModalProps) {
+  const [form] = Form.useForm<ToolsetFormValues>();
+  const [selectedTools, setSelectedTools] = useState<MCPToolsetTool[]>(initialToolset?.tools || []);
+  const [saving, setSaving] = useState(false);
+  const [serverSearch, setServerSearch] = useState("");
+  const { data: mcpServers = [] } = useMCPServers();
+
+  React.useEffect(() => {
+    if (open) {
+      form.setFieldsValue({
+        toolset_name: initialToolset?.toolset_name || "",
+        description: initialToolset?.description || "",
+      });
+      setSelectedTools(initialToolset?.tools || []);
+      setServerSearch("");
+    }
+  }, [open, initialToolset]);
+
+  const handleToggleTool = (tool: MCPToolsetTool) => {
+    setSelectedTools((prev) => {
+      const exists = prev.some((t) => t.server_id === tool.server_id && t.tool_name === tool.tool_name);
+      return exists
+        ? prev.filter((t) => !(t.server_id === tool.server_id && t.tool_name === tool.tool_name))
+        : [...prev, tool];
+    });
+  };
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      await onSave(values.toolset_name, values.description, selectedTools);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const filteredServers = mcpServers.filter((s) => {
+    const q = serverSearch.toLowerCase();
+    return (
+      !q ||
+      (s.alias || "").toLowerCase().includes(q) ||
+      (s.server_name || "").toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      title={initialToolset ? "Edit Toolset" : "New Toolset"}
+      width={960}
+      footer={null}
+      forceRender
+    >
+      <Form form={form} layout="vertical" className="mt-2">
+        <div className="flex gap-4 mb-4">
+          <Form.Item
+            label="Toolset Name"
+            name="toolset_name"
+            rules={[{ required: true, message: "Please enter a toolset name" }]}
+            className="flex-1 mb-0"
+          >
+            <Input placeholder="e.g. github-linear-tools" />
+          </Form.Item>
+          <Form.Item label="Description" name="description" className="flex-1 mb-0">
+            <Input placeholder="Optional description" />
+          </Form.Item>
+        </div>
+      </Form>
+
+      <div className="flex gap-4 mt-2" style={{ minHeight: 360 }}>
+        {/* Left panel: Available Tools */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between mb-2">
+            <Text className="text-sm font-semibold text-gray-700">Available Tools</Text>
+          </div>
+          <Input
+            placeholder="Search MCP servers..."
+            value={serverSearch}
+            onChange={(e) => setServerSearch(e.target.value)}
+            className="mb-2"
+            allowClear
+          />
+          <div className="space-y-2 overflow-y-auto" style={{ maxHeight: 300 }}>
+            {filteredServers.length === 0 ? (
+              <Text className="text-gray-400 text-sm">{mcpServers.length === 0 ? "No MCP servers configured" : "No servers match your search"}</Text>
+            ) : (
+              filteredServers.map((server) => (
+                <MCPToolList
+                  key={server.server_id}
+                  serverId={server.server_id}
+                  serverName={server.alias || server.server_name || server.server_id}
+                  accessToken={accessToken}
+                  selectedTools={selectedTools}
+                  onToggle={handleToggleTool}
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="w-px bg-gray-200 flex-shrink-0" />
+
+        {/* Right panel: Your Toolset */}
+        <div className="w-72 flex-shrink-0">
+          <Text className="text-sm font-semibold text-gray-700 mb-2 block">
+            Your Toolset{" "}
+            <span className="text-xs font-normal text-gray-400">({selectedTools.length} tools)</span>
+          </Text>
+          <div className="space-y-1 overflow-y-auto" style={{ maxHeight: 340 }}>
+            {selectedTools.length === 0 ? (
+              <Text className="text-gray-400 text-sm">No tools added yet</Text>
+            ) : (
+              selectedTools.map((tool, idx) => (
+                <button
+                  key={idx}
+                  type="button"
+                  onClick={() => handleToggleTool(tool)}
+                  className="w-full flex items-center justify-between px-3 py-1.5 rounded-lg border border-purple-200 bg-purple-50 hover:bg-red-50 hover:border-red-200 group transition-colors"
+                >
+                  <div className="min-w-0 text-left">
+                    <span className="text-xs font-medium text-purple-800 group-hover:text-red-600 truncate block">{tool.tool_name}</span>
+                    <span className="text-[10px] text-purple-400 truncate block">{tool.server_id.slice(0, 8)}…</span>
+                  </div>
+                  <span className="ml-2 text-purple-300 group-hover:text-red-400 text-xs flex-shrink-0">✕</span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 mt-4 pt-4 border-t border-gray-200">
+        <Button variant="secondary" onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSubmit} loading={saving}>
+          {initialToolset ? "Save Changes" : "Create Toolset"}
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+function toolsetColumns(
+  isAdmin: boolean,
+  onEdit: (t: MCPToolset) => void,
+  onDelete: (id: string) => void,
+  proxyBaseUrl: string,
+): ColumnDef<MCPToolset>[] {
+  return [
+    {
+      header: "Toolset ID",
+      accessorKey: "toolset_id",
+      cell: ({ row }) => (
+        <span className="font-mono text-xs bg-gray-100 px-2 py-0.5 rounded text-gray-600">
+          {row.original.toolset_id.slice(0, 8)}…
+        </span>
+      ),
+    },
+    {
+      header: "Name",
+      accessorKey: "toolset_name",
+      cell: ({ row }) => {
+        const url = `${proxyBaseUrl}/toolset/${row.original.toolset_name}/mcp`;
+        return (
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <span className="inline-block w-2 h-2 rounded-full bg-purple-500 flex-shrink-0" />
+              <span className="font-medium text-gray-900">{row.original.toolset_name}</span>
+            </div>
+            <button
+              type="button"
+              className="text-xs text-gray-400 hover:text-purple-600 font-mono truncate max-w-xs text-left transition-colors"
+              onClick={() => navigator.clipboard.writeText(url)}
+              title="Click to copy endpoint URL"
+            >
+              {url}
+            </button>
+          </div>
+        );
+      },
+    },
+    {
+      header: "Description",
+      accessorKey: "description",
+      cell: ({ row }) => (
+        <span className="text-sm text-gray-500">{row.original.description || "—"}</span>
+      ),
+    },
+    {
+      header: "Tools",
+      accessorKey: "tools",
+      cell: ({ row }) => {
+        const tools = row.original.tools;
+        return (
+          <div className="flex flex-wrap gap-1 max-w-xs">
+            {tools.slice(0, 4).map((t, i) => (
+              <span key={i} className="inline-flex items-center px-1.5 py-0.5 rounded bg-purple-50 border border-purple-200 text-purple-700 text-xs">
+                {t.tool_name}
+              </span>
+            ))}
+            {tools.length > 4 && (
+              <span className="text-xs text-gray-400 self-center">+{tools.length - 4} more</span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      header: "Created",
+      accessorKey: "created_at",
+      cell: ({ row }) => (
+        <span className="text-xs text-gray-500">
+          {row.original.created_at ? new Date(row.original.created_at).toLocaleDateString() : "—"}
+        </span>
+      ),
+    },
+    ...(isAdmin ? [{
+      header: "",
+      id: "actions",
+      cell: ({ row }: { row: { original: MCPToolset } }) => (
+        <div className="flex items-center gap-1 justify-end">
+          <button
+            type="button"
+            className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-700 transition-colors"
+            onClick={() => onEdit(row.original)}
+          >
+            <PencilIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className="p-1.5 rounded-lg hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors"
+            onClick={() => onDelete(row.original.toolset_id)}
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ),
+    } as ColumnDef<MCPToolset>] : []),
+  ];
+}
+
+function ToolsetUsageGuide() {
+  const [copied, setCopied] = useState(false);
+  const proxyBaseUrl = getProxyBaseUrl();
+
+  const snippet = `{
+  "mcpServers": {
+    "my-toolset": {
+      "url": "${proxyBaseUrl}/toolset/<toolset-name>/mcp",
+      "headers": { "x-litellm-api-key": "Bearer <your-api-key>" }
+    }
+  }
+}`;
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="mb-6 rounded-lg border border-gray-200 bg-gray-50 px-5 py-4">
+      <p className="text-sm font-medium text-gray-700 mb-1">How toolsets work</p>
+      <p className="text-sm text-gray-500 mb-3">
+        Create a toolset, assign it to a key via <span className="font-medium text-gray-700">API Keys → Edit Key → MCP Servers</span>, then point your MCP client at the toolset URL. The client only sees the tools you picked.
+      </p>
+      <div className="text-xs text-gray-400 mb-1">Claude Code / Cursor config</div>
+      <div className="relative">
+        <pre className="bg-white border border-gray-200 rounded px-4 py-3 text-xs font-mono text-gray-700 overflow-x-auto leading-relaxed pr-14">
+          {snippet}
+        </pre>
+        <button
+          type="button"
+          onClick={copy}
+          className="absolute top-2 right-2 px-2 py-1 text-xs rounded border bg-white hover:bg-gray-50 text-gray-400 hover:text-gray-600 border-gray-200 transition-colors"
+        >
+          {copied ? "✓" : "copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function MCPToolsetsTab({ accessToken, userRole }: MCPToolsetsTabProps) {
+  const queryClient = useQueryClient();
+  const { data: toolsets = [], isLoading } = useMCPToolsets();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editToolset, setEditToolset] = useState<MCPToolset | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const isAdmin = userRole === "Admin" || userRole === "proxy_admin";
+
+  const handleCreate = async (name: string, description: string | undefined, tools: MCPToolsetTool[]) => {
+    if (!accessToken) return;
+    await createMCPToolset(accessToken, { toolset_name: name, description, tools });
+    message.success("Toolset created");
+    queryClient.invalidateQueries({ queryKey: ["mcpToolsets"] });
+  };
+
+  const handleUpdate = async (name: string, description: string | undefined, tools: MCPToolsetTool[]) => {
+    if (!accessToken || !editToolset) return;
+    await updateMCPToolset(accessToken, { toolset_id: editToolset.toolset_id, toolset_name: name, description, tools });
+    message.success("Toolset updated");
+    queryClient.invalidateQueries({ queryKey: ["mcpToolsets"] });
+    setEditToolset(null);
+  };
+
+  const handleDelete = async () => {
+    if (!accessToken || !deleteId) return;
+    setDeleting(true);
+    try {
+      await deleteMCPToolset(accessToken, deleteId);
+      message.success("Toolset deleted");
+      queryClient.invalidateQueries({ queryKey: ["mcpToolsets"] });
+      setDeleteId(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const proxyBaseUrl = getProxyBaseUrl();
+  const columns = toolsetColumns(isAdmin, setEditToolset, setDeleteId, proxyBaseUrl);
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <Title>MCP Toolsets</Title>
+          <Text className="text-gray-500 text-sm">
+            Curated collections of tools from one or more MCP servers. Assign toolsets to keys and teams via the MCP permissions dropdown.
+          </Text>
+        </div>
+        {isAdmin && (
+          <Button icon={PlusIcon} onClick={() => setCreateOpen(true)}>
+            New Toolset
+          </Button>
+        )}
+      </div>
+
+      <ToolsetUsageGuide />
+
+      <DataTable
+        data={toolsets}
+        columns={columns}
+        renderSubComponent={() => <div />}
+        getRowCanExpand={() => false}
+        isLoading={isLoading}
+        noDataMessage="No toolsets yet. Click 'New Toolset' to create one."
+        loadingMessage="Loading toolsets..."
+        enableSorting={true}
+      />
+
+      <CreateToolsetModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSave={handleCreate}
+        accessToken={accessToken}
+      />
+
+      {editToolset && (
+        <CreateToolsetModal
+          open={!!editToolset}
+          onClose={() => setEditToolset(null)}
+          onSave={handleUpdate}
+          accessToken={accessToken}
+          initialToolset={editToolset}
+        />
+      )}
+
+      <Modal
+        open={!!deleteId}
+        onCancel={() => setDeleteId(null)}
+        onOk={handleDelete}
+        okText="Delete"
+        okButtonProps={{ danger: true, loading: deleting }}
+        title="Delete Toolset"
+      >
+        <p>Are you sure you want to delete this toolset? Keys and teams using it will lose access to the scoped tools.</p>
+      </Modal>
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -9,6 +9,7 @@ import { useMCPServerHealth } from "../../app/(dashboard)/hooks/mcpServers/useMC
 import NotificationsManager from "../molecules/notifications_manager";
 import { deleteMCPServer } from "../networking";
 import { MCPSubmissionsTab } from "./MCPSubmissionsTab";
+import { MCPToolsetsTab } from "./MCPToolsetsTab";
 import { DataTable } from "../view_logs/table";
 import CreateMCPServer from "./create_mcp_server";
 import MCPConnect from "./mcp_connect";
@@ -348,6 +349,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
         <TabList className="flex justify-between mt-2 w-full items-center">
           <div className="flex">
             <Tab>All Servers</Tab>
+            <Tab>Toolsets</Tab>
             <Tab>Connect</Tab>
             <Tab>Semantic Filter</Tab>
             <Tab>Network Settings</Tab>
@@ -425,6 +427,9 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
                 </div>
               </div>
             )}
+          </TabPanel>
+          <TabPanel>
+            <MCPToolsetsTab accessToken={accessToken} userRole={userRole} />
           </TabPanel>
           <TabPanel>
             <MCPConnect />

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -231,6 +231,20 @@ export interface MCPServerProps {
   userID: string | null;
 }
 
+export interface MCPToolsetTool {
+  server_id: string;
+  tool_name: string;
+}
+
+export interface MCPToolset {
+  toolset_id: string;
+  toolset_name: string;
+  description?: string;
+  tools: MCPToolsetTool[];
+  created_at?: string;
+  created_by?: string;
+}
+
 // Discoverable MCP server from the curated registry
 export interface DiscoverableMCPServer {
   name: string;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6657,6 +6657,99 @@ export const deleteMCPServer = async (accessToken: string, serverId: string) => 
   }
 };
 
+export const fetchMCPToolsets = async (accessToken: string): Promise<any[]> => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/toolset`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.GET,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to fetch MCP toolsets:", error);
+    throw error;
+  }
+};
+
+export const createMCPToolset = async (accessToken: string, formValues: Record<string, any>) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/toolset`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.POST,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(formValues),
+    });
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to create MCP toolset:", error);
+    throw error;
+  }
+};
+
+export const updateMCPToolset = async (accessToken: string, formValues: Record<string, any>) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/toolset`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.PUT,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(formValues),
+    });
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to update MCP toolset:", error);
+    throw error;
+  }
+};
+
+export const deleteMCPToolset = async (accessToken: string, toolsetId: string) => {
+  try {
+    const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/toolset/${toolsetId}`;
+    const response = await fetch(url, {
+      method: HTTP_REQUEST.DELETE,
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+  } catch (error) {
+    console.error("Failed to delete MCP toolset:", error);
+    throw error;
+  }
+};
+
 export const registerMCPServer = async (accessToken: string, formValues: Record<string, any>) => {
   try {
     const url = (proxyBaseUrl ? `${proxyBaseUrl}` : "") + `/v1/mcp/server/register`;

--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -9,6 +9,7 @@ interface ObjectPermission {
   mcp_servers: string[];
   mcp_access_groups?: string[];
   mcp_tool_permissions?: Record<string, string[]>;
+  mcp_toolsets?: string[];
   vector_stores: string[];
   agents?: string[];
   agent_access_groups?: string[];
@@ -31,17 +32,19 @@ export function ObjectPermissionsView({
   const mcpServers = objectPermission?.mcp_servers || [];
   const mcpAccessGroups = objectPermission?.mcp_access_groups || [];
   const mcpToolPermissions = objectPermission?.mcp_tool_permissions || {};
+  const mcpToolsets = objectPermission?.mcp_toolsets || [];
   const agents = objectPermission?.agents || [];
   const agentAccessGroups = objectPermission?.agent_access_groups || [];
 
   const content = (
     <div className={variant === "card" ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" : "space-y-4"}>
       <VectorStorePermissions vectorStores={vectorStores} accessToken={accessToken} />
-      <MCPServerPermissions 
-        mcpServers={mcpServers} 
-        mcpAccessGroups={mcpAccessGroups} 
+      <MCPServerPermissions
+        mcpServers={mcpServers}
+        mcpAccessGroups={mcpAccessGroups}
         mcpToolPermissions={mcpToolPermissions}
-        accessToken={accessToken} 
+        mcpToolsets={mcpToolsets}
+        accessToken={accessToken}
       />
       <AgentPermissions
         agents={agents}

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -2,25 +2,28 @@ import React, { useState, useEffect } from "react";
 import { Text, Badge } from "@tremor/react";
 import { ServerIcon, ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/outline";
 import { Tooltip } from "antd";
-import { fetchMCPServers } from "../networking";
-import { MCPServer } from "../mcp_tools/types";
+import { fetchMCPServers, fetchMCPToolsets } from "../networking";
+import { MCPServer, MCPToolset } from "../mcp_tools/types";
 
 interface MCPServerPermissionsProps {
   mcpServers: string[];
   mcpAccessGroups?: string[];
   mcpToolPermissions?: Record<string, string[]>;
+  mcpToolsets?: string[];
   accessToken?: string | null;
 }
 
-export function MCPServerPermissions({ 
-  mcpServers, 
-  mcpAccessGroups = [], 
+export function MCPServerPermissions({
+  mcpServers,
+  mcpAccessGroups = [],
   mcpToolPermissions = {},
-  accessToken 
+  mcpToolsets = [],
+  accessToken
 }: MCPServerPermissionsProps) {
   const [mcpServerDetails, setMCPServerDetails] = useState<MCPServer[]>([]);
-  const [accessGroupNames, setAccessGroupNames] = useState<string[]>([]);
+  const [toolsetDetails, setToolsetDetails] = useState<MCPToolset[]>([]);
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
+  const [expandedToolsets, setExpandedToolsets] = useState<Set<string>>(new Set());
 
   const toggleServerExpansion = (serverId: string) => {
     setExpandedServers((prev) => {
@@ -29,6 +32,18 @@ export function MCPServerPermissions({
         newSet.delete(serverId);
       } else {
         newSet.add(serverId);
+      }
+      return newSet;
+    });
+  };
+
+  const toggleToolsetExpansion = (toolsetId: string) => {
+    setExpandedToolsets((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(toolsetId)) {
+        newSet.delete(toolsetId);
+      } else {
+        newSet.add(toolsetId);
       }
       return newSet;
     });
@@ -53,20 +68,23 @@ export function MCPServerPermissions({
     fetchMCPServerDetails();
   }, [accessToken, mcpServers.length]);
 
-  // Fetch MCP access group names
+  // Fetch toolset details
   useEffect(() => {
-    const fetchGroups = async () => {
-      if (accessToken && mcpAccessGroups.length > 0) {
+    const fetchToolsets = async () => {
+      if (accessToken && mcpToolsets.length > 0) {
         try {
-          const groups = await import("../networking").then((m) => m.fetchMCPAccessGroups(accessToken));
-          setAccessGroupNames(Array.isArray(groups) ? groups : groups.data || []);
+          const all = await fetchMCPToolsets(accessToken);
+          const filtered = Array.isArray(all)
+            ? all.filter((t: MCPToolset) => mcpToolsets.includes(t.toolset_id))
+            : [];
+          setToolsetDetails(filtered);
         } catch (error) {
-          console.error("Error fetching MCP access groups:", error);
+          console.error("Error fetching toolsets:", error);
         }
       }
     };
-    fetchGroups();
-  }, [accessToken, mcpAccessGroups.length]);
+    fetchToolsets();
+  }, [accessToken, mcpToolsets.length]);
 
   // Function to get display name for MCP server
   const getMCPServerDisplayName = (serverId: string) => {
@@ -78,17 +96,12 @@ export function MCPServerPermissions({
     return serverId;
   };
 
-  // Function to get display name for access group
-  const getAccessGroupDisplayName = (group: string) => {
-    return group;
-  };
-
   // Merge servers and access groups into one list
   const mergedItems = [
     ...mcpServers.map((server) => ({ type: "server", value: server })),
     ...mcpAccessGroups.map((group) => ({ type: "accessGroup", value: group })),
   ];
-  const totalCount = mergedItems.length;
+  const totalCount = mergedItems.length + mcpToolsets.length;
 
   return (
     <div className="space-y-3">
@@ -99,21 +112,21 @@ export function MCPServerPermissions({
           {totalCount}
         </Badge>
       </div>
-      
+
       {totalCount > 0 ? (
         <div className="max-h-[400px] overflow-y-auto space-y-2 pr-1">
           {mergedItems.map((item, index) => {
             const toolsForServer = item.type === "server" ? mcpToolPermissions[item.value] : undefined;
             const hasToolRestrictions = toolsForServer && toolsForServer.length > 0;
             const isExpanded = expandedServers.has(item.value);
-            
+
             return (
               <div key={index} className="space-y-2">
-                <div 
+                <div
                   onClick={() => hasToolRestrictions && toggleServerExpansion(item.value)}
                   className={`flex items-center gap-3 py-2 px-3 rounded-lg border border-gray-200 transition-all ${
-                    hasToolRestrictions 
-                      ? 'cursor-pointer hover:bg-gray-50 hover:border-gray-300' 
+                    hasToolRestrictions
+                      ? 'cursor-pointer hover:bg-gray-50 hover:border-gray-300'
                       : 'bg-white'
                   }`}
                 >
@@ -128,14 +141,14 @@ export function MCPServerPermissions({
                     ) : (
                       <div className="inline-flex items-center gap-2 min-w-0">
                         <span className="inline-block w-1.5 h-1.5 bg-green-500 rounded-full flex-shrink-0"></span>
-                        <span className="text-sm font-medium text-gray-900 truncate">{getAccessGroupDisplayName(item.value)}</span>
+                        <span className="text-sm font-medium text-gray-900 truncate">{item.value}</span>
                         <span className="ml-1 px-1.5 py-0.5 text-[9px] font-semibold text-green-600 bg-green-50 border border-green-200 rounded uppercase tracking-wide flex-shrink-0">
                           Group
                         </span>
                       </div>
                     )}
                   </div>
-                  
+
                   {hasToolRestrictions && (
                     <div className="flex items-center gap-1 flex-shrink-0 whitespace-nowrap">
                       <span className="text-xs font-medium text-gray-600">{toolsForServer.length}</span>
@@ -148,7 +161,7 @@ export function MCPServerPermissions({
                     </div>
                   )}
                 </div>
-                
+
                 {/* Show tool permissions if expanded */}
                 {hasToolRestrictions && isExpanded && (
                   <div className="ml-4 pl-4 border-l-2 border-blue-200 pb-1">
@@ -167,11 +180,66 @@ export function MCPServerPermissions({
               </div>
             );
           })}
+
+          {/* Toolsets section */}
+          {mcpToolsets.length > 0 && mcpToolsets.map((toolsetId, index) => {
+            const detail = toolsetDetails.find((t) => t.toolset_id === toolsetId);
+            const isExpanded = expandedToolsets.has(toolsetId);
+            const toolCount = detail?.tools.length ?? 0;
+
+            return (
+              <div key={`toolset-${index}`} className="space-y-2">
+                <div
+                  onClick={() => toolCount > 0 && toggleToolsetExpansion(toolsetId)}
+                  className={`flex items-center gap-3 py-2 px-3 rounded-lg border border-purple-200 transition-all ${
+                    toolCount > 0 ? 'cursor-pointer hover:bg-purple-50 hover:border-purple-300' : 'bg-white'
+                  }`}
+                >
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <span className="inline-block w-1.5 h-1.5 bg-purple-500 rounded-full flex-shrink-0"></span>
+                    <span className="text-sm font-medium text-gray-900 truncate">
+                      {detail?.toolset_name ?? toolsetId}
+                    </span>
+                    <span className="ml-1 px-1.5 py-0.5 text-[9px] font-semibold text-purple-600 bg-purple-50 border border-purple-200 rounded uppercase tracking-wide flex-shrink-0">
+                      Toolset
+                    </span>
+                  </div>
+                  {toolCount > 0 && (
+                    <div className="flex items-center gap-1 flex-shrink-0 whitespace-nowrap">
+                      <span className="text-xs font-medium text-gray-600">{toolCount}</span>
+                      <span className="text-xs text-gray-500">{toolCount === 1 ? "tool" : "tools"}</span>
+                      {isExpanded ? (
+                        <ChevronDownIcon className="h-3.5 w-3.5 text-gray-400 ml-0.5" />
+                      ) : (
+                        <ChevronRightIcon className="h-3.5 w-3.5 text-gray-400 ml-0.5" />
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {toolCount > 0 && isExpanded && detail && (
+                  <div className="ml-4 pl-4 border-l-2 border-purple-200 pb-1">
+                    <div className="flex flex-wrap gap-1.5">
+                      {detail.tools.map((tool, toolIndex) => (
+                        <span
+                          key={toolIndex}
+                          className="inline-flex items-center px-2.5 py-1 rounded-lg bg-purple-50 border border-purple-200 text-purple-800 text-xs font-medium"
+                        >
+                          <span className="text-purple-400 mr-1 text-[10px]">{tool.server_id.slice(0, 6)}…</span>
+                          {tool.tool_name}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       ) : (
         <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
           <ServerIcon className="h-4 w-4 text-gray-400" />
-          <Text className="text-gray-500 text-sm">No MCP servers or access groups configured</Text>
+          <Text className="text-gray-500 text-sm">No MCP servers, access groups, or toolsets configured</Text>
         </div>
       )}
     </div>

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ChatUI.tsx
@@ -34,7 +34,8 @@ import MCPToolArgumentsForm, { MCPToolArgumentsFormRef } from "../../mcp_tools/M
 import { MCPServer } from "../../mcp_tools/types";
 import { ByokCredentialModal } from "../../mcp_tools/ByokCredentialModal";
 import NotificationsManager from "../../molecules/notifications_manager";
-import { callMCPTool, fetchMCPServers, listMCPTools } from "../../networking";
+import { callMCPTool, fetchMCPServers, fetchMCPToolsets, listMCPTools } from "../../networking";
+import { MCPToolset } from "../../mcp_tools/types";
 import TagSelector from "../../tag_management/TagSelector";
 import VectorStoreSelector from "../../vector_store_management/VectorStoreSelector";
 import { makeA2ASendMessageRequest } from "../llm_calls/a2a_send_message";
@@ -111,6 +112,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
   fixedModel,
 }) => {
   const [mcpServers, setMCPServers] = useState<MCPServer[]>([]);
+  const [mcpToolsets, setMCPToolsets] = useState<MCPToolset[]>([]);
+  const [isToolsetsInfoModalVisible, setIsToolsetsInfoModalVisible] = useState(false);
   const [byokModalServer, setByokModalServer] = useState<MCPServer | null>(null);
   const [selectedMCPServers, setSelectedMCPServers] = useState<string[]>(() => {
     const saved = sessionStorage.getItem("selectedMCPServers");
@@ -255,15 +258,19 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 
-  // Fetch MCP servers
+  // Fetch MCP servers and toolsets
   const loadMCPServers = async () => {
     const userApiKey = apiKeySource === "session" ? accessToken : apiKey;
     if (!userApiKey) return;
 
     setIsLoadingMCPServers(true);
     try {
-      const servers = await fetchMCPServers(userApiKey);
+      const [servers, toolsets] = await Promise.all([
+        fetchMCPServers(userApiKey),
+        fetchMCPToolsets(userApiKey).catch(() => []),
+      ]);
       setMCPServers(Array.isArray(servers) ? servers : servers.data || []);
+      setMCPToolsets(Array.isArray(toolsets) ? toolsets : []);
     } catch (error) {
       console.error("Error fetching MCP servers:", error);
     } finally {
@@ -412,17 +419,29 @@ const ChatUI: React.FC<ChatUIProps> = ({
     loadMCPServers();
   }, [accessToken, userID, userRole, apiKeySource, apiKey, token, simplified]);
 
-  // Load tools when MCP direct mode has a server selected
+  // Load tools when MCP direct mode has a server (or toolset) selected
   useEffect(() => {
     if (
       endpointType === EndpointType.MCP &&
       selectedMCPServers.length === 1 &&
-      selectedMCPServers[0] !== "__all__" &&
-      !serverToolsMap[selectedMCPServers[0]]
+      selectedMCPServers[0] !== "__all__"
     ) {
-      loadServerTools(selectedMCPServers[0]);
+      const selected = selectedMCPServers[0];
+      if (selected.startsWith("toolset:")) {
+        // For a toolset, load tools for each server in it
+        const toolsetId = selected.slice("toolset:".length);
+        const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
+        if (toolset) {
+          const uniqueServerIds = [...new Set(toolset.tools.map((t) => t.server_id))];
+          uniqueServerIds.forEach((sid) => {
+            if (!serverToolsMap[sid]) loadServerTools(sid);
+          });
+        }
+      } else if (!serverToolsMap[selected]) {
+        loadServerTools(selected);
+      }
     }
-  }, [endpointType, selectedMCPServers, serverToolsMap]);
+  }, [endpointType, selectedMCPServers, serverToolsMap, mcpToolsets]);
 
   // Fetch agents when A2A endpoint is selected
   useEffect(() => {
@@ -568,19 +587,34 @@ const ChatUI: React.FC<ChatUIProps> = ({
     // For MCP direct mode, require server and tool selection, and get form values early
     let mcpToolArguments: Record<string, any> = {};
     if (endpointType === EndpointType.MCP) {
-      const mcpServerId =
+      const rawSelected =
         selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__"
           ? selectedMCPServers[0]
           : null;
-      if (!mcpServerId) {
+      if (!rawSelected) {
         NotificationsManager.fromBackend("Please select an MCP server to test");
         return;
       }
+      // Resolve the real server ID (toolsets use toolset: prefix)
+      const mcpServerId = rawSelected.startsWith("toolset:") ? rawSelected : rawSelected;
       if (!selectedMCPDirectTool) {
         NotificationsManager.fromBackend("Please select an MCP tool to call");
         return;
       }
-      const mcpTool = (serverToolsMap[selectedMCPServers[0]] || []).find(
+      // For toolsets, find the tool in the servers that back this toolset
+      const toolsetForSelected = rawSelected.startsWith("toolset:")
+        ? mcpToolsets.find((t) => t.toolset_id === rawSelected.slice("toolset:".length))
+        : null;
+      let searchPool: any[] = [];
+      if (toolsetForSelected) {
+        const uniqueServerIds = [...new Set(toolsetForSelected.tools.map((t) => t.server_id))];
+        uniqueServerIds.forEach((sid) => {
+          searchPool = searchPool.concat(serverToolsMap[sid] || []);
+        });
+      } else {
+        searchPool = serverToolsMap[rawSelected] || [];
+      }
+      const mcpTool = searchPool.find(
         (t: any) => t.name === selectedMCPDirectTool,
       );
       if (!mcpTool) {
@@ -738,6 +772,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
             mcpServerToolRestrictions,
             handleMCPEvent,
             mockTestFallbacks,
+            mcpToolsets,
           );
         } else if (endpointType === EndpointType.IMAGE) {
           // For image generation
@@ -818,6 +853,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
             customProxyBaseUrl || undefined,
             mcpServers,
             mcpServerToolRestrictions,
+            mcpToolsets,
           );
         } else if (endpointType === EndpointType.ANTHROPIC_MESSAGES) {
           const apiChatHistory = [
@@ -875,14 +911,22 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
       // Handle MCP direct tool calls (no chat completions)
       if (endpointType === EndpointType.MCP) {
-        const mcpServerId =
+        const rawSelected =
           selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__"
             ? selectedMCPServers[0]
             : null;
-        if (mcpServerId && selectedMCPDirectTool) {
+        // For toolsets, resolve the real server_id from the toolset's tool list
+        let resolvedServerId = rawSelected;
+        if (rawSelected?.startsWith("toolset:")) {
+          const toolsetId = rawSelected.slice("toolset:".length);
+          const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
+          const toolEntry = toolset?.tools.find((t) => t.tool_name === selectedMCPDirectTool);
+          resolvedServerId = toolEntry?.server_id ?? rawSelected;
+        }
+        if (resolvedServerId && !resolvedServerId.startsWith("toolset:") && selectedMCPDirectTool) {
           const result = await callMCPTool(
             effectiveApiKey,
-            mcpServerId,
+            resolvedServerId,
             selectedMCPDirectTool,
             mcpToolArguments,
             selectedGuardrails.length > 0 ? { guardrails: selectedGuardrails } : undefined,
@@ -1297,11 +1341,14 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     className="ml-1"
                     title={
                       endpointType === EndpointType.MCP
-                        ? "Select an MCP server to test tools directly."
-                        : "Select MCP servers to use in your conversation."
+                        ? "Select an MCP server or toolset to test tools directly."
+                        : "Select MCP servers or toolsets to use in your conversation."
                     }
                   >
-                    <InfoCircleOutlined />
+                    <InfoCircleOutlined
+                      className="cursor-pointer"
+                      onClick={() => setIsToolsetsInfoModalVisible(true)}
+                    />
                   </Tooltip>
                 </Text>
                 <Select
@@ -1357,7 +1404,18 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     if (option?.value === "__all__") {
                       return "All MCP Servers".toLowerCase().includes(input.toLowerCase());
                     }
-                    const server = mcpServers.find((s) => s.server_id === option?.value);
+                    const val = option?.value as string | undefined;
+                    if (val?.startsWith("toolset:")) {
+                      const toolsetId = val.slice("toolset:".length);
+                      const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
+                      if (!toolset) return false;
+                      return [toolset.toolset_name, toolset.description]
+                        .filter(Boolean)
+                        .join(" ")
+                        .toLowerCase()
+                        .includes(input.toLowerCase());
+                    }
+                    const server = mcpServers.find((s) => s.server_id === val);
                     if (!server) return false;
                     const searchText = [
                       server.server_name,
@@ -1381,44 +1439,99 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </Select.Option>
                   )}
 
+                  {/* Toolsets (purple badge) */}
+                  {mcpToolsets.length > 0 && (
+                    <Select.OptGroup label="Toolsets">
+                      {mcpToolsets.map((toolset) => (
+                        <Select.Option
+                          key={`toolset:${toolset.toolset_id}`}
+                          value={`toolset:${toolset.toolset_id}`}
+                          label={toolset.toolset_name}
+                          disabled={
+                            endpointType === EndpointType.MCP ? false : selectedMCPServers.includes("__all__")
+                          }
+                        >
+                          <div className="flex flex-col py-1">
+                            <div className="flex items-center gap-1">
+                              <span className="font-medium">{toolset.toolset_name}</span>
+                              <span
+                                className="text-xs px-1 rounded"
+                                style={{ background: "#ede9fe", color: "#7c3aed" }}
+                              >
+                                Toolset
+                              </span>
+                              <span className="text-xs text-gray-500">
+                                ({toolset.tools.length} tools)
+                              </span>
+                            </div>
+                            {toolset.description && (
+                              <span className="text-xs text-gray-500 mt-1">{toolset.description}</span>
+                            )}
+                          </div>
+                        </Select.Option>
+                      ))}
+                    </Select.OptGroup>
+                  )}
+
                   {/* Individual servers */}
-                  {mcpServers.map((server) => (
-                    <Select.Option
-                      key={server.server_id}
-                      value={server.server_id}
-                      label={server.alias || server.server_name || server.server_id}
-                      disabled={
-                        endpointType === EndpointType.MCP ? false : selectedMCPServers.includes("__all__")
-                      }
-                    >
-                      <div className="flex flex-col py-1">
-                        <span className="font-medium">{server.alias || server.server_name || server.server_id}</span>
-                        {server.description && <span className="text-xs text-gray-500 mt-1">{server.description}</span>}
-                      </div>
-                    </Select.Option>
-                  ))}
+                  {mcpServers.length > 0 && (
+                    <Select.OptGroup label="Servers">
+                      {mcpServers.map((server) => (
+                        <Select.Option
+                          key={server.server_id}
+                          value={server.server_id}
+                          label={server.alias || server.server_name || server.server_id}
+                          disabled={
+                            endpointType === EndpointType.MCP ? false : selectedMCPServers.includes("__all__")
+                          }
+                        >
+                          <div className="flex flex-col py-1">
+                            <span className="font-medium">{server.alias || server.server_name || server.server_id}</span>
+                            {server.description && <span className="text-xs text-gray-500 mt-1">{server.description}</span>}
+                          </div>
+                        </Select.Option>
+                      ))}
+                    </Select.OptGroup>
+                  )}
                 </Select>
 
                 {/* MCP Tool selector - only for MCP direct mode */}
                 {endpointType === EndpointType.MCP &&
                   selectedMCPServers.length === 1 &&
-                  selectedMCPServers[0] !== "__all__" && (
-                    <div className="mt-3">
-                      <Text className="text-xs text-gray-600 mb-1 block">Select Tool</Text>
-                      <Select
-                        style={{ width: "100%" }}
-                        placeholder="Select a tool to call"
-                        value={selectedMCPDirectTool}
-                        onChange={(value) => setSelectedMCPDirectTool(value)}
-                        options={(serverToolsMap[selectedMCPServers[0]] || []).map((tool: any) => ({
-                          value: tool.name,
-                          label: tool.name,
-                        }))}
-                        allowClear
-                        className="rounded-md"
-                      />
-                    </div>
-                  )}
+                  selectedMCPServers[0] !== "__all__" && (() => {
+                    const rawSel = selectedMCPServers[0];
+                    const isToolset = rawSel.startsWith("toolset:");
+                    let toolOptions: { value: string; label: string }[] = [];
+                    if (isToolset) {
+                      const toolsetId = rawSel.slice("toolset:".length);
+                      const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
+                      if (toolset) {
+                        toolOptions = toolset.tools.map((t) => ({
+                          value: t.tool_name,
+                          label: t.tool_name,
+                        }));
+                      }
+                    } else {
+                      toolOptions = (serverToolsMap[rawSel] || []).map((tool: any) => ({
+                        value: tool.name,
+                        label: tool.name,
+                      }));
+                    }
+                    return (
+                      <div className="mt-3">
+                        <Text className="text-xs text-gray-600 mb-1 block">Select Tool</Text>
+                        <Select
+                          style={{ width: "100%" }}
+                          placeholder="Select a tool to call"
+                          value={selectedMCPDirectTool}
+                          onChange={(value) => setSelectedMCPDirectTool(value)}
+                          options={toolOptions}
+                          allowClear
+                          className="rounded-md"
+                        />
+                      </div>
+                    );
+                  })()}
 
                 {/* Tool restrictions UI (optional) - hidden for MCP direct mode */}
                 {selectedMCPServers.length > 0 &&
@@ -1920,7 +2033,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   selectedMCPDirectTool ? (
                     <div className="flex-1 overflow-y-auto max-h-48 min-h-[44px] p-2 border border-gray-200 rounded-lg bg-gray-50/50">
                       {(() => {
-                        const mcpTool = (serverToolsMap[selectedMCPServers[0]] || []).find(
+                        const rawSel = selectedMCPServers[0];
+                        let toolPool: any[] = [];
+                        if (rawSel.startsWith("toolset:")) {
+                          const toolsetId = rawSel.slice("toolset:".length);
+                          const toolset = mcpToolsets.find((t) => t.toolset_id === toolsetId);
+                          if (toolset) {
+                            const uniqueServerIds = [...new Set(toolset.tools.map((t) => t.server_id))];
+                            uniqueServerIds.forEach((sid) => {
+                              toolPool = toolPool.concat(serverToolsMap[sid] || []);
+                            });
+                          }
+                        } else {
+                          toolPool = serverToolsMap[rawSel] || [];
+                        }
+                        const mcpTool = toolPool.find(
                           (t: any) => t.name === selectedMCPDirectTool,
                         );
                         return mcpTool ? (
@@ -2066,6 +2193,47 @@ const ChatUI: React.FC<ChatUIProps> = ({
           accessToken={accessToken || ""}
         />
       )}
+
+      {/* Toolsets info modal */}
+      <Modal
+        title="How Toolsets Work"
+        open={isToolsetsInfoModalVisible}
+        onCancel={() => setIsToolsetsInfoModalVisible(false)}
+        footer={[
+          <Button key="close" onClick={() => setIsToolsetsInfoModalVisible(false)}>
+            Close
+          </Button>,
+        ]}
+        width={600}
+      >
+        <div className="space-y-4 py-2">
+          <p className="text-gray-700">
+            <strong>Toolsets</strong> are named collections of specific tools from one or more MCP servers.
+            Instead of exposing all tools from a server, a toolset gives an agent exactly the tools it needs.
+          </p>
+          <div>
+            <h4 className="font-semibold text-gray-800 mb-2">How to use a toolset:</h4>
+            <ol className="list-decimal list-inside space-y-2 text-gray-700">
+              <li>Select a <span style={{ color: "#7c3aed", fontWeight: 600 }}>Toolset</span> (purple badge) from the MCP Servers dropdown.</li>
+              <li>The tool picker will show only the tools included in that toolset.</li>
+              <li>Select a tool and fill in its parameters, then send.</li>
+              <li>The tool call is routed to the correct underlying MCP server automatically.</li>
+            </ol>
+          </div>
+          <div className="bg-purple-50 border border-purple-200 rounded p-3">
+            <p className="text-sm text-purple-800">
+              <strong>Example:</strong> A &quot;GitHub Read-only&quot; toolset might include only <code>list_repos</code> and <code>get_file</code> from a GitHub MCP server — preventing agents from making writes.
+            </p>
+          </div>
+          <div>
+            <h4 className="font-semibold text-gray-800 mb-1">Creating toolsets:</h4>
+            <p className="text-sm text-gray-600">
+              Admins can create and manage toolsets from the <strong>MCP</strong> page → <strong>Toolsets</strong> tab.
+              Toolsets can then be assigned to keys and teams to scope their tool access.
+            </p>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/playground/llm_calls/chat_completion.tsx
@@ -3,7 +3,7 @@ import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { TokenUsage } from "../chat_ui/ResponseMetrics";
 import { VectorStoreSearchResponse } from "../chat_ui/types";
 import { getProxyBaseUrl } from "@/components/networking";
-import { MCPServer, type MCPEvent } from "../../mcp_tools/types";
+import { MCPServer, MCPToolset, type MCPEvent } from "../../mcp_tools/types";
 
 export async function makeOpenAIChatCompletionRequest(
   chatHistory: { role: string; content: string | any[] }[],
@@ -30,6 +30,7 @@ export async function makeOpenAIChatCompletionRequest(
   mcpServerToolRestrictions?: Record<string, string[]>,
   onMCPEvent?: (event: MCPEvent) => void,
   mockTestFallbacks?: boolean,
+  mcpToolsets?: MCPToolset[],
 ) {
   // base url should be the current base_url
   const isLocal = process.env.NODE_ENV === "development";
@@ -82,19 +83,31 @@ export async function makeOpenAIChatCompletionRequest(
           require_approval: "never",
         });
       } else {
-        // Individual servers selected - create one entry per server
+        // Individual servers/toolsets selected - create one entry per item
         selectedMCPServers.forEach((serverId) => {
-          const server = mcpServers?.find((s) => s.server_id === serverId);
-          const serverName = server?.alias || server?.server_name || serverId;
-          const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
+          if (serverId.startsWith("toolset:")) {
+            const toolsetId = serverId.slice("toolset:".length);
+            const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
+            const toolsetName = toolset?.toolset_name || toolsetId;
+            tools.push({
+              type: "mcp",
+              server_label: toolsetName,
+              server_url: `litellm_proxy/mcp/${encodeURIComponent(toolsetName)}`,
+              require_approval: "never",
+            });
+          } else {
+            const server = mcpServers?.find((s) => s.server_id === serverId);
+            const serverName = server?.alias || server?.server_name || serverId;
+            const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
 
-          tools.push({
-            type: "mcp",
-            server_label: "litellm",
-            server_url: `litellm_proxy/mcp/${serverName}`,
-            require_approval: "never",
-            ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
-          });
+            tools.push({
+              type: "mcp",
+              server_label: "litellm",
+              server_url: `litellm_proxy/mcp/${serverName}`,
+              require_approval: "never",
+              ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
+            });
+          }
         });
       }
     }

--- a/ui/litellm-dashboard/src/components/playground/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/playground/llm_calls/responses_api.tsx
@@ -4,7 +4,7 @@ import { TokenUsage } from "../chat_ui/ResponseMetrics";
 import { getProxyBaseUrl } from "@/components/networking";
 import NotificationManager from "@/components/molecules/notifications_manager";
 import type { MCPEvent } from "../../mcp_tools/types";
-import { MCPServer } from "../../mcp_tools/types";
+import { MCPServer, MCPToolset } from "../../mcp_tools/types";
 import {
   CodeInterpreterResult,
   CodeInterpreterState,
@@ -37,6 +37,7 @@ export async function makeOpenAIResponsesRequest(
   customBaseUrl?: string,
   mcpServers?: MCPServer[],
   mcpServerToolRestrictions?: Record<string, string[]>,
+  mcpToolsets?: MCPToolset[],
 ) {
   if (!accessToken) {
     throw new Error("Virtual Key is required");
@@ -102,21 +103,34 @@ export async function makeOpenAIResponsesRequest(
           require_approval: "never",
         });
       } else {
-        // Individual servers selected - create one entry per server
+        // Individual servers/toolsets selected - create one entry per item
         selectedMCPServers.forEach((serverId) => {
-          const server = mcpServers?.find((s) => s.server_id === serverId);
-          // Use server_name for both routing and labelling. server_name is the
-          // unique registered identifier; aliases can collide across servers.
-          const routeName = server?.server_name || serverId;
-          const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
+          if (serverId.startsWith("toolset:")) {
+            // Toolset: same /{name}/mcp pattern as individual servers
+            const toolsetId = serverId.slice("toolset:".length);
+            const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
+            const toolsetName = toolset?.toolset_name || toolsetId;
+            tools.push({
+              type: "mcp",
+              server_label: toolsetName,
+              server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(toolsetName)}`,
+              require_approval: "never",
+            });
+          } else {
+            const server = mcpServers?.find((s) => s.server_id === serverId);
+            // Use server_name for both routing and labelling. server_name is the
+            // unique registered identifier; aliases can collide across servers.
+            const routeName = server?.server_name || serverId;
+            const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
 
-          tools.push({
-            type: "mcp",
-            server_label: routeName, // unique per request — collisions cause silent tool-routing failures
-            server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(routeName)}`,
-            require_approval: "never",
-            ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
-          });
+            tools.push({
+              type: "mcp",
+              server_label: routeName, // unique per request — collisions cause silent tool-routing failures
+              server_url: `${proxyBaseUrl}/mcp/${encodeURIComponent(routeName)}`,
+              require_approval: "never",
+              ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
+            });
+          }
         });
       }
     }

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -102,6 +102,7 @@ export interface TeamData {
       mcp_servers: string[];
       mcp_access_groups?: string[];
       mcp_tool_permissions?: Record<string, string[]>;
+      mcp_toolsets?: string[];
       vector_stores: string[];
       agents?: string[];
       agent_access_groups?: string[];
@@ -511,9 +512,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       }
 
       // Handle object_permission updates
-      const { servers, accessGroups } = values.mcp_servers_and_groups || {
+      const { servers, accessGroups, toolsets } = values.mcp_servers_and_groups || {
         servers: [],
         accessGroups: [],
+        toolsets: [],
       };
       const serverIds = new Set(servers || []);
       const mcpToolPermissions = Object.fromEntries(
@@ -529,6 +531,9 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       }
       if (mcpToolPermissions) {
         updateData.object_permission.mcp_tool_permissions = mcpToolPermissions;
+      }
+      if (toolsets) {
+        updateData.object_permission.mcp_toolsets = toolsets;
       }
       delete values.mcp_servers_and_groups;
       delete values.mcp_tool_permissions;
@@ -826,6 +831,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       mcp_servers_and_groups: {
                         servers: info.object_permission?.mcp_servers || [],
                         accessGroups: info.object_permission?.mcp_access_groups || [],
+                        toolsets: info.object_permission?.mcp_toolsets || [],
                       },
                       mcp_tool_permissions: info.object_permission?.mcp_tool_permissions || {},
                       agents_and_groups: {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -160,11 +160,12 @@ export default function KeyInfoView({
       }
 
       if (formValues.mcp_servers_and_groups !== undefined) {
-        const { servers, accessGroups } = formValues.mcp_servers_and_groups || { servers: [], accessGroups: [] };
+        const { servers, accessGroups, toolsets } = formValues.mcp_servers_and_groups || { servers: [], accessGroups: [], toolsets: [] };
         formValues.object_permission = {
           ...currentKeyData.object_permission,
           mcp_servers: servers || [],
           mcp_access_groups: accessGroups || [],
+          mcp_toolsets: toolsets || [],
         };
         // Remove mcp_servers_and_groups from the top level as it should be in object_permission
         delete formValues.mcp_servers_and_groups;


### PR DESCRIPTION
## Feat - Add MCP Toolsets on LiteLLM 

<img width="4260" height="2508" alt="Group 7322" src="https://github.com/user-attachments/assets/6027affc-0983-4180-83a7-451b1ca0bac3" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

Adds **MCP Toolsets** — a way to bundle a named subset of tools from one or more MCP servers and assign that bundle to keys/teams.

**Problem:** Today you can grant a key access to an entire MCP server (all 50 tools). There's no way to say "this key gets only `get_build_logs` and `run_pipeline` from CircleCI, and `read_wiki_structure` from DeepWiki."

**What this adds:**

Backend:
- New `LiteLLM_MCPToolsetTable` DB table + prisma migration (`toolset_id`, `toolset_name`, `tools: [{server_id, tool_name}]`)
- `mcp_toolsets: String[]` added to `LiteLLM_ObjectPermissionTable`
- CRUD endpoints: `POST/GET/PUT/DELETE /v1/mcp/toolset`
- `_apply_toolset_scope()` — sets `object_permission.mcp_servers` and `mcp_tool_permissions` to exactly the toolset's tools when a toolset route is hit
- Bug fix: `allow_all_keys` servers (e.g. test servers) were bleeding into toolset-scoped requests even when `mcp_servers` was explicitly set. Fixed by skipping `allow_all_server_ids` injection when there's an explicit permission boundary.
- Bug fix: responses API path — toolset names passed as `server_url` (e.g. `litellm_proxy/mcp/devtooling-prod`) were not resolved to actual toolsets, causing all tools to be returned. Now resolved via `get_mcp_toolset_by_name` before tool fetch.

UI:
- `MCPToolsetsTab` — list/create/edit/delete toolsets from the MCP page
- `MCPServerSelector` — toolsets now appear as a third category (purple) alongside servers (blue) and access groups (green)
- Key and team forms extract `mcp_toolsets` from the combined selector and send it in `object_permission`
- `MCPServerPermissions` read view shows assigned toolsets
- Playground (chat completions + responses API) resolves selected toolsets to the correct `litellm_proxy/mcp/{name}` URL

Docs:
- `docs/mcp_toolsets.md` with ASCII diagram, step-by-step UI screenshots, API examples, and management curl examples
- Added to sidebar under MCP Gateway