### PR TITLE
fix(vertex_ai): forward dimensions parameter in multimodalembedding requests

### DIFF
--- a/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
@@ -203,7 +203,7 @@ class VertexAIMultimodalEmbeddingConfig(BaseEmbeddingConfig):
 
         if "outputDimensionality" in optional_params:
             request_data["parameters"] = {
-                "outputDimensionality": optional_params["outputDimensionality"]
+                "dimension": optional_params["outputDimensionality"]
             }
 
         return cast(dict, request_data)

--- a/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
@@ -201,6 +201,11 @@ class VertexAIMultimodalEmbeddingConfig(BaseEmbeddingConfig):
 
             request_data["instances"] = [vertex_request_instance]
 
+        if "outputDimensionality" in optional_params:
+            request_data["parameters"] = {
+                "outputDimensionality": optional_params["outputDimensionality"]
+            }
+
         return cast(dict, request_data)
 
     def transform_embedding_response(

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -514,8 +514,9 @@ class Instance(TypedDict, total=False):
     video: InstanceVideo
 
 
-class VertexMultimodalEmbeddingRequest(TypedDict):
-    instances: List[Instance]
+class VertexMultimodalEmbeddingRequest(TypedDict, total=False):
+    instances: Required[List[Instance]]
+    parameters: dict
 
 
 class VideoEmbedding(TypedDict):

--- a/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
@@ -136,8 +136,8 @@ class TestVertexMultimodalEmbedding:
         result = self.config.process_openai_embedding_input(input_data)
         assert result == expected_output, f"Expected {expected_output}, but got {result}"
 
-    def test_dimensions_parameter_forwarded_as_output_dimensionality(self):
-        """Test that the dimensions parameter is forwarded as outputDimensionality
+    def test_dimensions_parameter_forwarded_as_dimension(self):
+        """Test that the dimensions parameter is forwarded as dimension
         in the request body parameters field.
 
         Fixes: https://github.com/BerriAI/litellm/issues/24392

--- a/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
@@ -156,7 +156,7 @@ class TestVertexMultimodalEmbedding:
             headers={},
         )
         assert "parameters" in request, "Request should contain 'parameters' field"
-        assert request["parameters"]["outputDimensionality"] == 128
+        assert request["parameters"]["dimension"] == 128
 
     def test_no_parameters_field_when_dimensions_not_set(self):
         """Test that no parameters field is added when dimensions is not set."""

--- a/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
@@ -135,3 +135,35 @@ class TestVertexMultimodalEmbedding:
         ]
         result = self.config.process_openai_embedding_input(input_data)
         assert result == expected_output, f"Expected {expected_output}, but got {result}"
+
+    def test_dimensions_parameter_forwarded_as_output_dimensionality(self):
+        """Test that the dimensions parameter is forwarded as outputDimensionality
+        in the request body parameters field.
+
+        Fixes: https://github.com/BerriAI/litellm/issues/24392
+        """
+        optional_params = {}
+        optional_params = self.config.map_openai_params(
+            non_default_params={"dimensions": 128},
+            optional_params=optional_params,
+            model="multimodalembedding",
+            drop_params=False,
+        )
+        request = self.config.transform_embedding_request(
+            model="multimodalembedding",
+            input="Hello world",
+            optional_params=optional_params,
+            headers={},
+        )
+        assert "parameters" in request, "Request should contain 'parameters' field"
+        assert request["parameters"]["outputDimensionality"] == 128
+
+    def test_no_parameters_field_when_dimensions_not_set(self):
+        """Test that no parameters field is added when dimensions is not set."""
+        request = self.config.transform_embedding_request(
+            model="multimodalembedding",
+            input="Hello world",
+            optional_params={},
+            headers={},
+        )
+        assert "parameters" not in request


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/24392

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The `dimensions` parameter was correctly mapped to `outputDimensionality` in `map_openai_params`, but `transform_embedding_request` never placed it in the request body. The Vertex AI multimodal embedding predict endpoint expects it as `dimension` under a `parameters` field ([docs](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-multimodal-embeddings)):

```json
{
  "instances": [...],
  "parameters": {"dimension": 128}
}
```

Without this fix, the request always omits `parameters`, so the API returns the default 1408-dim embedding regardless of the `dimensions` value.

**Note:** The Vertex AI multimodal embedding API uses `dimension` (not `outputDimensionality` which is the Gemini embedContent API param). Verified empirically with curl against the live API.

### Changes

- **`litellm/types/llms/vertex_ai.py`**: Added optional `parameters` field to `VertexMultimodalEmbeddingRequest`
- **`litellm/llms/vertex_ai/multimodal_embeddings/transformation.py`**: Extract `outputDimensionality` from `optional_params` and map it to `dimension` in the request body

### Tests added

- `test_dimensions_parameter_forwarded_as_output_dimensionality` — verifies `dimensions=128` produces `parameters.dimension=128` in the request
- `test_no_parameters_field_when_dimensions_not_set` — verifies no `parameters` field when dimensions is not specified