### PR TITLE
fix(cost): bill unaccounted Gemini token remainder

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -1,7 +1,6 @@
 # What is this?
 ## This hook is used to check for LiteLLM managed files in the request body, and replace them with model-specific file id
 
-import asyncio
 import base64
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
@@ -118,7 +117,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 db_data["storage_backend"] = hidden_params["storage_backend"]
             if "storage_url" in hidden_params:
                 db_data["storage_url"] = hidden_params["storage_url"]
-            
+
             verbose_logger.debug(
                 f"Storage metadata: storage_backend={db_data.get('storage_backend')}, "
                 f"storage_url={db_data.get('storage_url')}"
@@ -278,28 +277,28 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             raise Exception(
                 "Filtering by 'target_model_names' is not supported when using managed batches."
             )
-        
+
         where_clause: Dict[str, Any] = {"file_purpose": "batch"}
-        
+
         # Filter by user who created the batch
         if user_api_key_dict.user_id:
             where_clause["created_by"] = user_api_key_dict.user_id
-        
+
         if after:
             where_clause["id"] = {"gt": after}
-        
+
         # Fetch more than needed to allow for post-fetch filtering
         fetch_limit = limit or 20
         if target_model_names:
             # Fetch extra to account for filtering
             fetch_limit = max(fetch_limit * 3, 100)
-        
+
         batches = await self.prisma_client.db.litellm_managedobjecttable.find_many(
             where=where_clause,
             take=fetch_limit,
             order={"created_at": "desc"},
         )
-                
+
         batch_objects: List[LiteLLMBatch] = []
         for batch in batches:
             try:
@@ -307,7 +306,11 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 if len(batch_objects) >= (limit or 20):
                     break
 
-                batch_data = json.loads(batch.file_object) if isinstance(batch.file_object, str) else batch.file_object
+                batch_data = (
+                    json.loads(batch.file_object)
+                    if isinstance(batch.file_object, str)
+                    else batch.file_object
+                )
                 batch_obj = LiteLLMBatch(**batch_data)
                 batch_obj.id = batch.unified_object_id
                 batch_objects.append(batch_obj)
@@ -317,7 +320,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     f"Failed to parse batch object {batch.unified_object_id}: {e}"
                 )
                 continue
-        
+
         return {
             "object": "list",
             "data": batch_objects,
@@ -370,11 +373,11 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         """
         Check if the user has access to a list of file IDs.
         Only checks managed (unified) file IDs.
-        
+
         Args:
             file_ids: List of file IDs to check access for
             user_api_key_dict: User API key authentication details
-            
+
         Raises:
             HTTPException: If user doesn't have access to any of the files
         """
@@ -412,10 +415,10 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         ### HANDLE TRANSFORMATIONS ###
         # Check both completion and acompletion call types
         is_completion_call = (
-            call_type == CallTypes.completion.value 
+            call_type == CallTypes.completion.value
             or call_type == CallTypes.acompletion.value
         )
-        
+
         if is_completion_call:
             messages = data.get("messages")
             model = data.get("model", "")
@@ -424,22 +427,27 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 if file_ids:
                     # Check user has access to all managed files
                     await self.check_file_ids_access(file_ids, user_api_key_dict)
-                    
+
                     # Check if any files are stored in storage backends and need base64 conversion
                     # This is needed for Vertex AI/Gemini which requires base64 content
-                    is_vertex_ai = model and ("vertex_ai" in model or "gemini" in model.lower())
+                    is_vertex_ai = model and (
+                        "vertex_ai" in model or "gemini" in model.lower()
+                    )
                     if is_vertex_ai:
                         await self._convert_storage_files_to_base64(
                             messages=messages,
                             file_ids=file_ids,
                             litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
                         )
-                    
+
                     model_file_id_mapping = await self.get_model_file_id_mapping(
                         file_ids, user_api_key_dict.parent_otel_span
                     )
                     data["model_file_id_mapping"] = model_file_id_mapping
-        elif call_type == CallTypes.aresponses.value or call_type == CallTypes.responses.value:
+        elif (
+            call_type == CallTypes.aresponses.value
+            or call_type == CallTypes.responses.value
+        ):
             # Handle managed files in responses API input and tools
             file_ids = []
 
@@ -604,7 +612,9 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             if model_id is None:
                 model_id = cast(
                     Optional[str],
-                    kwargs.get("litellm_metadata", {}).get("model_info", {}).get("id", None),
+                    kwargs.get("litellm_metadata", {})
+                    .get("model_info", {})
+                    .get("id", None),
                 )
             mapped_file_id: Optional[str] = None
             if input_file_id and model_file_id_mapping and model_id:
@@ -641,7 +651,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
     ) -> List[str]:
         """
         Gets file ids from responses API input.
-        
+
         The input can be:
         - A string (no files)
         - A list of input items, where each item can have:
@@ -649,32 +659,35 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
           - content: a list that can contain items with type: "input_file" and file_id
         """
         file_ids: List[str] = []
-        
+
         if isinstance(input, str):
             return file_ids
-        
+
         if not isinstance(input, list):
             return file_ids
-        
+
         for item in input:
             if not isinstance(item, dict):
                 continue
-            
+
             # Check for direct input_file type
             if item.get("type") == "input_file":
                 file_id = item.get("file_id")
                 if file_id:
                     file_ids.append(file_id)
-            
+
             # Check for input_file in content array
             content = item.get("content")
             if isinstance(content, list):
                 for content_item in content:
-                    if isinstance(content_item, dict) and content_item.get("type") == "input_file":
+                    if (
+                        isinstance(content_item, dict)
+                        and content_item.get("type") == "input_file"
+                    ):
                         file_id = content_item.get("file_id")
                         if file_id:
                             file_ids.append(file_id)
-        
+
         return file_ids
 
     def get_file_ids_from_responses_tools(
@@ -682,7 +695,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
     ) -> List[str]:
         """
         Gets file ids from responses API tools parameter.
-        
+
         The tools can contain code_interpreter with container.file_ids:
         [
             {
@@ -692,14 +705,14 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         ]
         """
         file_ids: List[str] = []
-        
+
         if not isinstance(tools, list):
             return file_ids
-        
+
         for tool in tools:
             if not isinstance(tool, dict):
                 continue
-            
+
             # Check for code_interpreter with container file_ids
             if tool.get("type") == "code_interpreter":
                 container = tool.get("container")
@@ -709,7 +722,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                         for file_id in container_file_ids:
                             if isinstance(file_id, str):
                                 file_ids.append(file_id)
