### PR TITLE
test: isolate Redis cluster env cache detection

### DIFF
--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -67,7 +67,7 @@ async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
 
 @patch("litellm._redis.get_redis_connection_pool")
 @patch("litellm._redis.get_redis_client")
-@patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
+@patch.object(RedisCache, "_setup_health_pings")
 def test_cache_init_creates_cluster_cache_from_env_var(mock_health, mock_get_client, mock_get_pool, monkeypatch):
     """
     Test that Cache() creates RedisClusterCache when REDIS_CLUSTER_NODES env var is set.
@@ -75,8 +75,11 @@ def test_cache_init_creates_cluster_cache_from_env_var(mock_health, mock_get_cli
     Regression test for https://github.com/BerriAI/litellm/issues/22748
     """
     from litellm.caching.caching import Cache
+    import litellm
 
     startup_nodes = [{"host": "127.0.0.1", "port": "7001"}]
+    monkeypatch.setattr(litellm, "secret_manager_client", None)
+    monkeypatch.setattr(litellm, "_key_management_settings", None)
     monkeypatch.setenv("REDIS_CLUSTER_NODES", json.dumps(startup_nodes))
     monkeypatch.delenv("REDIS_HOST", raising=False)
     monkeypatch.delenv("REDIS_PORT", raising=False)
@@ -92,7 +95,7 @@ def test_cache_init_creates_cluster_cache_from_env_var(mock_health, mock_get_cli
 
 @patch("litellm._redis.get_redis_connection_pool")
 @patch("litellm._redis.get_redis_client")
-@patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
+@patch.object(RedisCache, "_setup_health_pings")
 def test_cache_init_creates_redis_cache_without_cluster_config(
     mock_health, mock_get_client, mock_get_pool, monkeypatch
 ):
@@ -154,11 +157,11 @@ def test_router_create_redis_cache_cluster_detection(startup_nodes, env_var, exp
 
     Regression test for https://github.com/BerriAI/litellm/issues/22748
     """
-    from litellm import Router
     import litellm
+    from litellm import Router
 
-    litellm.secret_manager_client = None
-    litellm._key_management_settings = None
+    monkeypatch.setattr(litellm, "secret_manager_client", None)
+    monkeypatch.setattr(litellm, "_key_management_settings", None)
 
     cache_config = dict(
         host="mockhost",

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -6,9 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.caching.redis_cache import RedisCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
@@ -70,9 +68,7 @@ async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
 @patch("litellm._redis.get_redis_connection_pool")
 @patch("litellm._redis.get_redis_client")
 @patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
-def test_cache_init_creates_cluster_cache_from_env_var(
-    mock_health, mock_get_client, mock_get_pool, monkeypatch
-):
+def test_cache_init_creates_cluster_cache_from_env_var(mock_health, mock_get_client, mock_get_pool, monkeypatch):
     """
     Test that Cache() creates RedisClusterCache when REDIS_CLUSTER_NODES env var is set.
 
@@ -150,9 +146,7 @@ def test_cache_init_creates_redis_cache_without_cluster_config(
         ),
     ],
 )
-def test_router_create_redis_cache_cluster_detection(
-    startup_nodes, env_var, expected_cache_type, monkeypatch
-):
+def test_router_create_redis_cache_cluster_detection(startup_nodes, env_var, expected_cache_type, monkeypatch):
     """
     Test that Router._create_redis_cache() creates RedisClusterCache when
     either startup_nodes is in config or REDIS_CLUSTER_NODES env var is set.
@@ -161,6 +155,10 @@ def test_router_create_redis_cache_cluster_detection(
     Regression test for https://github.com/BerriAI/litellm/issues/22748
     """
     from litellm import Router
+    import litellm
+
+    litellm.secret_manager_client = None
+    litellm._key_management_settings = None
 
     cache_config = dict(
         host="mockhost",

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -105,7 +105,11 @@ def test_cache_init_creates_redis_cache_without_cluster_config(
     Ensures backward compatibility: without REDIS_CLUSTER_NODES or
     redis_startup_nodes, the standard RedisCache is still used.
     """
+    import litellm
     from litellm.caching.caching import Cache
+
+    monkeypatch.setattr(litellm, "secret_manager_client", None)
+    monkeypatch.setattr(litellm, "_key_management_settings", None)
 
     monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
     monkeypatch.setenv("REDIS_HOST", "localhost")


### PR DESCRIPTION
## Relevant issues

Related to #22748

## Type

✅ Test

## Changes

- clear shared secret-manager state before asserting `REDIS_CLUSTER_NODES`-driven cluster detection
- apply the same isolation to both the `Cache(type="redis")` and `Router._create_redis_cache(...)` env-var regressions
- patch `RedisCache._setup_health_pings` via `patch.object(...)` so the test file is robust even though `litellm.caching` is a runtime flag on the root module
- keep the Redis cluster cache regression deterministic under full-suite execution

## Verification

- `poetry run pytest tests/test_litellm/caching/test_redis_cluster_cache.py -vv` -> `8 passed`
