### PR TITLE
fix(gemini): handle null text in Gemini image generation responses

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1285,8 +1285,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             _content_str = ""
             if "text" in part:
                 text_content = part["text"]
+                # Guard against null text (e.g., Gemini image generation responses)
+                if text_content is None:
+                    continue
                 # Check if text content is audio data URI - if so, exclude from text content
-                if text_content.startswith("data:audio") and ";base64," in text_content:
+                elif text_content.startswith("data:audio") and ";base64," in text_content:
                     try:
                         if is_base64_encoded(text_content):
                             media_type, _ = text_content.split("data:")[1].split(

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -431,6 +431,26 @@ def test_vertex_ai_empty_content():
     assert reasoning_content is None
 
 
+def test_vertex_ai_gemini_image_generation_text_null():
+    """Test that get_assistant_content_message handles text: null (Gemini image generation responses)."""
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+    from litellm.types.llms.vertex_ai import HttpxPartType
+
+    v = VertexGeminiConfig()
+    # Gemini image generation responses have text: null in the part
+    parts = [
+        HttpxPartType(
+            text=None,
+        ),
+    ]
+    # Should not raise AttributeError: 'NoneType' object has no attribute 'startswith'
+    content, reasoning_content = v.get_assistant_content_message(parts=parts)
+    assert content is None
+    assert reasoning_content is None
+
+
 @pytest.mark.parametrize(
     "usage_metadata, inclusive, expected_usage",
     [


### PR DESCRIPTION
Guard against null text in `get_assistant_content_message` to prevent AttributeError when Gemini returns image generation responses with `text: null`.

Fixes #24385