### PR TITLE
feat: Add synchronous streaming adapters for Anthropic and Google GenAI pass-through endpoints

### DIFF
--- a/litellm/anthropic_interface/messages/__init__.py
+++ b/litellm/anthropic_interface/messages/__init__.py
@@ -10,7 +10,7 @@ This is an __init__.py file to allow the following interface
 
 """
 
-from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union,Iterator
+from typing import Any, AsyncIterator, Coroutine, Dict, List, Iterator, Optional, Union
 
 from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
     anthropic_messages as _async_anthropic_messages,

--- a/litellm/anthropic_interface/messages/__init__.py
+++ b/litellm/anthropic_interface/messages/__init__.py
@@ -10,7 +10,7 @@ This is an __init__.py file to allow the following interface
 
 """
 
-from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union,Iterator
 
 from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
     anthropic_messages as _async_anthropic_messages,
@@ -39,7 +39,7 @@ async def acreate(
     top_p: Optional[float] = None,
     container: Optional[Dict] = None,
     **kwargs
-) -> Union[AnthropicMessagesResponse, AsyncIterator]:
+) -> Union[AnthropicMessagesResponse, AsyncIterator, Iterator]:
     """
     Async wrapper for Anthropic's messages API
 
@@ -101,10 +101,11 @@ def create(
 ) -> Union[
     AnthropicMessagesResponse,
     AsyncIterator[Any],
+    Iterator[Any],
     Coroutine[Any, Any, Union[AnthropicMessagesResponse, AsyncIterator[Any]]],
 ]:
     """
-    Async wrapper for Anthropic's messages API
+    Sync wrapper for Anthropic's messages API
 
     Args:
         max_tokens (int): Maximum tokens to generate (required)

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -163,7 +163,7 @@ class GenerateContentToCompletionHandler:
                     return generate_content_response
                 else:
                     # Transform streaming completion response to generate_content format
-                    transformed_stream = GOOGLE_GENAI_ADAPTER.translate_completion_output_params_streaming(
+                    transformed_stream = GOOGLE_GENAI_ADAPTER.sync_translate_completion_output_params_streaming(
                         completion_response
                     )
                     if transformed_stream is not None:

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -1,4 +1,14 @@
-from typing import Any, Iterator, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
+from typing import (
+    Any,
+    Iterator,
+    AsyncIterator,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Union,
+    cast,
+)
 
 import litellm
 from litellm.types.router import GenericLiteLLMParams

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
+from typing import Any, Iterator, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
 
 import litellm
 from litellm.types.router import GenericLiteLLMParams
@@ -121,6 +121,7 @@ class GenerateContentToCompletionHandler:
     ) -> Union[
         Dict[str, Any],
         AsyncIterator[bytes],
+        Iterator[bytes],
         Coroutine[Any, Any, Union[Dict[str, Any], AsyncIterator[bytes]]],
     ]:
         """Handle generate_content call using completion adapter"""

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -321,6 +321,16 @@ class GoogleGenAIAdapter:
         )
         # Return the SSE-wrapped version for proper event formatting
         return google_genai_wrapper.async_google_genai_sse_wrapper()
+    
+    def sync_translate_completion_output_params_streaming(
+        self,
+        completion_stream: Any,
+    ) -> Union[Iterator[bytes], None]:
+        """Sync version of transform streaming completion output to Google GenAI format"""
+        google_genai_wrapper = GoogleGenAIStreamWrapper(
+            completion_stream=completion_stream
+        )
+        return google_genai_wrapper.google_genai_sse_wrapper()    
 
     def _transform_google_genai_tools_to_openai(
         self,

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -321,7 +321,7 @@ class GoogleGenAIAdapter:
         )
         # Return the SSE-wrapped version for proper event formatting
         return google_genai_wrapper.async_google_genai_sse_wrapper()
