### PR TITLE
Feat/prometheus org budget metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -180,6 +180,31 @@ class PrometheusLogger(CustomLogger):
                 ),
             )
 
+            # Remaining Budget for Org
+            self.litellm_remaining_org_budget_metric = self._gauge_factory(
+                "litellm_remaining_org_budget_metric",
+                "Remaining budget for org",
+                labelnames=self.get_labels_for_metric(
+                    "litellm_remaining_org_budget_metric"
+                ),
+            )
+
+            # Max Budget for Org
+            self.litellm_org_max_budget_metric = self._gauge_factory(
+                "litellm_org_max_budget_metric",
+                "Maximum budget set for org",
+                labelnames=self.get_labels_for_metric("litellm_org_max_budget_metric"),
+            )
+
+            # Org Budget Reset At
+            self.litellm_org_budget_remaining_hours_metric = self._gauge_factory(
+                "litellm_org_budget_remaining_hours_metric",
+                "Remaining hours for org budget to be reset",
+                labelnames=self.get_labels_for_metric(
+                    "litellm_org_budget_remaining_hours_metric"
+                ),
+            )
+
             # Remaining Budget for API Key
             self.litellm_remaining_api_key_budget_metric = self._gauge_factory(
                 "litellm_remaining_api_key_budget_metric",
@@ -922,6 +947,9 @@ class PrometheusLogger(CustomLogger):
         user_api_team_alias = standard_logging_payload["metadata"][
             "user_api_key_team_alias"
         ]
+        user_api_key_org_id = standard_logging_payload["metadata"].get(
+            "user_api_key_org_id"
+        )
         output_tokens = standard_logging_payload["completion_tokens"]
         tokens_used = standard_logging_payload["total_tokens"]
         response_cost = standard_logging_payload["response_cost"]
@@ -1026,6 +1054,7 @@ class PrometheusLogger(CustomLogger):
             litellm_params=litellm_params,
             response_cost=response_cost,
             user_id=user_id,
+            user_api_key_org_id=user_api_key_org_id,
         )
 
         # set proxy virtual key rpm/tpm metrics
@@ -1181,6 +1210,7 @@ class PrometheusLogger(CustomLogger):
         litellm_params: dict,
         response_cost: float,
         user_id: Optional[str] = None,
+        user_api_key_org_id: Optional[str] = None,
     ):
         _metadata = litellm_params.get("metadata") or {}
         _team_spend = _metadata.get("user_api_key_team_spend", None)
@@ -1213,12 +1243,16 @@ class PrometheusLogger(CustomLogger):
                 user_max_budget=_user_max_budget,
                 response_cost=response_cost,
             ),
