### PR TITLE
fix(exceptions): return 400 for GuardrailRaisedException and BlockedPiiEntityError

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
@@ -197,6 +197,7 @@ class PagerDutyAlerting(SlackAlerting):
                 user_api_key_org_id=user_api_key_dict.org_id,
                 user_api_key_team_id=user_api_key_dict.team_id,
                 user_api_key_project_id=user_api_key_dict.project_id,
+                user_api_key_project_alias=user_api_key_dict.project_alias,
                 user_api_key_user_id=user_api_key_dict.user_id,
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -917,10 +917,12 @@ class GuardrailRaisedException(Exception):
         guardrail_name: Optional[str] = None,
         message: str = "",
         should_wrap_with_default_message: bool = True,
+        status_code: int = 400,
     ):
         default_message = f"Guardrail raised an exception, Guardrail: {guardrail_name}, Message: {message}"
         self.guardrail_name = guardrail_name
         self.message = default_message if should_wrap_with_default_message else message
+        self.status_code = status_code
         super().__init__(self.message)
 
 
@@ -929,12 +931,14 @@ class BlockedPiiEntityError(Exception):
         self,
         entity_type: str,
         guardrail_name: Optional[str] = None,
+        status_code: int = 400,
     ):
         """
         Raised when a blocked entity is detected by a guardrail.
         """
         self.entity_type = entity_type
         self.guardrail_name = guardrail_name
+        self.status_code = status_code
         self.message = f"Blocked entity detected: {entity_type} by Guardrail: {guardrail_name}. This entity is not allowed to be used in this request."
         super().__init__(self.message)
 

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -281,7 +281,7 @@ class Timeout(openai.APITimeoutError):  # type: ignore
         return _message
 
 
-class PermissionDeniedError(openai.PermissionDeniedError):  # type:ignore
+class PermissionDeniedError(openai.PermissionDeniedError):  # type: ignore
     def __init__(
         self,
         message,

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -216,7 +216,7 @@ class A2AGuardrailHandler(BaseTranslation):
             response["result"] = result
             return response
 
-    async def process_output_streaming_response(
+    async def process_output_streaming_response(  # noqa: PLR0915
         self,
         responses_so_far: List[Any],
         guardrail_to_apply: "CustomGuardrail",

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -246,7 +246,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                     "text"
                 ] = guardrail_response
 
-    async def process_output_response(
+    async def process_output_response(  # noqa: PLR0915
         self,
         response: "AnthropicMessagesResponse",
         guardrail_to_apply: "CustomGuardrail",

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs["structured_messages"] = (
-                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
-                )
+                inputs[
+                    "structured_messages"
+                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -815,7 +815,7 @@ if MCP_AVAILABLE:
         except BlockedPiiEntityError as e:
             verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {str(e)}")
             raise HTTPException(
-                status_code=400,
+                status_code=getattr(e, "status_code", 400),
                 detail={
                     "error": "blocked_pii_entity",
                     "message": str(e),
@@ -826,7 +826,7 @@ if MCP_AVAILABLE:
         except GuardrailRaisedException as e:
             verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {str(e)}")
             raise HTTPException(
-                status_code=400,
+                status_code=getattr(e, "status_code", 400),
                 detail={
                     "error": "guardrail_violation",
                     "message": str(e),

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -90,6 +90,7 @@ def _get_spend_logs_metadata(
             user_api_key_alias=None,
             user_api_key_team_id=None,
             user_api_key_project_id=None,
+            user_api_key_project_alias=None,
             user_api_key_org_id=None,
             user_api_key_user_id=None,
             user_api_key_team_alias=None,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -553,6 +553,7 @@ class TestGuardrailActions:
             # Verify the exception has the clean error message (no wrapper)
             assert str(exc_info.value) == "Content contains harmful instructions"
             assert exc_info.value.guardrail_name == "generic_guardrail_api"
+            assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_action_intervened_modifies_content(

--- a/tests/test_litellm/test_guardrail_exception_status_codes.py
+++ b/tests/test_litellm/test_guardrail_exception_status_codes.py
@@ -1,0 +1,60 @@
+"""
+Tests that guardrail exceptions return proper HTTP status codes.
+
+GuardrailRaisedException and BlockedPiiEntityError should return 400,
+not 500, since guardrail blocks are client-triggered errors.
+"""
+
+import pytest
+
+from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
+
+
+class TestGuardrailRaisedExceptionStatusCode:
+    def test_default_status_code_is_400(self):
+        exc = GuardrailRaisedException(
+            guardrail_name="test-guardrail",
+            message="blocked",
+        )
+        assert exc.status_code == 400
+
+    def test_custom_status_code(self):
+        exc = GuardrailRaisedException(
+            guardrail_name="test-guardrail",
+            message="rate limited",
+            status_code=429,
+        )
+        assert exc.status_code == 429
+
+    def test_getattr_returns_status_code(self):
+        """Mirrors the pattern used in _handle_llm_api_exception"""
+        exc = GuardrailRaisedException(
+            guardrail_name="test-guardrail",
+            message="blocked",
+        )
+        assert getattr(exc, "status_code", 500) == 400
+
+
+class TestBlockedPiiEntityErrorStatusCode:
+    def test_default_status_code_is_400(self):
+        exc = BlockedPiiEntityError(
+            entity_type="CREDIT_CARD",
+            guardrail_name="presidio",
+        )
+        assert exc.status_code == 400
+
+    def test_custom_status_code(self):
+        exc = BlockedPiiEntityError(
+            entity_type="CREDIT_CARD",
+            guardrail_name="presidio",
+            status_code=403,
+        )
+        assert exc.status_code == 403
+
+    def test_getattr_returns_status_code(self):
+        """Mirrors the pattern used in _handle_llm_api_exception"""
+        exc = BlockedPiiEntityError(
+            entity_type="CREDIT_CARD",
+            guardrail_name="presidio",
+        )
+        assert getattr(exc, "status_code", 500) == 400

--- a/tests/test_litellm/test_guardrail_exception_status_codes.py
+++ b/tests/test_litellm/test_guardrail_exception_status_codes.py
@@ -5,8 +5,6 @@ GuardrailRaisedException and BlockedPiiEntityError should return 400,
 not 500, since guardrail blocks are client-triggered errors.
 """
 
-import pytest
-
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
 
 


### PR DESCRIPTION
Closes #24348

## Summary

- `GuardrailRaisedException` and `BlockedPiiEntityError` both lacked a `status_code` attribute, so the generic exception handler (`getattr(e, "status_code", 500)`) defaulted to HTTP 500.
- Added `status_code=400` to both classes. Guardrail blocks are client-triggered, not server errors.
- This also addresses the gap noted in #24347's review — `BlockedPiiEntityError` (raised by the Presidio guardrail) had the same problem.

## Changes

- **`litellm/exceptions.py`**: Add `status_code: int = 400` param and `self.status_code` to both `GuardrailRaisedException` and `BlockedPiiEntityError`
- **`tests/test_litellm/test_guardrail_exception_status_codes.py`**: New test file covering default status code, custom status code, and the `getattr` fallback pattern for both exceptions
- **`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py`**: Added `status_code == 400` assertion to existing blocked-action test

## Test plan

- [x] 6 new unit tests pass (`pytest tests/test_litellm/test_guardrail_exception_status_codes.py`)
- [x] Existing blocked-action test updated with status_code assertion