### PR TITLE
fix(model-prices): migrate 38 models from legacy max_tokens to max_input_tokens/max_output_tokens

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14604,17 +14604,14 @@
         "uses_embed_content": true
     },
     "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_audio_per_second": 0.00016,
-        "input_cost_per_image": 0.00012,
-        "input_cost_per_token": 2e-07,
-        "input_cost_per_video_per_second": 0.00079,
+        "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
         "supports_multimodal": true,
         "uses_embed_content": true
     },
@@ -14629,18 +14626,6 @@
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-        "uses_embed_content": true
-    },
-    "vertex_ai/gemini-embedding-2-preview": {
-        "input_cost_per_token": 1.5e-07,
-        "litellm_provider": "vertex_ai",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0,
-        "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#multimodal",
-        "supports_multimodal": true,
         "uses_embed_content": true
     },
     "gemini/gemini-embedding-001": {
@@ -19656,7 +19641,7 @@
     },
     "gradient_ai/alibaba-qwen3-32b": {
         "litellm_provider": "gradient_ai",
-        "max_tokens": 2048,
+        "max_tokens": 40960,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions"
@@ -19664,7 +19649,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 40960
     },
     "gradient_ai/anthropic-claude-3-opus": {
         "input_cost_per_token": 1.5e-05,
@@ -19678,7 +19665,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 1024
     },
     "gradient_ai/anthropic-claude-3.5-haiku": {
         "input_cost_per_token": 8e-07,
@@ -19692,7 +19681,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 1024
     },
     "gradient_ai/anthropic-claude-3.5-sonnet": {
         "input_cost_per_token": 3e-06,
@@ -19706,7 +19697,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 1024
     },
     "gradient_ai/anthropic-claude-3.7-sonnet": {
         "input_cost_per_token": 3e-06,
@@ -19720,7 +19713,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 1024
     },
     "gradient_ai/deepseek-r1-distill-llama-70b": {
         "input_cost_per_token": 9.9e-07,
@@ -19734,7 +19729,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8000
     },
     "gradient_ai/llama3-8b-instruct": {
         "input_cost_per_token": 2e-07,
@@ -19748,7 +19745,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 512
     },
     "gradient_ai/llama3.3-70b-instruct": {
         "input_cost_per_token": 6.5e-07,
@@ -19762,7 +19761,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048
     },
     "gradient_ai/mistral-nemo-instruct-2407": {
         "input_cost_per_token": 3e-07,
@@ -19776,7 +19777,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 512
     },
     "gradient_ai/openai-gpt-4o": {
         "litellm_provider": "gradient_ai",
@@ -19788,7 +19791,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384
     },
     "gradient_ai/openai-gpt-4o-mini": {
         "litellm_provider": "gradient_ai",
@@ -19800,7 +19805,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384
     },
     "gradient_ai/openai-o3": {
         "input_cost_per_token": 2e-06,
@@ -19814,7 +19821,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000
     },
     "gradient_ai/openai-o3-mini": {
         "input_cost_per_token": 1.1e-06,
@@ -19828,7 +19837,9 @@
         "supported_modalities": [
             "text"
         ],
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000
     },
     "lemonade/Qwen3-Coder-30B-A3B-Instruct-GGUF": {
         "input_cost_per_token": 0,
@@ -20128,11 +20139,13 @@
     },
     "heroku/claude-3-5-haiku": {
         "litellm_provider": "heroku",
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "mode": "chat",
         "supports_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192
     },
     "heroku/claude-3-5-sonnet-latest": {
         "litellm_provider": "heroku",
@@ -20140,7 +20153,9 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192
     },
     "heroku/claude-3-7-sonnet": {
         "litellm_provider": "heroku",
@@ -20148,7 +20163,9 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192
     },
     "heroku/claude-4-sonnet": {
         "litellm_provider": "heroku",
@@ -20156,7 +20173,9 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192
     },
     "high/1024-x-1024/gpt-image-1": {
         "input_cost_per_image": 0.167,
@@ -20869,48 +20888,6 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ]
-    },
-    "luminous-base": {
-        "input_cost_per_token": 3e-05,
-        "litellm_provider": "aleph_alpha",
-        "max_tokens": 2048,
-        "mode": "completion",
-        "output_cost_per_token": 3.3e-05
-    },
-    "luminous-base-control": {
-        "input_cost_per_token": 3.75e-05,
-        "litellm_provider": "aleph_alpha",
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 4.125e-05
-    },
-    "luminous-extended": {
-        "input_cost_per_token": 4.5e-05,
-        "litellm_provider": "aleph_alpha",
-        "max_tokens": 2048,
-        "mode": "completion",
-        "output_cost_per_token": 4.95e-05
-    },
-    "luminous-extended-control": {
-        "input_cost_per_token": 5.625e-05,
-        "litellm_provider": "aleph_alpha",
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 6.1875e-05
-    },
-    "luminous-supreme": {
-        "input_cost_per_token": 0.000175,
-        "litellm_provider": "aleph_alpha",
-        "max_tokens": 2048,
-        "mode": "completion",
-        "output_cost_per_token": 0.0001925
-    },
-    "luminous-supreme-control": {
-        "input_cost_per_token": 0.00021875,
-        "litellm_provider": "aleph_alpha",
-        "max_tokens": 2048,
-        "mode": "chat",
-        "output_cost_per_token": 0.000240625
     },
     "max-x-max/50-steps/stability.stable-diffusion-xl-v0": {
         "litellm_provider": "bedrock",
@@ -24048,12 +24025,14 @@
         "input_cost_per_image": 0.0004,
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "openrouter",
-        "max_tokens": 200000,
+        "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096
     },
     "openrouter/anthropic/claude-3.5-sonnet": {
         "input_cost_per_token": 3e-06,
@@ -24570,18 +24549,22 @@
     "openrouter/mancer/weaver": {
         "input_cost_per_token": 5.625e-06,
         "litellm_provider": "openrouter",
-        "max_tokens": 8000,
+        "max_tokens": 2000,
         "mode": "chat",
         "output_cost_per_token": 5.625e-06,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 8000,
+        "max_output_tokens": 2000
     },
     "openrouter/meta-llama/llama-3-70b-instruct": {
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "openrouter",
-        "max_tokens": 8192,
+        "max_tokens": 8000,
         "mode": "chat",
         "output_cost_per_token": 7.9e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8000
     },
     "openrouter/minimax/minimax-m2": {
         "input_cost_per_token": 2.55e-07,
@@ -24669,34 +24652,42 @@
     "openrouter/mistralai/mistral-7b-instruct": {
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "openrouter",
-        "max_tokens": 8192,
+        "max_tokens": 8191,
         "mode": "chat",
         "output_cost_per_token": 1.3e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8191
     },
     "openrouter/mistralai/mistral-large": {
         "input_cost_per_token": 8e-06,
         "litellm_provider": "openrouter",
-        "max_tokens": 32000,
+        "max_tokens": 8191,
         "mode": "chat",
         "output_cost_per_token": 2.4e-05,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191
     },
     "openrouter/mistralai/mistral-small-3.1-24b-instruct": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
-        "max_tokens": 32000,
+        "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 3e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072
     },
     "openrouter/mistralai/mistral-small-3.2-24b-instruct": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
-        "max_tokens": 32000,
+        "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 3e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000
     },
     "openrouter/mistralai/mixtral-8x22b-instruct": {
         "input_cost_per_token": 6.5e-07,
@@ -24704,7 +24695,9 @@
         "max_tokens": 65536,
         "mode": "chat",
         "output_cost_per_token": 6.5e-07,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 65536,
+        "max_output_tokens": 65536
     },
     "openrouter/moonshotai/kimi-k2.5": {
         "cache_read_input_token_cost": 1e-07,
@@ -24724,26 +24717,32 @@
     "openrouter/openai/gpt-3.5-turbo": {
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
-        "max_tokens": 4095,
+        "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 2e-06,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096
     },
     "openrouter/openai/gpt-3.5-turbo-16k": {
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
-        "max_tokens": 16383,
+        "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096
     },
     "openrouter/openai/gpt-4": {
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openrouter",
-        "max_tokens": 8192,
+        "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 6e-05,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 8191,
+        "max_output_tokens": 4096
     },
     "openrouter/openai/gpt-4.1": {
         "cache_read_input_token_cost": 5e-07,
@@ -25251,10 +25250,12 @@
     "openrouter/undi95/remm-slerp-l2-13b": {
         "input_cost_per_token": 1.875e-06,
         "litellm_provider": "openrouter",
-        "max_tokens": 6144,
+        "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 1.875e-06,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 6144,
+        "max_output_tokens": 4096
     },
     "openrouter/x-ai/grok-4": {
         "input_cost_per_token": 3e-06,
@@ -27862,14 +27863,16 @@
     "together_ai/deepseek-ai/DeepSeek-V3.1": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
-        "max_tokens": 128000,
+        "max_tokens": 16384,
         "mode": "chat",
         "output_cost_per_token": 1.7e-06,
         "source": "https://www.together.ai/models/deepseek-v3-1",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_reasoning": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384
     },
     "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo": {
         "litellm_provider": "together_ai",
@@ -31147,7 +31150,9 @@
         "mode": "chat",
         "output_cost_per_token": 3.2e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#glm-models",
-        "supported_regions": ["global"],
+        "supported_regions": [
+            "global"
+        ],
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/18967

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Models using only the legacy `max_tokens` field now have proper `max_input_tokens`/`max_output_tokens` based on provider documentation.

### OpenRouter (13 models)
- Fixed models where `max_tokens` was the context window, not the output limit
- `max_input_tokens` from OpenRouter API `context_length`
- `max_output_tokens` from OpenRouter API `max_completion_tokens`, or from Azure/Bedrock entries for the same base model when OpenRouter returns null

### Gradient AI (13 models)
- `max_input_tokens` from Gradient AI docs (context window)
- `max_output_tokens` preserved from original `max_tokens` values (Gradient-imposed output limits) for legacy models not in current docs
- Updated to Gradient docs values where available (Qwen3-32B: 40960, DeepSeek R1: 8000, GPT-4o: 16384, etc.)

### Heroku (4 models)
- Claude model wrappers — Anthropic's published specs (200k input, 8192 output)

### Together AI (1 model)
- `together_ai/deepseek-ai/DeepSeek-V3.1`: 128k input, 16k output

- **Aleph Alpha Luminous** (6 models): removed entirely — Aleph Alpha deprecated Luminous in September 2024, pivoted to Pharia. Models no longer documented or supported.
- **together-ai-8.1b-21b**: legacy model without reliable token data, left as-is (only `max_tokens`)
- **openrouter/gryphe/mythomax-l2-13b**: shared context window model without separate output limit, left as-is

Data-only change to `model_prices_and_context_window.json`. No code modified.