+            self._set_org_budget_metrics_after_api_request(
+                org_id=user_api_key_org_id,
+                response_cost=response_cost,
+            ),
             return_exceptions=True,
         )
         for i, r in enumerate(results):
             if isinstance(r, Exception):
                 verbose_logger.debug(
-                    f"[Non-Blocking] Prometheus: Budget metric lookup {['key', 'team', 'user'][i]} failed: {r}"
+                    f"[Non-Blocking] Prometheus: Budget metric lookup {['key', 'team', 'user', 'org'][i]} failed: {r}"
                 )
 
     def _increment_top_level_request_and_spend_metrics(
@@ -2741,6 +2775,110 @@ class PrometheusLogger(CustomLogger):
             self.litellm_team_budget_remaining_hours_metric.labels(**_labels).set(
                 self._get_remaining_hours_for_budget_reset(
                     budget_reset_at=team.budget_reset_at
+                )
+            )
+
+    async def _set_org_budget_metrics_after_api_request(
+        self,
+        org_id: Optional[str],
+        response_cost: float,
+    ):
+        """
+        Set org budget metrics after an LLM API request
+
+        - Fetches org info from db
+        - Sets org budget metrics
+        """
+        if not org_id:
+            return
+
+        from litellm.proxy.proxy_server import prisma_client
+
+        if prisma_client is None:
+            return
+
+        try:
+            org_row = await prisma_client.db.litellm_organizationtable.find_unique(
+                where={"organization_id": org_id},
+                include={"litellm_budget_table": True},
+            )
+        except Exception as e:
+            verbose_logger.debug(
+                f"[Non-Blocking] Prometheus: Error getting org info: {str(e)}"
+            )
+            return
+
+        if org_row is None:
+            return
+
+        org_alias = org_row.organization_alias or ""
+        spend = org_row.spend or 0.0
+        budget_table = org_row.litellm_budget_table
+        max_budget = budget_table.max_budget if budget_table else None
+        budget_reset_at = (
+            getattr(budget_table, "budget_reset_at", None) if budget_table else None
+        )
+
+        self._set_org_budget_metrics(
+            org_id=org_id,
+            org_alias=org_alias,
+            spend=spend,
+            max_budget=max_budget,
+            budget_reset_at=budget_reset_at,
+        )
+
+    def _set_org_budget_metrics(
+        self,
+        org_id: str,
+        org_alias: str,
+        spend: float,
+        max_budget: Optional[float],
+        budget_reset_at: Optional[datetime],
+    ):
+        """
+        Set org budget metrics for a single org
+
+        - Remaining Budget
+        - Max Budget
+        - Budget Reset At
+        """
+        enum_values = UserAPIKeyLabelValues(
+            org_id=org_id,
+            org_alias=org_alias,
+        )
+
+        _labels = prometheus_label_factory(
+            supported_enum_labels=self.get_labels_for_metric(
+                metric_name="litellm_remaining_org_budget_metric"
+            ),
+            enum_values=enum_values,
+        )
+        self.litellm_remaining_org_budget_metric.labels(**_labels).set(
+            self._safe_get_remaining_budget(
+                max_budget=max_budget,
+                spend=spend,
+            )
+        )
+
+        if max_budget is not None:
+            _labels = prometheus_label_factory(
+                supported_enum_labels=self.get_labels_for_metric(
+                    metric_name="litellm_org_max_budget_metric"
+                ),
+                enum_values=enum_values,
+            )
+            self.litellm_org_max_budget_metric.labels(**_labels).set(max_budget)
+
+        if budget_reset_at is not None:
+            _labels = prometheus_label_factory(
+                supported_enum_labels=self.get_labels_for_metric(
+                    metric_name="litellm_org_budget_remaining_hours_metric"
+                ),
+                enum_values=enum_values,
+            )
+            self.litellm_org_budget_remaining_hours_metric.labels(**_labels).set(
+                self._get_remaining_hours_for_budget_reset(
+                    budget_reset_at=budget_reset_at
                 )
             )
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2571,6 +2571,37 @@ class PrometheusLogger(CustomLogger):
             data_type="users",
         )
 
