### PR TITLE
fix: use local_timeout_duration inside asyncio.wait_for

### DIFF
--- a/litellm/timeout.py
+++ b/litellm/timeout.py
@@ -71,7 +71,7 @@ def timeout(timeout_duration: float = 0.0, exception_to_raise=Timeout):
                 local_timeout_duration = kwargs["request_timeout"]
             try:
                 value = await asyncio.wait_for(
-                    func(*args, **kwargs), timeout=timeout_duration
+                    func(*args, **kwargs), timeout=local_timeout_duration
                 )
                 return value
             except asyncio.TimeoutError:


### PR DESCRIPTION
## Description
In , the  function uses  in , completely ignoring the calculated  (which considers  and  overrides).

This PR fixes it to use , bringing parity with the sync wrapper.

*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*