### PR TITLE
fix(cost): read Gemini web search grounding cost from model_info

### DIFF
--- a/litellm/llms/gemini/cost_calculator.py
+++ b/litellm/llms/gemini/cost_calculator.py
@@ -31,11 +31,20 @@ def cost_per_token(
 def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> float:
     """
     Calculates the cost per web search request for a given model, prompt tokens, and completion tokens.
+
+    Reads the per-request cost from model_info["web_search_cost_per_request"] so that
+    different model families (e.g. Gemini 2.x at $35/1K vs Gemini 3.x at $14/1K) are
+    billed correctly.  Falls back to $35/1K when the field is absent for backward
+    compatibility.
     """
     from litellm.types.utils import PromptTokensDetailsWrapper
 
-    # cost per web search request
-    cost_per_web_search_request = 35e-3
+    # Read per-request cost from model_info; fall back to legacy $35/1K default
+    _cost_per_request = (
+        model_info.get("web_search_cost_per_request") if model_info else None
+    )
+    if _cost_per_request is None:
+        _cost_per_request = 35e-3
 
     number_of_web_search_requests = 0
     # Get number of web search requests
@@ -47,10 +56,8 @@ def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> floa
         and usage.prompt_tokens_details.web_search_requests is not None
     ):
         number_of_web_search_requests = usage.prompt_tokens_details.web_search_requests
-    else:
-        number_of_web_search_requests = 0
 
     # Calculate total cost
-    total_cost = cost_per_web_search_request * number_of_web_search_requests
+    total_cost = _cost_per_request * number_of_web_search_requests
 
     return total_cost

--- a/litellm/llms/vertex_ai/gemini/cost_calculator.py
+++ b/litellm/llms/vertex_ai/gemini/cost_calculator.py
@@ -14,9 +14,10 @@ def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> floa
     """
     Calculate the cost of a web search request for Vertex AI Gemini.
 
-    Vertex AI charges $35/1000 prompts, independent of the number of web search requests.
-
-    For a single call, this is $35e-3 USD.
+    Vertex AI charges per grounded prompt. The rate varies by model family
+    (e.g. $35/1K for Gemini 2.x, $14/1K for Gemini 3.x). The per-call cost
+    is read from model_info["web_search_cost_per_request"] and falls back to
+    $35e-3 when the field is absent.
 
     Args:
         usage: The usage object for the web search request.
@@ -27,8 +28,12 @@ def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> floa
     """
     from litellm.types.utils import PromptTokensDetailsWrapper
 
