### PR TITLE
fix(guardrails): return HTTP 400 instead of 500 for blocked requests

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -917,10 +917,12 @@ class GuardrailRaisedException(Exception):
         guardrail_name: Optional[str] = None,
         message: str = "",
         should_wrap_with_default_message: bool = True,
+        status_code: int = 400,
     ):
         default_message = f"Guardrail raised an exception, Guardrail: {guardrail_name}, Message: {message}"
         self.guardrail_name = guardrail_name
         self.message = default_message if should_wrap_with_default_message else message
+        self.status_code = status_code
         super().__init__(self.message)
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -553,6 +553,8 @@ class TestGuardrailActions:
             # Verify the exception has the clean error message (no wrapper)
             assert str(exc_info.value) == "Content contains harmful instructions"
             assert exc_info.value.guardrail_name == "generic_guardrail_api"
+            # Guardrail blocks should map to 400, not 500
+            assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_action_intervened_modifies_content(


### PR DESCRIPTION
## Summary

- `GuardrailRaisedException` had no `status_code` attribute. When the generic exception handler in `_handle_llm_api_exception()` processed a guardrail block, it fell through to `getattr(e, "status_code", 500)`, defaulting to HTTP 500.
- Guardrail blocks are client errors (request content violated policy), not server errors. This PR adds `status_code=400` to `GuardrailRaisedException` so the proxy returns the correct HTTP status code.
- Affects all guardrail providers using the Generic Guardrail API (and any other guardrail that raises `GuardrailRaisedException`).

## Changes

- **`litellm/exceptions.py`**: Add `status_code: int = 400` parameter and `self.status_code` attribute to `GuardrailRaisedException`
- **`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py`**: Assert `status_code == 400` in the existing blocked-action test

## Test plan

- [x] Existing test `test_action_blocked_raises_exception` updated to verify `status_code=400`
- [x] `make test-unit` passes