### PR TITLE
fix(hosted_vllm): convert Anthropic tool_result blocks to OpenAI tool messages

### DIFF
--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -2,7 +2,7 @@
 Translate from OpenAI's `/v1/chat/completions` to VLLM's `/v1/chat/completions`
 """
 
-from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, cast, overload
+from typing import Any, Coroutine, Dict, List, Literal, Optional, Tuple, Union, cast, overload
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     _get_image_mime_type_from_url,
@@ -12,6 +12,7 @@ from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionFileObject,
+    ChatCompletionToolMessage,
     ChatCompletionVideoObject,
     ChatCompletionVideoUrlObject,
 )
@@ -118,6 +119,30 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
             )
         raise ValueError("file_id or file_data is required")
 
+    @staticmethod
+    def _extract_tool_result_content(content: Any) -> str:
+        """
+        Extract text content from an Anthropic tool_result content field.
+
+        The content field can be:
+        - a string
+        - a list of content blocks (each with type "text" and a "text" field)
+        - missing/None (empty string)
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text_parts = []
+            for item in content:
+                if isinstance(item, str):
+                    text_parts.append(item)
+                elif isinstance(item, dict) and item.get("type") == "text":
+                    text_parts.append(item.get("text", ""))
+            return " ".join(text_parts) if text_parts else ""
+        return str(content)
+
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
@@ -140,7 +165,17 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
         Support translating:
         - video files from file_id or file_data to video_url
         - thinking_blocks on assistant messages to content blocks
