### PR TITLE
fix(responses-api): apply GPT-5 temperature validation

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -87,6 +87,8 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                         message=(
                             "gpt-5 models don't support temperature={}. "
                             "Only temperature=1 is supported. "
+                            "For models like gpt-5.1/5.4, temperature is supported "
+                            "when reasoning.effort='none' (or not specified). "
                             "To drop unsupported params set `litellm.drop_params = True`"
                         ).format(temperature),
                         status_code=400,

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -60,8 +60,39 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         model: str,
         drop_params: bool,
     ) -> Dict:
-        """No mapping applied since inputs are in OpenAI spec already"""
-        return dict(response_api_optional_params)
+        """No mapping applied since inputs are in OpenAI spec already.
+
+        GPT-5 models have restrictions on temperature (only temperature=1
+        is accepted unless reasoning_effort='none' on models that support it).
+        Apply the same validation used by the chat completions path.
+        """
+        from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
+
+        params = dict(response_api_optional_params)
+
+        if OpenAIGPT5Config.is_model_gpt_5_model(model=model):
+            temperature = params.get("temperature")
+            if temperature is not None and temperature != 1:
+                reasoning = params.get("reasoning") or {}
+                effort = reasoning.get("effort") if isinstance(reasoning, dict) else None
+                supports_none = OpenAIGPT5Config._supports_reasoning_effort_level(
+                    model=model, level="none"
+                )
+                if supports_none and (effort == "none" or effort is None):
+                    pass  # flexible temperature allowed
+                elif drop_params or litellm.drop_params:
+                    params.pop("temperature", None)
+                else:
+                    raise litellm.UnsupportedParamsError(
+                        message=(
+                            "gpt-5 models don't support temperature={}. "
+                            "Only temperature=1 is supported. "
+                            "To drop unsupported params set `litellm.drop_params = True`"
+                        ).format(temperature),
+                        status_code=400,
+                    )
+
+        return params
 
     def transform_responses_api_request(
         self,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1114,3 +1114,48 @@ def test_responses_gpt5_chat_allow_temperature(
         drop_params=False,
     )
     assert params["temperature"] == 0.3
+
+
+def test_responses_gpt51_allow_temperature_no_reasoning(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """gpt-5.1 supports reasoning_effort='none'; no reasoning defaults to 'none',
+    so temperature should be allowed."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.5,
+        ),
+        model="gpt-5.1",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.5
+
+
+def test_responses_gpt51_drop_temperature_with_high_effort(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """gpt-5.1 with reasoning.effort='high' should drop temperature!=1."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.5,
+            reasoning={"effort": "high"},
+        ),
+        model="gpt-5.1",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_responses_gpt54_allow_temperature_effort_none(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """gpt-5.4 with explicit reasoning.effort='none' should allow temperature."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.7,
+            reasoning={"effort": "none"},
+        ),
+        model="gpt-5.4",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.7

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1031,3 +1031,86 @@ def test_gpt5_1_logprobs_dropped_with_reasoning_effort(config: OpenAIConfig):
     assert "logprobs" not in params
     assert "top_p" not in params
     assert params["reasoning_effort"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# Responses API: GPT-5 temperature validation (#16090)
+# ---------------------------------------------------------------------------
+
+from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
+
+
+@pytest.fixture()
+def responses_config() -> OpenAIResponsesAPIConfig:
+    return OpenAIResponsesAPIConfig()
+
+
+def test_responses_gpt5_drop_temperature(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """drop_params=True should silently drop temperature!=1 for gpt-5."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.5,
+        ),
+        model="gpt-5",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_responses_gpt5_reject_temperature(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """Without drop_params, temperature!=1 should raise UnsupportedParamsError."""
+    with pytest.raises(litellm.UnsupportedParamsError):
+        responses_config.map_openai_params(
+            response_api_optional_params=ResponsesAPIOptionalRequestParams(
+                temperature=0.5,
+            ),
+            model="gpt-5",
+            drop_params=False,
+        )
+
+
+def test_responses_gpt5_allow_temperature_1(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """temperature=1 should always be allowed for gpt-5."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=1,
+        ),
+        model="gpt-5",
+        drop_params=False,
+    )
+    assert params["temperature"] == 1
+
+
+def test_responses_gpt5_mini_drop_temperature(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """gpt-5-mini should also drop temperature!=1."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.7,
+        ),
+        model="gpt-5-mini",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_responses_gpt5_chat_allow_temperature(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """gpt-5-chat models should allow any temperature (not GPT-5 restricted)."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.3,
+        ),
+        model="gpt-5-chat-latest",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.3


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/berriAI/litellm/issues/16090

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The Responses API `map_openai_params` passed all params through without model-specific validation. GPT-5 models (except gpt-5-chat) only accept `temperature=1` unless `reasoning.effort="none"` on models that support it (5.1, 5.2, 5.4). The chat completions path already validates this, but the Responses API path did not.


### Tests added

- `test_responses_gpt5_drop_temperature` — drop_params drops temperature!=1
- `test_responses_gpt5_reject_temperature` — raises error without drop_params
- `test_responses_gpt5_allow_temperature_1` — temperature=1 always allowed
- `test_responses_gpt5_mini_drop_temperature` — gpt-5-mini also drops
- `test_responses_gpt5_chat_allow_temperature` — gpt-5-chat not restricted