### PR TITLE
[#24356] Preserve text and parallel_tool_calls in ChatGPT responses allowlist

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -96,9 +96,11 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "stream",
             "store",
             "include",
+            "parallel_tool_calls",
             "tools",
             "tool_choice",
             "reasoning",
+            "text",
             "previous_response_id",
             "truncation",
         }

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -103,9 +103,57 @@ class TestChatGPTResponsesAPITransformation:
 
         assert request["stream"] is True
         assert "reasoning.encrypted_content" in request["include"]
-        assert request["instructions"].startswith(
-            "You are Codex, based on GPT-5."
+        assert request["instructions"].startswith("You are Codex, based on GPT-5.")
+
+    @pytest.mark.parametrize(
+        "text_value",
+        [
+            {
+                "format": {
+                    "type": "json_schema",
+                    "name": "answer_schema",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": ["answer"],
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                }
+            },
+            {"format": {"type": "json_object"}},
+            {"format": {"type": "text"}},
+        ],
+        ids=["json_schema", "json_object", "text"],
+    )
+    def test_chatgpt_preserves_text_param(self, text_value):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.2-codex",
+            input="hi",
+            response_api_optional_request_params={"text": text_value},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
         )
+
+        assert request["text"] == text_value
+        assert request["stream"] is True
+        assert "reasoning.encrypted_content" in request["include"]
+        assert request["instructions"].startswith("You are Codex, based on GPT-5.")
+
+    def test_chatgpt_preserves_parallel_tool_calls(self):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.2-codex",
+            input="hi",
+            response_api_optional_request_params={"parallel_tool_calls": False},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["parallel_tool_calls"] is False
+        assert request["stream"] is True
+        assert "reasoning.encrypted_content" in request["include"]
 
     @pytest.mark.parametrize(
         "model_name",
@@ -124,14 +172,18 @@ class TestChatGPTResponsesAPITransformation:
                 "user": "user_123",
                 "temperature": 0.2,
                 "top_p": 0.9,
-                "context_management": [{"type": "compaction", "compact_threshold": 200000}],
+                "context_management": [
+                    {"type": "compaction", "compact_threshold": 200000}
+                ],
                 "metadata": {"foo": "bar"},
                 "max_output_tokens": 123,
                 "stream_options": {"include_usage": True},
                 # supported and should be preserved
                 "truncation": "auto",
                 "previous_response_id": "resp_123",
+                "parallel_tool_calls": False,
                 "reasoning": {"effort": "medium"},
+                "text": {"format": {"type": "json_object"}},
                 "tools": [{"type": "function", "function": {"name": "hello"}}],
                 "tool_choice": {"type": "function", "function": {"name": "hello"}},
             },
@@ -149,9 +201,14 @@ class TestChatGPTResponsesAPITransformation:
 
         assert request["truncation"] == "auto"
         assert request["previous_response_id"] == "resp_123"
+        assert request["parallel_tool_calls"] is False
         assert request["reasoning"] == {"effort": "medium"}
+        assert request["text"] == {"format": {"type": "json_object"}}
         assert request["tools"] == [{"type": "function", "function": {"name": "hello"}}]
-        assert request["tool_choice"] == {"type": "function", "function": {"name": "hello"}}
+        assert request["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "hello"},
+        }
 
     @pytest.mark.parametrize(
         ("model_name", "response_model"),


### PR DESCRIPTION
## Relevant issues

Fixes #24356

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://github.com/BerriAI/litellm/commit/2950e3a9bb6e93469658818fb10682fb171e031c/checks

- [x] **CI run for the last commit**  
       Link: https://github.com/BerriAI/litellm/commit/2950e3a9bb6e93469658818fb10682fb171e031c/checks

- [ ] **Merge / cherry-pick CI run**  
       Links: pending

## Type

🐛 Bug Fix
✅ Test

## Changes

## Summary
- Add `text` and `parallel_tool_calls` back to the ChatGPT responses allowlist.
- Add regression coverage to preserve `text.format` (`json_schema`, `json_object`, `text`) and `parallel_tool_calls` while still dropping unsupported params.

## Background
- The chat/completions -> responses bridge already transforms `response_format` into `text.format`, but `ChatGPTResponsesAPIConfig.transform_responses_api_request()` dropped `text` because it was missing from `allowed_keys`.
- Direct backend validation against `https://chatgpt.com/backend-api/codex/responses` shows the ChatGPT Codex backend accepts both `text` and `text.format.type=json_schema`.
- I also verified `parallel_tool_calls=false` is accepted and echoed by the backend, so this was another allowlist omission.

## Relevant logs

Direct backend proof:

```text
=== plain ===
status 200
event: response.created
... "text":{"format":{"type":"text"},"verbosity":"medium"} ...
event: response.output_text.done
... "text":"ok"

=== json_schema ===
status 200
event: response.created
... "text":{"format":{"type":"json_schema","name":"answer_schema","schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false},"strict":true},"verbosity":"medium"} ...
event: response.output_text.done
... "text":"{\"answer\":\"ok\"}"
```

Downstream failure before fix:

```text
2026-03-22 21:15:11,147 - html_analyzer - ERROR - JSON解析失败: Expecting value: line 1 column 1 (char 0)
2026-03-22 21:15:11,147 - selector_updater - WARNING - 从URL https://www.cell.com/cell/current?page=2 未提取到有效选择器
2026-03-22 21:15:53,303 - html_analyzer - ERROR - JSON解析失败: Expecting value: line 1 column 1 (char 0)
```

LiteLLM transformation repro before fix:

```text
bridge keys: ['client', 'input', 'litellm_logging_obj', 'model', 'stream', 'text']
provider keys: ['include', 'input', 'instructions', 'model', 'store', 'stream']
text missing from final provider request
```

## Verification
- `ruff check litellm/llms/chatgpt/responses/transformation.py tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py` -> passed
- `black --check litellm/llms/chatgpt/responses/transformation.py tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py` -> passed
- `PYTHONPATH=/Users/hemuling/Projects/litellm-pr24356-clean /Users/hemuling/Projects/journal-database/.venv/bin/python -m pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -vv -n 4` -> `18 passed`
