### PR TITLE
ci: skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: github.repository == 'BerriAI/litellm'
+    if: github.event_name != 'schedule' || github.repository == 'BerriAI/litellm'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.repository == 'BerriAI/litellm'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/create_daily_staging_branch.yml
+++ b/.github/workflows/create_daily_staging_branch.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   create-staging-branch:
+    if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
 
     steps:
@@ -43,6 +44,7 @@ jobs:
           fi
 
   create-internal-dev-branch:
+    if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
## Relevant issues

N/A — housekeeping fix noticed while maintaining a fork.

## Pre-Submission checklist

- [x] No tests needed — CI-only change (workflow YAML files), no application code modified
- [x] PR scope is isolated: only adds fork guards to 3 scheduled workflow files
- [ ] Greptile review requested

## Type

🚄 Infrastructure

## Changes

Three scheduled workflows (`stale.yml`, `codeql.yml`, `create_daily_staging_branch.yml`) run on all forks, wasting Actions minutes and creating noise (stale-bot closing fork issues, staging branches created in forks, etc.).

This PR adds `if: github.repository == 'BerriAI/litellm'` to each scheduled job, matching the existing pattern already used in `auto_update_price_and_context_window.yml` (line 10).

**Files changed:**
- `.github/workflows/stale.yml` — guard on `stale` job
- `.github/workflows/codeql.yml` — guard on `analyze` job  
- `.github/workflows/create_daily_staging_branch.yml` — guard on both `create-staging-branch` and `create-internal-dev-branch` jobs