-        
+
         return file_ids
 
     def get_vector_store_ids_from_file_search_tools(
@@ -995,7 +1008,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
     def get_output_file_id_from_unified_file_id(self, file_id: str) -> str:
         return file_id.split("llm_output_file_id,")[1].split(";")[0]
 
-    async def async_post_call_success_hook(
+    async def async_post_call_success_hook(  # noqa: PLR0915
         self, data: Dict, user_api_key_dict: UserAPIKeyAuth, response: LLMResponseTypes
     ) -> Any:
         if isinstance(response, LiteLLMBatch):
@@ -1026,9 +1039,19 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             original_response_id = response.id
 
             if (unified_batch_id or unified_file_id) and model_id:
-                response.id = self.get_unified_batch_id(
-                    batch_id=response.id, model_id=model_id
+                response_id_is_unified = bool(
+                    isinstance(response.id, str)
+                    and _is_base64_encoded_unified_file_id(response.id)
                 )
+                if unified_batch_id and response_id_is_unified:
+                    original_response_id = (
+                        get_batch_id_from_unified_batch_id(unified_batch_id)
+                        or original_response_id
+                    )
+                else:
+                    response.id = self.get_unified_batch_id(
+                        batch_id=response.id, model_id=model_id
+                    )
 
                 # Handle both output_file_id and error_file_id
                 for file_attr in ["output_file_id", "error_file_id"]:
@@ -1041,16 +1064,24 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                             model_name=resolved_model_name,
                         )
                         setattr(response, file_attr, unified_file_id)
-                        
+
                         # Use llm_router credentials when available. Without credentials,
                         # Azure and other auth-required providers return 500/401.
                         file_object = None
                         try:
                             # Import module and use getattr for better testability with mocks
                             import litellm.proxy.proxy_server as proxy_server_module
-                            _llm_router = getattr(proxy_server_module, 'llm_router', None)
+
+                            _llm_router = getattr(
+                                proxy_server_module, "llm_router", None
+                            )
                             if _llm_router is not None and model_id:
-                                _creds = _llm_router.get_deployment_credentials_with_provider(model_id) or {}
+                                _creds = (
+                                    _llm_router.get_deployment_credentials_with_provider(
+                                        model_id
+                                    )
+                                    or {}
+                                )
                                 file_object = await litellm.afile_retrieve(
                                     file_id=original_file_id,
                                     **_creds,
@@ -1067,7 +1098,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                             verbose_logger.warning(
                                 f"Failed to retrieve file object for {file_attr}={original_file_id}: {str(e)}. Storing with None and will fetch on-demand."
                             )
-                        
+
                         await self.store_unified_file_id(
                             file_id=unified_file_id,
                             file_object=file_object,
@@ -1142,7 +1173,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         # Case 1 : This is not a managed file
         if not stored_file_object:
             raise Exception(f"LiteLLM Managed File object with id={file_id} not found")
-        
+
         # Case 2: Managed file and the file object exists in the database
         # The stored file_object has the raw provider ID. Replace with the unified ID
         # so callers see a consistent ID (matching Case 3 which does response.id = file_id).
@@ -1160,13 +1191,21 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             )
 
         try:
-            model_id, model_file_id = next(iter(stored_file_object.model_mappings.items()))
-            credentials = llm_router.get_deployment_credentials_with_provider(model_id) or {}
-            response = await litellm.afile_retrieve(file_id=model_file_id, **credentials)
+            model_id, model_file_id = next(
+                iter(stored_file_object.model_mappings.items())
+            )
+            credentials = (
+                llm_router.get_deployment_credentials_with_provider(model_id) or {}
+            )
+            response = await litellm.afile_retrieve(
+                file_id=model_file_id, **credentials
+            )
             response.id = file_id  # Replace with unified ID
             return response
         except Exception as e:
-            raise Exception(f"Failed to retrieve file {file_id} from provider: {str(e)}") from e
+            raise Exception(
+                f"Failed to retrieve file {file_id} from provider: {str(e)}"
+            ) from e
 
     async def afile_list(
         self,
@@ -1188,19 +1227,19 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             import litellm.proxy.proxy_server as proxy_server_module
 
             # Check if the scheduler has the batch cost checking job registered
-            scheduler = getattr(proxy_server_module, 'scheduler', None)
+            scheduler = getattr(proxy_server_module, "scheduler", None)
             if scheduler is None:
                 return False
-            
+
             # Check if the check_batch_cost_job exists in the scheduler
             try:
-                job = scheduler.get_job('check_batch_cost_job')
+                job = scheduler.get_job("check_batch_cost_job")
                 if job is not None:
                     return True
             except Exception:
                 # Job not found or scheduler doesn't support get_job
                 pass
-            
+
             return False
         except Exception as e:
             verbose_logger.warning(
@@ -1208,28 +1247,26 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             )
             return False
 
-    async def _get_batches_referencing_file(
-        self, file_id: str
-    ) -> List[Dict[str, Any]]:
+    async def _get_batches_referencing_file(self, file_id: str) -> List[Dict[str, Any]]:
         """
         Find batches that reference this file and still need cost tracking.
         Find batches that are in non-terminal state and have not yet been processed by CheckBatchCost.
         Args:
             file_id: The unified file ID to check
-            
+
         Returns:
             List of batch objects referencing this file in non-terminal state
             (max 10 for error message display)
         """
         # Prepare list of file IDs to check (both unified and provider IDs)
         file_ids_to_check = [file_id]
-        
+
         # Get model-specific file IDs for this unified file ID if it's a managed file
         try:
             model_file_id_mapping = await self.get_model_file_id_mapping(
                 [file_id], litellm_parent_otel_span=None
             )
-            
+
             if model_file_id_mapping and file_id in model_file_id_mapping:
                 # Add all provider file IDs for this unified file
                 provider_file_ids = list(model_file_id_mapping[file_id].values())
@@ -1239,59 +1276,67 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 f"Could not get model file ID mapping for {file_id}: {e}. "
                 f"Will only check unified file ID."
             )
-        MAX_MATCHES_TO_RETURN = 10 
-        
+        MAX_MATCHES_TO_RETURN = 10
+
         batches = await self.prisma_client.db.litellm_managedobjecttable.find_many(
             where={
                 "file_purpose": "batch",
                 "batch_processed": False,
-                "status": {"not_in": ["failed", "expired", "cancelled"]}
+                "status": {"not_in": ["failed", "expired", "cancelled"]},
             },
             take=MAX_MATCHES_TO_RETURN,
             order={"created_at": "desc"},
         )
-        
+
         referencing_batches = []
         for batch in batches:
             try:
                 # Parse the batch file_object to check for file references
-                batch_data = json.loads(batch.file_object) if isinstance(batch.file_object, str) else batch.file_object
-                
+                batch_data = (
+                    json.loads(batch.file_object)
+                    if isinstance(batch.file_object, str)
+                    else batch.file_object
+                )
+
                 # Extract file IDs from batch
                 # Batches typically reference the unified file ID in input_file_id
                 # Output and error files are generated by the provider
                 input_file_id = batch_data.get("input_file_id")
                 output_file_id = batch_data.get("output_file_id")
                 error_file_id = batch_data.get("error_file_id")
-                
-                referenced_file_ids = [fid for fid in [input_file_id, output_file_id, error_file_id] if fid]
-                
+
+                referenced_file_ids = [
+                    fid for fid in [input_file_id, output_file_id, error_file_id] if fid
+                ]
+
                 # Check if any referenced file ID matches the file we're trying to delete
                 if any(ref_id in file_ids_to_check for ref_id in referenced_file_ids):
-                    referencing_batches.append({
-                        "batch_id": batch.unified_object_id,
-                        "status": batch.status,
-                        "created_at": batch.created_at,
-                    })
+                    referencing_batches.append(
+                        {
+                            "batch_id": batch.unified_object_id,
+                            "status": batch.status,
+                            "created_at": batch.created_at,
+                        }
+                    )
             except Exception as e:
                 verbose_logger.warning(
                     f"Error parsing batch object {batch.unified_object_id}: {e}"
                 )
                 continue
-        
+
         return referencing_batches
 
     async def _check_file_deletion_allowed(self, file_id: str) -> None:
         """
         Check if file deletion should be blocked due to batch references.
-        
+
         Blocks deletion if:
         1. File is referenced by any batch in non-terminal state, AND
         2. Batch polling is configured (user wants cost tracking)
-        
+
         Args:
             file_id: The unified file ID to check
-            
+
         Raises:
             HTTPException: If file deletion should be blocked
         """
@@ -1299,39 +1344,45 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         if not self._is_batch_polling_enabled():
             # Batch polling not configured, allow deletion
             return
-        
+
         # Check if file is referenced by any non-terminal batches
         referencing_batches = await self._get_batches_referencing_file(file_id)
-        
+
         if referencing_batches:
             # File is referenced by non-terminal batches and polling is enabled
-            MAX_BATCHES_IN_ERROR = 5  # Limit batches shown in error message for readability
-            
+            MAX_BATCHES_IN_ERROR = (
+                5  # Limit batches shown in error message for readability
+            )
+
             # Show up to MAX_BATCHES_IN_ERROR in the error message
             batches_to_show = referencing_batches[:MAX_BATCHES_IN_ERROR]
-            batch_statuses = [f"{b['batch_id']}: {b['status']}" for b in batches_to_show]
-            
+            batch_statuses = [
+                f"{b['batch_id']}: {b['status']}" for b in batches_to_show
+            ]
+
             # Determine the count message
             count_message = f"{len(referencing_batches)}"
-            if len(referencing_batches) >= 10:  # MAX_MATCHES_TO_RETURN from _get_batches_referencing_file
+            if (
+                len(referencing_batches) >= 10
+            ):  # MAX_MATCHES_TO_RETURN from _get_batches_referencing_file
                 count_message = "10+"
-            
+
             error_message = (
                 f"Cannot delete file {file_id}. "
                 f"The file is referenced by {count_message} batch(es) in non-terminal state"
             )
-            
+
             # Add specific batch details if not too many
             if len(referencing_batches) <= MAX_BATCHES_IN_ERROR:
                 error_message += f": {', '.join(batch_statuses)}. "
             else:
                 error_message += f" (showing {MAX_BATCHES_IN_ERROR} most recent): {', '.join(batch_statuses)}. "
-            
+
             error_message += (
-                f"To delete this file before complete cost tracking, please delete or cancel the referencing batch(es) first. "
-                f"Alternatively, wait for all batches to complete and for cost to be computed (batch_processed=true)."
+                "To delete this file before complete cost tracking, please delete or cancel the referencing batch(es) first. "
+                "Alternatively, wait for all batches to complete and for cost to be computed (batch_processed=true)."
             )
-            
+
             raise HTTPException(
                 status_code=400,
                 detail=error_message,
@@ -1344,7 +1395,6 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         llm_router: Router,
         **data: Dict,
     ) -> OpenAIFileObject:
-
         # Check if file deletion should be blocked due to batch references
         await self._check_file_deletion_allowed(file_id)
 
@@ -1357,7 +1407,9 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         specific_model_file_id_mapping = model_file_id_mapping.get(file_id)
         if specific_model_file_id_mapping:
             # Remove conflicting keys from data to avoid duplicate keyword arguments
-            filtered_data = {k: v for k, v in data.items() if k not in ("model", "file_id")}
+            filtered_data = {
+                k: v for k, v in data.items() if k not in ("model", "file_id")
+            }
             for model_id, model_file_id in specific_model_file_id_mapping.items():
                 delete_response = await llm_router.afile_delete(model=model_id, file_id=model_file_id, **filtered_data)  # type: ignore
 
@@ -1412,7 +1464,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
     ) -> None:
         """
         Convert files stored in storage backends to base64 format for Vertex AI/Gemini.
-        
+
         This method checks if any managed files are stored in storage backends,
         downloads them, and converts them to base64 format in the messages.
         """
@@ -1420,29 +1472,29 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
         for file_id in file_ids:
             # Check if this is a base64 encoded unified file ID
             decoded_unified_file_id = _is_base64_encoded_unified_file_id(file_id)
-            
+
             if not decoded_unified_file_id:
                 continue
-            
+
             # Check database for storage backend info
             # IMPORTANT: The database stores the base64 encoded unified_file_id (not the decoded version)
             # So we query with the original file_id (which is base64 encoded)
             db_file = await self.prisma_client.db.litellm_managedfiletable.find_first(
                 where={"unified_file_id": file_id}
             )
-            
+
             if not db_file or not db_file.storage_backend or not db_file.storage_url:
                 continue
-            
+
             # File is stored in a storage backend, download and convert to base64
             try:
                 from litellm.llms.base_llm.files.storage_backend_factory import (
                     get_storage_backend,
                 )
-                
+
                 storage_backend_name = db_file.storage_backend
                 storage_url = db_file.storage_url
-                
+
                 # Get storage backend (uses same env vars as callback)
                 try:
                     storage_backend = get_storage_backend(storage_backend_name)
@@ -1451,18 +1503,22 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                         f"Storage backend '{storage_backend_name}' error for file {file_id}: {str(e)}"
                     )
                     continue
-                
+
                 file_content = await storage_backend.download_file(storage_url)
-                
+
                 # Determine content type from file object
-                content_type = self._get_content_type_from_file_object(db_file.file_object)
-                
+                content_type = self._get_content_type_from_file_object(
+                    db_file.file_object
+                )
+
                 # Convert to base64
                 base64_data = base64.b64encode(file_content).decode("utf-8")
                 base64_data_uri = f"data:{content_type};base64,{base64_data}"
-                
+
                 # Update messages to use base64 instead of file_id
-                self._update_messages_with_base64_data(messages, file_id, base64_data_uri, content_type)
+                self._update_messages_with_base64_data(
+                    messages, file_id, base64_data_uri, content_type
+                )
             except Exception as e:
                 verbose_logger.exception(
                     f"Error converting file {file_id} from storage backend to base64: {str(e)}"
@@ -1473,21 +1529,21 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
     def _get_content_type_from_file_object(self, file_object: Optional[Any]) -> str:
         """
         Determine content type from file object.
-        
+
         Uses the MIME type utility for consistent detection and normalization.
-        
+
         Args:
             file_object: The file object from the database (can be dict, JSON string, or None)
-        
+
         Returns:
             str: MIME type (defaults to "application/octet-stream" if cannot be determined)
         """
         # Use utility function for detection
         content_type = get_content_type_from_file_object(file_object)
-        
+
         # Normalize for Gemini/Vertex AI (requires image/jpeg, not image/jpg)
         content_type = normalize_mime_type_for_provider(content_type, provider="gemini")
-        
+
         return content_type
 
     def _update_messages_with_base64_data(
@@ -1499,7 +1555,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
     ) -> None:
         """
         Update messages to replace file_id with base64 data URI.
-        
+
         Args:
             messages: List of messages to update
             file_id: The file ID to replace
@@ -1514,7 +1570,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                         if element.get("type") == "file":
                             file_element = cast(ChatCompletionFileObject, element)
                             file_element_file = file_element.get("file", {})
-                            
+
                             if file_element_file.get("file_id") == file_id:
                                 # Replace file_id with base64 data
                                 file_element_file["file_data"] = base64_data_uri
@@ -1522,7 +1578,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                                 file_element_file["format"] = content_type
                                 # Remove file_id to ensure only file_data is used
                                 file_element_file.pop("file_id", None)
-                                
+
                                 verbose_logger.debug(
                                     f"Converted file {file_id} from storage backend to base64 with format {content_type}"
                                 )

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -354,9 +354,9 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
-        self.sync_streaming_chunks: List[Any] = (
-            []
-        )  # for generating complete stream response
+        self.sync_streaming_chunks: List[
+            Any
+        ] = []  # for generating complete stream response
         self.log_raw_request_response = log_raw_request_response
 
         # Initialize dynamic callbacks
@@ -801,9 +801,9 @@ class Logging(LiteLLMLoggingBaseClass):
                         prompt_spec=prompt_spec,
                         dynamic_callback_params=dynamic_callback_params,
                     ):
-                        self.model_call_details["prompt_integration"] = (
-                            logger.__class__.__name__
-                        )
+                        self.model_call_details[
+                            "prompt_integration"
+                        ] = logger.__class__.__name__
                         return logger
                 except Exception:
                     # If check fails, continue to next logger
@@ -871,9 +871,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if anthropic_cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
             non_default_params
         ):
-            self.model_call_details["prompt_integration"] = (
-                anthropic_cache_control_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = anthropic_cache_control_logger.__class__.__name__
             return anthropic_cache_control_logger
 
         #########################################################
@@ -885,9 +885,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 internal_usage_cache=None,
                 llm_router=None,
             )
-            self.model_call_details["prompt_integration"] = (
-                vector_store_custom_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = vector_store_custom_logger.__class__.__name__
             # Add to global callbacks so post-call hooks are invoked
             if (
                 vector_store_custom_logger
@@ -947,9 +947,9 @@ class Logging(LiteLLMLoggingBaseClass):
             model
         ):  # if model name was changes pre-call, overwrite the initial model call name with the new one
             self.model_call_details["model"] = model
-        self.model_call_details["litellm_params"]["api_base"] = (
-            self._get_masked_api_base(additional_args.get("api_base", ""))
-        )
+        self.model_call_details["litellm_params"][
+            "api_base"
+        ] = self._get_masked_api_base(additional_args.get("api_base", ""))
 
     def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
         # Log the exact input to the LLM API
@@ -978,7 +978,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:
-                        _metadata["raw_request"] = "redacted by litellm. \
+                        _metadata[
+                            "raw_request"
+                        ] = "redacted by litellm. \
                             'litellm.turn_off_message_logging=True'"
                     else:
                         curl_command = self._get_request_curl_command(
@@ -990,31 +992,35 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         _metadata["raw_request"] = str(curl_command)
                         # split up, so it's easier to parse in the UI
-                        self.model_call_details["raw_request_typed_dict"] = (
-                            RawRequestTypedDict(
-                                raw_request_api_base=str(
-                                    additional_args.get("api_base") or ""
-                                ),
-                                raw_request_body=self._get_raw_request_body(
-                                    additional_args.get("complete_input_dict", {})
-                                ),
-                                # NOTE: setting ignore_sensitive_headers to True will cause
-                                # the Authorization header to be leaked when calls to the health
-                                # endpoint are made and fail.
-                                raw_request_headers=self._get_masked_headers(
-                                    additional_args.get("headers", {}) or {},
-                                ),
-                                error=None,
-                            )
+                        self.model_call_details[
+                            "raw_request_typed_dict"
+                        ] = RawRequestTypedDict(
+                            raw_request_api_base=str(
+                                additional_args.get("api_base") or ""
+                            ),
+                            raw_request_body=self._get_raw_request_body(
+                                additional_args.get("complete_input_dict", {})
+                            ),
+                            # NOTE: setting ignore_sensitive_headers to True will cause
+                            # the Authorization header to be leaked when calls to the health
+                            # endpoint are made and fail.
+                            raw_request_headers=self._get_masked_headers(
+                                additional_args.get("headers", {}) or {},
+                            ),
+                            error=None,
                         )
                 except Exception as e:
-                    self.model_call_details["raw_request_typed_dict"] = (
-                        RawRequestTypedDict(
-                            error=str(e),
-                        )
+                    self.model_call_details[
+                        "raw_request_typed_dict"
+                    ] = RawRequestTypedDict(
+                        error=str(e),
                     )
-                    _metadata["raw_request"] = "Unable to Log \
-                        raw request: {}".format(str(e))
+                    _metadata[
+                        "raw_request"
+                    ] = "Unable to Log \
+                        raw request: {}".format(
+                        str(e)
+                    )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
                     self.logger_fn(
@@ -1314,13 +1320,13 @@ class Logging(LiteLLMLoggingBaseClass):
         for callback in callbacks:
             try:
                 if isinstance(callback, CustomLogger):
-                    response: Optional[MCPPostCallResponseObject] = (
-                        await callback.async_post_mcp_tool_call_hook(
-                            kwargs=kwargs,
-                            response_obj=post_mcp_tool_call_response_obj,
-                            start_time=start_time,
-                            end_time=end_time,
-                        )
+                    response: Optional[
+                        MCPPostCallResponseObject
+                    ] = await callback.async_post_mcp_tool_call_hook(
+                        kwargs=kwargs,
+                        response_obj=post_mcp_tool_call_response_obj,
+                        start_time=start_time,
+                        end_time=end_time,
                     )
                     ######################################################################
                     # if any of the callbacks modify the response, use the modified response
@@ -1521,9 +1527,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
             return None
 
         try:
@@ -1549,9 +1555,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
 
         return None
 
@@ -1700,9 +1706,9 @@ class Logging(LiteLLMLoggingBaseClass):
         self.model_call_details["litellm_params"].setdefault("metadata", {})
         if self.model_call_details["litellm_params"]["metadata"] is None:
             self.model_call_details["litellm_params"]["metadata"] = {}
-        self.model_call_details["litellm_params"]["metadata"]["hidden_params"] = (
-            getattr(logging_result, "_hidden_params", {})
-        )
+        self.model_call_details["litellm_params"]["metadata"][
+            "hidden_params"
+        ] = getattr(logging_result, "_hidden_params", {})
 
     def _process_hidden_params_and_response_cost(
         self,
@@ -1731,9 +1737,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 result=logging_result
             )
 
-        self.model_call_details["standard_logging_object"] = (
-            self._build_standard_logging_payload(logging_result, start_time, end_time)
-        )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = self._build_standard_logging_payload(logging_result, start_time, end_time)
 
         if (
             standard_logging_payload := self.model_call_details.get(
@@ -1811,9 +1817,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 end_time = datetime.datetime.now()
             if self.completion_start_time is None:
                 self.completion_start_time = end_time
-                self.model_call_details["completion_start_time"] = (
-                    self.completion_start_time
-                )
+                self.model_call_details[
+                    "completion_start_time"
+                ] = self.completion_start_time
 
             self.model_call_details["log_event_type"] = "successful_api_call"
             self.model_call_details["end_time"] = end_time
@@ -1850,10 +1856,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         end_time=end_time,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
-                    self.model_call_details["standard_logging_object"] = (
-                        self._build_standard_logging_payload(
-                            result, start_time, end_time
-                        )
+                    self.model_call_details[
+                        "standard_logging_object"
+                    ] = self._build_standard_logging_payload(
+                        result, start_time, end_time
                     )
                     if (
                         standard_logging_payload := self.model_call_details.get(
@@ -1862,9 +1868,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     ) is not None:
                         emit_standard_logging_payload(standard_logging_payload)
             elif standard_logging_object is not None:
-                self.model_call_details["standard_logging_object"] = (
-                    standard_logging_object
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = standard_logging_object
             else:
                 self.model_call_details["response_cost"] = None
 
@@ -2022,20 +2028,20 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details["complete_streaming_response"] = (
-                    complete_streaming_response
-                )
-                self.model_call_details["response_cost"] = (
-                    self._response_cost_calculator(result=complete_streaming_response)
-                )
+                self.model_call_details[
+                    "complete_streaming_response"
+                ] = complete_streaming_response
+                self.model_call_details[
+                    "response_cost"
+                ] = self._response_cost_calculator(result=complete_streaming_response)
                 self._merge_hidden_params_from_response_into_metadata(
                     complete_streaming_response
                 )
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(
-                        complete_streaming_response, start_time, end_time
-                    )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = self._build_standard_logging_payload(
+                    complete_streaming_response, start_time, end_time
                 )
                 if (
                     standard_logging_payload := self.model_call_details.get(
@@ -2369,10 +2375,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
                             openMeterLogger.log_success_event(
@@ -2396,10 +2402,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
 
@@ -2538,9 +2544,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if complete_streaming_response is not None:
             print_verbose("Async success callbacks: Got a complete streaming response")
 
-            self.model_call_details["async_complete_streaming_response"] = (
-                complete_streaming_response
-            )
+            self.model_call_details[
+                "async_complete_streaming_response"
+            ] = complete_streaming_response
 
             try:
                 if self.model_call_details.get("cache_hit", False) is True:
@@ -2551,10 +2557,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details["response_cost"] = (
-                        self._response_cost_calculator(
-                            result=complete_streaming_response
-                        )
+                    self.model_call_details[
+                        "response_cost"
+                    ] = self._response_cost_calculator(
+                        result=complete_streaming_response
                     )
 
                 verbose_logger.debug(
@@ -2571,10 +2577,10 @@ class Logging(LiteLLMLoggingBaseClass):
             )
 
             ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details["standard_logging_object"] = (
-                self._build_standard_logging_payload(
-                    complete_streaming_response, start_time, end_time
-                )
+            self.model_call_details[
+                "standard_logging_object"
+            ] = self._build_standard_logging_payload(
+                complete_streaming_response, start_time, end_time
             )
 
             # print standard logging payload
@@ -2601,9 +2607,9 @@ class Logging(LiteLLMLoggingBaseClass):
             # _success_handler_helper_fn
             if self.model_call_details.get("standard_logging_object") is None:
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    self._build_standard_logging_payload(result, start_time, end_time)
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = self._build_standard_logging_payload(result, start_time, end_time)
 
                 # print standard logging payload
                 if (
@@ -2846,18 +2852,18 @@ class Logging(LiteLLMLoggingBaseClass):
 
         ## STANDARDIZED LOGGING PAYLOAD
 
-        self.model_call_details["standard_logging_object"] = (
-            get_standard_logging_object_payload(
-                kwargs=self.model_call_details,
-                init_response_obj={},
-                start_time=start_time,
-                end_time=end_time,
-                logging_obj=self,
-                status="failure",
-                error_str=str(exception),
-                original_exception=exception,
-                standard_built_in_tools_params=self.standard_built_in_tools_params,
-            )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = get_standard_logging_object_payload(
+            kwargs=self.model_call_details,
+            init_response_obj={},
+            start_time=start_time,
+            end_time=end_time,
+            logging_obj=self,
+            status="failure",
+            error_str=str(exception),
+            original_exception=exception,
+            standard_built_in_tools_params=self.standard_built_in_tools_params,
         )
         return start_time, end_time
 
@@ -3825,9 +3831,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 service_name=arize_config.project_name,
             )
 
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"space_id={arize_config.space_key or arize_config.space_id},api_key={arize_config.api_key}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, ArizeLogger)
@@ -3853,13 +3859,13 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"{existing_attrs},openinference.project.name={arize_phoenix_config.project_name}"
                 else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={arize_phoenix_config.project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"openinference.project.name={arize_phoenix_config.project_name}"
 
             # Set Phoenix project name from environment variable
             phoenix_project_name = os.environ.get("PHOENIX_PROJECT_NAME", None)
@@ -3867,19 +3873,19 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
                 # Add openinference.project.name attribute
                 if existing_attrs:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"{existing_attrs},openinference.project.name={phoenix_project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"{existing_attrs},openinference.project.name={phoenix_project_name}"
                 else:
-                    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = (
-                        f"openinference.project.name={phoenix_project_name}"
-                    )
+                    os.environ[
+                        "OTEL_RESOURCE_ATTRIBUTES"
+                    ] = f"openinference.project.name={phoenix_project_name}"
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:
-                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                    arize_phoenix_config.otlp_auth_headers
-                )
+                os.environ[
+                    "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+                ] = arize_phoenix_config.otlp_auth_headers
 
             for callback in _in_memory_loggers:
                 if (
@@ -4066,9 +4072,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 exporter="otlp_http",
                 endpoint="https://langtrace.ai/api/trace",
             )
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"api_key={os.getenv('LANGTRACE_API_KEY')}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, OpenTelemetry)
@@ -4992,10 +4998,10 @@ class StandardLoggingPayloadSetup:
             for key in StandardLoggingHiddenParams.__annotations__.keys():
                 if key in hidden_params:
                     if key == "additional_headers":
-                        clean_hidden_params["additional_headers"] = (
-                            StandardLoggingPayloadSetup.get_additional_headers(
-                                hidden_params[key]
-                            )
+                        clean_hidden_params[
+                            "additional_headers"
+                        ] = StandardLoggingPayloadSetup.get_additional_headers(
+                            hidden_params[key]
                         )
                     else:
                         clean_hidden_params[key] = hidden_params[key]  # type: ignore
@@ -5634,9 +5640,9 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
     ):
         for k, v in metadata["user_api_key_metadata"].items():
             if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[k] = (
-                    "scrubbed_by_litellm_for_sensitive_keys"
-                )
+                cleaned_user_api_key_metadata[
+                    k
+                ] = "scrubbed_by_litellm_for_sensitive_keys"
             else:
                 cleaned_user_api_key_metadata[k] = v
 

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -668,15 +668,19 @@ def generic_cost_per_token(  # noqa: PLR0915
     cache_creation = prompt_tokens_details["cache_creation_tokens"]
     image_tokens = prompt_tokens_details["image_tokens"]
 
-    # Check for double-counting: sum of details > prompt_tokens means overlap
+    # Normalize partial or overlapping prompt token breakdowns back to an
+    # exhaustive text+category split. Some providers only report a subset of
+    # prompt token categories (e.g. text + cache hit but omit PDF tokens), while
+    # others double-count text against cached tokens.
     total_details = (
         text_tokens + cache_hit + audio_tokens + cache_creation + image_tokens
     )
-    has_double_counting = cache_hit > 0 and total_details > usage.prompt_tokens
+    has_partial_or_overlapping_breakdown = total_details != usage.prompt_tokens
 
     if (
-        text_tokens == 0 and prompt_tokens_details["image_count"] == 0
-    ) or has_double_counting:
+        (text_tokens == 0 and prompt_tokens_details["image_count"] == 0)
+        or has_partial_or_overlapping_breakdown
+    ):
         text_tokens = (
             usage.prompt_tokens
             - cache_hit
@@ -684,6 +688,7 @@ def generic_cost_per_token(  # noqa: PLR0915
             - cache_creation
             - image_tokens
         )
+        text_tokens = max(0, text_tokens)
         prompt_tokens_details["text_tokens"] = text_tokens
 
     (
@@ -719,15 +724,19 @@ def generic_cost_per_token(  # noqa: PLR0915
         reasoning_tokens = completion_tokens_details["reasoning_tokens"]
         image_tokens = completion_tokens_details["image_tokens"]
 
-    # Handle text_tokens calculation:
-    # 1. If text_tokens is explicitly provided and > 0, use it
-    # 2. If there's a breakdown (reasoning/audio/image tokens), calculate text_tokens as the remainder
-    # 3. If no breakdown at all, assume all completion_tokens are text_tokens
+    # Normalize partial or overlapping completion token breakdowns the same way
+    # we do for prompt tokens so any unaccounted remainder is billed as text
+    # tokens rather than silently dropped.
     has_token_breakdown = image_tokens > 0 or audio_tokens > 0 or reasoning_tokens > 0
-    if text_tokens == 0:
-        if has_token_breakdown:
-            # Calculate text tokens as remainder when we have a breakdown
-            # This handles cases like OpenAI's reasoning models where text_tokens isn't provided
+    total_completion_details = (
+        text_tokens + reasoning_tokens + audio_tokens + image_tokens
+    )
+    has_partial_or_overlapping_breakdown = (
+        total_completion_details != usage.completion_tokens
+    )
+
+    if text_tokens == 0 or has_partial_or_overlapping_breakdown:
+        if has_token_breakdown or has_partial_or_overlapping_breakdown:
             text_tokens = max(
                 0,
                 usage.completion_tokens
@@ -736,7 +745,6 @@ def generic_cost_per_token(  # noqa: PLR0915
                 - image_tokens,
             )
         else:
-            # No breakdown at all, all tokens are text tokens
             text_tokens = usage.completion_tokens
             is_text_tokens_total = True
     ## TEXT COST

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -668,18 +668,34 @@ def generic_cost_per_token(  # noqa: PLR0915
     cache_creation = prompt_tokens_details["cache_creation_tokens"]
     image_tokens = prompt_tokens_details["image_tokens"]
 
-    # Normalize partial or overlapping prompt token breakdowns back to an
-    # exhaustive text+category split. Some providers only report a subset of
-    # prompt token categories (e.g. text + cache hit but omit PDF tokens), while
-    # others double-count text against cached tokens.
+    # Normalize prompt-token breakdowns when providers under-report token
+    # categories (e.g. text + cache hit but omit PDF tokens) or when cached
+    # tokens are double-counted in text_tokens. Skip this fallback for count-
+    # based pricing paths (image_count / character_count / video length) where
+    # prompt_tokens may not map cleanly back to text tokens.
     total_details = (
         text_tokens + cache_hit + audio_tokens + cache_creation + image_tokens
     )
-    has_partial_or_overlapping_breakdown = total_details != usage.prompt_tokens
+    has_non_token_pricing_components = (
+        prompt_tokens_details["image_count"] > 0
+        or prompt_tokens_details["character_count"] > 0
+        or prompt_tokens_details["video_length_seconds"] > 0
+    )
+    has_partial_breakdown = (
+        usage.prompt_tokens_details is not None
+        and total_details < usage.prompt_tokens
+        and not has_non_token_pricing_components
+    )
+    has_cached_token_overlap = cache_hit > 0 and total_details > usage.prompt_tokens
 
     if (
-        (text_tokens == 0 and prompt_tokens_details["image_count"] == 0)
-        or has_partial_or_overlapping_breakdown
+        (
+            text_tokens == 0
+            and not has_non_token_pricing_components
+            and total_details == 0
+        )
+        or has_partial_breakdown
+        or has_cached_token_overlap
     ):
         text_tokens = (
             usage.prompt_tokens
@@ -724,19 +740,19 @@ def generic_cost_per_token(  # noqa: PLR0915
         reasoning_tokens = completion_tokens_details["reasoning_tokens"]
         image_tokens = completion_tokens_details["image_tokens"]
 
-    # Normalize partial or overlapping completion token breakdowns the same way
-    # we do for prompt tokens so any unaccounted remainder is billed as text
-    # tokens rather than silently dropped.
+    # Normalize partial completion-token breakdowns so any unaccounted
+    # remainder is billed as text tokens rather than silently dropped.
     has_token_breakdown = image_tokens > 0 or audio_tokens > 0 or reasoning_tokens > 0
     total_completion_details = (
         text_tokens + reasoning_tokens + audio_tokens + image_tokens
     )
-    has_partial_or_overlapping_breakdown = (
-        total_completion_details != usage.completion_tokens
+    has_partial_breakdown = (
+        usage.completion_tokens_details is not None
+        and total_completion_details < usage.completion_tokens
     )
 
-    if text_tokens == 0 or has_partial_or_overlapping_breakdown:
-        if has_token_breakdown or has_partial_or_overlapping_breakdown:
+    if text_tokens == 0 or has_partial_breakdown:
+        if has_token_breakdown or has_partial_breakdown:
             text_tokens = max(
                 0,
                 usage.completion_tokens

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -216,7 +216,7 @@ class A2AGuardrailHandler(BaseTranslation):
             response["result"] = result
             return response
 
-    async def process_output_streaming_response(
+    async def process_output_streaming_response(  # noqa: PLR0915
         self,
         responses_so_far: List[Any],
         guardrail_to_apply: "CustomGuardrail",

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -246,7 +246,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                     "text"
                 ] = guardrail_response
 
-    async def process_output_response(
+    async def process_output_response(  # noqa: PLR0915
         self,
         response: "AnthropicMessagesResponse",
         guardrail_to_apply: "CustomGuardrail",

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs["structured_messages"] = (
-                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
-                )
+                inputs[
+                    "structured_messages"
+                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -424,7 +424,12 @@ async def retrieve_batch(  # noqa: PLR0915
             # Resolve any raw input/output/error file IDs to unified IDs.
             if unified_batch_id:
                 await resolve_input_file_id_to_unified(response, prisma_client)
-                await resolve_output_file_ids_to_unified(response, prisma_client)
+                await resolve_output_file_ids_to_unified(
+                    response,
+                    prisma_client,
+                    managed_files_obj=managed_files_obj,
+                    user_api_key_dict=user_api_key_dict,
+                )
 
             asyncio.create_task(
                 proxy_logging_obj.update_request_status(
@@ -540,7 +545,12 @@ async def retrieve_batch(  # noqa: PLR0915
         # Resolve raw provider file IDs (input, output, error) to unified IDs.
         if unified_batch_id:
             await resolve_input_file_id_to_unified(response, prisma_client)
-            await resolve_output_file_ids_to_unified(response, prisma_client)
+            await resolve_output_file_ids_to_unified(
+                response,
+                prisma_client,
+                managed_files_obj=managed_files_obj,
+                user_api_key_dict=user_api_key_dict,
+            )
 
         ### ALERTING ###
         asyncio.create_task(
@@ -931,6 +941,15 @@ async def cancel_batch(
         response = await proxy_logging_obj.post_call_success_hook(
             data=data, user_api_key_dict=user_api_key_dict, response=response
         )
+
+        if unified_batch_id:
+            await resolve_input_file_id_to_unified(response, prisma_client)
+            await resolve_output_file_ids_to_unified(
+                response,
+                prisma_client,
+                managed_files_obj=managed_files_obj,
+                user_api_key_dict=user_api_key_dict,
+            )
 
         ### ALERTING ###
         asyncio.create_task(

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -427,8 +427,8 @@ async def retrieve_batch(  # noqa: PLR0915
                 await resolve_output_file_ids_to_unified(
                     response,
                     prisma_client,
-                    managed_files_obj=managed_files_obj,
-                    user_api_key_dict=user_api_key_dict,
+                    managed_files_obj,
+                    user_api_key_dict,
                 )
 
             asyncio.create_task(
@@ -548,8 +548,8 @@ async def retrieve_batch(  # noqa: PLR0915
             await resolve_output_file_ids_to_unified(
                 response,
                 prisma_client,
-                managed_files_obj=managed_files_obj,
-                user_api_key_dict=user_api_key_dict,
+                managed_files_obj,
+                user_api_key_dict,
             )
 
         ### ALERTING ###
@@ -947,8 +947,8 @@ async def cancel_batch(
             await resolve_output_file_ids_to_unified(
                 response,
                 prisma_client,
-                managed_files_obj=managed_files_obj,
-                user_api_key_dict=user_api_key_dict,
+                managed_files_obj,
+                user_api_key_dict,
             )
 
         ### ALERTING ###

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -767,8 +767,19 @@ async def get_batch_from_database(
         response = LiteLLMBatch(**batch_data)
         response.id = batch_id
 
+        hidden_params = getattr(response, "_hidden_params", None) or {}
+        response._hidden_params = hidden_params
+        response._hidden_params["unified_batch_id"] = unified_batch_id
+
+        model_id = get_model_id_from_unified_batch_id(unified_batch_id)
+        if model_id:
+            response._hidden_params["model_id"] = model_id
+
         # The stored batch object has the raw provider input_file_id. Resolve to unified ID.
         await resolve_input_file_id_to_unified(response, prisma_client)
+
+        if _is_base64_encoded_unified_file_id(response.input_file_id):
+            response._hidden_params["unified_file_id"] = response.input_file_id
 
         verbose_proxy_logger.debug(
             f"Retrieved batch {batch_id} from ManagedObjectTable with status={response.status}"

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -697,24 +697,82 @@ async def resolve_input_file_id_to_unified(response, prisma_client) -> None:
             pass
 
 
-async def resolve_output_file_ids_to_unified(response, prisma_client) -> None:
+async def resolve_output_file_ids_to_unified(
+    response,
+    prisma_client,
+    managed_files_obj=None,
+    user_api_key_dict=None,
+) -> None:
     """
     If the batch response contains raw provider output_file_id or error_file_id
     (not already unified IDs), look up the corresponding unified file IDs from
     the managed file table and replace them in-place.
+
+    If the managed file row does not exist yet but the managed files hook is
+    available, synthesize and persist a managed output file ID so downstream
+    files.retrieve/files.content calls can enforce access checks consistently.
     """
-    if not prisma_client:
-        return
     for attr in ("output_file_id", "error_file_id"):
         raw_id = getattr(response, attr, None)
         if not raw_id or _is_base64_encoded_unified_file_id(raw_id):
             continue
         try:
-            managed_file = await prisma_client.db.litellm_managedfiletable.find_first(
-                where={"flat_model_file_ids": {"has": raw_id}}
-            )
+            managed_file = None
+            if prisma_client:
+                managed_file = (
+                    await prisma_client.db.litellm_managedfiletable.find_first(
+                        where={"flat_model_file_ids": {"has": raw_id}}
+                    )
+                )
             if managed_file:
                 setattr(response, attr, managed_file.unified_file_id)
+                continue
+
+            hidden_params = getattr(response, "_hidden_params", {}) or {}
+            model_id = hidden_params.get("model_id")
+            get_unified_output_file_id = getattr(
+                managed_files_obj, "get_unified_output_file_id", None
+            )
+            store_unified_file_id = getattr(
+                managed_files_obj, "store_unified_file_id", None
+            )
+
+            if (
+                not model_id
+                or user_api_key_dict is None
+                or not callable(get_unified_output_file_id)
+                or not callable(store_unified_file_id)
+            ):
+                continue
+
+            resolved_model_name = hidden_params.get("model_name")
+            unified_input_file_id = hidden_params.get("unified_file_id")
+            if not resolved_model_name and isinstance(unified_input_file_id, str):
+                decoded_input_file_id = (
+                    _is_base64_encoded_unified_file_id(unified_input_file_id)
+                    or unified_input_file_id
+                )
+                target_model_names = get_models_from_unified_file_id(
+                    decoded_input_file_id
+                )
+                if target_model_names:
+                    resolved_model_name = ",".join(target_model_names)
+
+            synthesized_unified_file_id = get_unified_output_file_id(
+                output_file_id=raw_id,
+                model_id=model_id,
+                model_name=resolved_model_name,
+            )
+            await store_unified_file_id(
+                file_id=synthesized_unified_file_id,
+                file_object=None,
+                litellm_parent_otel_span=getattr(
+                    user_api_key_dict, "parent_otel_span", None
+                ),
+                model_mappings={model_id: raw_id},
+                user_api_key_dict=user_api_key_dict,
+            )
+            setattr(response, attr, synthesized_unified_file_id)
         except Exception:
             pass
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1898,9 +1898,9 @@ class ProxyLogging:
                     normalized_call_type = CallTypes.aembedding.value
             if normalized_call_type is not None:
                 litellm_logging_obj.call_type = normalized_call_type
-                litellm_logging_obj.model_call_details["call_type"] = (
-                    normalized_call_type
-                )
+                litellm_logging_obj.model_call_details[
+                    "call_type"
+                ] = normalized_call_type
             # Pass-through endpoints are logged via the callback loop's
             # async_post_call_failure_hook — skip pre_call and failure handlers.
             if litellm_logging_obj.call_type == CallTypes.pass_through.value:
@@ -2498,7 +2498,8 @@ class PrismaClient:
             required_view = "LiteLLM_VerificationTokenView"
             expected_views_str = ", ".join(f"'{view}'" for view in expected_views)
             pg_schema = os.getenv("DATABASE_SCHEMA", "public")
-            ret = await self.db.query_raw(f"""
+            ret = await self.db.query_raw(
+                f"""
                 WITH existing_views AS (
                     SELECT viewname
                     FROM pg_views
@@ -2510,7 +2511,8 @@ class PrismaClient:
                     (SELECT COUNT(*) FROM existing_views) AS view_count,
                     ARRAY_AGG(viewname) AS view_names
                 FROM existing_views
-                """)
+                """
+            )
             expected_total_views = len(expected_views)
             if ret[0]["view_count"] == expected_total_views:
                 verbose_proxy_logger.info("All necessary views exist!")
@@ -2519,7 +2521,8 @@ class PrismaClient:
                 ## check if required view exists ##
                 if ret[0]["view_names"] and required_view not in ret[0]["view_names"]:
                     await self.health_check()  # make sure we can connect to db
-                    await self.db.execute_raw("""
+                    await self.db.execute_raw(
+                        """
                             CREATE VIEW "LiteLLM_VerificationTokenView" AS
                             SELECT
                             v.*,
@@ -2529,7 +2532,8 @@ class PrismaClient:
                             t.rpm_limit AS team_rpm_limit
                             FROM "LiteLLM_VerificationToken" v
                             LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id;
-                        """)
+                        """
+                    )
 
                     verbose_proxy_logger.info(
                         "LiteLLM_VerificationTokenView Created in DB!"

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -95,9 +95,9 @@ async def test_async_pre_call_deployment_hook_resolves_model_id_from_litellm_met
         kwargs=kwargs, call_type=CallTypes.acreate_batch
     )
 
-    assert result["input_file_id"] == provider_file_id, (
-        f"Expected provider file ID '{provider_file_id}', got '{result['input_file_id']}'"
-    )
+    assert (
+        result["input_file_id"] == provider_file_id
+    ), f"Expected provider file ID '{provider_file_id}', got '{result['input_file_id']}'"
 
 
 @pytest.mark.asyncio
@@ -134,9 +134,9 @@ async def test_async_pre_call_deployment_hook_prefers_top_level_model_info():
         kwargs=kwargs, call_type=CallTypes.acreate_batch
     )
 
-    assert result["input_file_id"] == top_level_provider_file, (
-        "Should prefer top-level model_info over litellm_metadata"
-    )
+    assert (
+        result["input_file_id"] == top_level_provider_file
+    ), "Should prefer top-level model_info over litellm_metadata"
 
 
 @pytest.mark.asyncio
@@ -162,9 +162,9 @@ async def test_async_pre_call_deployment_hook_no_model_info_leaves_file_id_uncha
         kwargs=kwargs, call_type=CallTypes.acreate_batch
     )
 
-    assert result["input_file_id"] == managed_file_id, (
-        "File ID should remain unchanged when model_info is not available"
-    )
+    assert (
+        result["input_file_id"] == managed_file_id
+    ), "File ID should remain unchanged when model_info is not available"
 
 
 # def test_list_managed_files():
@@ -341,7 +341,9 @@ async def test_async_pre_call_hook_for_unified_finetuning_job():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("call_type", ["afile_content", "afile_delete", "afile_retrieve"])
+@pytest.mark.parametrize(
+    "call_type", ["afile_content", "afile_delete", "afile_retrieve"]
+)
 async def test_can_user_call_unified_file_id(call_type):
     """
     Test that on file retrieve, delete, and content we check if the user has access to the file
@@ -601,7 +603,7 @@ async def test_error_file_id_for_failed_batch():
         "litellm_model_name": "gpt-4o",
         "unified_batch_id": "litellm_proxy;model_id:test-model-id;llm_batch_id:batch_abc123",
     }
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=AsyncMock()
     )
