### PR TITLE
chore: migrate route_preview.tsx from Tremor to Ant Design

### DIFF
--- a/ui/litellm-dashboard/src/components/route_preview.tsx
+++ b/ui/litellm-dashboard/src/components/route_preview.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { Card, Title, Subtitle } from "@tremor/react";
+import { Card, Typography } from "antd";
 import { RightOutlined, InfoCircleOutlined } from "@ant-design/icons";
+
+const { Title, Text } = Typography;
 import { getProxyBaseUrl } from "./networking";
 
 interface RoutePreviewProps {
@@ -23,8 +25,8 @@ const RoutePreview: React.FC<RoutePreviewProps> = ({ pathValue, targetValue, inc
 
   return (
     <Card className="p-5">
-      <Title className="text-lg font-semibold text-gray-900 mb-2">Route Preview</Title>
-      <Subtitle className="text-gray-600 mb-5">How your requests will be routed</Subtitle>
+      <Title level={5} className="text-lg font-semibold text-gray-900 mb-2">Route Preview</Title>
+      <Text type="secondary" className="text-gray-600 mb-5" style={{ display: "block" }}>How your requests will be routed</Text>
 
       <div className="space-y-5">
         {/* Basic routing */}


### PR DESCRIPTION
## Type

🧹 Refactoring

## Changes

Replace @tremor/react imports (Card, Title, Subtitle) with antd equivalents (Card, Typography.Title, Typography.Text)
Part of ongoing Tremor → Ant Design migration effort

Changes
Card → antd Card (1:1 swap, Tailwind classes preserved)
Title → Typography.Title level={5}
Subtitle → Typography.Text type="secondary" with display: block

<img width="998" height="976" alt="Screenshot 2026-03-23 at 10 48 27 PM" src="https://github.com/user-attachments/assets/887268ad-c450-4738-8e9a-bd798e6d8909" />