+    async def _initialize_org_budget_metrics(self):
+        """
+        Initialize org budget metrics by reusing the generic pagination logic.
+        """
+        from litellm.proxy.proxy_server import prisma_client
+
+        if prisma_client is None:
+            verbose_logger.debug(
+                "Prometheus: skipping org metrics initialization, DB not initialized"
+            )
+            return
+
+        async def fetch_orgs(
+            page_size: int, page: int
+        ) -> Tuple[list, Optional[int]]:
+            skip = (page - 1) * page_size
+            orgs = await prisma_client.db.litellm_organizationtable.find_many(
+                skip=skip,
+                take=page_size,
+                order={"created_at": "desc"},
+                include={"litellm_budget_table": True},
+            )
+            total_count = await prisma_client.db.litellm_organizationtable.count()
+            return orgs, total_count
+
+        await self._initialize_budget_metrics(
+            data_fetch_function=fetch_orgs,
+            set_metrics_function=self._set_org_list_budget_metrics,
+            data_type="orgs",
+        )
+
     async def initialize_remaining_budget_metrics(self):
         """
         Handler for initializing remaining budget metrics for all teams to avoid metric discrepancies.
@@ -2605,10 +2636,11 @@ class PrometheusLogger(CustomLogger):
         """
         Helper to initialize remaining budget metrics for all teams, API keys, and users.
         """
-        verbose_logger.debug("Emitting key, team, user budget metrics....")
+        verbose_logger.debug("Emitting key, team, user, org budget metrics....")
         await self._initialize_team_budget_metrics()
         await self._initialize_api_key_budget_metrics()
         await self._initialize_user_budget_metrics()
+        await self._initialize_org_budget_metrics()
         await self._initialize_user_and_team_count_metrics()
 
     async def _initialize_user_and_team_count_metrics(self):
@@ -2663,6 +2695,20 @@ class PrometheusLogger(CustomLogger):
         """Helper function to set budget metrics for a list of users"""
         for user in users:
             self._set_user_budget_metrics(user)
+
+    async def _set_org_list_budget_metrics(self, orgs: list):
+        """Helper function to set budget metrics for a list of orgs"""
+        for org in orgs:
+            budget_table = getattr(org, "litellm_budget_table", None)
+            self._set_org_budget_metrics(
+                org_id=org.organization_id or "",
+                org_alias=org.organization_alias or "",
+                spend=org.spend or 0.0,
+                max_budget=budget_table.max_budget if budget_table else None,
+                budget_reset_at=getattr(budget_table, "budget_reset_at", None)
+                if budget_table
+                else None,
+            )
 
     async def _set_team_budget_metrics_after_api_request(
         self,
@@ -2793,21 +2839,24 @@ class PrometheusLogger(CustomLogger):
         """
         Set org budget metrics after an LLM API request
 