+        - Anthropic tool_result content blocks to OpenAI tool messages
+
+        When Claude Code sends tool results (e.g. from WebFetch) through LiteLLM
+        to hosted_vllm, they arrive as Anthropic-format tool_result blocks inside
+        user messages. vLLM (OpenAI-compatible) expects these as separate messages
+        with role="tool". This method extracts tool_result blocks and converts them
+        to proper OpenAI tool messages.
+
+        Fixes: https://github.com/BerriAI/litellm/issues/24491
         """
+        transformed_messages: List[AllMessageValues] = []
         for message in messages:
             if message["role"] == "assistant":
                 thinking_blocks = message.pop("thinking_blocks", None)  # type: ignore
@@ -157,21 +192,70 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                     elif isinstance(existing_content, list):
                         new_content.extend(existing_content)
                     message["content"] = new_content  # type: ignore
+                transformed_messages.append(message)
             elif message["role"] == "user":
                 message_content = message.get("content")
                 if message_content and isinstance(message_content, list):
-                    replaced_content_items: List[
-                        Tuple[int, ChatCompletionFileObject]
-                    ] = []
-                    for idx, content_item in enumerate(message_content):
-                        if content_item.get("type") == "file":
-                            content_item = cast(ChatCompletionFileObject, content_item)
-                            if self._is_video_file(content_item):
-                                replaced_content_items.append((idx, content_item))
-                    for idx, content_item in replaced_content_items:
-                        message_content[idx] = self._convert_file_to_video_url(
-                            content_item
-                        )
+                    # Separate Anthropic tool_result blocks from regular content
+                    tool_messages: List[AllMessageValues] = []
+                    remaining_content: List[Dict[str, Any]] = []
+
+                    for content_item in message_content:
+                        if isinstance(content_item, dict) and content_item.get("type") == "tool_result":
+                            # Convert Anthropic tool_result to OpenAI tool message
+                            tool_content = self._extract_tool_result_content(
+                                content_item.get("content", "")
+                            )
+                            tool_msg: ChatCompletionToolMessage = {
+                                "role": "tool",
+                                "tool_call_id": content_item.get("tool_use_id", ""),
+                                "content": tool_content,
+                            }
+                            tool_messages.append(tool_msg)  # type: ignore[arg-type]
+                        else:
+                            remaining_content.append(content_item)
+
+                    # Add extracted tool messages before the user message
+                    if tool_messages:
+                        transformed_messages.extend(tool_messages)
+
+                    if remaining_content:
+                        message["content"] = remaining_content  # type: ignore
+                        # Handle video file replacements on remaining content
+                        for idx, ci in enumerate(remaining_content):
+                            if ci.get("type") == "file":
+                                file_item = cast(ChatCompletionFileObject, ci)
+                                if self._is_video_file(file_item):
+                                    remaining_content[idx] = self._convert_file_to_video_url(file_item)  # type: ignore
+                        transformed_messages.append(message)
+                    elif not tool_messages:
+                        # No content at all, keep the message as-is
+                        transformed_messages.append(message)
+                    # If only tool_results were present and no remaining content,
+                    # skip the now-empty user message
+                else:
+                    # String content or empty — handle video files in the old path
+                    if message_content and isinstance(message_content, list):
+                        replaced_content_items: List[
+                            Tuple[int, ChatCompletionFileObject]
+                        ] = []
+                        for idx, content_item in enumerate(message_content):
+                            if content_item.get("type") == "file":
+                                content_item = cast(ChatCompletionFileObject, content_item)
+                                if self._is_video_file(content_item):
+                                    replaced_content_items.append((idx, content_item))
+                        for idx, content_item in replaced_content_items:
+                            message_content[idx] = self._convert_file_to_video_url(
+                                content_item
+                            )
+                    transformed_messages.append(message)
+            else:
+                transformed_messages.append(message)
+
+        # Replace original messages list in-place for compatibility with callers
+        messages.clear()
+        messages.extend(transformed_messages)
+
         if is_async:
             return super()._transform_messages(
                 messages, model, is_async=cast(Literal[True], True)

--- a/tests/llms/test_hosted_vllm_tool_result_conversion.py
+++ b/tests/llms/test_hosted_vllm_tool_result_conversion.py
@@ -1,0 +1,255 @@
+"""
+Tests for Anthropic tool_result → OpenAI tool message conversion in hosted_vllm.
+
+When Claude Code uses tools like WebFetch via LiteLLM routing to hosted_vllm,
+tool results arrive as Anthropic-format tool_result content blocks inside user
+messages. These must be converted to OpenAI-format tool role messages.
+
+Fixes: https://github.com/BerriAI/litellm/issues/24491
+"""
+
+import pytest
+
+from litellm.llms.hosted_vllm.chat.transformation import HostedVLLMChatConfig
+
+
+@pytest.fixture
+def config():
+    return HostedVLLMChatConfig()
+
+
+class TestExtractToolResultContent:
+    """Unit tests for _extract_tool_result_content helper."""
+
+    def test_string_content(self):
+        assert HostedVLLMChatConfig._extract_tool_result_content("hello") == "hello"
+
+    def test_none_content(self):
+        assert HostedVLLMChatConfig._extract_tool_result_content(None) == ""
+
+    def test_list_with_text_blocks(self):
+        content = [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ]
+        assert HostedVLLMChatConfig._extract_tool_result_content(content) == "first second"
+
+    def test_list_with_single_text_block(self):
+        content = [{"type": "text", "text": "fetched content"}]
+        assert HostedVLLMChatConfig._extract_tool_result_content(content) == "fetched content"
+
+    def test_list_with_strings(self):
+        content = ["part1", "part2"]
+        assert HostedVLLMChatConfig._extract_tool_result_content(content) == "part1 part2"
+
+    def test_empty_list(self):
+        assert HostedVLLMChatConfig._extract_tool_result_content([]) == ""
+
+    def test_empty_string(self):
+        assert HostedVLLMChatConfig._extract_tool_result_content("") == ""
+
+
+class TestToolResultConversion:
+    """Test that tool_result blocks in user messages are converted to OpenAI tool messages."""
+
+    def test_single_tool_result_string_content(self, config):
+        """Basic case: single tool_result with string content."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_abc123",
+                        "content": "fetched content from web",
+                    }
+                ],
+            }
+        ]
+        result = config._transform_messages(messages, model="test-model")
+        # Should produce a single tool message (user message with no remaining content is dropped)
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "toolu_abc123"
+        assert tool_msgs[0]["content"] == "fetched content from web"
+
+    def test_single_tool_result_list_content(self, config):
+        """tool_result with list content containing text blocks."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_xyz",
+                        "content": [
+                            {"type": "text", "text": "page title"},
+                            {"type": "text", "text": "page body"},
+                        ],
+                    }
+                ],
+            }
+        ]
+        result = config._transform_messages(messages, model="test-model")
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "toolu_xyz"
+        assert tool_msgs[0]["content"] == "page title page body"
+
+    def test_tool_result_with_no_content(self, config):
+        """tool_result with missing content field."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_empty",
+                    }
+                ],
+            }
+        ]
+        result = config._transform_messages(messages, model="test-model")
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "toolu_empty"
+        assert tool_msgs[0]["content"] == ""
+
+    def test_tool_result_mixed_with_text(self, config):
+        """User message with both text and tool_result blocks."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Here are the results:"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_fetch1",
+                        "content": "fetched data",
+                    },
+                ],
+            }
+        ]
+        result = config._transform_messages(messages, model="test-model")
+
+        # Should have tool message first, then user message with remaining text
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        user_msgs = [m for m in result if m.get("role") == "user"]
+
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "fetched data"
+
+        assert len(user_msgs) == 1
+        assert user_msgs[0]["content"] == [{"type": "text", "text": "Here are the results:"}]
+
+    def test_multiple_tool_results(self, config):
+        """Multiple tool_result blocks in a single user message."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "result 1",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_2",
+                        "content": "result 2",
+                    },
+                ],
+            }
+        ]
+        result = config._transform_messages(messages, model="test-model")
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_msgs) == 2
+        assert tool_msgs[0]["tool_call_id"] == "toolu_1"
+        assert tool_msgs[0]["content"] == "result 1"
+        assert tool_msgs[1]["tool_call_id"] == "toolu_2"
+        assert tool_msgs[1]["content"] == "result 2"
+
+    def test_no_tool_results_unchanged(self, config):
+        """Messages without tool_result blocks should not be modified."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": [{"type": "text", "text": "How are you?"}]},
+        ]
+        result = config._transform_messages(messages, model="test-model")
+        assert len(result) == 3
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == "Hello"
+        assert result[1]["role"] == "assistant"
+        assert result[2]["role"] == "user"
+
+    def test_preserves_message_order(self, config):
+        """Verify tool messages are inserted before the user message they came from."""
+        messages = [
+            {"role": "assistant", "content": "I'll fetch that for you."},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_web",
+                        "content": "web page content",
+                    },
+                    {"type": "text", "text": "Please summarize this."},
+                ],
+            },
+        ]
+        result = config._transform_messages(messages, model="test-model")
+        assert len(result) == 3
+        assert result[0]["role"] == "assistant"
+        assert result[1]["role"] == "tool"
+        assert result[1]["content"] == "web page content"
+        assert result[2]["role"] == "user"
+        assert result[2]["content"] == [{"type": "text", "text": "Please summarize this."}]
+
+    def test_claude_code_webfetch_scenario(self, config):
+        """
+        End-to-end scenario: Claude Code uses WebFetch tool, result comes back
+        as Anthropic tool_result, needs conversion for hosted_vllm.
+        """
+        messages = [
+            {"role": "user", "content": "What's on example.com?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I'll fetch that page for you."},
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call_webfetch_001",
+                        "type": "function",
+                        "function": {
+                            "name": "WebFetch",
+                            "arguments": '{"url": "https://example.com"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_webfetch_001",
+                        "content": "<html><body>Example Domain</body></html>",
+                    }
+                ],
+            },
+        ]
+        result = config._transform_messages(messages, model="test-model")
+
+        # The tool_result should be converted to a tool message
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "call_webfetch_001"
+        assert "Example Domain" in tool_msgs[0]["content"]
+
+        # Original user and assistant messages should be preserved
+        user_msgs = [m for m in result if m.get("role") == "user"]
+        assert len(user_msgs) == 1  # Only the first user message remains
+        assert user_msgs[0]["content"] == "What's on example.com?"


### PR DESCRIPTION
## Summary

Fixes #24491

## Problem

When using Claude Code with LiteLLM routing to `hosted_vllm`, tool results (e.g., from WebFetch) were silently dropped during message transformation.

Claude Code sends tool results as Anthropic-format `tool_result` content blocks inside user messages:
```json
{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "abc", "content": "result"}]}
```

vLLM (OpenAI-compatible) expects these as separate messages:
```json
{"role": "tool", "tool_call_id": "abc", "content": "result"}
```

The `HostedVLLMChatConfig._transform_messages()` method did not handle `tool_result` content blocks, so they were passed through as-is and effectively lost. The model received no tool output and reported errors like "The Webfetch tool did not return a response".

## Fix

Added explicit handling for `tool_result` content blocks in `HostedVLLMChatConfig._transform_messages()`. The fix:
1. Detects `tool_result` blocks in user message content arrays
2. Extracts them into proper OpenAI `tool` role messages with `tool_call_id`
3. Handles string, list (with text blocks), and missing content formats
4. Preserves remaining non-tool content in the user message
5. Maintains correct message ordering (tool messages before any remaining user content)

## Changes

- `litellm/llms/hosted_vllm/chat/transformation.py`: Added `_extract_tool_result_content()` helper and updated `_transform_messages()` to convert Anthropic tool_result blocks
- `tests/llms/test_hosted_vllm_tool_result_conversion.py`: 15 tests covering all tool_result conversion scenarios including the Claude Code WebFetch end-to-end case

## Testing

All 15 new tests pass:
- String content extraction
- List content with text blocks
- Missing/empty content
- Mixed tool_result + text content in user messages
- Multiple tool_results
- Message ordering preservation
- Full Claude Code WebFetch scenario

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)