### PR TITLE
fix(utils): drop empty tools list when drop_params=True

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3909,6 +3909,17 @@ def get_optional_params(  # noqa: PLR0915
         custom_llm_provider=custom_llm_provider,
     )
 
+    # When drop_params=True, treat an empty tools list as a droppable parameter.
+    # An empty list ([]) passes the `v != default_param_values[k]` check (since
+    # the default is None), so it ends up in non_default_params and gets forwarded
+    # to the provider, where many providers reject it with a validation error
+    # (e.g. "[] is too short").  Removing it here is consistent with the intent
+    # of drop_params: silently strip parameters that would cause the call to fail.
+    if (drop_params is True or litellm.drop_params is True) and non_default_params.get(
+        "tools"
+    ) == []:
+        non_default_params.pop("tools", None)
+
     def _check_valid_arg(supported_params: List[str]):
         """
         Check if the params passed to completion() are supported by the provider

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3679,3 +3679,49 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+def test_drop_params_drops_empty_tools_list():
+    """When drop_params=True, an empty tools=[] should be removed from
+    optional_params and not forwarded to the provider.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/24378.
+    """
+    from litellm.utils import get_optional_params
+
+    optional_params = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        tools=[],  # empty list – should be dropped
+        drop_params=True,
+    )
+
+    assert "tools" not in optional_params, (
+        "Empty tools list should be dropped when drop_params=True, "
+        f"but got: {optional_params}"
+    )
+
+
+def test_drop_params_keeps_non_empty_tools_list():
+    """drop_params=True must NOT remove a non-empty tools list."""
+    from litellm.utils import get_optional_params
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    optional_params = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        tools=[tool],
+        drop_params=True,
+    )
+
+    assert "tools" in optional_params, (
+        "Non-empty tools list must NOT be dropped"
+    )


### PR DESCRIPTION
## Description

When `drop_params: true` is set, an empty `tools=[]` was still forwarded to the provider, causing validation errors such as:

```
"[] is too short"
```

This happened because `tools=[]` differs from the default `tools=None`, so it passed the `non_default_params` filter and was included in the request body.

## Fix

In `get_optional_params()`, after `non_default_params` is built, add a check: if `drop_params=True` **and** `tools` is an empty list, remove it — consistent with the intent of `drop_params`: silently strip parameters that would cause the provider call to fail.

```python
if (drop_params is True or litellm.drop_params is True) and non_default_params.get("tools") == []:
    non_default_params.pop("tools", None)
```

## Testing

Added two unit tests in `tests/test_litellm/test_utils.py`:
- `test_drop_params_drops_empty_tools_list` – empty `tools=[]` is dropped
- `test_drop_params_keeps_non_empty_tools_list` – non-empty tools are preserved

Fixes #24378