### PR TITLE
fix: map Zhipu GLM non-standard finish_reason values

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -89,6 +89,9 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "IMAGE_PROHIBITED_CONTENT": "content_filter",
     "TOO_MANY_TOOL_CALLS": "stop",
     "MALFORMED_RESPONSE": "stop",
+    # Zhipu GLM
+    "network_error": "stop",
+    "sensitive": "content_filter",
     # Bedrock
     "guardrail_intervened": "content_filter",
     # OpenAI passthrough

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -126,6 +126,14 @@ class TestMapFinishReasonBedrock:
         assert map_finish_reason("guardrail_intervened") == "content_filter"
 
 
+class TestMapFinishReasonZhipu:
+    def test_network_error(self):
+        assert map_finish_reason("network_error") == "stop"
+
+    def test_sensitive(self):
+        assert map_finish_reason("sensitive") == "content_filter"
+
+
 class TestMapFinishReasonOpenAIPassthrough:
     @pytest.mark.parametrize(
         "reason", ["stop", "length", "tool_calls", "function_call", "content_filter"]


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/berriAI/litellm/issues/23386

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Zhipu GLM returns non-standard `finish_reason` values during streaming when inference fails mid-request. These values are not in LiteLLM's `_FINISH_REASON_MAP`, causing a Pydantic validation crash in `stream_chunk_builder`.

Add two mappings to the centralized `_FINISH_REASON_MAP` in `core_helpers.py`:
- `"network_error"` → `"stop"` (inference interrupted)
- `"sensitive"` → `"content_filter"` (content policy violation)

### Tests added

- `TestMapFinishReasonZhipu::test_network_error`
- `TestMapFinishReasonZhipu::test_sensitive`