-        - Fetches org info from db
+        - Fetches org info via cache (get_org_object)
         - Sets org budget metrics
         """
         if not org_id:
             return
 
-        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.auth.auth_checks import get_org_object
+        from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
         if prisma_client is None:
             return
 
         try:
-            org_row = await prisma_client.db.litellm_organizationtable.find_unique(
-                where={"organization_id": org_id},
-                include={"litellm_budget_table": True},
+            org_info = await get_org_object(
+                org_id=org_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                include_budget_table=True,
             )
         except Exception as e:
             verbose_logger.debug(
@@ -2815,12 +2864,12 @@ class PrometheusLogger(CustomLogger):
             )
             return
 
-        if org_row is None:
+        if org_info is None:
             return
 
-        org_alias = org_row.organization_alias or ""
-        spend = org_row.spend or 0.0
-        budget_table = org_row.litellm_budget_table
+        org_alias = org_info.organization_alias or ""
+        _total_org_spend = (org_info.spend or 0.0) + response_cost
+        budget_table = org_info.litellm_budget_table
         max_budget = budget_table.max_budget if budget_table else None
         budget_reset_at = (
             getattr(budget_table, "budget_reset_at", None) if budget_table else None
@@ -2829,7 +2878,7 @@ class PrometheusLogger(CustomLogger):
         self._set_org_budget_metrics(
             org_id=org_id,
             org_alias=org_alias,
-            spend=spend,
+            spend=_total_org_spend,
             max_budget=max_budget,
             budget_reset_at=budget_reset_at,
         )

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1441,6 +1441,9 @@ class PrometheusLogger(CustomLogger):
         user_api_team_alias = standard_logging_payload["metadata"][
             "user_api_key_team_alias"
         ]
+        user_api_key_org_id = standard_logging_payload["metadata"].get(
+            "user_api_key_org_id"
+        )
 
         try:
             self.litellm_llm_api_failed_requests_metric.labels(
@@ -1456,6 +1459,10 @@ class PrometheusLogger(CustomLogger):
                 ),
             ).inc()
             self.set_llm_deployment_failure_metrics(kwargs)
+            await self._set_org_budget_metrics_after_api_request(
+                org_id=user_api_key_org_id,
+                response_cost=0,
+            )
         except Exception as e:
             verbose_logger.exception(
                 "prometheus Layer Error(): Exception occured - {}".format(str(e))

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -185,6 +185,8 @@ class UserAPIKeyLabelNames(Enum):
     USER_AGENT = "user_agent"
     CALLBACK_NAME = "callback_name"
     STREAM = "stream"
+    ORG_ID = "org_id"
+    ORG_ALIAS = "org_alias"
 
 
 DEFINED_PROMETHEUS_METRICS = Literal[
@@ -207,6 +209,9 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_remaining_team_budget_metric",
     "litellm_team_max_budget_metric",
     "litellm_team_budget_remaining_hours_metric",
+    "litellm_remaining_org_budget_metric",
+    "litellm_org_max_budget_metric",
+    "litellm_org_budget_remaining_hours_metric",
     "litellm_remaining_api_key_budget_metric",
     "litellm_api_key_max_budget_metric",
     "litellm_api_key_budget_remaining_hours_metric",
@@ -490,6 +495,21 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
     ]
 
+    litellm_remaining_org_budget_metric = [
+        UserAPIKeyLabelNames.ORG_ID.value,
+        UserAPIKeyLabelNames.ORG_ALIAS.value,
+    ]
+
+    litellm_org_max_budget_metric = [
+        UserAPIKeyLabelNames.ORG_ID.value,
+        UserAPIKeyLabelNames.ORG_ALIAS.value,
+    ]
+
+    litellm_org_budget_remaining_hours_metric = [
+        UserAPIKeyLabelNames.ORG_ID.value,
+        UserAPIKeyLabelNames.ORG_ALIAS.value,
+    ]
+
     litellm_remaining_api_key_budget_metric = [
         UserAPIKeyLabelNames.API_KEY_HASH.value,
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
@@ -720,6 +740,12 @@ class UserAPIKeyLabelValues(BaseModel):
     ] = None
     stream: Annotated[
         Optional[str], Field(..., alias=UserAPIKeyLabelNames.STREAM.value)
+    ] = None
+    org_id: Annotated[
+        Optional[str], Field(..., alias=UserAPIKeyLabelNames.ORG_ID.value)
+    ] = None
+    org_alias: Annotated[
+        Optional[str], Field(..., alias=UserAPIKeyLabelNames.ORG_ALIAS.value)
     ] = None
 
     @field_validator("stream", mode="before")

--- a/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
@@ -2,7 +2,7 @@
 Unit tests for Prometheus user and team count metrics
 """
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from prometheus_client import REGISTRY
@@ -523,3 +523,150 @@ async def test_set_user_budget_metrics_after_api_request_inf_when_genuinely_no_b
     assert actual_value == float("inf"), (
         "remaining_user_budget_metric should be +Inf when user truly has no budget"
     )
