### PR TITLE
fix(google): guard against null text in Gemini parts before startswith call

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1271,7 +1271,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         for part in parts:
             _content_str = ""
-            if "text" in part:
+            if "text" in part and part.get("text") is not None:
                 text_content = part["text"]
                 # Check if text content is audio data URI - if so, exclude from text content
                 if text_content.startswith("data:audio") and ";base64," in text_content:
@@ -1379,7 +1379,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ) -> Optional[ChatCompletionAudioResponse]:
         """Extract audio response from parts if present"""
         for part in parts:
-            if "text" in part:
+            if "text" in part and part.get("text") is not None:
                 text_content = part["text"]
                 # Check if text content contains audio data URI
                 if text_content.startswith("data:audio") and ";base64," in text_content:

--- a/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -288,3 +288,40 @@ def test_map_function_enterprise_web_search_snake_case():
 
     assert len(result) == 1
     assert "enterpriseWebSearch" in result[0]
+
+def test_get_assistant_content_message_null_text():
+    """
+    Test that get_assistant_content_message handles parts with text=null
+    without raising AttributeError. Regression for GitHub issue #24385.
+
+    Gemini image generation responses may include parts with {"text": null},
+    which caused AttributeError: 'NoneType' object has no attribute 'startswith'.
+    """
+    config = VertexGeminiConfig()
+
+    # Parts where text is explicitly null (as returned by Gemini image-gen responses)
+    parts = [
+        {"text": None},  # null text - should not cause AttributeError
+        {"text": "Hello world"},  # normal text part
+    ]
+
+    content, reasoning = config.get_assistant_content_message(parts=parts)
+
+    # null text part should be skipped; normal text should be included
+    assert content == "Hello world"
+    assert reasoning is None
+
+
+def test_get_assistant_content_message_all_null_text():
+    """
+    Test that get_assistant_content_message returns None
+    when all parts have text=null.
+    """
+    config = VertexGeminiConfig()
+
+    parts = [{"text": None}, {"text": None}]
+
+    content, reasoning = config.get_assistant_content_message(parts=parts)
+
+    assert content is None
+    assert reasoning is None


### PR DESCRIPTION
## Description

When Gemini returns an image generation response, the `parts` array can contain `{"text": null}`. The existing `if "text" in part` guard does not prevent a subsequent `.startswith()` call from raising `AttributeError: 'NoneType' object has no attribute 'startswith'`, which LiteLLM incorrectly surfaces as a 403 error.

## Fix

Added an explicit `is not None` check in both `get_assistant_content_message()` and `_extract_audio_response_from_parts()` before dereferencing the text value.

## Testing

Added two unit tests covering:
- Parts with mixed null and non-null text (null parts are skipped)
- Parts where all text values are null (returns None)

Fixes #24385