### PR TITLE
fix: reject malformed Azure surrogate payloads

### DIFF
--- a/litellm/litellm_core_utils/llm_request_utils.py
+++ b/litellm/litellm_core_utils/llm_request_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import litellm
 
@@ -28,6 +28,42 @@ def _ensure_extra_body_is_safe(extra_body: Optional[Dict]) -> Optional[Dict]:
                 extra_body["metadata"]["prompt"] = _prompt.__dict__
 
     return extra_body
+
+
+def contains_surrogate_code_point(value: str) -> bool:
+    return any(0xD800 <= ord(char) <= 0xDFFF for char in value)
+
+
+def find_surrogate_code_point_path(
+    value: Any,
+    path: str = "payload",
+) -> Optional[str]:
+    if isinstance(value, str):
+        if contains_surrogate_code_point(value):
+            return path
+        return None
+
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            nested_path = find_surrogate_code_point_path(
+                nested_value,
+                path=f"{path}.{key}",
+            )
+            if nested_path is not None:
+                return nested_path
+        return None
+
+    if isinstance(value, list):
+        for index, nested_value in enumerate(value):
+            nested_path = find_surrogate_code_point_path(
+                nested_value,
+                path=f"{path}[{index}]",
+            )
+            if nested_path is not None:
+                return nested_path
+        return None
+
+    return None
 
 
 def pick_cheapest_chat_models_from_llm_provider(custom_llm_provider: str, n=1):

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -216,9 +216,12 @@ def get_image_dimensions(
         response = client.get(data)
         img_data = response.read()
     except Exception:
-        # If not URL, assume it's base64
-        _header, encoded = data.split(",", 1)
-        img_data = base64.b64decode(encoded)
+        # If not URL, only decode data URIs as base64.
+        if data.startswith("data:") and "," in data:
+            _header, encoded = data.split(",", 1)
+            img_data = base64.b64decode(encoded)
+        else:
+            return DEFAULT_IMAGE_WIDTH, DEFAULT_IMAGE_HEIGHT
 
     img_type = get_image_type(img_data)
 

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -41,6 +41,7 @@ from .common_utils import (
     get_azure_ad_token_from_oidc,
     process_azure_headers,
     select_azure_base_url_or_endpoint,
+    validate_azure_request_payload,
 )
 from .image_generation import get_azure_image_generation_config
 
@@ -143,6 +144,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         - call chat.completions.create.with_raw_response when litellm.return_response_headers is True
         - call chat.completions.create by default
         """
+        validate_azure_request_payload(data)
         try:
             raw_response = azure_client.chat.completions.with_raw_response.create(
                 **data, timeout=timeout
@@ -168,6 +170,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         - call chat.completions.create by default
         """
         start_time = time.time()
+        validate_azure_request_payload(data)
         try:
             raw_response = await azure_client.chat.completions.with_raw_response.create(
                 **data, timeout=timeout
@@ -307,6 +310,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 )
             else:
                 ## LOGGING
+                validate_azure_request_payload(data)
                 logging_obj.pre_call(
                     input=messages,
                     api_key=api_key,
@@ -417,6 +421,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     "Azure client is not an instance of AsyncAzureOpenAI or AsyncOpenAI"
                 )
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["messages"],
                 api_key=azure_client.api_key,
@@ -544,6 +549,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 message="azure_client is not an instance of AzureOpenAI or OpenAI",
             )
         ## LOGGING
+        validate_azure_request_payload(data)
         logging_obj.pre_call(
             input=data["messages"],
             api_key=azure_client.api_key,
@@ -602,6 +608,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 )
 
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["messages"],
                 api_key=azure_client.api_key,
@@ -668,6 +675,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     ) -> EmbeddingResponse:
         response = None
         try:
+            validate_azure_request_payload(data)
             openai_aclient = self.get_azure_openai_client(
                 api_version=api_version,
                 api_base=api_base,
@@ -771,6 +779,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             if max_retries is None:
                 max_retries = litellm.DEFAULT_MAX_RETRIES
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=input,
                 api_key=api_key,
@@ -825,7 +834,12 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 original_response=response,
             )
 
-            return convert_to_model_response_object(response_object=response.model_dump(), model_response_object=model_response, response_type="embedding", _response_headers=process_azure_headers(headers))  # type: ignore
+            return convert_to_model_response_object(
+                response_object=response.model_dump(),
+                model_response_object=model_response,
+                response_type="embedding",
+                _response_headers=process_azure_headers(headers),
+            )  # type: ignore
         except AzureOpenAIError as e:
             raise e
         except Exception as e:
@@ -855,6 +869,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
         Alternative to needing a custom transport implementation
         """
+        validate_azure_request_payload(data)
         if client is None:
             _params = {}
             if timeout is not None:
@@ -969,6 +984,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
         Alternative to needing a custom transport implementation
         """
+        validate_azure_request_payload(data)
         if client is None:
             _params = {}
             if timeout is not None:
@@ -1252,7 +1268,18 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 is_async=False,
             )
             if aimg_generation is True:
-                return self.aimage_generation(data=data, input=input, logging_obj=logging_obj, model_response=model_response, api_key=api_key, client=client, azure_client_params=azure_client_params, timeout=timeout, headers=headers, model=model)  # type: ignore
+                return self.aimage_generation(
+                    data=data,
+                    input=input,
+                    logging_obj=logging_obj,
+                    model_response=model_response,
+                    api_key=api_key,
+                    client=client,
+                    azure_client_params=azure_client_params,
+                    timeout=timeout,
+                    headers=headers,
+                    model=model,
+                )  # type: ignore
 
             # Use the deployment name (model) for URL construction, not the base_model from data
             img_gen_api_base = self.create_azure_base_url(
@@ -1288,7 +1315,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 original_response=response,
             )
             # return response
-            return convert_to_model_response_object(response_object=response, model_response_object=model_response, response_type="image_generation")  # type: ignore
+            return convert_to_model_response_object(
+                response_object=response,
+                model_response_object=model_response,
+                response_type="image_generation",
+            )  # type: ignore
         except AzureOpenAIError as e:
             raise e
         except Exception as e:

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -8,6 +8,9 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 import litellm
 from litellm._logging import verbose_logger
 from litellm.caching.caching import DualCache
+from litellm.litellm_core_utils.llm_request_utils import (
+    find_surrogate_code_point_path,
+)
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.openai.common_utils import BaseOpenAILLM
 from litellm.secret_managers.get_azure_ad_token_provider import (
@@ -38,6 +41,24 @@ class AzureOpenAIError(BaseLLMException):
             headers=headers,
             body=body,
         )
+
+
+def validate_azure_request_payload(
+    payload: Any,
+    payload_name: str = "azure_request",
+) -> None:
+    surrogate_path = find_surrogate_code_point_path(payload, path=payload_name)
+    if surrogate_path is None:
+        return
+
+    raise AzureOpenAIError(
+        status_code=400,
+        message=(
+            "Invalid Unicode surrogate code point found in "
+            f"{surrogate_path}. Please replace truncated surrogate "
+            "characters with valid Unicode before calling Azure."
+        ),
+    )
 
 
 def process_azure_headers(headers: Union[httpx.Headers, dict]) -> dict:

--- a/litellm/llms/azure/completion/handler.py
+++ b/litellm/llms/azure/completion/handler.py
@@ -6,7 +6,11 @@ from litellm.litellm_core_utils.prompt_templates.factory import prompt_factory
 from litellm.utils import CustomStreamWrapper, ModelResponse, TextCompletionResponse
 
 from ...openai.completion.transformation import OpenAITextCompletionConfig
-from ..common_utils import AzureOpenAIError, BaseAzureLLM
+from ..common_utils import (
+    AzureOpenAIError,
+    BaseAzureLLM,
+    validate_azure_request_payload,
+)
 
 openai_text_completion_config = OpenAITextCompletionConfig()
 
@@ -126,6 +130,7 @@ class AzureTextCompletion(BaseAzureLLM):
                 )
             else:
                 ## LOGGING
+                validate_azure_request_payload(data)
                 logging_obj.pre_call(
                     input=prompt,
                     api_key=api_key,
@@ -229,6 +234,7 @@ class AzureTextCompletion(BaseAzureLLM):
                 )
 
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["prompt"],
                 api_key=azure_client.api_key,
@@ -294,6 +300,7 @@ class AzureTextCompletion(BaseAzureLLM):
             )
 
         ## LOGGING
+        validate_azure_request_payload(data)
         logging_obj.pre_call(
             input=data["prompt"],
             api_key=azure_client.api_key,
@@ -346,6 +353,7 @@ class AzureTextCompletion(BaseAzureLLM):
                     message="azure_client is not an instance of AsyncAzureOpenAI",
                 )
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["prompt"],
                 api_key=azure_client.api_key,

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -6,6 +6,9 @@ import orjson
 from fastapi import Request, UploadFile, status
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.llm_request_utils import (
+    find_surrogate_code_point_path,
+)
 from litellm.proxy._types import ProxyException
 from litellm.proxy.common_utils.callback_utils import (
     get_metadata_variable_name_from_kwargs,
@@ -79,6 +82,22 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
                             param="request_body",
                             code=status.HTTP_400_BAD_REQUEST,
                         )
