### PR TITLE
fix(proxy): passthrough subpath auth bypass with include_subpath

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -389,7 +389,7 @@ def get_api_key(
         api_key = google_auth_key
     elif pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
-            if endpoint.get("path", "") == route:
+            if _pass_through_endpoint_matches_route(endpoint=endpoint, route=route):
                 headers: Optional[dict] = endpoint.get("headers", None)
                 if headers is not None:
                     header_key: str = headers.get("litellm_user_api_key", "")
@@ -415,9 +415,20 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
     if is_mapped_pass_through_route:
         if request.headers.get("litellm_user_api_key") is not None:
             api_key = request.headers.get("litellm_user_api_key") or ""
+    # Check the registered route registry for no-auth subpath endpoints.
+    # This handles dynamically registered passthrough routes (e.g. from DB)
+    # that are not in the config-based pass_through_endpoints list.
+    no_auth_registered = _get_no_auth_registered_pass_through_route(
+        request=request, route=route
+    )
+    if no_auth_registered is not None:
+        return no_auth_registered
+
     if pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
-            if isinstance(endpoint, dict) and endpoint.get("path", "") == route:
+            if isinstance(endpoint, dict) and _pass_through_endpoint_matches_route(
+                endpoint=endpoint, route=route
+            ):
                 ## IF AUTH DISABLED
                 if endpoint.get("auth") is not True:
                     return UserAPIKeyAuth()
@@ -445,6 +456,100 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                         ):
                             api_key = request.headers.get(key=header_key)  # type: ignore
     return api_key
+
+
+def _route_matches_pass_through_path(
+    route: str, path: str, include_subpath: bool
+) -> bool:
+    """Check if a request route matches a passthrough endpoint path.
+
+    When include_subpath is True, performs prefix matching so that
+    e.g. route="/chatgpt/responses" matches path="/chatgpt".
+    Normalizes paths to prevent traversal attacks (e.g. /chatgpt/../admin).
+    """
+    import posixpath
+
+    normalized_route = posixpath.normpath(route)
+
+    if normalized_route == path:
+        return True
+
+    if include_subpath:
+        # Ensure consistent trailing-slash handling:
+        # path="/chatgpt" should match route="/chatgpt/foo" but not "/chatgptfoo"
+        normalized_path = path.rstrip("/")
+        if normalized_path == "":
+            # Edge case: path is "/" — avoid matching everything
+            normalized_path = path
+        if normalized_path and normalized_route.startswith(normalized_path + "/"):
+            return True
+
+    return False
+
+
+def _pass_through_endpoint_matches_route(endpoint: dict, route: str) -> bool:
+    """Check if a passthrough endpoint config dict matches the given route.
+
+    Considers both the raw route and the root_path-normalized route.
+    """
+    path = endpoint.get("path")
+    if not isinstance(path, str) or len(path) == 0:
+        return False
+
+    include_subpath = bool(endpoint.get("include_subpath", False))
+    candidate_routes = [route]
+    normalized_route = normalize_route_for_root_path(route)
+    if normalized_route is not None and normalized_route != route:
+        candidate_routes.append(normalized_route)
+
+    for candidate_route in candidate_routes:
+        if _route_matches_pass_through_path(
+            route=candidate_route,
+            path=path,
+            include_subpath=include_subpath,
+        ):
+            return True
+
+    return False
+
+
+def _get_no_auth_registered_pass_through_route(
+    request: Request, route: str
+) -> Optional[UserAPIKeyAuth]:
+    """Check the internal route registry for passthrough endpoints registered
+    without auth dependencies. Returns UserAPIKeyAuth if the route is registered
+    with no auth, None otherwise.
+    """
+    try:
+        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+            InitPassThroughEndpointHelpers,
+        )
+
+        registered_route = (
+            InitPassThroughEndpointHelpers.get_registered_pass_through_route(
+                route=route,
+                method=request.method,
+            )
+        )
+        if registered_route is None:
+            return None
+
+        dependencies = (
+            registered_route.get("passthrough_params", {}).get("dependencies") or []
+        )
+        if len(dependencies) == 0:
+            return UserAPIKeyAuth()
+    except ImportError:
+        verbose_proxy_logger.debug(
+            "pass_through_endpoints module not available for auth bypass check"
+        )
+    except Exception:
+        verbose_proxy_logger.warning(
+            "Unable to inspect registered pass-through route for auth bypass",
+            exc_info=True,
+        )
+
+    return None
 
 
 async def _resolve_jwt_to_virtual_key(

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -2,14 +2,12 @@ import asyncio
 import json
 import os
 import sys
-from typing import Tuple
+from typing import Optional, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
-
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,7 +16,18 @@ from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import LiteLLM_JWTAuth, UserAPIKeyAuth
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.route_checks import RouteChecks
-from litellm.proxy.auth.user_api_key_auth import get_api_key, user_api_key_auth
+from starlette.datastructures import URL
+from starlette.requests import Request
+
+from litellm.proxy.auth.user_api_key_auth import (
+    check_api_key_for_custom_headers_or_pass_through_endpoints,
+    get_api_key,
+    user_api_key_auth,
+)
+from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+    InitPassThroughEndpointHelpers,
+    _registered_pass_through_routes,
+)
 
 
 def test_get_api_key():
