### PR TITLE
fix: Handle Gemini empty responses with finishReason=STOP but no content/parts

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2383,16 +2383,17 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if not model_response.choices and _candidates:
                 for candidate in _candidates:
                     finish_reason_str = candidate.get("finishReason")
-                    choice = litellm.Choices(
-                        finish_reason=VertexGeminiConfig._check_finish_reason(
-                            None, finish_reason_str
-                        ),
-                        index=candidate.get("index", 0),
-                        message={"role": "assistant", "content": None},
-                        logprobs=None,
-                        enhancements=None,
-                    )
-                    model_response.choices.append(choice)
+                    if finish_reason_str is not None:
+                        choice = litellm.Choices(
+                            finish_reason=VertexGeminiConfig._check_finish_reason(
+                                None, finish_reason_str
+                            ),
+                            index=candidate.get("index", 0),
+                            message={"role": "assistant", "content": None},
+                            logprobs=None,
+                            enhancements=None,
+                        )
+                        model_response.choices.append(choice)
 
             usage = VertexGeminiConfig._calculate_usage(
                 completion_response=completion_response

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2375,6 +2375,25 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     _candidates, model_response, logging_obj.optional_params
                 )
 
+            # Handle the case where _process_candidates produced no choices.
+            # This can happen when Gemini returns candidates with finishReason=STOP
+            # but no content/parts (e.g., empty response in agentic tasks with
+            # gemini-2.5-flash-lite). See https://discuss.ai.google.dev/t/
+            # finishreason-stop-but-parts-is-missing-inside-candidate/99331
+            if not model_response.choices and _candidates:
+                for candidate in _candidates:
+                    finish_reason_str = candidate.get("finishReason")
+                    choice = litellm.Choices(
+                        finish_reason=VertexGeminiConfig._check_finish_reason(
+                            None, finish_reason_str
+                        ),
+                        index=candidate.get("index", 0),
+                        message={"role": "assistant", "content": None},
+                        logprobs=None,
+                        enhancements=None,
+                    )
+                    model_response.choices.append(choice)
+
             usage = VertexGeminiConfig._calculate_usage(
                 completion_response=completion_response
             )

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -672,6 +672,71 @@ def test_check_finish_reason():
         )
 
 
+def test_vertex_ai_empty_content_with_stop_finish_reason():
+    """
+    Test that Gemini responses with finishReason=STOP but no content/parts
+    (empty response in agentic tasks) are handled correctly.
+
+    See: https://github.com/BerriAI/litellm/issues/24442
+    See: https://discuss.ai.google.dev/t/finishreason-stop-but-parts-is-missing-inside-candidate/99331
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+    from litellm.types.llms.vertex_ai import GenerateContentResponseBody
+
+    v = VertexGeminiConfig()
+
+    # Simulate the raw API response that has finishReason=STOP but no parts
+    raw_response = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model"
+                    # Note: no "parts" key - this is the bug condition
+                },
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 3130,
+            "totalTokenCount": 3130,
+            "promptTokensDetails": [
+                {"modality": "TEXT", "tokenCount": 3130}
+            ],
+        },
+        "modelVersion": "gemini-2.5-flash-lite",
+        "responseId": "8ZfBaYu9LarVz7IPlJG7gQU",
+    }
+
+    # Mock the logging object
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.optional_params = {}
+
+    # Transform the response
+    model_response = ModelResponse()
+    model_response._hidden_params = {}
+
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    result = v._transform_google_generate_content_to_openai_model_response(
+        completion_response=GenerateContentResponseBody(**raw_response),
+        model_response=model_response,
+        model="gemini-2.5-flash-lite",
+        logging_obj=mock_logging_obj,
+        raw_response=MagicMock(headers={}),
+    )
+
+    # The response should have a choice with finish_reason=stop and content=None
+    assert len(result.choices) == 1
+    assert result.choices[0].finish_reason == "stop"
+    assert result.choices[0].message.content is None
+    assert result.choices[0].message.role == "assistant"
+
+
 def test_finish_reason_unspecified_and_malformed_function_call():
     """
     Test that FINISH_REASON_UNSPECIFIED and MALFORMED_FUNCTION_CALL

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -687,14 +687,11 @@ def test_vertex_ai_empty_content_with_stop_finish_reason():
 
     v = VertexGeminiConfig()
 
-    # Simulate the raw API response that has finishReason=STOP but no parts
+    # Simulate the raw API response that has finishReason=STOP but no content
     raw_response = {
         "candidates": [
             {
-                "content": {
-                    "role": "model"
-                    # Note: no "parts" key - this is the bug condition
-                },
+                # No "content" field at all - this triggers the fallback path
                 "finishReason": "STOP",
                 "index": 0,
             }
@@ -717,10 +714,6 @@ def test_vertex_ai_empty_content_with_stop_finish_reason():
     # Transform the response
     model_response = ModelResponse()
     model_response._hidden_params = {}
-
-    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
-        VertexGeminiConfig,
-    )
 
     result = v._transform_google_generate_content_to_openai_model_response(
         completion_response=GenerateContentResponseBody(**raw_response),

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

When Gemini (particularly `gemini-2.5-flash-lite`) returns candidates with `finishReason=STOP` but without the `parts` field in content (e.g., in long-running agentic tasks), `_process_candidates` skips these candidates because it requires `parts` to be present. This resulted in an empty choices list without any error being raised.

## Root Cause

In `_transform_google_generate_content_to_openai_model_response`, `_process_candidates` iterates over candidates and only creates choices when `candidate["content"].get("parts")` exists. When a candidate has no `parts` (but does have `finishReason=STOP`), it is silently skipped, leaving `model_response.choices = []`.

## Fix

Added a fallback after `_process_candidates`: if `choices` is still empty but candidates exist, create a choice with `finish_reason=stop` and `content=None`. This is consistent with the streaming path (lines 3080-3097) which already handles this case.

## Test

Added `test_vertex_ai_empty_content_with_stop_finish_reason` which simulates the exact API response from issue #24442.

Fixes https://github.com/BerriAI/litellm/issues/24442