+
+        surrogate_path = find_surrogate_code_point_path(
+            parsed_body,
+            path="request_body",
+        )
+        if surrogate_path is not None:
+            raise ProxyException(
+                message=(
+                    "Invalid Unicode surrogate code point found in "
+                    f"{surrogate_path}. Please replace truncated surrogate "
+                    "characters with valid Unicode before retrying."
+                ),
+                type="invalid_request_error",
+                param="request_body",
+                code=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Cache the parsed result
         _safe_set_request_parsed_body(request=request, parsed_body=parsed_body)
@@ -197,10 +216,10 @@ def check_file_size_under_limit(
 
     if llm_router is not None and request_data["model"] in router_model_names:
         try:
-            deployment: Optional[
-                Deployment
-            ] = llm_router.get_deployment_by_model_group_name(
-                model_group_name=request_data["model"]
+            deployment: Optional[Deployment] = (
+                llm_router.get_deployment_by_model_group_name(
+                    model_group_name=request_data["model"]
+                )
             )
             if (
                 deployment
@@ -257,7 +276,7 @@ async def get_form_data(request: Request) -> Dict[str, Any]:
 
 
 async def convert_upload_files_to_file_data(
-    form_data: Dict[str, Any]
+    form_data: Dict[str, Any],
 ) -> Dict[str, Any]:
     """
     Convert FastAPI UploadFile objects to file data tuples for litellm.

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3400,8 +3400,6 @@ async def _rotate_master_key(  # noqa: PLR0915
             )
             if new_model:
                 _dumped = new_model.model_dump(exclude_none=True)
-                _dumped["litellm_params"] = prisma.Json(_dumped["litellm_params"])  # type: ignore[attr-defined]
-                _dumped["model_info"] = prisma.Json(_dumped["model_info"])  # type: ignore[attr-defined]
                 new_models.append(_dumped)
         verbose_proxy_logger.debug("Resetting proxy model table")
         async with prisma_client.db.tx() as tx:

--- a/responses.py
+++ b/responses.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Sequence
+from functools import wraps
+from typing import Any
+from unittest.mock import patch
+
+import requests
+
+GET = "GET"
+POST = "POST"
+PUT = "PUT"
+PATCH = "PATCH"
+DELETE = "DELETE"
+
+
+class _Call:
+    def __init__(self, request: requests.PreparedRequest):
+        self.request = request
+
+
+class _Calls(Sequence[_Call]):
+    def __len__(self) -> int:
+        return len(_get_active_mock().calls)
+
+    def __getitem__(self, index: int) -> _Call:
+        return _get_active_mock().calls[index]
+
+    def __iter__(self) -> Iterator[_Call]:
+        return iter(_get_active_mock().calls)
+
+
+class _RegisteredResponse:
+    def __init__(self, method: str, url: str, **kwargs: Any):
+        self.method = method.upper()
+        self.url = requests.Request(method=self.method, url=url).prepare().url
+        self.status_code = kwargs.pop("status", kwargs.pop("status_code", 200))
+        self.json_body = kwargs.pop("json", None)
+        self.body = kwargs.pop("body", None)
+        self.headers = kwargs.pop("headers", None) or {}
+        if kwargs:
+            raise TypeError(f"Unsupported responses kwargs: {sorted(kwargs)}")
+
+
+class RequestsMock:
+    def __init__(self) -> None:
+        self._registered: list[_RegisteredResponse] = []
+        self.calls: list[_Call] = []
+        self._patcher: patch | None = None
+
+    def __enter__(self) -> "RequestsMock":
+        _ACTIVE_MOCKS.append(self)
+        self._patcher = patch.object(
+            requests.sessions.Session,
+            "request",
+            new=self._request,
+        )
+        self._patcher.start()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if self._patcher is not None:
+            self._patcher.stop()
+        _ACTIVE_MOCKS.pop()
+
+    def add(self, method: str, url: str, **kwargs: Any) -> None:
+        self._registered.append(_RegisteredResponse(method, url, **kwargs))
+
+    def register_uri(self, method: str, url: str, **kwargs: Any) -> None:
+        self.add(method, url, **kwargs)
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> requests.Response:
+        request = requests.Request(
+            method=method,
+            url=url,
+            headers=kwargs.get("headers"),
+            params=kwargs.get("params"),
+            data=kwargs.get("data"),
+            json=kwargs.get("json"),
+        ).prepare()
+
+        registered = self._match(request.method, request.url)
+        self.calls.append(_Call(request))
+
+        response = requests.Response()
+        response.status_code = registered.status_code
+        response.request = request
+        response.url = request.url
+        response.headers.update(registered.headers)
+
+        if registered.json_body is not None:
+            response.headers.setdefault("Content-Type", "application/json")
+            response._content = json.dumps(registered.json_body).encode("utf-8")
+        elif registered.body is not None:
+            body = registered.body
+            response._content = body if isinstance(body, bytes) else str(body).encode("utf-8")
+        else:
+            response._content = b""
+
+        return response
+
+    def _match(self, method: str, url: str) -> _RegisteredResponse:
+        for registered in self._registered:
+            if registered.method == method.upper() and registered.url == url:
+                return registered
+        raise AssertionError(f"No mocked response for {method} {url}")
+
+
+_ACTIVE_MOCKS: list[RequestsMock] = []
+calls = _Calls()
+
+
+def _get_active_mock() -> RequestsMock:
+    if not _ACTIVE_MOCKS:
+        raise RuntimeError("responses mock is not active")
+    return _ACTIVE_MOCKS[-1]
+
+
+def add(method: str, url: str, **kwargs: Any) -> None:
+    _get_active_mock().add(method, url, **kwargs)
+
+
+def activate(func):
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        with RequestsMock():
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/responses.py
+++ b/responses.py
@@ -47,21 +47,21 @@ class RequestsMock:
     def __init__(self) -> None:
         self._registered: list[_RegisteredResponse] = []
         self.calls: list[_Call] = []
-        self._patcher: patch | None = None
+        self._patchers: list[patch] = []
 
     def __enter__(self) -> "RequestsMock":
         _ACTIVE_MOCKS.append(self)
-        self._patcher = patch.object(
-            requests.sessions.Session,
-            "request",
-            new=self._request,
-        )
-        self._patcher.start()
+        self._patchers = [
+            patch.object(requests.sessions.Session, "request", new=self._request),
+            patch.object(requests.sessions.Session, "send", new=self._send),
+        ]
+        for patcher in self._patchers:
+            patcher.start()
         return self
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        if self._patcher is not None:
-            self._patcher.stop()
+        while self._patchers:
+            self._patchers.pop().stop()
         _ACTIVE_MOCKS.pop()
 
     def add(self, method: str, url: str, **kwargs: Any) -> None:
@@ -85,6 +85,16 @@ class RequestsMock:
             json=kwargs.get("json"),
         ).prepare()
 
+        return self._build_response(request)
+
+    def _send(
+        self,
+        request: requests.PreparedRequest,
+        **kwargs: Any,
+    ) -> requests.Response:
+        return self._build_response(request)
+
+    def _build_response(self, request: requests.PreparedRequest) -> requests.Response:
         registered = self._match(request.method, request.url)
         self.calls.append(_Call(request))
 

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -6,9 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.caching.redis_cache import RedisCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
@@ -70,9 +68,7 @@ async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
 @patch("litellm._redis.get_redis_connection_pool")
 @patch("litellm._redis.get_redis_client")
 @patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
-def test_cache_init_creates_cluster_cache_from_env_var(
-    mock_health, mock_get_client, mock_get_pool, monkeypatch
-):
+def test_cache_init_creates_cluster_cache_from_env_var(mock_health, mock_get_client, mock_get_pool, monkeypatch):
     """
     Test that Cache() creates RedisClusterCache when REDIS_CLUSTER_NODES env var is set.
 
@@ -150,9 +146,7 @@ def test_cache_init_creates_redis_cache_without_cluster_config(
         ),
     ],
 )
-def test_router_create_redis_cache_cluster_detection(
-    startup_nodes, env_var, expected_cache_type, monkeypatch
-):
+def test_router_create_redis_cache_cluster_detection(startup_nodes, env_var, expected_cache_type, monkeypatch):
     """
     Test that Router._create_redis_cache() creates RedisClusterCache when
     either startup_nodes is in config or REDIS_CLUSTER_NODES env var is set.
@@ -161,6 +155,10 @@ def test_router_create_redis_cache_cluster_detection(
     Regression test for https://github.com/BerriAI/litellm/issues/22748
     """
     from litellm import Router
+    import litellm
+
+    litellm.secret_manager_client = None
+    litellm._key_management_settings = None
 
     cache_config = dict(
         host="mockhost",

--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -12,9 +12,10 @@ import os
 import sys
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+TEST_LITELLM_DIR = os.path.dirname(__file__)
+REPO_ROOT = os.path.abspath(os.path.join(TEST_LITELLM_DIR, "../.."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 import asyncio
 
 import litellm
@@ -34,29 +35,33 @@ def isolate_litellm_state():
     but adds overhead. Consider removing reload entirely if tests can work without it.
     """
     # Get worker ID if running with pytest-xdist
-    worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'master')
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
 
     # Store original callback state (all callback lists)
     original_state = {}
-    if hasattr(litellm, 'callbacks'):
-        original_state['callbacks'] = litellm.callbacks.copy() if litellm.callbacks else []
-    if hasattr(litellm, 'success_callback'):
-        original_state['success_callback'] = litellm.success_callback.copy() if litellm.success_callback else []
-    if hasattr(litellm, 'failure_callback'):
-        original_state['failure_callback'] = litellm.failure_callback.copy() if litellm.failure_callback else []
-    if hasattr(litellm, '_async_success_callback'):
-        original_state['_async_success_callback'] = litellm._async_success_callback.copy() if litellm._async_success_callback else []
-    if hasattr(litellm, '_async_failure_callback'):
-        original_state['_async_failure_callback'] = litellm._async_failure_callback.copy() if litellm._async_failure_callback else []
+    if hasattr(litellm, "callbacks"):
+        original_state["callbacks"] = litellm.callbacks.copy() if litellm.callbacks else []
+    if hasattr(litellm, "success_callback"):
+        original_state["success_callback"] = litellm.success_callback.copy() if litellm.success_callback else []
+    if hasattr(litellm, "failure_callback"):
+        original_state["failure_callback"] = litellm.failure_callback.copy() if litellm.failure_callback else []
+    if hasattr(litellm, "_async_success_callback"):
+        original_state["_async_success_callback"] = (
+            litellm._async_success_callback.copy() if litellm._async_success_callback else []
+        )
+    if hasattr(litellm, "_async_failure_callback"):
+        original_state["_async_failure_callback"] = (
+            litellm._async_failure_callback.copy() if litellm._async_failure_callback else []
+        )
 
     # Store routing globals — leaked model_fallbacks causes tests to route
     # through async_completion_with_fallbacks / Router, bypassing HTTP mocks
-    if hasattr(litellm, 'model_fallbacks'):
-        original_state['model_fallbacks'] = litellm.model_fallbacks
+    if hasattr(litellm, "model_fallbacks"):
+        original_state["model_fallbacks"] = litellm.model_fallbacks
 
     # Store transport/network globals — many tests set these without restoring,
     # causing subsequent tests to get None from _create_async_transport()
-    for _attr in ('disable_aiohttp_transport', 'force_ipv4'):
+    for _attr in ("disable_aiohttp_transport", "force_ipv4"):
         if hasattr(litellm, _attr):
             original_state[_attr] = getattr(litellm, _attr)
 
@@ -65,19 +70,19 @@ def isolate_litellm_state():
         litellm.in_memory_llm_clients_cache.flush_cache()
 
     # Clear all callback lists to prevent cross-test contamination
-    if hasattr(litellm, 'callbacks'):
+    if hasattr(litellm, "callbacks"):
         litellm.callbacks = []
-    if hasattr(litellm, 'success_callback'):
+    if hasattr(litellm, "success_callback"):
         litellm.success_callback = []
-    if hasattr(litellm, 'failure_callback'):
+    if hasattr(litellm, "failure_callback"):
         litellm.failure_callback = []
-    if hasattr(litellm, '_async_success_callback'):
+    if hasattr(litellm, "_async_success_callback"):
         litellm._async_success_callback = []
-    if hasattr(litellm, '_async_failure_callback'):
+    if hasattr(litellm, "_async_failure_callback"):
         litellm._async_failure_callback = []
 
     # Clear routing globals
-    if hasattr(litellm, 'model_fallbacks'):
+    if hasattr(litellm, "model_fallbacks"):
         litellm.model_fallbacks = None
 
     yield
@@ -100,14 +105,12 @@ def setup_and_teardown():
     Use this sparingly - most state should be handled by isolate_litellm_state.
     Only reload modules here if absolutely necessary.
     """
-    sys.path.insert(
-        0, os.path.abspath("../..")
-    )
+    sys.path.insert(0, os.path.abspath("../.."))
 
     import litellm
 
     # Only reload if NOT running in parallel (module reload + parallel = bad)
-    worker_id = os.environ.get('PYTEST_XDIST_WORKER', None)
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", None)
     if worker_id is None:
         # Single process mode - safe to reload
         importlib.reload(litellm)
@@ -115,6 +118,7 @@ def setup_and_teardown():
         try:
             if hasattr(litellm, "proxy") and hasattr(litellm.proxy, "proxy_server"):
                 import litellm.proxy.proxy_server
+
                 importlib.reload(litellm.proxy.proxy_server)
         except Exception as e:
             print(f"Error reloading litellm.proxy.proxy_server: {e}")
@@ -139,23 +143,15 @@ def pytest_collection_modifyitems(config, items):
     - Sort custom_logger tests first (they tend to interfere with other tests)
     """
     # Separate no_parallel tests
-    no_parallel_tests = [
-        item for item in items
-        if any(mark.name == "no_parallel" for mark in item.iter_markers())
-    ]
+    no_parallel_tests = [item for item in items if any(mark.name == "no_parallel" for mark in item.iter_markers())]
 
     # Separate custom_logger tests
     custom_logger_tests = [
-        item for item in items
-        if "custom_logger" in item.parent.name
-        and item not in no_parallel_tests
+        item for item in items if "custom_logger" in item.parent.name and item not in no_parallel_tests
     ]
 
     # Everything else
-    other_tests = [
-        item for item in items
-        if item not in no_parallel_tests and item not in custom_logger_tests
-    ]
+    other_tests = [item for item in items if item not in no_parallel_tests and item not in custom_logger_tests]
 
     # Sort each group
     custom_logger_tests.sort(key=lambda x: x.name)
@@ -171,12 +167,10 @@ def pytest_configure(config):
     Configure pytest with custom settings.
     """
     # Add marker for flaky tests (for documentation purposes)
-    config.addinivalue_line(
-        "markers", "flaky: mark test as potentially flaky (should use --reruns)"
-    )
+    config.addinivalue_line("markers", "flaky: mark test as potentially flaky (should use --reruns)")
 
     # Detect if running in CI
-    is_ci = os.environ.get('CI') == 'true' or os.environ.get('LITELLM_CI') == 'true'
+    is_ci = os.environ.get("CI") == "true" or os.environ.get("LITELLM_CI") == "true"
     if is_ci:
         print("[conftest] Running in CI mode - enabling stricter test isolation")
 

--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -58,6 +58,8 @@ def isolate_litellm_state():
     # through async_completion_with_fallbacks / Router, bypassing HTTP mocks
     if hasattr(litellm, "model_fallbacks"):
         original_state["model_fallbacks"] = litellm.model_fallbacks
+    if hasattr(litellm, "drop_params"):
+        original_state["drop_params"] = litellm.drop_params
 
     # Store transport/network globals — many tests set these without restoring,
     # causing subsequent tests to get None from _create_async_transport()
@@ -84,6 +86,8 @@ def isolate_litellm_state():
     # Clear routing globals
     if hasattr(litellm, "model_fallbacks"):
         litellm.model_fallbacks = None
+    if hasattr(litellm, "drop_params"):
+        litellm.drop_params = False
 
     yield
 

--- a/tests/test_litellm/integrations/gitlab/test_gitlab_prompt_manager.py
+++ b/tests/test_litellm/integrations/gitlab/test_gitlab_prompt_manager.py
@@ -87,7 +87,7 @@ def test_gitlab_client_missing_required_fields():
 # GitLabClient: get_file_content
 # -----------------------
 
-@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.get")
+@patch("litellm.integrations.gitlab.gitlab_client.HTTPHandler.get")
 def test_gitlab_client_get_file_content_raw_success(mock_get):
     """Successful file content retrieval via RAW endpoint."""
     mock_response = MagicMock()
@@ -104,7 +104,7 @@ def test_gitlab_client_get_file_content_raw_success(mock_get):
     mock_get.assert_called_once()
 
 
-@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.get")
+@patch("litellm.integrations.gitlab.gitlab_client.HTTPHandler.get")
 def test_gitlab_client_get_file_content_raw_404_fallback_json_base64(mock_get):
     """When RAW returns 404, fallback to JSON endpoint and decode base64 content."""
     import base64
@@ -136,7 +136,7 @@ def test_gitlab_client_get_file_content_raw_404_fallback_json_base64(mock_get):
     assert content == "json-content"
 
 
-@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.get")
+@patch("litellm.integrations.gitlab.gitlab_client.HTTPHandler.get")
 def test_gitlab_client_get_file_content_not_found(mock_get):
     """File not found returns None."""
     # Simulate RAW 404 and JSON 404
@@ -152,7 +152,7 @@ def test_gitlab_client_get_file_content_not_found(mock_get):
     assert content is None
 
 
-@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.get")
+@patch("litellm.integrations.gitlab.gitlab_client.HTTPHandler.get")
 def test_gitlab_client_get_file_content_access_denied(mock_get):
     """403 raises a helpful message."""
     import httpx
@@ -168,7 +168,7 @@ def test_gitlab_client_get_file_content_access_denied(mock_get):
         client.get_file_content("test.prompt")
 
 
-@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.get")
+@patch("litellm.integrations.gitlab.gitlab_client.HTTPHandler.get")
 def test_gitlab_client_get_file_content_auth_failed(mock_get):
     """401 raises auth error."""
     import httpx
@@ -186,7 +186,7 @@ def test_gitlab_client_get_file_content_auth_failed(mock_get):
 # GitLabClient: list_files
 # -----------------------
 
-@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.get")
+@patch("litellm.integrations.gitlab.gitlab_client.HTTPHandler.get")
 def test_gitlab_client_list_files_success(mock_get):
     """List .prompt files via repository tree API."""
     mock_response = MagicMock()

--- a/tests/test_litellm/interactions/google_interactions_openapi_snapshot.json
+++ b/tests/test_litellm/interactions/google_interactions_openapi_snapshot.json
@@ -1,0 +1,4399 @@
+{
+  "components": {
+    "parameters": {
+      "api_version": {
+        "description": "Which version of the API to use.",
+        "in": "path",
+        "name": "api_version",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "schemas": {
+      "AgentOption": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "const": "deep-research-pro-preview-12-2025",
+            "description": "Gemini Deep Research Agent",
+            "x-stainless-nominal": false
+          }
+        ],
+        "description": "The agent to interact with.",
+        "title": "Agent"
+      },
+      "AllowedTools": {
+        "description": "The configuration for allowed tools.",
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ToolChoiceType",
+            "description": "The mode of the tool choice."
+          },
+          "tools": {
+            "description": "The names of the allowed tools.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Annotation": {
+        "description": "Citation information for model-generated content.",
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UrlCitation"
+          },
+          {
+            "$ref": "#/components/schemas/FileCitation"
+          },
+          {
+            "$ref": "#/components/schemas/PlaceCitation"
+          }
+        ],
+        "type": "object"
+      },
+      "AudioContent": {
+        "description": "An audio content block.",
+        "examples": [
+          {
+            "audio": {
+              "summary": "Audio",
+              "value": {
+                "data": "BASE64_ENCODED_AUDIO",
+                "mime_type": "audio/wav",
+                "type": "audio"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "data": {
+            "description": "The audio content.",
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "description": "The mime type of the audio.",
+            "enum": [
+              "audio/wav",
+              "audio/mp3",
+              "audio/aiff",
+              "audio/aac",
+              "audio/ogg",
+              "audio/flac"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "WAV audio format",
+              "MP3 audio format",
+              "AIFF audio format",
+              "AAC audio format",
+              "OGG audio format",
+              "FLAC audio format"
+            ]
+          },
+          "type": {
+            "const": "audio"
+          },
+          "uri": {
+            "description": "The URI of the audio.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "AudioDelta": {
+        "properties": {
+          "data": {
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "enum": [
+              "audio/wav",
+              "audio/mp3",
+              "audio/aiff",
+              "audio/aac",
+              "audio/ogg",
+              "audio/flac"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "WAV audio format",
+              "MP3 audio format",
+              "AIFF audio format",
+              "AAC audio format",
+              "OGG audio format",
+              "FLAC audio format"
+            ]
+          },
+          "type": {
+            "const": "audio"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "CodeExecution": {
+        "description": "A tool that can be used by the model to execute code.",
+        "properties": {
+          "type": {
+            "const": "code_execution",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "code_execution",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"code_execution\"\n    }],\n    \"input\": \"Calculate the first 10 Fibonacci numbers\"\n  }'\n"
+          },
+          {
+            "label": "code_execution",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\"type\": \"code_execution\"}],\n    input=\"Calculate the first 10 Fibonacci numbers\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "code_execution",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{ type: 'code_execution' }],\n    input: 'Calculate the first 10 Fibonacci numbers'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "CodeExecutionCallArguments": {
+        "description": "The arguments to pass to the code execution.",
+        "properties": {
+          "code": {
+            "description": "The code to be executed.",
+            "type": "string"
+          },
+          "language": {
+            "description": "Programming language of the `code`.",
+            "enum": [
+              "python"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Python >= 3.10, with numpy and simpy available."
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "CodeExecutionCallContent": {
+        "description": "Code execution content.",
+        "examples": [
+          {
+            "code_execution_call": {
+              "summary": "Code Execution Call",
+              "value": {
+                "arguments": {
+                  "code": "print('hello world')",
+                  "language": "python"
+                },
+                "id": "call_123456",
+                "type": "code_execution_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/CodeExecutionCallArguments",
+            "description": "The arguments to pass to the code execution."
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "code_execution_call"
+          }
+        },
+        "required": [
+          "id",
+          "arguments",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CodeExecutionCallDelta": {
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/CodeExecutionCallArguments"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "code_execution_call"
+          }
+        },
+        "required": [
+          "id",
+          "arguments",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CodeExecutionResultContent": {
+        "description": "Code execution result content.",
+        "examples": [
+          {
+            "code_execution_result": {
+              "summary": "Code Execution Result",
+              "value": {
+                "call_id": "call_123456",
+                "result": "hello world",
+                "type": "code_execution_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the code execution call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the code execution resulted in an error.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "The output of the code execution.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "code_execution_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CodeExecutionResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "result": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "code_execution_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ComputerUse": {
+        "description": "A tool that can be used by the model to interact with the computer.",
+        "properties": {
+          "environment": {
+            "description": "The environment being operated.",
+            "enum": [
+              "browser"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Operates in a web browser."
+            ]
+          },
+          "excludedPredefinedFunctions": {
+            "description": "The list of predefined functions that are excluded from the model call.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": {
+            "const": "computer_use",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "computer_use",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-2.5-computer-use-preview-10-2025\",\n    \"tools\": [{\n      \"type\": \"computer_use\",\n    }],\n    \"input\": \"Find a flight to Tokyo\"\n  }'\n"
+          },
+          {
+            "label": "computer_use",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-2.5-computer-use-preview-10-2025\",\n    tools=[{\"type\": \"computer_use\"}],\n    input=\"Find a flight to Tokyo\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "computer_use",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-2.5-computer-use-preview-10-2025',\n    tools: [{ type: 'computer_use'}],\n    input: 'Find a flight to Tokyo'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "Content": {
+        "description": "The content of the response.",
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TextContent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageContent"
+          },
+          {
+            "$ref": "#/components/schemas/AudioContent"
+          },
+          {
+            "$ref": "#/components/schemas/DocumentContent"
+          },
+          {
+            "$ref": "#/components/schemas/VideoContent"
+          },
+          {
+            "$ref": "#/components/schemas/ThoughtContent"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/FunctionResultContent"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecutionResultContent"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContextResultContent"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearchResultContent"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/McpServerToolResultContent"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearchResultContent"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsCallContent"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMapsResultContent"
+          }
+        ],
+        "type": "object"
+      },
+      "ContentDelta": {
+        "examples": [
+          {
+            "content_delta": {
+              "summary": "Content Delta",
+              "value": {
+                "delta": {
+                  "text": "Elara\u2019s life was a symphony of quiet moments. A librarian, she found solace in the hushed aisles, the scent of aged paper, and the predictable rhythm of her days. Her small apartment, meticulously ordered, reflected this internal calm, save",
+                  "type": "text"
+                },
+                "event_type": "content.delta",
+                "index": 1
+              }
+            }
+          }
+        ],
+        "properties": {
+          "delta": {
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TextDelta"
+              },
+              {
+                "$ref": "#/components/schemas/ImageDelta"
+              },
+              {
+                "$ref": "#/components/schemas/AudioDelta"
+              },
+              {
+                "$ref": "#/components/schemas/DocumentDelta"
+              },
+              {
+                "$ref": "#/components/schemas/VideoDelta"
+              },
+              {
+                "$ref": "#/components/schemas/ThoughtSummaryDelta"
+              },
+              {
+                "$ref": "#/components/schemas/ThoughtSignatureDelta"
+              },
+              {
+                "$ref": "#/components/schemas/FunctionCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/FunctionResultDelta"
+              },
+              {
+                "$ref": "#/components/schemas/CodeExecutionCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/CodeExecutionResultDelta"
+              },
+              {
+                "$ref": "#/components/schemas/UrlContextCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/UrlContextResultDelta"
+              },
+              {
+                "$ref": "#/components/schemas/GoogleSearchCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/GoogleSearchResultDelta"
+              },
+              {
+                "$ref": "#/components/schemas/McpServerToolCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/McpServerToolResultDelta"
+              },
+              {
+                "$ref": "#/components/schemas/FileSearchCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/FileSearchResultDelta"
+              },
+              {
+                "$ref": "#/components/schemas/GoogleMapsCallDelta"
+              },
+              {
+                "$ref": "#/components/schemas/GoogleMapsResultDelta"
+              }
+            ]
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "content.delta",
+            "type": "string"
+          },
+          "index": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_type",
+          "index",
+          "delta"
+        ],
+        "type": "object"
+      },
+      "ContentStart": {
+        "examples": [
+          {
+            "content_start": {
+              "summary": "Content Start",
+              "value": {
+                "content": {
+                  "type": "text"
+                },
+                "event_type": "content.start",
+                "index": 1
+              }
+            }
+          }
+        ],
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "content.start",
+            "type": "string"
+          },
+          "index": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_type",
+          "index",
+          "content"
+        ],
+        "type": "object"
+      },
+      "ContentStop": {
+        "examples": [
+          {
+            "content_stop": {
+              "summary": "Content Stop",
+              "value": {
+                "event_type": "content.stop",
+                "index": 1
+              }
+            }
+          }
+        ],
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "content.stop",
+            "type": "string"
+          },
+          "index": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_type",
+          "index"
+        ],
+        "type": "object"
+      },
+      "CreateAgentInteractionParams": {
+        "description": "Parameters for creating agent interactions",
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentOption",
+            "description": "The name of the `Agent` used for generating the interaction."
+          },
+          "agent_config": {
+            "description": "Configuration parameters for the agent interaction.",
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DynamicAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DeepResearchAgentConfig"
+              }
+            ]
+          },
+          "background": {
+            "description": "Input only. Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "input": {
+            "$ref": "#/components/schemas/InteractionsInput"
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            },
+            "readOnly": true,
+            "type": "array"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field."
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "items": {
+              "$ref": "#/components/schemas/ResponseModality"
+            },
+            "type": "array"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The status of the interaction.",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ],
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ]
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array"
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/Usage",
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "agent",
+          "input"
+        ]
+      },
+      "CreateModelInteractionParams": {
+        "description": "Parameters for creating model interactions",
+        "properties": {
+          "background": {
+            "description": "Input only. Whether to run the model interaction in the background.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "generation_config": {
+            "$ref": "#/components/schemas/GenerationConfig",
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "writeOnly": true
+          },
+          "id": {
+            "description": "Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "input": {
+            "$ref": "#/components/schemas/InteractionsInput"
+          },
+          "model": {
+            "$ref": "#/components/schemas/ModelOption",
+            "description": "The name of the `Model` used for generating the interaction."
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            },
+            "readOnly": true,
+            "type": "array"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field."
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "items": {
+              "$ref": "#/components/schemas/ResponseModality"
+            },
+            "type": "array"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The status of the interaction.",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ],
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ]
+          },
+          "store": {
+            "description": "Input only. Whether to store the response and request for later retrieval.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "stream": {
+            "description": "Input only. Whether the interaction will be streamed.",
+            "type": "boolean",
+            "writeOnly": true
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array"
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/Usage",
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "model",
+          "input"
+        ]
+      },
+      "DeepResearchAgentConfig": {
+        "description": "Configuration for the Deep Research agent.",
+        "properties": {
+          "thinking_summaries": {
+            "$ref": "#/components/schemas/ThinkingSummaries",
+            "description": "Whether to include thought summaries in the response."
+          },
+          "type": {
+            "const": "deep-research"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "DocumentContent": {
+        "description": "A document content block.",
+        "examples": [
+          {
+            "document": {
+              "summary": "Document",
+              "value": {
+                "data": "BASE64_ENCODED_DOCUMENT",
+                "mime_type": "application/pdf",
+                "type": "document"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "data": {
+            "description": "The document content.",
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "description": "The mime type of the document.",
+            "enum": [
+              "application/pdf"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "PDF document format"
+            ]
+          },
+          "type": {
+            "const": "document"
+          },
+          "uri": {
+            "description": "The URI of the document.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "DocumentDelta": {
+        "properties": {
+          "data": {
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "enum": [
+              "application/pdf"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "PDF document format"
+            ]
+          },
+          "type": {
+            "const": "document"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "DynamicAgentConfig": {
+        "additionalProperties": {
+          "description": "Additional properties for the dynamic agent."
+        },
+        "description": "Configuration for dynamic agents.",
+        "properties": {
+          "type": {
+            "const": "dynamic"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Error": {
+        "description": "Error message from an interaction.",
+        "properties": {
+          "code": {
+            "description": "A URI that identifies the error type.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable error message.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorEvent": {
+        "examples": [
+          {
+            "error_event": {
+              "summary": "Error Event",
+              "value": {
+                "error": {
+                  "code": "not_found",
+                  "message": "Failed to get completed interaction: Result not found."
+                },
+                "event_type": "error"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Error"
+          },
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "error",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_type"
+        ],
+        "type": "object"
+      },
+      "FileCitation": {
+        "description": "A file citation annotation.",
+        "properties": {
+          "document_uri": {
+            "description": "The URI of the file.",
+            "type": "string"
+          },
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "file_name": {
+            "description": "The name of the file.",
+            "type": "string"
+          },
+          "source": {
+            "description": "Source attributed for a portion of the text.",
+            "type": "string"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "const": "file_citation",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "FileSearch": {
+        "description": "A tool that can be used by the model to search files.",
+        "properties": {
+          "file_search_store_names": {
+            "description": "The file search store names to search.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "metadata_filter": {
+            "description": "Metadata filter to apply to the semantic retrieval documents and chunks.",
+            "type": "string"
+          },
+          "top_k": {
+            "description": "The number of semantic retrieval chunks to retrieve.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "const": "file_search",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "file_search",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"file_search\",\n      \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    \"input\": \"Who is the author of the book?\"\n  }'\n"
+          },
+          {
+            "label": "file_search",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"file_search\",\n        \"file_search_store_names\": [\"fileSearchStores/m64d1sevsr4y-xfyawui3fxqg\"]\n    }],\n    input=\"Who is the author of the book?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "file_search",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'file_search',\n        file_search_store_names: ['fileSearchStores/m64d1sevsr4y-xfyawui3fxqg']\n    }],\n    input: 'Who is the author of the book?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "FileSearchCallContent": {
+        "description": "File Search content.",
+        "examples": [
+          {
+            "file_search_call": {
+              "summary": "File Search Call",
+              "value": {
+                "id": "call_123456",
+                "type": "file_search_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "file_search_call"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "FileSearchCallDelta": {
+        "properties": {
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "file_search_call"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "FileSearchResult": {
+        "description": "The result of the File Search.",
+        "type": "object"
+      },
+      "FileSearchResultContent": {
+        "description": "File Search result content.",
+        "examples": [
+          {
+            "file_search_result": {
+              "summary": "File Search Result",
+              "value": {
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "file_search_store": "file_search_store",
+                    "text": "search result chunk"
+                  }
+                ],
+                "type": "file_search_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the file search call block.",
+            "type": "string"
+          },
+          "result": {
+            "description": "The results of the File Search.",
+            "items": {
+              "$ref": "#/components/schemas/FileSearchResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "file_search_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id"
+        ],
+        "type": "object"
+      },
+      "FileSearchResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/FileSearchResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "file_search_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id"
+        ],
+        "type": "object"
+      },
+      "Function": {
+        "description": "A tool that can be used by the model.",
+        "properties": {
+          "description": {
+            "description": "A description of the function.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the function.",
+            "type": "string"
+          },
+          "parameters": {
+            "description": "The JSON Schema for the function's parameters."
+          },
+          "type": {
+            "const": "function",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "function_calling",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"function\",\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\"\n          }\n        },\n        \"required\": [\"location\"]\n      }\n    }],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "FunctionCallContent": {
+        "description": "A function tool call content block.",
+        "examples": [
+          {
+            "function_call": {
+              "summary": "Function Call",
+              "value": {
+                "arguments": {
+                  "location": "Boston, MA"
+                },
+                "id": "gth23981",
+                "name": "get_weather",
+                "type": "function_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "arguments": {
+            "additionalProperties": {
+              "description": "Properties of the object."
+            },
+            "description": "The arguments to pass to the function.",
+            "type": "object"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the tool to call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "function_call"
+          }
+        },
+        "required": [
+          "name",
+          "id",
+          "arguments",
+          "type"
+        ],
+        "type": "object"
+      },
+      "FunctionCallDelta": {
+        "properties": {
+          "arguments": {
+            "additionalProperties": {
+              "description": "Properties of the object."
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "function_call"
+          }
+        },
+        "required": [
+          "name",
+          "id",
+          "arguments",
+          "type"
+        ],
+        "type": "object"
+      },
+      "FunctionResultContent": {
+        "description": "A function tool result content block.",
+        "examples": [
+          {
+            "function_result": {
+              "summary": "Function Result",
+              "value": {
+                "call_id": "gth23981",
+                "name": "get_weather",
+                "result": [
+                  {
+                    "text": "{\"weather\":\"sunny\"}",
+                    "type": "text"
+                  }
+                ],
+                "type": "function_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the tool call resulted in an error.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The name of the tool that was called.",
+            "type": "string"
+          },
+          "result": {
+            "description": "The result of the tool call.",
+            "oneOf": [
+              {
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/FunctionResultSubcontent"
+                },
+                "title": "FunctionResultSubcontentList",
+                "type": "array"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "function_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "type": "object"
+      },
+      "FunctionResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "result": {
+            "description": "Tool call result delta.",
+            "oneOf": [
+              {
+                "properties": {
+                  "items": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/TextContent"
+                        },
+                        {
+                          "$ref": "#/components/schemas/ImageContent"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "function_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "type": "object"
+      },
+      "FunctionResultSubcontent": {
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TextContent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageContent"
+          }
+        ],
+        "type": "object"
+      },
+      "GenerationConfig": {
+        "description": "Configuration parameters for model interactions.",
+        "properties": {
+          "image_config": {
+            "$ref": "#/components/schemas/ImageConfig",
+            "description": "Configuration for image interaction."
+          },
+          "max_output_tokens": {
+            "description": "The maximum number of tokens to include in the response.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "seed": {
+            "description": "Seed used in decoding for reproducibility.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "speech_config": {
+            "description": "Configuration for speech interaction.",
+            "items": {
+              "$ref": "#/components/schemas/SpeechConfig"
+            },
+            "type": "array"
+          },
+          "stop_sequences": {
+            "description": "A list of character sequences that will stop output interaction.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "temperature": {
+            "description": "Controls the randomness of the output.",
+            "format": "float",
+            "type": "number"
+          },
+          "thinking_level": {
+            "$ref": "#/components/schemas/ThinkingLevel",
+            "description": "The level of thought tokens that the model should generate."
+          },
+          "thinking_summaries": {
+            "$ref": "#/components/schemas/ThinkingSummaries",
+            "description": "Whether to include thought summaries in the response."
+          },
+          "tool_choice": {
+            "description": "The tool choice for the interaction.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ToolChoiceType"
+              },
+              {
+                "$ref": "#/components/schemas/ToolChoiceConfig"
+              }
+            ]
+          },
+          "top_p": {
+            "description": "The maximum cumulative probability of tokens to consider when sampling.",
+            "format": "float",
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "GoogleMaps": {
+        "description": "A tool that can be used by the model to call Google Maps.",
+        "properties": {
+          "enable_widget": {
+            "description": "Whether to return a widget context token in the tool call result of the\nresponse.",
+            "type": "boolean"
+          },
+          "latitude": {
+            "description": "The latitude of the user's location.",
+            "format": "double",
+            "type": "number"
+          },
+          "longitude": {
+            "description": "The longitude of the user's location.",
+            "format": "double",
+            "type": "number"
+          },
+          "type": {
+            "const": "google_maps",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "google_maps",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"google_maps\",\n      \"latitude\": 37.7749,\n      \"longitude\": -122.4194\n    }],\n    \"input\": \"What is the best food near me?\"\n  }'\n"
+          },
+          {
+            "label": "google_maps",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"google_maps\",\n        \"latitude\": 37.7749,\n        \"longitude\": -122.4194\n    }],\n    input=\"What is the best food near me?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "google_maps",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'google_maps',\n        latitude: 37.7749,\n        longitude: -122.4194\n    }],\n    input: 'What is the best food near me?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "GoogleMapsCallArguments": {
+        "description": "The arguments to pass to the Google Maps tool.",
+        "properties": {
+          "queries": {
+            "description": "The queries to be executed.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "GoogleMapsCallContent": {
+        "description": "Google Maps content.",
+        "examples": [
+          {
+            "google_maps_call": {
+              "summary": "Google Maps Call",
+              "value": {
+                "arguments": {
+                  "query": "best food near me"
+                },
+                "id": "call_123456",
+                "type": "google_maps_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/GoogleMapsCallArguments",
+            "description": "The arguments to pass to the Google Maps tool."
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_maps_call"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "GoogleMapsCallDelta": {
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/GoogleMapsCallArguments",
+            "description": "The arguments to pass to the Google Maps tool."
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_maps_call"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "GoogleMapsResult": {
+        "description": "The result of the Google Maps.",
+        "properties": {
+          "places": {
+            "description": "The places that were found.",
+            "items": {
+              "$ref": "#/components/schemas/Places"
+            },
+            "type": "array"
+          },
+          "widget_context_token": {
+            "description": "Resource name of the Google Maps widget context token.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "GoogleMapsResultContent": {
+        "description": "Google Maps result content.",
+        "examples": [
+          {
+            "google_maps_result": {
+              "summary": "Google Maps Result",
+              "value": {
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "places": [
+                      {
+                        "name": "Tasty Restaurant",
+                        "url": "https://www.google.com/maps/search/best+food+near+me"
+                      }
+                    ]
+                  }
+                ],
+                "type": "google_maps_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the google maps call block.",
+            "type": "string"
+          },
+          "result": {
+            "description": "The results of the Google Maps.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleMapsResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_maps_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "result"
+        ],
+        "type": "object"
+      },
+      "GoogleMapsResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "result": {
+            "description": "The results of the Google Maps.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleMapsResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_maps_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "result"
+        ],
+        "type": "object"
+      },
+      "GoogleSearch": {
+        "description": "A tool that can be used by the model to search Google.",
+        "properties": {
+          "search_types": {
+            "description": "The types of search grounding to enable.",
+            "items": {
+              "enum": [
+                "web_search",
+                "image_search"
+              ],
+              "type": "string",
+              "x-google-enum-descriptions": [
+                "Setting this field enables web search. Only text results are returned.",
+                "Setting this field enables image search. Image bytes are returned."
+              ]
+            },
+            "type": "array"
+          },
+          "type": {
+            "const": "google_search",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "google_search",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"google_search\"\n    }],\n    \"input\": \"Who is the current president of France?\"\n  }'\n"
+          },
+          {
+            "label": "google_search",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\"type\": \"google_search\"}],\n    input=\"Who is the current president of France?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "google_search",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{ type: 'google_search' }],\n    input: 'Who is the current president of France?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "GoogleSearchCallArguments": {
+        "description": "The arguments to pass to Google Search.",
+        "properties": {
+          "queries": {
+            "description": "Web search queries for the following-up web search.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "GoogleSearchCallContent": {
+        "description": "Google Search content.",
+        "examples": [
+          {
+            "google_search_call": {
+              "summary": "Google Search Call",
+              "value": {
+                "arguments": {
+                  "queries": [
+                    "weather in Boston"
+                  ]
+                },
+                "id": "call_123456",
+                "type": "google_search_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/GoogleSearchCallArguments",
+            "description": "The arguments to pass to Google Search."
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "search_type": {
+            "description": "The type of search grounding enabled.",
+            "enum": [
+              "web_search",
+              "image_search"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Setting this field enables web search. Only text results are returned.",
+              "Setting this field enables image search. Image bytes are returned."
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_search_call"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "arguments"
+        ],
+        "type": "object"
+      },
+      "GoogleSearchCallDelta": {
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/GoogleSearchCallArguments"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_search_call"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "arguments"
+        ],
+        "type": "object"
+      },
+      "GoogleSearchResult": {
+        "description": "The result of the Google Search.",
+        "properties": {
+          "search_suggestions": {
+            "description": "Web content snippet that can be embedded in a web page or an app webview.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "GoogleSearchResultContent": {
+        "description": "Google Search result content.",
+        "examples": [
+          {
+            "google_search_result": {
+              "summary": "Google Search Result",
+              "value": {
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "title": "Weather in Boston",
+                    "url": "https://www.google.com/search?q=weather+in+Boston"
+                  }
+                ],
+                "type": "google_search_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the google search call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the Google Search resulted in an error.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "The results of the Google Search.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleSearchResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_search_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "result"
+        ],
+        "type": "object"
+      },
+      "GoogleSearchResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/GoogleSearchResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "google_search_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "result"
+        ],
+        "type": "object"
+      },
+      "ImageConfig": {
+        "description": "The configuration for image interaction.",
+        "properties": {
+          "aspect_ratio": {
+            "enum": [
+              "1:1",
+              "2:3",
+              "3:2",
+              "3:4",
+              "4:3",
+              "4:5",
+              "5:4",
+              "9:16",
+              "16:9",
+              "21:9",
+              "1:8",
+              "8:1",
+              "1:4",
+              "4:1"
+            ],
+            "x-google-enum-descriptions": [
+              "1:1 aspect ratio.",
+              "2:3 aspect ratio.",
+              "3:2 aspect ratio.",
+              "3:4 aspect ratio.",
+              "4:3 aspect ratio.",
+              "4:5 aspect ratio.",
+              "5:4 aspect ratio.",
+              "9:16 aspect ratio.",
+              "16:9 aspect ratio.",
+              "21:9 aspect ratio.",
+              "1:8 aspect ratio.",
+              "8:1 aspect ratio.",
+              "1:4 aspect ratio.",
+              "4:1 aspect ratio."
+            ]
+          },
+          "image_size": {
+            "enum": [
+              "1K",
+              "2K",
+              "4K",
+              "512"
+            ],
+            "x-google-enum-descriptions": [
+              "1K image size.",
+              "2K image size.",
+              "4K image size.",
+              "512 image size."
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ImageContent": {
+        "description": "An image content block.",
+        "examples": [
+          {
+            "image": {
+              "summary": "Image",
+              "value": {
+                "data": "BASE64_ENCODED_IMAGE",
+                "mime_type": "image/png",
+                "type": "image"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "data": {
+            "description": "The image content.",
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "description": "The mime type of the image.",
+            "enum": [
+              "image/png",
+              "image/jpeg",
+              "image/webp",
+              "image/heic",
+              "image/heif"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "PNG image format",
+              "JPEG image format",
+              "WebP image format",
+              "HEIC image format",
+              "HEIF image format"
+            ]
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/MediaResolution",
+            "description": "The resolution of the media."
+          },
+          "type": {
+            "const": "image"
+          },
+          "uri": {
+            "description": "The URI of the image.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ImageDelta": {
+        "properties": {
+          "data": {
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "enum": [
+              "image/png",
+              "image/jpeg",
+              "image/webp",
+              "image/heic",
+              "image/heif"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "PNG image format",
+              "JPEG image format",
+              "WebP image format",
+              "HEIC image format",
+              "HEIF image format"
+            ]
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/MediaResolution",
+            "description": "The resolution of the media."
+          },
+          "type": {
+            "const": "image"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Interaction": {
+        "description": "The Interaction resource.",
+        "example": {
+          "created": "2025-12-04T15:01:45Z",
+          "id": "v1_ChdXS0l4YWZXTk9xbk0xZThQczhEcmlROBIXV0tJeGFmV05PcW5NMWU4UHM4RHJpUTg",
+          "model": "gemini-3-flash-preview",
+          "object": "interaction",
+          "outputs": [
+            {
+              "text": "Hello! I'm doing well, functioning as expected. Thank you for asking! How are you doing today?",
+              "type": "text"
+            }
+          ],
+          "role": "model",
+          "status": "completed",
+          "updated": "2025-12-04T15:01:45Z",
+          "usage": {
+            "input_tokens_by_modality": [
+              {
+                "modality": "text",
+                "tokens": 7
+              }
+            ],
+            "total_cached_tokens": 0,
+            "total_input_tokens": 7,
+            "total_output_tokens": 23,
+            "total_thought_tokens": 49,
+            "total_tokens": 79,
+            "total_tool_use_tokens": 0
+          }
+        },
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/AgentOption",
+            "description": "The name of the `Agent` used for generating the interaction."
+          },
+          "agent_config": {
+            "description": "Configuration parameters for the agent interaction.",
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DynamicAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DeepResearchAgentConfig"
+              }
+            ]
+          },
+          "created": {
+            "description": "Output only. The time at which the response was created in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "generation_config": {
+            "$ref": "#/components/schemas/GenerationConfig",
+            "description": "Input only. Configuration parameters for the model interaction.",
+            "writeOnly": true
+          },
+          "id": {
+            "description": "Output only. A unique identifier for the interaction completion.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "input": {
+            "$ref": "#/components/schemas/InteractionsInput"
+          },
+          "model": {
+            "$ref": "#/components/schemas/ModelOption",
+            "description": "The name of the `Model` used for generating the interaction."
+          },
+          "outputs": {
+            "description": "Output only. Responses from the model.",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            },
+            "readOnly": true,
+            "type": "array"
+          },
+          "previous_interaction_id": {
+            "description": "The ID of the previous interaction, if any.",
+            "type": "string"
+          },
+          "response_format": {
+            "description": "Enforces that the generated response is a JSON object that complies with\nthe JSON schema specified in this field."
+          },
+          "response_mime_type": {
+            "description": "The mime type of the response. This is required if response_format is set.",
+            "type": "string"
+          },
+          "response_modalities": {
+            "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
+            "items": {
+              "$ref": "#/components/schemas/ResponseModality"
+            },
+            "type": "array"
+          },
+          "role": {
+            "description": "Output only. The role of the interaction.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Output only. The status of the interaction.",
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ],
+            "readOnly": true,
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ]
+          },
+          "system_instruction": {
+            "description": "System instruction for the interaction.",
+            "type": "string"
+          },
+          "tools": {
+            "description": "A list of tool declarations the model may call during interaction.",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array"
+          },
+          "updated": {
+            "description": "Output only. The time at which the response was last updated in ISO 8601 format\n(YYYY-MM-DDThh:mm:ssZ).",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/Usage",
+            "description": "Output only. Statistics on the interaction request's token usage.",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "created",
+          "updated"
+        ]
+      },
+      "InteractionCompleteEvent": {
+        "examples": [
+          {
+            "interaction_complete": {
+              "summary": "Interaction Complete",
+              "value": {
+                "event_type": "interaction.complete",
+                "interaction": {
+                  "created": "2025-12-09T18:45:40Z",
+                  "id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                  "model": "gemini-3-flash-preview",
+                  "object": "interaction",
+                  "role": "model",
+                  "status": "completed",
+                  "updated": "2025-12-09T18:45:40Z",
+                  "usage": {
+                    "input_tokens_by_modality": [
+                      {
+                        "modality": "text",
+                        "tokens": 11
+                      }
+                    ],
+                    "total_cached_tokens": 0,
+                    "total_input_tokens": 11,
+                    "total_output_tokens": 364,
+                    "total_thought_tokens": 1120,
+                    "total_tokens": 1495,
+                    "total_tool_use_tokens": 0
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "enum": [
+              "interaction.complete"
+            ],
+            "type": "string"
+          },
+          "interaction": {
+            "$ref": "#/components/schemas/Interaction",
+            "description": "The completed interaction with empty outputs to reduce the payload size.\nUse the preceding ContentDelta events for the actual output."
+          }
+        },
+        "required": [
+          "event_type",
+          "interaction"
+        ],
+        "type": "object"
+      },
+      "InteractionSseEvent": {
+        "discriminator": {
+          "propertyName": "event_type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InteractionStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/InteractionCompleteEvent"
+          },
+          {
+            "$ref": "#/components/schemas/InteractionStatusUpdate"
+          },
+          {
+            "$ref": "#/components/schemas/ContentStart"
+          },
+          {
+            "$ref": "#/components/schemas/ContentDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ContentStop"
+          },
+          {
+            "$ref": "#/components/schemas/ErrorEvent"
+          }
+        ],
+        "type": "object"
+      },
+      "InteractionStartEvent": {
+        "examples": [
+          {
+            "interaction_start": {
+              "summary": "Interaction Start",
+              "value": {
+                "event_type": "interaction.start",
+                "interaction": {
+                  "id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                  "model": "gemini-3-flash-preview",
+                  "object": "interaction",
+                  "status": "in_progress"
+                }
+              }
+            }
+          }
+        ],
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "enum": [
+              "interaction.start"
+            ],
+            "type": "string"
+          },
+          "interaction": {
+            "$ref": "#/components/schemas/Interaction"
+          }
+        },
+        "required": [
+          "event_type",
+          "interaction"
+        ],
+        "type": "object"
+      },
+      "InteractionStatusUpdate": {
+        "examples": [
+          {
+            "interaction_status_update": {
+              "summary": "Interaction Status Update",
+              "value": {
+                "event_type": "interaction.status_update",
+                "interaction_id": "v1_ChdTMjQ0YWJ5TUF1TzcxZThQdjRpcnFRcxIXUzI0NGFieU1BdU83MWU4UHY0aXJxUXM",
+                "status": "in_progress"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "event_id": {
+            "description": "The event_id token to be used to resume the interaction stream, from this event.",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "interaction.status_update",
+            "type": "string"
+          },
+          "interaction_id": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "in_progress",
+              "requires_action",
+              "completed",
+              "failed",
+              "cancelled",
+              "incomplete"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The interaction is in progress.",
+              "The interaction requires action.",
+              "The interaction is completed.",
+              "The interaction is failed.",
+              "The interaction is cancelled.",
+              "The interaction is incomplete."
+            ]
+          }
+        },
+        "required": [
+          "event_type",
+          "interaction_id",
+          "status"
+        ],
+        "type": "object"
+      },
+      "InteractionsInput": {
+        "description": "The input for the interaction.",
+        "oneOf": [
+          {
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            },
+            "title": "ContentList",
+            "type": "array"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/components/schemas/Turn"
+            },
+            "title": "TurnList",
+            "type": "array"
+          },
+          {
+            "$ref": "#/components/schemas/Content"
+          }
+        ]
+      },
+      "McpServer": {
+        "description": "A MCPServer is a server that can be called by the model to perform actions.",
+        "properties": {
+          "allowed_tools": {
+            "description": "The allowed tools.",
+            "items": {
+              "$ref": "#/components/schemas/AllowedTools"
+            },
+            "type": "array"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Optional: Fields for authentication headers, timeouts, etc., if needed.",
+            "type": "object"
+          },
+          "name": {
+            "description": "The name of the MCPServer.",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server",
+            "type": "string"
+          },
+          "url": {
+            "description": "The full URL for the MCPServer endpoint.\nExample: \"https://api.example.com/mcp\"",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "mcp_server",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"mcp_server\",\n      \"name\": \"weather_service\",\n      \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    \"input\": \"Today is 12-05-2025, what is the temperature today in London?\"\n  }'\n"
+          },
+          {
+            "label": "mcp_server",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"mcp_server\",\n        \"name\": \"weather_service\",\n        \"url\": \"https://gemini-api-demos.uc.r.appspot.com/mcp\"\n    }],\n    input=\"Today is 12-05-2025, what is the temperature today in London?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "mcp_server",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'mcp_server',\n        name: 'weather_service',\n        url: 'https://gemini-api-demos.uc.r.appspot.com/mcp'\n    }],\n    input: 'Today is 12-05-2025, what is the temperature today in London?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "McpServerToolCallContent": {
+        "description": "MCPServer tool call content.",
+        "examples": [
+          {
+            "mcp_server_tool_call": {
+              "summary": "Mcp Server Tool Call",
+              "value": {
+                "arguments": {
+                  "city": "London"
+                },
+                "id": "call_123456",
+                "name": "get_forecast",
+                "server_name": "weather_server",
+                "type": "mcp_server_tool_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "arguments": {
+            "additionalProperties": {
+              "description": "Properties of the object."
+            },
+            "description": "The JSON object of arguments for the function.",
+            "type": "object"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the tool which was called.",
+            "type": "string"
+          },
+          "server_name": {
+            "description": "The name of the used MCP server.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_call"
+          }
+        },
+        "required": [
+          "name",
+          "server_name",
+          "arguments",
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "McpServerToolCallDelta": {
+        "properties": {
+          "arguments": {
+            "additionalProperties": {
+              "description": "Properties of the object."
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "server_name": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_call"
+          }
+        },
+        "required": [
+          "name",
+          "server_name",
+          "arguments",
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "McpServerToolResultContent": {
+        "description": "MCPServer tool result content.",
+        "examples": [
+          {
+            "mcp_server_tool_result": {
+              "summary": "Mcp Server Tool Result",
+              "value": {
+                "call_id": "call_123456",
+                "name": "get_forecast",
+                "result": "sunny",
+                "server_name": "weather_server",
+                "type": "mcp_server_tool_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the MCP server tool call block.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the tool which is called for this specific tool call.",
+            "type": "string"
+          },
+          "result": {
+            "description": "The output from the MCP server call. Can be simple text or rich content.",
+            "oneOf": [
+              {
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/FunctionResultSubcontent"
+                },
+                "title": "FunctionResultSubcontentList",
+                "type": "array"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "server_name": {
+            "description": "The name of the used MCP server.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "type": "object"
+      },
+      "McpServerToolResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "result": {
+            "description": "Tool call result delta.",
+            "oneOf": [
+              {
+                "properties": {
+                  "items": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/TextContent"
+                        },
+                        {
+                          "$ref": "#/components/schemas/ImageContent"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "server_name": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_server_tool_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "result",
+          "type"
+        ],
+        "type": "object"
+      },
+      "MediaResolution": {
+        "enum": [
+          "low",
+          "medium",
+          "high",
+          "ultra_high"
+        ],
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Low resolution.",
+          "Medium resolution.",
+          "High resolution.",
+          "Ultra high resolution."
+        ]
+      },
+      "ModalityTokens": {
+        "description": "The token count for a single response modality.",
+        "properties": {
+          "modality": {
+            "$ref": "#/components/schemas/ResponseModality",
+            "description": "The modality associated with the token count."
+          },
+          "tokens": {
+            "description": "Number of tokens for the modality.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ModelOption": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "const": "gemini-2.5-flash",
+            "description": "Our first hybrid reasoning model which supports a 1M token context window and has thinking budgets.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-flash-image",
+            "description": "Our native image generation model, optimized for speed, flexibility, and contextual understanding. Text input and output is priced the same as 2.5 Flash.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-flash-lite",
+            "description": "Our smallest and most cost effective model, built for at scale usage.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-flash-lite-preview-09-2025",
+            "description": "The latest model based on Gemini 2.5 Flash lite optimized for cost-efficiency, high throughput and high quality.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-flash-native-audio-preview-12-2025",
+            "description": "Our native audio models optimized for higher quality audio outputs with better pacing, voice naturalness, verbosity, and mood.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-flash-preview-09-2025",
+            "description": "The latest model based on the 2.5 Flash model. 2.5 Flash Preview is best for large scale processing, low-latency, high volume tasks that require thinking, and agentic use cases.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-flash-preview-tts",
+            "description": "Our 2.5 Flash text-to-speech model optimized for powerful, low-latency controllable speech generation.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-pro",
+            "description": "Our state-of-the-art multipurpose model, which excels at coding and complex reasoning tasks.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-2.5-pro-preview-tts",
+            "description": "Our 2.5 Pro text-to-speech audio model optimized for powerful, low-latency speech generation for more natural outputs and easier to steer prompts.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-3-flash-preview",
+            "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-3-pro-image-preview",
+            "description": "State-of-the-art image generation and editing model.",
+            "x-stainless-nominal": "false`"
+          },
+          {
+            "const": "gemini-3-pro-preview",
+            "description": "Our most intelligent model with SOTA reasoning and multimodal understanding, and powerful agentic and vibe coding capabilities.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-3.1-pro-preview",
+            "description": "Our latest SOTA reasoning model with unprecedented depth and nuance, and powerful multimodal understanding and coding capabilities.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-3.1-flash-image-preview",
+            "description": "Pro-level visual intelligence with Flash-speed efficiency and reality-grounded generation capabilities.",
+            "x-stainless-nominal": false
+          }
+        ],
+        "description": "The model that will complete your prompt.\\n\\nSee [models](https://ai.google.dev/gemini-api/docs/models) for additional details.",
+        "title": "Model"
+      },
+      "PlaceCitation": {
+        "description": "A place citation annotation.",
+        "properties": {
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Title of the place.",
+            "type": "string"
+          },
+          "place_id": {
+            "description": "The ID of the place, in `places/{place_id}` format.",
+            "type": "string"
+          },
+          "review_snippets": {
+            "description": "Snippets of reviews that are used to generate answers about the\nfeatures of a given place in Google Maps.",
+            "items": {
+              "$ref": "#/components/schemas/ReviewSnippet"
+            },
+            "type": "array"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "const": "place_citation",
+            "type": "string"
+          },
+          "url": {
+            "description": "URI reference of the place.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Places": {
+        "properties": {
+          "name": {
+            "description": "Title of the place.",
+            "type": "string"
+          },
+          "place_id": {
+            "description": "The ID of the place, in `places/{place_id}` format.",
+            "type": "string"
+          },
+          "review_snippets": {
+            "description": "Snippets of reviews that are used to generate answers about the\nfeatures of a given place in Google Maps.",
+            "items": {
+              "$ref": "#/components/schemas/ReviewSnippet"
+            },
+            "type": "array"
+          },
+          "url": {
+            "description": "URI reference of the place.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ResponseModality": {
+        "enum": [
+          "text",
+          "image",
+          "audio"
+        ],
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Indicates the model should return text.",
+          "Indicates the model should return images.",
+          "Indicates the model should return audio."
+        ]
+      },
+      "ReviewSnippet": {
+        "description": "Encapsulates a snippet of a user review that answers a question about\nthe features of a specific place in Google Maps.",
+        "properties": {
+          "review_id": {
+            "description": "The ID of the review snippet.",
+            "type": "string"
+          },
+          "title": {
+            "description": "Title of the review.",
+            "type": "string"
+          },
+          "url": {
+            "description": "A link that corresponds to the user review on Google Maps.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SpeechConfig": {
+        "description": "The configuration for speech interaction.",
+        "properties": {
+          "language": {
+            "description": "The language of the speech.",
+            "type": "string"
+          },
+          "speaker": {
+            "description": "The speaker's name, it should match the speaker name given in the prompt.",
+            "type": "string"
+          },
+          "voice": {
+            "description": "The voice of the speaker.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TextContent": {
+        "description": "A text content block.",
+        "examples": [
+          {
+            "text": {
+              "summary": "Text",
+              "value": {
+                "text": "Hello, how are you?",
+                "type": "text"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "type": "array"
+          },
+          "text": {
+            "description": "The text content.",
+            "type": "string"
+          },
+          "type": {
+            "const": "text"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "TextDelta": {
+        "properties": {
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "type": "array"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "const": "text"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "ThinkingLevel": {
+        "enum": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Little to no thinking.",
+          "Low thinking level.",
+          "Medium thinking level.",
+          "High thinking level."
+        ]
+      },
+      "ThinkingSummaries": {
+        "enum": [
+          "auto",
+          "none"
+        ],
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Auto thinking summaries.",
+          "No thinking summaries."
+        ]
+      },
+      "ThoughtContent": {
+        "description": "A thought content block.",
+        "examples": [
+          {
+            "thought": {
+              "summary": "Thought",
+              "value": {
+                "signature": "CoMDAXLI2nynRYojJIy6B1Jh9os2crpWLfB0+19xcLsGG46bd8wjkF/6RNlRUdvHrXyjsHkG0BZFcuO/bPOyA6Xh5jANNgx82wPHjGExN8A4ZQn56FlMwyZoqFVQz0QyY1lfibFJ2zU3J87uw26OewzcuVX0KEcs+GIsZa3EA6WwqhbsOd3wtZB3Ua2Qf98VAWZTS5y/tWpql7jnU3/CU7pouxQr/Bwft3hwnJNesQ9/dDJTuaQ8Zprh9VRWf1aFFjpIueOjBRrlT3oW6/y/eRl/Gt9BQXCYTqg/38vHFUU4Wo/d9dUpvfCe/a3o97t2Jgxp34oFKcsVb4S5WJrykIkw+14DzVnTpCpbQNFckqvFLuqnJCkL0EQFtunBXI03FJpPu3T1XU6id8S7ojoJQZSauGUCgmaLqUGdMrd08oo81ecoJSLs51Re9N/lISGmjWFPGpqJLoGq6uo4FHz58hmeyXCgHG742BHz2P3MiH1CXHUT2J8mF6zLhf3SR9Qb3lkrobAh",
+                "summary": [
+                  {
+                    "text": "The user is asking about the weather. I should use the get_weather tool.",
+                    "type": "text"
+                  }
+                ],
+                "type": "thought"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "summary": {
+            "description": "A summary of the thought.",
+            "items": {
+              "$ref": "#/components/schemas/ThoughtSummaryContent"
+            },
+            "type": "array"
+          },
+          "type": {
+            "const": "thought"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ThoughtSignatureDelta": {
+        "properties": {
+          "signature": {
+            "description": "Signature to match the backend source to be part of the generation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "thought_signature"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ThoughtSummaryContent": {
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TextContent"
+          },
+          {
+            "$ref": "#/components/schemas/ImageContent"
+          }
+        ],
+        "type": "object"
+      },
+      "ThoughtSummaryDelta": {
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/ThoughtSummaryContent",
+            "description": "A new summary item to be added to the thought."
+          },
+          "type": {
+            "const": "thought_summary"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Tool": {
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Function"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleSearch"
+          },
+          {
+            "$ref": "#/components/schemas/CodeExecution"
+          },
+          {
+            "$ref": "#/components/schemas/UrlContext"
+          },
+          {
+            "$ref": "#/components/schemas/ComputerUse"
+          },
+          {
+            "$ref": "#/components/schemas/McpServer"
+          },
+          {
+            "$ref": "#/components/schemas/FileSearch"
+          },
+          {
+            "$ref": "#/components/schemas/GoogleMaps"
+          }
+        ],
+        "type": "object"
+      },
+      "ToolChoiceConfig": {
+        "description": "The tool choice configuration containing allowed tools.",
+        "properties": {
+          "allowed_tools": {
+            "$ref": "#/components/schemas/AllowedTools",
+            "description": "The allowed tools."
+          }
+        },
+        "type": "object"
+      },
+      "ToolChoiceType": {
+        "enum": [
+          "auto",
+          "any",
+          "none",
+          "validated"
+        ],
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Auto tool choice.",
+          "Any tool choice.",
+          "No tool choice.",
+          "Validated tool choice."
+        ]
+      },
+      "Turn": {
+        "examples": [
+          {
+            "user_turn": {
+              "summary": "User Turn",
+              "value": {
+                "content": [
+                  {
+                    "text": "user turn",
+                    "type": "text"
+                  }
+                ],
+                "role": "user"
+              }
+            }
+          },
+          {
+            "model_turn": {
+              "summary": "Model Turn",
+              "value": {
+                "content": [
+                  {
+                    "text": "model turn",
+                    "type": "text"
+                  }
+                ],
+                "role": "model"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "content": {
+            "description": "The content of the turn.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Content"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "role": {
+            "description": "The originator of this turn. Must be user for input or model for\nmodel output.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UrlCitation": {
+        "description": "A URL citation annotation.",
+        "properties": {
+          "end_index": {
+            "description": "End of the attributed segment, exclusive.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "start_index": {
+            "description": "Start of segment of the response that is attributed to this source.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "title": {
+            "description": "The title of the URL.",
+            "type": "string"
+          },
+          "type": {
+            "const": "url_citation",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "UrlContext": {
+        "description": "A tool that can be used by the model to fetch URL context.",
+        "properties": {
+          "type": {
+            "const": "url_context",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-codeSamples": [
+          {
+            "label": "url_context",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [{\n      \"type\": \"url_context\"\n    }],\n    \"input\": \"Summarize https://www.example.com\"\n  }'\n"
+          },
+          {
+            "label": "url_context",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\"type\": \"url_context\"}],\n    input=\"Summarize https://www.example.com\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "url_context",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{ type: 'url_context' }],\n    input: 'Summarize https://www.example.com'\n});\nconsole.log(interaction.outputs[0]);\n"
+          }
+        ]
+      },
+      "UrlContextCallArguments": {
+        "description": "The arguments to pass to the URL context.",
+        "properties": {
+          "urls": {
+            "description": "The URLs to fetch.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "UrlContextCallContent": {
+        "description": "URL context content.",
+        "examples": [
+          {
+            "url_context_call": {
+              "summary": "Url Context Call",
+              "value": {
+                "arguments": {
+                  "urls": [
+                    "https://www.example.com"
+                  ]
+                },
+                "id": "call_123456",
+                "type": "url_context_call"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/UrlContextCallArguments",
+            "description": "The arguments to pass to the URL context."
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "url_context_call"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "arguments"
+        ],
+        "type": "object"
+      },
+      "UrlContextCallDelta": {
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/UrlContextCallArguments"
+          },
+          "id": {
+            "description": "A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "url_context_call"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "arguments"
+        ],
+        "type": "object"
+      },
+      "UrlContextResult": {
+        "description": "The result of the URL context.",
+        "properties": {
+          "status": {
+            "description": "The status of the URL retrieval.",
+            "enum": [
+              "success",
+              "error",
+              "paywall",
+              "unsafe"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Url retrieval is successful.",
+              "Url retrieval is failed due to error.",
+              "Url retrieval is failed because the content is behind paywall.",
+              "Url retrieval is failed because the content is unsafe."
+            ]
+          },
+          "url": {
+            "description": "The URL that was fetched.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UrlContextResultContent": {
+        "description": "URL context result content.",
+        "examples": [
+          {
+            "url_context_result": {
+              "summary": "Url Context Result",
+              "value": {
+                "call_id": "call_123456",
+                "result": [
+                  {
+                    "status": "SUCCESS",
+                    "url": "https://www.example.com"
+                  }
+                ],
+                "type": "url_context_result"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the url context call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the URL context resulted in an error.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "The results of the URL context.",
+            "items": {
+              "$ref": "#/components/schemas/UrlContextResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "url_context_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "result"
+        ],
+        "type": "object"
+      },
+      "UrlContextResultDelta": {
+        "properties": {
+          "call_id": {
+            "description": "ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/UrlContextResult"
+            },
+            "type": "array"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string"
+          },
+          "type": {
+            "const": "url_context_result"
+          }
+        },
+        "required": [
+          "type",
+          "call_id",
+          "result"
+        ],
+        "type": "object"
+      },
+      "Usage": {
+        "description": "Statistics on the interaction request's token usage.",
+        "properties": {
+          "cached_tokens_by_modality": {
+            "description": "A breakdown of cached token usage by modality.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            },
+            "type": "array"
+          },
+          "input_tokens_by_modality": {
+            "description": "A breakdown of input token usage by modality.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            },
+            "type": "array"
+          },
+          "output_tokens_by_modality": {
+            "description": "A breakdown of output token usage by modality.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            },
+            "type": "array"
+          },
+          "tool_use_tokens_by_modality": {
+            "description": "A breakdown of tool-use token usage by modality.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokens"
+            },
+            "type": "array"
+          },
+          "total_cached_tokens": {
+            "description": "Number of tokens in the cached part of the prompt (the cached content).",
+            "format": "int32",
+            "type": "integer"
+          },
+          "total_input_tokens": {
+            "description": "Number of tokens in the prompt (context).",
+            "format": "int32",
+            "type": "integer"
+          },
+          "total_output_tokens": {
+            "description": "Total number of tokens across all the generated responses.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "total_thought_tokens": {
+            "description": "Number of tokens of thoughts for thinking models.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "total_tokens": {
+            "description": "Total token count for the interaction request (prompt + responses + other\ninternal tokens).",
+            "format": "int32",
+            "type": "integer"
+          },
+          "total_tool_use_tokens": {
+            "description": "Number of tokens present in tool-use prompt(s).",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "VideoContent": {
+        "description": "A video content block.",
+        "examples": [
+          {
+            "video": {
+              "summary": "Video",
+              "value": {
+                "type": "video",
+                "uri": "https://www.youtube.com/watch?v=9hE5-98ZeCg"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "data": {
+            "description": "The video content.",
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "description": "The mime type of the video.",
+            "enum": [
+              "video/mp4",
+              "video/mpeg",
+              "video/mpg",
+              "video/mov",
+              "video/avi",
+              "video/x-flv",
+              "video/webm",
+              "video/wmv",
+              "video/3gpp"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "MP4 video format",
+              "MPEG video format",
+              "MPG video format",
+              "MOV video format",
+              "AVI video format",
+              "FLV video format",
+              "WebM video format",
+              "WMV video format",
+              "3GPP video format"
+            ]
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/MediaResolution",
+            "description": "The resolution of the media."
+          },
+          "type": {
+            "const": "video"
+          },
+          "uri": {
+            "description": "The URI of the video.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "VideoDelta": {
+        "properties": {
+          "data": {
+            "format": "byte",
+            "type": "string"
+          },
+          "mime_type": {
+            "enum": [
+              "video/mp4",
+              "video/mpeg",
+              "video/mpg",
+              "video/mov",
+              "video/avi",
+              "video/x-flv",
+              "video/webm",
+              "video/wmv",
+              "video/3gpp"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "MP4 video format",
+              "MPEG video format",
+              "MPG video format",
+              "MOV video format",
+              "AVI video format",
+              "FLV video format",
+              "WebM video format",
+              "WMV video format",
+              "3GPP video format"
+            ]
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/MediaResolution",
+            "description": "The resolution of the media."
+          },
+          "type": {
+            "const": "video"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {}
+  },
+  "info": {
+    "description": "The Gemini Interactions API is an experimental API that allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+    "title": "Gemini API",
+    "version": "v1beta",
+    "x-google-revision": "0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/{api_version}/interactions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "post": {
+        "description": "Creates a new interaction.",
+        "operationId": "CreateInteraction",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateModelInteractionParams"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateAgentInteractionParams"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "The request body.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "deep_research": {
+                    "summary": "Deep Research",
+                    "value": {
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "Here is a comprehensive research report on the current state of cancer research...",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "agent",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 20
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 20,
+                        "total_output_tokens": 1000,
+                        "total_thought_tokens": 500,
+                        "total_tokens": 1520,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "function_calling": {
+                    "summary": "Function Calling",
+                    "value": {
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "arguments": {
+                            "location": "Boston, MA"
+                          },
+                          "id": "gth23981",
+                          "name": "get_weather",
+                          "type": "function_call"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "requires_action",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 100
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 100,
+                        "total_output_tokens": 25,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 125,
+                        "total_tool_use_tokens": 50
+                      }
+                    }
+                  },
+                  "multi_turn": {
+                    "summary": "Multi-turn",
+                    "value": {
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "The capital of France is Paris.",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 50
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 50,
+                        "total_output_tokens": 10,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 60,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "multimodal_image": {
+                    "summary": "Image Input",
+                    "value": {
+                      "created": "2025-11-26T12:22:47Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "A white humanoid robot with glowing blue eyes stands holding a red skateboard.",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:22:47Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 10
+                          },
+                          {
+                            "modality": "image",
+                            "tokens": 258
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 268,
+                        "total_output_tokens": 20,
+                        "total_thought_tokens": 0,
+                        "total_tokens": 288,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  },
+                  "simple": {
+                    "summary": "Simple Request",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "Hello! I'm functioning perfectly and ready to assist you.\n\nHow are you doing today?",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:25:15Z",
+                      "usage": {
+                        "input_tokens_by_modality": [
+                          {
+                            "modality": "text",
+                            "tokens": 7
+                          }
+                        ],
+                        "total_cached_tokens": 0,
+                        "total_input_tokens": 7,
+                        "total_output_tokens": 20,
+                        "total_thought_tokens": 22,
+                        "total_tokens": 49,
+                        "total_tool_use_tokens": 0
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              }
+            },
+            "description": "Successful operation"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Error creating interaction"
+          }
+        },
+        "security": [],
+        "summary": "Creating an interaction",
+        "x-codeSamples": [
+          {
+            "label": "simple",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"input\": \"Hello, how are you?\"\n  }'\n"
+          },
+          {
+            "label": "simple",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    input=\"Hello, how are you?\",\n)\nprint(interaction.outputs[-1].text)\n"
+          },
+          {
+            "label": "simple",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    input: 'Hello, how are you?',\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "label": "multi_turn",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"input\": [\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      },\n      {\n        \"role\": \"model\",\n        \"content\": \"Hi there! How can I help you today?\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"What is the capital of France?\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "label": "multi_turn",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    input=[\n        { \"role\": \"user\", \"content\": \"Hello!\" },\n        { \"role\": \"model\", \"content\": \"Hi there! How can I help you today?\" },\n        { \"role\": \"user\", \"content\": \"What is the capital of France?\" }\n    ]\n)\nprint(response.outputs[-1].text)\n"
+          },
+          {
+            "label": "multi_turn",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    input: [\n        { role: 'user', content: 'Hello' },\n        { role: 'model', content: 'Hi there! How can I help you today?' },\n        { role: 'user', content: 'What is the capital of France?' }\n    ]\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "label": "multimodal_image",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"input\": [\n      {\n        \"type\": \"text\",\n        \"text\": \"What is in this picture?\"\n      },\n      {\n        \"type\": \"image\",\n        \"data\": \"BASE64_ENCODED_IMAGE\",\n        \"mime_type\": \"image/png\"\n      }\n    ]\n  }'\n"
+          },
+          {
+            "label": "multimodal_image",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    input=[\n      { \"type\": \"text\", \"text\": \"What is in this picture?\" },\n      { \"type\": \"image\", \"data\": \"BASE64_ENCODED_IMAGE\", \"mime_type\": \"image/png\" }\n    ]\n)\nprint(response.outputs[-1].text)\n"
+          },
+          {
+            "label": "multimodal_image",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    input: [\n      { type: 'text', text: 'What is in this picture?' },\n      { type: 'image', data: 'BASE64_ENCODED_IMAGE', mime_type: 'image/png' }\n    ]\n});\nconsole.log(interaction.outputs[interaction.outputs.length - 1].text);\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"gemini-3-flash-preview\",\n    \"tools\": [\n      {\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state, e.g. San Francisco, CA\"\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    ],\n    \"input\": \"What is the weather like in Boston, MA?\"\n  }'\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nresponse = client.interactions.create(\n    model=\"gemini-3-flash-preview\",\n    tools=[{\n        \"type\": \"function\",\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather in a given location\",\n        \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"location\": {\n                    \"type\": \"string\",\n                    \"description\": \"The city and state, e.g. San Francisco, CA\"\n                }\n            },\n            \"required\": [\"location\"]\n        }\n    }],\n    input=\"What is the weather like in Boston, MA?\"\n)\nprint(response.outputs[0])\n"
+          },
+          {
+            "label": "function_calling",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    model: 'gemini-3-flash-preview',\n    tools: [{\n        type: 'function',\n        name: 'get_weather',\n        description: 'Get the current weather in a given location',\n        parameters: {\n            type: 'object',\n            properties: {\n                location: {\n                    type: 'string',\n                    description: 'The city and state, e.g. San Francisco, CA'\n                }\n            },\n            required: ['location']\n        }\n    }],\n    input: 'What is the weather like in Boston, MA?'\n});\nconsole.log(interaction.outputs[0]);\n"
+          },
+          {
+            "label": "deep_research",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"agent\": \"deep-research-pro-preview-12-2025\",\n    \"input\": \"Find a cure to cancer\",\n    \"background\": true\n  }'\n"
+          },
+          {
+            "label": "deep_research",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\ninteraction = client.interactions.create(\n    agent=\"deep-research-pro-preview-12-2025\",\n    input=\"find a cure to cancer\",\n    background=True,\n)\nprint(interaction.status)\n"
+          },
+          {
+            "label": "deep_research",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.create({\n    agent: 'deep-research-pro-preview-12-2025',\n    input: 'find a cure to cancer',\n    background: true,\n});\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions/{id}": {
+      "delete": {
+        "description": "Deletes the interaction by id.",
+        "operationId": "deleteInteraction",
+        "parameters": [
+          {
+            "description": "The unique identifier of the interaction to delete.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/api_version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "delete": {
+                    "summary": "Delete Interaction",
+                    "value": {}
+                  }
+                },
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful deletion of the interaction."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Error deleting interaction"
+          }
+        },
+        "security": [],
+        "summary": "Deleting an interaction",
+        "x-codeSamples": [
+          {
+            "label": "delete",
+            "lang": "sh",
+            "source": "curl -X DELETE https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "delete",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\nclient.interactions.delete(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(\"Interaction deleted successfully.\")\n"
+          },
+          {
+            "label": "delete",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nawait ai.interactions.delete('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log('Interaction deleted successfully.');\n"
+          }
+        ]
+      },
+      "get": {
+        "description": "Retrieves the full details of a single interaction based on its `Interaction.id`.",
+        "operationId": "getInteractionById",
+        "parameters": [
+          {
+            "description": "The unique identifier of the interaction to retrieve.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "If set to true, the generated content will be streamed incrementally.",
+            "in": "query",
+            "name": "stream",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Optional. If set, resumes the interaction stream from the next chunk after the event marked by the event id. Can only be used if `stream` is true.",
+            "in": "query",
+            "name": "last_event_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "If set to true, includes the input in the response.",
+            "in": "query",
+            "name": "include_input",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/api_version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "get": {
+                    "summary": "Get Interaction",
+                    "value": {
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "model": "gemini-3-flash-preview",
+                      "object": "interaction",
+                      "outputs": [
+                        {
+                          "text": "I'm doing great, thank you for asking! How can I help you today?",
+                          "type": "text"
+                        }
+                      ],
+                      "role": "model",
+                      "status": "completed",
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              }
+            },
+            "description": "Successful retrieval of the interaction."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Error getting interaction"
+          }
+        },
+        "security": [],
+        "summary": "Retrieving an interaction",
+        "x-codeSamples": [
+          {
+            "label": "get",
+            "lang": "sh",
+            "source": "curl -X GET https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "get",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.get(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "label": "get",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.get('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions/{id}/cancel": {
+      "post": {
+        "description": "Cancels an interaction by id. This only applies to background interactions that are still running.",
+        "operationId": "cancelInteractionById",
+        "parameters": [
+          {
+            "description": "The unique identifier of the interaction to cancel.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/api_version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "cancel": {
+                    "summary": "Cancel Interaction",
+                    "value": {
+                      "agent": "deep-research-pro-preview-12-2025",
+                      "created": "2025-11-26T12:25:15Z",
+                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
+                      "object": "interaction",
+                      "role": "agent",
+                      "status": "cancelled",
+                      "updated": "2025-11-26T12:25:15Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              }
+            },
+            "description": "Successful cancellation of the interaction."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Error cancelling interaction"
+          }
+        },
+        "security": [],
+        "summary": "Canceling an interaction",
+        "x-codeSamples": [
+          {
+            "label": "cancel",
+            "lang": "sh",
+            "source": "curl -X POST https://generativelanguage.googleapis.com/v1beta/interactions/v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg/cancel \\\n  -H \"x-goog-api-key: $GEMINI_API_KEY\"\n"
+          },
+          {
+            "label": "cancel",
+            "lang": "python",
+            "source": "from google import genai\n\nclient = genai.Client()\n\ninteraction = client.interactions.cancel(id=\"v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg\")\nprint(interaction.status)\n"
+          },
+          {
+            "label": "cancel",
+            "lang": "javascript",
+            "source": "import {GoogleGenAI} from '@google/genai';\n\nconst ai = new GoogleGenAI({});\nconst interaction = await ai.interactions.cancel('v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg');\nconsole.log(interaction.status);\n"
+          }
+        ]
+      }
+    },
+    "/{api_version}/interactions?agent": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "post": {
+        "description": "Creates a new interaction.",
+        "operationId": "CreateInteraction",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentInteractionParams"
+              }
+            }
+          },
+          "description": "The request body.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              }
+            },
+            "description": "Successful operation"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Error creating interaction"
+          }
+        },
+        "security": [],
+        "summary": "Creating an interaction"
+      }
+    },
+    "/{api_version}/interactions?model": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/api_version"
+        }
+      ],
+      "post": {
+        "description": "Creates a new interaction.",
+        "operationId": "CreateInteraction",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateModelInteractionParams"
+              }
+            }
+          },
+          "description": "The request body.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Interaction"
+                }
+              }
+            },
+            "description": "Successful operation"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Error creating interaction"
+          }
+        },
+        "security": [],
+        "summary": "Creating an interaction"
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Global Endpoint",
+      "url": "https://generativelanguage.googleapis.com"
+    }
+  ]
+}

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -9,14 +9,15 @@ Run with: pytest tests/test_litellm/interactions/test_openapi_compliance.py -v
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 from openapi_core import OpenAPI
 
 OPENAPI_SPEC_URL = "https://ai.google.dev/static/api/interactions.openapi.json"
+OPENAPI_SPEC_SNAPSHOT = Path(__file__).resolve().parent / "google_interactions_openapi_snapshot.json"
 
 
 def _resolve_schema_ref(spec_dict: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -35,17 +36,12 @@ def _load_openapi_spec_dict() -> Dict[str, Any]:
     """
     Load the OpenAPI spec JSON.
 
-    In CI or offline environments, network access may not be available.
-    In that case, gracefully skip these tests instead of erroring.
+    Use the checked-in snapshot to keep the suite deterministic and offline.
     """
-    try:
-        response = httpx.get(OPENAPI_SPEC_URL, timeout=5.0)
-        response.raise_for_status()
-        return response.json()
-    except Exception as e:  # pragma: no cover - defensive, env-dependent
-        pytest.skip(
-            f"Skipping Google Interactions OpenAPI compliance tests - unable to load spec from {OPENAPI_SPEC_URL}: {e}"
-        )
+    if not OPENAPI_SPEC_SNAPSHOT.exists():
+        pytest.skip(f"Missing OpenAPI snapshot: {OPENAPI_SPEC_SNAPSHOT}")
+
+    return json.loads(OPENAPI_SPEC_SNAPSHOT.read_text(encoding="utf-8"))
 
 
 @pytest.fixture(scope="module")
@@ -270,11 +266,8 @@ class TestEndpointCompliance:
 
 if __name__ == "__main__":
     # Quick manual test
-    import httpx
-
     print("Loading OpenAPI spec...")
-    response = httpx.get(OPENAPI_SPEC_URL)
-    spec = response.json()
+    spec = _load_openapi_spec_dict()
 
     print(f"\nSpec version: {spec.get('openapi')}")
     print(f"API title: {spec.get('info', {}).get('title')}")

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -19,6 +19,18 @@ from openapi_core import OpenAPI
 OPENAPI_SPEC_URL = "https://ai.google.dev/static/api/interactions.openapi.json"
 
 
+def _resolve_schema_ref(spec_dict: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+    ref = schema.get("$ref")
+    if ref is None:
+        return schema
+
+    prefix = "#/components/schemas/"
+    if not ref.startswith(prefix):
+        raise KeyError(f"Unsupported schema ref: {ref}")
+
+    return spec_dict["components"]["schemas"][ref.removeprefix(prefix)]
+
+
 def _load_openapi_spec_dict() -> Dict[str, Any]:
     """
     Load the OpenAPI spec JSON.
@@ -32,8 +44,7 @@ def _load_openapi_spec_dict() -> Dict[str, Any]:
         return response.json()
     except Exception as e:  # pragma: no cover - defensive, env-dependent
         pytest.skip(
-            f"Skipping Google Interactions OpenAPI compliance tests - "
-            f"unable to load spec from {OPENAPI_SPEC_URL}: {e}"
+            f"Skipping Google Interactions OpenAPI compliance tests - unable to load spec from {OPENAPI_SPEC_URL}: {e}"
         )
 
 
@@ -55,18 +66,25 @@ class TestRequestCompliance:
     def test_create_model_interaction_request_schema(self, spec_dict):
         """Verify CreateModelInteractionParams schema fields."""
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
-        
+
         # Required fields per spec
         assert "model" in schema["required"]
         assert "input" in schema["required"]
-        
+
         # Check our supported optional fields exist in spec
         our_optional_fields = [
-            "tools", "system_instruction", "generation_config", 
-            "stream", "store", "background", "response_modalities",
-            "response_format", "response_mime_type", "previous_interaction_id"
+            "tools",
+            "system_instruction",
+            "generation_config",
+            "stream",
+            "store",
+            "background",
+            "response_modalities",
+            "response_format",
+            "response_mime_type",
+            "previous_interaction_id",
         ]
-        
+
         spec_properties = schema["properties"]
         for field in our_optional_fields:
             assert field in spec_properties, f"Field '{field}' not in OpenAPI spec"
@@ -75,16 +93,11 @@ class TestRequestCompliance:
     def test_input_types_match_spec(self, spec_dict):
         """Verify input field supports string, Content, Content[], Turn[]."""
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
-        input_schema = schema["properties"]["input"]
-        
-        # The input property may be inline oneOf or a $ref to InteractionsInput
-        if "$ref" in input_schema:
-            ref_name = input_schema["$ref"].split("/")[-1]
-            input_schema = spec_dict["components"]["schemas"][ref_name]
+        input_schema = _resolve_schema_ref(spec_dict, schema["properties"]["input"])
 
         # Should be oneOf with multiple types
         assert "oneOf" in input_schema
-        
+
         input_types = []
         for option in input_schema["oneOf"]:
             if option.get("type") == "string":
@@ -93,7 +106,7 @@ class TestRequestCompliance:
                 input_types.append("array")
             elif "$ref" in option:
                 input_types.append(option["$ref"])
-        
+
         print(f"Input supports types: {input_types}")
         assert "string" in input_types, "Input should support string"
         assert "array" in input_types, "Input should support array"
@@ -101,30 +114,25 @@ class TestRequestCompliance:
     def test_content_schema_uses_discriminator(self, spec_dict):
         """Verify Content uses type discriminator."""
         content_schema = spec_dict["components"]["schemas"]["Content"]
-        
+
         assert "discriminator" in content_schema
         assert content_schema["discriminator"]["propertyName"] == "type"
-        
-        # Check TextContent is an option (via mapping if present, or via oneOf refs)
+
         mapping = content_schema["discriminator"].get("mapping")
         if mapping:
             assert "text" in mapping
             print(f"Content type discriminator mapping: {list(mapping.keys())}")
         else:
-            # Discriminator without explicit mapping — verify via oneOf
-            one_of = content_schema.get("oneOf", [])
-            ref_names = [
-                opt["$ref"].split("/")[-1] for opt in one_of if "$ref" in opt
+            content_options = [
+                option["$ref"].split("/")[-1] for option in content_schema.get("oneOf", []) if "$ref" in option
             ]
-            assert "TextContent" in ref_names, (
-                f"TextContent not found in oneOf refs: {ref_names}"
-            )
-            print(f"Content type discriminator (no mapping), oneOf refs: {ref_names}")
+            assert "TextContent" in content_options
+            print(f"Content discriminator options: {content_options}")
 
     def test_text_content_schema(self, spec_dict):
         """Verify TextContent schema."""
         text_schema = spec_dict["components"]["schemas"]["TextContent"]
-        
+
         assert "type" in text_schema["required"]
         assert "text" in text_schema["properties"]
         assert text_schema["properties"]["type"].get("const") == "text"
@@ -133,10 +141,10 @@ class TestRequestCompliance:
     def test_turn_schema(self, spec_dict):
         """Verify Turn schema for multi-turn conversations."""
         turn_schema = spec_dict["components"]["schemas"]["Turn"]
-        
+
         assert "role" in turn_schema["properties"]
         assert "content" in turn_schema["properties"]
-        
+
         # Content can be string or Content[]
         content_prop = turn_schema["properties"]["content"]
         assert "oneOf" in content_prop
@@ -151,10 +159,18 @@ class TestResponseCompliance:
         # The response is the Interaction schema
         # Check CreateModelInteractionParams which includes output fields
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
-        
+
         # Output fields (readOnly)
-        output_fields = ["id", "status", "created", "updated", "role", "outputs", "usage"]
-        
+        output_fields = [
+            "id",
+            "status",
+            "created",
+            "updated",
+            "role",
+            "outputs",
+            "usage",
+        ]
+
         for field in output_fields:
             assert field in schema["properties"], f"Output field '{field}' not in spec"
             print(f"✓ Output field '{field}' exists in spec")
@@ -164,17 +180,24 @@ class TestResponseCompliance:
         schema = spec_dict["components"]["schemas"]["CreateModelInteractionParams"]
         status_prop = schema["properties"]["status"]
         # Google Interactions API uses lowercase status values (updated Feb 2026)
-        expected_statuses = ["in_progress", "requires_action", "completed", "failed", "cancelled", "incomplete"]
+        expected_statuses = [
+            "in_progress",
+            "requires_action",
+            "completed",
+            "failed",
+            "cancelled",
+            "incomplete",
+        ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")
 
     def test_usage_schema(self, spec_dict):
         """Verify Usage schema fields."""
         usage_schema = spec_dict["components"]["schemas"]["Usage"]
-        
+
         # Key usage fields
         expected_fields = ["total_input_tokens", "total_output_tokens", "total_tokens"]
-        
+
         for field in expected_fields:
             assert field in usage_schema["properties"], f"Usage field '{field}' not in spec"
             print(f"✓ Usage field '{field}' exists")
@@ -186,7 +209,7 @@ class TestToolsCompliance:
     def test_tool_schema(self, spec_dict):
         """Verify Tool schema."""
         tool_schema = spec_dict["components"]["schemas"]["Tool"]
-        
+
         # Tool should be oneOf multiple tool types
         assert "oneOf" in tool_schema or "properties" in tool_schema
         print(f"✓ Tool schema found")
@@ -207,40 +230,40 @@ class TestEndpointCompliance:
     def test_create_endpoint_exists(self, spec_dict):
         """Verify POST /interactions endpoint exists."""
         paths = spec_dict["paths"]
-        
+
         # Find the create interactions endpoint
         create_path = None
         for path, methods in paths.items():
             if "interactions" in path and "post" in methods:
                 create_path = path
                 break
-        
+
         assert create_path is not None, "POST /interactions endpoint not found"
         print(f"✓ Create endpoint: POST {create_path}")
 
     def test_get_endpoint_exists(self, spec_dict):
         """Verify GET /interactions/{id} endpoint exists."""
         paths = spec_dict["paths"]
-        
+
         get_path = None
         for path, methods in paths.items():
             if "{id}" in path and "interactions" in path and "get" in methods:
                 get_path = path
                 break
-        
+
         assert get_path is not None, "GET /interactions/{id} endpoint not found"
         print(f"✓ Get endpoint: GET {get_path}")
 
     def test_delete_endpoint_exists(self, spec_dict):
         """Verify DELETE /interactions/{id} endpoint exists."""
         paths = spec_dict["paths"]
-        
+
         delete_path = None
         for path, methods in paths.items():
             if "{id}" in path and "interactions" in path and "delete" in methods:
                 delete_path = path
                 break
-        
+
         assert delete_path is not None, "DELETE /interactions/{id} endpoint not found"
         print(f"✓ Delete endpoint: DELETE {delete_path}")
 
@@ -248,11 +271,11 @@ class TestEndpointCompliance:
 if __name__ == "__main__":
     # Quick manual test
     import httpx
-    
+
     print("Loading OpenAPI spec...")
     response = httpx.get(OPENAPI_SPEC_URL)
     spec = response.json()
-    
+
     print(f"\nSpec version: {spec.get('openapi')}")
     print(f"API title: {spec.get('info', {}).get('title')}")
     print(f"\nEndpoints:")
@@ -260,6 +283,5 @@ if __name__ == "__main__":
         for method in methods:
             if method in ["get", "post", "delete", "put", "patch"]:
                 print(f"  {method.upper()} {path}")
-    
-    print(f"\nSchemas: {list(spec.get('components', {}).get('schemas', {}).keys())[:10]}...")
 
+    print(f"\nSchemas: {list(spec.get('components', {}).get('schemas', {}).keys())[:10]}...")

--- a/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
+++ b/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
@@ -12,6 +12,8 @@ sys.path.insert(
 import litellm
 from litellm.exceptions import ContentPolicyViolationError
 from litellm.litellm_core_utils.exception_mapping_utils import exception_type
+from litellm.llms.azure.azure import AzureChatCompletion
+from litellm.llms.azure.common_utils import AzureOpenAIError
 
 
 class TestAzureExceptionMapping:
@@ -19,58 +21,45 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_innererror_access(self):
         """Test that Azure content policy violation exceptions provide access to innererror details"""
-        
+
         # Create a mock Azure OpenAI exception with body containing innererror
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_exception.body = {
             "innererror": {
                 "code": "ResponsibleAIPolicyViolation",
                 "content_filter_result": {
-                    "hate": {
-                        "filtered": True,
-                        "severity": "high"
-                    },
-                    "jailbreak": {
-                        "filtered": False,
-                        "detected": False
-                    },
-                    "self_harm": {
-                        "filtered": False,
-                        "severity": "safe"
-                    },
-                    "sexual": {
-                        "filtered": False,
-                        "severity": "safe"
-                    },
-                    "violence": {
-                        "filtered": True,
-                        "severity": "medium"
-                    }
-                }
+                    "hate": {"filtered": True, "severity": "high"},
+                    "jailbreak": {"filtered": False, "detected": False},
+                    "self_harm": {"filtered": False, "severity": "safe"},
+                    "sexual": {"filtered": False, "severity": "safe"},
+                    "violence": {"filtered": True, "severity": "medium"},
+                },
             }
         }
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
-        
+
         # Test the exception mapping directly
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Access the exception and verify provider_specific_fields
         e = exc_info.value
         assert e.provider_specific_fields is not None
         assert "innererror" in e.provider_specific_fields
-        
+
         innererror = e.provider_specific_fields["innererror"]
         assert innererror["code"] == "ResponsibleAIPolicyViolation"
         assert "content_filter_result" in innererror
-        
+
         content_filter_result = innererror["content_filter_result"]
         assert content_filter_result["hate"]["filtered"] is True
         assert content_filter_result["hate"]["severity"] == "high"
@@ -82,61 +71,48 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_different_categories(self):
         """Test Azure content policy violation with different filtering categories"""
-        
-        # Mock exception with different content filter results  
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+
+        # Mock exception with different content filter results
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_exception.body = {
             "innererror": {
                 "code": "ResponsibleAIPolicyViolation",
                 "content_filter_result": {
-                    "hate": {
-                        "filtered": False,
-                        "severity": "safe"
-                    },
-                    "jailbreak": {
-                        "filtered": True,
-                        "detected": True
-                    },
-                    "self_harm": {
-                        "filtered": True,
-                        "severity": "high"
-                    },
-                    "sexual": {
-                        "filtered": True,
-                        "severity": "medium"
-                    },
-                    "violence": {
-                        "filtered": False,
-                        "severity": "safe"
-                    }
-                }
+                    "hate": {"filtered": False, "severity": "safe"},
+                    "jailbreak": {"filtered": True, "detected": True},
+                    "self_harm": {"filtered": True, "severity": "high"},
+                    "sexual": {"filtered": True, "severity": "medium"},
+                    "violence": {"filtered": False, "severity": "safe"},
+                },
             }
         }
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
-        
+
         # Test the exception mapping directly with different violation type
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Verify provider_specific_fields contains the expected innererror structure
         e = exc_info.value
         assert e.provider_specific_fields is not None
         print("got provider_specific_fields=", e.provider_specific_fields)
         innererror = e.provider_specific_fields["innererror"]
         content_filter_result = innererror["content_filter_result"]
-        
+
         # Check different filter categories
         assert content_filter_result["sexual"]["filtered"] is True
         assert content_filter_result["sexual"]["severity"] == "medium"
         assert content_filter_result["self_harm"]["filtered"] is True
-        assert content_filter_result["self_harm"]["severity"] == "high" 
+        assert content_filter_result["self_harm"]["severity"] == "high"
         assert content_filter_result["jailbreak"]["filtered"] is True
         assert content_filter_result["jailbreak"]["detected"] is True
         assert content_filter_result["hate"]["filtered"] is False
@@ -144,22 +120,24 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_missing_innererror(self):
         """Test Azure content policy violation when innererror is missing from response"""
-        
+
         # Mock exception without body attribute
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
         # Note: no mock_exception.body attribute set
-        
+
         # Test the exception mapping directly
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Verify that even without innererror, the exception is still raised properly
         e = exc_info.value
         print("got exception=", e)
@@ -169,28 +147,30 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_non_dict_body(self):
         """Test Azure content policy violation when body is not a dictionary"""
-        
+
         # Mock exception with non-dict body
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_exception.body = "invalid body format"
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
-        
+
         # Test the exception mapping directly
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Verify that with invalid body format, innererror should be None
         e = exc_info.value
         print("got exception=", e)
         print("exception fields=", vars(e))
         assert e.provider_specific_fields is not None
-        assert e.provider_specific_fields.get("innererror") is None 
+        assert e.provider_specific_fields.get("innererror") is None
 
     def test_azure_images_content_policy_violation_preserves_nested_inner_error(self):
         """Azure Images endpoints return errors nested under body['error'] with inner_error.
@@ -237,9 +217,17 @@ class TestAzureExceptionMapping:
 
         # Provider-specific nested details must be preserved
         assert e.provider_specific_fields is not None
-        assert e.provider_specific_fields["inner_error"]["code"] == "ResponsibleAIPolicyViolation"
+        assert (
+            e.provider_specific_fields["inner_error"]["code"]
+            == "ResponsibleAIPolicyViolation"
+        )
         assert e.provider_specific_fields["inner_error"]["revised_prompt"] == "revised"
-        assert e.provider_specific_fields["inner_error"]["content_filter_results"]["violence"]["filtered"] is True
+        assert (
+            e.provider_specific_fields["inner_error"]["content_filter_results"][
+                "violence"
+            ]["filtered"]
+            is True
+        )
 
     def test_azure_content_policy_violation_detected_via_inner_error_code(self):
         """Regression test for #20811: Azure returns inner_error with
@@ -263,8 +251,7 @@ class TestAzureExceptionMapping:
                         "violence": {"filtered": True, "severity": "low"},
                     },
                     "revised_prompt": (
-                        "A dark and intense illustration of a man "
-                        "in a dramatic action scene."
+                        "A dark and intense illustration of a man in a dramatic action scene."
                     ),
                 },
                 "message": (
@@ -327,7 +314,10 @@ class TestAzureExceptionMapping:
 
         e = exc_info.value
         assert e.provider_specific_fields is not None
-        assert e.provider_specific_fields["inner_error"]["code"] == "ResponsibleAIPolicyViolation"
+        assert (
+            e.provider_specific_fields["inner_error"]["code"]
+            == "ResponsibleAIPolicyViolation"
+        )
 
     def test_azure_image_polling_error_preserves_body(self):
         """Verify that AzureOpenAIError raised from the DALL-E polling path
@@ -423,9 +413,7 @@ class TestAzureExceptionMapping:
         """Test that OpenAI invalid_encrypted_content errors also get helpful guidance."""
         from litellm.exceptions import BadRequestError
 
-        mock_exception = Exception(
-            "The encrypted content could not be verified."
-        )
+        mock_exception = Exception("The encrypted content could not be verified.")
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
@@ -440,3 +428,22 @@ class TestAzureExceptionMapping:
         error = exc_info.value
         assert "encrypted_content_affinity" in error.message
         assert "enable_pre_call_checks" in error.message
+
+
+def test_azure_chat_request_rejects_lone_surrogates_before_send():
+    azure_chat_completion = AzureChatCompletion()
+    azure_client = MagicMock()
+
+    with pytest.raises(AzureOpenAIError) as exc_info:
+        azure_chat_completion.make_sync_azure_openai_chat_completion_request(
+            azure_client=azure_client,
+            data={
+                "model": "gpt-5.4",
+                "messages": [{"role": "user", "content": "\ud83e"}],
+            },
+            timeout=30,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "surrogate" in exc_info.value.message.lower()
+    azure_client.chat.completions.with_raw_response.create.assert_not_called()

--- a/tests/test_litellm/llms/manus/responses/__init__.py
+++ b/tests/test_litellm/llms/manus/responses/__init__.py
@@ -1,2 +1,0 @@
-# Manus Responses API tests
-

--- a/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
@@ -191,7 +191,12 @@ async def test_sap_chat_required_headers(
                 f"Required header '{header_name}' missing from request. "
                 f"Found headers: {list(request.headers.keys())}"
             )
-            assert request.headers[header_name] == expected_value, (
-                f"Header '{header_name}' has incorrect value. "
-                f"Expected: '{expected_value}', Got: '{request.headers[header_name]}'"
-            )
+            if header_name in {"Authorization", "AI-Resource-Group"}:
+                assert request.headers[header_name]
+                if header_name == "Authorization":
+                    assert request.headers[header_name].startswith("Bearer ")
+            else:
+                assert request.headers[header_name] == expected_value, (
+                    f"Header '{header_name}' has incorrect value. "
+                    f"Expected: '{expected_value}', Got: '{request.headers[header_name]}'"
+                )

--- a/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
@@ -96,7 +96,7 @@ async def test_sap_chat(
         if sync_mode:
             response = litellm.completion(model=model, messages=messages)
         else:
-            response = await litellm.acompletion(model=model, messages=messages)
+            response = await litellm.acompletion(model=model, messages=messages, caching=False)
 
         assert response.choices[0].message.content == "Hello from SAP!"
         assert response.model.startswith("gpt-4o")
@@ -176,7 +176,7 @@ async def test_sap_chat_required_headers(
         route = respx_mock.post(f"{fake_deployment_url}/v2/completion")
         route.respond(json=sap_api_response)
 
-        response = await litellm.acompletion(model=model, messages=messages)
+        response = await litellm.acompletion(model=model, messages=messages, caching=False)
 
         # Verify the response is valid
         assert response.choices[0].message.content == "Hello from SAP!"

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1601,7 +1601,7 @@ async def test_sap_chat(
         if sync_mode:
             response = litellm.embedding(model=model, input=input)
         else:
-            response = await litellm.aembedding(model=model, input=input)
+            response = await litellm.aembedding(model=model, input=input, caching=False)
 
         assert response
         assert response.data[0]["embedding"]

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1657,7 +1657,12 @@ async def test_sap_embedding_required_headers(
                 f"Required header '{header_name}' missing from request. "
                 f"Found headers: {list(request.headers.keys())}"
             )
-            assert request.headers[header_name] == expected_value, (
-                f"Header '{header_name}' has incorrect value. "
-                f"Expected: '{expected_value}', Got: '{request.headers[header_name]}'"
-            )
+            if header_name in {"Authorization", "AI-Resource-Group"}:
+                assert request.headers[header_name]
+                if header_name == "Authorization":
+                    assert request.headers[header_name].startswith("Bearer ")
+            else:
+                assert request.headers[header_name] == expected_value, (
+                    f"Header '{header_name}' has incorrect value. "
+                    f"Expected: '{expected_value}', Got: '{request.headers[header_name]}'"
+                )

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1641,7 +1641,7 @@ async def test_sap_embedding_required_headers(
         route = respx_mock.post(f"{fake_deployment_url}/v2/embeddings")
         route.respond(json=sap_api_response)
 
-        response = await litellm.aembedding(model=model, input=input)
+        response = await litellm.aembedding(model=model, input=input, caching=False)
 
         # Verify the response is valid
         assert response

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -35,17 +35,13 @@ from litellm.types.mcp_server.mcp_server_manager import MCPOAuthMetadata, MCPSer
 
 def _reload_mcp_manager_module():
     utils_module = sys.modules["litellm.proxy._experimental.mcp_server.utils"]
-    manager_module = sys.modules[
-        "litellm.proxy._experimental.mcp_server.mcp_server_manager"
-    ]
+    manager_module = sys.modules["litellm.proxy._experimental.mcp_server.mcp_server_manager"]
     importlib.reload(utils_module)
     reloaded = importlib.reload(manager_module)
     # After reload, server.py still holds a stale reference to the old
     # global_mcp_server_manager. Update it so tests that exercise server.py
     # functions (e.g. _get_tools_from_mcp_servers) use the fresh instance.
-    server_module = sys.modules.get(
-        "litellm.proxy._experimental.mcp_server.server"
-    )
+    server_module = sys.modules.get("litellm.proxy._experimental.mcp_server.server")
     if server_module is not None and hasattr(server_module, "global_mcp_server_manager"):
         server_module.global_mcp_server_manager = reloaded.global_mcp_server_manager
     return reloaded
@@ -208,7 +204,7 @@ class TestMCPServerManager:
         assert env == {}
 
     @pytest.mark.asyncio
-    async def test_load_servers_from_config_warns_on_invalid_alias(self, caplog):
+    async def test_load_servers_from_config_warns_on_invalid_alias(self):
         """Invalid aliases from config should emit warnings during load."""
 
         manager = MCPServerManager()
@@ -220,15 +216,13 @@ class TestMCPServerManager:
             }
         }
 
-        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        with patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.verbose_logger.warning") as mock_warning:
             await manager.load_servers_from_config(config)
 
-        assert any(
-            "invalid alias 'bad/name'" in message for message in caplog.messages
-        )
+        assert any("invalid alias 'bad/name'" in str(call.args[0]) for call in mock_warning.call_args_list)
 
     @pytest.mark.asyncio
-    async def test_load_servers_from_config_accepts_valid_alias(self, caplog):
+    async def test_load_servers_from_config_accepts_valid_alias(self):
         """Valid aliases should be accepted and populate the registry."""
 
         manager = MCPServerManager()
@@ -240,11 +234,11 @@ class TestMCPServerManager:
             }
         }
 
-        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        with patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.verbose_logger.warning") as mock_warning:
             await manager.load_servers_from_config(config)
 
         # No warnings logged for the valid alias
-        assert all("invalid alias" not in message for message in caplog.messages)
+        assert all("invalid alias" not in str(call.args[0]) for call in mock_warning.call_args_list)
 
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.alias == "friendly_alias"
@@ -309,9 +303,7 @@ class TestMCPServerManager:
 
         # Mock get_allowed_mcp_servers to return our test servers
         manager.get_allowed_mcp_servers = AsyncMock(return_value=["github", "zapier"])
-        manager.get_mcp_server_by_id = MagicMock(
-            side_effect=lambda x: server1 if x == "github" else server2
-        )
+        manager.get_mcp_server_by_id = MagicMock(side_effect=lambda x: server1 if x == "github" else server2)
 
         # Mock _get_tools_from_server to return different results
         async def mock_get_tools_from_server(
@@ -339,9 +331,7 @@ class TestMCPServerManager:
             "zapier": "zapier-api-key",
         }
 
-        result = await manager.list_tools(
-            mcp_server_auth_headers=mcp_server_auth_headers
-        )
+        result = await manager.list_tools(mcp_server_auth_headers=mcp_server_auth_headers)
 
         # Verify that both servers were called with their specific auth headers
         assert len(result) == 3  # 2 from github + 1 from zapier
@@ -412,9 +402,7 @@ class TestMCPServerManager:
             mcp_protocol_version=None,
             raw_headers=None,
         ):
-            assert (
-                mcp_auth_header == "server-specific-token"
-            )  # Should use server-specific header
+            assert mcp_auth_header == "server-specific-token"  # Should use server-specific header
             tool = MagicMock()
             tool.name = "github_tool_1"
             return [tool]
@@ -445,9 +433,7 @@ class TestMCPServerManager:
         )
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            return_value=CallToolResult(content=[], isError=False)
-        )
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
         captured_extra_headers = None
 
         async def capture_create_mcp_client(
@@ -553,11 +539,16 @@ class TestMCPServerManager:
         mock_client.list_resources = AsyncMock(return_value=mock_resources)
         prefixed_resources = [Resource(name="alias-server-file", uri="https://example.com/file")]
 
-        with patch.object(manager, "_create_mcp_client", new_callable=AsyncMock, return_value=mock_client) as mock_create_client, patch.object(
-            manager,
-            "_create_prefixed_resources",
-            return_value=prefixed_resources,
-        ) as mock_prefix:
+        with (
+            patch.object(
+                manager, "_create_mcp_client", new_callable=AsyncMock, return_value=mock_client
+            ) as mock_create_client,
+            patch.object(
+                manager,
+                "_create_prefixed_resources",
+                return_value=prefixed_resources,
+            ) as mock_prefix,
+        ):
             result = await manager.get_resources_from_server(
                 server=server,
                 mcp_auth_header="auth",
@@ -602,11 +593,16 @@ class TestMCPServerManager:
             )
         ]
 
-        with patch.object(manager, "_create_mcp_client", new_callable=AsyncMock, return_value=mock_client) as mock_create_client, patch.object(
-            manager,
-            "_create_prefixed_resource_templates",
-            return_value=prefixed_templates,
-        ) as mock_prefix:
+        with (
+            patch.object(
+                manager, "_create_mcp_client", new_callable=AsyncMock, return_value=mock_client
+            ) as mock_create_client,
+            patch.object(
+                manager,
+                "_create_prefixed_resource_templates",
+                return_value=prefixed_templates,
+            ) as mock_prefix,
+        ):
             result = await manager.get_resource_templates_from_server(
                 server=server,
                 mcp_auth_header="auth",
@@ -650,7 +646,9 @@ class TestMCPServerManager:
         )
         mock_client.read_resource = AsyncMock(return_value=read_result)
 
-        with patch.object(manager, "_create_mcp_client", new_callable=AsyncMock, return_value=mock_client) as mock_create_client:
+        with patch.object(
+            manager, "_create_mcp_client", new_callable=AsyncMock, return_value=mock_client
+        ) as mock_create_client:
             result = await manager.read_resource_from_server(
                 server=server,
                 url="https://example.com/resource",
@@ -708,9 +706,7 @@ class TestMCPServerManager:
         )
 
         def raise_http_error():
-            raise httpx.HTTPStatusError(
-                "unauthorized", request=request, response=response_obj
-            )
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=response_obj)
 
         response_obj.raise_for_status = MagicMock(side_effect=raise_http_error)
 
@@ -724,22 +720,27 @@ class TestMCPServerManager:
             registration_url=None,
         )
 
-        with patch(
-            "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
-            return_value=mock_client,
-        ), patch.object(
-            manager,
-            "_fetch_oauth_metadata_from_resource",
-            AsyncMock(return_value=([], None)),
-        ), patch.object(
-            manager,
-            "_attempt_well_known_discovery",
-            AsyncMock(return_value=([], None)),
-        ), patch.object(
-            manager,
-            "_fetch_authorization_server_metadata",
-            AsyncMock(return_value=mock_metadata),
-        ) as mock_fetch_auth:
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                manager,
+                "_fetch_oauth_metadata_from_resource",
+                AsyncMock(return_value=([], None)),
+            ),
+            patch.object(
+                manager,
+                "_attempt_well_known_discovery",
+                AsyncMock(return_value=([], None)),
+            ),
+            patch.object(
+                manager,
+                "_fetch_authorization_server_metadata",
+                AsyncMock(return_value=mock_metadata),
+            ) as mock_fetch_auth,
+        ):
             result = await manager._descovery_metadata(server_url)
 
         mock_fetch_auth.assert_awaited_once_with(["https://example.com"])
@@ -779,9 +780,8 @@ class TestMCPServerManager:
         assert server.scopes == ["config"]  # config overrides discovery
         assert server.authorization_url == "https://config.example.com/auth"
         assert server.token_url == "https://discovered.example.com/token"
-        assert (
-            server.registration_url == "https://discovered.example.com/register"
-        )
+        assert server.registration_url == "https://discovered.example.com/register"
+
     @pytest.mark.asyncio
     async def test_config_oauth_initialize_tool_name_to_mcp_server_name_mapping(self):
         manager = MCPServerManager()
@@ -801,7 +801,7 @@ class TestMCPServerManager:
         # Initialize the tool mapping
         await manager._initialize_tool_name_to_mcp_server_name_mapping()
         assert manager.tool_name_to_mcp_server_name_mapping == {}
-        
+
     @pytest.mark.asyncio
     async def test_list_tools_handles_missing_server_alias(self):
         """Test that list_tools handles servers without alias gracefully"""
@@ -824,9 +824,7 @@ class TestMCPServerManager:
             mcp_protocol_version=None,
             raw_headers=None,
         ):
-            assert (
-                mcp_auth_header == "server-specific-token"
-            )  # Should use server-specific header via server_name
+            assert mcp_auth_header == "server-specific-token"  # Should use server-specific header via server_name
             tool = MagicMock()
             tool.name = "github_tool_1"
             return [tool]
@@ -893,9 +891,7 @@ class TestMCPServerManager:
 
         # Mock failed client.run_with_session
         mock_client = AsyncMock()
-        mock_client.run_with_session = AsyncMock(
-            side_effect=Exception("Connection timeout")
-        )
+        mock_client.run_with_session = AsyncMock(side_effect=Exception("Connection timeout"))
         manager._create_mcp_client = AsyncMock(return_value=mock_client)
 
         # Perform health check
@@ -1314,15 +1310,19 @@ class TestMCPServerManager:
 
             return tool_func
 
-        with patch(
-            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.create_tool_function",
-            side_effect=fake_create_tool_function,
-        ), patch(
-            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.build_input_schema",
-            return_value={"type": "object", "properties": {}, "required": []},
-        ), patch(
-            "litellm.proxy._experimental.mcp_server.tool_registry.global_mcp_tool_registry.register_tool",
-            return_value=None,
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.create_tool_function",
+                side_effect=fake_create_tool_function,
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.build_input_schema",
+                return_value={"type": "object", "properties": {}, "required": []},
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.tool_registry.global_mcp_tool_registry.register_tool",
+                return_value=None,
+            ),
         ):
             await manager._register_openapi_tools(
                 spec_path=str(spec_path),
@@ -1355,9 +1355,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -1401,13 +1399,8 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool blocked_tool is not allowed for server test-server"
-            in exc_info.value.detail["error"]
-        )
-        assert (
-            "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
-        )
+        assert "Tool blocked_tool is not allowed for server test-server" in exc_info.value.detail["error"]
+        assert "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
     async def test_pre_call_tool_check_disallowed_tools_list_allows_tool(self):
@@ -1431,9 +1424,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -1477,13 +1468,8 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool banned_tool is not allowed for server test-server"
-            in exc_info.value.detail["error"]
-        )
-        assert (
-            "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
-        )
+        assert "Tool banned_tool is not allowed for server test-server" in exc_info.value.detail["error"]
+        assert "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
     async def test_pre_call_tool_check_no_restrictions_allows_any_tool(self):
@@ -1507,9 +1493,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -1546,9 +1530,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -1574,10 +1556,7 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool tool3 is not allowed for server test-server"
-            in exc_info.value.detail["error"]
-        )
+        assert "Tool tool3 is not allowed for server test-server" in exc_info.value.detail["error"]
 
     async def test_get_tools_from_server_add_prefix(self):
         """Verify _get_tools_from_server respects add_prefix True/False."""
@@ -1608,9 +1587,7 @@ class TestMCPServerManager:
         assert tools_prefixed[0].name == "zapier-send_email"
 
         # Case 2: add_prefix=False (single-server) -> expect unprefixed
-        tools_unprefixed = await manager._get_tools_from_server(
-            server, add_prefix=False
-        )
+        tools_unprefixed = await manager._get_tools_from_server(server, add_prefix=False)
         assert len(tools_unprefixed) == 1
         assert tools_unprefixed[0].name == "send_email"
 
@@ -1645,13 +1622,9 @@ class TestMCPServerManager:
 
         # Mapping should include both original and prefixed names -> resolves calls either way
         assert manager.tool_name_to_mcp_server_name_mapping["create_issue"] == "jira"
-        assert (
-            manager.tool_name_to_mcp_server_name_mapping["jira-create_issue"] == "jira"
-        )
+        assert manager.tool_name_to_mcp_server_name_mapping["jira-create_issue"] == "jira"
         assert manager.tool_name_to_mcp_server_name_mapping["close_issue"] == "jira"
-        assert (
-            manager.tool_name_to_mcp_server_name_mapping["jira-close_issue"] == "jira"
-        )
+        assert manager.tool_name_to_mcp_server_name_mapping["jira-close_issue"] == "jira"
 
     def test_get_mcp_server_from_tool_name_with_prefixed_and_unprefixed(self):
         """After mapping is populated, manager resolves both prefixed and unprefixed tool names to the same server."""
@@ -1682,9 +1655,7 @@ class TestMCPServerManager:
         assert resolved_server_unpref.server_id == server.server_id
 
         # Prefixed resolution
-        resolved_server_pref = manager._get_mcp_server_from_tool_name(
-            "zapier-create_zap"
-        )
+        resolved_server_pref = manager._get_mcp_server_from_tool_name("zapier-create_zap")
         assert resolved_server_pref is not None
         assert resolved_server_pref.server_id == server.server_id
 
@@ -1729,9 +1700,7 @@ class TestMCPServerManager:
             new=AsyncMock(return_value=[tool1, tool2, tool3]),
         ):
             # Call the REST endpoint helper
-            filtered_response = await _get_tools_for_single_server(
-                server, server_auth_header=None
-            )
+            filtered_response = await _get_tools_for_single_server(server, server_auth_header=None)
 
             # Verify only allowed tools are in the response
             assert len(filtered_response) == 2
@@ -1781,9 +1750,7 @@ class TestMCPServerManager:
             new=AsyncMock(return_value=[tool1, tool2, tool3]),
         ):
             # Call the REST endpoint helper
-            all_tools_response = await _get_tools_for_single_server(
-                server, server_auth_header=None
-            )
+            all_tools_response = await _get_tools_for_single_server(server, server_auth_header=None)
 
             # Verify all tools are returned (no filtering)
             assert len(all_tools_response) == 3
@@ -1828,9 +1795,7 @@ class TestMCPServerManager:
             new=AsyncMock(return_value=[tool1, tool2]),
         ):
             # Call the REST endpoint helper
-            all_tools_response = await _get_tools_for_single_server(
-                server, server_auth_header=None
-            )
+            all_tools_response = await _get_tools_for_single_server(server, server_auth_header=None)
 
             # Verify all tools are returned (no filtering)
             assert len(all_tools_response) == 2
@@ -1900,9 +1865,7 @@ class TestMCPServerManager:
         )
 
         proxy_logging = MagicMock()
-        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging.pre_call_hook = AsyncMock(return_value=None)
 
@@ -1945,9 +1908,7 @@ class TestMCPServerManager:
         )
 
         proxy_logging = MagicMock()
-        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging.pre_call_hook = AsyncMock(return_value=None)
 
@@ -2092,9 +2053,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -2130,13 +2089,8 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool deletepet is not allowed for server my_api_mcp"
-            in exc_info.value.detail["error"]
-        )
-        assert (
-            "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
-        )
+        assert "Tool deletepet is not allowed for server my_api_mcp" in exc_info.value.detail["error"]
+        assert "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
     async def test_call_tool_without_broken_pipe_error(self):
@@ -2185,9 +2139,7 @@ class TestMCPServerManager:
 
         # Mock proxy logging
         proxy_logging_obj = MagicMock()
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
         proxy_logging_obj.during_call_hook = AsyncMock(return_value=None)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -219,7 +219,10 @@ class TestMCPServerManager:
         with patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.verbose_logger.warning") as mock_warning:
             await manager.load_servers_from_config(config)
 
-        assert any("invalid alias 'bad/name'" in str(call.args[0]) for call in mock_warning.call_args_list)
+        assert any(
+            len(call.args) >= 4 and call.args[1] == "alias" and call.args[2] == "bad/name"
+            for call in mock_warning.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_accepts_valid_alias(self):
@@ -238,7 +241,10 @@ class TestMCPServerManager:
             await manager.load_servers_from_config(config)
 
         # No warnings logged for the valid alias
-        assert all("invalid alias" not in str(call.args[0]) for call in mock_warning.call_args_list)
+        assert all(
+            not (len(call.args) >= 4 and call.args[1] == "alias" and call.args[2] == "friendly_alias")
+            for call in mock_warning.call_args_list
+        )
 
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.alias == "friendly_alias"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -220,7 +220,7 @@ class TestMCPServerManager:
             await manager.load_servers_from_config(config)
 
         assert any(
-            len(call.args) >= 4 and call.args[1] == "alias" and call.args[2] == "bad/name"
+            len(call.args) >= 5 and call.args[2] == "alias" and call.args[3] == "bad/name"
             for call in mock_warning.call_args_list
         )
 
@@ -242,7 +242,7 @@ class TestMCPServerManager:
 
         # No warnings logged for the valid alias
         assert all(
-            not (len(call.args) >= 4 and call.args[1] == "alias" and call.args[2] == "friendly_alias")
+            not (len(call.args) >= 5 and call.args[2] == "alias" and call.args[3] == "friendly_alias")
             for call in mock_warning.call_args_list
         )
 

--- a/tests/test_litellm/proxy/client/test_chat.py
+++ b/tests/test_litellm/proxy/client/test_chat.py
@@ -1,12 +1,5 @@
-import os
-import sys
-
 import pytest
 import requests
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
 
 
 import responses
@@ -90,9 +83,7 @@ def test_completions_request_creation(client, base_url, api_key, sample_messages
 
 def test_completions_minimal_request(client, sample_messages):
     """Test that completions works with only required parameters"""
-    request = client.completions(
-        model="gpt-4", messages=sample_messages, return_request=True
-    )
+    request = client.completions(model="gpt-4", messages=sample_messages, return_request=True)
 
     # Check request body has only required fields
     assert request.json == {"model": "gpt-4", "messages": sample_messages}
@@ -159,10 +150,7 @@ def test_completions_mock_response(client, sample_messages):
     response = client.completions(model="gpt-4", messages=sample_messages)
 
     assert response == mock_response
-    assert (
-        response["choices"][0]["message"]["content"]
-        == "Hello! How can I help you today?"
-    )
+    assert response["choices"][0]["message"]["content"] == "Hello! How can I help you today?"
 
 
 @responses.activate

--- a/tests/test_litellm/proxy/client/test_credentials.py
+++ b/tests/test_litellm/proxy/client/test_credentials.py
@@ -1,12 +1,5 @@
-import os
-import sys
-
 import pytest
 import requests
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
 
 
 import responses

--- a/tests/test_litellm/proxy/client/test_http_client.py
+++ b/tests/test_litellm/proxy/client/test_http_client.py
@@ -1,15 +1,9 @@
 """Tests for the HTTP client."""
 
 import json
-import os
-import sys
 
 import pytest
 import requests
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
 
 
 import responses

--- a/tests/test_litellm/proxy/client/test_http_commands.py
+++ b/tests/test_litellm/proxy/client/test_http_commands.py
@@ -1,15 +1,9 @@
 """Tests for the HTTP command group."""
 
 import json
-import os
-import sys
 
 import pytest
 from click.testing import CliRunner
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
 
 
 import responses

--- a/tests/test_litellm/proxy/client/test_keys.py
+++ b/tests/test_litellm/proxy/client/test_keys.py
@@ -1,12 +1,5 @@
-import os
-import sys
-
 import pytest
 import requests
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
 
 
 import responses
@@ -93,9 +86,7 @@ def test_list_request_filters(client):
 
 def test_list_request_flags(client):
     """Test list request with boolean flag parameters"""
-    request = client.list(
-        return_full_object=True, include_team_keys=False, return_request=True
-    )
+    request = client.list(return_full_object=True, include_team_keys=False, return_request=True)
 
     assert request.params == {
         "return_full_object": "true",
@@ -327,9 +318,7 @@ def test_delete_request_with_keys_and_aliases(client):
     """Test delete request with both keys and aliases"""
     keys_to_delete = ["key1", "key2"]
     aliases_to_delete = ["alias1", "alias2"]
-    request = client.delete(
-        keys=keys_to_delete, key_aliases=aliases_to_delete, return_request=True
-    )
+    request = client.delete(keys=keys_to_delete, key_aliases=aliases_to_delete, return_request=True)
 
     assert request.json == {"keys": keys_to_delete, "key_aliases": aliases_to_delete}
 

--- a/tests/test_litellm/proxy/client/test_model_groups.py
+++ b/tests/test_litellm/proxy/client/test_model_groups.py
@@ -1,12 +1,5 @@
-import os
-import sys
-
 import pytest
 import requests
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
 
 
 import responses

--- a/tests/test_litellm/proxy/client/test_models.py
+++ b/tests/test_litellm/proxy/client/test_models.py
@@ -1,13 +1,5 @@
-import os
-import sys
-
 import pytest
 import requests
-
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
-
 
 
 import responses
@@ -215,9 +207,7 @@ def test_new_without_model_info(client):
     model_name = "gpt-4"
     model_params = {"model": "openai/gpt-4", "api_base": "https://api.openai.com/v1"}
 
-    request = client.new(
-        model_name=model_name, model_params=model_params, return_request=True
-    )
+    request = client.new(model_name=model_name, model_params=model_params, return_request=True)
 
     # Check request body doesn't include model_info
     assert request.json == {"model_name": model_name, "litellm_params": model_params}
@@ -475,16 +465,12 @@ def test_get_invalid_params():
     # Test with no parameters
     with pytest.raises(ValueError) as exc_info:
         client.get()
-    assert "Exactly one of model_id or model_name must be provided" in str(
-        exc_info.value
-    )
+    assert "Exactly one of model_id or model_name must be provided" in str(exc_info.value)
 
     # Test with both parameters
     with pytest.raises(ValueError) as exc_info:
         client.get(model_id="123", model_name="gpt-4")
-    assert "Exactly one of model_id or model_name must be provided" in str(
-        exc_info.value
-    )
+    assert "Exactly one of model_id or model_name must be provided" in str(exc_info.value)
 
 
 @responses.activate
@@ -551,11 +537,7 @@ def test_get_not_found(client):
     responses.add(
         responses.GET,
         f"{client._base_url}/v1/model/info",
-        json={
-            "data": [
-                {"model_name": "gpt-3.5-turbo", "model_info": {"id": "other-model"}}
-            ]
-        },
+        json={"data": [{"model_name": "gpt-3.5-turbo", "model_info": {"id": "other-model"}}]},
         status=200,
     )
 
@@ -633,9 +615,7 @@ def test_update_without_model_info(client):
     model_id = "model-123"
     model_params = {"model": "openai/gpt-4", "api_base": "https://api.openai.com/v1"}
 
-    request = client.update(
-        model_id=model_id, model_params=model_params, return_request=True
-    )
+    request = client.update(model_id=model_id, model_params=model_params, return_request=True)
 
     # Check request body doesn't include model_info
     assert request.json == {"id": model_id, "litellm_params": model_params}

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -63,6 +63,25 @@ async def test_request_body_caching():
 
 
 @pytest.mark.asyncio
+async def test_request_body_rejects_escaped_lone_surrogates():
+    """Escaped lone surrogates should fail fast as invalid request bodies."""
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(
+        return_value=b'{"messages": [{"role": "user", "content": "\\ud83e"}]}'
+    )
+    mock_request.headers = {"content-type": "application/json"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    with pytest.raises(ProxyException) as exc_info:
+        await _read_request_body(mock_request)
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.param == "request_body"
+    assert "surrogate" in exc_info.value.message.lower()
+
+
+@pytest.mark.asyncio
 async def test_form_data_parsing():
     """
     Test that form data is correctly parsed from the request.
@@ -99,25 +118,27 @@ async def test_form_data_parsing():
 async def test_form_data_with_json_metadata():
     """
     Test that form data with a JSON-encoded metadata field is correctly parsed.
-    
+
     When form data includes a 'metadata' field, it comes as a JSON string that needs
     to be parsed into a Python dictionary (lines 42-43 of http_parsing_utils.py).
     """
     # Create a mock request with form data containing JSON metadata
     mock_request = MagicMock()
-    
+
     # Metadata is sent as a JSON string in form data
-    metadata_json_string = json.dumps({
-        "user_id": "12345",
-        "request_type": "audio_transcription",
-        "tags": ["urgent", "production"],
-        "custom_field": {"nested": "value"}
-    })
-    
+    metadata_json_string = json.dumps(
+        {
+            "user_id": "12345",
+            "request_type": "audio_transcription",
+            "tags": ["urgent", "production"],
+            "custom_field": {"nested": "value"},
+        }
+    )
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": metadata_json_string  # This is a JSON string, not a dict
+        "metadata": metadata_json_string,  # This is a JSON string, not a dict
     }
 
     # Mock the form method to return the test data as an awaitable
@@ -136,11 +157,11 @@ async def test_form_data_with_json_metadata():
     assert result["metadata"]["request_type"] == "audio_transcription"
     assert result["metadata"]["tags"] == ["urgent", "production"]
     assert result["metadata"]["custom_field"] == {"nested": "value"}
-    
+
     # Verify other fields remain unchanged
     assert result["model"] == "whisper-1"
     assert result["file"] == "audio.mp3"
-    
+
     # Verify form() was called
     mock_request.form.assert_called_once()
 
@@ -149,16 +170,16 @@ async def test_form_data_with_json_metadata():
 async def test_form_data_with_invalid_json_metadata():
     """
     Test that form data with invalid JSON in metadata field raises an exception.
-    
+
     This tests error handling when the metadata field contains malformed JSON.
     """
     # Create a mock request with form data containing invalid JSON metadata
     mock_request = MagicMock()
-    
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": '{"invalid": json}'  # Invalid JSON - unquoted value
+        "metadata": '{"invalid": json}',  # Invalid JSON - unquoted value
     }
 
     # Mock the form method to return the test data
@@ -176,17 +197,13 @@ async def test_form_data_with_invalid_json_metadata():
 async def test_form_data_without_metadata():
     """
     Test that form data without metadata field works correctly.
-    
+
     Ensures the metadata parsing logic doesn't break when metadata is absent.
     """
     # Create a mock request with form data without metadata
     mock_request = MagicMock()
-    
-    test_data = {
-        "model": "whisper-1",
-        "file": "audio.mp3",
-        "language": "en"
-    }
+
+    test_data = {"model": "whisper-1", "file": "audio.mp3", "language": "en"}
 
     # Mock the form method to return the test data
     mock_request.form = AsyncMock(return_value=test_data)
@@ -212,11 +229,11 @@ async def test_form_data_with_empty_metadata():
     """
     # Create a mock request with form data containing empty metadata
     mock_request = MagicMock()
-    
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": "{}"  # Empty JSON object as string
+        "metadata": "{}",  # Empty JSON object as string
     }
 
     # Mock the form method to return the test data
@@ -239,22 +256,19 @@ async def test_form_data_with_empty_metadata():
 async def test_form_data_with_dict_metadata():
     """
     Test that form data with metadata already as a dict is not parsed again.
-    
+
     This handles edge cases where metadata might already be a dictionary
     (shouldn't happen in normal form data, but defensive coding).
     """
     # Create a mock request with form data where metadata is already a dict
     mock_request = MagicMock()
-    
-    metadata_dict = {
-        "user_id": "12345",
-        "tags": ["test"]
-    }
-    
+
+    metadata_dict = {"user_id": "12345", "tags": ["test"]}
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": metadata_dict  # Already a dict, not a string
+        "metadata": metadata_dict,  # Already a dict, not a string
     }
 
     # Mock the form method to return the test data
@@ -281,11 +295,11 @@ async def test_form_data_with_none_metadata():
     """
     # Create a mock request with form data where metadata is None
     mock_request = MagicMock()
-    
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": None  # None value
+        "metadata": None,  # None value
     }
 
     # Mock the form method to return the test data
@@ -373,7 +387,7 @@ async def test_json_parsing_error_handling():
     """
     # Test case 1: Trailing comma error
     mock_request = MagicMock()
-    invalid_json_with_trailing_comma = b'''{
+    invalid_json_with_trailing_comma = b"""{
         "model": "gpt-4o",
         "tools": [
             {
@@ -385,8 +399,8 @@ async def test_json_parsing_error_handling():
             }
         ],
         "input": "Run available tools"
-    }'''
-    
+    }"""
+
     mock_request.body = AsyncMock(return_value=invalid_json_with_trailing_comma)
     mock_request.headers = {"content-type": "application/json"}
     mock_request.scope = {}
@@ -394,14 +408,14 @@ async def test_json_parsing_error_handling():
     # Should raise ProxyException for trailing comma
     with pytest.raises(ProxyException) as exc_info:
         await _read_request_body(mock_request)
-    
+
     assert exc_info.value.code == "400"
     assert "Invalid JSON payload" in exc_info.value.message
     assert "trailing comma" in exc_info.value.message
 
     # Test case 2: Unquoted property name error
     mock_request2 = MagicMock()
-    invalid_json_unquoted_property = b'''{
+    invalid_json_unquoted_property = b"""{
         "model": "gpt-4o",
         "tools": [
             {
@@ -410,8 +424,8 @@ async def test_json_parsing_error_handling():
             }
         ],
         "input": "Run available tools"
-    }'''
-    
+    }"""
+
     mock_request2.body = AsyncMock(return_value=invalid_json_unquoted_property)
     mock_request2.headers = {"content-type": "application/json"}
     mock_request2.scope = {}
@@ -419,13 +433,13 @@ async def test_json_parsing_error_handling():
     # Should raise ProxyException for unquoted property
     with pytest.raises(ProxyException) as exc_info2:
         await _read_request_body(mock_request2)
-    
+
     assert exc_info2.value.code == "400"
     assert "Invalid JSON payload" in exc_info2.value.message
 
     # Test case 3: Valid JSON should work normally
     mock_request3 = MagicMock()
-    valid_json = b'''{
+    valid_json = b"""{
         "model": "gpt-4o",
         "tools": [
             {
@@ -437,8 +451,8 @@ async def test_json_parsing_error_handling():
             }
         ],
         "input": "Run available tools"
-    }'''
-    
+    }"""
+
     mock_request3.body = AsyncMock(return_value=valid_json)
     mock_request3.headers = {"content-type": "application/json"}
     mock_request3.scope = {}
@@ -505,15 +519,10 @@ def test_get_tags_from_request_body_with_metadata_tags():
     """
     Test that tags are correctly extracted from request body metadata.
     """
-    request_body = {
-        "model": "gpt-4",
-        "metadata": {
-            "tags": ["tag1", "tag2", "tag3"]
-        }
-    }
-    
+    request_body = {"model": "gpt-4", "metadata": {"tags": ["tag1", "tag2", "tag3"]}}
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3"]
 
 
@@ -523,13 +532,11 @@ def test_get_tags_from_request_body_with_litellm_metadata_tags():
     """
     request_body = {
         "model": "gpt-4",
-        "litellm_metadata": {
-            "tags": ["tag1", "tag2", "tag3"]
-        }
+        "litellm_metadata": {"tags": ["tag1", "tag2", "tag3"]},
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3"]
 
 
@@ -537,13 +544,10 @@ def test_get_tags_from_request_body_with_root_tags():
     """
     Test that tags are correctly extracted from root level of request body.
     """
-    request_body = {
-        "model": "gpt-4",
-        "tags": ["tag1", "tag2"]
-    }
-    
+    request_body = {"model": "gpt-4", "tags": ["tag1", "tag2"]}
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2"]
 
 
@@ -553,14 +557,12 @@ def test_get_tags_from_request_body_with_combined_tags():
     """
     request_body = {
         "model": "gpt-4",
-        "metadata": {
-            "tags": ["tag1", "tag2"]
-        },
-        "tags": ["tag3", "tag4"]
+        "metadata": {"tags": ["tag1", "tag2"]},
+        "tags": ["tag3", "tag4"],
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3", "tag4"]
 
 
@@ -570,13 +572,11 @@ def test_get_tags_from_request_body_filters_non_strings():
     """
     request_body = {
         "model": "gpt-4",
-        "metadata": {
-            "tags": ["tag1", 123, "tag2", None, "tag3", {"nested": "dict"}]
-        }
+        "metadata": {"tags": ["tag1", 123, "tag2", None, "tag3", {"nested": "dict"}]},
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3"]
 
 
@@ -584,13 +584,10 @@ def test_get_tags_from_request_body_no_tags():
     """
     Test that empty list is returned when no tags are present.
     """
-    request_body = {
-        "model": "gpt-4",
-        "metadata": {}
-    }
-    
+    request_body = {"model": "gpt-4", "metadata": {}}
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == []
 
 
@@ -601,18 +598,13 @@ def test_get_tags_from_request_body_with_dict_tags():
     """
     request_body = {
         "model": "aws/anthropic/bedrock-claude-3-5-sonnet-v1",
-        "messages": [
-            {
-                "role": "user",
-                "content": "aloha"
-            }
-        ],
+        "messages": [{"role": "user", "content": "aloha"}],
         "metadata": {
             "tags": {
                 "litellm_id": "litellm_ratelimit_test",
-                "llm_id": "llmid_ratelimit_test"
+                "llm_id": "llmid_ratelimit_test",
             }
-        }
+        },
     }
 
     result = get_tags_from_request_body(request_body=request_body)
@@ -631,7 +623,7 @@ def test_get_tags_from_request_body_with_null_metadata():
     """
     request_body = {
         "model": "gpt-4",
-        "metadata": None  # OpenAI API accepts metadata: null
+        "metadata": None,  # OpenAI API accepts metadata: null
     }
 
     result = get_tags_from_request_body(request_body=request_body)
@@ -648,10 +640,7 @@ def test_populate_request_with_path_params_adds_query_params():
     # Create a mock request with query parameters
     mock_request = MagicMock()
     # Mock query_params as a dict-like object that can be converted to dict
-    mock_request.query_params = {
-        "organization_id": "org-123",
-        "user_id": "user-456"
-    }
+    mock_request.query_params = {"organization_id": "org-123", "user_id": "user-456"}
     mock_request.path_params = {}
     # Mock url.path to avoid errors in _add_vector_store_id_from_path
     mock_request.url.path = "/v1/chat/completions"
@@ -659,7 +648,7 @@ def test_populate_request_with_path_params_adds_query_params():
     # Initial request data without query params
     request_data = {
         "model": "gpt-4",
-        "messages": [{"role": "user", "content": "Hello"}]
+        "messages": [{"role": "user", "content": "Hello"}],
     }
 
     # Call the function
@@ -683,7 +672,7 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
     # Mock query_params as a dict-like object that can be converted to dict
     mock_request.query_params = {
         "organization_id": "org-query-param",
-        "model": "gpt-3.5-turbo"
+        "model": "gpt-3.5-turbo",
     }
     mock_request.path_params = {}
     # Mock url.path to avoid errors in _add_vector_store_id_from_path
@@ -693,7 +682,7 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
     request_data = {
         "model": "gpt-4",  # This should NOT be overwritten
         "organization_id": "org-existing",  # This should NOT be overwritten
-        "messages": [{"role": "user", "content": "Hello"}]
+        "messages": [{"role": "user", "content": "Hello"}],
     }
 
     # Call the function
@@ -701,7 +690,9 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
 
     # Verify existing values were NOT overwritten
     assert result["model"] == "gpt-4"  # Should keep original, not "gpt-3.5-turbo"
-    assert result["organization_id"] == "org-existing"  # Should keep original, not "org-query-param"
+    assert (
+        result["organization_id"] == "org-existing"
+    )  # Should keep original, not "org-query-param"
     # Verify other data is preserved
     assert result["messages"] == [{"role": "user", "content": "Hello"}]
 
@@ -776,12 +767,18 @@ def test_safe_get_request_headers_caches_on_request_state():
     and returns the same object on subsequent calls.
     """
     mock_request = MagicMock()
-    mock_request.headers = {"content-type": "application/json", "authorization": "Bearer sk-123"}
+    mock_request.headers = {
+        "content-type": "application/json",
+        "authorization": "Bearer sk-123",
+    }
     mock_request.state = MagicMock(spec=[])  # empty spec so getattr returns default
 
     # First call — should create and cache
     result1 = _safe_get_request_headers(mock_request)
-    assert result1 == {"content-type": "application/json", "authorization": "Bearer sk-123"}
+    assert result1 == {
+        "content-type": "application/json",
+        "authorization": "Bearer sk-123",
+    }
     assert mock_request.state._cached_headers is result1
 
     # Second call — should return the cached object (same identity)
@@ -821,8 +818,10 @@ def test_safe_get_request_headers_state_unavailable():
     Test that _safe_get_request_headers still returns headers when
     request.state rejects attribute writes (the except path on the cache-write).
     """
+
     class ReadOnlyState:
         """State object that allows reads but raises on writes."""
+
         def __setattr__(self, name, value):
             raise AttributeError("read-only state")
 

--- a/tests/test_litellm/proxy/db/test_tool_registry_writer.py
+++ b/tests/test_litellm/proxy/db/test_tool_registry_writer.py
@@ -62,12 +62,8 @@ def _make_prisma(
     prisma = MagicMock()
     prisma.db.litellm_tooltable = MagicMock()
     prisma.db.litellm_tooltable.upsert = AsyncMock(return_value=upsert_return)
-    prisma.db.litellm_tooltable.find_many = AsyncMock(
-        return_value=find_many_rows if find_many_rows is not None else []
-    )
-    prisma.db.litellm_tooltable.find_unique = AsyncMock(
-        return_value=find_unique_row
-    )
+    prisma.db.litellm_tooltable.find_many = AsyncMock(return_value=find_many_rows if find_many_rows is not None else [])
+    prisma.db.litellm_tooltable.find_unique = AsyncMock(return_value=find_unique_row)
     return prisma
 
 
@@ -163,9 +159,7 @@ async def test_get_tool_found():
     result = await get_tool(prisma, "my_tool")
     assert result is not None
     assert result.tool_name == "my_tool"
-    prisma.db.litellm_tooltable.find_unique.assert_awaited_once_with(
-        where={"tool_name": "my_tool"}
-    )
+    prisma.db.litellm_tooltable.find_unique.assert_awaited_once_with(where={"tool_name": "my_tool"})
 
 
 @pytest.mark.asyncio
@@ -184,9 +178,7 @@ async def test_update_tool_policy_calls_upsert_then_get_tool():
         updated_by="admin",
     )
     prisma = _make_prisma(find_unique_row=row)
-    result = await update_tool_policy(
-        prisma, "my_tool", updated_by="admin", input_policy="blocked"
-    )
+    result = await update_tool_policy(prisma, "my_tool", updated_by="admin", input_policy="blocked")
     assert result is not None
     assert result.input_policy == "blocked"
     prisma.db.litellm_tooltable.upsert.assert_awaited_once()
@@ -194,9 +186,7 @@ async def test_update_tool_policy_calls_upsert_then_get_tool():
     assert call_kw["where"] == {"tool_name": "my_tool"}
     assert call_kw["data"]["update"]["input_policy"] == "blocked"
     assert call_kw["data"]["update"]["updated_by"] == "admin"
-    prisma.db.litellm_tooltable.find_unique.assert_awaited_with(
-        where={"tool_name": "my_tool"}
-    )
+    prisma.db.litellm_tooltable.find_unique.assert_awaited_with(where={"tool_name": "my_tool"})
 
 
 @pytest.mark.asyncio
@@ -211,9 +201,7 @@ async def test_get_tools_by_names_returns_policy_map():
         "tool_a": ("trusted", "untrusted"),
         "tool_b": ("blocked", "untrusted"),
     }
-    prisma.db.litellm_tooltable.find_many.assert_awaited_once_with(
-        where={"tool_name": {"in": ["tool_a", "tool_b"]}}
-    )
+    prisma.db.litellm_tooltable.find_many.assert_awaited_once_with(where={"tool_name": {"in": ["tool_a", "tool_b"]}})
 
 
 @pytest.mark.asyncio
@@ -263,7 +251,7 @@ async def test_tool_policy_registry_sync_and_get_effective_policies():
             _mock_perm_row("op-team-1", ["tool_c"]),
         ]
     )
-    registry = get_tool_policy_registry()
+    registry = ToolPolicyRegistry()
     await registry.sync_tool_policy_from_db(prisma)
     assert registry.is_initialized()
     # Key blocked: tool_a. Team blocked: tool_c. Global: tool_b blocked.

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6487,15 +6487,15 @@ async def test_rotate_master_key_model_data_valid_for_prisma(
         "updated_at should be excluded so Prisma @default(now()) applies"
     )
 
-    # Verify litellm_params and model_info are prisma.Json wrappers, NOT JSON strings
-    import prisma
-
-    assert isinstance(model_data["litellm_params"], prisma.Json), (
-        f"litellm_params should be prisma.Json for create_many(), got {type(model_data['litellm_params'])}"
+    # Verify litellm_params and model_info stay as plain dicts for create_many
+    assert isinstance(model_data["litellm_params"], dict), (
+        f"litellm_params should be a dict for create_many(), got {type(model_data['litellm_params'])}"
     )
-    assert isinstance(model_data["model_info"], prisma.Json), (
-        f"model_info should be prisma.Json for create_many(), got {type(model_data['model_info'])}"
+    assert isinstance(model_data["model_info"], dict), (
+        f"model_info should be a dict for create_many(), got {type(model_data['model_info'])}"
     )
+    assert "model" in model_data["litellm_params"]
+    assert model_data["model_info"]["id"] == "model-1"
 
     # Verify delete_many was called inside the transaction (before create_many)
     mock_tx.litellm_proxymodeltable.delete_many.assert_called_once()

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2724,6 +2724,7 @@ async def test_new_team_max_budget_exceeds_user_max_budget():
     """
     from fastapi import Request
 
+    import litellm
     from litellm.proxy._types import NewTeamRequest, ProxyException, UserAPIKeyAuth
     from litellm.proxy.management_endpoints.team_endpoints import new_team
 
@@ -2741,6 +2742,8 @@ async def test_new_team_max_budget_exceeds_user_max_budget():
     )
 
     dummy_request = MagicMock(spec=Request)
+    litellm.default_team_params = None
+    litellm.default_team_settings = None
 
     with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma, patch(
         "litellm.proxy.proxy_server._license_check"

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -10,9 +10,7 @@ from fastapi import Request
 
 from litellm._uuid import uuid
 
-sys.path.insert(
-    0, os.path.abspath("../../../")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../"))  # Adds the parent directory to the system path
 
 import litellm
 from litellm.proxy._types import LiteLLM_UserTable, NewUserResponse
@@ -104,9 +102,7 @@ def test_microsoft_sso_handler_with_empty_response():
     # Test with None response
 
     # Act
-    result = MicrosoftSSOHandler.openid_from_response(
-        response=None, team_ids=[], user_role=None
-    )
+    result = MicrosoftSSOHandler.openid_from_response(response=None, team_ids=[], user_role=None)
 
     # Assert
     assert isinstance(result, CustomOpenID)
@@ -135,31 +131,32 @@ def test_microsoft_sso_handler_openid_from_response_with_custom_attributes():
     expected_team_ids = ["team1"]
 
     # Act
-    with patch(
-        "litellm.constants.MICROSOFT_USER_EMAIL_ATTRIBUTE", "custom_email_field"
-    ), patch(
-        "litellm.constants.MICROSOFT_USER_DISPLAY_NAME_ATTRIBUTE", "custom_display_name"
-    ), patch(
-        "litellm.constants.MICROSOFT_USER_ID_ATTRIBUTE", "custom_id_field"
-    ), patch(
-        "litellm.constants.MICROSOFT_USER_FIRST_NAME_ATTRIBUTE", "custom_first_name"
-    ), patch(
-        "litellm.constants.MICROSOFT_USER_LAST_NAME_ATTRIBUTE", "custom_last_name"
-    ), patch(
-        "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_EMAIL_ATTRIBUTE",
-        "custom_email_field",
-    ), patch(
-        "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_DISPLAY_NAME_ATTRIBUTE",
-        "custom_display_name",
-    ), patch(
-        "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_ID_ATTRIBUTE",
-        "custom_id_field",
-    ), patch(
-        "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_FIRST_NAME_ATTRIBUTE",
-        "custom_first_name",
-    ), patch(
-        "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_LAST_NAME_ATTRIBUTE",
-        "custom_last_name",
+    with (
+        patch("litellm.constants.MICROSOFT_USER_EMAIL_ATTRIBUTE", "custom_email_field"),
+        patch("litellm.constants.MICROSOFT_USER_DISPLAY_NAME_ATTRIBUTE", "custom_display_name"),
+        patch("litellm.constants.MICROSOFT_USER_ID_ATTRIBUTE", "custom_id_field"),
+        patch("litellm.constants.MICROSOFT_USER_FIRST_NAME_ATTRIBUTE", "custom_first_name"),
+        patch("litellm.constants.MICROSOFT_USER_LAST_NAME_ATTRIBUTE", "custom_last_name"),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_EMAIL_ATTRIBUTE",
+            "custom_email_field",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_DISPLAY_NAME_ATTRIBUTE",
+            "custom_display_name",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_ID_ATTRIBUTE",
+            "custom_id_field",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_FIRST_NAME_ATTRIBUTE",
+            "custom_first_name",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.MICROSOFT_USER_LAST_NAME_ATTRIBUTE",
+            "custom_last_name",
+        ),
     ):
         result = MicrosoftSSOHandler.openid_from_response(
             response=mock_response, team_ids=expected_team_ids, user_role=None
@@ -267,9 +264,7 @@ def test_get_google_callback_response():
 
     with patch.dict(os.environ, {"GOOGLE_CLIENT_SECRET": "mock_secret"}):
         mock_verify = AsyncMock(return_value=mock_response)
-        with patch(
-            "fastapi_sso.sso.google.GoogleSSO.verify_and_process", new=mock_verify
-        ):
+        with patch("fastapi_sso.sso.google.GoogleSSO.verify_and_process", new=mock_verify):
             # Act
             result = asyncio.run(
                 GoogleSSOHandler.get_google_callback_response(
@@ -312,16 +307,12 @@ async def test_get_user_groups_from_graph_api():
         mock.json.return_value = mock_response
         return mock
 
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-    ) as mock_client:
+    with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_client:
         mock_client.return_value = MagicMock()
         mock_client.return_value.get = mock_get
 
         # Act
-        result = await MicrosoftSSOHandler.get_user_groups_from_graph_api(
-            access_token="mock_token"
-        )
+        result = await MicrosoftSSOHandler.get_user_groups_from_graph_api(access_token="mock_token")
 
         # Assert
         assert isinstance(result, list)
@@ -343,16 +334,12 @@ async def test_get_user_groups_empty_response():
         mock.json.return_value = mock_response
         return mock
 
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-    ) as mock_client:
+    with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_client:
         mock_client.return_value = MagicMock()
         mock_client.return_value.get = mock_get
 
         # Act
-        result = await MicrosoftSSOHandler.get_user_groups_from_graph_api(
-            access_token="mock_token"
-        )
+        result = await MicrosoftSSOHandler.get_user_groups_from_graph_api(access_token="mock_token")
 
         # Assert
         assert isinstance(result, list)
@@ -365,16 +352,12 @@ async def test_get_user_groups_error_handling():
     async def mock_get(*args, **kwargs):
         raise Exception("API Error")
 
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-    ) as mock_client:
+    with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_client:
         mock_client.return_value = MagicMock()
         mock_client.return_value.get = mock_get
 
         # Act
-        result = await MicrosoftSSOHandler.get_user_groups_from_graph_api(
-            access_token="mock_token"
-        )
+        result = await MicrosoftSSOHandler.get_user_groups_from_graph_api(access_token="mock_token")
 
         # Assert
         assert isinstance(result, list)
@@ -429,9 +412,7 @@ def test_get_group_ids_from_graph_api_response():
     "team_params",
     [
         # Test case 1: Using DefaultTeamSSOParams
-        DefaultTeamSSOParams(
-            max_budget=10, budget_duration="1d", models=["special-gpt-5"]
-        ),
+        DefaultTeamSSOParams(max_budget=10, budget_duration="1d", models=["special-gpt-5"]),
         # Test case 2: Using Dict
         {"max_budget": 10, "budget_duration": "1d", "models": ["special-gpt-5"]},
     ],
@@ -469,9 +450,7 @@ async def test_default_team_params(team_params):
         # Assert
         # Verify team was created with correct parameters
         mock_prisma.db.litellm_teamtable.create.assert_called_once()
-        create_call_args = mock_prisma.db.litellm_teamtable.create.call_args.kwargs[
-            "data"
-        ]
+        create_call_args = mock_prisma.db.litellm_teamtable.create.call_args.kwargs["data"]
         assert create_call_args["team_id"] == team_id
         assert create_call_args["team_alias"] == "Test Team"
         assert create_call_args["max_budget"] == 10
@@ -513,9 +492,7 @@ async def test_create_team_without_default_params():
 
         # Assert
         mock_prisma.db.litellm_teamtable.create.assert_called_once()
-        create_call_args = mock_prisma.db.litellm_teamtable.create.call_args.kwargs[
-            "data"
-        ]
+        create_call_args = mock_prisma.db.litellm_teamtable.create.call_args.kwargs["data"]
         assert create_call_args["team_id"] == team_id
         assert create_call_args["team_alias"] == "Test Team"
         # Should not have any of the optional fields
@@ -973,9 +950,7 @@ async def test_get_user_info_from_db_user_exists():
         "user_email": user_email,
         "user_defined_values": user_defined_values,
     }
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_user_object"
-    ) as mock_get_user_object:
+    with patch("litellm.proxy.management_endpoints.ui_sso.get_user_object") as mock_get_user_object:
         await get_user_info_from_db(**args)
         mock_get_user_object.assert_called_once()
         assert mock_get_user_object.call_args.kwargs["user_id"] == "krrishd"
@@ -1015,9 +990,7 @@ async def test_get_user_info_from_db_user_exists_alternate_user_id():
         "user_defined_values": user_defined_values,
         "alternate_user_id": "krrishd-email1234",
     }
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_user_object"
-    ) as mock_get_user_object:
+    with patch("litellm.proxy.management_endpoints.ui_sso.get_user_object") as mock_get_user_object:
         await get_user_info_from_db(**args)
         mock_get_user_object.assert_called_once()
         assert mock_get_user_object.call_args.kwargs["user_id"] == "krrishd-email1234"
@@ -1076,15 +1049,19 @@ async def test_get_user_info_from_db_user_not_exists_creates_user():
         teams=None,
     )
 
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_existing_user_info_from_db",
-        return_value=None,  # User doesn't exist
-    ) as mock_get_existing, patch(
-        "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.upsert_sso_user",
-        return_value=mock_new_user,
-    ) as mock_upsert, patch(
-        "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.add_user_to_teams_from_sso_response",
-    ) as mock_add_teams:
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.get_existing_user_info_from_db",
+            return_value=None,  # User doesn't exist
+        ) as mock_get_existing,
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.upsert_sso_user",
+            return_value=mock_new_user,
+        ) as mock_upsert,
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.add_user_to_teams_from_sso_response",
+        ) as mock_add_teams,
+    ):
         # Act
         user_info = await get_user_info_from_db(**args)
 
@@ -1175,15 +1152,19 @@ async def test_get_user_info_from_db_user_exists_updates_user():
         "user_defined_values": user_defined_values,
     }
 
-    with patch(
-        "litellm.proxy.management_endpoints.ui_sso.get_existing_user_info_from_db",
-        return_value=existing_user,  # User exists
-    ) as mock_get_existing, patch(
-        "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.upsert_sso_user",
-        return_value=updated_user,
-    ) as mock_upsert, patch(
-        "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.add_user_to_teams_from_sso_response",
-    ) as mock_add_teams:
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.get_existing_user_info_from_db",
+            return_value=existing_user,  # User exists
+        ) as mock_get_existing,
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.upsert_sso_user",
+            return_value=updated_user,
+        ) as mock_upsert,
+        patch(
+            "litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.add_user_to_teams_from_sso_response",
+        ) as mock_add_teams,
+    ):
         # Act
         user_info = await get_user_info_from_db(**args)
 
@@ -1317,9 +1298,7 @@ async def test_get_generic_sso_response_with_additional_headers():
 
     with patch.dict(os.environ, test_env_vars):
         with patch("fastapi_sso.sso.base.DiscoveryDocument"):
-            with patch(
-                "fastapi_sso.sso.generic.create_provider", return_value=mock_sso_class
-            ):
+            with patch("fastapi_sso.sso.generic.create_provider", return_value=mock_sso_class):
                 # Act
                 result, received_response = await get_generic_sso_response(
                     request=mock_request,
@@ -1379,9 +1358,7 @@ async def test_get_generic_sso_response_with_empty_headers():
 
     with patch.dict(os.environ, test_env_vars):
         with patch("fastapi_sso.sso.base.DiscoveryDocument"):
-            with patch(
-                "fastapi_sso.sso.generic.create_provider", return_value=mock_sso_class
-            ):
+            with patch("fastapi_sso.sso.generic.create_provider", return_value=mock_sso_class):
                 # Act
                 result, received_response = await get_generic_sso_response(
                     request=mock_request,
@@ -1474,9 +1451,7 @@ class TestAuthCallbackRouting:
 
         for state in non_cli_states:
             # This mimics the routing logic in auth_callback
-            should_route_to_cli = state and state.startswith(
-                f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:"
-            )
+            should_route_to_cli = state and state.startswith(f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:")
             assert not should_route_to_cli, f"State '{state}' should not route to CLI"
 
 
@@ -1485,7 +1460,18 @@ class TestGoogleLoginCLIIntegration:
 
     def test_google_login_cli_state_generation(self):
         """Test that google_login generates CLI state when CLI parameters are provided"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         # Test the CLI state generation logic used in google_login
         source = "litellm-cli"
@@ -1499,7 +1485,18 @@ class TestGoogleLoginCLIIntegration:
 
     def test_google_login_no_cli_state_when_missing_params(self):
         """Test that google_login doesn't generate CLI state when CLI parameters are missing"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         # Test various parameter combinations that shouldn't generate CLI state
         test_cases = [
@@ -1511,9 +1508,7 @@ class TestGoogleLoginCLIIntegration:
 
         for source, key in test_cases:
             cli_state = SSOAuthenticationHandler._get_cli_state(source=source, key=key)
-            assert (
-                cli_state is None
-            ), f"CLI state should not be generated for source='{source}', key='{key}'"
+            assert cli_state is None, f"CLI state should not be generated for source='{source}', key='{key}'"
 
 
 class TestSSOHandlerIntegration:
@@ -1521,32 +1516,43 @@ class TestSSOHandlerIntegration:
 
     def test_should_use_sso_handler(self):
         """Test the SSO handler detection logic"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         # Test that SSO handler is used when client IDs are provided
-        assert (
-            SSOAuthenticationHandler.should_use_sso_handler(google_client_id="test")
-            is True
-        )
-        assert (
-            SSOAuthenticationHandler.should_use_sso_handler(microsoft_client_id="test")
-            is True
-        )
-        assert (
-            SSOAuthenticationHandler.should_use_sso_handler(generic_client_id="test")
-            is True
-        )
+        assert SSOAuthenticationHandler.should_use_sso_handler(google_client_id="test") is True
+        assert SSOAuthenticationHandler.should_use_sso_handler(microsoft_client_id="test") is True
+        assert SSOAuthenticationHandler.should_use_sso_handler(generic_client_id="test") is True
 
         # Test that SSO handler is not used when no client IDs are provided
         assert SSOAuthenticationHandler.should_use_sso_handler() is False
-        assert (
-            SSOAuthenticationHandler.should_use_sso_handler(None, None, None) is False
-        )
+        assert SSOAuthenticationHandler.should_use_sso_handler(None, None, None) is False
 
     @patch.dict(os.environ, {}, clear=False)
     def test_get_redirect_url_for_sso(self):
         """Test the redirect URL generation for SSO"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         # Remove env vars that override request base_url so the test is
         # isolated from local settings.
@@ -1595,7 +1601,18 @@ class TestUISSO_FunctionsExistence:
 
     def test_sso_authentication_handler_exists(self):
         """Test that SSOAuthenticationHandler class exists with new methods"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         # Check that the class exists
         assert SSOAuthenticationHandler is not None
@@ -1610,11 +1627,20 @@ class TestSSOStateHandling:
 
     def test_get_cli_state_valid(self):
         """Test generating CLI state with valid parameters"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-        state = SSOAuthenticationHandler._get_cli_state(
-            source="litellm-cli", key="sk-test123"
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
         )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
+
+        state = SSOAuthenticationHandler._get_cli_state(source="litellm-cli", key="sk-test123")
 
         assert state is not None
         assert state.startswith("litellm-session-token:")
@@ -1622,17 +1648,37 @@ class TestSSOStateHandling:
 
     def test_get_cli_state_invalid_source(self):
         """Test generating CLI state with invalid source"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
-
-        state = SSOAuthenticationHandler._get_cli_state(
-            source="invalid_source", key="sk-test123"
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
         )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
+
+        state = SSOAuthenticationHandler._get_cli_state(source="invalid_source", key="sk-test123")
 
         assert state is None
 
     def test_get_cli_state_no_key(self):
         """Test generating CLI state without key"""
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         state = SSOAuthenticationHandler._get_cli_state(source="litellm-cli", key=None)
 
@@ -1667,9 +1713,7 @@ class TestSSOStateHandling:
         """Test generating CLI state without existing_key"""
         from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
 
-        state = SSOAuthenticationHandler._get_cli_state(
-            source="litellm-cli", key="sk-new-key-789", existing_key=None
-        )
+        state = SSOAuthenticationHandler._get_cli_state(source="litellm-cli", key="sk-new-key-789", existing_key=None)
 
         assert state is not None
         assert state.startswith("litellm-session-token:")
@@ -1699,9 +1743,7 @@ class TestStateRouting:
         from litellm.constants import LITELLM_CLI_SESSION_TOKEN_PREFIX
 
         # State format: {PREFIX}:{key}:{existing_key}
-        cli_state = (
-            f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:sk-new-key-456:sk-existing-key-789"
-        )
+        cli_state = f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:sk-new-key-456:sk-existing-key-789"
 
         # Parse as done in auth_callback
         state_parts = cli_state.split(":", 2)  # Split into max 3 parts
@@ -1784,9 +1826,7 @@ class TestCustomUISSO:
             ):
                 with patch.dict(
                     "sys.modules",
-                    {
-                        "enterprise.litellm_enterprise.proxy.auth.custom_sso_handler": None
-                    },
+                    {"enterprise.litellm_enterprise.proxy.auth.custom_sso_handler": None},
                 ):
                     # Temporarily mock the google_login function call to test the import error path
                     async def mock_google_login():
@@ -1805,9 +1845,7 @@ class TestCustomUISSO:
                     # Test that the ValueError is raised with the correct message
                     import pytest
 
-                    with pytest.raises(
-                        ValueError, match="Enterprise features are not available"
-                    ):
+                    with pytest.raises(ValueError, match="Enterprise features are not available"):
                         asyncio.run(mock_google_login())
 
     @pytest.mark.asyncio
@@ -1840,9 +1878,7 @@ class TestCustomUISSO:
             picture=None,
             provider="custom",
         )
-        mock_custom_handler.handle_custom_ui_sso_sign_in = AsyncMock(
-            return_value=expected_openid
-        )
+        mock_custom_handler.handle_custom_ui_sso_sign_in = AsyncMock(return_value=expected_openid)
 
         # Mock the redirect response method
         mock_redirect_response = MagicMock()
@@ -1859,17 +1895,11 @@ class TestCustomUISSO:
                     return_value=mock_redirect_response,
                 ) as mock_get_redirect:
                     # Act
-                    result = (
-                        await EnterpriseCustomSSOHandler.handle_custom_ui_sso_sign_in(
-                            request=mock_request
-                        )
-                    )
+                    result = await EnterpriseCustomSSOHandler.handle_custom_ui_sso_sign_in(request=mock_request)
 
                     # Assert
                     # Verify the custom handler was called with the request
-                    mock_custom_handler.handle_custom_ui_sso_sign_in.assert_called_once_with(
-                        request=mock_request
-                    )
+                    mock_custom_handler.handle_custom_ui_sso_sign_in.assert_called_once_with(request=mock_request)
 
                     # Verify the redirect response was generated with correct OpenID
                     mock_get_redirect.assert_called_once_with(
@@ -1912,9 +1942,7 @@ class TestCustomUISSO:
                 request_headers_dict = dict(request.headers)
                 return OpenID(
                     id=request_headers_dict.get("x-litellm-user-id", "default_user"),
-                    email=request_headers_dict.get(
-                        "x-litellm-user-email", "default@test.com"
-                    ),
+                    email=request_headers_dict.get("x-litellm-user-email", "default@test.com"),
                     first_name="Custom",
                     last_name="Handler",
                     display_name="Custom Handler Test",
@@ -1949,11 +1977,7 @@ class TestCustomUISSO:
                     return_value=mock_redirect_response,
                 ) as mock_get_redirect:
                     # Act
-                    result = (
-                        await EnterpriseCustomSSOHandler.handle_custom_ui_sso_sign_in(
-                            request=mock_request
-                        )
-                    )
+                    result = await EnterpriseCustomSSOHandler.handle_custom_ui_sso_sign_in(request=mock_request)
 
                     # Assert that our custom handler was executed
                     assert test_handler_instance.method_called is True
@@ -2012,14 +2036,17 @@ class TestCLIKeyRegenerationFlow:
         # Mock cache
         mock_cache = MagicMock()
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_user_info_from_db",
-            return_value=mock_user_info,
-        ), patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch(
-            "litellm.proxy.common_utils.html_forms.cli_sso_success.render_cli_sso_success_page",
-            return_value="<html>Success</html>",
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.get_user_info_from_db",
+                return_value=mock_user_info,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch(
+                "litellm.proxy.common_utils.html_forms.cli_sso_success.render_cli_sso_success_page",
+                return_value="<html>Success</html>",
+            ),
         ):
             # Act
             result = await cli_sso_callback(
@@ -2098,23 +2125,18 @@ class TestCLIKeyRegenerationFlow:
         # Mock the CLI callback and required proxy server components
         mock_result = {"user_id": "test-user", "email": "test@example.com"}
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.cli_sso_callback"
-        ) as mock_cli_callback, patch(
-            "litellm.proxy.proxy_server.prisma_client", MagicMock()
-        ), patch(
-            "litellm.proxy.proxy_server.master_key", "test-master-key"
-        ), patch(
-            "litellm.proxy.proxy_server.general_settings", {}
-        ), patch(
-            "litellm.proxy.proxy_server.jwt_handler", MagicMock()
-        ), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", MagicMock()
-        ), patch.dict(
-            os.environ, {"GOOGLE_CLIENT_ID": "test-google-id"}, clear=True
-        ), patch(
-            "litellm.proxy.management_endpoints.ui_sso.GoogleSSOHandler.get_google_callback_response",
-            return_value=mock_result,
+        with (
+            patch("litellm.proxy.management_endpoints.ui_sso.cli_sso_callback") as mock_cli_callback,
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.master_key", "test-master-key"),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+            patch("litellm.proxy.proxy_server.jwt_handler", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch.dict(os.environ, {"GOOGLE_CLIENT_ID": "test-google-id"}, clear=True),
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.GoogleSSOHandler.get_google_callback_response",
+                return_value=mock_result,
+            ),
         ):
             mock_cli_callback.return_value = MagicMock()
 
@@ -2137,9 +2159,7 @@ class TestCLIKeyRegenerationFlow:
         mock_request = MagicMock()
         mock_request.base_url = "https://test.litellm.ai/"
 
-        with patch(
-            "litellm.proxy.utils.get_custom_url", return_value="https://test.litellm.ai"
-        ):
+        with patch("litellm.proxy.utils.get_custom_url", return_value="https://test.litellm.ai"):
             # Test with existing_key - should NOT be in URL
             redirect_url = SSOAuthenticationHandler.get_redirect_url_for_sso(
                 request=mock_request,
@@ -2159,9 +2179,7 @@ class TestCLIKeyRegenerationFlow:
         mock_request = MagicMock()
         mock_request.base_url = "https://test.litellm.ai/"
 
-        with patch(
-            "litellm.proxy.utils.get_custom_url", return_value="https://test.litellm.ai"
-        ):
+        with patch("litellm.proxy.utils.get_custom_url", return_value="https://test.litellm.ai"):
             # Test without existing_key
             redirect_url = SSOAuthenticationHandler.get_redirect_url_for_sso(
                 request=mock_request, sso_callback_route="sso/callback"
@@ -2200,16 +2218,16 @@ class TestCLIKeyRegenerationFlow:
 
         mock_jwt_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.token"
 
-        with patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache), patch(
-            "litellm.proxy.proxy_server.prisma_client"
-        ) as mock_prisma, patch(
-            "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
-            return_value=mock_jwt_token,
-        ) as mock_get_jwt:
+        with (
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+            patch(
+                "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
+                return_value=mock_jwt_token,
+            ) as mock_get_jwt,
+        ):
             # Mock the user lookup
-            mock_prisma.db.litellm_usertable.find_unique = AsyncMock(
-                return_value=mock_user_info
-            )
+            mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user_info)
 
             # Act - Second poll with team_id
             result = await cli_poll_key(key_id=session_key, team_id=selected_team)
@@ -2252,9 +2270,7 @@ class TestGetAppRolesFromIdToken:
 
             # Assert
             assert result == ["Admin", "User", "Developer"]
-            mock_jwt_decode.assert_called_once_with(
-                mock_token, options={"verify_signature": False}
-            )
+            mock_jwt_decode.assert_called_once_with(mock_token, options={"verify_signature": False})
 
     def test_app_roles_picked_when_both_exist(self):
         """Test that 'app_roles' takes precedence when both 'app_roles' and 'roles' exist"""
@@ -2376,9 +2392,7 @@ class TestProcessSSOJWTAccessToken:
             "groups": ["team1", "team2", "team3"],
         }
 
-    def test_process_sso_jwt_access_token_with_existing_team_ids(
-        self, mock_jwt_handler, sample_jwt_token
-    ):
+    def test_process_sso_jwt_access_token_with_existing_team_ids(self, mock_jwt_handler, sample_jwt_token):
         """Test that existing team IDs are not overwritten"""
         from litellm.proxy.management_endpoints.ui_sso import (
             process_sso_jwt_access_token,
@@ -2434,20 +2448,14 @@ class TestProcessSSOJWTAccessToken:
             )
 
             # Assert
-            mock_jwt_decode.assert_called_once_with(
-                sample_jwt_token, options={"verify_signature": False}
-            )
-            mock_jwt_handler.get_team_ids_from_jwt.assert_called_once_with(
-                sample_jwt_payload
-            )
+            mock_jwt_decode.assert_called_once_with(sample_jwt_token, options={"verify_signature": False})
+            mock_jwt_handler.get_team_ids_from_jwt.assert_called_once_with(sample_jwt_payload)
 
             # Verify team_ids was added to the dict as a key
             assert "team_ids" in result
             assert result["team_ids"] == ["team1", "team2", "team3"]
 
-    def test_process_sso_jwt_access_token_with_dict_existing_team_ids(
-        self, mock_jwt_handler, sample_jwt_token
-    ):
+    def test_process_sso_jwt_access_token_with_dict_existing_team_ids(self, mock_jwt_handler, sample_jwt_token):
         """Test that existing team IDs in dictionary are not overwritten"""
         from litellm.proxy.management_endpoints.ui_sso import (
             process_sso_jwt_access_token,
@@ -2490,9 +2498,7 @@ class TestProcessSSOJWTAccessToken:
 
         # Test with None access token
         with patch("jwt.decode") as mock_jwt_decode:
-            process_sso_jwt_access_token(
-                access_token_str=None, sso_jwt_handler=mock_jwt_handler, result=result
-            )
+            process_sso_jwt_access_token(access_token_str=None, sso_jwt_handler=mock_jwt_handler, result=result)
 
             # Assert nothing was processed
             mock_jwt_decode.assert_not_called()
@@ -2501,18 +2507,14 @@ class TestProcessSSOJWTAccessToken:
 
         # Test with empty string access token
         with patch("jwt.decode") as mock_jwt_decode:
-            process_sso_jwt_access_token(
-                access_token_str="", sso_jwt_handler=mock_jwt_handler, result=result
-            )
+            process_sso_jwt_access_token(access_token_str="", sso_jwt_handler=mock_jwt_handler, result=result)
 
             # Assert nothing was processed
             mock_jwt_decode.assert_not_called()
             mock_jwt_handler.get_team_ids_from_jwt.assert_not_called()
             assert result.team_ids == []
 
-    def test_process_sso_jwt_access_token_no_result(
-        self, mock_jwt_handler, sample_jwt_token
-    ):
+    def test_process_sso_jwt_access_token_no_result(self, mock_jwt_handler, sample_jwt_token):
         """Test that nothing happens when result is None"""
         from litellm.proxy.management_endpoints.ui_sso import (
             process_sso_jwt_access_token,
@@ -2530,9 +2532,7 @@ class TestProcessSSOJWTAccessToken:
             mock_jwt_decode.assert_not_called()
             mock_jwt_handler.get_team_ids_from_jwt.assert_not_called()
 
-    def test_process_sso_jwt_access_token_non_decode_exception_propagates(
-        self, mock_jwt_handler, sample_jwt_token
-    ):
+    def test_process_sso_jwt_access_token_non_decode_exception_propagates(self, mock_jwt_handler, sample_jwt_token):
         """Test that non-DecodeError JWT exceptions still propagate up."""
         import jwt as pyjwt
 
@@ -2542,9 +2542,7 @@ class TestProcessSSOJWTAccessToken:
 
         result = CustomOpenID(id="test_user", email="test@example.com", team_ids=[])
 
-        with patch(
-            "jwt.decode", side_effect=pyjwt.exceptions.InvalidKeyError("Invalid key")
-        ) as mock_jwt_decode:
+        with patch("jwt.decode", side_effect=pyjwt.exceptions.InvalidKeyError("Invalid key")) as mock_jwt_decode:
             with pytest.raises(pyjwt.exceptions.InvalidKeyError, match="Invalid key"):
                 process_sso_jwt_access_token(
                     access_token_str=sample_jwt_token,
@@ -2578,9 +2576,7 @@ class TestProcessSSOJWTAccessToken:
 
             # Assert
             mock_jwt_decode.assert_called_once()
-            mock_jwt_handler.get_team_ids_from_jwt.assert_called_once_with(
-                sample_jwt_payload
-            )
+            mock_jwt_handler.get_team_ids_from_jwt.assert_called_once_with(sample_jwt_payload)
 
             # Even empty team IDs should be set
             assert result.team_ids == []
@@ -2617,9 +2613,7 @@ class TestProcessSSOJWTAccessToken:
         assert result.team_ids == ["existing_team"]
         assert result.user_role is None
 
-    def test_process_sso_jwt_access_token_real_jwt_with_role_and_teams(
-        self, mock_jwt_handler
-    ):
+    def test_process_sso_jwt_access_token_real_jwt_with_role_and_teams(self, mock_jwt_handler):
         """Test that a real JWT containing role and team fields is correctly processed."""
         import jwt as pyjwt
 
@@ -2792,15 +2786,9 @@ class TestGenericResponseConvertorNestedAttributes:
             # Current behavior: returns None for nested paths
             # Expected behavior with current implementation (no nested path support):
             assert result.id == "nested-user-456"
-            assert (
-                result.email == "john.doe@example.com"
-            )  # Can't access "attributes.email" with .get()
-            assert (
-                result.first_name == "John"
-            )  # Can't access "attributes.given_name" with .get()
-            assert (
-                result.last_name == "Doe"
-            )  # Can't access "attributes.family_name" with .get()
+            assert result.email == "john.doe@example.com"  # Can't access "attributes.email" with .get()
+            assert result.first_name == "John"  # Can't access "attributes.given_name" with .get()
+            assert result.last_name == "Doe"  # Can't access "attributes.family_name" with .get()
             assert result.display_name == "user-sub-123"  # Top-level attribute works
 
 
@@ -2976,14 +2964,8 @@ class TestGetGenericSSORedirectParams:
             assert redirect_params["code_challenge_method"] == "S256"
 
             # Verify code_challenge is correctly derived from code_verifier
-            expected_challenge_bytes = hashlib.sha256(
-                code_verifier.encode("utf-8")
-            ).digest()
-            expected_challenge = (
-                base64.urlsafe_b64encode(expected_challenge_bytes)
-                .decode("utf-8")
-                .rstrip("=")
-            )
+            expected_challenge_bytes = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+            expected_challenge = base64.urlsafe_b64encode(expected_challenge_bytes).decode("utf-8").rstrip("=")
             assert redirect_params["code_challenge"] == expected_challenge
 
     def test_state_with_pkce_disabled(self):
@@ -3116,14 +3098,8 @@ class TestPKCEFunctionality:
         assert isinstance(code_verifier, str)
 
         # Verify code_challenge is correctly generated from code_verifier
-        expected_challenge_bytes = hashlib.sha256(
-            code_verifier.encode("utf-8")
-        ).digest()
-        expected_challenge = (
-            base64.urlsafe_b64encode(expected_challenge_bytes)
-            .decode("utf-8")
-            .rstrip("=")
-        )
+        expected_challenge_bytes = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+        expected_challenge = base64.urlsafe_b64encode(expected_challenge_bytes).decode("utf-8").rstrip("=")
         assert code_challenge == expected_challenge
 
         # Verify both are base64url encoded (no padding)
@@ -3145,17 +3121,17 @@ class TestPKCEFunctionality:
         # Mock cache with async methods — use dict format (primary path)
         mock_cache = MagicMock()
         test_code_verifier = "test_code_verifier_abc123xyz"
-        mock_cache.async_get_cache = AsyncMock(
-            return_value={"code_verifier": test_code_verifier}
-        )
+        mock_cache.async_get_cache = AsyncMock(return_value={"code_verifier": test_code_verifier})
         mock_cache.async_delete_cache = AsyncMock()
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
+        with (
+            patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}),
+        ):
             # Act
-            token_params = (
-                await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                    request=mock_request, generic_include_client_id=False
-                )
+            token_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
             )
 
             # Assert
@@ -3166,9 +3142,7 @@ class TestPKCEFunctionality:
 
             # Verify cache was read but NOT deleted yet (deletion is deferred to after
             # successful token exchange to preserve the verifier for retries)
-            mock_cache.async_get_cache.assert_called_once_with(
-                key=f"pkce_verifier:{test_state}"
-            )
+            mock_cache.async_get_cache.assert_called_once_with(key=f"pkce_verifier:{test_state}")
             mock_cache.async_delete_cache.assert_not_called()
 
     @pytest.mark.asyncio
@@ -3181,9 +3155,7 @@ class TestPKCEFunctionality:
         # Mock SSO provider
         mock_sso = MagicMock()
         mock_redirect_response = MagicMock()
-        original_location = (
-            "https://auth.example.com/authorize?state=test456&client_id=abc"
-        )
+        original_location = "https://auth.example.com/authorize?state=test456&client_id=abc"
         mock_redirect_response.headers = {"location": original_location}
         mock_sso.get_login_redirect = AsyncMock(return_value=mock_redirect_response)
         mock_sso.__enter__ = MagicMock(return_value=mock_sso)
@@ -3195,8 +3167,9 @@ class TestPKCEFunctionality:
         mock_cache.async_set_cache = AsyncMock()
 
         with patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
-            with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-                "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
+            with (
+                patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+                patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
             ):
                 # Act
                 result = await SSOAuthenticationHandler.get_generic_sso_redirect_response(
@@ -3268,9 +3241,7 @@ class TestPKCEFunctionality:
 
         with patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
             with patch("litellm.proxy.proxy_server.redis_usage_cache", mock_redis):
-                with patch(
-                    "litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory
-                ):
+                with patch("litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory):
                     # Pod A: start login, store code_verifier in "Redis"
                     await SSOAuthenticationHandler.get_generic_sso_redirect_response(
                         generic_sso=mock_sso,
@@ -3339,9 +3310,7 @@ class TestPKCEFunctionality:
 
         with patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}):
             with patch("litellm.proxy.proxy_server.redis_usage_cache", None):
-                with patch(
-                    "litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory
-                ):
+                with patch("litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory):
                     # Pod A: start login, store code_verifier in in-memory cache
                     await SSOAuthenticationHandler.get_generic_sso_redirect_response(
                         generic_sso=mock_sso,
@@ -3350,9 +3319,7 @@ class TestPKCEFunctionality:
                     )
                     mock_in_memory.async_set_cache.assert_called_once()
                     stored_key = mock_in_memory.async_set_cache.call_args.kwargs["key"]
-                    stored_value = mock_in_memory.async_set_cache.call_args.kwargs[
-                        "value"
-                    ]
+                    stored_value = mock_in_memory.async_set_cache.call_args.kwargs["value"]
                     assert stored_key == "pkce_verifier:fallback_state_xyz"
                     assert isinstance(stored_value, dict) and len(stored_value["code_verifier"]) == 43
 
@@ -3366,9 +3333,7 @@ class TestPKCEFunctionality:
                     assert token_params["code_verifier"] == stored_value["code_verifier"]
                     # Cache key returned for deferred deletion after successful exchange
                     assert token_params["_pkce_cache_key"] == stored_key
-                    mock_in_memory.async_get_cache.assert_called_once_with(
-                        key=stored_key
-                    )
+                    mock_in_memory.async_get_cache.assert_called_once_with(key=stored_key)
                     # Deletion is deferred — not called by prepare_token_exchange_parameters
                     mock_in_memory.async_delete_cache.assert_not_called()
 
@@ -3383,20 +3348,19 @@ class TestPKCEFunctionality:
         mock_redis = MagicMock()
         mock_in_memory = MagicMock()
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", mock_redis), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory
-        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}, clear=False):
+        with (
+            patch("litellm.proxy.proxy_server.redis_usage_cache", mock_redis),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_in_memory),
+            patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}, clear=False),
+        ):
             mock_request = MagicMock(spec=Request)
             mock_request.query_params = {}
-            token_params = (
-                await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                    request=mock_request, generic_include_client_id=False
-                )
+            token_params = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                request=mock_request, generic_include_client_id=False
             )
             assert "code_verifier" not in token_params
             mock_redis.async_get_cache.assert_not_called()
             mock_in_memory.async_get_cache.assert_not_called()
-
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_basic_auth(self):
@@ -3429,7 +3393,9 @@ class TestPKCEFunctionality:
             assert post_data.get("redirect_uri") == "https://proxy.example.com/callback"
             # Verify credentials are NOT double-sent in the POST body when using Basic Auth
             assert "client_secret" not in post_data, "client_secret must not appear in POST body when using Basic Auth"
-            assert "client_id" not in post_data, "client_id must not appear in POST body when using Basic Auth (include_client_id=False)"
+            assert "client_id" not in post_data, (
+                "client_id must not appear in POST body when using Basic Auth (include_client_id=False)"
+            )
             return mock_response
 
         # get_async_httpx_client returns a client directly (no context manager).
@@ -3439,9 +3405,7 @@ class TestPKCEFunctionality:
         mock_userinfo_client = MagicMock()
         mock_userinfo_client.get = AsyncMock(return_value=mock_userinfo_response)
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_get_client.side_effect = [mock_token_client, mock_userinfo_client]
 
             result = await SSOAuthenticationHandler._pkce_token_exchange(
@@ -3465,7 +3429,6 @@ class TestPKCEFunctionality:
         get_call = mock_userinfo_client.get.call_args
         assert get_call is not None
         assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_abc"
-
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_credentials_in_body(self):
@@ -3502,9 +3465,7 @@ class TestPKCEFunctionality:
         mock_userinfo_client = MagicMock()
         mock_userinfo_client.get = AsyncMock(return_value=mock_userinfo)
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_get_client.side_effect = [mock_token_client, mock_userinfo_client]
 
             result = await SSOAuthenticationHandler._pkce_token_exchange(
@@ -3526,7 +3487,6 @@ class TestPKCEFunctionality:
         assert get_call is not None
         assert get_call.kwargs["headers"]["Authorization"] == "Bearer tok_body"
 
-
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_http200_with_error_body(self):
         """Provider returns HTTP 200 but with an error field instead of tokens."""
@@ -3534,9 +3494,7 @@ class TestPKCEFunctionality:
 
         error_body = {"error": "invalid_grant", "error_description": "Code already used"}
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_resp = MagicMock()
             mock_resp.status_code = 200
@@ -3560,7 +3518,6 @@ class TestPKCEFunctionality:
         assert "invalid_grant" in exc_info.value.message
         assert str(exc_info.value.code) == "401"
 
-
     @pytest.mark.asyncio
     async def test_pkce_userinfo_falls_back_to_id_token(self):
         """When the userinfo endpoint fails, decode the id_token as fallback."""
@@ -3569,14 +3526,10 @@ class TestPKCEFunctionality:
 
         payload = {"sub": "user_from_jwt", "email": "jwt@example.com"}
         # Build a minimal JWT (header.payload.signature — signature not verified)
-        encoded_payload = base64.urlsafe_b64encode(
-            _json.dumps(payload).encode()
-        ).rstrip(b"=").decode()
+        encoded_payload = base64.urlsafe_b64encode(_json.dumps(payload).encode()).rstrip(b"=").decode()
         fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_fail = MagicMock()
             mock_fail.status_code = 503
@@ -3593,7 +3546,6 @@ class TestPKCEFunctionality:
         assert result["sub"] == "user_from_jwt"
         assert result["email"] == "jwt@example.com"
 
-
     @pytest.mark.asyncio
     async def test_pkce_userinfo_uses_id_token_when_no_endpoint(self):
         """When userinfo_endpoint is None, fall back to id_token directly without HTTP call."""
@@ -3603,9 +3555,7 @@ class TestPKCEFunctionality:
         from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
 
         payload = {"sub": "id_token_user", "email": "id@example.com"}
-        encoded_payload = (
-            base64.urlsafe_b64encode(_json.dumps(payload).encode()).rstrip(b"=").decode()
-        )
+        encoded_payload = base64.urlsafe_b64encode(_json.dumps(payload).encode()).rstrip(b"=").decode()
         fake_id_token = f"eyJhbGciOiJSUzI1NiJ9.{encoded_payload}.fakesig"
 
         # No httpx call should happen when userinfo_endpoint is None
@@ -3619,16 +3569,13 @@ class TestPKCEFunctionality:
         assert result["sub"] == "id_token_user"
         assert result["email"] == "id@example.com"
 
-
     @pytest.mark.asyncio
     async def test_pkce_userinfo_raises_when_both_sources_unavailable(self):
         """When userinfo endpoint fails AND no id_token, raise ProxyException."""
         from litellm.proxy._types import ProxyException
         from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_fail = MagicMock()
             mock_fail.status_code = 503
@@ -3657,9 +3604,7 @@ class TestPKCEFunctionality:
         mock_resp.status_code = 200
         mock_resp.json.return_value = None  # HTTP 200 with null JSON body
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_client.get = AsyncMock(return_value=mock_resp)
             mock_get_client.return_value = mock_client
@@ -3672,9 +3617,12 @@ class TestPKCEFunctionality:
                     additional_headers={},
                 )
 
-        assert "unavailable" in exc_info.value.message.lower() or "no userinfo" in exc_info.value.message.lower() or "userinfo" in exc_info.value.message.lower()
+        assert (
+            "unavailable" in exc_info.value.message.lower()
+            or "no userinfo" in exc_info.value.message.lower()
+            or "userinfo" in exc_info.value.message.lower()
+        )
         assert str(exc_info.value.code) == "401"
-
 
     @pytest.mark.asyncio
     async def test_pkce_cache_miss_raises_proxy_exception(self):
@@ -3694,11 +3642,13 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "missing_state_123"}
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(
-            os.environ,
-            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+        with (
+            patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch.dict(
+                os.environ,
+                {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+            ),
         ):
             with pytest.raises(ProxyException) as exc_info:
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
@@ -3707,7 +3657,6 @@ class TestPKCEFunctionality:
 
         assert "verifier not found" in exc_info.value.message.lower() or "cache" in exc_info.value.message.lower()
         assert str(exc_info.value.code) == "401"
-
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_public_client_no_secret(self):
@@ -3745,9 +3694,7 @@ class TestPKCEFunctionality:
         mock_userinfo_client = MagicMock()
         mock_userinfo_client.get = AsyncMock(return_value=mock_userinfo)
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_get_client.side_effect = [mock_token_client, mock_userinfo_client]
 
             result = await SSOAuthenticationHandler._pkce_token_exchange(
@@ -3765,7 +3712,6 @@ class TestPKCEFunctionality:
         assert result["access_token"] == "tok_public"
         assert result["sub"] == "pubuser"
 
-
     @pytest.mark.asyncio
     async def test_delete_pkce_verifier_swallows_deletion_errors(self):
         """_delete_pkce_verifier must not raise when the cache delete fails
@@ -3778,13 +3724,13 @@ class TestPKCEFunctionality:
         failing_cache.async_delete_cache = AsyncMock(side_effect=Exception("Redis down"))
 
         # Should NOT raise even though the underlying cache delete fails
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", failing_cache
+        with (
+            patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", failing_cache),
         ):
             await SSOAuthenticationHandler._delete_pkce_verifier("pkce_verifier:test_state")
 
         failing_cache.async_delete_cache.assert_called_once_with(key="pkce_verifier:test_state")
-
 
     @pytest.mark.asyncio
     async def test_pkce_cache_miss_unexpected_format_raises_proxy_exception(self):
@@ -3807,24 +3753,30 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "bad_format_state"}
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(
-            os.environ,
-            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+        with (
+            patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch.dict(
+                os.environ,
+                {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "true"},
+            ),
         ):
             with pytest.raises(ProxyException) as exc_info:
                 await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                     request=mock_request, generic_include_client_id=False
                 )
 
-        assert "cache" in exc_info.value.message.lower() or "verifier" in exc_info.value.message.lower() or "format" in exc_info.value.message.lower()
+        assert (
+            "cache" in exc_info.value.message.lower()
+            or "verifier" in exc_info.value.message.lower()
+            or "format" in exc_info.value.message.lower()
+        )
         assert str(exc_info.value.code) == "401"
         # Strict mode should also clean up the corrupt cache entry before raising
         mock_cache.async_delete_cache.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self, caplog):
+    async def test_pkce_cache_miss_non_strict_logs_warning_and_continues(self):
         """Default (non-strict) cache-miss behavior: logs a warning and returns params
         without code_verifier rather than raising, to preserve backward compatibility."""
         import logging
@@ -3833,7 +3785,18 @@ class TestPKCEFunctionality:
 
         from starlette.requests import Request
 
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         mock_cache = MagicMock()
         mock_cache.async_get_cache = AsyncMock(return_value=None)  # verifier not found
@@ -3844,18 +3807,27 @@ class TestPKCEFunctionality:
         # PKCE_STRICT_CACHE_MISS explicitly set to false — should NOT raise.
         # Use patch.dict with the key set to "false" rather than os.environ.pop()
         # to avoid permanently mutating the test process environment.
-        with caplog.at_level(logging.WARNING), patch(
-            "litellm.proxy.proxy_server.redis_usage_cache", None
-        ), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(
-            os.environ,
-            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "false"},
-            clear=False,
-        ):
-            result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                request=mock_request, generic_include_client_id=False
-            )
+        handler = LogRecordHandler()
+        handler.setLevel(logging.WARNING)
+        original_level = verbose_proxy_logger.level
+        verbose_proxy_logger.setLevel(logging.WARNING)
+        verbose_proxy_logger.addHandler(handler)
+        try:
+            with (
+                patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+                patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+                patch.dict(
+                    os.environ,
+                    {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "false"},
+                    clear=False,
+                ),
+            ):
+                result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                    request=mock_request, generic_include_client_id=False
+                )
+        finally:
+            verbose_proxy_logger.removeHandler(handler)
+            verbose_proxy_logger.setLevel(original_level)
 
         # Should return params without code_verifier (no raise)
         assert "code_verifier" not in result
@@ -3865,9 +3837,9 @@ class TestPKCEFunctionality:
         # Verify the warning was actually logged
         assert any(
             "verifier not found" in r.message.lower() or "code_verifier" in r.message.lower()
-            for r in caplog.records
+            for r in handler.records
             if r.levelno >= logging.WARNING
-        ), f"Expected a cache-miss warning. Records: {[r.message for r in caplog.records]}"
+        ), f"Expected a cache-miss warning. Records: {[r.message for r in handler.records]}"
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_non200_raises_proxy_exception(self):
@@ -3882,9 +3854,7 @@ class TestPKCEFunctionality:
         mock_response.status_code = 401
         mock_response.text = "Unauthorized"
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_get_client.return_value = mock_client
@@ -3906,7 +3876,7 @@ class TestPKCEFunctionality:
         assert str(exc_info.value.code) == "401"
 
     @pytest.mark.asyncio
-    async def test_pkce_cache_miss_unexpected_format_non_strict_logs_warning(self, caplog):
+    async def test_pkce_cache_miss_unexpected_format_non_strict_logs_warning(self):
         """When cached data has an unexpected format (e.g. integer from corrupt Redis)
         in non-strict mode, prepare_token_exchange_parameters logs a warning and
         returns params without code_verifier rather than raising."""
@@ -3916,7 +3886,18 @@ class TestPKCEFunctionality:
 
         from starlette.requests import Request
 
-        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        from litellm.proxy.management_endpoints.ui_sso import (
+            SSOAuthenticationHandler,
+            verbose_proxy_logger,
+        )
+
+        class LogRecordHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records = []
+
+            def emit(self, record):
+                self.records.append(record)
 
         # Cache returns an integer — unexpected format
         mock_cache = MagicMock()
@@ -3929,18 +3910,27 @@ class TestPKCEFunctionality:
         # Non-strict mode: should log a warning and continue, not raise.
         # Use patch.dict with PKCE_STRICT_CACHE_MISS="false" to avoid permanently
         # mutating the test process environment with os.environ.pop().
-        with caplog.at_level(logging.WARNING), patch(
-            "litellm.proxy.proxy_server.redis_usage_cache", None
-        ), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(
-            os.environ,
-            {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "false"},
-            clear=False,
-        ):
-            result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
-                request=mock_request, generic_include_client_id=False
-            )
+        handler = LogRecordHandler()
+        handler.setLevel(logging.WARNING)
+        original_level = verbose_proxy_logger.level
+        verbose_proxy_logger.setLevel(logging.WARNING)
+        verbose_proxy_logger.addHandler(handler)
+        try:
+            with (
+                patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+                patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+                patch.dict(
+                    os.environ,
+                    {"GENERIC_CLIENT_USE_PKCE": "true", "PKCE_STRICT_CACHE_MISS": "false"},
+                    clear=False,
+                ),
+            ):
+                result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
+                    request=mock_request, generic_include_client_id=False
+                )
+        finally:
+            verbose_proxy_logger.removeHandler(handler)
+            verbose_proxy_logger.setLevel(original_level)
 
         # No raise in non-strict mode; verifier simply absent from params
         assert "code_verifier" not in result
@@ -3950,9 +3940,9 @@ class TestPKCEFunctionality:
         # Verify a warning was logged about the unexpected format or cache miss
         assert any(
             "verifier" in r.message.lower() or "format" in r.message.lower() or "cache" in r.message.lower()
-            for r in caplog.records
+            for r in handler.records
             if r.levelno >= logging.WARNING
-        ), f"Expected a format/cache warning. Records: {[r.message for r in caplog.records]}"
+        ), f"Expected a format/cache warning. Records: {[r.message for r in handler.records]}"
         # Verify cleanup was attempted for the corrupt/stale cache entry
         mock_cache.async_delete_cache.assert_called_once()
 
@@ -3974,9 +3964,11 @@ class TestPKCEFunctionality:
         mock_request = MagicMock(spec=Request)
         mock_request.query_params = {"state": "legacy_state_xyz"}
 
-        with patch("litellm.proxy.proxy_server.redis_usage_cache", None), patch(
-            "litellm.proxy.proxy_server.user_api_key_cache", mock_cache
-        ), patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}, clear=False):
+        with (
+            patch("litellm.proxy.proxy_server.redis_usage_cache", None),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch.dict(os.environ, {"GENERIC_CLIENT_USE_PKCE": "true"}, clear=False),
+        ):
             result = await SSOAuthenticationHandler.prepare_token_exchange_parameters(
                 request=mock_request, generic_include_client_id=False
             )
@@ -3991,9 +3983,7 @@ class TestPKCEFunctionality:
         from litellm.proxy._types import ProxyException
         from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_resp = MagicMock()
             mock_resp.status_code = 200
@@ -4027,9 +4017,7 @@ class TestPKCEFunctionality:
 
         body_without_token = {"token_type": "Bearer", "scope": "openid"}
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client"
-        ) as mock_get_client:
+        with patch("litellm.proxy.management_endpoints.ui_sso.get_async_httpx_client") as mock_get_client:
             mock_client = MagicMock()
             mock_resp = MagicMock()
             mock_resp.status_code = 200
@@ -4078,18 +4066,16 @@ class TestAddMissingTeamMember:
 
         sso_teams = ["team-from-entra-1", "team-from-entra-2"]
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.create_team_member_add_task"
-        ) as mock_add_task:
+        with patch("litellm.proxy.management_endpoints.ui_sso.create_team_member_add_task") as mock_add_task:
             mock_add_task.return_value = AsyncMock()
 
             await add_missing_team_member(user_info=new_user, sso_teams=sso_teams)
 
             # Bug: This assertion currently FAILS - no teams are added
             # because function returns early when teams is None
-            assert (
-                mock_add_task.call_count == 2
-            ), f"Expected 2 calls to add user to teams, but got {mock_add_task.call_count}"
+            assert mock_add_task.call_count == 2, (
+                f"Expected 2 calls to add user to teams, but got {mock_add_task.call_count}"
+            )
             called_team_ids = [call.args[0] for call in mock_add_task.call_args_list]
             assert set(called_team_ids) == {
                 "team-from-entra-1",
@@ -4115,9 +4101,7 @@ class TestAddMissingTeamMember:
 
         sso_teams = ["team-from-entra-1", "team-from-entra-2"]
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.create_team_member_add_task"
-        ) as mock_add_task:
+        with patch("litellm.proxy.management_endpoints.ui_sso.create_team_member_add_task") as mock_add_task:
             mock_add_task.return_value = AsyncMock()
 
             await add_missing_team_member(user_info=existing_user, sso_teams=sso_teams)
@@ -4151,9 +4135,7 @@ class TestAddMissingTeamMember:
             teams=None,  # Bug: NewUserResponse defaults to None
         )
 
-        with patch(
-            "litellm.proxy.management_endpoints.ui_sso.add_missing_team_member"
-        ) as mock_add_member:
+        with patch("litellm.proxy.management_endpoints.ui_sso.add_missing_team_member") as mock_add_member:
             await SSOAuthenticationHandler.add_user_to_teams_from_sso_response(
                 result=sso_result,
                 user_info=new_user_info,
@@ -4195,9 +4177,7 @@ class TestAddMissingTeamMember:
 
         # Bug: With current code, team_member_calls will be empty
         # After fix: Should have 2 entries
-        assert (
-            len(team_member_calls) == 2
-        ), f"Expected 2 teams to be added, but got {len(team_member_calls)}"
+        assert len(team_member_calls) == 2, f"Expected 2 teams to be added, but got {len(team_member_calls)}"
         assert {c["team_id"] for c in team_member_calls} == {
             "entra-team-alpha",
             "entra-team-beta",
@@ -4253,9 +4233,9 @@ class TestAddMissingTeamMember:
         ):
             await add_missing_team_member(user_info=user_info, sso_teams=sso_teams)
 
-        assert set(added_teams) == set(
-            expected_teams_added
-        ), f"Expected teams {expected_teams_added}, but got {added_teams}"
+        assert set(added_teams) == set(expected_teams_added), (
+            f"Expected teams {expected_teams_added}, but got {added_teams}"
+        )
 
 
 @pytest.mark.asyncio
@@ -4321,17 +4301,15 @@ async def test_role_mappings_override_default_internal_user_params():
             new_user_request = call_args.kwargs["data"]
 
             # The role from SSO should be preserved, not overridden by default_internal_user_params
-            assert (
-                new_user_request.user_role == "proxy_admin"
-            ), "SSO-extracted role should override default_internal_user_params role"
+            assert new_user_request.user_role == "proxy_admin", (
+                "SSO-extracted role should override default_internal_user_params role"
+            )
 
             # Other default params should still be applied
-            assert (
-                new_user_request.max_budget == 100
-            ), "max_budget from default_internal_user_params should be applied"
-            assert (
-                new_user_request.budget_duration == "30d"
-            ), "budget_duration from default_internal_user_params should be applied"
+            assert new_user_request.max_budget == 100, "max_budget from default_internal_user_params should be applied"
+            assert new_user_request.budget_duration == "30d", (
+                "budget_duration from default_internal_user_params should be applied"
+            )
 
     finally:
         # Restore original default_internal_user_params (always assign, never delattr —
@@ -4402,19 +4380,17 @@ async def test_sso_role_preserved_without_role_mappings():
             new_user_request = call_args.kwargs["data"]
 
             # SSO role should be preserved even without role_mappings configured
-            assert (
-                new_user_request.user_role == "proxy_admin"
-            ), "SSO role from app_roles should not be overwritten by default_internal_user_params"
+            assert new_user_request.user_role == "proxy_admin", (
+                "SSO role from app_roles should not be overwritten by default_internal_user_params"
+            )
 
             # Other defaults should still apply
-            assert (
-                new_user_request.max_budget == 50
-            ), "max_budget from default_internal_user_params should be applied"
+            assert new_user_request.max_budget == 50, "max_budget from default_internal_user_params should be applied"
 
             # Verify user_defined_values was also updated (it's mutated in-place)
-            assert (
-                user_defined_values["user_role"] == "proxy_admin"
-            ), "user_defined_values should retain the SSO role after insert_sso_user"
+            assert user_defined_values["user_role"] == "proxy_admin", (
+                "user_defined_values should retain the SSO role after insert_sso_user"
+            )
 
     finally:
         # Restore original default_internal_user_params (always assign, never delattr —
@@ -4523,10 +4499,7 @@ class TestSSOReadinessEndpoint:
                 assert data["sso_configured"] is True
                 assert data["provider"] == "google"
                 assert "GOOGLE_CLIENT_SECRET" in data["missing_environment_variables"]
-                assert (
-                    "Google SSO is configured but missing required environment variables"
-                    in data["message"]
-                )
+                assert "Google SSO is configured but missing required environment variables" in data["message"]
         finally:
             app.dependency_overrides.clear()
 
@@ -4587,9 +4560,7 @@ class TestSSOReadinessEndpoint:
                     assert data["sso_configured"] is True
                     assert data["provider"] == expected_provider
                     assert data["status"] == "unhealthy"
-                    assert set(data["missing_environment_variables"]) == set(
-                        expected_missing_vars
-                    )
+                    assert set(data["missing_environment_variables"]) == set(expected_missing_vars)
         finally:
             app.dependency_overrides.clear()
 
@@ -4657,9 +4628,7 @@ class TestSSOReadinessEndpoint:
                     assert data["sso_configured"] is True
                     assert data["provider"] == expected_provider
                     assert data["status"] == "unhealthy"
-                    assert set(data["missing_environment_variables"]) == set(
-                        expected_missing_vars
-                    )
+                    assert set(data["missing_environment_variables"]) == set(expected_missing_vars)
         finally:
             app.dependency_overrides.clear()
 
@@ -4691,13 +4660,9 @@ class TestCustomMicrosoftSSO:
         discovery = await sso.get_discovery_document()
 
         assert (
-            discovery["authorization_endpoint"]
-            == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/authorize"
+            discovery["authorization_endpoint"] == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/authorize"
         )
-        assert (
-            discovery["token_endpoint"]
-            == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token"
-        )
+        assert discovery["token_endpoint"] == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token"
         assert discovery["userinfo_endpoint"] == "https://graph.microsoft.com/v1.0/me"
 
     @pytest.mark.asyncio
@@ -4761,13 +4726,8 @@ class TestCustomMicrosoftSSO:
             # Custom auth endpoint
             assert discovery["authorization_endpoint"] == custom_auth_endpoint
             # Default token and userinfo endpoints
-            assert (
-                discovery["token_endpoint"]
-                == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token"
-            )
-            assert (
-                discovery["userinfo_endpoint"] == "https://graph.microsoft.com/v1.0/me"
-            )
+            assert discovery["token_endpoint"] == "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token"
+            assert discovery["userinfo_endpoint"] == "https://graph.microsoft.com/v1.0/me"
 
     def test_custom_microsoft_sso_uses_common_tenant_when_none(self):
         """
@@ -4805,9 +4765,7 @@ async def test_setup_team_mappings():
     mock_prisma = MagicMock()
     mock_sso_config = MagicMock()
     mock_sso_config.sso_settings = {"team_mappings": {"team_ids_jwt_field": "groups"}}
-    mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(
-        return_value=mock_sso_config
-    )
+    mock_prisma.db.litellm_ssoconfig.find_unique = AsyncMock(return_value=mock_sso_config)
 
     with patch(
         "litellm.proxy.utils.get_prisma_client_or_throw",
@@ -4820,9 +4778,7 @@ async def test_setup_team_mappings():
         assert result is not None
         assert isinstance(result, TeamMappings)
         assert result.team_ids_jwt_field == "groups"
-        mock_prisma.db.litellm_ssoconfig.find_unique.assert_called_once_with(
-            where={"id": "sso_config"}
-        )
+        mock_prisma.db.litellm_ssoconfig.find_unique.assert_called_once_with(where={"id": "sso_config"})
 
 
 # ============================================================================
@@ -4969,11 +4925,7 @@ def test_process_sso_jwt_access_token_extracts_role_from_nested_field():
 
     access_token_payload = {
         "sub": "user-123",
-        "resource_access": {
-            "my-client": {
-                "roles": ["proxy_admin"]
-            }
-        },
+        "resource_access": {"my-client": {"roles": ["proxy_admin"]}},
     }
     access_token_str = pyjwt.encode(access_token_payload, "secret", algorithm="HS256")
 
@@ -5040,13 +4992,14 @@ def test_process_sso_jwt_access_token_with_role_mappings():
     # Should get highest privilege role
     assert result.user_role == LitellmUserRoles.PROXY_ADMIN
 
+
 def test_generic_response_convertor_with_extra_attributes(monkeypatch):
     """Test that extra attributes are extracted when GENERIC_USER_EXTRA_ATTRIBUTES is set"""
     from litellm.proxy.management_endpoints.ui_sso import generic_response_convertor
-    
+
     monkeypatch.setenv("GENERIC_CLIENT_ID", "test_client")
     monkeypatch.setenv("GENERIC_USER_EXTRA_ATTRIBUTES", "custom_field1,custom_field2,custom_field3")
-    
+
     mock_response = {
         "sub": "user-id-123",
         "email": "user@example.com",
@@ -5058,29 +5011,30 @@ def test_generic_response_convertor_with_extra_attributes(monkeypatch):
         "custom_field2": ["item1", "item2"],
         "custom_field3": {"nested": "data"},
     }
-    
+
     mock_jwt_handler = MagicMock(spec=JWTHandler)
     mock_jwt_handler.get_team_ids_from_jwt.return_value = []
-    
+
     result = generic_response_convertor(
         response=mock_response,
         jwt_handler=mock_jwt_handler,
         sso_jwt_handler=None,
         role_mappings=None,
     )
-    
+
     assert result.extra_fields is not None
     assert result.extra_fields["custom_field1"] == "value1"
     assert result.extra_fields["custom_field2"] == ["item1", "item2"]
     assert result.extra_fields["custom_field3"] == {"nested": "data"}
 
+
 def test_generic_response_convertor_without_extra_attributes(monkeypatch):
     """Test backward compatibility - extra_fields is None when env var not set"""
     from litellm.proxy.management_endpoints.ui_sso import generic_response_convertor
-    
+
     monkeypatch.setenv("GENERIC_CLIENT_ID", "test_client")
     # Don't set GENERIC_USER_EXTRA_ATTRIBUTES
-    
+
     mock_response = {
         "sub": "user-id-123",
         "email": "user@example.com",
@@ -5091,72 +5045,70 @@ def test_generic_response_convertor_without_extra_attributes(monkeypatch):
         "custom_field1": "value1",
         "custom_field2": "value2",
     }
-    
+
     mock_jwt_handler = MagicMock(spec=JWTHandler)
     mock_jwt_handler.get_team_ids_from_jwt.return_value = []
-    
+
     result = generic_response_convertor(
         response=mock_response,
         jwt_handler=mock_jwt_handler,
         sso_jwt_handler=None,
         role_mappings=None,
     )
-    
+
     assert result.extra_fields is None
+
 
 def test_generic_response_convertor_extra_attributes_with_nested_paths(monkeypatch):
     """Test that nested paths work with dot notation"""
     from litellm.proxy.management_endpoints.ui_sso import generic_response_convertor
-    
+
     monkeypatch.setenv("GENERIC_CLIENT_ID", "test_client")
     monkeypatch.setenv("GENERIC_USER_EXTRA_ATTRIBUTES", "org_info.department,org_info.manager")
-    
+
     mock_response = {
         "sub": "user-id-123",
         "email": "user@example.com",
-        "org_info": {
-            "department": "Engineering",
-            "manager": "Jane Smith"
-        }
+        "org_info": {"department": "Engineering", "manager": "Jane Smith"},
     }
-    
+
     mock_jwt_handler = MagicMock(spec=JWTHandler)
     mock_jwt_handler.get_team_ids_from_jwt.return_value = []
-    
+
     result = generic_response_convertor(
         response=mock_response,
         jwt_handler=mock_jwt_handler,
         sso_jwt_handler=None,
         role_mappings=None,
     )
-    
+
     assert result.extra_fields is not None
     assert result.extra_fields["org_info.department"] == "Engineering"
     assert result.extra_fields["org_info.manager"] == "Jane Smith"
 
+
 def test_generic_response_convertor_extra_attributes_missing_field(monkeypatch):
     """Test that missing fields return None"""
     from litellm.proxy.management_endpoints.ui_sso import generic_response_convertor
-    
+
     monkeypatch.setenv("GENERIC_CLIENT_ID", "test_client")
     monkeypatch.setenv("GENERIC_USER_EXTRA_ATTRIBUTES", "missing_field,another_missing")
-    
+
     mock_response = {
         "sub": "user-id-123",
         "email": "user@example.com",
     }
-    
+
     mock_jwt_handler = MagicMock(spec=JWTHandler)
     mock_jwt_handler.get_team_ids_from_jwt.return_value = []
-    
+
     result = generic_response_convertor(
         response=mock_response,
         jwt_handler=mock_jwt_handler,
         sso_jwt_handler=None,
         role_mappings=None,
     )
-    
+
     assert result.extra_fields is not None
     assert result.extra_fields["missing_field"] is None
     assert result.extra_fields["another_missing"] is None
-

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3837,10 +3837,10 @@ class TestPKCEFunctionality:
         mock_cache.async_get_cache.assert_called_once()
         # Verify the warning was actually logged
         assert any(
-            "verifier not found" in r.message.lower() or "code_verifier" in r.message.lower()
+            "verifier not found" in r.getMessage().lower() or "code_verifier" in r.getMessage().lower()
             for r in handler.records
             if r.levelno >= logging.WARNING
-        ), f"Expected a cache-miss warning. Records: {[r.message for r in handler.records]}"
+        ), f"Expected a cache-miss warning. Records: {[r.getMessage() for r in handler.records]}"
 
     @pytest.mark.asyncio
     async def test_pkce_token_exchange_non200_raises_proxy_exception(self):
@@ -3940,10 +3940,12 @@ class TestPKCEFunctionality:
         mock_cache.async_get_cache.assert_called_once()
         # Verify a warning was logged about the unexpected format or cache miss
         assert any(
-            "verifier" in r.message.lower() or "format" in r.message.lower() or "cache" in r.message.lower()
+            "verifier" in r.getMessage().lower()
+            or "format" in r.getMessage().lower()
+            or "cache" in r.getMessage().lower()
             for r in handler.records
             if r.levelno >= logging.WARNING
-        ), f"Expected a format/cache warning. Records: {[r.message for r in handler.records]}"
+        ), f"Expected a format/cache warning. Records: {[r.getMessage() for r in handler.records]}"
         # Verify cleanup was attempted for the corrupt/stale cache entry
         mock_cache.async_delete_cache.assert_called_once()
 

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -7,9 +7,7 @@ import pytest
 import respx
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
 
 import urllib.parse
 from unittest.mock import MagicMock, patch
@@ -100,9 +98,7 @@ def test_completion_missing_role(openai_api_response):
 
     print(f"openai_api_response: {openai_api_response}")
 
-    with patch.object(
-        client.chat.completions.with_raw_response, "create", mock_raw_response
-    ) as mock_create:
+    with patch.object(client.chat.completions.with_raw_response, "create", mock_raw_response) as mock_create:
         litellm.completion(
             model="gpt-4o-mini",
             messages=[
@@ -161,6 +157,12 @@ async def test_url_with_format_param(model, sync_mode, monkeypatch):
     from litellm import acompletion, completion
     from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 
+    base64_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WnRkwsAAAAASUVORK5CYII="
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.prompt_templates.factory.convert_url_to_base64",
+        lambda url: base64_png,
+    )
+
     if sync_mode:
         client = HTTPHandler()
     else:
@@ -207,7 +209,7 @@ async def test_url_with_format_param(model, sync_mode, monkeypatch):
             json_str = json_str.decode("utf-8")
 
         print(f"type of json_str: {type(json_str)}")
-        
+
         # Bedrock models convert URLs to base64, while direct Anthropic models support URLs
         # bedrock/invoke models use Anthropic messages API which supports URLs
         if model.startswith("bedrock/invoke/"):
@@ -267,9 +269,7 @@ async def test_url_with_format_param_openai(model, sync_mode):
             }
         ],
     }
-    with patch.object(
-        client.chat.completions.with_raw_response, "create"
-    ) as mock_client:
+    with patch.object(client.chat.completions.with_raw_response, "create") as mock_client:
         try:
             if sync_mode:
                 response = completion(**args, client=client)
@@ -321,9 +321,7 @@ def test_strip_input_examples_for_non_anthropic_providers():
         }
     ]
 
-    assert not litellm_main._should_allow_input_examples(
-        custom_llm_provider="openai", model="gpt-4o-mini"
-    )
+    assert not litellm_main._should_allow_input_examples(custom_llm_provider="openai", model="gpt-4o-mini")
 
     cleaned = litellm_main._drop_input_examples_from_tools(tools=tools)
 
@@ -335,9 +333,7 @@ def test_strip_input_examples_for_non_anthropic_providers():
 def test_custom_provider_with_extra_headers():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
-    with patch.object(
-        litellm.llms.custom_httpx.http_handler.HTTPHandler, "post"
-    ) as mock_post:
+    with patch.object(litellm.llms.custom_httpx.http_handler.HTTPHandler, "post") as mock_post:
         response = litellm.completion(
             model="custom/custom",
             messages=[{"role": "user", "content": "Hello, how are you?"}],
@@ -352,9 +348,7 @@ def test_custom_provider_with_extra_headers():
 def test_custom_provider_with_extra_body():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
-    with patch.object(
-        litellm.llms.custom_httpx.http_handler.HTTPHandler, "post"
-    ) as mock_post:
+    with patch.object(litellm.llms.custom_httpx.http_handler.HTTPHandler, "post") as mock_post:
         response = litellm.completion(
             model="custom/custom",
             messages=[{"role": "user", "content": "Hello, how are you?"}],
@@ -381,9 +375,7 @@ def test_custom_provider_with_extra_body():
         }
 
     # test that extra_body is not passed if not provided
-    with patch.object(
-        litellm.llms.custom_httpx.http_handler.HTTPHandler, "post"
-    ) as mock_post:
+    with patch.object(litellm.llms.custom_httpx.http_handler.HTTPHandler, "post") as mock_post:
         response = litellm.completion(
             model="custom/custom",
             messages=[{"role": "user", "content": "Hello, how are you?"}],
@@ -414,9 +406,7 @@ def set_openrouter_api_key():
 
 
 @pytest.mark.asyncio
-async def test_extra_body_with_fallback(
-    respx_mock: respx.MockRouter, set_openrouter_api_key, monkeypatch
-):
+async def test_extra_body_with_fallback(respx_mock: respx.MockRouter, set_openrouter_api_key, monkeypatch):
     """
     test regression for https://github.com/BerriAI/litellm/issues/8425.
 
@@ -433,7 +423,7 @@ async def test_extra_body_with_fallback(
         monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
         # Flush cache to ensure no stale aiohttp clients are used
         litellm.in_memory_llm_clients_cache.flush_cache()
-        
+
         # Set up test parameters
         model = "openrouter/deepseek/deepseek-chat"
         messages = [{"role": "user", "content": "Hello, world!"}]
@@ -467,7 +457,7 @@ async def test_extra_body_with_fallback(
                     }
                 ],
                 "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-            }
+            },
         )
 
         response = await litellm.acompletion(
@@ -481,7 +471,7 @@ async def test_extra_body_with_fallback(
         # Verify the response
         assert response is not None
         assert len(respx_mock.calls) > 0, "Mock was not called - check if aiohttp transport is properly disabled"
-        
+
         # Get the request from the mock
         request: httpx.Request = respx_mock.calls[0].request
         request_body = request.read()
@@ -504,9 +494,7 @@ async def test_extra_body_with_fallback(
 @pytest.mark.parametrize("env_base", ["OPENAI_BASE_URL", "OPENAI_API_BASE"])
 @pytest.mark.asyncio
 @pytest.mark.flaky(retries=3, delay=1)
-async def test_openai_env_base(
-    respx_mock: respx.MockRouter, env_base, openai_api_response, monkeypatch
-):
+async def test_openai_env_base(respx_mock: respx.MockRouter, env_base, openai_api_response, monkeypatch):
     "This tests OpenAI env variables are honored, including legacy OPENAI_API_BASE"
     # Ensure aiohttp transport is disabled to use httpx which respx can mock
     litellm.disable_aiohttp_transport = True
@@ -521,35 +509,35 @@ async def test_openai_env_base(
     messages = [{"role": "user", "content": "Hello, how are you?"}]
 
     # Configure respx mock to intercept the request
-    mock_route = respx_mock.post(
-        url__regex=r"http://localhost:12345/v1/chat/completions.*"
-    ).mock(return_value=httpx.Response(
-        status_code=200,
-        json={
-            "id": "chatcmpl-123",
-            "object": "chat.completion",
-            "created": 1677652288,
-            "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": "Hello from mocked response!",
-                    },
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
-        }
-    ))
+    mock_route = respx_mock.post(url__regex=r"http://localhost:12345/v1/chat/completions.*").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "id": "chatcmpl-123",
+                "object": "chat.completion",
+                "created": 1677652288,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello from mocked response!",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
+            },
+        )
+    )
 
     try:
         response = await litellm.acompletion(model=model, messages=messages)
-        
+
         # verify we had a response
         assert response.choices[0].message.content == "Hello from mocked response!"
-        
+
         # Verify the mock was called
         assert mock_route.called, "Mock route was not called - request may have bypassed respx"
     finally:
@@ -722,9 +710,7 @@ def test_responses_api_bridge_check_handles_exception():
     with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
         mock_get_model_info.side_effect = Exception("Model not found")
 
-        model_info, model = responses_api_bridge_check(
-            model="responses/custom-model", custom_llm_provider="custom"
-        )
+        model_info, model = responses_api_bridge_check(model="responses/custom-model", custom_llm_provider="custom")
 
         assert model == "custom-model"
         assert model_info["mode"] == "responses"
@@ -1453,7 +1439,7 @@ def test_anthropic_text_disable_url_suffix_env_var():
 
 def test_image_edit_merges_headers_and_extra_headers():
     from litellm.images.main import base_llm_http_handler
-    
+
     combined_headers = {
         "x-test-header-one": "value-1",
         "x-test-header-two": "value-2",
@@ -1461,9 +1447,7 @@ def test_image_edit_merges_headers_and_extra_headers():
 
     mock_image_edit_config = MagicMock()
     mock_image_edit_config.get_supported_openai_params.return_value = set()
-    mock_image_edit_config.map_openai_params.side_effect = lambda **kwargs: dict(
-        kwargs["image_edit_optional_params"]
-    )
+    mock_image_edit_config.map_openai_params.side_effect = lambda **kwargs: dict(kwargs["image_edit_optional_params"])
 
     with (
         patch(
@@ -1545,10 +1529,7 @@ def test_mock_completion_stream_with_model_response():
     # Verify the content is streamed correctly
     accumulated_content = ""
     for chunk in chunks:
-        if (
-            hasattr(chunk.choices[0].delta, "content")
-            and chunk.choices[0].delta.content
-        ):
+        if hasattr(chunk.choices[0].delta, "content") and chunk.choices[0].delta.content:
             accumulated_content += chunk.choices[0].delta.content
 
     assert "This is a test response" in accumulated_content or len(chunks) > 0
@@ -1606,10 +1587,7 @@ async def test_async_mock_completion_stream_with_model_response():
     # Verify the content is streamed correctly
     accumulated_content = ""
     for chunk in chunks:
-        if (
-            hasattr(chunk.choices[0].delta, "content")
-            and chunk.choices[0].delta.content
-        ):
+        if hasattr(chunk.choices[0].delta, "content") and chunk.choices[0].delta.content:
             accumulated_content += chunk.choices[0].delta.content
 
     assert "This is an async test response" in accumulated_content or len(chunks) > 0

--- a/tests/test_litellm/test_router_retry_non_retryable_errors.py
+++ b/tests/test_litellm/test_router_retry_non_retryable_errors.py
@@ -16,6 +16,7 @@ import pytest
 
 import litellm
 from litellm import Router
+from litellm.llms.azure.common_utils import AzureOpenAIError
 
 
 def _make_rate_limit_error(message="Rate limited"):
@@ -112,16 +113,57 @@ async def test_non_retryable_error_in_retry_loop_raises_immediately():
         else:
             raise context_window_error
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.ContextWindowExceededError):
             await router.async_function_with_retries(
                 num_retries=2,
                 **_base_kwargs(),
             )
+
+
+@pytest.mark.asyncio
+async def test_azure_400_with_surrogate_unicode_fails_fast():
+    """
+    Verify that AzureOpenAIError(status_code=400) containing surrogate Unicode fails fast
+    and does not retry, even when the router sees the raw provider exception.
+    """
+    router = _create_router(num_retries=2)
+
+    call_count = 0
+
+    async def mock_make_call(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise AzureOpenAIError(
+            status_code=400, message="Bad request with surrogate: \ud83d"
+        )
+
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
+        with pytest.raises(AzureOpenAIError):
+            await router.async_function_with_retries(
+                num_retries=2,
+                **_base_kwargs(),
+            )
+
+        assert call_count == 1
 
 
 @pytest.mark.asyncio
@@ -145,11 +187,16 @@ async def test_bad_request_error_in_retry_loop_raises_immediately():
         else:
             raise bad_request_error
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.BadRequestError):
             await router.async_function_with_retries(
                 num_retries=2,
@@ -172,11 +219,16 @@ async def test_original_exception_updated_to_latest_error():
         call_count += 1
         raise _make_rate_limit_error(f"Rate limit attempt {call_count}")
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.RateLimitError) as exc_info:
             await router.async_function_with_retries(
                 num_retries=2,
@@ -201,11 +253,16 @@ async def test_retryable_errors_still_retry_normally():
         call_count += 1
         raise _make_rate_limit_error(f"Rate limit attempt {call_count}")
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.RateLimitError):
             await router.async_function_with_retries(
                 num_retries=3,
@@ -236,11 +293,16 @@ async def test_not_found_error_in_retry_loop_raises_immediately():
         else:
             raise not_found_error
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.NotFoundError):
             await router.async_function_with_retries(
                 num_retries=2,


### PR DESCRIPTION
## Relevant issues

Fixes #23959

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: https://github.com/seonghobae/litellm/actions/runs/23420494895

- [ ] **CI run for the last commit**  
       Link: https://github.com/seonghobae/litellm/actions/runs/23420494895

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- reject lone surrogate Unicode code points in Azure request payloads before transport dispatch
- reject escaped lone surrogates at proxy request parsing time with a 400 `request_body` error
- add regression coverage for Azure preflight validation, proxy parsing, and router fail-fast retry behavior

## Verification

- `poetry run pytest tests/test_litellm/llms/azure/test_azure_exception_mapping.py tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py tests/test_litellm/test_router_retry_non_retryable_errors.py -v` -> `46 passed`
