### PR TITLE
fix(proxy): guard against malformed SSE chunks in Anthropic passthrough logging

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -290,6 +290,20 @@ class AnthropicPassthroughLoggingHandler:
 
                 except (StopIteration, StopAsyncIteration):
                     break
+                except Exception as e:
+                    # Some models (e.g. anthropic/deepseek-reasoner) may emit SSE
+                    # events with non-standard JSON or extra fields that the
+                    # Anthropic chunk parser cannot handle.  Silently skip
+                    # individual malformed events so that valid events in the same
+                    # stream are still logged rather than dropping the entire
+                    # logging call with an unhandled JSONDecodeError.
+                    verbose_proxy_logger.debug(
+                        "Skipping unparseable Anthropic SSE event during passthrough "
+                        "logging. Error: %s. Event (truncated): %.200s",
+                        str(e),
+                        event_str,
+                    )
+                    continue
 
         complete_streaming_response = litellm.stream_chunk_builder(
             chunks=all_openai_chunks,


### PR DESCRIPTION
## Problem

Closes #24281

When proxying models like `anthropic/deepseek-reasoner` via the LiteLLM proxy, certain SSE stream events contain JSON structures (e.g. thinking-block events) that the Anthropic chunk parser cannot handle. This produces a noisy ERROR-level log on every streaming request:

```
LiteLLM Proxy:ERROR: streaming_handler.py:197 - Error in _route_streaming_logging_to_handler:
Expecting value: line 1 column 3 (char 2)
```

### Root Cause

In `_build_complete_streaming_response`, the per-event loop inside `AnthropicPassthroughLoggingHandler` only caught `StopIteration` / `StopAsyncIteration`. Any other exception (`json.JSONDecodeError`, `KeyError`, …) from `convert_str_chunk_to_generic_chunk` propagated all the way up to the broad `except Exception` in `_route_streaming_logging_to_handler` — which swallowed it silently **but not before logging an ERROR** and **aborting the entire logging call** for that request.

## Solution

Add an `except Exception` guard around the per-event conversion in `_build_complete_streaming_response`:
- Unparseable individual events are **skipped** with a `DEBUG`-level log
- All valid events in the same stream are still processed and logged
- The overall logging call is no longer aborted by a single malformed event

```python
except Exception as e:
    verbose_proxy_logger.debug(
        "Skipping unparseable Anthropic SSE event during passthrough "
        "logging. Error: %s. Event (truncated): %.200s",
        str(e), event_str,
    )
    continue
```

## Testing

- Verified with a mock `deepseek-reasoner` response that includes thinking-block SSE events
- ERROR log no longer appears; valid chunks are still logged correctly