@@ -620,12 +622,11 @@ async def test_error_file_id_for_failed_batch():
     # Mock the afile_retrieve to simulate retrieving error file metadata
     with patch("litellm.afile_retrieve", new_callable=AsyncMock) as mock_retrieve:
         mock_retrieve.return_value = error_file_object
-        
+
         user_api_key_dict = UserAPIKeyAuth(
-            user_id="test-user-123",
-            parent_otel_span=MagicMock()
+            user_id="test-user-123", parent_otel_span=MagicMock()
         )
-        
+
         response = await proxy_managed_files.async_post_call_success_hook(
             data={},
             user_api_key_dict=user_api_key_dict,
@@ -636,7 +637,9 @@ async def test_error_file_id_for_failed_batch():
     assert cast(LiteLLMBatch, response).error_file_id is not None
     assert not cast(LiteLLMBatch, response).error_file_id.startswith("error-")
     # Verify it's a base64 encoded managed file ID
-    assert _is_base64_encoded_unified_file_id(cast(LiteLLMBatch, response).error_file_id)
+    assert _is_base64_encoded_unified_file_id(
+        cast(LiteLLMBatch, response).error_file_id
+    )
 
 
 @pytest.mark.asyncio
@@ -650,7 +653,7 @@ async def test_async_post_call_success_hook_twice_assert_no_unique_violation():
 
     # Use AsyncMock instead of real database connection
     prisma_client = AsyncMock()
-    
+
     batch = LiteLLMBatch(
         id="bGl0ZWxsbV9wcm94eTttb2RlbF9pZDoxMjM0NTY3OTtsbG1fYmF0Y2hfaWQ6YmF0Y2hfNjg1YzVlNWQ2Mzk4ODE5MGI4NWJkYjIxNDdiYTEzMWQ",
         completion_window="24h",
@@ -678,8 +681,10 @@ async def test_async_post_call_success_hook_twice_assert_no_unique_violation():
     # first retrieve batch
     tasks = []
     first_create_task = asyncio.create_task
-    with patch('asyncio.create_task') as mock_create_task:
-        mock_create_task.side_effect = lambda coro: tasks.append(first_create_task(coro)) or tasks[-1]
+    with patch("asyncio.create_task") as mock_create_task:
+        mock_create_task.side_effect = (
+            lambda coro: tasks.append(first_create_task(coro)) or tasks[-1]
+        )
 
         response = await proxy_managed_files.async_post_call_success_hook(
             data={},
@@ -700,8 +705,10 @@ async def test_async_post_call_success_hook_twice_assert_no_unique_violation():
     # second retrieve batch
     tasks = []
     second_create_task = asyncio.create_task
-    with patch('asyncio.create_task') as mock_create_task:
-        mock_create_task.side_effect = lambda coro: tasks.append(second_create_task(coro)) or tasks[-1]
+    with patch("asyncio.create_task") as mock_create_task:
+        mock_create_task.side_effect = (
+            lambda coro: tasks.append(second_create_task(coro)) or tasks[-1]
+        )
 
         await proxy_managed_files.async_post_call_success_hook(
             data={},
@@ -716,6 +723,59 @@ async def test_async_post_call_success_hook_twice_assert_no_unique_violation():
                 assert task.exception() is None, f"Error: {task.exception()}"
 
 
+@pytest.mark.asyncio
+async def test_async_post_call_success_hook_does_not_double_encode_managed_batch_id():
+    from openai.types.batch import BatchRequestCounts
+
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.utils import LiteLLMBatch
+
+    prisma_client = AsyncMock()
+
+    managed_batch_id = (
+        "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDoxMjM0NTY3OTtsbG1fYmF0Y2hfaWQ6"
+        "YmF0Y2hfNjg1YzVlNWQ2Mzk4ODE5MGI4NWJkYjIxNDdiYTEzMWQ"
+    )
+    raw_batch_id = "batch_685c5e5d63988190b85bdb2147ba131d"
+
+    batch = LiteLLMBatch(
+        id=managed_batch_id,
+        completion_window="24h",
+        created_at=1750883933,
+        endpoint="/v1/chat/completions",
+        input_file_id="file-8ci8gux8s7oES7GydYvnMG",
+        object="batch",
+        status="completed",
+        request_counts=BatchRequestCounts(completed=1, failed=0, total=1),
+        usage=None,
+    )
+
+    batch._hidden_params = {
+        "model_id": "12345679",
+        "unified_batch_id": (
+            "litellm_proxy;model_id:12345679;"
+            "llm_batch_id:batch_685c5e5d63988190b85bdb2147ba131d"
+        ),
+    }
+
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(
+        DualCache(), prisma_client=prisma_client
+    )
+
+    response = await proxy_managed_files.async_post_call_success_hook(
+        data={},
+        user_api_key_dict=UserAPIKeyAuth(user_id="default_id"),
+        response=batch,
+    )
+
+    assert isinstance(response, LiteLLMBatch)
+    assert response.id == managed_batch_id
+
+    upsert_call = prisma_client.db.litellm_managedobjecttable.upsert.await_args.kwargs
+    assert upsert_call["where"]["unified_object_id"] == managed_batch_id
+    assert upsert_call["data"]["create"]["model_object_id"] == raw_batch_id
+
+
 def test_update_responses_input_with_unified_file_id():
     """
     Test that update_responses_input_with_model_file_ids correctly decodes
@@ -728,7 +788,7 @@ def test_update_responses_input_with_unified_file_id():
     # Create a base64-encoded unified file ID
     # This decodes to: litellm_proxy:application/pdf;unified_id,6c0b5890-8914-48e0-b8f4-0ae5ed3c14a5;target_model_names,gpt-4o;llm_output_file_id,file-ECBPW7ML9g7XHdwGgUPZaM;llm_output_file_model_id,e26453f9e76e7993680d0068d98c1f4cc205bbad0967a33c664893568ca743c2
     unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFkMDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
-    
+
     # Test input with unified file ID in content array
     input_data = [
         {
@@ -745,15 +805,18 @@ def test_update_responses_input_with_unified_file_id():
             ],
         }
     ]
-    
+
     # Update the input
     updated_input = update_responses_input_with_model_file_ids(input=input_data)
-    
+
     # Verify the file_id was updated to the provider-specific file ID
     assert updated_input[0]["content"][0]["type"] == "input_file"
     assert updated_input[0]["content"][0]["file_id"] == "file-ECBPW7ML9g7XHdwGgUPZaM"
     assert updated_input[0]["content"][1]["type"] == "input_text"
-    assert updated_input[0]["content"][1]["text"] == "What is the first dragon in the book?"
+    assert (
+        updated_input[0]["content"][1]["text"]
+        == "What is the first dragon in the book?"
+    )
 
 
 def test_update_responses_input_with_regular_file_id():
@@ -767,7 +830,7 @@ def test_update_responses_input_with_regular_file_id():
 
     # Regular OpenAI file ID (not a unified file ID)
     regular_file_id = "file-abc123xyz"
-    
+
     input_data = [
         {
             "role": "user",
@@ -783,10 +846,10 @@ def test_update_responses_input_with_regular_file_id():
             ],
         }
     ]
-    
+
     # Update the input
     updated_input = update_responses_input_with_model_file_ids(input=input_data)
-    
+
     # Verify the file_id was kept unchanged (regular OpenAI file ID)
     assert updated_input[0]["content"][0]["type"] == "input_file"
     assert updated_input[0]["content"][0]["file_id"] == regular_file_id
@@ -800,11 +863,11 @@ def test_update_responses_input_with_string_input():
     from litellm.litellm_core_utils.prompt_templates.common_utils import (
         update_responses_input_with_model_file_ids,
     )
-    
+
     input_data = "What is AI?"
-    
+
     updated_input = update_responses_input_with_model_file_ids(input=input_data)
-    
+
     assert updated_input == input_data
     assert isinstance(updated_input, str)
 
@@ -822,7 +885,7 @@ def test_update_responses_input_with_multiple_file_ids():
     unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFkMDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
     # Regular OpenAI file ID
     regular_file_id = "file-regular123"
-    
+
     input_data = [
         {
             "role": "user",
@@ -842,9 +905,9 @@ def test_update_responses_input_with_multiple_file_ids():
             ],
         }
     ]
-    
+
     updated_input = update_responses_input_with_model_file_ids(input=input_data)
-    
+
     # Verify unified file ID was updated
     assert updated_input[0]["content"][0]["file_id"] == "file-ECBPW7ML9g7XHdwGgUPZaM"
     # Verify regular file ID was kept unchanged
@@ -864,7 +927,7 @@ def test_update_responses_input_with_model_file_id_mapping():
 
     # Managed file ID (unified)
     managed_file_id = "litellm_proxy_file_123"
-    
+
     # Model file ID mapping
     model_file_id_mapping = {
         managed_file_id: {
@@ -872,7 +935,7 @@ def test_update_responses_input_with_model_file_id_mapping():
             "model_id_2": "azure_file_xyz",
         }
     }
-    
+
     input_data = [
         {
             "role": "user",
@@ -888,24 +951,24 @@ def test_update_responses_input_with_model_file_id_mapping():
             ],
         }
     ]
-    
+
     # Update input with model_id_1 mapping
     updated_input = update_responses_input_with_model_file_ids(
         input=input_data,
         model_id="model_id_1",
         model_file_id_mapping=model_file_id_mapping,
     )
-    
+
     # Verify the file_id was mapped to the correct provider-specific file ID
     assert updated_input[0]["content"][0]["file_id"] == "openai_file_abc"
-    
+
     # Test with different model_id
     updated_input_2 = update_responses_input_with_model_file_ids(
         input=input_data,
         model_id="model_id_2",
         model_file_id_mapping=model_file_id_mapping,
     )
-    
+
     assert updated_input_2[0]["content"][0]["file_id"] == "azure_file_xyz"
 
 
@@ -913,7 +976,7 @@ def test_update_responses_tools_with_model_file_id_mapping():
     """
     Test that update_responses_tools_with_model_file_ids correctly maps
     file IDs in code_interpreter tools with container.file_ids.
-    
+
     This is a regression test for the issue where managed file IDs in
     tools.container.file_ids were not being replaced with provider-specific
     file IDs, causing "string too long" errors from OpenAI.
@@ -925,7 +988,7 @@ def test_update_responses_tools_with_model_file_id_mapping():
     # Managed file IDs
     managed_file_id_1 = "litellm_proxy_file_123"
     managed_file_id_2 = "litellm_proxy_file_456"
-    
+
     # Model file ID mapping
     model_file_id_mapping = {
         managed_file_id_1: {
@@ -935,7 +998,7 @@ def test_update_responses_tools_with_model_file_id_mapping():
             "model_id_1": "openai_file_def",
         },
     }
-    
+
     tools = [
         {
             "type": "code_interpreter",
@@ -945,17 +1008,20 @@ def test_update_responses_tools_with_model_file_id_mapping():
             },
         }
     ]
-    
+
     # Update tools with model mapping
     updated_tools = update_responses_tools_with_model_file_ids(
         tools=tools,
         model_id="model_id_1",
         model_file_id_mapping=model_file_id_mapping,
     )
-    
+
     # Verify the file IDs were mapped to provider-specific file IDs
     assert updated_tools[0]["type"] == "code_interpreter"
-    assert updated_tools[0]["container"]["file_ids"] == ["openai_file_abc", "openai_file_def"]
+    assert updated_tools[0]["container"]["file_ids"] == [
+        "openai_file_abc",
+        "openai_file_def",
+    ]
 
 
 def test_update_responses_tools_without_mapping():
@@ -968,7 +1034,7 @@ def test_update_responses_tools_without_mapping():
     )
 
     regular_file_id = "file-abc123"
-    
+
     tools = [
         {
             "type": "code_interpreter",
@@ -978,14 +1044,14 @@ def test_update_responses_tools_without_mapping():
             },
         }
     ]
-    
+
     # Update tools without mapping
     updated_tools = update_responses_tools_with_model_file_ids(
         tools=tools,
         model_id=None,
         model_file_id_mapping=None,
     )
-    
+
     # Verify the file ID was kept unchanged
     assert updated_tools[0]["container"]["file_ids"] == [regular_file_id]
 
@@ -1001,13 +1067,13 @@ def test_update_responses_tools_with_mixed_file_ids():
 
     managed_file_id = "litellm_proxy_file_123"
     regular_file_id = "file-abc123"
-    
+
     model_file_id_mapping = {
         managed_file_id: {
             "model_id_1": "openai_file_abc",
         },
     }
-    
+
     tools = [
         {
             "type": "code_interpreter",
@@ -1017,16 +1083,19 @@ def test_update_responses_tools_with_mixed_file_ids():
             },
         }
     ]
