### PR TITLE
docs(opencode): add guidance for dropping reasoningSummary param

### DIFF
--- a/docs/my-website/docs/tutorials/opencode_integration.md
+++ b/docs/my-website/docs/tutorials/opencode_integration.md
@@ -253,7 +253,7 @@ model_list:
     litellm_params:
       model: openai/gpt-4
       api_key: os.environ/OPENAI_API_KEY
-  
+
   - model_name: gpt-4o
     litellm_params:
       model: openai/gpt-4o
@@ -264,12 +264,25 @@ model_list:
     litellm_params:
       model: anthropic/claude-3-5-sonnet-20241022
       api_key: os.environ/ANTHROPIC_API_KEY
-  
+
   # DeepSeek models
   - model_name: deepseek-chat
     litellm_params:
       model: deepseek/deepseek-chat
       api_key: os.environ/DEEPSEEK_API_KEY
+```
+
+### Dropping OpenCode-specific parameters
+
+OpenCode sends a `reasoningSummary` parameter (a Responses API concept) with certain models. This parameter is not supported by the Chat Completions API and will cause errors. Use `additional_drop_params` in your `litellm_params` to drop it:
+
+```yaml
+model_list:
+  - model_name: gpt-5
+    litellm_params:
+      model: gpt-5
+      api_key: os.environ/OPENAI_API_KEY
+      additional_drop_params: ["reasoningSummary"]
 ```
 
 ## Troubleshooting
@@ -293,6 +306,16 @@ model_list:
 - Check the config file path and permissions
 - Validate JSON syntax using a JSON validator
 - Ensure the `$schema` URL is accessible
+
+**`Unknown parameter: 'reasoningSummary'` error:**
+- OpenCode sends a `reasoningSummary` parameter that is not supported by the Chat Completions API. Add `additional_drop_params: ["reasoningSummary"]` to your model's `litellm_params` to drop it automatically:
+  ```yaml
+  - model_name: gpt-5
+    litellm_params:
+      model: gpt-5
+      api_key: os.environ/OPENAI_API_KEY
+      additional_drop_params: ["reasoningSummary"]
+  ```
 
 ## Tips
 

--- a/docs/my-website/docs/tutorials/opencode_integration.md
+++ b/docs/my-website/docs/tutorials/opencode_integration.md
@@ -274,7 +274,7 @@ model_list:
 
 ### Dropping OpenCode-specific parameters
 
-OpenCode sends a `reasoningSummary` parameter (a Responses API concept) with reasoning-capable models such as `gpt-5`. This parameter is not supported by the Chat Completions API and will cause errors. Add `additional_drop_params` to every model entry in your `model_list` that will receive requests from OpenCode with reasoning enabled:
+OpenCode sends a `reasoningSummary` parameter with reasoning-capable models such as `gpt-5`. This parameter is not supported by the Chat Completions API and will cause errors. Add `additional_drop_params` to every model entry in your `model_list` that will receive requests from OpenCode with reasoning enabled:
 
 ```yaml
 model_list:

--- a/docs/my-website/docs/tutorials/opencode_integration.md
+++ b/docs/my-website/docs/tutorials/opencode_integration.md
@@ -274,13 +274,13 @@ model_list:
 
 ### Dropping OpenCode-specific parameters
 
-OpenCode sends a `reasoningSummary` parameter (a Responses API concept) with certain models. This parameter is not supported by the Chat Completions API and will cause errors. Use `additional_drop_params` in your `litellm_params` to drop it:
+OpenCode sends a `reasoningSummary` parameter (a Responses API concept) with reasoning-capable models such as `gpt-5`. This parameter is not supported by the Chat Completions API and will cause errors. Add `additional_drop_params` to every model entry in your `model_list` that will receive requests from OpenCode with reasoning enabled:
 
 ```yaml
 model_list:
   - model_name: gpt-5
     litellm_params:
-      model: gpt-5
+      model: openai/gpt-5
       api_key: os.environ/OPENAI_API_KEY
       additional_drop_params: ["reasoningSummary"]
 ```
@@ -308,11 +308,11 @@ model_list:
 - Ensure the `$schema` URL is accessible
 
 **`Unknown parameter: 'reasoningSummary'` error:**
-- OpenCode sends a `reasoningSummary` parameter that is not supported by the Chat Completions API. Add `additional_drop_params: ["reasoningSummary"]` to your model's `litellm_params` to drop it automatically:
+- OpenCode sends a `reasoningSummary` parameter that is not supported by the Chat Completions API. Add `additional_drop_params: ["reasoningSummary"]` to each affected model entry in your `litellm_params`:
   ```yaml
   - model_name: gpt-5
     litellm_params:
-      model: gpt-5
+      model: openai/gpt-5
       api_key: os.environ/OPENAI_API_KEY
       additional_drop_params: ["reasoningSummary"]
   ```


### PR DESCRIPTION
## Summary
Fixes #21998

- OpenCode sends a `reasoningSummary` parameter alongside chat completion requests, which causes `Unknown parameter: 'reasoningSummary'` 400 errors from the OpenAI API
- Added a "Dropping OpenCode-specific parameters" section to the OpenCode integration docs showing how to use `additional_drop_params: ["reasoningSummary"]` in `litellm_params`
- Added a matching Troubleshooting entry for the exact error message

## Test plan
- [ ] Docs-only change — no code changes