### PR TITLE
feat(bedrock): add Z.AI GLM-5 model support

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -32693,6 +32693,20 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "zai.glm-5": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "zai.glm-4.7-flash": {
         "input_cost_per_token": 7e-08,
         "litellm_provider": "bedrock_converse",


### PR DESCRIPTION
## Relevant issues

Fixes #24227

## Pre-Submission checklist

- [x] I have Added testing - N/A (model pricing JSON update only, no code logic changes)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Add `zai.glm-5` to `model_prices_and_context_window.json` with `bedrock_converse` provider routing.

- **Input cost:** $1.00 / 1M tokens
- **Output cost:** $3.20 / 1M tokens
- **Max input tokens:** 200,000
- **Max output tokens:** 128,000
- **Supports:** function calling, reasoning, system messages, tool choice
- **Source:** https://aws.amazon.com/bedrock/pricing/

Verified live with boto3 Converse API and `litellm.completion("bedrock/zai.glm-5", ...)` in us-east-1.