### PR TITLE
fix(security): use Jinja2 SandboxedEnvironment in prompt managers to prevent SSTI

### DIFF
--- a/litellm/integrations/arize/arize_phoenix_prompt_manager.py
+++ b/litellm/integrations/arize/arize_phoenix_prompt_manager.py
@@ -5,7 +5,8 @@ Fetches prompt versions from Arize Phoenix and provides workspace-based access c
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from jinja2 import DictLoader, Environment, select_autoescape
+from jinja2 import DictLoader, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 from litellm.integrations.prompt_management_base import (
@@ -74,7 +75,7 @@ class ArizePhoenixTemplateManager:
             api_key=self.api_key, api_base=self.api_base
         )
 
-        self.jinja_env = Environment(
+        self.jinja_env = SandboxedEnvironment(
             loader=DictLoader({}),
             autoescape=select_autoescape(["html", "xml"]),
             # Use Mustache/Handlebars-style delimiters

--- a/litellm/integrations/bitbucket/bitbucket_prompt_manager.py
+++ b/litellm/integrations/bitbucket/bitbucket_prompt_manager.py
@@ -5,7 +5,8 @@ Fetches .prompt files from BitBucket repositories and provides team-based access
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-from jinja2 import DictLoader, Environment, select_autoescape
+from jinja2 import DictLoader, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 
@@ -74,7 +75,7 @@ class BitBucketTemplateManager:
         self.prompts: Dict[str, BitBucketPromptTemplate] = {}
         self.bitbucket_client = BitBucketClient(bitbucket_config)
 
-        self.jinja_env = Environment(
+        self.jinja_env = SandboxedEnvironment(
             loader=DictLoader({}),
             autoescape=select_autoescape(["html", "xml"]),
             # Use Handlebars-style delimiters to match Dotprompt spec

--- a/litellm/integrations/dotprompt/prompt_manager.py
+++ b/litellm/integrations/dotprompt/prompt_manager.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
-from jinja2 import DictLoader, Environment, select_autoescape
+from jinja2 import DictLoader, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 
 class PromptTemplate:
@@ -59,7 +60,7 @@ class PromptManager:
         self.prompt_directory = Path(prompt_directory) if prompt_directory else None
         self.prompts: Dict[str, PromptTemplate] = {}
         self.prompt_file = prompt_file
-        self.jinja_env = Environment(
+        self.jinja_env = SandboxedEnvironment(
             loader=DictLoader({}),
             autoescape=select_autoescape(["html", "xml"]),
             # Use Handlebars-style delimiters to match Dotprompt spec

--- a/litellm/integrations/gitlab/gitlab_prompt_manager.py
+++ b/litellm/integrations/gitlab/gitlab_prompt_manager.py
@@ -4,7 +4,8 @@ GitLab prompt manager with configurable prompts folder.
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-from jinja2 import DictLoader, Environment, select_autoescape
+from jinja2 import DictLoader, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 
@@ -90,7 +91,7 @@ class GitLabTemplateManager:
             or ""
         ).strip("/")
 
-        self.jinja_env = Environment(
+        self.jinja_env = SandboxedEnvironment(
             loader=DictLoader({}),
             autoescape=select_autoescape(["html", "xml"]),
             variable_start_string="{{",

--- a/tests/litellm/integrations/test_ssti_sandboxed_environment.py
+++ b/tests/litellm/integrations/test_ssti_sandboxed_environment.py
@@ -1,0 +1,178 @@
+"""
+Tests that all prompt managers use Jinja2 SandboxedEnvironment to prevent SSTI attacks.
+
+Verifies:
+1. Normal template variable substitution still works
+2. Malicious templates attempting to access unsafe attributes are blocked
+
+Covers:
+- litellm/integrations/dotprompt/prompt_manager.py
+- litellm/integrations/arize/arize_phoenix_prompt_manager.py
+- litellm/integrations/bitbucket/bitbucket_prompt_manager.py
+- litellm/integrations/gitlab/gitlab_prompt_manager.py
+- litellm/proxy/prompts/prompt_endpoints.py (uses dotprompt PromptManager.jinja_env)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from jinja2.sandbox import SandboxedEnvironment, SecurityError
+
+from litellm.integrations.dotprompt.prompt_manager import PromptManager
+
+
+class TestDotpromptSandboxedEnvironment:
+    """Test that DotpromptManager's jinja_env blocks SSTI payloads."""
+
+    def setup_method(self):
+        self.manager = PromptManager()
+
+    def test_jinja_env_is_sandboxed(self):
+        """jinja_env must be a SandboxedEnvironment instance."""
+        assert isinstance(self.manager.jinja_env, SandboxedEnvironment)
+
+    def test_normal_variable_substitution(self):
+        """Normal {{ variable }} rendering should work."""
+        template = self.manager.jinja_env.from_string(
+            "Hello {{ name }}, you are {{ role }}."
+        )
+        result = template.render(name="Alice", role="admin")
+        assert result == "Hello Alice, you are admin."
+
+    def test_empty_variables(self):
+        """Template with no variables should render as-is."""
+        template = self.manager.jinja_env.from_string("No variables here.")
+        result = template.render()
+        assert result == "No variables here."
+
+    def test_ssti_dunder_class_blocked(self):
+        """Accessing __class__ on objects should be blocked."""
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ config.__class__.__init__.__globals__['os'].popen('id').read() }}"
+            )
+            template.render(config={})
+
+    def test_ssti_dunder_mro_blocked(self):
+        """Accessing __mro__ should be blocked."""
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+            )
+            template.render()
+
+    def test_ssti_dunder_globals_blocked(self):
+        """Accessing __globals__ should be blocked."""
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ request.__class__.__init__.__globals__ }}"
+            )
+            template.render(request="test")
+
+    def test_ssti_getattr_bypass_blocked(self):
+        """Attempting getattr-based bypass should be blocked."""
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ lipsum.__globals__['os'].popen('id').read() }}"
+            )
+            template.render()
+
+
+class TestArizePhoenixSandboxedEnvironment:
+    """Test that ArizePhoenixTemplateManager's jinja_env blocks SSTI payloads."""
+
+    def setup_method(self):
+        from litellm.integrations.arize.arize_phoenix_prompt_manager import (
+            ArizePhoenixTemplateManager,
+        )
+
+        with patch(
+            "litellm.integrations.arize.arize_phoenix_prompt_manager.ArizePhoenixClient"
+        ):
+            self.manager = ArizePhoenixTemplateManager(
+                api_key="fake-key", api_base="https://fake.arize.com"
+            )
+
+    def test_jinja_env_is_sandboxed(self):
+        assert isinstance(self.manager.jinja_env, SandboxedEnvironment)
+
+    def test_normal_variable_substitution(self):
+        template = self.manager.jinja_env.from_string("Hello {{ name }}.")
+        result = template.render(name="World")
+        assert result == "Hello World."
+
+    def test_ssti_blocked(self):
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+            )
+            template.render()
+
+
+class TestBitBucketSandboxedEnvironment:
+    """Test that BitBucketTemplateManager's jinja_env blocks SSTI payloads."""
+
+    def setup_method(self):
+        from litellm.integrations.bitbucket.bitbucket_prompt_manager import (
+            BitBucketTemplateManager,
+        )
+
+        with patch(
+            "litellm.integrations.bitbucket.bitbucket_prompt_manager.BitBucketClient"
+        ):
+            self.manager = BitBucketTemplateManager(
+                bitbucket_config={
+                    "bitbucket_api_base": "https://api.bitbucket.org",
+                    "bitbucket_workspace": "test",
+                    "bitbucket_repo_slug": "test",
+                }
+            )
+
+    def test_jinja_env_is_sandboxed(self):
+        assert isinstance(self.manager.jinja_env, SandboxedEnvironment)
+
+    def test_normal_variable_substitution(self):
+        template = self.manager.jinja_env.from_string("Hello {{ name }}.")
+        result = template.render(name="World")
+        assert result == "Hello World."
+
+    def test_ssti_blocked(self):
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+            )
+            template.render()
+
+
+class TestGitLabSandboxedEnvironment:
+    """Test that GitLabTemplateManager's jinja_env blocks SSTI payloads."""
+
+    def setup_method(self):
+        from litellm.integrations.gitlab.gitlab_prompt_manager import (
+            GitLabTemplateManager,
+        )
+
+        with patch(
+            "litellm.integrations.gitlab.gitlab_prompt_manager.GitLabClient"
+        ):
+            self.manager = GitLabTemplateManager(
+                gitlab_config={
+                    "project": "test/repo",
+                    "access_token": "fake-token",
+                }
+            )
+
+    def test_jinja_env_is_sandboxed(self):
+        assert isinstance(self.manager.jinja_env, SandboxedEnvironment)
+
+    def test_normal_variable_substitution(self):
+        template = self.manager.jinja_env.from_string("Hello {{ name }}.")
+        result = template.render(name="World")
+        assert result == "Hello World."
+
+    def test_ssti_blocked(self):
+        with pytest.raises(SecurityError):
+            template = self.manager.jinja_env.from_string(
+                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+            )
+            template.render()

