### PR TITLE
[#24356] Preserve text and parallel_tool_calls in ChatGPT responses allowlist

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -96,9 +96,11 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "stream",
             "store",
             "include",
+            "parallel_tool_calls",
             "tools",
             "tool_choice",
             "reasoning",
+            "text",
             "previous_response_id",
             "truncation",
         }

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -767,8 +767,10 @@ async def get_batch_from_database(
         response = LiteLLMBatch(**batch_data)
         response.id = batch_id
 
-        # The stored batch object has the raw provider input_file_id. Resolve to unified ID.
+        # The stored batch object may contain raw provider file IDs. Resolve them to
+        # unified IDs before returning the batch to callers.
         await resolve_input_file_id_to_unified(response, prisma_client)
+        await resolve_output_file_ids_to_unified(response, prisma_client)
 
         verbose_proxy_logger.debug(
             f"Retrieved batch {batch_id} from ManagedObjectTable with status={response.status}"

--- a/tests/test_litellm/enterprise/proxy/test_batch_retrieve_returns_unified_input_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_retrieve_returns_unified_input_file_id.py
@@ -8,10 +8,11 @@ batch is later read from DB, get_batch_from_database returns the raw ID
 without resolving it to the unified ID.
 """
 
+import base64
 import json
-import pytest
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from litellm.proxy.openai_files_endpoints.common_utils import get_batch_from_database
 
@@ -53,7 +54,7 @@ async def test_should_resolve_raw_input_file_id_to_unified_id():
         "input_file_id": raw_input_file_id,
         "object": "batch",
         "status": "completed",
-        "output_file_id": "file-output-raw",
+        "output_file_id": None,
     }
 
     managed_file_record = MagicMock()
@@ -84,6 +85,62 @@ async def test_should_resolve_raw_input_file_id_to_unified_id():
 
 
 @pytest.mark.asyncio
+async def test_should_resolve_raw_output_file_id_to_unified_id():
+    """
+    When output_file_id in the stored batch is a raw provider ID,
+    get_batch_from_database must look up the unified ID from the
+    managed files table.
+    """
+    unified_batch_id = "bGl0ZWxsbV9wcm94eTpiYXRjaF9pZA"
+    unified_output_file_id = "bGl0ZWxsbV9wcm94eTp1bmlmaWVkX291dHB1dA"
+    raw_output_file_id = "file-output-raw"
+    managed_input_file_id = (
+        base64.urlsafe_b64encode(
+            "litellm_proxy:application/octet-stream;unified_id,input-123".encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
+
+    batch_data = {
+        "id": "batch-raw-123",
+        "completion_window": "24h",
+        "created_at": 1700000000,
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": managed_input_file_id,
+        "object": "batch",
+        "status": "completed",
+        "output_file_id": raw_output_file_id,
+    }
+
+    managed_file_record = MagicMock()
+    managed_file_record.unified_file_id = unified_output_file_id
+
+    prisma = _mock_prisma(
+        batch_json=json.dumps(batch_data),
+        managed_file_record=managed_file_record,
+    )
+
+    _, response = await get_batch_from_database(
+        batch_id=unified_batch_id,
+        unified_batch_id="decoded_unified_batch_id",
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma,
+        verbose_proxy_logger=MagicMock(),
+    )
+
+    assert response is not None
+    assert response.output_file_id == unified_output_file_id, (
+        f"output_file_id should be resolved to '{unified_output_file_id}', "
+        f"got raw: '{response.output_file_id}'"
+    )
+
+    prisma.db.litellm_managedfiletable.find_first.assert_called_once_with(
+        where={"flat_model_file_ids": {"has": raw_output_file_id}}
+    )
+
+
+@pytest.mark.asyncio
 async def test_should_preserve_already_managed_input_file_id():
     """
     When input_file_id is already a managed/unified ID, it should
@@ -93,7 +150,9 @@ async def test_should_preserve_already_managed_input_file_id():
 
     unified_batch_id = "bGl0ZWxsbV9wcm94eTpiYXRjaF9pZA"
     decoded_unified = "litellm_proxy:application/octet-stream;unified_id,test-123"
-    base64_input_file_id = base64.urlsafe_b64encode(decoded_unified.encode()).decode().rstrip("=")
+    base64_input_file_id = (
+        base64.urlsafe_b64encode(decoded_unified.encode()).decode().rstrip("=")
+    )
 
     batch_data = {
         "id": "batch-raw-123",

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -103,9 +103,57 @@ class TestChatGPTResponsesAPITransformation:
 
         assert request["stream"] is True
         assert "reasoning.encrypted_content" in request["include"]
-        assert request["instructions"].startswith(
-            "You are Codex, based on GPT-5."
+        assert request["instructions"].startswith("You are Codex, based on GPT-5.")
+
+    @pytest.mark.parametrize(
+        "text_value",
+        [
+            {
+                "format": {
+                    "type": "json_schema",
+                    "name": "answer_schema",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": ["answer"],
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                }
+            },
+            {"format": {"type": "json_object"}},
+            {"format": {"type": "text"}},
+        ],
+        ids=["json_schema", "json_object", "text"],
+    )
+    def test_chatgpt_preserves_text_param(self, text_value):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.2-codex",
+            input="hi",
+            response_api_optional_request_params={"text": text_value},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
         )
+
+        assert request["text"] == text_value
+        assert request["stream"] is True
+        assert "reasoning.encrypted_content" in request["include"]
+        assert request["instructions"].startswith("You are Codex, based on GPT-5.")
+
+    def test_chatgpt_preserves_parallel_tool_calls(self):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.2-codex",
+            input="hi",
+            response_api_optional_request_params={"parallel_tool_calls": False},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["parallel_tool_calls"] is False
+        assert request["stream"] is True
+        assert "reasoning.encrypted_content" in request["include"]
 
     @pytest.mark.parametrize(
         "model_name",
@@ -124,14 +172,18 @@ class TestChatGPTResponsesAPITransformation:
                 "user": "user_123",
                 "temperature": 0.2,
                 "top_p": 0.9,
-                "context_management": [{"type": "compaction", "compact_threshold": 200000}],
+                "context_management": [
+                    {"type": "compaction", "compact_threshold": 200000}
+                ],
                 "metadata": {"foo": "bar"},
                 "max_output_tokens": 123,
                 "stream_options": {"include_usage": True},
                 # supported and should be preserved
                 "truncation": "auto",
                 "previous_response_id": "resp_123",
+                "parallel_tool_calls": False,
                 "reasoning": {"effort": "medium"},
+                "text": {"format": {"type": "json_object"}},
                 "tools": [{"type": "function", "function": {"name": "hello"}}],
                 "tool_choice": {"type": "function", "function": {"name": "hello"}},
             },
@@ -149,9 +201,14 @@ class TestChatGPTResponsesAPITransformation:
 
         assert request["truncation"] == "auto"
         assert request["previous_response_id"] == "resp_123"
+        assert request["parallel_tool_calls"] is False
         assert request["reasoning"] == {"effort": "medium"}
+        assert request["text"] == {"format": {"type": "json_object"}}
         assert request["tools"] == [{"type": "function", "function": {"name": "hello"}}]
-        assert request["tool_choice"] == {"type": "function", "function": {"name": "hello"}}
+        assert request["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "hello"},
+        }
 
     @pytest.mark.parametrize(
         ("model_name", "response_model"),


### PR DESCRIPTION
## Relevant issues

Fixes #24356

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: pending

- [ ] **CI run for the last commit**  
       Link: pending

- [ ] **Merge / cherry-pick CI run**  
       Links: pending

## Type

🐛 Bug Fix
✅ Test

## Changes

## Summary
- Add `text` and `parallel_tool_calls` back to the ChatGPT responses allowlist.
- Add regression coverage to preserve `text.format` (`json_schema`, `json_object`, `text`) and `parallel_tool_calls` while still dropping unsupported params.

## Background
- `response_format` was already transformed into `text.format` by the chat/completions -> responses bridge, but `ChatGPTResponsesAPIConfig.transform_responses_api_request()` dropped `text` because it was missing from `allowed_keys`.
- Direct backend validation against `https://chatgpt.com/backend-api/codex/responses` shows the backend accepts both `text` and `text.format.type=json_schema`.
- I also verified `parallel_tool_calls=false` is accepted and echoed by the backend, so this was another allowlist omission.

## Relevant logs

Direct backend proof:

```text
=== plain ===
status 200
event: response.created
... "text":{"format":{"type":"text"},"verbosity":"medium"} ...
event: response.output_text.done
... "text":"ok"

=== json_schema ===
status 200
event: response.created
... "text":{"format":{"type":"json_schema","name":"answer_schema","schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false},"strict":true},"verbosity":"medium"} ...
event: response.output_text.done
... "text":"{\"answer\":\"ok\"}"
```

Downstream failure before fix:

```text
2026-03-22 21:15:11,147 - html_analyzer - ERROR - JSON解析失败: Expecting value: line 1 column 1 (char 0)
2026-03-22 21:15:11,147 - selector_updater - WARNING - 从URL https://www.cell.com/cell/current?page=2 未提取到有效选择器
2026-03-22 21:15:53,303 - html_analyzer - ERROR - JSON解析失败: Expecting value: line 1 column 1 (char 0)
```

LiteLLM transformation repro before fix:

```text
bridge keys: ['client', 'input', 'litellm_logging_obj', 'model', 'stream', 'text']
provider keys: ['include', 'input', 'instructions', 'model', 'store', 'stream']
text missing from final provider request
```

Validation after fix:

```text
completion(..., response_format=json_schema, parallel_tool_calls=False)
CONTENT {"answer":"ok"}
PARSED {"answer": "ok"}

responses(..., text_format=Answer, parallel_tool_calls=False)
OUTPUT_TEXT {"answer":"ok"}
PARSED {"answer": "ok"}
```

## Verification
- `pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -vv -n 4` -> `18 passed`
- `pytest tests/test_litellm/proxy/client/test_chat.py tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -vv -n 4` -> `27 passed`
- `ruff check litellm/llms/chatgpt/responses/transformation.py tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py` -> passed
- `black --check litellm/llms/chatgpt/responses/transformation.py tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py` -> passed

## Current repo-wide blockers
- `pytest tests/test_litellm -x -vv -n 4` currently fails at collection with `AttributeError: module 'responses' has no attribute 'activate'` in `tests/test_litellm/proxy/client/test_chat.py`, but that file passes when run alone and when run alongside the new ChatGPT tests.
- repo-wide `black --check .` also reports unrelated pre-existing formatting diffs under `litellm/proxy/enterprise/litellm_enterprise/...`.