-    # check if usage object has web search requests
-    cost_per_llm_call_with_web_search = 35e-3
+    # Read per-call cost from model_info; fall back to legacy $35/1K default
+    _cost_per_call = (
+        model_info.get("web_search_cost_per_request") if model_info else None
+    )
+    if _cost_per_call is None:
+        _cost_per_call = 35e-3
 
     makes_web_search_request = False
     if (
@@ -40,6 +45,6 @@ def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> floa
 
     # Calculate total cost
     if makes_web_search_request:
-        return cost_per_llm_call_with_web_search
+        return _cost_per_call
     else:
         return 0.0

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -235,6 +235,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     search_context_cost_per_query: Optional[
         SearchContextCostPerQuery
     ]  # Cost for using web search tool
+    web_search_cost_per_request: Optional[
+        float
+    ]  # Per-request cost for grounding with Google Search (Gemini / Vertex AI)
     citation_cost_per_token: Optional[float]  # Cost per citation token for Perplexity
     tiered_pricing: Optional[
         List[Dict[str, Any]]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13383,7 +13383,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.0-flash-001": {
         "cache_read_input_token_cost": 3.75e-08,
@@ -13421,7 +13422,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.0-flash-lite": {
         "cache_read_input_token_cost": 1.875e-08,
@@ -13457,7 +13459,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.0-flash-lite-001": {
         "cache_read_input_token_cost": 1.875e-08,
@@ -13493,7 +13496,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash": {
         "cache_read_input_token_cost": 3e-08,
@@ -13538,7 +13542,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -13621,7 +13626,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini-3.1-flash-image-preview": {
         "input_cost_per_image": 0.00056,
@@ -13653,7 +13659,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -13704,7 +13711,8 @@
         "supports_video_input": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "web_search_cost_per_request": 0.014
     },
     "deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
@@ -13738,7 +13746,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash-lite": {
         "cache_read_input_token_cost": 1e-08,
@@ -13783,7 +13792,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
@@ -13828,7 +13838,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -13873,7 +13884,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -13917,7 +13929,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -13963,7 +13976,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
@@ -14009,7 +14023,8 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -14054,7 +14069,8 @@
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-3-pro-preview": {
         "deprecation_date": "2026-03-26",
@@ -14111,7 +14127,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini-3.1-pro-preview": {
         "cache_read_input_token_cost": 2e-07,
@@ -14169,7 +14186,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini-3.1-pro-preview-customtools": {
         "cache_read_input_token_cost": 2e-07,
@@ -14220,7 +14238,8 @@
         "supports_vision": true,
         "supports_web_search": true,
         "supports_url_context": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "web_search_cost_per_request": 0.014
     },
     "vertex_ai/gemini-3-pro-preview": {
         "cache_read_input_token_cost": 2e-07,
@@ -14276,7 +14295,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "vertex_ai/gemini-3-flash-preview": {
         "cache_read_input_token_cost": 5e-08,
@@ -14325,7 +14345,8 @@
         "input_cost_per_audio_token_priority": 1.8e-06,
         "output_cost_per_token_priority": 5.4e-06,
         "cache_read_input_token_cost_priority": 9e-08,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "vertex_ai/gemini-3.1-pro-preview": {
         "cache_read_input_token_cost": 2e-07,
@@ -14383,7 +14404,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "vertex_ai/gemini-3.1-pro-preview-customtools": {
         "cache_read_input_token_cost": 2e-07,
@@ -14441,7 +14463,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini-2.5-pro-preview-tts": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -14477,7 +14500,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-robotics-er-1.5-preview": {
         "cache_read_input_token_cost": 0,
@@ -14552,7 +14576,8 @@
         "supports_vision": true,
         "supports_web_search": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-computer-use-preview-10-2025": {
         "input_cost_per_token": 1.25e-06,
@@ -14604,17 +14629,14 @@
         "uses_embed_content": true
     },
     "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_audio_per_second": 0.00016,
-        "input_cost_per_image": 0.00012,
-        "input_cost_per_token": 2e-07,
-        "input_cost_per_video_per_second": 0.00079,
+        "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
         "supports_multimodal": true,
         "uses_embed_content": true
     },
@@ -14629,18 +14651,6 @@
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-        "uses_embed_content": true
-    },
-    "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_token": 1.5e-07,
-        "litellm_provider": "vertex_ai",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0,
-        "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
-        "supports_multimodal": true,
         "uses_embed_content": true
     },
     "gemini/gemini-embedding-001": {
@@ -14725,7 +14735,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 10000000
+        "tpm": 10000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.0-flash-001": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -14764,7 +14775,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 10000000
+        "tpm": 10000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.0-flash-lite": {
         "cache_read_input_token_cost": 1.875e-08,
@@ -14801,7 +14813,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 4000000
+        "tpm": 4000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash": {
         "cache_read_input_token_cost": 3e-08,
@@ -14848,7 +14861,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -14898,7 +14912,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -14934,7 +14949,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/gemini-3.1-flash-image-preview": {
         "input_cost_per_token": 2.5e-07,
@@ -14970,7 +14986,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
@@ -15006,7 +15023,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash-lite": {
         "cache_read_input_token_cost": 1e-08,
@@ -15053,7 +15071,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
@@ -15100,7 +15119,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -15147,7 +15167,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-flash-latest": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -15194,7 +15215,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-flash-lite-latest": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -15241,7 +15263,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
@@ -15289,7 +15312,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-flash-preview-tts": {
         "input_cost_per_token": 3e-07,
@@ -15352,7 +15376,8 @@
         "supports_video_input": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 800000
+        "tpm": 800000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-2.5-computer-use-preview-10-2025": {
         "input_cost_per_token": 1.25e-06,
@@ -15440,7 +15465,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -15493,7 +15519,8 @@
         "supports_vision": true,
         "supports_web_search": true,
         "supports_native_streaming": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/gemini-3-flash-preview": {
         "cache_read_input_token_cost": 5e-08,
@@ -15546,7 +15573,8 @@
         "input_cost_per_audio_token_priority": 1.8e-06,
         "output_cost_per_token_priority": 5.4e-06,
         "cache_read_input_token_cost_priority": 9e-08,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/gemini-3.1-pro-preview": {
         "cache_read_input_token_cost": 2e-07,
@@ -15604,7 +15632,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/gemini-3.1-pro-preview-customtools": {
         "cache_read_input_token_cost": 2e-07,
@@ -15662,7 +15691,8 @@
         "output_cost_per_token_above_200k_tokens_priority": 3.24e-05,
         "cache_read_input_token_cost_priority": 3.6e-07,
         "cache_read_input_token_cost_above_200k_tokens_priority": 7.2e-07,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini-3-flash-preview": {
         "cache_read_input_token_cost": 5e-08,
@@ -15713,7 +15743,8 @@
         "input_cost_per_audio_token_priority": 1.8e-06,
         "output_cost_per_token_priority": 5.4e-06,
         "cache_read_input_token_cost_priority": 9e-08,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "web_search_cost_per_request": 0.014
     },
     "gemini/gemini-2.5-pro-preview-tts": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -15750,7 +15781,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 10000000
+        "tpm": 10000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-exp-1114": {
         "input_cost_per_token": 0,
@@ -30809,7 +30841,8 @@
         "supports_video_input": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "web_search_cost_per_request": 0.014
     },
     "vertex_ai/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
