### PR TITLE
feat(logging): add component and logger fields to JSON logs for 3rd p…

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -195,8 +195,6 @@ class JsonFormatter(Formatter):
             "message": message_str,
             "level": record.levelname,
             "timestamp": self.formatTime(record),
-            "component": record.name,
-            "logger": f"{record.filename}:{record.lineno}",
         }
 
         # Parse embedded JSON or Python dict repr in message so sub-fields become first-class properties
@@ -212,6 +210,12 @@ class JsonFormatter(Formatter):
         for key, value in record.__dict__.items():
             if key not in _STANDARD_RECORD_ATTRS and key not in json_record:
                 json_record[key] = value
+
+        # Set component/logger only if not already supplied via extra={...}
+        if "component" not in json_record:
+            json_record["component"] = record.name
+        if "logger" not in json_record:
+            json_record["logger"] = f"{record.filename}:{record.lineno}"
 
         if record.exc_info:
             json_record["stacktrace"] = record.exc_text or self.formatException(

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -195,6 +195,8 @@ class JsonFormatter(Formatter):
             "message": message_str,
             "level": record.levelname,
             "timestamp": self.formatTime(record),
+            "component": record.name,
+            "logger": f"{record.filename}:{record.lineno}",
         }
 
         # Parse embedded JSON or Python dict repr in message so sub-fields become first-class properties

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -177,6 +177,52 @@ def test_json_formatter_parses_embedded_python_dict_repr():
     assert obj["model_info"]["db_model"] is False
 
 
+def test_json_formatter_includes_component_field():
+    """
+    Test that JsonFormatter always emits a 'component' field equal to the logger name.
+    This allows filtering by component (e.g. "LiteLLM Proxy") in Datadog / third-party log services.
+    """
+    formatter = JsonFormatter()
+    for logger_name in ("LiteLLM Proxy", "LiteLLM Router", "LiteLLM"):
+        record = logging.LogRecord(
+            name=logger_name,
+            level=logging.ERROR,
+            pathname="proxy_server.py",
+            lineno=42,
+            msg="something went wrong",
+            args=(),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        obj = json.loads(output)
+        assert obj["component"] == logger_name, (
+            f"Expected component={logger_name!r}, got {obj.get('component')!r}"
+        )
+
+
+def test_json_formatter_includes_logger_field():
+    """
+    Test that JsonFormatter always emits a 'logger' field with filename:lineno.
+    This allows pinpointing the exact source of a log line in third-party services.
+    """
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="LiteLLM Proxy",
+        level=logging.INFO,
+        pathname="/app/litellm/proxy/proxy_server.py",
+        lineno=123,
+        msg="request received",
+        args=(),
+        exc_info=None,
+    )
+    output = formatter.format(record)
+    obj = json.loads(output)
+    assert "logger" in obj, "'logger' field missing from JSON log output"
+    assert obj["logger"].endswith(":123"), (
+        f"Expected logger field to end with ':123', got {obj['logger']!r}"
+    )
+
+
 def test_initialize_loggers_with_handler_sets_propagate_false():
     """
     Test that the initialize_loggers_with_handler function sets propagate to False for all loggers

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -217,9 +217,29 @@ def test_json_formatter_includes_logger_field():
     )
     output = formatter.format(record)
     obj = json.loads(output)
-    assert "logger" in obj, "'logger' field missing from JSON log output"
-    assert obj["logger"].endswith(":123"), (
-        f"Expected logger field to end with ':123', got {obj['logger']!r}"
+    assert obj["logger"] == "proxy_server.py:123", (
+        f"Expected logger='proxy_server.py:123', got {obj['logger']!r}"
+    )
+
+
+def test_json_formatter_extra_component_not_overwritten():
+    """
+    User-supplied extra={"component": "..."} must not be silently dropped.
+    """
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="LiteLLM Proxy",
+        level=logging.INFO,
+        pathname="proxy_server.py",
+        lineno=1,
+        msg="event",
+        args=(),
+        exc_info=None,
+    )
+    record.component = "auth-service"
+    obj = json.loads(formatter.format(record))
+    assert obj["component"] == "auth-service", (
+        f"User-supplied component was overwritten, got {obj['component']!r}"
     )
 
 


### PR DESCRIPTION
## Relevant issues

Resolves #23884 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Add `component` and `logger` fields to structured JSON logs

Adds two fields to the `JsonFormatter` output:
- `component`: the logger name (e.g. `LiteLLM Proxy`, `LiteLLM Router`)
- `logger`: source file and line number (e.g. `proxy_server.py:412`)

Makes it easier to filter and route logs by component in third-party
observability tools (Datadog, Grafana, CloudWatch) without parsing the
message string.