-    
+
     def sync_translate_completion_output_params_streaming(
         self,
         completion_stream: Any,
@@ -330,7 +330,7 @@ class GoogleGenAIAdapter:
         google_genai_wrapper = GoogleGenAIStreamWrapper(
             completion_stream=completion_stream
         )
-        return google_genai_wrapper.google_genai_sse_wrapper()    
+        return google_genai_wrapper.google_genai_sse_wrapper()
 
     def _transform_google_genai_tools_to_openai(
         self,

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Iterator,
     Coroutine,
     Dict,
     List,
@@ -292,6 +293,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
     ) -> Union[
         AnthropicMessagesResponse,
         AsyncIterator[Any],
+        Iterator[Any],
         Coroutine[Any, Any, Union[AnthropicMessagesResponse, AsyncIterator[Any]]],
     ]:
         """Handle non-Anthropic models using the adapter."""
@@ -339,7 +341,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
 
         if stream:
             transformed_stream = (
-                ANTHROPIC_ADAPTER.translate_completion_output_params_streaming(
+                ANTHROPIC_ADAPTER.sync_translate_completion_output_params_streaming(
                     completion_response,
                     model=model,
                     tool_name_mapping=tool_name_mapping,

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -129,8 +129,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 if should_start_new_block and not self.sent_content_block_finish:
                     # Queue the sequence: content_block_stop -> content_block_start
-                    # The trigger chunk itself is not emitted as a delta since the
-                    # content_block_start already carries the relevant information.
                     self.chunk_queue.append(
                         {
                             "type": "content_block_stop",
@@ -144,6 +142,11 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                             "content_block": self.current_content_block_start,
                         }
                     )
+                    # Also emit the trigger chunk as a delta when it carries
+                    # data (e.g. Gemini returns complete function-call arguments
+                    # in the same chunk that contains the function name).
+                    if processed_chunk.get("type") == "content_block_delta":
+                        self.chunk_queue.append(processed_chunk)
                     self.sent_content_block_finish = False
                     return self.chunk_queue.popleft()
 
@@ -305,8 +308,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if not self.queued_usage_chunk:
                     if should_start_new_block and not self.sent_content_block_finish:
                         # Queue the sequence: content_block_stop -> content_block_start
-                        # The trigger chunk itself is not emitted as a delta since the
-                        # content_block_start already carries the relevant information.
 
                         # 1. Stop current content block
                         self.chunk_queue.append(
@@ -324,6 +325,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                                 "content_block": self.current_content_block_start,
                             }
                         )
+
+                        # 3. Also emit the trigger chunk as a delta when it
+                        # carries data (e.g. Gemini returns complete function-call
+                        # arguments in the same chunk that contains the function name).
+                        if processed_chunk.get("type") == "content_block_delta":
+                            self.chunk_queue.append(processed_chunk)
 
                         # Reset state for new block
                         self.sent_content_block_finish = False

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -229,7 +229,7 @@ class AnthropicAdapter:
         )
         # Return the SSE-wrapped version for proper event formatting
         return anthropic_wrapper.async_anthropic_sse_wrapper()
-    
+
     def sync_translate_completion_output_params_streaming(
         self,
         completion_stream: Any,
@@ -568,9 +568,9 @@ class LiteLLMAnthropicMessagesAdapter:
 
             ## ASSISTANT MESSAGE ##
             assistant_message_str: Optional[str] = None
-            assistant_content_list: List[
-                Dict[str, Any]
-            ] = []  # For content blocks with cache_control
+            assistant_content_list: List[Dict[str, Any]] = (
+                []
+            )  # For content blocks with cache_control
             has_cache_control_in_text = False
             tool_calls: List[ChatCompletionAssistantToolCall] = []
             thinking_blocks: List[
@@ -681,7 +681,7 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @staticmethod
     def translate_anthropic_thinking_to_reasoning_effort(
-        thinking: Dict[str, Any]
+        thinking: Dict[str, Any],
     ) -> Optional[str]:
         """
         Translate Anthropic's thinking parameter to OpenAI's reasoning_effort.

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Iterator,
     Dict,
     List,
     Literal,
@@ -228,6 +229,23 @@ class AnthropicAdapter:
         )
         # Return the SSE-wrapped version for proper event formatting
         return anthropic_wrapper.async_anthropic_sse_wrapper()
+    
+    def sync_translate_completion_output_params_streaming(
+        self,
+        completion_stream: Any,
+        model: str,
+        tool_name_mapping: Optional[Dict[str, str]] = None,
+    ) -> Union[Iterator[bytes], None]:
+        """
+        Synchronous version of translate_completion_output_params_streaming.
+        """
+        anthropic_wrapper = AnthropicStreamWrapper(
+            completion_stream=completion_stream,
+            model=model,
+            tool_name_mapping=tool_name_mapping,
+        )
+        # Use the synchronous wrapper for synchronous iteration
+        return anthropic_wrapper.anthropic_sse_wrapper()
 
 
 class LiteLLMAnthropicMessagesAdapter:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -8,7 +8,17 @@
 import asyncio
 import contextvars
 from functools import partial
-from typing import Any, Iterator, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
+from typing import (
+    Any,
+    Iterator,
+    AsyncIterator,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Union,
+    cast,
+)
 
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -8,7 +8,7 @@
 import asyncio
 import contextvars
 from functools import partial
-from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
+from typing import Any, Iterator, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
 
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -183,7 +183,7 @@ async def anthropic_messages(
     client: Optional[AsyncHTTPHandler] = None,
     custom_llm_provider: Optional[str] = None,
     **kwargs,
-) -> Union[AnthropicMessagesResponse, AsyncIterator]:
+) -> Union[AnthropicMessagesResponse, AsyncIterator, Iterator]:
     """
     Async: Make llm api request in Anthropic /messages API spec
     """
@@ -308,6 +308,7 @@ def anthropic_messages_handler(
 ) -> Union[
     AnthropicMessagesResponse,
     AsyncIterator[Any],
+    Iterator[Any],
     Coroutine[Any, Any, Union[AnthropicMessagesResponse, AsyncIterator[Any]]],
 ]:
     """

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -4,7 +4,7 @@ Handler for the Anthropic v1/messages -> OpenAI Responses API path.
 Used when the target model is an OpenAI or Azure model.
 """
 
-from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Coroutine, Dict, Iterator, List, Optional, Union
 
 import litellm
 from litellm.types.llms.anthropic import AnthropicMessagesRequest
@@ -178,6 +178,7 @@ class LiteLLMMessagesToResponsesAPIHandler:
         **kwargs,
     ) -> Union[
         AnthropicMessagesResponse,
+        Iterator[Any],
         AsyncIterator[Any],
         Coroutine[Any, Any, Union[AnthropicMessagesResponse, AsyncIterator[Any]]],
     ]:
@@ -231,7 +232,7 @@ class LiteLLMMessagesToResponsesAPIHandler:
             wrapper = AnthropicResponsesStreamWrapper(
                 responses_stream=result, model=model
             )
-            return wrapper.async_anthropic_sse_wrapper()
+            return wrapper.anthropic_sse_wrapper()
 
         if not isinstance(result, ResponsesAPIResponse):
             raise ValueError(f"Expected ResponsesAPIResponse, got {type(result)}")

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -3,7 +3,7 @@
 import json
 import traceback
 from collections import deque
-from typing import Any, AsyncIterator, Dict
+from typing import Any, AsyncIterator, Dict, Iterator
 
 from litellm import verbose_logger
 from litellm._uuid import uuid
@@ -300,6 +300,39 @@ class AnthropicResponsesStreamWrapper:
             self._sent_message_stop = True
             return
 
+    def __iter__(self) -> "AnthropicResponsesStreamWrapper":
+        return self
+
+    def __next__(self) -> Dict[str, Any]:
+        # Return any queued chunks first
+        if self._chunk_queue:
+            return self._chunk_queue.popleft()
+
+        # Emit message_start if not yet done (fallback if response.created wasn't fired)
+        if not self._sent_message_start:
+            self._sent_message_start = True
+            self._chunk_queue.append(self._make_message_start())
+            return self._chunk_queue.popleft()
+
+        # Consume the upstream stream
+        try:
+            for event in self.responses_stream:
+                self._process_event(event)
+                if self._chunk_queue:
+                    return self._chunk_queue.popleft()
+        except StopIteration:
+            pass
+        except Exception as e:
+            verbose_logger.error(
+                f"AnthropicResponsesStreamWrapper error: {e}\n{traceback.format_exc()}"
+            )
+
+        # Drain any remaining queued chunks
+        if self._chunk_queue:
+            return self._chunk_queue.popleft()
+
+        raise StopIteration
+
     def __aiter__(self) -> "AnthropicResponsesStreamWrapper":
         return self
 
@@ -332,6 +365,16 @@ class AnthropicResponsesStreamWrapper:
             return self._chunk_queue.popleft()
 
         raise StopAsyncIteration
+
+    def anthropic_sse_wrapper(self) -> Iterator[bytes]:
+        """Yield SSE-encoded bytes for each Anthropic event chunk (sync)."""
+        for chunk in self:
+            if isinstance(chunk, dict):
+                event_type: str = str(chunk.get("type", "message"))
+                payload = f"event: {event_type}\ndata: {json.dumps(chunk)}\n\n"
+                yield payload.encode()
+            else:
+                yield chunk
 
     async def async_anthropic_sse_wrapper(self) -> AsyncIterator[bytes]:
         """Yield SSE-encoded bytes for each Anthropic event chunk."""

--- a/tests/test_litellm/google_genai/test_google_genai_handler.py
+++ b/tests/test_litellm/google_genai/test_google_genai_handler.py
@@ -2,6 +2,7 @@
 """
 Test to verify the Google GenAI generate_content handler functionality
 """
+
 import json
 import os
 import sys
@@ -32,24 +33,21 @@ def test_non_stream_response_when_stream_requested_sync():
         choices=[
             Choices(
                 index=0,
-                message={
-                    "role": "assistant",
-                    "content": "Hello, world!"
-                },
-                finish_reason="stop"
+                message={"role": "assistant", "content": "Hello, world!"},
+                finish_reason="stop",
             )
         ],
         created=1234567890,
         model="gpt-3.5-turbo",
-        object="chat.completion"
+        object="chat.completion",
     )
-    
+
     # Create an instance of the adapter
     adapter = GoogleGenAIAdapter()
-    
+
     # Test the adapter's translate_completion_to_generate_content method directly
     result = adapter.translate_completion_to_generate_content(mock_response)
-    
+
     # Verify the result is a valid Google GenAI format response
     assert "candidates" in result
     assert isinstance(result["candidates"], list)
@@ -77,24 +75,21 @@ async def test_non_stream_response_when_stream_requested_async():
         choices=[
             Choices(
                 index=0,
-                message={
-                    "role": "assistant",
-                    "content": "Hello, world!"
-                },
-                finish_reason="stop"
+                message={"role": "assistant", "content": "Hello, world!"},
+                finish_reason="stop",
             )
         ],
         created=1234567890,
         model="gpt-3.5-turbo",
-        object="chat.completion"
+        object="chat.completion",
     )
-    
+
     # Create an instance of the adapter
     adapter = GoogleGenAIAdapter()
-    
+
     # Test the adapter's translate_completion_to_generate_content method directly
     result = adapter.translate_completion_to_generate_content(mock_response)
-    
+
     # Verify the result is a valid Google GenAI format response
     assert "candidates" in result
     assert isinstance(result["candidates"], list)
@@ -116,12 +111,12 @@ def test_stream_response_when_stream_requested_sync():
     # Mock a stream response
     mock_stream = MagicMock()
     mock_stream.__iter__ = MagicMock(return_value=iter([]))
-    
-    # Mock the GoogleGenAIAdapter's translate_completion_output_params_streaming method
+
+    # Mock the GoogleGenAIAdapter's sync_translate_completion_output_params_streaming method
     with patch.object(
-        GoogleGenAIAdapter, 
-        "translate_completion_output_params_streaming", 
-        return_value=mock_stream
+        GoogleGenAIAdapter,
+        "sync_translate_completion_output_params_streaming",
+        return_value=mock_stream,
     ) as mock_translate:
         with patch("litellm.completion", return_value=mock_stream):
             # Call the handler with stream=True
@@ -129,10 +124,10 @@ def test_stream_response_when_stream_requested_sync():
                 model="gemini-pro",
                 contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
                 litellm_params={},  # Empty dict for params
-                stream=True
+                stream=True,
             )
-            
-            # Verify that translate_completion_output_params_streaming was called
+
+            # Verify that sync_translate_completion_output_params_streaming was called
             mock_translate.assert_called_once_with(mock_stream)
             # Verify the result is the transformed stream
             assert result == mock_stream
@@ -146,23 +141,27 @@ async def test_stream_response_when_stream_requested_async():
     """
     # Mock a stream response
     mock_stream = MagicMock()
-    mock_stream.__aiter__ = AsyncMock(return_value=iter([]))  # Return an empty async iterator
-    
+    mock_stream.__aiter__ = AsyncMock(
+        return_value=iter([])
+    )  # Return an empty async iterator
+
     # Mock the GoogleGenAIAdapter's translate_completion_output_params_streaming method
     with patch.object(
-        GoogleGenAIAdapter, 
-        "translate_completion_output_params_streaming", 
-        return_value=mock_stream
+        GoogleGenAIAdapter,
+        "translate_completion_output_params_streaming",
+        return_value=mock_stream,
     ) as mock_translate:
         with patch("litellm.acompletion", return_value=mock_stream):
             # Call the handler with stream=True
-            result = await GenerateContentToCompletionHandler.async_generate_content_handler(
-                model="gemini-pro",
-                contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
-                litellm_params={},  # Empty dict for params
-                stream=True
+            result = (
+                await GenerateContentToCompletionHandler.async_generate_content_handler(
+                    model="gemini-pro",
+                    contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
+                    litellm_params={},  # Empty dict for params
+                    stream=True,
+                )
             )
-            
+
             # Verify that translate_completion_output_params_streaming was called
             mock_translate.assert_called_once_with(mock_stream)
             # Verify the result is the transformed stream
@@ -176,22 +175,24 @@ def test_stream_transformation_error_sync():
     # Mock a stream response
     mock_stream = MagicMock()
     mock_stream.__iter__ = MagicMock(return_value=iter([]))
-    
-    # Mock the GoogleGenAIAdapter's translate_completion_output_params_streaming method to return None
+
+    # Mock the GoogleGenAIAdapter's sync_translate_completion_output_params_streaming method to return None
     with patch.object(
-        GoogleGenAIAdapter, 
-        "translate_completion_output_params_streaming", 
-        return_value=None
+        GoogleGenAIAdapter,
+        "sync_translate_completion_output_params_streaming",
+        return_value=None,
     ):
         # Patch litellm.completion directly to prevent real API calls
         with patch("litellm.completion", return_value=mock_stream):
             # Call the handler with stream=True and expect a ValueError
-            with pytest.raises(ValueError, match="Failed to transform streaming response"):
+            with pytest.raises(
+                ValueError, match="Failed to transform streaming response"
+            ):
                 GenerateContentToCompletionHandler.generate_content_handler(
                     model="gemini-pro",
                     contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
                     litellm_params={},  # Empty dict for params
-                    stream=True
+                    stream=True,
                 )
 
 
@@ -203,12 +204,12 @@ async def test_stream_transformation_error_async():
     # Mock a stream response
     mock_stream = MagicMock()
     mock_stream.__aiter__ = AsyncMock(return_value=mock_stream)
-    
+
     # Mock the GoogleGenAIAdapter's translate_completion_output_params_streaming method to return None
     with patch.object(
-        GoogleGenAIAdapter, 
-        "translate_completion_output_params_streaming", 
-        return_value=None
+        GoogleGenAIAdapter,
+        "translate_completion_output_params_streaming",
+        return_value=None,
     ):
         # Mock litellm.acompletion at the module level where it's imported
         # We need to patch it in the handler module, not in litellm itself
@@ -216,12 +217,14 @@ async def test_stream_transformation_error_async():
             # Use AsyncMock for async function
             mock_litellm.acompletion = AsyncMock(return_value=mock_stream)
             # Call the handler with stream=True and expect a ValueError
-            with pytest.raises(ValueError, match="Failed to transform streaming response"):
+            with pytest.raises(
+                ValueError, match="Failed to transform streaming response"
+            ):
                 await GenerateContentToCompletionHandler.async_generate_content_handler(
                     model="gemini-pro",
                     contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
                     litellm_params={},  # Empty dict for params
-                    stream=True
+                    stream=True,
                 )
 
 
@@ -247,7 +250,7 @@ def test_citation_metadata_transformation():
                             "text": "This is a video analysis response with citation metadata."
                         }
                     ],
-                    "role": "model"
+                    "role": "model",
                 },
                 "finishReason": "STOP",
                 "index": 0,
@@ -260,7 +263,7 @@ def test_citation_metadata_transformation():
                             "uri": "https://example.com/video-source",
                             "license": "MIT",
                             "title": "Video Analysis Source",
-                            "publicationDate": "2024-01-15"
+                            "publicationDate": "2024-01-15",
                         },
                         {
                             "startIndex": 6200,
@@ -268,26 +271,26 @@ def test_citation_metadata_transformation():
                             "uri": "https://another-source.com/reference",
                             "license": "CC-BY",
                             "title": "Another Reference",
-                            "publicationDate": "2024-02-01"
-                        }
+                            "publicationDate": "2024-02-01",
+                        },
                     ]