@@ -31119,7 +31152,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "web_search_cost_per_request": 0.035
     },
     "vertex_ai/zai-org/glm-4.7-maas": {
         "input_cost_per_token": 6e-07,
@@ -31147,7 +31181,9 @@
         "mode": "chat",
         "output_cost_per_token": 3.2e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models",
-        "supported_regions": ["global"],
+        "supported_regions": [
+            "global"
+        ],
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -36756,7 +36792,8 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 4000000
+        "tpm": 4000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-2.5-flash-native-audio-latest": {
         "input_cost_per_audio_token": 1e-06,
@@ -36963,7 +37000,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-flash-lite-latest": {
         "cache_read_input_token_cost": 1e-08,
@@ -37010,7 +37048,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 250000
+        "tpm": 250000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-pro-latest": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -37056,7 +37095,8 @@
         "supports_video_input": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 800000
+        "tpm": 800000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini/gemini-pro-latest": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -37102,7 +37142,8 @@
         "supports_video_input": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 800000
+        "tpm": 800000,
+        "web_search_cost_per_request": 0.035
     },
     "gemini-exp-1206": {
         "cache_read_input_token_cost": 3e-08,
@@ -37149,7 +37190,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "web_search_cost_per_request": 0.035
     },
     "vertex_ai/claude-sonnet-4-6@default": {
         "cache_creation_input_token_cost": 3.75e-06,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -160,6 +160,62 @@ def test_get_cost_for_gemini_web_search(model):
     assert cost > 0.0
 
 
+def test_gemini_web_search_cost_uses_model_info():
+    """
+    Verify that the Gemini cost calculator reads web_search_cost_per_request
+    from model_info instead of always using the hardcoded $0.035 value.
+
+    Gemini 3.x models are priced at $14/1K requests ($0.014 each) while
+    Gemini 2.x models remain at $35/1K ($0.035 each).
+    """
+    from litellm.llms.gemini.cost_calculator import cost_per_web_search_request
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    usage = Usage(
+        prompt_tokens_details=PromptTokensDetailsWrapper(web_search_requests=1)
+    )
+
+    # Gemini 3.x pricing: $0.014 per request
+    model_info_gemini3 = {"web_search_cost_per_request": 0.014}
+    cost_gemini3 = cost_per_web_search_request(usage=usage, model_info=model_info_gemini3)
+    assert cost_gemini3 == pytest.approx(0.014)
+
+    # Gemini 2.x pricing: $0.035 per request
+    model_info_gemini2 = {"web_search_cost_per_request": 0.035}
+    cost_gemini2 = cost_per_web_search_request(usage=usage, model_info=model_info_gemini2)
+    assert cost_gemini2 == pytest.approx(0.035)
+
+    # Fallback when field is absent: should default to $0.035
+    model_info_no_field = {}
+    cost_fallback = cost_per_web_search_request(usage=usage, model_info=model_info_no_field)
+    assert cost_fallback == pytest.approx(0.035)
+
+
+def test_vertex_ai_gemini_web_search_cost_uses_model_info():
+    """
+    Verify that the Vertex AI Gemini cost calculator reads
+    web_search_cost_per_request from model_info.
+    """
+    from litellm.llms.vertex_ai.gemini.cost_calculator import (
+        cost_per_web_search_request,
+    )
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    usage = Usage(
+        prompt_tokens_details=PromptTokensDetailsWrapper(web_search_requests=1)
+    )
+
+    # Gemini 3.x pricing via Vertex AI
+    model_info_gemini3 = {"web_search_cost_per_request": 0.014}
+    cost = cost_per_web_search_request(usage=usage, model_info=model_info_gemini3)
+    assert cost == pytest.approx(0.014)
+
+    # Fallback when field is absent
+    model_info_no_field = {}
+    cost_fallback = cost_per_web_search_request(usage=usage, model_info=model_info_no_field)
+    assert cost_fallback == pytest.approx(0.035)
+
+
 @pytest.mark.parametrize(
     "model,custom_llm_provider",
     [

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -1,17 +1,14 @@
-import json
 import os
 import sys
-from unittest.mock import MagicMock
 
 import pytest
-from fastapi.testclient import TestClient
 
 import litellm
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
     StandardBuiltInToolCostTracking,
 )
 from litellm.types.llms.openai import FileSearchTool, WebSearchOptions
-from litellm.types.utils import ModelInfo, ModelResponse, StandardBuiltInToolsParams
+from litellm.types.utils import ModelResponse, StandardBuiltInToolsParams
 
 sys.path.insert(
     0, os.path.abspath("../../..")


### PR DESCRIPTION
## Summary

Fixes #24369

The Gemini and Vertex AI cost calculators hardcode `$0.035` per web search request, which is incorrect for Gemini 3.x models (priced at `$0.014/request` per Google's current pricing).

## Changes

- **`litellm/llms/gemini/cost_calculator.py`** and **`litellm/llms/vertex_ai/gemini/cost_calculator.py`**: Read `web_search_cost_per_request` from `model_info` instead of using a hardcoded value. Falls back to `$0.035` when the field is absent for backward compatibility.
- **`litellm/types/utils.py`**: Add `web_search_cost_per_request` field to `ModelInfoBase` TypedDict.
- **`model_prices_and_context_window.json`**: Add `web_search_cost_per_request` to all Gemini/Vertex AI models with `supports_web_search: true`:
  - Gemini 2.x models: `0.035` ($35/1K requests)
  - Gemini 3.x models: `0.014` ($14/1K requests)
- **Tests**: Add unit tests verifying the cost calculator reads from `model_info` and falls back correctly.

This also enables custom pricing overrides via `model_info` for users who need non-default rates.