### PR TITLE
fix: raise health check max_tokens default to 16

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -44,8 +44,8 @@ class HealthCheckHelpers:
         model_params["litellm_logging_obj"] = litellm_logging_obj
         model_params["fallbacks"] = fallback_models
         model_params["max_tokens"] = model_params.get(
-            "max_tokens", 10
-        )  # gpt-5-nano throws errors for max_tokens=1
+            "max_tokens", 16
+        )  # GPT-5 models require max_output_tokens >= 16
         await acompletion(**model_params)
         return {}
 

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -240,7 +240,7 @@ def _update_litellm_params_for_health_check(
     elif "*" not in (
         model_info.get("health_check_model") or litellm_params.get("model") or ""
     ):
-        litellm_params["max_tokens"] = 1
+        litellm_params["max_tokens"] = 16
 
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -14,7 +14,7 @@ async def test_update_litellm_params_max_tokens_default():
 
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
 
-    assert updated_params["max_tokens"] == 1
+    assert updated_params["max_tokens"] == 16
 
 
 @pytest.mark.asyncio
@@ -62,7 +62,7 @@ async def test_ahealth_check_wildcard_models_respects_max_tokens():
             model_params=model_params,
             litellm_logging_obj=MagicMock(),
         )
-        assert model_params["max_tokens"] == 10
+        assert model_params["max_tokens"] == 16
 
         # Test Case 2: Custom health_check_max_tokens passed via model_params, should be respected
         model_params = {"max_tokens": 3}


### PR DESCRIPTION
## Relevant issues

Fixes #23836.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai`

## Type

🐛 Bug Fix

## Changes

GPT-5 models (and Azure, Groq) reject `max_output_tokens < 16`. The health check path hardcodes `max_tokens=1` for non-wildcard models, causing all health checks to fail on these providers.

- `litellm/proxy/health_check.py`: default `max_tokens` from 1 to 16
- `litellm/litellm_core_utils/health_check_helpers.py`: wildcard default from 10 to 16 for consistency
- `tests/test_litellm/proxy/test_health_check_max_tokens.py`: updated assertions to match new defaults