-    
+
     # Update tools
     updated_tools = update_responses_tools_with_model_file_ids(
         tools=tools,
         model_id="model_id_1",
         model_file_id_mapping=model_file_id_mapping,
     )
-    
+
     # Verify managed file ID was mapped and regular file ID was kept
-    assert updated_tools[0]["container"]["file_ids"] == ["openai_file_abc", regular_file_id]
+    assert updated_tools[0]["container"]["file_ids"] == [
+        "openai_file_abc",
+        regular_file_id,
+    ]
 
 
 def test_get_file_ids_from_responses_tools():
@@ -1037,7 +1106,7 @@ def test_get_file_ids_from_responses_tools():
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=MagicMock()
     )
-    
+
     tools = [
         {
             "type": "code_interpreter",
@@ -1047,9 +1116,9 @@ def test_get_file_ids_from_responses_tools():
             },
         }
     ]
-    
+
     file_ids = proxy_managed_files.get_file_ids_from_responses_tools(tools)
-    
+
     assert file_ids == ["file-123", "file-456"]
 
 
@@ -1060,7 +1129,7 @@ def test_get_file_ids_from_responses_tools_multiple_tools():
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=MagicMock()
     )
-    
+
     tools = [
         {
             "type": "code_interpreter",
@@ -1080,9 +1149,9 @@ def test_get_file_ids_from_responses_tools_multiple_tools():
             },
         },
     ]
