### PR TITLE
fix(gemini): filter params from embedding requests

### DIFF
--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -141,6 +141,19 @@ def _is_multimodal_input(input: EmbeddingInput) -> bool:
     return False
 
 
+_SUPPORTED_EMBED_PARAMS = {"outputDimensionality", "taskType", "title"}
+
+
+def _filter_embed_params(optional_params: dict) -> dict:
+    """Map and filter optional_params to only include Gemini embedding fields."""
+    gemini_params = optional_params.copy()
+    if "dimensions" in gemini_params:
+        gemini_params["outputDimensionality"] = gemini_params.pop("dimensions")
+    if "task_type" in gemini_params:
+        gemini_params["taskType"] = gemini_params.pop("task_type")
+    return {k: v for k, v in gemini_params.items() if k in _SUPPORTED_EMBED_PARAMS}
+
+
 def transform_openai_input_gemini_content(
     input: EmbeddingInput, model: str, optional_params: dict
 ) -> VertexAIBatchEmbeddingsRequestBody:
@@ -149,11 +162,7 @@ def transform_openai_input_gemini_content(
     """
     gemini_model_name = "models/{}".format(model)
 
-    gemini_params = optional_params.copy()
-    if "dimensions" in gemini_params:
-        gemini_params["outputDimensionality"] = gemini_params.pop("dimensions")
-    if "task_type" in gemini_params:
-        gemini_params["taskType"] = gemini_params.pop("task_type")
+    gemini_params = _filter_embed_params(optional_params)
 
     requests: List[EmbedContentRequest] = []
     if isinstance(input, str):
@@ -195,11 +204,7 @@ def transform_openai_input_gemini_embed_content(
     """
     resolved_files = resolved_files or {}
 
-    gemini_params = optional_params.copy()
-    if "dimensions" in gemini_params:
-        gemini_params["outputDimensionality"] = gemini_params.pop("dimensions")
-    if "task_type" in gemini_params:
-        gemini_params["taskType"] = gemini_params.pop("task_type")
+    gemini_params = _filter_embed_params(optional_params)
 
     input_list = [input] if isinstance(input, str) else input
     parts: List[PartType] = []

--- a/tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py
+++ b/tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py
@@ -19,6 +19,7 @@ import pytest
 import litellm
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.vertex_ai.gemini_embeddings.batch_embed_content_transformation import (
+    _filter_embed_params,
     _is_multimodal_input,
     _parse_data_url,
     process_embed_content_response,
@@ -562,4 +563,51 @@ def test_vertex_ai_text_only_embedding_uses_embed_content():
         assert len(data["content"]["parts"]) == 1
         assert data["content"]["parts"][0]["text"] == "Hello, world!"
         assert len(response.data) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unsupported params filtering tests (#24293)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_embed_params_drops_unsupported():
+    """Unsupported params like max_tokens should be filtered out."""
+    result = _filter_embed_params({"dimensions": 768, "max_tokens": 256, "temperature": 0.5})
+    assert result == {"outputDimensionality": 768}
+
+
+def test_filter_embed_params_keeps_supported():
+    """All supported Gemini embedding params should pass through."""
+    result = _filter_embed_params({
+        "dimensions": 768,
+        "task_type": "RETRIEVAL_DOCUMENT",
+        "title": "My doc",
+    })
+    assert result == {
+        "outputDimensionality": 768,
+        "taskType": "RETRIEVAL_DOCUMENT",
+        "title": "My doc",
+    }
+
+
+def test_batch_embed_content_drops_max_tokens():
+    """max_tokens in optional_params should not appear in the batch request."""
+    result = transform_openai_input_gemini_content(
+        input="test text",
+        model="text-embedding-004",
+        optional_params={"max_tokens": 256},
+    )
+    for request in result["requests"]:
+        assert "max_tokens" not in request
+
+
+def test_embed_content_drops_max_tokens():
+    """max_tokens in optional_params should not appear in the embedContent request."""
+    result = transform_openai_input_gemini_embed_content(
+        input=["test text"],
+        model="gemini-embedding-001",
+        optional_params={"max_tokens": 256},
+        resolved_files=None,
+    )
+    assert "max_tokens" not in result
 


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/berriAI/litellm/issues/24293

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Gemini batch embedding transformation spreads all `optional_params` into the request body via `**gemini_params`. Params like `max_tokens` (injected by `add_provider_specific_params_to_optional_params` for non-OpenAI providers) reach the Gemini API and cause a `400 BadRequestError`.

`drop_params: true` doesn't prevent this because the param is re-injected after the drop_params check runs.

Extract `_filter_embed_params()` that maps `dimensions`/`task_type` and keeps only the fields Gemini embeddings accept (`outputDimensionality`, `taskType`, `title`). Applied to both `transform_openai_input_gemini_content` and `transform_openai_input_gemini_embed_content`.

### Tests added

- `test_filter_embed_params_drops_unsupported` — verifies max_tokens/temperature are filtered
- `test_filter_embed_params_keeps_supported` — verifies dimensions/task_type/title pass through
- `test_batch_embed_content_drops_max_tokens` — integration test for batchEmbedContents path
- `test_embed_content_drops_max_tokens` — integration test for embedContent path