### PR TITLE
fix(proxy): ignore return_to in SSO when control_plane_url is not con…

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -404,14 +404,14 @@ async def google_login(
             state=cli_state,
         )
         if return_to is not None and sso_redirect is not None:
-            SSOAuthenticationHandler._validate_return_to(return_to)
-            sso_redirect.set_cookie(
-                key="litellm_cp_return_to",
-                value=return_to,
-                max_age=600,
-                httponly=True,
-                samesite="lax",
-            )
+            if SSOAuthenticationHandler._validate_return_to(return_to):
+                sso_redirect.set_cookie(
+                    key="litellm_cp_return_to",
+                    value=return_to,
+                    max_age=600,
+                    httponly=True,
+                    samesite="lax",
+                )
         return sso_redirect
     elif ui_username is not None:
         # No Google, Microsoft SSO
@@ -1778,22 +1778,19 @@ class SSOAuthenticationHandler:
     """
 
     @staticmethod
-    def _validate_return_to(return_to: str) -> None:
+    def _validate_return_to(return_to: str) -> bool:
         """
         Validate that return_to matches the configured control_plane_url origin.
 
-        Raises HTTPException(400) if:
-        - control_plane_url is not configured in general_settings
-        - return_to origin does not match control_plane_url origin
+        Returns True if return_to is valid and should be used.
+        Returns False if control_plane_url is not configured (return_to is ignored).
+        Raises HTTPException(400) if return_to origin does not match control_plane_url origin.
         """
         from litellm.proxy.proxy_server import general_settings
 
         control_plane_url = general_settings.get("control_plane_url")
         if control_plane_url is None:
-            raise HTTPException(
-                status_code=400,
-                detail="return_to is not allowed: control_plane_url is not configured",
-            )
+            return False
 
         def _origin(url: str) -> tuple:
             parsed = urlparse(url)
@@ -1808,6 +1805,8 @@ class SSOAuthenticationHandler:
                 status_code=400,
                 detail="return_to does not match the configured control_plane_url",
             )
+
+        return True
 
     @staticmethod
     async def get_sso_login_redirect(
@@ -2589,9 +2588,9 @@ class SSOAuthenticationHandler:
         # Control-plane cross-origin: store JWT behind a single-use opaque
         # code (60s TTL) so the token never appears in browser history / logs.
         # The control plane redeems it via POST /v3/login/exchange.
-        if return_to is not None:
-            SSOAuthenticationHandler._validate_return_to(return_to)
-
+        if return_to is not None and SSOAuthenticationHandler._validate_return_to(
+            return_to
+        ):
             code = secrets.token_urlsafe(32)
             cache_key = f"login_code:{code}"
             cache_value = {"token": jwt_token, "redirect_url": return_to}

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -5164,15 +5164,13 @@ def test_generic_response_convertor_extra_attributes_missing_field(monkeypatch):
 class TestValidateReturnTo:
     """Tests for SSOAuthenticationHandler._validate_return_to"""
 
-    def test_rejects_when_no_control_plane_url_configured(self, monkeypatch):
-        """return_to should be rejected if control_plane_url is not in general_settings."""
+    def test_returns_false_when_no_control_plane_url_configured(self, monkeypatch):
+        """return_to should be silently ignored if control_plane_url is not in general_settings."""
         monkeypatch.setattr(
             "litellm.proxy.proxy_server.general_settings", {}
         )
-        with pytest.raises(HTTPException) as exc_info:
-            SSOAuthenticationHandler._validate_return_to("https://cp.example.com/ui")
-        assert exc_info.value.status_code == 400
-        assert "not configured" in exc_info.value.detail
+        result = SSOAuthenticationHandler._validate_return_to("https://cp.example.com/ui")
+        assert result is False
 
     def test_allows_matching_origin(self, monkeypatch):
         """return_to matching the configured control_plane_url origin should pass."""


### PR DESCRIPTION
## Type

🐛 Bug Fix

## Changes

- `_validate_return_to()` now returns `False` instead of raising a 400 when `control_plane_url` is not configured, allowing callers to silently skip the cross-origin `return_to` flow
- Both call sites (`/sso/key/generate` endpoint and `get_redirect_response_from_openid`) check the return value and fall through to the normal same-origin SSO redirect

The SSO login button in `LoginPage.tsx` on `main` unconditionally passes `return_to` to `/sso/key/generate`. For users without a control plane setup (no `control_plane_url` in `general_settings`), this causes a 400 error — breaking SSO login entirely.

Rather than only fixing the frontend, the backend should be resilient: if `control_plane_url` isn't configured, `return_to` should be ignored and the normal SSO flow should proceed.
