### PR TITLE
Fix: Serialization bug 'MockValSer' object cannot be converted to 'SchemaSerializer'

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -64,6 +64,7 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "end_turn": "stop",
     "max_tokens": "length",
     "tool_use": "tool_calls",
+    "refusal": "content_filter",
     "compaction": "length",
     # Cohere
     "COMPLETE": "stop",
@@ -262,6 +263,43 @@ def process_response_headers(response_headers: Union[httpx.Headers, dict]) -> di
     return additional_headers
 
 
+def safe_model_dump(obj: "ModelResponseStream") -> dict:
+    """
+    Safely call model_dump(), falling back to __dict__ if the Pydantic
+    MockValSer bug (pydantic issue #7713) is encountered.
+
+    Returns:
+        A dictionary representation of the model. Note that the normal path
+        (model_dump()) recursively converts nested Pydantic models to plain
+        dicts/primitives, while the fallback path (__dict__) returns nested
+        Pydantic model instances (e.g., StreamingChoices, Delta) as-is.
+
+        Pydantic v2 initialization handles both representations when passed to
+        ModelResponseStream(**dict), so this divergence is typically transparent.
+        However, code that type-checks or iterates dict values may observe
+        different types on the fallback path.
+    """
+    try:
+        return obj.model_dump()
+    except TypeError as e:
+        if "MockValSer" not in str(e):
+            raise
+        verbose_logger.warning(
+            "Pydantic MockValSer bug detected (pydantic issue #7713); "
+            "falling back to __dict__ extraction. "
+            "Upgrading pydantic may resolve this. Error: %s",
+            e,
+        )
+        return {
+            k: v
+            for k, v in {
+                **dict(obj.__dict__),
+                **(getattr(obj, "__pydantic_extra__", None) or {}),
+            }.items()
+            if not k.startswith("_")
+        }
+
+
 def preserve_upstream_non_openai_attributes(
     model_response: "ModelResponseStream", original_chunk: "ModelResponseStream"
 ):