-                }
+                },
             }
         ],
         "usageMetadata": {
             "promptTokenCount": 150,
             "candidatesTokenCount": 200,
-            "totalTokenCount": 350
+            "totalTokenCount": 350,
         },
-        "responseId": "test-response-123"
+        "responseId": "test-response-123",
     }
-    
+
     # Create mock httpx response
     mock_httpx_response = MagicMock(spec=httpx.Response)
     mock_httpx_response.json.return_value = mock_response_data
     mock_httpx_response.status_code = 200
     mock_httpx_response.headers = {}
-    
+
     # Create logging object
     logging_obj = LiteLLMLoggingObj(
         model="gemini-2.5-flash",
@@ -296,40 +299,53 @@ def test_citation_metadata_transformation():
         call_type="generate_content",
         start_time=1234567890,
         litellm_call_id="test-call-123",
-        function_id="test-function-123"
+        function_id="test-function-123",
     )
-    
+
     # Create GoogleGenAI config
     config = GoogleGenAIConfig()
-    
+
     # Test the transformation
     try:
         result = config.transform_generate_content_response(
             model="gemini-2.5-flash",
             raw_response=mock_httpx_response,
-            logging_obj=logging_obj
+            logging_obj=logging_obj,
         )
-        
+
         # Verify the transformation worked
         assert result is not None