+
+
+# ---------------------------------------------------------------------------
+# Org budget metric tests
+# ---------------------------------------------------------------------------
+
+
+def test_org_budget_metrics_initialized(prometheus_logger):
+    """Test that the 3 org budget gauge metrics are initialized."""
+    assert hasattr(prometheus_logger, "litellm_remaining_org_budget_metric")
+    assert hasattr(prometheus_logger, "litellm_org_max_budget_metric")
+    assert hasattr(prometheus_logger, "litellm_org_budget_remaining_hours_metric")
+    assert prometheus_logger.litellm_remaining_org_budget_metric is not None
+    assert prometheus_logger.litellm_org_max_budget_metric is not None
+    assert prometheus_logger.litellm_org_budget_remaining_hours_metric is not None
+
+
+def test_set_org_budget_metrics_remaining_budget(prometheus_logger):
+    """_set_org_budget_metrics sets remaining budget gauge correctly."""
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    prometheus_logger._set_org_budget_metrics(
+        org_id="org-abc",
+        org_alias="my-org",
+        spend=200.0,
+        max_budget=500.0,
+        budget_reset_at=None,
+    )
+
+    set_call = prometheus_logger.litellm_remaining_org_budget_metric.labels().set
+    set_call.assert_called_once()
+    actual = set_call.call_args[0][0]
+    assert abs(actual - 300.0) < 0.01, f"Expected 300.0, got {actual}"
+
+
+def test_set_org_budget_metrics_max_budget(prometheus_logger):
+    """_set_org_budget_metrics sets max budget gauge when max_budget is not None."""
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    prometheus_logger._set_org_budget_metrics(
+        org_id="org-abc",
+        org_alias="my-org",
+        spend=100.0,
+        max_budget=1000.0,
+        budget_reset_at=None,
+    )
+
+    prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_called_once_with(
+        1000.0
+    )
+
+
+def test_set_org_budget_metrics_no_max_budget(prometheus_logger):
+    """_set_org_budget_metrics does not set max budget gauge when max_budget is None."""
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    prometheus_logger._set_org_budget_metrics(
+        org_id="org-abc",
+        org_alias="my-org",
+        spend=50.0,
+        max_budget=None,
+        budget_reset_at=None,
+    )
+
+    prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_not_called()
+
+
+def test_set_org_budget_metrics_remaining_hours(prometheus_logger):
+    """_set_org_budget_metrics sets remaining hours gauge when budget_reset_at is set."""
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    future_reset = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    prometheus_logger._set_org_budget_metrics(
+        org_id="org-abc",
+        org_alias="my-org",
+        spend=10.0,
+        max_budget=500.0,
+        budget_reset_at=future_reset,
+    )
+
+    prometheus_logger.litellm_org_budget_remaining_hours_metric.labels().set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_set_org_budget_metrics_after_api_request(prometheus_logger):
+    """_set_org_budget_metrics_after_api_request fetches from DB and sets gauges."""
+    import sys
+
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    budget_mock = MagicMock()
+    budget_mock.max_budget = 1000.0
+    budget_mock.budget_reset_at = datetime(2099, 1, 1, tzinfo=timezone.utc)
+
+    org_mock = MagicMock()
+    org_mock.organization_id = "org-xyz"
+    org_mock.organization_alias = "test-org"
+    org_mock.spend = 300.0
+    org_mock.litellm_budget_table = budget_mock
+    org_mock.model_dump.return_value = {}
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(
+        return_value=org_mock
+    )
+
+    mock_proxy_server = MagicMock()
+    mock_proxy_server.prisma_client = mock_prisma
+
+    with patch.dict(sys.modules, {"litellm.proxy.proxy_server": mock_proxy_server}):
+        await prometheus_logger._set_org_budget_metrics_after_api_request(
+            org_id="org-xyz",
+            response_cost=0.0,
+        )
+
+    prometheus_logger.litellm_remaining_org_budget_metric.labels().set.assert_called_once()
+    prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_called_once_with(
+        1000.0
+    )
+    prometheus_logger.litellm_org_budget_remaining_hours_metric.labels().set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_set_org_budget_metrics_after_api_request_no_org_id(prometheus_logger):
+    """_set_org_budget_metrics_after_api_request is a no-op when org_id is None."""
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    await prometheus_logger._set_org_budget_metrics_after_api_request(
+        org_id=None,
+        response_cost=1.0,
+    )
+
+    prometheus_logger.litellm_remaining_org_budget_metric.labels().set.assert_not_called()
+    prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_not_called()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric.labels().set.assert_not_called()

--- a/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
@@ -616,7 +616,7 @@ def test_set_org_budget_metrics_remaining_hours(prometheus_logger):
 
 @pytest.mark.asyncio
 async def test_set_org_budget_metrics_after_api_request(prometheus_logger):
