### PR TITLE
fix: handle Pydantic serialization failures without exposing excluded fields

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -44,7 +44,15 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             seen.remove(id(obj))
             return result
         elif isinstance(obj, BaseModel):
-            dumped = obj.model_dump()
+            try:
+                dumped = obj.model_dump()
+            except Exception:
+                # Fall back to json mode serialization if standard dump fails
+                # (e.g. empty ChoiceLogprobs with MockValSer in pydantic v2)
+                try:
+                    dumped = obj.model_dump(mode="json")
+                except Exception:
+                    return str(obj)
             result = _serialize(dumped, seen, depth + 1)
             seen.remove(id(obj))
             return result

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any, Final
 
 from pydantic import BaseModel
+from pydantic_core import PydanticSerializationError
 
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 
@@ -10,6 +11,16 @@ from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 def strip_null_bytes(value: str) -> str:
     """Strip NUL bytes, which PostgreSQL text/jsonb columns reject (error 22P05)."""
     return value.replace("\x00", "")
+
+
+def _dump_model(model: BaseModel) -> dict[str, object] | str:
+    try:
+        return model.model_dump()
+    except (PydanticSerializationError, TypeError):
+        try:
+            return model.model_dump(mode="json")
+        except (PydanticSerializationError, TypeError):
+            return str(model)
 
 
 def safe_dumps(
@@ -66,7 +77,7 @@ def safe_dumps(
             seen.remove(id(obj))
             return result
         elif isinstance(obj, BaseModel):
-            dumped: Final = obj.model_dump()
+            dumped: Final = _dump_model(obj)
             result = _serialize(dumped, seen, depth + 1, key)
             seen.remove(id(obj))
             return result

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -20,7 +20,7 @@ def _dump_model(model: BaseModel) -> dict[str, object] | str:
         try:
             return model.model_dump(mode="json")
         except (PydanticSerializationError, TypeError):
-            return str(model)
+            return "Unserializable Pydantic Model"
 
 
 def safe_dumps(

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -170,3 +170,26 @@ def test_pydantic_base_model():
     assert len(result["healthy_endpoints"]) == 2
     assert result["healthy_endpoints"][0]["name"] == "test"
     assert result["healthy_endpoints"][1] == {"value": 1, "label": "one"}
+
+
+def test_pydantic_model_with_serialization_error():
+    """Test that safe_dumps gracefully handles pydantic models that fail standard serialization.
+
+    This covers the case where model_dump() raises an error (e.g. MockValSer issue
+    with empty ChoiceLogprobs in streaming chunks).
+    """
+    from pydantic import BaseModel
+
+    class FailingModel(BaseModel):
+        value: int = 42
+
+        def model_dump(self, **kwargs):
+            if kwargs.get("mode") != "json":
+                raise Exception("Simulated serialization failure")
+            return {"value": self.value}
+
+    model = FailingModel()
+    # Should not raise - falls back to model_dump(mode="json") then str()
+    result = safe_dumps(model)
+    parsed = json.loads(result)
+    assert parsed["value"] == 42

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -2,8 +2,48 @@ import json
 
 import pytest
 
-
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps, strip_null_bytes
+
+
+@pytest.mark.parametrize("json_succeeds", [True, False])
+def test_repeated_pydantic_model_with_serialization_error(json_succeeds: bool) -> None:
+    from typing import Final
+
+    from pydantic import BaseModel, SerializationInfo, model_serializer
+
+    class FailingModel(BaseModel):
+        value: int = 42
+
+        @model_serializer
+        def serialize_model(self, info: SerializationInfo) -> dict[str, int]:
+            if json_succeeds and info.mode == "json":
+                return {"value": self.value}
+            raise ValueError("serialization failed")
+
+    model: Final = FailingModel()
+    expected: Final = {"value": 42} if json_succeeds else str(model)
+    assert json.loads(safe_dumps([model, model])) == [expected, expected]
+
+
+def test_pydantic_string_fallback_preserves_value_transform() -> None:
+    from typing import Final
+
+    from pydantic import BaseModel, model_serializer
+
+    class FailingModel(BaseModel):
+        @model_serializer
+        def serialize_model(self) -> dict[str, object]:
+            raise ValueError("serialization failed")
+
+        def __str__(self) -> str:
+            return "secret\x00"
+
+    model: Final = FailingModel()
+    assert json.loads(
+        safe_dumps(
+            {"token": model, "other": model}, value_transform=lambda key, value: "redacted" if key == "token" else value
+        )
+    ) == {"token": "redacted", "other": "secret"}
 
 
 def test_primitive_types():
@@ -205,9 +245,7 @@ def test_pydantic_base_model():
         inner: InnerModel
         tags: list
 
-    outer = OuterModel(
-        name="test", inner=InnerModel(value=42, label="hello"), tags=["a", "b"]
-    )
+    outer = OuterModel(name="test", inner=InnerModel(value=42, label="hello"), tags=["a", "b"])
 
     # Test a pydantic model at the top level
     result = json.loads(safe_dumps(outer))

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -21,29 +21,28 @@ def test_repeated_pydantic_model_with_serialization_error(json_succeeds: bool) -
             raise ValueError("serialization failed")
 
     model: Final = FailingModel()
-    expected: Final = {"value": 42} if json_succeeds else str(model)
+    expected: Final = {"value": 42} if json_succeeds else "Unserializable Pydantic Model"
     assert json.loads(safe_dumps([model, model])) == [expected, expected]
 
 
-def test_pydantic_string_fallback_preserves_value_transform() -> None:
+def test_pydantic_fallback_excludes_fields_and_preserves_value_transform() -> None:
     from typing import Final
 
-    from pydantic import BaseModel, model_serializer
+    from pydantic import BaseModel, Field, model_serializer
 
     class FailingModel(BaseModel):
+        password: str = Field(default="do-not-log\x00", exclude=True)
+
         @model_serializer
         def serialize_model(self) -> dict[str, object]:
             raise ValueError("serialization failed")
-
-        def __str__(self) -> str:
-            return "secret\x00"
 
     model: Final = FailingModel()
     assert json.loads(
         safe_dumps(
             {"token": model, "other": model}, value_transform=lambda key, value: "redacted" if key == "token" else value
         )
-    ) == {"token": "redacted", "other": "secret"}
+    ) == {"token": "redacted", "other": "Unserializable Pydantic Model"}
 
 
 def test_primitive_types():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Pydantic serialization failures escape from `safe_dumps`
- Repeated failing models become false circular references
- String fallback exposes fields excluded from serialization

How it solves it:

- Retry JSON-mode serialization after Python-mode failure
- Return an opaque marker if both modes fail
- Preserve circular tracking and value transforms

## Relevant issues

Related to #24357. This hardens the shared serializer used by streaming fallback paths. The original provider-specific streaming report has not been reproduced end to end

## Testing

The focused `test_safe_json_dumps.py` suite passes all 18 cases with real Pydantic serializers. The new excluded-field regression fails on the previous PR head and passes with the opaque fallback. Coverage includes JSON-mode recovery, repeated failing objects, value transforms, NUL cleanup, circular references and depth limits

## Review follow-up

Both failing dump modes now yield `Unserializable Pydantic Model`, without calling the model representation. This addresses the field-exclusion finding in the latest review. The repeated-object cleanup remains on the normal recursive serialization path

The PR targets `litellm_internal_staging`, the current default branch. #31427 covers the separate non-model fallback branch

## Caveats

### Low

- Failed models lose their structured data in the opaque fallback
- Provider integration and full CI remain unverified
