### PR TITLE
style: run black formatter on files failing CI lint

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -101,9 +101,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         # Case 1: Target by role + index (e.g., index=-1 among assistant messages)
         if targetted_index is not None and targetted_role is not None:
             role_indices = [
-                i
-                for i, msg in enumerate(messages)
-                if msg.get("role") == targetted_role
+                i for i, msg in enumerate(messages) if msg.get("role") == targetted_role
             ]
             if role_indices:
                 try:
@@ -116,10 +114,10 @@ class AnthropicCacheControlHook(CustomPromptManagement):
                         f"Skipping cache control injection for this point."
                     )
                 else:
-                    messages[actual_idx] = (
-                        AnthropicCacheControlHook._safe_insert_cache_control_in_message(
-                            messages[actual_idx], control
-                        )
+                    messages[
+                        actual_idx
+                    ] = AnthropicCacheControlHook._safe_insert_cache_control_in_message(
+                        messages[actual_idx], control
                     )
         # Case 2: Target by index only
         elif targetted_index is not None:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1408,10 +1408,10 @@ def convert_to_gemini_tool_call_invoke(
         if tool_calls is not None:
             for idx, tool in enumerate(tool_calls):
                 if "function" in tool:
-                    gemini_function_call: Optional[VertexFunctionCall] = (
-                        _gemini_tool_call_invoke_helper(
-                            function_call_params=tool["function"]
-                        )
+                    gemini_function_call: Optional[
+                        VertexFunctionCall
+                    ] = _gemini_tool_call_invoke_helper(
+                        function_call_params=tool["function"]
                     )
                     if gemini_function_call is not None:
                         part_dict: VertexPartType = {
@@ -1555,7 +1555,9 @@ def convert_to_gemini_tool_call_result(  # noqa: PLR0915
                         file_data = (
                             file_content.get("file_data", "")
                             if isinstance(file_content, dict)
-                            else file_content if isinstance(file_content, str) else ""
+                            else file_content
+                            if isinstance(file_content, str)
+                            else ""
                         )
 
                     if file_data:
@@ -2059,9 +2061,9 @@ def _sanitize_empty_text_content(
         if isinstance(content, str):
             if not content or not content.strip():
                 message = cast(AllMessageValues, dict(message))  # Make a copy
-                message["content"] = (
-                    "[System: Empty message content sanitised to satisfy protocol]"
-                )
+                message[
+                    "content"
+                ] = "[System: Empty message content sanitised to satisfy protocol]"
                 verbose_logger.debug(
                     f"_sanitize_empty_text_content: Replaced empty text content in {message.get('role')} message"
                 )
@@ -2401,9 +2403,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             # Convert ChatCompletionImageUrlObject to dict if needed
                             image_url_value = m["image_url"]
                             if isinstance(image_url_value, str):
-                                image_url_input: Union[str, dict[str, Any]] = (
-                                    image_url_value
-                                )
+                                image_url_input: Union[
+                                    str, dict[str, Any]
+                                ] = image_url_value
                             else:
                                 # ChatCompletionImageUrlObject or dict case - convert to dict
                                 image_url_input = {
@@ -2430,9 +2432,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             )
 
                             if "cache_control" in _content_element:
-                                _anthropic_content_element["cache_control"] = (
-                                    _content_element["cache_control"]
-                                )
+                                _anthropic_content_element[
+                                    "cache_control"
+                                ] = _content_element["cache_control"]
                             user_content.append(_anthropic_content_element)
                         elif m.get("type", "") == "text":
                             m = cast(ChatCompletionTextObject, m)
@@ -2492,9 +2494,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     )
 
                     if "cache_control" in _content_element:
-                        _anthropic_content_text_element["cache_control"] = (
-                            _content_element["cache_control"]
-                        )
+                        _anthropic_content_text_element[
+                            "cache_control"
+                        ] = _content_element["cache_control"]
 
                     user_content.append(_anthropic_content_text_element)
 
@@ -2627,9 +2629,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                         original_content_element=dict(assistant_content_block),
                     )
                     if "cache_control" in _content_element:
-                        _anthropic_text_content_element["cache_control"] = (
-                            _content_element["cache_control"]
-                        )
+                        _anthropic_text_content_element[
+                            "cache_control"
+                        ] = _content_element["cache_control"]
                     text_element = _anthropic_text_content_element
 
                 # Interleave: each thinking block precedes its server tool group.
@@ -2789,9 +2791,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     )
 
                     if "cache_control" in _content_element:
-                        _anthropic_text_content_element["cache_control"] = (
-                            _content_element["cache_control"]
-                        )
+                        _anthropic_text_content_element[
+                            "cache_control"
+                        ] = _content_element["cache_control"]
 
                     assistant_content.append(_anthropic_text_content_element)
 
@@ -5233,7 +5235,9 @@ def default_response_schema_prompt(response_schema: dict) -> str:
     prompt_str = """Use this JSON schema: 
     ```json 
     {}
-    ```""".format(response_schema)
+    ```""".format(
+        response_schema
+    )
     return prompt_str
 
 

--- a/litellm/llms/minimax/chat/transformation.py
+++ b/litellm/llms/minimax/chat/transformation.py
@@ -18,7 +18,7 @@ class MinimaxChatConfig(OpenAIGPTConfig):
 
     Note: MiniMax's Claude-compatible `/anthropic/v1/messages` support is implemented
     separately in `litellm/llms/minimax/messages/transformation.py`.
-    
+
     Supported models:
     - MiniMax-M2.1
     - MiniMax-M2.1-highspeed


### PR DESCRIPTION
## Summary
- Run Black formatter on 3 files that were failing the lint CI check on the staging branch
- `anthropic_cache_control_hook.py`, `factory.py`, `minimax/chat/transformation.py`
- These files were contributed by PRs merged into staging without formatting

## Test plan
- [x] `black --check` passes on all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)