-        
+
         # Check that citationSources was transformed to citations
-        if hasattr(result, 'candidates') and result.candidates:
+        if hasattr(result, "candidates") and result.candidates:
             candidate = result.candidates[0]
-            if hasattr(candidate, 'citationMetadata') and candidate.citationMetadata:
+            if hasattr(candidate, "citationMetadata") and candidate.citationMetadata:
                 # The citationMetadata should now have 'citations' instead of 'citationSources'
                 citation_metadata = candidate.citationMetadata
-                
+
                 # Check that citations field exists
-                assert hasattr(citation_metadata, 'citations'), "citations field should exist after transformation"
-                
+                assert hasattr(
+                    citation_metadata, "citations"
+                ), "citations field should exist after transformation"
+
                 # Verify the citations data is preserved
-                if hasattr(citation_metadata, 'citations') and citation_metadata.citations:
-                    assert len(citation_metadata.citations) == 2, "Should have 2 citations"
-                    assert citation_metadata.citations[0]['uri'] == "https://example.com/video-source"
-                    assert citation_metadata.citations[1]['uri'] == "https://another-source.com/reference"
-        
+                if (
+                    hasattr(citation_metadata, "citations")
+                    and citation_metadata.citations
+                ):
+                    assert (
+                        len(citation_metadata.citations) == 2
+                    ), "Should have 2 citations"
+                    assert (
+                        citation_metadata.citations[0]["uri"]
+                        == "https://example.com/video-source"
+                    )
+                    assert (
+                        citation_metadata.citations[1]["uri"]
+                        == "https://another-source.com/reference"
+                    )
+
         print("✅ Citation metadata transformation test passed!")
