### PR TITLE
fix: guard against None text in Gemini image generation response parts

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1281,6 +1281,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             _content_str = ""
             if "text" in part:
                 text_content = part["text"]
+                if text_content is None:
+                    continue
                 # Check if text content is audio data URI - if so, exclude from text content
                 if text_content.startswith("data:audio") and ";base64," in text_content:
                     try:
@@ -1389,6 +1391,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         for part in parts:
             if "text" in part:
                 text_content = part["text"]
+                if text_content is None:
+                    continue
                 # Check if text content contains audio data URI
                 if text_content.startswith("data:audio") and ";base64," in text_content:
                     try:


### PR DESCRIPTION
## Summary

Fixes #24385.

When Gemini returns image generation responses, the `parts` array can contain a `"text"` key whose JSON value is `null`. The existing code checked for key existence (`if "text" in part`) but did not guard against a `null` value before calling `.startswith()`, causing:

```
AttributeError: 'NoneType' object has no attribute 'startswith'
```

This exception was then incorrectly surfaced to the client as a 403 error.

## Fix

Added `if text_content is None: continue` immediately after reading `part["text"]` in two methods:

- `VertexGeminiConfig.get_assistant_content_message()` (line ~1283)
- `VertexGeminiConfig._extract_audio_response_from_parts()` (line ~1391)

Both methods iterate over response parts and call `.startswith()` on `text_content` without checking for `None`.

## Test plan

- [ ] Reproduce with a Gemini image generation response containing `{"text": null}` in parts
- [ ] Confirm no `AttributeError` is raised after this fix
- [ ] Confirm text parts with actual string values still work correctly
- [ ] Confirm audio data URI detection still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)