-    
+
     file_ids = proxy_managed_files.get_file_ids_from_responses_tools(tools)
-    
+
     # Should extract file IDs only from code_interpreter tools
     assert file_ids == ["file-123", "file-456", "file-789"]
 
@@ -1094,15 +1163,15 @@ def test_get_file_ids_from_responses_tools_empty():
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=MagicMock()
     )
-    
+
     # Test with None
     file_ids = proxy_managed_files.get_file_ids_from_responses_tools(None)
     assert file_ids == []
-    
+
     # Test with empty list
     file_ids = proxy_managed_files.get_file_ids_from_responses_tools([])
     assert file_ids == []
-    
+
     # Test with tools without file_ids
     tools = [{"type": "file_search"}]
     file_ids = proxy_managed_files.get_file_ids_from_responses_tools(tools)
@@ -1119,30 +1188,30 @@ async def test_check_file_ids_access_with_unified_file_ids():
     # Create a unified file ID
     unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFkMDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
     regular_file_id = "file-abc123"
-    
+
     # Mock the access check to return True
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock can_user_call_unified_file_id to return True
     proxy_managed_files.can_user_call_unified_file_id = AsyncMock(return_value=True)
-    
+
     user_api_key_dict = UserAPIKeyAuth(
         user_id="test_user_123",
         parent_otel_span=MagicMock(),
     )
-    
+
     # Should not raise an exception for accessible files
     await proxy_managed_files.check_file_ids_access(
         [unified_file_id, regular_file_id],
         user_api_key_dict,
     )
