### PR TITLE
fix: replace mutable default arguments with None in function signatures

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -950,7 +950,8 @@ class Logging(LiteLLMLoggingBaseClass):
             masked_api_base = api_base
         return str(masked_api_base)
 
-    def _pre_call(self, input, api_key, model=None, additional_args={}):
+    def _pre_call(self, input, api_key, model=None, additional_args=None):
+        additional_args = additional_args or {}
         """
         Common helper function across the sync + async pre-call function
         """
@@ -967,7 +968,8 @@ class Logging(LiteLLMLoggingBaseClass):
             self._get_masked_api_base(additional_args.get("api_base", ""))
         )
 
-    def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
+    def pre_call(self, input, api_key, model=None, additional_args=None):
+        additional_args = additional_args or {}  # noqa: PLR0915
         # Log the exact input to the LLM API
         litellm.error_logs["PRE_CALL"] = locals()
         try:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -968,8 +968,8 @@ class Logging(LiteLLMLoggingBaseClass):
             self._get_masked_api_base(additional_args.get("api_base", ""))
         )
 
-    def pre_call(self, input, api_key, model=None, additional_args=None):
-        additional_args = additional_args or {}  # noqa: PLR0915
+    def pre_call(self, input, api_key, model=None, additional_args=None):  # noqa: PLR0915
+        additional_args = additional_args or {}
         # Log the exact input to the LLM API
         litellm.error_logs["PRE_CALL"] = locals()
         try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7136,7 +7136,8 @@ def select_data_generator(
     )
 
 
-def get_litellm_model_info(model: dict = {}):
+def get_litellm_model_info(model: dict = None):
+    model = model or {}
     model_info = model.get("model_info", {})
     model_to_lookup = model.get("litellm_params", {}).get("model", None)
     try:

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -31,9 +31,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: dict = None):
         self.router_cache = router_cache
-        self.routing_args = RoutingArgs(**routing_args)
+        self.routing_args = RoutingArgs(**(routing_args or {}))
 
     def log_success_event(  # noqa: PLR0915
         self, kwargs, response_obj, start_time, end_time

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -22,9 +22,9 @@ class LowestTPMLoggingHandler(CustomLogger):
     logged_failure: int = 0
     default_cache_time_seconds: int = 1 * 60 * 60  # 1 hour
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: dict = None):
         self.router_cache = router_cache
-        self.routing_args = RoutingArgs(**routing_args)
+        self.routing_args = RoutingArgs(**(routing_args or {}))
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3417,11 +3417,11 @@ class LiteLLMLoggingBaseClass:
     Meant to simplify type checking for logging obj.
     """
 
-    def pre_call(self, input, api_key, model=None, additional_args={}):
+    def pre_call(self, input, api_key, model=None, additional_args=None):
         pass
 
     def post_call(
-        self, original_response, input=None, api_key=None, additional_args={}
+        self, original_response, input=None, api_key=None, additional_args=None
     ):
         pass
 


### PR DESCRIPTION
## Description
This PR replaces mutable default arguments (`dict = {}`) with `None` across several function signatures in the codebase, preventing potential side effects from shared state across function calls.

**Affected areas**:
- `litellm/router_strategy/lowest_tpm_rpm.py`
- `litellm/router_strategy/lowest_latency.py`
- `litellm/litellm_core_utils/litellm_logging.py`
- `litellm/proxy/proxy_server.py`
- `litellm/types/utils.py`