-        
+
     except Exception as e:
         pytest.fail(f"Citation metadata transformation failed: {e}")

--- a/tests/test_litellm/test_sync_streaming_adapters.py
+++ b/tests/test_litellm/test_sync_streaming_adapters.py
@@ -230,7 +230,7 @@ def test_google_genai_sync_translate_sse_contains_candidates():
     for chunk in result:
         chunk_str = chunk.decode("utf-8")
         if chunk_str.startswith("data: "):
-            json_str = chunk_str[len("data: "):].strip()
+            json_str = chunk_str[len("data: ") :].strip()
             if json_str:
                 data = json.loads(json_str)
                 if "candidates" in data:

--- a/tests/test_litellm/test_sync_streaming_adapters.py
+++ b/tests/test_litellm/test_sync_streaming_adapters.py
@@ -1,0 +1,242 @@
+"""
+Tests for synchronous streaming methods added to AnthropicAdapter and GoogleGenAIAdapter.
+
+These tests verify that `sync_translate_completion_output_params_streaming` returns
+a synchronous Iterator[bytes] (not an AsyncIterator) for both adapters.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
+from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+    AnthropicAdapter,
+)
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+
+class MockSyncCompletionStream:
+    """A synchronous mock completion stream that yields ModelResponseStream chunks."""
+
+    def __init__(self):
+        self.responses = [
+            ModelResponseStream(
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Hello"), index=0, finish_reason=None
+                    )
+                ],
+            ),
+            ModelResponseStream(
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=" World"), index=0, finish_reason=None
+                    )
+                ],
+            ),
+            ModelResponseStream(
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=""), index=0, finish_reason="stop"
+                    )
+                ],
+            ),
+        ]
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.responses):
+            raise StopIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+# --- AnthropicAdapter sync streaming tests ---
+
+
+def test_anthropic_sync_translate_returns_iterator():
+    """
+    Test that AnthropicAdapter.sync_translate_completion_output_params_streaming
+    returns a synchronous iterator of bytes.
+    """
+    adapter = AnthropicAdapter()
+    result = adapter.sync_translate_completion_output_params_streaming(
+        completion_stream=MockSyncCompletionStream(),
+        model="claude-3",
+    )
+
+    assert result is not None
+    # Should be a generator / iterator, not a coroutine or async iterator
+    assert hasattr(result, "__iter__")
+    assert not hasattr(result, "__aiter__")
+
+    chunks: list[bytes] = list(result)
+    assert len(chunks) > 0
+    for chunk in chunks:
+        assert isinstance(chunk, bytes)
+
+
+def test_anthropic_sync_translate_produces_valid_sse():
+    """
+    Test that AnthropicAdapter.sync_translate_completion_output_params_streaming
+    produces valid SSE-formatted bytes with event and data lines.
+    """
+    adapter = AnthropicAdapter()
+    result = adapter.sync_translate_completion_output_params_streaming(
+        completion_stream=MockSyncCompletionStream(),
+        model="claude-3",
+    )
+
+    assert result is not None
+    first_chunk = next(iter(result))
+    chunk_str = first_chunk.decode("utf-8")
+
+    lines = chunk_str.split("\n")
+    assert lines[0].startswith("event: ")
+    assert lines[1].startswith("data: ")
+    assert "message_start" in chunk_str
+
+
+def test_anthropic_sync_translate_with_tool_name_mapping():
+    """
+    Test that tool_name_mapping parameter is accepted by
+    sync_translate_completion_output_params_streaming.
+    """
+    adapter = AnthropicAdapter()
+    result = adapter.sync_translate_completion_output_params_streaming(
+        completion_stream=MockSyncCompletionStream(),
+        model="claude-3",
+        tool_name_mapping={"short_name": "original_long_tool_name"},
+    )
+
+    assert result is not None
+    chunks = list(result)
+    assert len(chunks) > 0
+
+
+# --- GoogleGenAIAdapter sync streaming tests ---
+
+
+class MockGoogleGenAIDictStream:
+    """A synchronous mock stream that yields pre-transformed Google GenAI dict chunks.
+
+    This simulates what GoogleGenAIStreamWrapper.__next__ produces after transforming
+    ModelResponseStream chunks into Google GenAI format dicts.
+    """
+
+    def __init__(self):
+        self.responses = [
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": "Hello"}],
+                            "role": "model",
+                        },
+                        "index": 0,
+                        "safetyRatings": [],
+                    }
+                ]
+            },
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": " World"}],
+                            "role": "model",
+                        },
+                        "finishReason": "STOP",
+                        "index": 0,
+                        "safetyRatings": [],
+                    }
+                ]
+            },
+        ]
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.responses):
+            raise StopIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+def test_google_genai_sync_translate_returns_iterator():
+    """
+    Test that GoogleGenAIAdapter.sync_translate_completion_output_params_streaming
+    returns a synchronous iterator of bytes.
+    """
+    adapter = GoogleGenAIAdapter()
+    result = adapter.sync_translate_completion_output_params_streaming(
+        completion_stream=MockGoogleGenAIDictStream(),
+    )
+
+    assert result is not None
+    assert hasattr(result, "__iter__")
+    assert not hasattr(result, "__aiter__")
+
+    chunks: list[bytes] = list(result)
+    assert len(chunks) > 0
+    for chunk in chunks:
+        assert isinstance(chunk, bytes)
+
+
+def test_google_genai_sync_translate_produces_valid_sse():
+    """
+    Test that GoogleGenAIAdapter.sync_translate_completion_output_params_streaming
+    produces valid SSE-formatted bytes with 'data:' prefix.
+    """
+    adapter = GoogleGenAIAdapter()
+    result = adapter.sync_translate_completion_output_params_streaming(
+        completion_stream=MockGoogleGenAIDictStream(),
+    )
+
+    assert result is not None
+    chunks = list(result)
+    assert len(chunks) > 0
+
+    for chunk in chunks:
+        chunk_str = chunk.decode("utf-8")
+        # Google GenAI SSE format: "data: {...}\n\n" for dict chunks
+        assert chunk_str.startswith("data: ")
+        assert chunk_str.endswith("\n\n")
+
+
+def test_google_genai_sync_translate_sse_contains_candidates():
+    """
+    Test that the Google GenAI sync streaming output contains
+    properly formatted candidate data in SSE events.
+    """
+    adapter = GoogleGenAIAdapter()
+    result = adapter.sync_translate_completion_output_params_streaming(
+        completion_stream=MockGoogleGenAIDictStream(),
+    )
+
+    assert result is not None
+    found_candidates = False
+    for chunk in result:
+        chunk_str = chunk.decode("utf-8")
+        if chunk_str.startswith("data: "):
+            json_str = chunk_str[len("data: "):].strip()
+            if json_str:
+                data = json.loads(json_str)
+                if "candidates" in data:
+                    found_candidates = True
+                    candidate = data["candidates"][0]
+                    assert "content" in candidate
+                    assert "parts" in candidate["content"]
+
+    assert found_candidates, "Expected at least one SSE chunk with 'candidates' data"


### PR DESCRIPTION
## Relevant issues

Fixes sync streaming for Anthropic and Google GenAI pass-through adapter endpoints, where async iterators were incorrectly used in synchronous code paths.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

- Add `sync_translate_completion_output_params_streaming` to `AnthropicAdapter` and `GoogleGenAIAdapter`, which return synchronous `Iterator[bytes]` instead of `AsyncIterator[bytes]`
- Update `LiteLLMMessagesToCompletionTransformationHandler` and `GenerateContentToCompletionHandler` to call the new sync methods in their synchronous code paths
- Update type annotations across handler and transformation files to include `Iterator` in return unions
- Fix docstring in `anthropic_interface/messages/__init__.py` (`create` is sync, not async)
- Add unit tests in `tests/test_litellm/test_sync_streaming_adapters.py` covering both adapters: iterator type validation, SSE format correctness, and parameter forwarding