@@ -67,6 +76,180 @@ def test_get_api_key_with_custom_litellm_key_header(
         route="",
         request=MagicMock(),
     ) == (api_key, passed_in_key)
+
+
+def _make_request(
+    path: str,
+    method: str = "POST",
+    headers: Optional[list] = None,
+) -> Request:
+    """Create a minimal Starlette Request for testing."""
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "headers": headers or [],
+        "query_string": b"",
+        "scheme": "https",
+        "server": ("testserver", 443),
+        "client": ("testclient", 50000),
+        "root_path": "",
+    }
+    request = Request(scope, receive=receive)
+    request._url = URL(url=path)
+    return request
+
+
+def test_passthrough_no_auth_subpath_from_config_bypasses_auth():
+    """When a passthrough endpoint has include_subpath=True and auth=False,
+    subpath requests should bypass master_key auth."""
+
+    async def _async_test():
+        route = "/chatgpt/responses"
+        request = _make_request(path=route)
+
+        result = await check_api_key_for_custom_headers_or_pass_through_endpoints(
+            request=request,
+            route=route,
+            pass_through_endpoints=[
+                {
+                    "path": "/chatgpt",
+                    "target": "https://chatgpt.com/backend-api/codex",
+                    "include_subpath": True,
+                    "auth": False,
+                }
+            ],
+            api_key="eyJhbGciOiJIUzI1NiJ9.payload.signature",
+        )
+
+        assert isinstance(result, UserAPIKeyAuth)
+
+    asyncio.run(_async_test())
+
+
+def test_passthrough_no_auth_exact_path_still_works():
+    """Exact path matches should continue to bypass auth as before."""
+
+    async def _async_test():
+        route = "/chatgpt"
+        request = _make_request(path=route)
+
+        result = await check_api_key_for_custom_headers_or_pass_through_endpoints(
+            request=request,
+            route=route,
+            pass_through_endpoints=[
+                {
+                    "path": "/chatgpt",
+                    "target": "https://chatgpt.com/backend-api/codex",
+                    "include_subpath": False,
+                    "auth": False,
+                }
+            ],
+            api_key="eyJhbGciOiJIUzI1NiJ9.payload.signature",
+        )
+
+        assert isinstance(result, UserAPIKeyAuth)
+
+    asyncio.run(_async_test())
+
+
+def test_passthrough_no_auth_subpath_does_not_match_without_flag():
+    """Without include_subpath=True, subpath requests should NOT bypass auth."""
+
+    async def _async_test():
+        route = "/chatgpt/responses"
+        request = _make_request(path=route)
+
+        result = await check_api_key_for_custom_headers_or_pass_through_endpoints(
+            request=request,
+            route=route,
+            pass_through_endpoints=[
+                {
+                    "path": "/chatgpt",
+                    "target": "https://chatgpt.com/backend-api/codex",
+                    "include_subpath": False,
+                    "auth": False,
+                }
+            ],
+            api_key="eyJhbGciOiJIUzI1NiJ9.payload.signature",
+        )
+
+        # Should return the api_key string, NOT a UserAPIKeyAuth object
+        assert isinstance(result, str)
+
+    asyncio.run(_async_test())
+
+
+def test_passthrough_path_traversal_does_not_bypass_auth():
+    """Path traversal attempts like /chatgpt/../admin should not match /chatgpt."""
+
+    async def _async_test():
+        route = "/chatgpt/../admin/secret"
+        request = _make_request(path=route)
+
+        result = await check_api_key_for_custom_headers_or_pass_through_endpoints(
+            request=request,
+            route=route,
+            pass_through_endpoints=[
+                {
+                    "path": "/chatgpt",
+                    "target": "https://chatgpt.com/backend-api/codex",
+                    "include_subpath": True,
+                    "auth": False,
+                }
+            ],
+            api_key="eyJhbGciOiJIUzI1NiJ9.payload.signature",
+        )
+
+        # /chatgpt/../admin/secret normalizes to /admin/secret, should NOT match
+        assert isinstance(result, str)
+
+    asyncio.run(_async_test())
+
+
+def test_passthrough_no_auth_subpath_from_registry_bypasses_auth():
+    """Dynamically registered passthrough routes (e.g. from DB) should also
+    bypass auth when registered without dependencies."""
+
+    async def _async_test():
+        endpoint_id = "test-no-auth-registry"
+        base_path = "/registry-chatgpt"
+        methods_str = "DELETE,GET,PATCH,POST,PUT"
+        route_key = f"{endpoint_id}:subpath:{base_path}:{methods_str}"
+        route = f"{base_path}/responses"
+
+        try:
+            InitPassThroughEndpointHelpers.add_subpath_route(
+                app=MagicMock(),
+                path=base_path,
+                target="https://chatgpt.com/backend-api/codex",
+                custom_headers=None,
+                forward_headers=True,
+                merge_query_params=False,
+                dependencies=None,
+                cost_per_request=0,
+                endpoint_id=endpoint_id,
+            )
+
+            request = _make_request(path=route)
+
+            result = await check_api_key_for_custom_headers_or_pass_through_endpoints(
+                request=request,
+                route=route,
+                pass_through_endpoints=None,
+                api_key="eyJhbGciOiJIUzI1NiJ9.payload.signature",
+            )
+
+            assert isinstance(result, UserAPIKeyAuth)
+        finally:
+            _registered_pass_through_routes.pop(route_key, None)
+
+    asyncio.run(_async_test())
 
 
 def test_team_metadata_with_tags_flows_through_jwt_auth():


