### PR TITLE
Litellm ryan march 23

### DIFF
--- a/docs/my-website/docs/proxy/multiple_admins.md
+++ b/docs/my-website/docs/proxy/multiple_admins.md
@@ -79,6 +79,8 @@ litellm_settings:
 Audit logs are written as JSON files to:
 
 ```
+s3://<bucket>/audit_logs/<YYYY-MM-DD>/<HH-MM-SS>_<audit-log-id>.json
+# or, when s3_path is set:
 s3://<bucket>/<s3_path>/audit_logs/<YYYY-MM-DD>/<HH-MM-SS>_<audit-log-id>.json
 ```
 

--- a/docs/my-website/docs/proxy/multiple_admins.md
+++ b/docs/my-website/docs/proxy/multiple_admins.md
@@ -56,6 +56,38 @@ On the LiteLLM UI, navigate to Logs -> Audit Logs. You should see the audit log 
 />
 
 
+## Export Audit Logs to External Storage
+
+You can export audit logs to an external storage backend (e.g. S3) in addition to storing them in the database. Logs are batched and uploaded asynchronously, so they do not block your proxy requests.
+
+### S3 Example
+
+Add `audit_log_callbacks` and `s3_callback_params` to your `litellm_settings`:
+
+```yaml
+litellm_settings:
+  store_audit_logs: true
+  audit_log_callbacks: ["s3_v2"]
+  s3_callback_params:
+    s3_bucket_name: my-audit-logs-bucket     # AWS Bucket Name
+    s3_region_name: us-west-2                # AWS Region
+    s3_aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+    s3_aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+    s3_path: litellm-audit                   # [OPTIONAL] prefix path in the bucket
+```
+
+Audit logs are written as JSON files to:
+
+```
+s3://<bucket>/<s3_path>/audit_logs/<YYYY-MM-DD>/<HH-MM-SS>_<audit-log-id>.json
+```
+
+:::info
+
+Both `store_audit_logs: true` and `audit_log_callbacks` must be set. If `store_audit_logs` is not enabled, the callbacks will not fire.
+
+:::
+
 ## Advanced
 
 ### Attribute Management changes to Users

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -404,14 +404,14 @@ async def google_login(
             state=cli_state,
         )
         if return_to is not None and sso_redirect is not None:
-            SSOAuthenticationHandler._validate_return_to(return_to)
-            sso_redirect.set_cookie(
-                key="litellm_cp_return_to",
-                value=return_to,
-                max_age=600,
-                httponly=True,
-                samesite="lax",
-            )
+            if SSOAuthenticationHandler._validate_return_to(return_to):
+                sso_redirect.set_cookie(
+                    key="litellm_cp_return_to",
+                    value=return_to,
+                    max_age=600,
+                    httponly=True,
+                    samesite="lax",
+                )
         return sso_redirect
     elif ui_username is not None:
         # No Google, Microsoft SSO
@@ -1778,22 +1778,19 @@ class SSOAuthenticationHandler:
     """
 
     @staticmethod
-    def _validate_return_to(return_to: str) -> None:
+    def _validate_return_to(return_to: str) -> bool:
         """
         Validate that return_to matches the configured control_plane_url origin.
 