--- a/tests/litellm/integrations/test_ssti_sandboxed_environment.py
+++ b/tests/litellm/integrations/test_ssti_sandboxed_environment.py
@@ -13,7 +13,7 @@ Covers:
 - litellm/proxy/prompts/prompt_endpoints.py (uses dotprompt PromptManager.jinja_env)
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from jinja2.sandbox import SandboxedEnvironment, SecurityError
@@ -47,34 +47,34 @@ class TestDotpromptSandboxedEnvironment:
 
     def test_ssti_dunder_class_blocked(self):
         """Accessing __class__ on objects should be blocked."""
+        template = self.manager.jinja_env.from_string(
+            "{{ config.__class__.__init__.__globals__['os'].popen('id').read() }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ config.__class__.__init__.__globals__['os'].popen('id').read() }}"
-            )
             template.render(config={})
 
     def test_ssti_dunder_mro_blocked(self):
         """Accessing __mro__ should be blocked."""
+        template = self.manager.jinja_env.from_string(
+            "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
-            )
             template.render()
 
     def test_ssti_dunder_globals_blocked(self):
         """Accessing __globals__ should be blocked."""
+        template = self.manager.jinja_env.from_string(
+            "{{ request.__class__.__init__.__globals__ }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ request.__class__.__init__.__globals__ }}"
-            )
             template.render(request="test")
 
     def test_ssti_getattr_bypass_blocked(self):
         """Attempting getattr-based bypass should be blocked."""
