### PR TITLE
fix(lint): wire lint-ruff-FULL-dev into lint-dev to catch Ruff violations on changed files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ check-import-safety: install-dev
 lint: format-check lint-ruff lint-mypy check-circular-imports check-import-safety
 
 # Faster linting for local development (only checks changed code)
-lint-dev: lint-format-changed lint-mypy check-circular-imports check-import-safety
+lint-dev: lint-format-changed lint-ruff-FULL-dev lint-mypy check-circular-imports check-import-safety
 
 # Testing targets
 test: install-test-deps

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ check-import-safety: install-dev
 # Combined linting (matches test-linting.yml workflow)
 lint: format-check lint-ruff lint-mypy check-circular-imports check-import-safety
 
-# Faster linting for local development (only checks changed code)
+# Faster linting for local development (checks changed files in full + changed-line formatting + mypy)
 lint-dev: lint-format-changed lint-ruff-FULL-dev lint-mypy check-circular-imports check-import-safety
 
 # Testing targets


### PR DESCRIPTION
## Summary

- \`lint-dev\` was skipping Ruff entirely, only checking Black formatting on changed files
- This allowed \`PLR0915\` (and other Ruff violations) to pass the PR gate undetected and land in \`main\`
- This PR wires the existing-but-unused \`lint-ruff-FULL-dev\` target into \`lint-dev\`

## Why \`lint-ruff-FULL-dev\` and not \`lint-ruff-dev\`

Greptile suggested using \`lint-ruff-dev\` (diff-quality) as a more targeted alternative. However, \`lint-ruff-dev\` reports violations only on **changed lines** — and \`PLR0915\` is reported on the **function definition line**, not on the newly added statements. This means if a contributor pushes a function from 49 to 54 statements, the violation appears on an unchanged line and diff-quality silently skips it. That is exactly how the two violations that prompted this PR got into \`main\`.

\`lint-ruff-FULL-dev\` runs full \`ruff check\` on the entire content of any Python file touched relative to \`origin/main\`. It will also surface pre-existing violations in files you touch — this is intentional: it creates a forcing function to keep the codebase clean rather than allowing violations to accumulate indefinitely.

## Test plan
- [x] Verified \`lint-ruff-FULL-dev\` is defined in the Makefile and runs \`ruff check\` on \`git diff --name-only origin/main -- '*.py'\`
- [x] Confirmed the two \`PLR0915\` violations that prompted this PR (\`a2a/chat/guardrail_translation/handler.py\`, \`anthropic/chat/guardrail_translation/handler.py\`) would be caught by this gate since both files are changed relative to main