### PR TITLE
fix(minimax): use Bearer token in Authorization header

### DIFF
--- a/litellm/llms/minimax/messages/transformation.py
+++ b/litellm/llms/minimax/messages/transformation.py
@@ -1,7 +1,7 @@
 """
 MiniMax Anthropic transformation config - extends AnthropicConfig for MiniMax's Anthropic-compatible API
 """
-from typing import Optional
+from typing import Any, List, Optional, Tuple
 
 import litellm
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
@@ -16,7 +16,7 @@ class MinimaxMessagesConfig(AnthropicMessagesConfig):
     MiniMax provides an Anthropic-compatible API at:
     - International: https://api.minimax.io/anthropic
     - China: https://api.minimaxi.com/anthropic
-
+    
     Supported models:
     - MiniMax-M2.1
     - MiniMax-M2.1-lightning
@@ -32,7 +32,11 @@ class MinimaxMessagesConfig(AnthropicMessagesConfig):
         """
         Get MiniMax API key from environment or parameters.
         """
-        return api_key or get_secret_str("MINIMAX_API_KEY") or litellm.api_key
+        return (
+            api_key
+            or get_secret_str("MINIMAX_API_KEY")
+            or litellm.api_key
+        )
 
     @staticmethod
     def get_api_base(
@@ -64,13 +68,46 @@ class MinimaxMessagesConfig(AnthropicMessagesConfig):
         """
         # Get the base URL (either provided or default MiniMax endpoint)
         base_url = self.get_api_base(api_base=api_base)
-
+        
         # If the base URL already includes the full path, return it
         if base_url.endswith("/v1/messages"):
             return base_url
-
+        
         # Otherwise append the messages endpoint
         if base_url.endswith("/"):
             return f"{base_url}v1/messages"
         else:
             return f"{base_url}/v1/messages"
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[Any],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> Tuple[dict, Optional[str]]:
+        """
+        Validate MiniMax environment and set up authentication headers.
+
+        MiniMax requires ``Authorization: Bearer <api_key>`` format, unlike
+        Anthropic which uses the ``x-api-key`` header.  Override the parent
+        implementation so we always send the correct header.
+        """
+        api_key = self.get_api_key(api_key=api_key)
+
+        if api_key is None:
+            raise ValueError(
+                "MiniMax API key is required. "
+                "Set the MINIMAX_API_KEY environment variable or pass api_key parameter."
+            )
+
+        # MiniMax expects Bearer token authentication, not Anthropic's x-api-key
+        headers["Authorization"] = f"Bearer {api_key}"
+
+        if "content-type" not in headers:
+            headers["content-type"] = "application/json"
+
+        return headers, api_base


### PR DESCRIPTION
## Summary

Fixes #24483

### Problem

When connecting to the Minimax API via the Anthropic-compatible messages endpoint, the request fails with:
```
MinimaxException - {"type":"error","error":{"type":"authorized_error","message":"login fail: Please carry the API secret key in the 'Authorization' field of the request header (1004)"}}
```

`MinimaxMessagesConfig` inherits `validate_environment` from `AnthropicMessagesConfig`, which sets `x-api-key` (Anthropic auth format). However, the Minimax API requires `Authorization: Bearer <api_key>` authentication.

### Fix

Override `validate_environment` in `MinimaxMessagesConfig` to set `Authorization: Bearer <api_key>` instead of inheriting the Anthropic `x-api-key` header behavior.

Note: `MinimaxChatConfig` (OpenAI-compatible path) already uses Bearer auth correctly via `OpenAIGPTConfig.validate_environment`.

### Testing

Verified that the fix resolves the 401 authentication error when connecting to Minimax API via the Anthropic-compatible messages endpoint.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)