### PR TITLE
fix(schema): add missing source_url column to LiteLLM_MCPServerTable

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -320,6 +320,7 @@ model LiteLLM_MCPServerTable {
   is_byok               Boolean  @default(false)
   byok_description      String[] @default([])
   byok_api_key_help_url String?
+  source_url            String?
 }
 
 // Per-user BYOK credentials for MCP servers


### PR DESCRIPTION
The root schema.prisma was missing the source_url field that exists in
litellm/proxy/schema.prisma. At Docker build time, 'prisma generate'
runs against the root schema.prisma (which lacks source_url), so the
generated client never learns about the column.

Migrations add the column to the DB at runtime, and a sanity check
re-applies it on every restart, but the Prisma client (generated at build
time) never includes it in queries — causing the
'column LiteLLM_MCPServerTable.source_url does not exist' error.

Fixes #24433