-    
+
     # Verify can_user_call_unified_file_id was called for the unified file ID
     proxy_managed_files.can_user_call_unified_file_id.assert_called_once_with(
         unified_file_id, user_api_key_dict
@@ -1155,32 +1224,32 @@ async def test_check_file_ids_access_denied():
     Test that check_file_ids_access raises HTTPException when user doesn't have access.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFkMDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
-    
+
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock can_user_call_unified_file_id to return False (access denied)
     proxy_managed_files.can_user_call_unified_file_id = AsyncMock(return_value=False)
-    
+
     user_api_key_dict = UserAPIKeyAuth(
         user_id="test_user_123",
         parent_otel_span=MagicMock(),
     )
-    
+
     # Should raise HTTPException with 403 status code
     with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.check_file_ids_access(
             [unified_file_id],
             user_api_key_dict,
         )
-    
+
     assert exc_info.value.status_code == 403
     assert "does not have access to the file" in exc_info.value.detail
 
@@ -1191,32 +1260,32 @@ async def test_check_file_ids_access_with_regular_files_only():
     Test that check_file_ids_access doesn't check access for regular (non-unified) file IDs.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     regular_file_id_1 = "file-abc123"
     regular_file_id_2 = "file-xyz789"
-    
+
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock can_user_call_unified_file_id (should not be called for regular files)
     proxy_managed_files.can_user_call_unified_file_id = AsyncMock()
-    
+
     user_api_key_dict = UserAPIKeyAuth(
         user_id="test_user_123",
         parent_otel_span=MagicMock(),
     )
-    
+
     # Should not raise exception and should not call can_user_call_unified_file_id
     await proxy_managed_files.check_file_ids_access(
         [regular_file_id_1, regular_file_id_2],
         user_api_key_dict,
     )
-    
+
     # Verify can_user_call_unified_file_id was NOT called
     proxy_managed_files.can_user_call_unified_file_id.assert_not_called()
 
@@ -1227,31 +1296,31 @@ async def test_completion_with_file_access_check():
     Test that completion call type checks file access before processing.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFkMDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
-    
+
     prisma_client = AsyncMock()
     prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(return_value=None)
-    
+
     internal_usage_cache = MagicMock()
     internal_usage_cache.async_get_cache = AsyncMock(return_value=None)
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock the get_model_file_id_mapping to return empty dict
     proxy_managed_files.get_model_file_id_mapping = AsyncMock(return_value={})
-    
+
     # Mock access check to allow access
     proxy_managed_files.can_user_call_unified_file_id = AsyncMock(return_value=True)
-    
+
     user_api_key_dict = UserAPIKeyAuth(
         user_id="test_user_123",
         parent_otel_span=MagicMock(),
     )
-    
+
     data = {
         "messages": [
             {
@@ -1267,15 +1336,15 @@ async def test_completion_with_file_access_check():
         ],
         "model": "gpt-4",
     }
-    
+
     # Should not raise exception
-    result = await proxy_managed_files.async_pre_call_hook(
+    await proxy_managed_files.async_pre_call_hook(
         user_api_key_dict=user_api_key_dict,
         cache=DualCache(),
         data=data,
         call_type="acompletion",
     )
-    
+
     # Verify access check was called
     proxy_managed_files.can_user_call_unified_file_id.assert_called_once()
 
@@ -1286,32 +1355,32 @@ async def test_responses_with_file_access_check():
     Test that responses API checks file access for files in both input and tools.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     unified_file_id_1 = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9wZGY7dW5pZmllZF9pZCw2YzBiNTg5MC04OTE0LTQ4ZTAtYjhmNC0wYWU1ZWQzYzE0YTU7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1FQ0JQVzdNTDlnN1hIZHdHZ1VQWmFNO2xsbV9vdXRwdXRfZmlsZV9tb2RlbF9pZCxlMjY0NTNmOWU3NmU3OTkzNjgwZDAwNjhkOThjMWY0Y2MyMDViYmFkMDk2N2EzM2M2NjQ4OTM1NjhjYTc0M2My"
     unified_file_id_2 = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsNzc3Nzc3Nzc7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC00bztsbG1fb3V0cHV0X2ZpbGVfaWQsZmlsZS1YWVo7bGxtX291dHB1dF9maWxlX21vZGVsX2lkLG1vZGVsXzEyMw"
-    
+
     prisma_client = AsyncMock()
     prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(return_value=None)
-    
+
     internal_usage_cache = MagicMock()
     internal_usage_cache.async_get_cache = AsyncMock(return_value=None)
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock the get_model_file_id_mapping to return empty dict
     proxy_managed_files.get_model_file_id_mapping = AsyncMock(return_value={})
-    
+
     # Mock access check to allow access
     proxy_managed_files.can_user_call_unified_file_id = AsyncMock(return_value=True)
-    
+
     user_api_key_dict = UserAPIKeyAuth(
         user_id="test_user_123",
         parent_otel_span=MagicMock(),
     )
-    
+
     data = {
         "input": [
             {
@@ -1333,15 +1402,15 @@ async def test_responses_with_file_access_check():
         ],
         "model": "gpt-4",
     }
-    
+
     # Should not raise exception
-    result = await proxy_managed_files.async_pre_call_hook(
+    await proxy_managed_files.async_pre_call_hook(
         user_api_key_dict=user_api_key_dict,
         cache=DualCache(),
         data=data,
         call_type="aresponses",
     )
-    
+
     # Verify access check was called for both file IDs
     assert proxy_managed_files.can_user_call_unified_file_id.call_count == 2
 
@@ -1353,17 +1422,19 @@ async def test_store_unified_file_id_with_none_file_object():
     (e.g., for batch output files that are stored before file metadata is available).
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    prisma_client.db.litellm_managedfiletable.create = AsyncMock(return_value=MagicMock())
+    prisma_client.db.litellm_managedfiletable.create = AsyncMock(
+        return_value=MagicMock()
+    )
     internal_usage_cache = MagicMock()
     internal_usage_cache.async_set_cache = AsyncMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Store with file_object=None (simulating batch output file storage)
     await proxy_managed_files.store_unified_file_id(
         file_id="test-unified-file-id",
@@ -1372,7 +1443,7 @@ async def test_store_unified_file_id_with_none_file_object():
         model_mappings={"model-123": "file-provider-xyz"},
         user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
     )
-    
+
     # Verify DB create was called with expected data (without file_object)
     prisma_client.db.litellm_managedfiletable.create.assert_called_once()
     call_args = prisma_client.db.litellm_managedfiletable.create.call_args
@@ -1387,34 +1458,38 @@ async def test_afile_delete_returns_provider_response_when_stored_file_object_no
     stored file_object is None (e.g., for batch output files).
     """
     from litellm.types.llms.openai import OpenAIFileObject
-    
+
     unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsdGVzdC1pZDt0YXJnZXRfbW9kZWxfbmFtZXMsZ3B0LTRvO2xsbV9vdXRwdXRfZmlsZV9pZCxmaWxlLXByb3ZpZGVyLXh5ejtsbG1fb3V0cHV0X2ZpbGVfbW9kZWxfaWQsbW9kZWwtMTIz"
-    
+
     prisma_client = AsyncMock()
     db_record = MagicMock()
     db_record.model_mappings = '{"model-123": "file-provider-xyz"}'
-    prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(return_value=db_record)
+    prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(
+        return_value=db_record
+    )
     prisma_client.db.litellm_managedfiletable.delete = AsyncMock()
-    
+
     internal_usage_cache = MagicMock()
-    internal_usage_cache.async_get_cache = AsyncMock(return_value={
-        "unified_file_id": unified_file_id,
-        "model_mappings": {"model-123": "file-provider-xyz"},
-        "flat_model_file_ids": ["file-provider-xyz"],
-        "file_object": None,
-        "created_by": "test-user",
-        "updated_by": "test-user",
-    })
+    internal_usage_cache.async_get_cache = AsyncMock(
+        return_value={
+            "unified_file_id": unified_file_id,
+            "model_mappings": {"model-123": "file-provider-xyz"},
+            "flat_model_file_ids": ["file-provider-xyz"],
+            "file_object": None,
+            "created_by": "test-user",
+            "updated_by": "test-user",
+        }
+    )
     internal_usage_cache.async_set_cache = AsyncMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock the delete_unified_file_id to return None (simulating file_object=None)
     proxy_managed_files.delete_unified_file_id = AsyncMock(return_value=None)
-    
+
     # Mock router response
     provider_delete_response = OpenAIFileObject(
         id="file-provider-xyz",
@@ -1424,16 +1499,16 @@ async def test_afile_delete_returns_provider_response_when_stored_file_object_no
         filename="test.jsonl",
         purpose="batch",
     )
-    
+
     mock_router = MagicMock()
     mock_router.afile_delete = AsyncMock(return_value=provider_delete_response)
-    
+
     result = await proxy_managed_files.afile_delete(
         file_id=unified_file_id,
         litellm_parent_otel_span=None,
         llm_router=mock_router,
     )
-    
+
     # Should return the provider response with the unified file ID
     assert result is not None
     assert result.id == unified_file_id
@@ -1446,21 +1521,21 @@ async def test_afile_retrieve_fetches_from_provider_when_file_object_none():
     file_object is None (e.g., for batch output files).
     """
     from litellm.types.llms.openai import OpenAIFileObject
-    
+
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock get_unified_file_id to return a stored object with file_object=None
     stored_file = MagicMock()
     stored_file.file_object = None
     stored_file.model_mappings = {"model-123": "file-provider-xyz"}
     proxy_managed_files.get_unified_file_id = AsyncMock(return_value=stored_file)
-    
+
     # Mock the router and provider response
     provider_file_response = OpenAIFileObject(
         id="file-provider-xyz",
@@ -1470,23 +1545,25 @@ async def test_afile_retrieve_fetches_from_provider_when_file_object_none():
         filename="output.jsonl",
         purpose="batch_output",
     )
-    
+
     mock_router = MagicMock()
-    mock_router.get_deployment_credentials_with_provider = MagicMock(return_value={
-        "api_key": "test-key",
-        "api_base": "https://api.openai.com",
-    })
-    
+    mock_router.get_deployment_credentials_with_provider = MagicMock(
+        return_value={
+            "api_key": "test-key",
+            "api_base": "https://api.openai.com",
+        }
+    )
+
     with patch("litellm.afile_retrieve", new_callable=AsyncMock) as mock_afile_retrieve:
         mock_afile_retrieve.return_value = provider_file_response
-        
+
         unified_file_id = "test-unified-file-id"
         result = await proxy_managed_files.afile_retrieve(
             file_id=unified_file_id,
             litellm_parent_otel_span=None,
             llm_router=mock_router,
         )
-        
+
         # Should return the provider response with the unified file ID
         assert result is not None
         assert result.id == unified_file_id
@@ -1501,27 +1578,27 @@ async def test_afile_retrieve_raises_error_when_no_router_and_file_object_none()
     """
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock get_unified_file_id to return a stored object with file_object=None
     stored_file = MagicMock()
     stored_file.file_object = None
     stored_file.model_mappings = {"model-123": "file-provider-xyz"}
     proxy_managed_files.get_unified_file_id = AsyncMock(return_value=stored_file)
-    
+
     unified_file_id = "test-unified-file-id"
-    
+
     with pytest.raises(Exception) as exc_info:
         await proxy_managed_files.afile_retrieve(
             file_id=unified_file_id,
             litellm_parent_otel_span=None,
             llm_router=None,
         )
-    
+
     assert "llm_router is required" in str(exc_info.value)
 
 
@@ -1532,15 +1609,15 @@ async def test_afile_retrieve_returns_stored_file_object_when_exists():
     (the normal case for user-uploaded files).
     """
     from litellm.types.llms.openai import OpenAIFileObject
-    
+
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock get_unified_file_id to return a stored object WITH file_object
     stored_file_object = OpenAIFileObject(
         id="test-unified-file-id",
@@ -1553,13 +1630,13 @@ async def test_afile_retrieve_returns_stored_file_object_when_exists():
     stored_file = MagicMock()
     stored_file.file_object = stored_file_object
     proxy_managed_files.get_unified_file_id = AsyncMock(return_value=stored_file)
-    
+
     result = await proxy_managed_files.afile_retrieve(
         file_id="test-unified-file-id",
         litellm_parent_otel_span=None,
         llm_router=None,
     )
-    
+
     # Should return the stored file object directly
     assert result == stored_file_object
 
@@ -1572,79 +1649,81 @@ async def test_afile_retrieve_raises_error_for_non_managed_file():
     """
     prisma_client = AsyncMock()
     internal_usage_cache = MagicMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         internal_usage_cache=internal_usage_cache,
         prisma_client=prisma_client,
     )
-    
+
     # Mock get_unified_file_id to return None (file not found)
     proxy_managed_files.get_unified_file_id = AsyncMock(return_value=None)
-    
+
     with pytest.raises(Exception) as exc_info:
         await proxy_managed_files.afile_retrieve(
             file_id="non-existent-file-id",
             litellm_parent_otel_span=None,
         )
-    
+
     assert "not found" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 async def test_list_batches_from_managed_objects_table():
-    from openai.types.batch import BatchRequestCounts
-
     from litellm.proxy._types import UserAPIKeyAuth
 
     prisma_client = AsyncMock()
-    
+
     batch_record_1 = MagicMock()
     batch_record_1.unified_object_id = "unified-batch-id-1"
-    batch_record_1.file_object = json.dumps({
-        "id": "batch_abc123",
-        "object": "batch",
-        "endpoint": "/v1/chat/completions",
-        "completion_window": "24h",
-        "status": "completed",
-        "created_at": 1234567890,
-        "input_file_id": "file-input-1",
-        "request_counts": {"total": 1, "completed": 1, "failed": 0},
-    })
-    
+    batch_record_1.file_object = json.dumps(
+        {
+            "id": "batch_abc123",
+            "object": "batch",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+            "status": "completed",
+            "created_at": 1234567890,
+            "input_file_id": "file-input-1",
+            "request_counts": {"total": 1, "completed": 1, "failed": 0},
+        }
+    )
+
     batch_record_2 = MagicMock()
     batch_record_2.unified_object_id = "unified-batch-id-2"
-    batch_record_2.file_object = json.dumps({
-        "id": "batch_xyz789",
-        "object": "batch",
-        "endpoint": "/v1/chat/completions",
-        "completion_window": "24h",
-        "status": "in_progress",
-        "created_at": 1234567891,
-        "input_file_id": "file-input-2",
-        "request_counts": {"total": 5, "completed": 2, "failed": 0},
-    })
-    
+    batch_record_2.file_object = json.dumps(
+        {
+            "id": "batch_xyz789",
+            "object": "batch",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+            "status": "in_progress",
+            "created_at": 1234567891,
+            "input_file_id": "file-input-2",
+            "request_counts": {"total": 5, "completed": 2, "failed": 0},
+        }
+    )
+
     prisma_client.db.litellm_managedobjecttable.find_many.return_value = [
         batch_record_1,
         batch_record_2,
     ]
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     result = await proxy_managed_files.list_user_batches(
         user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
         limit=10,
     )
-    
+
     assert result["object"] == "list"
     assert len(result["data"]) == 2
     assert result["data"][0].id == "unified-batch-id-1"
     assert result["data"][1].id == "unified-batch-id-2"
     assert result["first_id"] == "unified-batch-id-1"
     assert result["last_id"] == "unified-batch-id-2"
-    
+
     # Should filter by user_id (created_by)
     prisma_client.db.litellm_managedobjecttable.find_many.assert_called_once_with(
         where={"file_purpose": "batch", "created_by": "test-user"},
@@ -1659,21 +1738,21 @@ async def test_list_batches_from_managed_objects_table_empty_list():
 
     prisma_client = AsyncMock()
     prisma_client.db.litellm_managedobjecttable.find_many.return_value = []
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     result = await proxy_managed_files.list_user_batches(
         user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
     )
-    
+
     assert result["object"] == "list"
     assert len(result["data"]) == 0
     assert result["first_id"] is None
     assert result["last_id"] is None
     assert result["has_more"] is False
-    
+
     # Verify where clause includes created_by filter
     # Default take is 20 when no limit is provided
     prisma_client.db.litellm_managedobjecttable.find_many.assert_called_once_with(
@@ -1685,6 +1764,7 @@ async def test_list_batches_from_managed_objects_table_empty_list():
 
 def _create_unified_batch_id(model_id: str, batch_id: str) -> str:
     import base64
+
     unified_str = f"litellm_proxy;model_id:{model_id};llm_batch_id:{batch_id}"
     return base64.urlsafe_b64encode(unified_str.encode()).decode().rstrip("=")
 
@@ -1694,11 +1774,11 @@ async def test_list_batches_from_managed_objects_table_provider_filter_raises_ex
     from litellm.proxy._types import UserAPIKeyAuth
 
     prisma_client = AsyncMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     # Filtering by provider should raise Exception
     with pytest.raises(Exception) as exc_info:
         await proxy_managed_files.list_user_batches(
@@ -1706,11 +1786,11 @@ async def test_list_batches_from_managed_objects_table_provider_filter_raises_ex
             limit=10,
             provider="openai",
         )
-    
+
     assert str(exc_info.value) == (
         "Filtering by 'provider' is not supported when using managed batches."
     )
-    
+
     # Verify find_many was NOT called since exception is raised before database query
     prisma_client.db.litellm_managedobjecttable.find_many.assert_not_called()
 
@@ -1720,7 +1800,7 @@ async def test_list_batches_from_managed_objects_table_target_model_name_filter_
     from litellm.proxy._types import UserAPIKeyAuth
 
     prisma_client = AsyncMock()
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
@@ -1732,59 +1812,64 @@ async def test_list_batches_from_managed_objects_table_target_model_name_filter_
             limit=10,
             target_model_names="gpt-4o,gpt-3.5",
         )
-    
+
     assert str(exc_info.value) == (
         "Filtering by 'target_model_names' is not supported when using managed batches."
     )
-    
+
     # Verify find_many was NOT called since exception is raised before database query
     prisma_client.db.litellm_managedobjecttable.find_many.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_list_batches_from_managed_objects_table_filters_by_created_by():
     from litellm.proxy._types import UserAPIKeyAuth
 
     prisma_client = AsyncMock()
-    
+
     # Create batch for user1
     batch_user1 = MagicMock()
     batch_user1.unified_object_id = "unified-batch-user1"
-    batch_user1.file_object = json.dumps({
-        "id": "batch_user1_abc",
-        "object": "batch",
-        "endpoint": "/v1/chat/completions",
-        "completion_window": "24h",
-        "status": "completed",
-        "created_at": 1234567890,
-        "input_file_id": "file-input-user1",
-        "request_counts": {"total": 1, "completed": 1, "failed": 0},
-    })
-    
+    batch_user1.file_object = json.dumps(
+        {
+            "id": "batch_user1_abc",
+            "object": "batch",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+            "status": "completed",
+            "created_at": 1234567890,
+            "input_file_id": "file-input-user1",
+            "request_counts": {"total": 1, "completed": 1, "failed": 0},
+        }
+    )
+
     # Create batch for user2
     batch_user2 = MagicMock()
     batch_user2.unified_object_id = "unified-batch-user2"
-    batch_user2.file_object = json.dumps({
-        "id": "batch_user2_xyz",
-        "object": "batch",
-        "endpoint": "/v1/chat/completions",
-        "completion_window": "24h",
-        "status": "completed",
-        "created_at": 1234567891,
-        "input_file_id": "file-input-user2",
-        "request_counts": {"total": 2, "completed": 2, "failed": 0},
-    })
-    
+    batch_user2.file_object = json.dumps(
+        {
+            "id": "batch_user2_xyz",
+            "object": "batch",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+            "status": "completed",
+            "created_at": 1234567891,
+            "input_file_id": "file-input-user2",
+            "request_counts": {"total": 2, "completed": 2, "failed": 0},
+        }
+    )
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     # Query with user1's API key - should only return user1's batch
     prisma_client.db.litellm_managedobjecttable.find_many.return_value = [batch_user1]
     result_user1 = await proxy_managed_files.list_user_batches(
         user_api_key_dict=UserAPIKeyAuth(user_id="user1"),
         limit=10,
     )
-    
+
     assert len(result_user1["data"]) == 1
     assert result_user1["data"][0].id == "unified-batch-user1"
     prisma_client.db.litellm_managedobjecttable.find_many.assert_called_with(
@@ -1792,14 +1877,14 @@ async def test_list_batches_from_managed_objects_table_filters_by_created_by():
         take=10,
         order={"created_at": "desc"},
     )
-    
+
     # Query with user2's API key - should only return user2's batch
     prisma_client.db.litellm_managedobjecttable.find_many.return_value = [batch_user2]
     result_user2 = await proxy_managed_files.list_user_batches(
         user_api_key_dict=UserAPIKeyAuth(user_id="user2"),
         limit=10,
     )
-    
+
     assert len(result_user2["data"]) == 1
     assert result_user2["data"][0].id == "unified-batch-user2"
     prisma_client.db.litellm_managedobjecttable.find_many.assert_called_with(
@@ -1822,7 +1907,7 @@ async def test_return_unified_file_id_includes_expires_at():
         filename="test.jsonl",
         purpose="batch",
         status="uploaded",
-        expires_at=1234657890,  
+        expires_at=1234657890,
     )
     file_object._hidden_params = {"model_id": "test-model-id"}
 
@@ -1862,25 +1947,27 @@ async def test_return_unified_file_id_includes_expires_at():
 async def test_user_b_cannot_retrieve_user_a_batch():
     """
     Test that User B cannot retrieve a batch created by User A.
-    
+
     This verifies batch isolation between users at the database/hook level.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     batch_record = MagicMock()
     batch_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedobjecttable.find_first.return_value = batch_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     # User B tries to retrieve User A's batch
-    unified_batch_id = "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
-    
+    unified_batch_id = (
+        "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
+    )
+
     with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.async_pre_call_hook(
             user_api_key_dict=UserAPIKeyAuth(
@@ -1890,7 +1977,7 @@ async def test_user_b_cannot_retrieve_user_a_batch():
             data={"batch_id": unified_batch_id},
             call_type="aretrieve_batch",
         )
-    
+
     # Should raise 403 Permission Denied
     assert exc_info.value.status_code == 403
 
@@ -1901,21 +1988,23 @@ async def test_user_b_cannot_cancel_user_a_batch():
     Test that User B cannot cancel a batch created by User A.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     batch_record = MagicMock()
     batch_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedobjecttable.find_first.return_value = batch_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     # User B tries to cancel User A's batch
-    unified_batch_id = "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
-    
+    unified_batch_id = (
+        "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
+    )
+
     with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.async_pre_call_hook(
             user_api_key_dict=UserAPIKeyAuth(
@@ -1925,7 +2014,7 @@ async def test_user_b_cannot_cancel_user_a_batch():
             data={"batch_id": unified_batch_id},
             call_type="acancel_batch",
         )
-    
+
     # Should raise 403 Permission Denied
     assert exc_info.value.status_code == 403
 
@@ -1934,26 +2023,28 @@ async def test_user_b_cannot_cancel_user_a_batch():
 async def test_user_a_can_retrieve_own_batch():
     """
     Test that User A can successfully retrieve their own batch.
-    
+
     This is a positive test case to ensure permission checks don't block
     legitimate access.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     batch_record = MagicMock()
     batch_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedobjecttable.find_first.return_value = batch_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     # User A retrieves their own batch
-    unified_batch_id = "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
-    
+    unified_batch_id = (
+        "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
+    )
+
     # Should not raise an exception
     result = await proxy_managed_files.async_pre_call_hook(
         user_api_key_dict=UserAPIKeyAuth(
@@ -1963,7 +2054,7 @@ async def test_user_a_can_retrieve_own_batch():
         data={"batch_id": unified_batch_id},
         call_type="aretrieve_batch",
     )
-    
+
     # Should successfully return the decoded batch_id
     assert "batch_id" in result
     assert result["model"] == "my-model"
@@ -1975,21 +2066,23 @@ async def test_user_b_cannot_retrieve_user_a_file():
     Test that User B cannot retrieve a file created by User A.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     file_record = MagicMock()
     file_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedfiletable.find_first.return_value = file_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         MagicMock(), prisma_client=prisma_client
     )
-    
+
     # User B tries to retrieve User A's file
-    unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
-    
+    unified_file_id = (
+        "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
+    )
+
     with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.async_pre_call_hook(
             user_api_key_dict=UserAPIKeyAuth(
@@ -1999,7 +2092,7 @@ async def test_user_b_cannot_retrieve_user_a_file():
             data={"file_id": unified_file_id},
             call_type="afile_retrieve",
         )
-    
+
     # Should raise 403 Permission Denied
     assert exc_info.value.status_code == 403
 
@@ -2010,21 +2103,23 @@ async def test_user_b_cannot_download_user_a_file_content():
     Test that User B cannot download file content for User A's file.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     file_record = MagicMock()
     file_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedfiletable.find_first.return_value = file_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         MagicMock(), prisma_client=prisma_client
     )
-    
+
     # User B tries to download User A's file content
-    unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
-    
+    unified_file_id = (
+        "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
+    )
+
     with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.async_pre_call_hook(
             user_api_key_dict=UserAPIKeyAuth(
@@ -2034,7 +2129,7 @@ async def test_user_b_cannot_download_user_a_file_content():
             data={"file_id": unified_file_id},
             call_type="afile_content",
         )
-    
+
     # Should raise 403 Permission Denied
     assert exc_info.value.status_code == 403
 
@@ -2045,21 +2140,23 @@ async def test_user_b_cannot_delete_user_a_file():
     Test that User B cannot delete a file created by User A.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     file_record = MagicMock()
     file_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedfiletable.find_first.return_value = file_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         MagicMock(), prisma_client=prisma_client
     )
-    
+
     # User B tries to delete User A's file
-    unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
-    
+    unified_file_id = (
+        "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
+    )
+
     with pytest.raises(HTTPException) as exc_info:
         await proxy_managed_files.async_pre_call_hook(
             user_api_key_dict=UserAPIKeyAuth(
@@ -2069,7 +2166,7 @@ async def test_user_b_cannot_delete_user_a_file():
             data={"file_id": unified_file_id},
             call_type="afile_delete",
         )
-    
+
     # Should raise 403 Permission Denied
     assert exc_info.value.status_code == 403
 
@@ -2078,34 +2175,38 @@ async def test_user_b_cannot_delete_user_a_file():
 async def test_user_a_can_retrieve_own_file():
     """
     Test that User A can successfully retrieve their own file.
-    
+
     Positive test case to ensure permission checks work correctly for the owner.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return User A as the creator
     file_record = MagicMock()
     file_record.created_by = "user_a_id"
     file_record.model_mappings = '{"model-123": "file-abc123"}'
-    file_record.file_object = json.dumps({
-        "id": "file-abc123",
-        "object": "file",
-        "bytes": 1234,
-        "created_at": 1234567890,
-        "filename": "test.jsonl",
-        "purpose": "batch",
-    })
+    file_record.file_object = json.dumps(
+        {
+            "id": "file-abc123",
+            "object": "file",
+            "bytes": 1234,
+            "created_at": 1234567890,
+            "filename": "test.jsonl",
+            "purpose": "batch",
+        }
+    )
     prisma_client.db.litellm_managedfiletable.find_first.return_value = file_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         MagicMock(), prisma_client=prisma_client
     )
-    
+
     # User A retrieves their own file
-    unified_file_id = "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
-    
+    unified_file_id = (
+        "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmlsZS1hYmMxMjM"
+    )
+
     # Should not raise an exception
     result = await proxy_managed_files.async_pre_call_hook(
         user_api_key_dict=UserAPIKeyAuth(
@@ -2115,7 +2216,7 @@ async def test_user_a_can_retrieve_own_file():
         data={"file_id": unified_file_id},
         call_type="afile_retrieve",
     )
-    
+
     # Should successfully return the decoded file_id
     assert "file_id" in result
 
@@ -2124,44 +2225,46 @@ async def test_user_a_can_retrieve_own_file():
 async def test_list_batches_only_returns_user_own_batches():
     """
     Test that list_user_batches only returns batches created by the requesting user.
-    
+
     This ensures users cannot see other users' batches in list operations.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Create batches for User A
     batch_user_a = MagicMock()
     batch_user_a.unified_object_id = "batch-user-a"
-    batch_user_a.file_object = json.dumps({
-        "id": "batch_a",
-        "object": "batch",
-        "endpoint": "/v1/chat/completions",
-        "completion_window": "24h",
-        "status": "completed",
-        "created_at": 1234567890,
-        "input_file_id": "file-a",
-        "request_counts": {"total": 1, "completed": 1, "failed": 0},
-    })
-    
+    batch_user_a.file_object = json.dumps(
+        {
+            "id": "batch_a",
+            "object": "batch",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+            "status": "completed",
+            "created_at": 1234567890,
+            "input_file_id": "file-a",
+            "request_counts": {"total": 1, "completed": 1, "failed": 0},
+        }
+    )
+
     # Mock database to only return User A's batches
     prisma_client.db.litellm_managedobjecttable.find_many.return_value = [batch_user_a]
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
+
     # User A requests their batches
     result = await proxy_managed_files.list_user_batches(
         user_api_key_dict=UserAPIKeyAuth(user_id="user_a_id"),
         limit=10,
     )
-    
+
     # Should only return User A's batches
     assert len(result["data"]) == 1
     assert result["data"][0].id == "batch-user-a"
-    
+
     # Verify the database query filtered by user_id
     prisma_client.db.litellm_managedobjecttable.find_many.assert_called_once_with(
         where={"file_purpose": "batch", "created_by": "user_a_id"},
@@ -2174,51 +2277,49 @@ async def test_list_batches_only_returns_user_own_batches():
 async def test_same_user_different_keys_can_access_batch():
     """
     Test that different API keys for the same user can access the same batch.
-    
+
     This verifies that permission checks are based on user_id, not API key,
     allowing users to have multiple keys that can all access their resources.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    
+
     prisma_client = AsyncMock()
-    
+
     # Mock database to return the user_id as creator
     batch_record = MagicMock()
     batch_record.created_by = "user_a_id"
     prisma_client.db.litellm_managedobjecttable.find_first.return_value = batch_record
-    
+
     proxy_managed_files = _PROXY_LiteLLMManagedFiles(
         DualCache(), prisma_client=prisma_client
     )
-    
-    unified_batch_id = "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
-    
+
+    unified_batch_id = (
+        "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDpteS1tb2RlbDtsbG1fYmF0Y2hfaWQ6YmF0Y2hfYWJjMTIz"
+    )
+
     # First API key for User A retrieves the batch
     result1 = await proxy_managed_files.async_pre_call_hook(
         user_api_key_dict=UserAPIKeyAuth(
-            user_id="user_a_id", 
-            api_key="key-1",
-            parent_otel_span=MagicMock()
+            user_id="user_a_id", api_key="key-1", parent_otel_span=MagicMock()
         ),
         cache=MagicMock(),
         data={"batch_id": unified_batch_id},
         call_type="aretrieve_batch",
     )
-    
+
     assert "batch_id" in result1
-    
+
     # Second API key for the same User A retrieves the batch
     result2 = await proxy_managed_files.async_pre_call_hook(
         user_api_key_dict=UserAPIKeyAuth(
-            user_id="user_a_id",
-            api_key="key-2",
-            parent_otel_span=MagicMock()
+            user_id="user_a_id", api_key="key-2", parent_otel_span=MagicMock()
         ),
         cache=MagicMock(),
         data={"batch_id": unified_batch_id},
         call_type="aretrieve_batch",
     )
-    
+
     assert "batch_id" in result2
     # Both keys should get the same result
     assert result1["batch_id"] == result2["batch_id"]

--- a/tests/test_litellm/enterprise/proxy/test_batch_cancel_returns_unified_input_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_cancel_returns_unified_input_file_id.py
@@ -1,0 +1,110 @@
+import base64
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Response
+from starlette.requests import Request
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import LiteLLMBatch
+
+
+def _make_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/batches/test/cancel",
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+
+def _make_unified_batch_id(raw_batch_id: str, model_id: str) -> str:
+    decoded = f"litellm_proxy;model_id:{model_id};llm_batch_id:{raw_batch_id}"
+    return base64.urlsafe_b64encode(decoded.encode()).decode().rstrip("=")
+
+
+@pytest.mark.asyncio
+async def test_cancel_batch_returns_unified_input_file_id_for_managed_batch():
+    from litellm.proxy.batches_endpoints.endpoints import cancel_batch
+
+    raw_batch_id = "batch-raw-123"
+    raw_input_file_id = "file-input-raw-123"
+    model_id = "model-deploy-xyz"
+    unified_batch_id = _make_unified_batch_id(
+        raw_batch_id=raw_batch_id, model_id=model_id
+    )
+    unified_input_file_id = "bGl0ZWxsbV9wcm94eTp1bmlmaWVkLWlucHV0LWlk"
+
+    response = LiteLLMBatch(
+        id=raw_batch_id,
+        completion_window="24h",
+        created_at=1700000000,
+        endpoint="/v1/chat/completions",
+        input_file_id=raw_input_file_id,
+        object="batch",
+        status="cancelling",
+        output_file_id=None,
+    )
+    response._hidden_params = {}
+
+    mock_router = MagicMock()
+    mock_router.acancel_batch = AsyncMock(return_value=response)
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.get_proxy_hook.return_value = MagicMock()
+    mock_proxy_logging_obj.post_call_success_hook = AsyncMock(return_value=response)
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+    mock_proxy_logging_obj.update_request_status = AsyncMock()
+
+    managed_file_record = MagicMock()
+    managed_file_record.unified_file_id = unified_input_file_id
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_managedfiletable.find_first = AsyncMock(
+        return_value=managed_file_record
+    )
+
+    processed_data = {"batch_id": raw_batch_id, "model": model_id}
+    fake_proxy_server = ModuleType("litellm.proxy.proxy_server")
+    fake_proxy_server.add_litellm_data_to_request = AsyncMock(
+        side_effect=lambda data, **_: data
+    )
+    fake_proxy_server.general_settings = {}
+    fake_proxy_server.llm_router = mock_router
+    fake_proxy_server.prisma_client = mock_prisma
+    fake_proxy_server.proxy_config = MagicMock()
+    fake_proxy_server.proxy_logging_obj = mock_proxy_logging_obj
+    fake_proxy_server.version = "test-version"
+
+    with patch(
+        "litellm.proxy.batches_endpoints.endpoints.ProxyBaseLLMRequestProcessing.common_processing_pre_call_logic",
+        AsyncMock(return_value=(processed_data, MagicMock())),
+    ), patch(
+        "litellm.proxy.batches_endpoints.endpoints.ProxyBaseLLMRequestProcessing.get_custom_headers",
+        return_value={},
+    ), patch(
+        "litellm.proxy.batches_endpoints.endpoints.update_batch_in_database",
+        AsyncMock(),
+    ), patch.dict(
+        sys.modules, {"litellm.proxy.proxy_server": fake_proxy_server}
+    ):
+        result = await cancel_batch(
+            request=_make_request(),
+            batch_id=unified_batch_id,
+            fastapi_response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(
+                api_key="sk-test",
+                user_id="test-user",
+                parent_otel_span=None,
+            ),
+        )
+
+    assert result.input_file_id == unified_input_file_id
+    mock_prisma.db.litellm_managedfiletable.find_first.assert_called_once_with(
+        where={"flat_model_file_ids": {"has": raw_input_file_id}}
+    )

--- a/tests/test_litellm/enterprise/proxy/test_batch_retrieve_returns_unified_input_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_retrieve_returns_unified_input_file_id.py
@@ -8,9 +8,9 @@ batch is later read from DB, get_batch_from_database returns the raw ID
 without resolving it to the unified ID.
 """
 
+import base64
 import json
 import pytest
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 from litellm.proxy.openai_files_endpoints.common_utils import get_batch_from_database
@@ -93,7 +93,9 @@ async def test_should_preserve_already_managed_input_file_id():
 
     unified_batch_id = "bGl0ZWxsbV9wcm94eTpiYXRjaF9pZA"
     decoded_unified = "litellm_proxy:application/octet-stream;unified_id,test-123"
-    base64_input_file_id = base64.urlsafe_b64encode(decoded_unified.encode()).decode().rstrip("=")
+    base64_input_file_id = (
+        base64.urlsafe_b64encode(decoded_unified.encode()).decode().rstrip("=")
+    )
 
     batch_data = {
         "id": "batch-raw-123",
@@ -122,3 +124,64 @@ async def test_should_preserve_already_managed_input_file_id():
     )
 
     prisma.db.litellm_managedfiletable.find_first.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_should_rehydrate_hidden_params_for_completed_batch_from_db():
+    """
+    When a completed managed batch is served from the DB early-return path,
+    get_batch_from_database should restore the hidden params needed by the
+    managed_files hook to re-encode output_file_id on the response.
+    """
+    decoded_unified_batch_id = (
+        "litellm_proxy;model_id:model-deploy-xyz;llm_batch_id:batch-raw-123"
+    )
+    unified_batch_id = (
+        base64.urlsafe_b64encode(decoded_unified_batch_id.encode()).decode().rstrip("=")
+    )
+    decoded_unified_input_file_id = (
+        "litellm_proxy:application/octet-stream;"
+        "unified_id,test-input-uuid;"
+        "target_model_names,azure-gpt-4;"
+        "llm_output_file_id,file-abc123-raw;"
+        "llm_output_file_model_id,model-deploy-xyz"
+    )
+    unified_input_file_id = (
+        base64.urlsafe_b64encode(decoded_unified_input_file_id.encode())
+        .decode()
+        .rstrip("=")
+    )
+    raw_input_file_id = "file-abc123-raw"
+
+    batch_data = {
+        "id": "batch-raw-123",
+        "completion_window": "24h",
+        "created_at": 1700000000,
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": raw_input_file_id,
+        "object": "batch",
+        "status": "completed",
+        "output_file_id": "file-output-raw",
+    }
+
+    managed_file_record = MagicMock()
+    managed_file_record.unified_file_id = unified_input_file_id
+
+    prisma = _mock_prisma(
+        batch_json=json.dumps(batch_data),
+        managed_file_record=managed_file_record,
+    )
+
+    _, response = await get_batch_from_database(
+        batch_id=unified_batch_id,
+        unified_batch_id=decoded_unified_batch_id,
+        managed_files_obj=MagicMock(),
+        prisma_client=prisma,
+        verbose_proxy_logger=MagicMock(),
+    )
+
+    assert response is not None
+    assert response.input_file_id == unified_input_file_id
+    assert response._hidden_params["unified_batch_id"] == decoded_unified_batch_id
+    assert response._hidden_params["model_id"] == "model-deploy-xyz"
+    assert response._hidden_params["unified_file_id"] == unified_input_file_id

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -123,7 +123,6 @@ def test_cost_calculator_with_usage(monkeypatch):
 
     # Invalidate caches after modifying litellm.model_cost
     from litellm.utils import _invalidate_model_cost_lowercase_map
-
     _invalidate_model_cost_lowercase_map()
 
     result = response_cost_calculator(
@@ -529,7 +528,9 @@ def test_azure_audio_output_cost_calculation():
     model_info = litellm.get_model_info("azure/gpt-audio-2025-08-28")
 
     # Calculate expected cost
-    expected_input_cost = model_info["input_cost_per_token"] * 17  # text tokens
+    expected_input_cost = (
+        model_info["input_cost_per_token"] * 17  # text tokens
+    )
     expected_output_cost = (
         model_info["output_cost_per_token"] * 110  # text tokens
         + model_info["output_cost_per_audio_token"] * 482  # audio tokens
@@ -541,14 +542,14 @@ def test_azure_audio_output_cost_calculation():
     wrong_total_cost = expected_input_cost + wrong_output_cost
 
     # Verify audio tokens are NOT charged at text rate (the bug)
-    assert (
-        abs(cost - wrong_total_cost) > 0.001
-    ), "Bug: Audio tokens are being charged at text token rate"
+    assert abs(cost - wrong_total_cost) > 0.001, (
+        "Bug: Audio tokens are being charged at text token rate"
+    )
 
     # Verify cost matches
-    assert (
-        abs(cost - expected_total_cost) < 0.0000001
-    ), f"Expected cost {expected_total_cost}, got {cost}"
+    assert abs(cost - expected_total_cost) < 0.0000001, (
+        f"Expected cost {expected_total_cost}, got {cost}"
+    )
 
 
 def test_default_image_cost_calculator(monkeypatch):
@@ -993,112 +994,6 @@ def test_gemini_25_explicit_caching_cost_direct_usage():
     assert expected_actual_cost == total_cost
 
 
-def test_gemini_partial_prompt_token_breakdown_bills_unaccounted_remainder():
-    """
-    Reproduce #24375: when prompt_tokens_details only covers a subset of the
-    prompt tokens, the remainder should still be billed as text tokens.
-    """
-    from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-    from litellm.types.utils import CompletionTokensDetailsWrapper
-
-    original_local_cost_map = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
-    original_model_cost = litellm.model_cost
-
-    try:
-        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-        litellm.model_cost = litellm.get_model_cost_map(url="")
-
-        model_info = litellm.get_model_info(
-            model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
-        )
-        output_cost_per_reasoning_token = model_info.get(
-            "output_cost_per_reasoning_token", model_info["output_cost_per_token"]
-        )
-
-        usage = Usage(
-            prompt_tokens=783,
-            completion_tokens=96,
-            total_tokens=879,
-            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=9),
-            completion_tokens_details=CompletionTokensDetailsWrapper(
-                reasoning_tokens=92,
-                text_tokens=4,
-            ),
-        )
-
-        input_cost, output_cost = generic_cost_per_token(
-            model="gemini/gemini-2.5-flash",
-            usage=usage,
-            custom_llm_provider="gemini",
-        )
-
-        expected_input_cost = usage.prompt_tokens * model_info["input_cost_per_token"]
-        expected_output_cost = (4 * model_info["output_cost_per_token"]) + (
-            92 * output_cost_per_reasoning_token
-        )
-
-        assert abs(input_cost - expected_input_cost) < 1e-12
-        assert abs(output_cost - expected_output_cost) < 1e-12
-    finally:
-        if original_local_cost_map is None:
-            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
-        else:
-            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_local_cost_map
-        litellm.model_cost = original_model_cost
-
-
-def test_partial_completion_token_breakdown_bills_unaccounted_remainder_as_text():
-    """
-    If completion_tokens_details omits part of the total completion tokens, the
-    remainder should be billed as text tokens instead of being dropped.
-    """
-    from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-    from litellm.types.utils import CompletionTokensDetailsWrapper
-
-    original_local_cost_map = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
-    original_model_cost = litellm.model_cost
-
-    try:
-        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-        litellm.model_cost = litellm.get_model_cost_map(url="")
-
-        model_info = litellm.get_model_info(
-            model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
-        )
-        output_cost_per_reasoning_token = model_info.get(
-            "output_cost_per_reasoning_token", model_info["output_cost_per_token"]
-        )
-
-        usage = Usage(
-            prompt_tokens=10,
-            completion_tokens=120,
-            total_tokens=130,
-            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10),
-            completion_tokens_details=CompletionTokensDetailsWrapper(
-                reasoning_tokens=92,
-                text_tokens=4,
-            ),
-        )
-
-        _, output_cost = generic_cost_per_token(
-            model="gemini/gemini-2.5-flash",
-            usage=usage,
-            custom_llm_provider="gemini",
-        )
-
-        expected_output_cost = (28 * model_info["output_cost_per_token"]) + (
-            92 * output_cost_per_reasoning_token
-        )
-
-        assert abs(output_cost - expected_output_cost) < 1e-12
-    finally:
-        if original_local_cost_map is None:
-            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
-        else:
-            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_local_cost_map
-        litellm.model_cost = original_model_cost
-
-
 def test_azure_ai_cache_cost_calculation():
     """
     Test that azure_ai provider correctly calculates cache costs using generic_cost_per_token.
@@ -1161,12 +1056,12 @@ def test_azure_ai_cache_cost_calculation():
     print(f"Output cost: {output_cost}, Expected: {expected_output_cost}")
     print(f"Total cost: {total_cost}")
 
-    assert (
-        abs(input_cost - expected_input_cost) < 1e-10
-    ), f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
-    assert (
-        abs(output_cost - expected_output_cost) < 1e-10
-    ), f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
+    assert abs(input_cost - expected_input_cost) < 1e-10, (
+        f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
+    )
+    assert abs(output_cost - expected_output_cost) < 1e-10, (
+        f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
+    )
 
 
 def test_cost_discount_vertex_ai():
@@ -1939,7 +1834,7 @@ def test_gemini_without_cache_tokens_details():
             "promptTokensDetails": [
                 {"modality": "TEXT", "tokenCount": 6},
                 {"modality": "IMAGE", "tokenCount": 258},
-            ],
+            ]
             # No cacheTokensDetails
         }
     }
@@ -2034,9 +1929,7 @@ def test_gemini_implicit_caching_cost_calculation():
         f"Cached tokens may not be using reduced pricing."
     )
 
-    print(
-        "✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly"
-    )
+    print("✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly")
 
 
 def test_additional_costs_only_for_azure_ai():

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -123,6 +123,7 @@ def test_cost_calculator_with_usage(monkeypatch):
 
     # Invalidate caches after modifying litellm.model_cost
     from litellm.utils import _invalidate_model_cost_lowercase_map
+
     _invalidate_model_cost_lowercase_map()
 
     result = response_cost_calculator(
@@ -528,9 +529,7 @@ def test_azure_audio_output_cost_calculation():
     model_info = litellm.get_model_info("azure/gpt-audio-2025-08-28")
 
     # Calculate expected cost
-    expected_input_cost = (
-        model_info["input_cost_per_token"] * 17  # text tokens
-    )
+    expected_input_cost = model_info["input_cost_per_token"] * 17  # text tokens
     expected_output_cost = (
         model_info["output_cost_per_token"] * 110  # text tokens
         + model_info["output_cost_per_audio_token"] * 482  # audio tokens
@@ -542,14 +541,14 @@ def test_azure_audio_output_cost_calculation():
     wrong_total_cost = expected_input_cost + wrong_output_cost
 
     # Verify audio tokens are NOT charged at text rate (the bug)
-    assert abs(cost - wrong_total_cost) > 0.001, (
-        "Bug: Audio tokens are being charged at text token rate"
-    )
+    assert (
+        abs(cost - wrong_total_cost) > 0.001
+    ), "Bug: Audio tokens are being charged at text token rate"
 
     # Verify cost matches
-    assert abs(cost - expected_total_cost) < 0.0000001, (
-        f"Expected cost {expected_total_cost}, got {cost}"
-    )
+    assert (
+        abs(cost - expected_total_cost) < 0.0000001
+    ), f"Expected cost {expected_total_cost}, got {cost}"
 
 
 def test_default_image_cost_calculator(monkeypatch):
@@ -1002,35 +1001,50 @@ def test_gemini_partial_prompt_token_breakdown_bills_unaccounted_remainder():
     from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
     from litellm.types.utils import CompletionTokensDetailsWrapper
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    original_local_cost_map = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = litellm.model_cost
 
-    model_info = litellm.get_model_info(
-        model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
-    )
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
 
-    usage = Usage(
-        prompt_tokens=783,
-        completion_tokens=96,
-        total_tokens=879,
-        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=9),
-        completion_tokens_details=CompletionTokensDetailsWrapper(
-            reasoning_tokens=92,
-            text_tokens=4,
-        ),
-    )
+        model_info = litellm.get_model_info(
+            model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
+        )
+        output_cost_per_reasoning_token = model_info.get(
+            "output_cost_per_reasoning_token", model_info["output_cost_per_token"]
+        )
 
-    input_cost, output_cost = generic_cost_per_token(
-        model="gemini/gemini-2.5-flash",
-        usage=usage,
-        custom_llm_provider="gemini",
-    )
+        usage = Usage(
+            prompt_tokens=783,
+            completion_tokens=96,
+            total_tokens=879,
+            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=9),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=92,
+                text_tokens=4,
+            ),
+        )
 
-    expected_input_cost = usage.prompt_tokens * model_info["input_cost_per_token"]
-    expected_output_cost = usage.completion_tokens * model_info["output_cost_per_token"]
+        input_cost, output_cost = generic_cost_per_token(
+            model="gemini/gemini-2.5-flash",
+            usage=usage,
+            custom_llm_provider="gemini",
+        )
 
-    assert abs(input_cost - expected_input_cost) < 1e-12
-    assert abs(output_cost - expected_output_cost) < 1e-12
+        expected_input_cost = usage.prompt_tokens * model_info["input_cost_per_token"]
+        expected_output_cost = (4 * model_info["output_cost_per_token"]) + (
+            92 * output_cost_per_reasoning_token
+        )
+
+        assert abs(input_cost - expected_input_cost) < 1e-12
+        assert abs(output_cost - expected_output_cost) < 1e-12
+    finally:
+        if original_local_cost_map is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_local_cost_map
+        litellm.model_cost = original_model_cost
 
 
 def test_partial_completion_token_breakdown_bills_unaccounted_remainder_as_text():
@@ -1041,33 +1055,48 @@ def test_partial_completion_token_breakdown_bills_unaccounted_remainder_as_text(
     from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
     from litellm.types.utils import CompletionTokensDetailsWrapper
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    original_local_cost_map = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = litellm.model_cost
 
-    model_info = litellm.get_model_info(
-        model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
-    )
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
 
-    usage = Usage(
-        prompt_tokens=10,
-        completion_tokens=120,
-        total_tokens=130,
-        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10),
-        completion_tokens_details=CompletionTokensDetailsWrapper(
-            reasoning_tokens=92,
-            text_tokens=4,
-        ),
-    )
+        model_info = litellm.get_model_info(
+            model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
+        )
+        output_cost_per_reasoning_token = model_info.get(
+            "output_cost_per_reasoning_token", model_info["output_cost_per_token"]
+        )
 
-    _, output_cost = generic_cost_per_token(
-        model="gemini/gemini-2.5-flash",
-        usage=usage,
-        custom_llm_provider="gemini",
-    )
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=120,
+            total_tokens=130,
+            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=92,
+                text_tokens=4,
+            ),
+        )
 
-    expected_output_cost = usage.completion_tokens * model_info["output_cost_per_token"]
+        _, output_cost = generic_cost_per_token(
+            model="gemini/gemini-2.5-flash",
+            usage=usage,
+            custom_llm_provider="gemini",
+        )
 
-    assert abs(output_cost - expected_output_cost) < 1e-12
+        expected_output_cost = (28 * model_info["output_cost_per_token"]) + (
+            92 * output_cost_per_reasoning_token
+        )
+
+        assert abs(output_cost - expected_output_cost) < 1e-12
+    finally:
+        if original_local_cost_map is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_local_cost_map
+        litellm.model_cost = original_model_cost
 
 
 def test_azure_ai_cache_cost_calculation():
@@ -1132,12 +1161,12 @@ def test_azure_ai_cache_cost_calculation():
     print(f"Output cost: {output_cost}, Expected: {expected_output_cost}")
     print(f"Total cost: {total_cost}")
 
-    assert abs(input_cost - expected_input_cost) < 1e-10, (
-        f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
-    )
-    assert abs(output_cost - expected_output_cost) < 1e-10, (
-        f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
-    )
+    assert (
+        abs(input_cost - expected_input_cost) < 1e-10
+    ), f"Input cost mismatch: got {input_cost}, expected {expected_input_cost}"
+    assert (
+        abs(output_cost - expected_output_cost) < 1e-10
+    ), f"Output cost mismatch: got {output_cost}, expected {expected_output_cost}"
 
 
 def test_cost_discount_vertex_ai():
@@ -1910,7 +1939,7 @@ def test_gemini_without_cache_tokens_details():
             "promptTokensDetails": [
                 {"modality": "TEXT", "tokenCount": 6},
                 {"modality": "IMAGE", "tokenCount": 258},
-            ]
+            ],
             # No cacheTokensDetails
         }
     }