-    """_set_org_budget_metrics_after_api_request fetches from DB and sets gauges."""
+    """_set_org_budget_metrics_after_api_request uses cache helper and accounts for response_cost."""
     import sys
 
     prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
@@ -632,23 +632,29 @@ async def test_set_org_budget_metrics_after_api_request(prometheus_logger):
     org_mock.organization_alias = "test-org"
     org_mock.spend = 300.0
     org_mock.litellm_budget_table = budget_mock
-    org_mock.model_dump.return_value = {}
 
     mock_prisma = MagicMock()
-    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(
-        return_value=org_mock
-    )
-
     mock_proxy_server = MagicMock()
     mock_proxy_server.prisma_client = mock_prisma
+    mock_proxy_server.user_api_key_cache = MagicMock()
 
-    with patch.dict(sys.modules, {"litellm.proxy.proxy_server": mock_proxy_server}):
+    with (
+        patch.dict(sys.modules, {"litellm.proxy.proxy_server": mock_proxy_server}),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_org_object",
+            AsyncMock(return_value=org_mock),
+        ),
+    ):
         await prometheus_logger._set_org_budget_metrics_after_api_request(
             org_id="org-xyz",
-            response_cost=0.0,
+            response_cost=50.0,
         )
 
-    prometheus_logger.litellm_remaining_org_budget_metric.labels().set.assert_called_once()
+    # remaining budget should reflect spend + response_cost (300 + 50 = 350, remaining = 1000 - 350 = 650)
+    remaining_call = prometheus_logger.litellm_remaining_org_budget_metric.labels().set.call_args
+    assert remaining_call is not None
+    assert remaining_call[0][0] == pytest.approx(650.0)
+
     prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_called_once_with(
         1000.0
     )
@@ -670,3 +676,40 @@ async def test_set_org_budget_metrics_after_api_request_no_org_id(prometheus_log
     prometheus_logger.litellm_remaining_org_budget_metric.labels().set.assert_not_called()
     prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_not_called()
     prometheus_logger.litellm_org_budget_remaining_hours_metric.labels().set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_initialize_org_budget_metrics(prometheus_logger):
+    """_initialize_org_budget_metrics fetches all orgs and sets gauges for each."""
+    import sys
+
+    prometheus_logger.litellm_remaining_org_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_max_budget_metric = MagicMock()
+    prometheus_logger.litellm_org_budget_remaining_hours_metric = MagicMock()
+
+    budget_mock = MagicMock()
+    budget_mock.max_budget = 500.0
+    budget_mock.budget_reset_at = None
+
+    org_mock = MagicMock()
+    org_mock.organization_id = "org-init"
+    org_mock.organization_alias = "init-org"
+    org_mock.spend = 100.0
+    org_mock.litellm_budget_table = budget_mock
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_organizationtable.find_many = AsyncMock(
+        return_value=[org_mock]
+    )
+    mock_prisma.db.litellm_organizationtable.count = AsyncMock(return_value=1)
+
+    mock_proxy_server = MagicMock()
+    mock_proxy_server.prisma_client = mock_prisma
+
+    with patch.dict(sys.modules, {"litellm.proxy.proxy_server": mock_proxy_server}):
+        await prometheus_logger._initialize_org_budget_metrics()
+
+    prometheus_logger.litellm_remaining_org_budget_metric.labels().set.assert_called_once()
+    prometheus_logger.litellm_org_max_budget_metric.labels().set.assert_called_once_with(
+        500.0
+    )


### PR DESCRIPTION
## Relevant issues

Resolves #24249 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Add organization budget Prometheus metrics

Adds three new gauge metrics tracking org-level budget:
- `litellm_remaining_org_budget_metric`
- `litellm_org_max_budget_metric`
- `litellm_org_budget_remaining_hours_metric`

Metrics are pre-populated at proxy startup and updated after every
request (success and failure). Org data is fetched via the existing
`get_org_object` cache helper to avoid per-request DB hits. Labels:
`org_id`, `org_alias`.