-        Raises HTTPException(400) if:
-        - control_plane_url is not configured in general_settings
-        - return_to origin does not match control_plane_url origin
+        Returns True if return_to is valid and should be used.
+        Returns False if control_plane_url is not configured (return_to is ignored).
+        Raises HTTPException(400) if return_to origin does not match control_plane_url origin.
         """
         from litellm.proxy.proxy_server import general_settings
 
         control_plane_url = general_settings.get("control_plane_url")
         if control_plane_url is None:
-            raise HTTPException(
-                status_code=400,
-                detail="return_to is not allowed: control_plane_url is not configured",
-            )
+            return False
 
         def _origin(url: str) -> tuple:
             parsed = urlparse(url)
@@ -1808,6 +1805,8 @@ class SSOAuthenticationHandler:
                 status_code=400,
                 detail="return_to does not match the configured control_plane_url",
             )
+
+        return True
 
     @staticmethod
     async def get_sso_login_redirect(
@@ -2589,9 +2588,9 @@ class SSOAuthenticationHandler:
         # Control-plane cross-origin: store JWT behind a single-use opaque
         # code (60s TTL) so the token never appears in browser history / logs.
         # The control plane redeems it via POST /v3/login/exchange.
-        if return_to is not None:
-            SSOAuthenticationHandler._validate_return_to(return_to)
-
+        if return_to is not None and SSOAuthenticationHandler._validate_return_to(
+            return_to
+        ):
             code = secrets.token_urlsafe(32)
             cache_key = f"login_code:{code}"
             cache_value = {"token": jwt_token, "redirect_url": return_to}

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -5164,15 +5164,13 @@ def test_generic_response_convertor_extra_attributes_missing_field(monkeypatch):
 class TestValidateReturnTo:
     """Tests for SSOAuthenticationHandler._validate_return_to"""
 
-    def test_rejects_when_no_control_plane_url_configured(self, monkeypatch):
-        """return_to should be rejected if control_plane_url is not in general_settings."""
+    def test_returns_false_when_no_control_plane_url_configured(self, monkeypatch):
+        """return_to should be silently ignored if control_plane_url is not in general_settings."""
         monkeypatch.setattr(
             "litellm.proxy.proxy_server.general_settings", {}
         )
-        with pytest.raises(HTTPException) as exc_info:
-            SSOAuthenticationHandler._validate_return_to("https://cp.example.com/ui")
-        assert exc_info.value.status_code == 400
-        assert "not configured" in exc_info.value.detail
+        result = SSOAuthenticationHandler._validate_return_to("https://cp.example.com/ui")
+        assert result is False
 
     def test_allows_matching_origin(self, monkeypatch):
         """return_to matching the configured control_plane_url origin should pass."""

--- a/ui/litellm-dashboard/src/components/Navbar/WorkerDropdown/WorkerDropdown.test.tsx
+++ b/ui/litellm-dashboard/src/components/Navbar/WorkerDropdown/WorkerDropdown.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the useWorker hook
+const mockUseWorker = vi.fn();
+vi.mock("@/hooks/useWorker", () => ({
+  useWorker: () => mockUseWorker(),
+}));
+
+// Mock antd Select
+vi.mock("antd", () => ({
+  Select: ({ value, options, onChange, style, disabled, ...props }: any) => (
+    <select
+      data-testid="worker-select"
+      value={value}
+      style={style}
+      onChange={(e) => onChange?.(e.target.value)}
+    >
+      {options?.map((opt: any) => (
+        <option key={opt.value} value={opt.value} disabled={opt.disabled}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+// Mock icon
+vi.mock("@ant-design/icons", () => ({
+  CloudServerOutlined: () => <span data-testid="cloud-icon" />,
+}));
+
+import WorkerDropdown from "./WorkerDropdown";
+
+describe("WorkerDropdown", () => {
+  const mockOnWorkerSwitch = vi.fn();
+  const workers = [
+    { worker_id: "w1", name: "Worker 1" },
+    { worker_id: "w2", name: "Worker 2" },
+    { worker_id: "w3", name: "Worker 3" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders null when isControlPlane is false", () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: false,
+      selectedWorker: workers[0],
+      workers,
+    });
+
+    const { container } = render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders null when selectedWorker is null", () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: true,
+      selectedWorker: null,
+      workers,
+    });
+
+    const { container } = render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the select when isControlPlane and selectedWorker exist", () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: true,
+      selectedWorker: workers[0],
+      workers,
+    });
+
+    render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    expect(screen.getByTestId("worker-select")).toBeInTheDocument();
+  });
+
+  it("renders all worker options", () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: true,
+      selectedWorker: workers[0],
+      workers,
+    });
+
+    render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    expect(screen.getByText("Worker 1")).toBeInTheDocument();
+    expect(screen.getByText("Worker 2")).toBeInTheDocument();
+    expect(screen.getByText("Worker 3")).toBeInTheDocument();
+  });
+
+  it("sets current worker as selected value", () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: true,
+      selectedWorker: workers[1],
+      workers,
+    });
+
+    render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    const select = screen.getByTestId("worker-select") as HTMLSelectElement;
+    expect(select.value).toBe("w2");
+  });
+
+  it("disables the currently selected worker in options", () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: true,
+      selectedWorker: workers[0],
+      workers,
+    });
+
+    render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    const options = screen.getAllByRole("option");
+    const selectedOption = options.find((opt) => (opt as HTMLOptionElement).value === "w1");
+    expect(selectedOption).toBeDisabled();
+  });
+
+  it("calls onWorkerSwitch when selection changes", async () => {
+    mockUseWorker.mockReturnValue({
+      isControlPlane: true,
+      selectedWorker: workers[0],
+      workers,
+    });
+
+    render(<WorkerDropdown onWorkerSwitch={mockOnWorkerSwitch} />);
+    const select = screen.getByTestId("worker-select");
+
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    await user.selectOptions(select, "w2");
+
+    expect(mockOnWorkerSwitch).toHaveBeenCalledWith("w2");
+  });
+});

--- a/ui/litellm-dashboard/src/components/agent_management/AgentSelector.test.tsx
+++ b/ui/litellm-dashboard/src/components/agent_management/AgentSelector.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock networking module
+const mockGetAgentsList = vi.fn();
+vi.mock("../networking", () => ({
+  getAgentsList: (...args: any[]) => mockGetAgentsList(...args),
+}));
+
+// Mock antd Select
+vi.mock("antd", () => {
+  const SelectComponent = ({ children, onChange, value, mode, placeholder, loading, disabled, ...props }: any) => (
+    <div data-testid="agent-select" data-loading={loading} data-disabled={disabled}>
+      <select
+        data-testid="select-input"
+        multiple={mode === "multiple"}
+        value={value || []}
+        onChange={(e) => {
+          const selected = Array.from(e.target.selectedOptions, (opt: any) => opt.value);
+          onChange?.(selected);
+        }}
+        disabled={disabled}
+      >
+        {children}
+      </select>
+      {loading && <span data-testid="loading-indicator">Loading</span>}
+    </div>
+  );
+
+  SelectComponent.Option = ({ children, value, ...props }: any) => (
+    <option value={value} {...props}>
+      {children}
+    </option>
+  );
+
+  return { Select: SelectComponent };
+});
+
+import AgentSelector from "./AgentSelector";
+
+describe("AgentSelector", () => {
+  const defaultProps = {
+    onChange: vi.fn(),
+    accessToken: "test-token",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAgentsList.mockResolvedValue({
+      agents: [
+        { agent_id: "agent-1", agent_name: "Agent One" },
+        { agent_id: "agent-2", agent_name: "Agent Two", agent_access_groups: ["group-a", "group-b"] },
+      ],
+    });
+  });
+
+  it("renders the selector", () => {
+    render(<AgentSelector {...defaultProps} />);
+    expect(screen.getByTestId("agent-select")).toBeInTheDocument();
+  });
+
+  it("fetches agents on mount with access token", async () => {
+    render(<AgentSelector {...defaultProps} />);
+    await waitFor(() => {
+      expect(mockGetAgentsList).toHaveBeenCalledWith("test-token");
+    });
+  });
+
+  it("does not fetch when accessToken is empty", () => {
+    render(<AgentSelector {...defaultProps} accessToken="" />);
+    expect(mockGetAgentsList).not.toHaveBeenCalled();
+  });
+
+  it("shows loading state while fetching", async () => {
+    // Keep the promise pending
+    let resolve: any;
+    mockGetAgentsList.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    render(<AgentSelector {...defaultProps} />);
+    expect(screen.getByTestId("agent-select")).toHaveAttribute("data-loading", "true");
+
+    // Resolve to clean up
+    resolve({ agents: [] });
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-select")).toHaveAttribute("data-loading", "false");
+    });
+  });
+
+  it("renders agent options after fetch", async () => {
+    render(<AgentSelector {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("Agent One")).toBeInTheDocument();
+      expect(screen.getByText("Agent Two")).toBeInTheDocument();
+    });
+  });
+
+  it("renders access group options with group prefix", async () => {
+    render(<AgentSelector {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("group-a")).toBeInTheDocument();
+      expect(screen.getByText("group-b")).toBeInTheDocument();
+    });
+  });
+
+  it("respects disabled prop", () => {
+    render(<AgentSelector {...defaultProps} disabled />);
+    expect(screen.getByTestId("agent-select")).toHaveAttribute("data-disabled", "true");
+  });
+
+  it("handles API error gracefully", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetAgentsList.mockRejectedValue(new Error("API error"));
+
+    render(<AgentSelector {...defaultProps} />);
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith("Error fetching agents:", expect.any(Error));
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("passes value as flattened selectedValues", async () => {
+    render(
+      <AgentSelector
+        {...defaultProps}
+        value={{ agents: ["agent-1"], accessGroups: ["group-a"] }}
+      />
+    );
+    await waitFor(() => {
+      const select = screen.getByTestId("select-input");
+      // The value should contain agent-1 and group:group-a
+      expect(select).toBeInTheDocument();
+    });
+  });
+
+  it("handles null response from API", async () => {
+    mockGetAgentsList.mockResolvedValue(null);
+    render(<AgentSelector {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-select")).toHaveAttribute("data-loading", "false");
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatInstallCommand,
+  extractCategories,
+  validatePluginName,
+  getSourceDisplayText,
+  getSourceLink,
+  getCategoryBadgeColor,
+  formatDateString,
+  truncateText,
+  filterPluginsBySearch,
+  filterPluginsByCategory,
+  isValidSemanticVersion,
+  isValidEmail,
+  isValidUrl,
+  parseKeywords,
+  formatKeywords,
+} from "./helpers";
+import { MarketplacePluginEntry, PluginSource } from "./types";
+
+describe("formatInstallCommand", () => {
+  it("formats github source with repo", () => {
+    const plugin = { name: "my-plugin", source: { source: "github" as const, repo: "org/repo" } };
+    expect(formatInstallCommand(plugin)).toBe("/plugin marketplace add org/repo");
+  });
+
+  it("formats url source", () => {
+    const plugin = { name: "my-plugin", source: { source: "url" as const, url: "https://example.com/plugin" } };
+    expect(formatInstallCommand(plugin)).toBe("/plugin marketplace add https://example.com/plugin");
+  });
+
+  it("falls back to plugin name when no repo or url", () => {
+    const plugin = { name: "my-plugin", source: { source: "github" as const } };
+    expect(formatInstallCommand(plugin)).toBe("/plugin marketplace add my-plugin");
+  });
+});
+
+describe("extractCategories", () => {
+  it("returns All and Other for empty list", () => {
+    expect(extractCategories([])).toEqual(["All", "Other"]);
+  });
+
+  it("extracts and sorts unique categories", () => {
+    const plugins = [
+      { category: "Development" },
+      { category: "Analytics" },
+      { category: "Development" },
+    ];
+    expect(extractCategories(plugins)).toEqual(["All", "Analytics", "Development", "Other"]);
+  });
+
+  it("ignores empty/whitespace categories", () => {
+    const plugins = [{ category: "" }, { category: "  " }, { category: "Tools" }];
+    expect(extractCategories(plugins)).toEqual(["All", "Tools", "Other"]);
+  });
+
+  it("handles undefined category", () => {
+    const plugins = [{ category: undefined }, { category: "Security" }];
+    expect(extractCategories(plugins)).toEqual(["All", "Security", "Other"]);
+  });
+});
+
+describe("validatePluginName", () => {
+  it("accepts valid kebab-case names", () => {
+    expect(validatePluginName("my-plugin")).toBe(true);
+    expect(validatePluginName("plugin123")).toBe(true);
+    expect(validatePluginName("a-b-c")).toBe(true);
+  });
+
+  it("rejects names with uppercase", () => {
+    expect(validatePluginName("MyPlugin")).toBe(false);
+  });
+
+  it("rejects names with spaces", () => {
+    expect(validatePluginName("my plugin")).toBe(false);
+  });
+
+  it("rejects empty/whitespace names", () => {
+    expect(validatePluginName("")).toBe(false);
+    expect(validatePluginName("  ")).toBe(false);
+  });
+
+  it("rejects names with special characters", () => {
+    expect(validatePluginName("my_plugin")).toBe(false);
+    expect(validatePluginName("my.plugin")).toBe(false);
+  });
+});
+
+describe("getSourceDisplayText", () => {
+  it("shows github repo", () => {
+    expect(getSourceDisplayText({ source: "github", repo: "org/repo" })).toBe("GitHub: org/repo");
+  });
+
+  it("shows url", () => {
+    expect(getSourceDisplayText({ source: "url", url: "https://example.com" })).toBe("https://example.com");
+  });
+
+  it("returns unknown for missing data", () => {
+    expect(getSourceDisplayText({ source: "github" })).toBe("Unknown source");
+  });
+});
+
+describe("getSourceLink", () => {
+  it("returns github link for github source", () => {
+    expect(getSourceLink({ source: "github", repo: "org/repo" })).toBe("https://github.com/org/repo");
+  });
+
+  it("returns url for url source", () => {
+    expect(getSourceLink({ source: "url", url: "https://example.com" })).toBe("https://example.com");
+  });
+
+  it("returns null when no repo or url", () => {
+    expect(getSourceLink({ source: "github" })).toBeNull();
+  });
+});
+
+describe("getCategoryBadgeColor", () => {
+  it("returns blue for development categories", () => {
+    expect(getCategoryBadgeColor("Development")).toBe("blue");
+    expect(getCategoryBadgeColor("dev-tools")).toBe("blue");
+  });
+
+  it("returns green for productivity categories", () => {
+    expect(getCategoryBadgeColor("Productivity")).toBe("green");
+    expect(getCategoryBadgeColor("Workflow")).toBe("green");
+  });
+
+  it("returns purple for learning categories", () => {
+    expect(getCategoryBadgeColor("Learning")).toBe("purple");
+    expect(getCategoryBadgeColor("Education")).toBe("purple");
+  });
+
+  it("returns red for security categories", () => {
+    expect(getCategoryBadgeColor("Security")).toBe("red");
+    expect(getCategoryBadgeColor("Safety")).toBe("red");
+  });
+
+  it("returns orange for data categories", () => {
+    expect(getCategoryBadgeColor("Data")).toBe("orange");
+    expect(getCategoryBadgeColor("Analytics")).toBe("orange");
+  });
+
+  it("returns yellow for integration categories", () => {
+    expect(getCategoryBadgeColor("Integration")).toBe("yellow");
+    expect(getCategoryBadgeColor("API")).toBe("yellow");
+  });
+
+  it("returns gray for unknown or undefined categories", () => {
+    expect(getCategoryBadgeColor("Unknown")).toBe("gray");
+    expect(getCategoryBadgeColor(undefined)).toBe("gray");
+  });
+});
+
+describe("formatDateString", () => {
+  it("formats valid date strings", () => {
+    const result = formatDateString("2024-01-15T12:00:00Z");
+    expect(result).toContain("2024");
+    expect(result).toContain("Jan");
+    expect(result).toContain("15");
+  });
+
+  it("returns N/A for undefined", () => {
+    expect(formatDateString(undefined)).toBe("N/A");
+  });
+
+  it("returns N/A for empty string", () => {
+    expect(formatDateString("")).toBe("N/A");
+  });
+});
+
+describe("truncateText", () => {
+  it("returns text unchanged if shorter than max", () => {
+    expect(truncateText("hello", 10)).toBe("hello");
+  });
+
+  it("truncates and adds ellipsis", () => {
+    expect(truncateText("hello world", 5)).toBe("hello...");
+  });
+
+  it("handles exact length", () => {
+    expect(truncateText("hello", 5)).toBe("hello");
+  });
+
+  it("handles empty text", () => {
+    expect(truncateText("", 5)).toBe("");
+  });
+});
+
+describe("filterPluginsBySearch", () => {
+  const plugins: MarketplacePluginEntry[] = [
+    {
+      name: "code-formatter",
+      source: { source: "github", repo: "org/formatter" },
+      description: "Formats code nicely",
+      keywords: ["format", "lint"],
+    },
+    {
+      name: "data-viewer",
+      source: { source: "github", repo: "org/viewer" },
+      description: "View data",
+      keywords: ["analytics"],
+    },
+  ];
+
+  it("returns all plugins for empty search", () => {
+    expect(filterPluginsBySearch(plugins, "")).toEqual(plugins);
+    expect(filterPluginsBySearch(plugins, "  ")).toEqual(plugins);
+  });
+
+  it("matches by name", () => {
+    expect(filterPluginsBySearch(plugins, "formatter")).toHaveLength(1);
+    expect(filterPluginsBySearch(plugins, "formatter")[0].name).toBe("code-formatter");
+  });
+
+  it("matches by description", () => {
+    expect(filterPluginsBySearch(plugins, "nicely")).toHaveLength(1);
+  });
+
+  it("matches by keyword", () => {
+    expect(filterPluginsBySearch(plugins, "analytics")).toHaveLength(1);
+    expect(filterPluginsBySearch(plugins, "analytics")[0].name).toBe("data-viewer");
+  });
+
+  it("is case insensitive", () => {
+    expect(filterPluginsBySearch(plugins, "FORMATTER")).toHaveLength(1);
+  });
+});
+
+describe("filterPluginsByCategory", () => {
+  const plugins: MarketplacePluginEntry[] = [
+    { name: "a", source: { source: "github" }, category: "Dev" },
+    { name: "b", source: { source: "github" }, category: "Security" },
+    { name: "c", source: { source: "github" }, category: "" },
+    { name: "d", source: { source: "github" } },
+  ];
+
+  it("returns all plugins for 'All'", () => {
+    expect(filterPluginsByCategory(plugins, "All")).toEqual(plugins);
+  });
+
+  it("returns uncategorized plugins for 'Other'", () => {
+    const result = filterPluginsByCategory(plugins, "Other");
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.name)).toEqual(["c", "d"]);
+  });
+
+  it("filters by specific category", () => {
+    const result = filterPluginsByCategory(plugins, "Dev");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("a");
+  });
+});
+
+describe("isValidSemanticVersion", () => {
+  it("accepts valid semver", () => {
+    expect(isValidSemanticVersion("1.0.0")).toBe(true);
+    expect(isValidSemanticVersion("0.1.0-alpha")).toBe(true);
+    expect(isValidSemanticVersion("2.3.4+build.1")).toBe(true);
+  });
+
+  it("rejects invalid semver", () => {
+    expect(isValidSemanticVersion("1.0")).toBe(false);
+    expect(isValidSemanticVersion("abc")).toBe(false);
+  });
+
+  it("returns true for undefined (optional)", () => {
+    expect(isValidSemanticVersion(undefined)).toBe(true);
+  });
+});
+
+describe("isValidEmail", () => {
+  it("accepts valid emails", () => {
+    expect(isValidEmail("user@example.com")).toBe(true);
+  });
+
+  it("rejects invalid emails", () => {
+    expect(isValidEmail("not-an-email")).toBe(false);
+    expect(isValidEmail("@example.com")).toBe(false);
+  });
+
+  it("returns true for undefined (optional)", () => {
+    expect(isValidEmail(undefined)).toBe(true);
+  });
+});
+
+describe("isValidUrl", () => {
+  it("accepts valid urls", () => {
+    expect(isValidUrl("https://example.com")).toBe(true);
+    expect(isValidUrl("http://localhost:3000")).toBe(true);
+  });
+
+  it("rejects invalid urls", () => {
+    expect(isValidUrl("not a url")).toBe(false);
+  });
+
+  it("returns true for undefined (optional)", () => {
+    expect(isValidUrl(undefined)).toBe(true);
+  });
+});
+
+describe("parseKeywords", () => {
+  it("splits comma-separated keywords", () => {
+    expect(parseKeywords("a, b, c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("trims whitespace", () => {
+    expect(parseKeywords("  foo ,  bar  ")).toEqual(["foo", "bar"]);
+  });
+
+  it("filters empty entries", () => {
+    expect(parseKeywords("a,,b,")).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseKeywords("")).toEqual([]);
+    expect(parseKeywords("  ")).toEqual([]);
+  });
+});
+
+describe("formatKeywords", () => {
+  it("joins keywords with comma and space", () => {
+    expect(formatKeywords(["a", "b", "c"])).toBe("a, b, c");
+  });
+
+  it("returns empty string for empty/undefined array", () => {
+    expect(formatKeywords([])).toBe("");
+    expect(formatKeywords(undefined)).toBe("");
+  });
+});

--- a/ui/litellm-dashboard/src/components/molecules/message_manager.test.ts
+++ b/ui/litellm-dashboard/src/components/molecules/message_manager.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Use vi.hoisted so the mock object is available when vi.mock is hoisted
+const mockStaticMessage = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+  loading: vi.fn(),
+  destroy: vi.fn(),
+}));
+
+vi.mock("antd", () => ({
+  message: mockStaticMessage,
+}));
+
+import MessageManager, { setMessageInstance } from "./message_manager";
+
+describe("MessageManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when no instance is set (falls back to static message)", () => {
+    it("delegates success to static message", () => {
+      MessageManager.success("done!");
+      expect(mockStaticMessage.success).toHaveBeenCalledWith("done!", undefined);
+    });
+
+    it("delegates error to static message", () => {
+      MessageManager.error("failed!", 5);
+      expect(mockStaticMessage.error).toHaveBeenCalledWith("failed!", 5);
+    });
+
+    it("delegates warning to static message", () => {
+      MessageManager.warning("watch out");
+      expect(mockStaticMessage.warning).toHaveBeenCalledWith("watch out", undefined);
+    });
+
+    it("delegates info to static message", () => {
+      MessageManager.info("fyi");
+      expect(mockStaticMessage.info).toHaveBeenCalledWith("fyi", undefined);
+    });
+
+    it("delegates loading to static message", () => {
+      MessageManager.loading("loading...", 3);
+      expect(mockStaticMessage.loading).toHaveBeenCalledWith("loading...", 3);
+    });
+
+    it("delegates destroy to static message", () => {
+      MessageManager.destroy();
+      expect(mockStaticMessage.destroy).toHaveBeenCalled();
+    });
+  });
+
+  describe("when a custom instance is set", () => {
+    const mockInstance = {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+      loading: vi.fn(),
+      destroy: vi.fn(),
+      open: vi.fn(),
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      setMessageInstance(mockInstance as any);
+    });
+
+    it("delegates success to custom instance", () => {
+      MessageManager.success("done!");
+      expect(mockInstance.success).toHaveBeenCalledWith("done!", undefined);
+      expect(mockStaticMessage.success).not.toHaveBeenCalled();
+    });
+
+    it("delegates error with duration to custom instance", () => {
+      MessageManager.error("failed!", 5);
+      expect(mockInstance.error).toHaveBeenCalledWith("failed!", 5);
+      expect(mockStaticMessage.error).not.toHaveBeenCalled();
+    });
+
+    it("delegates warning to custom instance", () => {
+      MessageManager.warning("watch out");
+      expect(mockInstance.warning).toHaveBeenCalledWith("watch out", undefined);
+    });
+
+    it("delegates info to custom instance", () => {
+      MessageManager.info("fyi", 2);
+      expect(mockInstance.info).toHaveBeenCalledWith("fyi", 2);
+    });
+
+    it("delegates loading to custom instance and returns result", () => {
+      const mockReturn = { then: vi.fn() };
+      mockInstance.loading.mockReturnValue(mockReturn);
+      const result = MessageManager.loading("loading...", 3);
+      expect(mockInstance.loading).toHaveBeenCalledWith("loading...", 3);
+      expect(result).toBe(mockReturn);
+    });
+
+    it("delegates destroy to custom instance", () => {
+      MessageManager.destroy();
+      expect(mockInstance.destroy).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/route_preview.tsx
+++ b/ui/litellm-dashboard/src/components/route_preview.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { Card, Title, Subtitle } from "@tremor/react";
+import { Card, Typography } from "antd";
 import { RightOutlined, InfoCircleOutlined } from "@ant-design/icons";
+
+const { Title, Text } = Typography;
 import { getProxyBaseUrl } from "./networking";
 
 interface RoutePreviewProps {
@@ -23,8 +25,8 @@ const RoutePreview: React.FC<RoutePreviewProps> = ({ pathValue, targetValue, inc
 
   return (
     <Card className="p-5">
-      <Title className="text-lg font-semibold text-gray-900 mb-2">Route Preview</Title>
-      <Subtitle className="text-gray-600 mb-5">How your requests will be routed</Subtitle>
+      <Title level={5} className="text-lg font-semibold text-gray-900 mb-2">Route Preview</Title>
+      <Text type="secondary" className="text-gray-600 mb-5" style={{ display: "block" }}>How your requests will be routed</Text>
 
       <div className="space-y-5">
         {/* Basic routing */}

--- a/ui/litellm-dashboard/src/components/ui/AntDLoadingSpinner.test.tsx
+++ b/ui/litellm-dashboard/src/components/ui/AntDLoadingSpinner.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock antd Spin component
+vi.mock("antd", () => ({
+  Spin: ({ indicator, size, ...props }: any) => (
+    <div data-testid="spin" data-size={size} {...props}>
+      {indicator}
+    </div>
+  ),
+}));
+
+// Mock the icon
+vi.mock("@ant-design/icons", () => ({
+  LoadingOutlined: ({ style, spin, ...props }: any) => (
+    <span
+      data-testid="loading-icon"
+      data-spin={spin}
+      style={style}
+      {...props}
+    />
+  ),
+}));
+
+import { AntDLoadingSpinner } from "./AntDLoadingSpinner";
+
+describe("AntDLoadingSpinner", () => {
+  it("renders without props", () => {
+    render(<AntDLoadingSpinner />);
+    expect(screen.getByTestId("spin")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-icon")).toBeInTheDocument();
+  });
+
+  it("passes size prop to Spin", () => {
+    render(<AntDLoadingSpinner size="large" />);
+    expect(screen.getByTestId("spin")).toHaveAttribute("data-size", "large");
+  });
+
+  it("passes small size to Spin", () => {
+    render(<AntDLoadingSpinner size="small" />);
+    expect(screen.getByTestId("spin")).toHaveAttribute("data-size", "small");
+  });
+
+  it("applies custom fontSize to the icon", () => {
+    render(<AntDLoadingSpinner fontSize={32} />);
+    const icon = screen.getByTestId("loading-icon");
+    expect(icon).toHaveStyle({ fontSize: "32px" });
+  });
+
+  it("does not set style when fontSize is not provided", () => {
+    render(<AntDLoadingSpinner />);
+    const icon = screen.getByTestId("loading-icon");
+    expect(icon.style.fontSize).toBe("");
+  });
+
+  it("sets spin attribute on icon", () => {
+    render(<AntDLoadingSpinner />);
+    const icon = screen.getByTestId("loading-icon");
+    expect(icon).toHaveAttribute("data-spin", "true");
+  });
+});


### PR DESCRIPTION
ryan daily branch

[fix: ignore return_to in SSO when control_plane_url not configured](https://github.com/BerriAI/litellm/pull/24475)
[fix: resolve all-team-models for project model access checks](https://github.com/BerriAI/litellm/pull/24481)
[chore: migrate route_preview.tsx from Tremor to Ant Design](https://github.com/BerriAI/litellm/pull/24485)
[docs: add audit log export to S3 documentation](https://github.com/BerriAI/litellm/pull/24486)