### PR TITLE
fix(websearch_interception): pass metadata to search calls for cost attribution

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -668,6 +668,11 @@ class WebSearchInterceptionLogger(CustomLogger):
     ) -> Any:
         """Execute litellm.search() and make follow-up request"""
 
+        # Extract metadata for cost attribution
+        _metadata = kwargs.get("metadata") or kwargs.get("litellm_params", {}).get(
+            "metadata"
+        )
+
         # Extract search queries from tool_use blocks
         search_tasks = []
         for tool_call in tool_calls:
@@ -676,7 +681,9 @@ class WebSearchInterceptionLogger(CustomLogger):
                 verbose_logger.debug(
                     f"WebSearchInterception: Queuing search for query='{query}'"
                 )
-                search_tasks.append(self._execute_search(query))
+                search_tasks.append(
+                    self._execute_search(query, metadata=_metadata)
+                )
             else:
                 verbose_logger.debug(
                     f"WebSearchInterception: Tool call {tool_call['id']} has no query"
@@ -792,8 +799,18 @@ class WebSearchInterceptionLogger(CustomLogger):
             )
             raise
 
-    async def _execute_search(self, query: str) -> str:
-        """Execute a single web search using router's search tools"""
+    async def _execute_search(
+        self, query: str, metadata: Optional[Dict] = None
+    ) -> str:
+        """Execute a single web search using router's search tools.
+
+        Args:
+            query: The search query string.
+            metadata: Optional metadata dict from the original request. When
+                provided, it is forwarded to ``litellm.asearch`` so that proxy
+                callbacks (e.g. spend tracking) can attribute the search cost
+                to the correct API key / user / team.
+        """
         try:
             # Import router from proxy_server
             try:
@@ -851,7 +868,13 @@ class WebSearchInterceptionLogger(CustomLogger):
             verbose_logger.debug(
                 f"WebSearchInterception: Executing search for '{query}' using provider '{search_provider}'"
             )
-            result = await litellm.asearch(query=query, search_provider=search_provider)
+            search_kwargs: Dict[str, Any] = {
+                "query": query,
+                "search_provider": search_provider,
+            }
+            if metadata:
+                search_kwargs["metadata"] = metadata
+            result = await litellm.asearch(**search_kwargs)
 
             # Format using transformation function
             search_result_text = WebSearchTransformation.format_search_response(result)
@@ -879,6 +902,11 @@ class WebSearchInterceptionLogger(CustomLogger):
     ) -> Any:
         """Execute litellm.search() and make follow-up chat completion request"""
 
+        # Extract metadata for cost attribution
+        _metadata = kwargs.get("metadata") or kwargs.get("litellm_params", {}).get(
+            "metadata"
+        )
+
         # Extract search queries from tool_calls
         search_tasks = []
         for tool_call in tool_calls:
@@ -897,7 +925,9 @@ class WebSearchInterceptionLogger(CustomLogger):
                 verbose_logger.debug(
                     f"WebSearchInterception: Queuing search for query='{query}'"
                 )
-                search_tasks.append(self._execute_search(query))
+                search_tasks.append(
+                    self._execute_search(query, metadata=_metadata)
+                )
             else:
                 verbose_logger.debug(
                     f"WebSearchInterception: Tool call {tool_call.get('id')} has no query"

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -4,7 +4,7 @@ Unit tests for WebSearch Interception Handler
 Tests the WebSearchInterceptionLogger class and helper functions.
 """
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -273,3 +273,54 @@ async def test_async_pre_call_deployment_hook_provider_derived_from_model_name()
     # Full kwargs preserved
     assert result["model"] == "openai/gpt-4o-mini"
     assert result["api_key"] == "fake-key"
+
+
+@pytest.mark.asyncio
+async def test_execute_search_forwards_metadata_to_asearch():
+    """Test that _execute_search forwards metadata to litellm.asearch().
+
+    When the proxy handles a web search interception, the original request's
+    metadata (API key, user, team, etc.) must be forwarded to the search call
+    so that spend tracking callbacks can attribute the search cost correctly.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    fake_metadata = {
+        "user_api_key_hash": "hashed-key-123",
+        "user_api_key_user_id": "user-456",
+        "user_api_key_team_id": "team-789",
+    }
+
+    mock_search_response = Mock()
+    mock_search_response.results = [
+        Mock(title="Result 1", url="https://example.com", snippet="A snippet")
+    ]
+
+    with patch("litellm.asearch", new_callable=AsyncMock, return_value=mock_search_response):
+        import litellm
+
+        await logger._execute_search("test query", metadata=fake_metadata)
+
+        litellm.asearch.assert_called_once()
+        call_kwargs = litellm.asearch.call_args
+        assert call_kwargs.kwargs.get("metadata") == fake_metadata
+
+
+@pytest.mark.asyncio
+async def test_execute_search_omits_metadata_when_none():
+    """Test that _execute_search does not pass metadata when it is None."""
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    mock_search_response = Mock()
+    mock_search_response.results = [
+        Mock(title="Result 1", url="https://example.com", snippet="A snippet")
+    ]
+
+    with patch("litellm.asearch", new_callable=AsyncMock, return_value=mock_search_response):
+        import litellm
+
+        await logger._execute_search("test query")
+
+        litellm.asearch.assert_called_once()
+        call_kwargs = litellm.asearch.call_args
+        assert "metadata" not in call_kwargs.kwargs


### PR DESCRIPTION
## Summary

The websearch interception handler executes search API calls via `litellm.asearch()` but does not forward the request metadata (API key, user, team, etc.) from the original request. This means the proxy's spend tracking callbacks cannot attribute search costs to the correct API key or user budget.

Search provider costs (e.g. `google_pse/search` at `$0.005/query`) are already defined in `model_prices_and_context_window_backup.json` and calculated by `search/cost_calculator.py`, but without metadata the costs never reach the proxy's spend tracking system.

## Changes

- Add optional `metadata` parameter to `_execute_search()`
- Extract metadata from `kwargs` in both `_execute_agentic_loop()` and `_execute_chat_completion_agentic_loop()`
- Forward metadata to `litellm.asearch()` so the `@client` decorator's logging pipeline can attribute costs correctly
- Add two unit tests verifying metadata forwarding behavior

## Test plan

- [x] All 54 existing + new websearch interception unit tests pass
- [x] No changes to public API surface