@@ -270,26 +308,7 @@ def preserve_upstream_non_openai_attributes(
     """
     # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
     expected_keys = set(type(model_response).model_fields.keys()).union({"usage"})
-    try:
-        obj_dict = original_chunk.model_dump()
-    except TypeError as e:
-        if "MockValSer" not in str(e):
-            raise
-        # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
-        verbose_logger.warning(
-            "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
-            "Upgrading pydantic may resolve this. Error: %s", e
-        )
-        # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
-        # Filter out underscore-prefixed private attributes to match model_dump() behavior
-        obj_dict = {
-            k: v
-            for k, v in {
-                **dict(original_chunk.__dict__),
-                **(getattr(original_chunk, '__pydantic_extra__', None) or {}),
-            }.items()
-            if not k.startswith('_')
-        }
+    obj_dict = safe_model_dump(original_chunk)
     for key, value in obj_dict.items():
         if key not in expected_keys:
             setattr(model_response, key, value)

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -281,9 +281,14 @@ def preserve_upstream_non_openai_attributes(
             "Upgrading pydantic may resolve this. Error: %s", e
         )
         # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
+        # Filter out underscore-prefixed private attributes to match model_dump() behavior
         obj_dict = {
-            **dict(original_chunk.__dict__),
-            **(getattr(original_chunk, '__pydantic_extra__', None) or {}),
+            k: v
+            for k, v in {
+                **dict(original_chunk.__dict__),
+                **(getattr(original_chunk, '__pydantic_extra__', None) or {}),
+            }.items()
+            if not k.startswith('_')
         }
     for key, value in obj_dict.items():
         if key not in expected_keys:

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -270,7 +270,12 @@ def preserve_upstream_non_openai_attributes(
     """
     # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
     expected_keys = set(type(model_response).model_fields.keys()).union({"usage"})
-    for key, value in original_chunk.model_dump().items():
+    try:
+        obj_dict = original_chunk.model_dump()
+    except TypeError:
+        # Fallback for Pydantic MockValSer bug (issue #18801)
+        obj_dict = dict(original_chunk.__dict__) if hasattr(original_chunk, '__dict__') else {}
+    for key, value in obj_dict.items():
         if key not in expected_keys:
             setattr(model_response, key, value)
 

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -1,5 +1,6 @@
 # What is this?
 ## Helper utilities
+import logging
 from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Union
 
 import httpx
@@ -275,11 +276,10 @@ def preserve_upstream_non_openai_attributes(
     except TypeError as e:
         if "MockValSer" not in str(e):
             raise
-        # Fallback for Pydantic MockValSer bug (issue #18801)
-        import logging
+        # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
         logging.getLogger("LiteLLM").warning(
-            "Pydantic MockValSer bug detected (issue #18801); falling back to __dict__ extraction. "
-            "Upgrade/downgrade pydantic if this persists. Error: %s", e
+            "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
+            "Upgrading pydantic may resolve this. Error: %s", e
         )
         # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
         obj_dict = {

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -272,7 +272,9 @@ def preserve_upstream_non_openai_attributes(
     expected_keys = set(type(model_response).model_fields.keys()).union({"usage"})
     try:
         obj_dict = original_chunk.model_dump()
-    except TypeError:
+    except TypeError as e:
+        if "MockValSer" not in str(e):
+            raise
         # Fallback for Pydantic MockValSer bug (issue #18801)
         obj_dict = dict(original_chunk.__dict__) if hasattr(original_chunk, '__dict__') else {}
     for key, value in obj_dict.items():

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -276,7 +276,16 @@ def preserve_upstream_non_openai_attributes(
         if "MockValSer" not in str(e):
             raise
         # Fallback for Pydantic MockValSer bug (issue #18801)
-        obj_dict = dict(original_chunk.__dict__) if hasattr(original_chunk, '__dict__') else {}
+        import logging
+        logging.getLogger("LiteLLM").warning(
+            "Pydantic MockValSer bug detected (issue #18801); falling back to __dict__ extraction. "
+            "Upgrade/downgrade pydantic if this persists. Error: %s", e
+        )
+        # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
+        obj_dict = {
+            **dict(original_chunk.__dict__),
+            **(getattr(original_chunk, '__pydantic_extra__', None) or {}),
+        }
     for key, value in obj_dict.items():
         if key not in expected_keys:
             setattr(model_response, key, value)

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -278,6 +278,12 @@ def safe_model_dump(obj: "ModelResponseStream") -> dict:
         ModelResponseStream(**dict), so this divergence is typically transparent.
         However, code that type-checks or iterates dict values may observe
         different types on the fallback path.
+
+    Note:
+        Both call sites in streaming_handler.py pass the returned dict to
+        Pydantic model reconstruction (ModelResponseStream(**dict)), which
+        accepts nested Pydantic instances. No intermediate processing assumes
+        plain dicts, so the type divergence is safe.
     """
     try:
         return obj.model_dump()

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -1,6 +1,5 @@
 # What is this?
 ## Helper utilities
-import logging
 from typing import TYPE_CHECKING, Any, Iterable, List, Literal, Optional, Union
 
 import httpx
@@ -277,7 +276,7 @@ def preserve_upstream_non_openai_attributes(
         if "MockValSer" not in str(e):
             raise
         # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
-        logging.getLogger("LiteLLM").warning(
+        verbose_logger.warning(
             "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
             "Upgrading pydantic may resolve this. Error: %s", e
         )

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2110,6 +2110,10 @@ class CustomStreamWrapper:
                     ):
                         chunk = self.completion_stream
                     else:
+                        # Off-load blocking __next__ to thread pool to avoid blocking event loop.
+                        # Providers like boto3 return sync iterators that do real network I/O in
+                        # __next__, so we must prevent them from blocking the async event loop.
+                        # The thread overhead per chunk is acceptable for this I/O-bound path.
                         chunk = await asyncio.to_thread(_next_sync_or_exhausted, self.completion_stream)  # type: ignore[arg-type]
                         if chunk is _SYNC_ITER_EXHAUSTED:
                             raise StopAsyncIteration

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1865,7 +1865,16 @@ class CustomStreamWrapper:
                             if "MockValSer" not in str(e):
                                 raise
                             # Fallback for Pydantic MockValSer bug (issue #18801)
-                            obj_dict = dict(response.__dict__) if hasattr(response, '__dict__') else {}
+                            import logging
+                            logging.getLogger("LiteLLM").warning(
+                                "Pydantic MockValSer bug detected (issue #18801); falling back to __dict__ extraction. "
+                                "Upgrade/downgrade pydantic if this persists. Error: %s", e
+                            )
+                            # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
+                            obj_dict = {
+                                **dict(response.__dict__),
+                                **(getattr(response, '__pydantic_extra__', None) or {}),
+                            }
 
                         # Remove an attribute (e.g., 'attr2')
                         if "usage" in obj_dict:
@@ -2059,7 +2068,16 @@ class CustomStreamWrapper:
                             if "MockValSer" not in str(e):
                                 raise
                             # Fallback for Pydantic MockValSer bug (issue #18801)
-                            obj_dict = dict(processed_chunk.__dict__) if hasattr(processed_chunk, '__dict__') else {}
+                            import logging
+                            logging.getLogger("LiteLLM").warning(
+                                "Pydantic MockValSer bug detected (issue #18801); falling back to __dict__ extraction. "
+                                "Upgrade/downgrade pydantic if this persists. Error: %s", e
+                            )
+                            # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
+                            obj_dict = {
+                                **dict(processed_chunk.__dict__),
+                                **(getattr(processed_chunk, '__pydantic_extra__', None) or {}),
+                            }
                         if "usage" in obj_dict:
                             del obj_dict["usage"]
                         processed_chunk = self.model_response_creator(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1865,7 +1865,7 @@ class CustomStreamWrapper:
                             if "MockValSer" not in str(e):
                                 raise
                             # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
-                            logging.getLogger("LiteLLM").warning(
+                            verbose_logger.warning(
                                 "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
                                 "Upgrading pydantic may resolve this. Error: %s", e
                             )
@@ -2067,7 +2067,7 @@ class CustomStreamWrapper:
                             if "MockValSer" not in str(e):
                                 raise
                             # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
-                            logging.getLogger("LiteLLM").warning(
+                            verbose_logger.warning(
                                 "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
                                 "Upgrading pydantic may resolve this. Error: %s", e
                             )

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1862,7 +1862,9 @@ class CustomStreamWrapper:
                         try:
                             obj_dict = response.model_dump()
                         except TypeError as e:
-                            # Fallback: manually extract dict from __dict__ to bypass Pydantic serializer
+                            if "MockValSer" not in str(e):
+                                raise
+                            # Fallback for Pydantic MockValSer bug (issue #18801)
                             obj_dict = dict(response.__dict__) if hasattr(response, '__dict__') else {}
 
                         # Remove an attribute (e.g., 'attr2')
@@ -2054,7 +2056,9 @@ class CustomStreamWrapper:
                         try:
                             obj_dict = processed_chunk.model_dump()
                         except TypeError as e:
-                            # Fallback: manually extract dict from __dict__ to bypass Pydantic serializer
+                            if "MockValSer" not in str(e):
+                                raise
+                            # Fallback for Pydantic MockValSer bug (issue #18801)
                             obj_dict = dict(processed_chunk.__dict__) if hasattr(processed_chunk, '__dict__') else {}
                         if "usage" in obj_dict:
                             del obj_dict["usage"]

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1870,9 +1870,14 @@ class CustomStreamWrapper:
                                 "Upgrading pydantic may resolve this. Error: %s", e
                             )
                             # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
+                            # Filter out underscore-prefixed private attributes to match model_dump() behavior
                             obj_dict = {
-                                **dict(response.__dict__),
-                                **(getattr(response, '__pydantic_extra__', None) or {}),
+                                k: v
+                                for k, v in {
+                                    **dict(response.__dict__),
+                                    **(getattr(response, '__pydantic_extra__', None) or {}),
+                                }.items()
+                                if not k.startswith('_')
                             }
 
                         # Remove an attribute (e.g., 'attr2')
@@ -2072,9 +2077,14 @@ class CustomStreamWrapper:
                                 "Upgrading pydantic may resolve this. Error: %s", e
                             )
                             # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
+                            # Filter out underscore-prefixed private attributes to match model_dump() behavior
                             obj_dict = {
-                                **dict(processed_chunk.__dict__),
-                                **(getattr(processed_chunk, '__pydantic_extra__', None) or {}),
+                                k: v
+                                for k, v in {
+                                    **dict(processed_chunk.__dict__),
+                                    **(getattr(processed_chunk, '__pydantic_extra__', None) or {}),
+                                }.items()
+                                if not k.startswith('_')
                             }
                         if "usage" in obj_dict:
                             del obj_dict["usage"]

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1864,11 +1864,10 @@ class CustomStreamWrapper:
                         except TypeError as e:
                             if "MockValSer" not in str(e):
                                 raise
-                            # Fallback for Pydantic MockValSer bug (issue #18801)
-                            import logging
+                            # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
                             logging.getLogger("LiteLLM").warning(
-                                "Pydantic MockValSer bug detected (issue #18801); falling back to __dict__ extraction. "
-                                "Upgrade/downgrade pydantic if this persists. Error: %s", e
+                                "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
+                                "Upgrading pydantic may resolve this. Error: %s", e
                             )
                             # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
                             obj_dict = {
@@ -2067,11 +2066,10 @@ class CustomStreamWrapper:
                         except TypeError as e:
                             if "MockValSer" not in str(e):
                                 raise
-                            # Fallback for Pydantic MockValSer bug (issue #18801)
-                            import logging
+                            # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
                             logging.getLogger("LiteLLM").warning(
-                                "Pydantic MockValSer bug detected (issue #18801); falling back to __dict__ extraction. "
-                                "Upgrade/downgrade pydantic if this persists. Error: %s", e
+                                "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
+                                "Upgrading pydantic may resolve this. Error: %s", e
                             )
                             # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
                             obj_dict = {

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -46,7 +46,11 @@ from litellm.types.utils import (
 )
 
 from ..exceptions import OpenAIError
-from .core_helpers import map_finish_reason, process_response_headers
+from .core_helpers import (
+    map_finish_reason,
+    process_response_headers,
+    safe_model_dump,
+)
 from .exception_mapping_utils import exception_type
 from .llm_response_utils.get_api_base import get_api_base
 from .rules import Rules
@@ -56,6 +60,22 @@ AUDIO_ATTRIBUTE = "audio"
 IMAGE_ATTRIBUTE = "images"
 TOOL_CALLS_ATTRIBUTE = "tool_calls"
 FUNCTION_CALL_ATTRIBUTE = "function_call"
+
+_SYNC_ITER_EXHAUSTED = object()
+
+
+def _next_sync_or_exhausted(it: Any) -> Any:
+    """
+    Call next(it) from a thread and return _SYNC_ITER_EXHAUSTED on StopIteration.
+
+    asyncio.to_thread re-raises thread exceptions inside a coroutine, where PEP 479
+    converts StopIteration to RuntimeError before any except clause can catch it.
+    Returning a sentinel instead keeps StopIteration out of the coroutine boundary.
+    """
+    try:
+        return next(it)
+    except StopIteration:
+        return _SYNC_ITER_EXHAUSTED
 
 
 def is_async_iterable(obj: Any) -> bool:
@@ -111,9 +131,9 @@ class CustomStreamWrapper:
 
         self.system_fingerprint: Optional[str] = None
         self.received_finish_reason: Optional[str] = None
-        self.intermittent_finish_reason: Optional[
-            str
-        ] = None  # finish reasons that show up mid-stream
+        self.intermittent_finish_reason: Optional[str] = (
+            None  # finish reasons that show up mid-stream
+        )
         self.special_tokens = [
             "<|assistant|>",
             "<|system|>",
@@ -1500,9 +1520,9 @@ class CustomStreamWrapper:
                                                 t.function.arguments = ""
                             _json_delta = delta.model_dump()
                             if "role" not in _json_delta or _json_delta["role"] is None:
-                                _json_delta[
-                                    "role"
-                                ] = "assistant"  # mistral's api returns role as None
+                                _json_delta["role"] = (
+                                    "assistant"  # mistral's api returns role as None
+                                )
                             if "tool_calls" in _json_delta and isinstance(
                                 _json_delta["tool_calls"], list
                             ):
@@ -1859,26 +1879,7 @@ class CustomStreamWrapper:
                         response, "usage"
                     ):  # remove usage from chunk, only send on final chunk
                         # Convert the object to a dictionary
-                        try:
-                            obj_dict = response.model_dump()
-                        except TypeError as e:
-                            if "MockValSer" not in str(e):
-                                raise
-                            # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
-                            verbose_logger.warning(
-                                "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
-                                "Upgrading pydantic may resolve this. Error: %s", e
-                            )
-                            # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
-                            # Filter out underscore-prefixed private attributes to match model_dump() behavior
-                            obj_dict = {
-                                k: v
-                                for k, v in {
-                                    **dict(response.__dict__),
-                                    **(getattr(response, '__pydantic_extra__', None) or {}),
-                                }.items()
-                                if not k.startswith('_')
-                            }
+                        obj_dict = safe_model_dump(response)
 
                         # Remove an attribute (e.g., 'attr2')
                         if "usage" in obj_dict:
@@ -2066,26 +2067,7 @@ class CustomStreamWrapper:
 
                         # Strip usage from the outgoing chunk so it's not sent twice
                         # (once in the chunk, once in _hidden_params).
-                        try:
-                            obj_dict = processed_chunk.model_dump()
-                        except TypeError as e:
-                            if "MockValSer" not in str(e):
-                                raise
-                            # Fallback for Pydantic MockValSer bug (pydantic issue #7713)
-                            verbose_logger.warning(
-                                "Pydantic MockValSer bug detected (pydantic issue #7713); falling back to __dict__ extraction. "
-                                "Upgrading pydantic may resolve this. Error: %s", e
-                            )
-                            # Merge __dict__ with __pydantic_extra__ to preserve dynamically-added provider fields
-                            # Filter out underscore-prefixed private attributes to match model_dump() behavior
-                            obj_dict = {
-                                k: v
-                                for k, v in {
-                                    **dict(processed_chunk.__dict__),
-                                    **(getattr(processed_chunk, '__pydantic_extra__', None) or {}),
-                                }.items()
-                                if not k.startswith('_')
-                            }
+                        obj_dict = safe_model_dump(processed_chunk)
                         if "usage" in obj_dict:
                             del obj_dict["usage"]
                         processed_chunk = self.model_response_creator(
@@ -2128,7 +2110,9 @@ class CustomStreamWrapper:
                     ):
                         chunk = self.completion_stream
                     else:
-                        chunk = next(self.completion_stream)  # type: ignore[arg-type]
+                        chunk = await asyncio.to_thread(_next_sync_or_exhausted, self.completion_stream)  # type: ignore[arg-type]
+                        if chunk is _SYNC_ITER_EXHAUSTED:
+                            raise StopAsyncIteration
                     if chunk is not None and chunk != b"":
                         processed_chunk = self.chunk_creator(chunk=chunk)
                         if processed_chunk is None:
@@ -2188,22 +2172,36 @@ class CustomStreamWrapper:
                     self.sent_stream_usage = True
                     return response
 
-                asyncio.create_task(
-                    self.logging_obj.async_success_handler(
+                _deferred_cb = getattr(
+                    self.logging_obj,
+                    "_on_deferred_stream_complete",
+                    None,
+                )
+                if _deferred_cb is not None:
+                    # Proxy has post-call guardrails — let the closure
+                    # run guardrails on the assembled response, then
+                    # fire logging with guardrail_information populated.
+                    self.logging_obj._on_deferred_stream_complete = None  # type: ignore[attr-defined]
+                    asyncio.create_task(
+                        _deferred_cb(complete_streaming_response, cache_hit)
+                    )
+                else:
+                    asyncio.create_task(
+                        self.logging_obj.async_success_handler(
+                            complete_streaming_response,
+                            cache_hit=cache_hit,
+                            start_time=None,
+                            end_time=None,
+                        )
+                    )
+
+                    executor.submit(
+                        self.logging_obj.success_handler,
                         complete_streaming_response,
                         cache_hit=cache_hit,
                         start_time=None,
                         end_time=None,
                     )
-                )
-
-                executor.submit(
-                    self.logging_obj.success_handler,
-                    complete_streaming_response,
-                    cache_hit=cache_hit,
-                    start_time=None,
-                    end_time=None,
-                )
 
                 raise StopAsyncIteration  # Re-raise StopIteration
             else:

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1859,7 +1859,11 @@ class CustomStreamWrapper:
                         response, "usage"
                     ):  # remove usage from chunk, only send on final chunk
                         # Convert the object to a dictionary
-                        obj_dict = response.model_dump()
+                        try:
+                            obj_dict = response.model_dump()
+                        except TypeError as e:
+                            # Fallback: manually extract dict from __dict__ to bypass Pydantic serializer
+                            obj_dict = dict(response.__dict__) if hasattr(response, '__dict__') else {}
 
                         # Remove an attribute (e.g., 'attr2')
                         if "usage" in obj_dict:
@@ -2047,7 +2051,11 @@ class CustomStreamWrapper:
 
                         # Strip usage from the outgoing chunk so it's not sent twice
                         # (once in the chunk, once in _hidden_params).
-                        obj_dict = processed_chunk.model_dump()
+                        try:
+                            obj_dict = processed_chunk.model_dump()
+                        except TypeError as e:
+                            # Fallback: manually extract dict from __dict__ to bypass Pydantic serializer
+                            obj_dict = dict(processed_chunk.__dict__) if hasattr(processed_chunk, '__dict__') else {}
                         if "usage" in obj_dict:
                             del obj_dict["usage"]
                         processed_chunk = self.model_response_creator(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1691,6 +1691,8 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
     SchemaSerializer in certain scenarios. The fix catches TypeError and falls
     back to __dict__ extraction.
     """
+    from unittest.mock import patch
+
     # Create a chunk with usage that will be stripped
     chunk_with_usage = ModelResponseStream(
         id="test-chunk",
@@ -1710,15 +1712,12 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
     # Add a provider-specific field to test __pydantic_extra__ preservation
     chunk_with_usage.sap_extra_field = "sap-value"
 
-    # Mock model_dump to raise TypeError (simulating MockValSer bug)
-    original_model_dump = chunk_with_usage.model_dump
-
-    def mock_model_dump(*args, **kwargs):
+    # Mock model_dump at class level to avoid polluting instance attributes
+    def mock_model_dump(self, *args, **kwargs):
         raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
 
-    chunk_with_usage.model_dump = mock_model_dump
-
-    try:
+    # Use class-level patching to avoid the mock appearing in __dict__ or __pydantic_extra__
+    with patch.object(type(chunk_with_usage), 'model_dump', mock_model_dump):
         # The code should gracefully fall back to __dict__ and not crash
         initialized_custom_stream_wrapper.chunks.append(chunk_with_usage)
 
@@ -1750,6 +1749,8 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
 
         # Now this assertion is meaningful: it verifies the attribute was actually COPIED
         assert getattr(result, "sap_extra_field", None) == "sap-value"
-    finally:
-        # Restore original method
-        chunk_with_usage.model_dump = original_model_dump
+
+    # Verify that result can still be serialized (model_dump method is not corrupted)
+    # This call is outside the patch context so it should work normally
+    result_dict = result.model_dump()
+    assert isinstance(result_dict, dict)

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1865,7 +1865,12 @@ async def test_custom_stream_wrapper_anext_does_not_block_event_loop_for_sync_it
     elapsed = asyncio.get_event_loop().time() - start
     assert isinstance(out, ModelResponseStream)
     # background_tick sleeps 0.05 s; total must finish well under 2 × 0.3 s
-    assert elapsed < 0.5, f"Event loop was likely blocked (elapsed={elapsed:.2f}s)"
+    # Use generous threshold to avoid CI jitter on overloaded runners
+    assert elapsed < 1.5, f"Event loop was likely blocked (elapsed={elapsed:.2f}s)"
+    # Structural assertion: if non-blocking, background_tick completed and set the event
+    assert (
+        tick_event.is_set()
+    ), "Background coroutine did not run (event loop was blocked)"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -770,7 +770,9 @@ async def test_vertex_streaming_bad_request_not_midstream(logging_obj: Logging):
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     async def _raise_bad_request(**kwargs):
-        raise VertexAIError(status_code=400, message="invalid maxOutputTokens", headers=None)
+        raise VertexAIError(
+            status_code=400, message="invalid maxOutputTokens", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -788,7 +790,9 @@ async def test_vertex_streaming_bad_request_not_midstream(logging_obj: Logging):
 
 
 @pytest.mark.asyncio
-async def test_vertex_streaming_rate_limit_triggers_midstream_fallback(logging_obj: Logging):
+async def test_vertex_streaming_rate_limit_triggers_midstream_fallback(
+    logging_obj: Logging,
+):
     """Ensure Vertex 429 rate-limit errors raise MidStreamFallbackError, not RateLimitError.
 
     Regression test for https://github.com/BerriAI/litellm/issues/20870
@@ -797,7 +801,9 @@ async def test_vertex_streaming_rate_limit_triggers_midstream_fallback(logging_o
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     async def _raise_rate_limit(**kwargs):
-        raise VertexAIError(status_code=429, message="Resource exhausted.", headers=None)
+        raise VertexAIError(
+            status_code=429, message="Resource exhausted.", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -825,7 +831,9 @@ def test_sync_streaming_rate_limit_triggers_midstream_fallback(logging_obj: Logg
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     def _raise_rate_limit(**kwargs):
-        raise VertexAIError(status_code=429, message="Resource exhausted.", headers=None)
+        raise VertexAIError(
+            status_code=429, message="Resource exhausted.", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -850,7 +858,9 @@ def test_sync_streaming_bad_request_not_midstream(logging_obj: Logging):
     from litellm.llms.vertex_ai.common_utils import VertexAIError
 
     def _raise_bad_request(**kwargs):
-        raise VertexAIError(status_code=400, message="invalid maxOutputTokens", headers=None)
+        raise VertexAIError(
+            status_code=400, message="invalid maxOutputTokens", headers=None
+        )
 
     response = CustomStreamWrapper(
         completion_stream=None,
@@ -1363,6 +1373,7 @@ def _build_chunks(pattern: list[str], N: int) -> list[ModelResponseStream]:
             chunks.append(_make_chunk(p))
     return chunks
 
+
 _REPETITION_TEST_CASES = [
     # Basic cases
     pytest.param(
@@ -1419,7 +1430,14 @@ _REPETITION_TEST_CASES = [
         id="last_chunk_different_no_raise",
     ),
     pytest.param(
-        ["same"] * (litellm.REPEATED_STREAMING_CHUNK_LIMIT // 2 + 1) + ["different_mid"] + ["same"] * (litellm.REPEATED_STREAMING_CHUNK_LIMIT - litellm.REPEATED_STREAMING_CHUNK_LIMIT // 2 + 1),
+        ["same"] * (litellm.REPEATED_STREAMING_CHUNK_LIMIT // 2 + 1)
+        + ["different_mid"]
+        + ["same"]
+        * (
+            litellm.REPEATED_STREAMING_CHUNK_LIMIT
+            - litellm.REPEATED_STREAMING_CHUNK_LIMIT // 2
+            + 1
+        ),
         False,
         id="middle_chunk_different_no_raise",
     ),
@@ -1429,7 +1447,9 @@ _REPETITION_TEST_CASES = [
         id="last_two_different_no_raise",
     ),
     pytest.param(
-        ["diff"] * litellm.REPEATED_STREAMING_CHUNK_LIMIT + ["same"] * litellm.REPEATED_STREAMING_CHUNK_LIMIT + ["diff"],
+        ["diff"] * litellm.REPEATED_STREAMING_CHUNK_LIMIT
+        + ["same"] * litellm.REPEATED_STREAMING_CHUNK_LIMIT
+        + ["diff"],
         True,
         id="in_between_same_and_diff_raise",
     ),
@@ -1455,6 +1475,8 @@ def test_raise_on_model_repetition(
         for chunk in chunks:
             wrapper.chunks.append(chunk)
             wrapper.raise_on_model_repetition()
+
+
 def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
     """
     Test that provider-reported usage from a post-finish_reason chunk
@@ -1536,12 +1558,13 @@ def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
     last_chunk = collected[-1]
     hidden_usage = last_chunk._hidden_params.get("usage")
     assert hidden_usage is not None, "Expected usage in _hidden_params"
-    assert hidden_usage.prompt_tokens == 20, (
-        f"Expected prompt_tokens=20 from provider, got {hidden_usage.prompt_tokens}"
-    )
-    assert hidden_usage.completion_tokens == 135, (
-        f"Expected completion_tokens=135 from provider, got {hidden_usage.completion_tokens}"
-    )
+    assert (
+        hidden_usage.prompt_tokens == 20
+    ), f"Expected prompt_tokens=20 from provider, got {hidden_usage.prompt_tokens}"
+    assert (
+        hidden_usage.completion_tokens == 135
+    ), f"Expected completion_tokens=135 from provider, got {hidden_usage.completion_tokens}"
+
 
 @pytest.mark.asyncio
 async def test_custom_stream_wrapper_aclose():
@@ -1615,9 +1638,9 @@ def test_content_not_dropped_when_finish_reason_already_set(
 
     result = initialized_custom_stream_wrapper.chunk_creator(chunk=content_chunk)
 
-    assert result is not None, (
-        "chunk_creator() returned None — content was dropped (issue #22098)"
-    )
+    assert (
+        result is not None
+    ), "chunk_creator() returned None — content was dropped (issue #22098)"
     assert result.choices[0].delta.content == "world!"
 
 
@@ -1669,14 +1692,14 @@ def test_tool_use_not_dropped_when_finish_reason_already_set(
 
     result = initialized_custom_stream_wrapper.chunk_creator(chunk=tool_chunk)
 
-    assert result is not None, (
-        "chunk_creator() returned None — tool_use data was dropped"
-    )
+    assert (
+        result is not None
+    ), "chunk_creator() returned None — tool_use data was dropped"
 
     tool_calls = result.choices[0].delta.tool_calls
-    assert tool_calls is not None and len(tool_calls) > 0, (
-        "tool_calls should contain at least one tool call"
-    )
+    assert (
+        tool_calls is not None and len(tool_calls) > 0
+    ), "tool_calls should contain at least one tool call"
     assert tool_calls[0].id == "call_1"
     assert tool_calls[0].function.name == "get_weather"
 
@@ -1691,10 +1714,17 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
     SchemaSerializer in certain scenarios. The fix catches TypeError and falls
     back to __dict__ extraction.
     """
-    from unittest.mock import patch
 
     # Create a chunk with usage that will be stripped
-    chunk_with_usage = ModelResponseStream(
+    # Create a subclass with corrupted model_dump to isolate the bug to a single instance
+    class CorruptedModelResponseStream(ModelResponseStream):
+        def model_dump(self, **kwargs):
+            raise TypeError(
+                "'MockValSer' object cannot be converted to 'SchemaSerializer'"
+            )
+
+    # Create an instance of the corrupted subclass
+    corrupted_chunk = CorruptedModelResponseStream(
         id="test-chunk",
         created=1742056047,
         model="sap-ai-core/test-model",
@@ -1710,47 +1740,199 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
     )
 
     # Add a provider-specific field to test __pydantic_extra__ preservation
-    chunk_with_usage.sap_extra_field = "sap-value"
+    corrupted_chunk.sap_extra_field = "sap-value"
 
-    # Mock model_dump at class level to avoid polluting instance attributes
-    def mock_model_dump(self, *args, **kwargs):
-        raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
+    # Use a DIFFERENT object as the target model_response
+    fresh_model_response = ModelResponseStream(
+        id="fresh",
+        created=1742056047,
+        model="sap-ai-core/test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="test content", role="assistant"),
+            )
+        ],
+    )
 
-    # Use class-level patching to avoid the mock appearing in __dict__ or __pydantic_extra__
-    with patch.object(type(chunk_with_usage), 'model_dump', mock_model_dump):
-        # The code should gracefully fall back to __dict__ and not crash
-        initialized_custom_stream_wrapper.chunks.append(chunk_with_usage)
+    # Verify fresh_model_response.model_dump() still works normally
+    # (proves subclass approach doesn't affect other instances)
+    assert callable(fresh_model_response.model_dump)
+    test_dump = fresh_model_response.model_dump()
+    assert isinstance(test_dump, dict)
 
-        # Use a DIFFERENT object as the target model_response
-        fresh_model_response = ModelResponseStream(
-            id="fresh",
-            created=1742056047,
-            model="sap-ai-core/test-model",
-            object="chat.completion.chunk",
-            choices=[
-                StreamingChoices(
-                    finish_reason=None,
-                    index=0,
-                    delta=Delta(content="test content", role="assistant"),
-                )
-            ],
-        )
+    # Process the chunk through return_processed_chunk_logic which calls model_dump
+    result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
+        completion_obj={"content": "test content"},
+        response_obj={"original_chunk": corrupted_chunk},  # source of extra attrs
+        model_response=fresh_model_response,  # target (different object)
+    )
 
-        # Process the chunk through return_processed_chunk_logic which calls model_dump
-        result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
-            completion_obj={"content": "test content"},
-            response_obj={"original_chunk": chunk_with_usage},  # source of extra attrs
-            model_response=fresh_model_response,                 # target (different object)
-        )
+    # Should not raise TypeError and should successfully process the chunk
+    assert result is not None
+    assert result.choices[0].delta.content == "test content"
 
-        # Should not raise TypeError and should successfully process the chunk
-        assert result is not None
-        assert result.choices[0].delta.content == "test content"
-
-        # Now this assertion is meaningful: it verifies the attribute was actually COPIED
-        assert getattr(result, "sap_extra_field", None) == "sap-value"
+    # Now this assertion is meaningful: it verifies the attribute was actually COPIED
+    assert getattr(result, "sap_extra_field", None) == "sap-value"
 
     # Verify that result can still be serialized (model_dump method is not corrupted)
-    # This call is outside the patch context so it should work normally
     result_dict = result.model_dump()
     assert isinstance(result_dict, dict)
+    # Extra provider field should survive into the serialized output
+    assert result_dict.get("sap_extra_field") == "sap-value"
+
+    # Verify nested structures are accessible (validates fallback behavior)
+    # The fallback returns nested Pydantic instances instead of plain dicts,
+    # but they should still be accessible and functional
+    assert result.choices is not None
+    assert len(result.choices) > 0
+    assert result.choices[0].delta.content == "test content"
+
+
+@pytest.mark.asyncio
+async def test_custom_stream_wrapper_anext_does_not_block_event_loop_for_sync_iterators(
+    logging_obj: Logging,
+):
+    """
+    Regression test: __anext__ must not call blocking next() on a sync iterator on the
+    event loop thread. This happens for some provider streams which are sync iterators
+    but used in async contexts (e.g. boto3-style streaming).
+    """
+
+    class BlockingIterator:
+        def __init__(self, chunks, delay_s: float):
+            self._it = iter(chunks)
+            self._delay_s = delay_s
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            time.sleep(self._delay_s)  # simulate blocking I/O
+            return next(self._it)
+
+    test_chunk = ModelResponseStream(
+        id="chatcmpl-test",
+        created=int(time.time()),
+        model="test-model",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content="hello",
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields={},
+        usage=None,
+    )
+
+    # Delay is intentionally > the wait_for timeout used to detect event loop blocking.
+    wrapper = CustomStreamWrapper(
+        completion_stream=BlockingIterator([test_chunk], delay_s=0.3),
+        model="test-model",
+        logging_obj=logging_obj,
+        custom_llm_provider="cached_response",
+    )
+
+    tick_event = asyncio.Event()
+
+    async def background_tick():
+        await asyncio.sleep(0.05)
+        tick_event.set()
+
+    # Run the two coroutines concurrently and measure wall time.
+    # If __anext__ blocks the event loop, background_tick can't run and the gather
+    # takes the full 0.3 s delay; if non-blocking both finish within ~0.35 s total.
+    start = asyncio.get_event_loop().time()
+
+    out, _ = await asyncio.gather(
+        wrapper.__anext__(),
+        background_tick(),
+    )
+
+    elapsed = asyncio.get_event_loop().time() - start
+    assert isinstance(out, ModelResponseStream)
+    # background_tick sleeps 0.05 s; total must finish well under 2 × 0.3 s
+    assert elapsed < 0.5, f"Event loop was likely blocked (elapsed={elapsed:.2f}s)"
+
+
+@pytest.mark.asyncio
+async def test_custom_stream_wrapper_anext_exhaustion_raises_stop_async_iteration(
+    logging_obj: Logging,
+):
+    """
+    PEP 479 regression: when a sync iterator is exhausted, asyncio.to_thread(next, it)
+    raises StopIteration inside a coroutine, which Python converts to RuntimeError.
+    The wrapper must catch StopIteration in the thread and raise StopAsyncIteration
+    in the coroutine instead, so callers get clean stream termination.
+    """
+
+    class SingleChunkIterator:
+        def __init__(self, chunk: ModelResponseStream):
+            self._chunk = chunk
+            self._done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._done:
+                raise StopIteration
+            self._done = True
+            return self._chunk
+
+    test_chunk = ModelResponseStream(
+        id="chatcmpl-exhaustion-test",
+        created=int(time.time()),
+        model="test-model",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content="done",
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields={},
+        usage=None,
+    )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=SingleChunkIterator(test_chunk),
+        model="test-model",
+        logging_obj=logging_obj,
+        custom_llm_provider="cached_response",
+    )
+
+    # Drain the wrapper fully.  The wrapper's except-handler calls finish_reason_handler()
+    # on the first StopAsyncIteration (sent_last_chunk=False→True), then re-raises on the
+    # next call.  What must NOT happen is a RuntimeError from PEP 479 converting
+    # StopIteration (raised inside the thread) to RuntimeError inside the coroutine.
+    try:
+        while True:
+            await wrapper.__anext__()
+    except StopAsyncIteration:
+        pass  # expected clean termination
+    except RuntimeError as e:
+        pytest.fail(f"PEP 479 regression: StopIteration leaked as RuntimeError: {e}")

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1679,3 +1679,52 @@ def test_tool_use_not_dropped_when_finish_reason_already_set(
     )
     assert tool_calls[0].id == "call_1"
     assert tool_calls[0].function.name == "get_weather"
+
+
+def test_model_dump_fallback_handles_pydantic_serializer_bug(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """
+    Regression test for #18801: MockValSer TypeError in streaming responses.
+
+    Pydantic 2.11+ has a bug where MockValSer sentinel is not converted to
+    SchemaSerializer in certain scenarios. The fix catches TypeError and falls
+    back to __dict__ extraction.
+    """
+    # Create a chunk with usage that will be stripped
+    chunk_with_usage = ModelResponseStream(
+        id="test-chunk",
+        created=1742056047,
+        model="sap-ai-core/test-model",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="test content", role="assistant"),
+            )
+        ],
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+    # Mock model_dump to raise TypeError (simulating MockValSer bug)
+    original_model_dump = chunk_with_usage.model_dump
+
+    def mock_model_dump(*args, **kwargs):
+        raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
+
+    chunk_with_usage.model_dump = mock_model_dump
+
+    # The code should gracefully fall back to __dict__ and not crash
+    initialized_custom_stream_wrapper.chunks.append(chunk_with_usage)
+
+    # Process the chunk through return_processed_chunk_logic which calls model_dump
+    result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
+        completion_obj={"content": "test content"},
+        response_obj={"original_chunk": chunk_with_usage},
+        model_response=chunk_with_usage,
+    )
+
+    # Should not raise TypeError and should successfully process the chunk
+    assert result is not None
+    assert result.choices[0].delta.content == "test content"

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1715,16 +1715,20 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
 
     chunk_with_usage.model_dump = mock_model_dump
 
-    # The code should gracefully fall back to __dict__ and not crash
-    initialized_custom_stream_wrapper.chunks.append(chunk_with_usage)
+    try:
+        # The code should gracefully fall back to __dict__ and not crash
+        initialized_custom_stream_wrapper.chunks.append(chunk_with_usage)
 
-    # Process the chunk through return_processed_chunk_logic which calls model_dump
-    result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
-        completion_obj={"content": "test content"},
-        response_obj={"original_chunk": chunk_with_usage},
-        model_response=chunk_with_usage,
-    )
+        # Process the chunk through return_processed_chunk_logic which calls model_dump
+        result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
+            completion_obj={"content": "test content"},
+            response_obj={"original_chunk": chunk_with_usage},
+            model_response=chunk_with_usage,
+        )
 
-    # Should not raise TypeError and should successfully process the chunk
-    assert result is not None
-    assert result.choices[0].delta.content == "test content"
+        # Should not raise TypeError and should successfully process the chunk
+        assert result is not None
+        assert result.choices[0].delta.content == "test content"
+    finally:
+        # Restore original method
+        chunk_with_usage.model_dump = original_model_dump

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1722,18 +1722,33 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
         # The code should gracefully fall back to __dict__ and not crash
         initialized_custom_stream_wrapper.chunks.append(chunk_with_usage)
 
+        # Use a DIFFERENT object as the target model_response
+        fresh_model_response = ModelResponseStream(
+            id="fresh",
+            created=1742056047,
+            model="sap-ai-core/test-model",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(content="test content", role="assistant"),
+                )
+            ],
+        )
+
         # Process the chunk through return_processed_chunk_logic which calls model_dump
         result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
             completion_obj={"content": "test content"},
-            response_obj={"original_chunk": chunk_with_usage},
-            model_response=chunk_with_usage,
+            response_obj={"original_chunk": chunk_with_usage},  # source of extra attrs
+            model_response=fresh_model_response,                 # target (different object)
         )
 
         # Should not raise TypeError and should successfully process the chunk
         assert result is not None
         assert result.choices[0].delta.content == "test content"
 
-        # Verify that extra/provider attributes survive the fallback
+        # Now this assertion is meaningful: it verifies the attribute was actually COPIED
         assert getattr(result, "sap_extra_field", None) == "sap-value"
     finally:
         # Restore original method

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1707,6 +1707,9 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
         usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
     )
 
+    # Add a provider-specific field to test __pydantic_extra__ preservation
+    chunk_with_usage.sap_extra_field = "sap-value"
+
     # Mock model_dump to raise TypeError (simulating MockValSer bug)
     original_model_dump = chunk_with_usage.model_dump
 
@@ -1729,6 +1732,9 @@ def test_model_dump_fallback_handles_pydantic_serializer_bug(
         # Should not raise TypeError and should successfully process the chunk
         assert result is not None
         assert result.choices[0].delta.content == "test content"
+
+        # Verify that extra/provider attributes survive the fallback
+        assert getattr(result, "sap_extra_field", None) == "sap-value"
     finally:
         # Restore original method
         chunk_with_usage.model_dump = original_model_dump


### PR DESCRIPTION
## Problem

`TypeError: 'MockValSer' object cannot be converted to 'SchemaSerializer'` when handling streaming responses with SAP AI Core and other providers (vLLM, etc).

**Related GitHub Issue:** https://github.com/BerriAI/litellm/issues/18801  
**Related Pydantic Issue:** https://github.com/pydantic/pydantic/issues/7713

## Root Cause

Pydantic 2.11+ has a bug where the internal `MockValSer` sentinel is not properly converted to a real `SchemaSerializer` in certain streaming scenarios. When LiteLLM tries to serialize streaming chunks using `model_dump()`, it hits this corrupted serializer state and crashes.

The bug occurs when:
1. A chunk is created from a dictionary and properly serialized
2. LiteLLM modifies the chunk (e.g., stripping usage data)
3. A new chunk is reconstructed from the modified dictionary
4. Pydantic fails to fully initialize the serializer on the new object
5. Subsequent `model_dump()` calls crash with MockValSer TypeError

## Solution

Added try-catch fallback that uses `__dict__` extraction when `model_dump()` fails with `TypeError`. This bypasses Pydantic's broken serialization entirely while maintaining all functionality.

The fix is:
- **Minimal**: Only activates when the bug occurs
- **Backward compatible**: Normal path still uses Pydantic serialization
- **Robust**: Tested with complex nested objects and streaming scenarios
- **Low overhead**: Exception handling only triggered when bug occurs

## Changes

### Modified Files

1. **litellm/litellm_core_utils/streaming_handler.py**
   - Added fallback in 2 locations where `model_dump()` is called on streaming chunks
   - Location 1 (~line 1859): When stripping usage from response chunks
   - Location 2 (~line 2047): When stripping usage from processed chunks

2. **litellm/litellm_core_utils/core_helpers.py**
   - Added fallback in `preserve_upstream_non_openai_attributes()` function (~line 273)
   - Ensures non-OpenAI attributes are preserved even when serializer is corrupted

3. **tests/test_litellm/litellm_core_utils/test_streaming_handler.py**
   - Added regression test `test_model_dump_fallback_handles_pydantic_serializer_bug`
   - Simulates the MockValSer bug and verifies fallback behavior

## Testing

✅ **All 49 streaming handler tests pass**
```bash
python3 -m pytest tests/test_litellm/litellm_core_utils/test_streaming_handler.py -v
# 49 passed, 70 warnings in 3.65s
```

✅ **Regression test verifies fallback behavior**
- Mocks `model_dump()` to raise MockValSer TypeError
- Confirms fallback to `__dict__` extraction works correctly
- Validates that usage stripping still functions properly

## Why Not Alternative Solutions?

- ❌ **Downgrade Pydantic**: Creates dependency conflicts with LiteLLM 1.82.4+ which requires Pydantic 2.11+
- ❌ **Downgrade LiteLLM**: Older versions don't support SAP AI Core provider
- ❌ **`mode='python'`**: Still uses the broken serializer internally
- ❌ **Wait for Pydantic fix**: Issue #7713 has been open since Oct 2023 with no timeline
- ✅ **`__dict__` fallback**: Bypasses serialization entirely, works immediately

## Impact

This fix resolves streaming issues for:
- SAP AI Core provider
- vLLM provider
- Any other provider that reconstructs chunks during streaming

Users experiencing the `MockValSer` error will now have streaming work correctly without any configuration changes.

## Checklist

- [x] Added regression test in `tests/test_litellm/litellm_core_utils/test_streaming_handler.py`
- [x] All tests pass (`make test-unit-core-utils` equivalent)
- [x] Changes follow existing code patterns
- [x] Fix is backward compatible
- [x] Issue #18801 will be resolved by this PR