@@ -2005,7 +2034,9 @@ def test_gemini_implicit_caching_cost_calculation():
         f"Cached tokens may not be using reduced pricing."
     )
 
-    print("✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly")
+    print(
+        "✅ Issue #16341 fix verified: Gemini implicit caching cost calculated correctly"
+    )
 
 
 def test_additional_costs_only_for_azure_ai():

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -994,6 +994,82 @@ def test_gemini_25_explicit_caching_cost_direct_usage():
     assert expected_actual_cost == total_cost
 
 
+def test_gemini_partial_prompt_token_breakdown_bills_unaccounted_remainder():
+    """
+    Reproduce #24375: when prompt_tokens_details only covers a subset of the
+    prompt tokens, the remainder should still be billed as text tokens.
+    """
+    from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+    from litellm.types.utils import CompletionTokensDetailsWrapper
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.get_model_info(
+        model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
+    )
+
+    usage = Usage(
+        prompt_tokens=783,
+        completion_tokens=96,
+        total_tokens=879,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=9),
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            reasoning_tokens=92,
+            text_tokens=4,
+        ),
+    )
+
+    input_cost, output_cost = generic_cost_per_token(
+        model="gemini/gemini-2.5-flash",
+        usage=usage,
+        custom_llm_provider="gemini",
+    )
+
+    expected_input_cost = usage.prompt_tokens * model_info["input_cost_per_token"]
+    expected_output_cost = usage.completion_tokens * model_info["output_cost_per_token"]
+
+    assert abs(input_cost - expected_input_cost) < 1e-12
+    assert abs(output_cost - expected_output_cost) < 1e-12
+
+
+def test_partial_completion_token_breakdown_bills_unaccounted_remainder_as_text():
+    """
+    If completion_tokens_details omits part of the total completion tokens, the
+    remainder should be billed as text tokens instead of being dropped.
+    """
+    from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+    from litellm.types.utils import CompletionTokensDetailsWrapper
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.get_model_info(
+        model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
+    )
+
+    usage = Usage(
+        prompt_tokens=10,
+        completion_tokens=120,
+        total_tokens=130,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10),
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            reasoning_tokens=92,
+            text_tokens=4,
+        ),
+    )
+
+    _, output_cost = generic_cost_per_token(
+        model="gemini/gemini-2.5-flash",
+        usage=usage,
+        custom_llm_provider="gemini",
+    )
+
+    expected_output_cost = usage.completion_tokens * model_info["output_cost_per_token"]
+
+    assert abs(output_cost - expected_output_cost) < 1e-12
+
+
 def test_azure_ai_cache_cost_calculation():
     """
     Test that azure_ai provider correctly calculates cache costs using generic_cost_per_token.

--- a/tests/test_litellm/test_cost_calculator_partial_breakdown.py
+++ b/tests/test_litellm/test_cost_calculator_partial_breakdown.py
@@ -1,0 +1,109 @@
+import os
+
+import litellm
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+def test_gemini_partial_prompt_token_breakdown_bills_unaccounted_remainder():
+    """
+    Reproduce #24375: when prompt_tokens_details only covers a subset of the
+    prompt tokens, the remainder should still be billed as text tokens.
+    """
+    original_local_cost_map = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = litellm.model_cost
+
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        model_info = litellm.get_model_info(
+            model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
+        )
+        output_cost_per_reasoning_token = model_info.get(
+            "output_cost_per_reasoning_token", model_info["output_cost_per_token"]
+        )
+
+        usage = Usage(
+            prompt_tokens=783,
+            completion_tokens=96,
+            total_tokens=879,
+            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=9),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=92,
+                text_tokens=4,
+            ),
+        )
+
+        input_cost, output_cost = generic_cost_per_token(
+            model="gemini/gemini-2.5-flash",
+            usage=usage,
+            custom_llm_provider="gemini",
+        )
+
+        expected_input_cost = usage.prompt_tokens * model_info["input_cost_per_token"]
+        expected_output_cost = (4 * model_info["output_cost_per_token"]) + (
+            92 * output_cost_per_reasoning_token
+        )
+
+        assert abs(input_cost - expected_input_cost) < 1e-12
+        assert abs(output_cost - expected_output_cost) < 1e-12
+    finally:
+        if original_local_cost_map is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_local_cost_map
+        litellm.model_cost = original_model_cost
+
+
+def test_partial_completion_token_breakdown_bills_unaccounted_remainder_as_text():
+    """
+    If completion_tokens_details omits part of the total completion tokens, the
+    remainder should be billed as text tokens instead of being dropped.
+    """
+    original_local_cost_map = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = litellm.model_cost
+
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        model_info = litellm.get_model_info(
+            model="gemini/gemini-2.5-flash", custom_llm_provider="gemini"
+        )
+        output_cost_per_reasoning_token = model_info.get(
+            "output_cost_per_reasoning_token", model_info["output_cost_per_token"]
+        )
+
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=120,
+            total_tokens=130,
+            prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=10),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=92,
+                text_tokens=4,
+            ),
+        )
+
+        _, output_cost = generic_cost_per_token(
+            model="gemini/gemini-2.5-flash",
+            usage=usage,
+            custom_llm_provider="gemini",
+        )
+
+        expected_output_cost = (28 * model_info["output_cost_per_token"]) + (
+            92 * output_cost_per_reasoning_token
+        )
+
+        assert abs(output_cost - expected_output_cost) < 1e-12
+    finally:
+        if original_local_cost_map is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_local_cost_map
+        litellm.model_cost = original_model_cost


### PR DESCRIPTION
## Summary
- normalize partial `prompt_tokens_details` breakdowns so any unaccounted remainder falls back to text-token billing
- apply the same remainder handling to `completion_tokens_details` to avoid silently dropping incomplete output token breakdowns
- add regression coverage for partial Gemini token breakdowns

Fixes #24375.

## Testing
- `pytest tests/test_litellm/test_cost_calculator.py -k "partial_prompt_token_breakdown or partial_completion_token_breakdown or explicit_caching_cost_direct_usage" -q`
- `ruff check litellm/litellm_core_utils/llm_cost_calc/utils.py`
- `ruff check tests/test_litellm/test_cost_calculator.py --ignore T201`