### PR DESCRIPTION
## Summary

Fixes #24500

- Pass-through endpoints with `include_subpath: true` and `auth: false` (default) now correctly bypass master_key auth for subpath requests
- Adds path traversal protection using `posixpath.normpath()` to prevent routes like `/chatgpt/../admin` from matching `/chatgpt`
- Also checks dynamically registered passthrough routes (e.g. from DB) for auth bypass

## Problem

When configuring a passthrough endpoint like:

```yaml
pass_through_endpoints:
  - path: "/chatgpt"
    target: "https://chatgpt.com/backend-api/codex"
    include_subpath: true
    forward_headers: true
```

Requests to `/chatgpt/responses` were rejected with `401 Unauthorized` because `check_api_key_for_custom_headers_or_pass_through_endpoints()` used exact path matching (`==`). The route `"/chatgpt/responses"` did not equal `"/chatgpt"`, so the auth bypass never triggered.

## Changes

**`litellm/proxy/auth/user_api_key_auth.py`:**
- Extract `_route_matches_pass_through_path()` — handles prefix matching with `posixpath.normpath()` for path traversal prevention
- Extract `_pass_through_endpoint_matches_route()` — considers both raw route and `root_path`-normalized route
- Add `_get_no_auth_registered_pass_through_route()` — checks internal route registry for dynamically registered endpoints
- Replace exact match (`==`) with `_pass_through_endpoint_matches_route()` in both `get_api_key()` and `check_api_key_for_custom_headers_or_pass_through_endpoints()`

**`tests/test_litellm/proxy/auth/test_user_api_key_auth.py`:**
- `test_passthrough_no_auth_subpath_from_config_bypasses_auth` — main fix validation
- `test_passthrough_no_auth_exact_path_still_works` — regression test
- `test_passthrough_no_auth_subpath_does_not_match_without_flag` — negative test
- `test_passthrough_path_traversal_does_not_bypass_auth` — security test
- `test_passthrough_no_auth_subpath_from_registry_bypasses_auth` — registry bypass test

## Test plan

- [x] All 5 new tests pass
- [x] Existing tests unaffected (only additive changes)