+        template = self.manager.jinja_env.from_string(
+            "{{ lipsum.__globals__['os'].popen('id').read() }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ lipsum.__globals__['os'].popen('id').read() }}"
-            )
             template.render()
 
 
@@ -102,10 +102,10 @@ class TestArizePhoenixSandboxedEnvironment:
         assert result == "Hello World."
 
     def test_ssti_blocked(self):
+        template = self.manager.jinja_env.from_string(
+            "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
-            )
             template.render()
 
 
@@ -137,10 +137,10 @@ class TestBitBucketSandboxedEnvironment:
         assert result == "Hello World."
 
     def test_ssti_blocked(self):
+        template = self.manager.jinja_env.from_string(
+            "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
-            )
             template.render()
 
 
@@ -171,8 +171,8 @@ class TestGitLabSandboxedEnvironment:
         assert result == "Hello World."
 
     def test_ssti_blocked(self):
+        template = self.manager.jinja_env.from_string(
+            "{{ ''.__class__.__mro__[1].__subclasses__() }}"
+        )
         with pytest.raises(SecurityError):
-            template = self.manager.jinja_env.from_string(
-                "{{ ''.__class__.__mro__[1].__subclasses__() }}"
-            )
             template.render()

--- a/tests/litellm/integrations/test_ssti_sandboxed_environment.py
+++ b/tests/litellm/integrations/test_ssti_sandboxed_environment.py
@@ -152,9 +152,7 @@ class TestGitLabSandboxedEnvironment:
             GitLabTemplateManager,
         )
 
-        with patch(
-            "litellm.integrations.gitlab.gitlab_prompt_manager.GitLabClient"
-        ):
+        with patch("litellm.integrations.gitlab.gitlab_prompt_manager.GitLabClient"):
             self.manager = GitLabTemplateManager(
                 gitlab_config={
                     "project": "test/repo",


### PR DESCRIPTION
## Summary

- Replace `jinja2.Environment()` with `jinja2.sandbox.SandboxedEnvironment()` in all prompt managers to prevent Server-Side Template Injection (SSTI)
- `SandboxedEnvironment` is a drop-in replacement that blocks access to unsafe attributes (`__class__`, `__globals__`, `__mro__`, etc.) while preserving normal `{{ variable }}` substitution
- Add tests verifying both normal rendering and SSTI payload blocking for all 4 prompt managers

## Affected Files

| # | File | Source of untrusted template |
|---|------|-----------------------------|
| 1 | `litellm/integrations/arize/arize_phoenix_prompt_manager.py:170` | Arize Phoenix API |
| 2 | `litellm/integrations/bitbucket/bitbucket_prompt_manager.py:172` | BitBucket repository |
| 3 | `litellm/integrations/dotprompt/prompt_manager.py:224` | External .prompt files |
| 4 | `litellm/integrations/gitlab/gitlab_prompt_manager.py:217` | GitLab repository |
| 5 | `litellm/proxy/prompts/prompt_endpoints.py:1075` | User-managed prompts (uses dotprompt `PromptManager.jinja_env`) |

## Risk

If an attacker can control the prompt template content (e.g., by compromising a GitLab/BitBucket repo, or as a malicious user creating prompts via the proxy API), they can execute arbitrary Python code on the LiteLLM server via Jinja2 SSTI:

```
{{ config.__class__.__init__.__globals__['os'].popen('id').read() }}
```

**CWE-1336**: Improper Neutralization of Special Elements Used in a Template Engine

## Fix

One-line change per file: `Environment(` → `SandboxedEnvironment(` with updated import from `jinja2.sandbox`. No functional changes to template rendering — `SandboxedEnvironment` is a subclass of `Environment` that adds attribute access restrictions.

## Test Plan

- [x] 16 new tests in `tests/litellm/integrations/test_ssti_sandboxed_environment.py`
- [x] Verify `isinstance(jinja_env, SandboxedEnvironment)` for all 4 managers
- [x] Verify normal `{{ variable }}` substitution still works
- [x] Verify SSTI payloads (`__class__`, `__mro__`, `__globals__`) raise `SecurityError`

Found by static analysis (llm-seclint LS007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)