### PR TITLE
fix: Add missing permissions to AWS bedrock session policy to allow Rerank model access via OIDC

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -700,7 +700,7 @@ class BaseAWSLLM:
             "RoleSessionName": aws_session_name,
             "WebIdentityToken": oidc_token,
             "DurationSeconds": 3600,
-            "Policy": '{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"true"},"StringLike":{"aws:UserAgent":"litellm/*"}}}]}',
+            "Policy": '{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream","bedrock:Rerank"],"Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"true"},"StringLike":{"aws:UserAgent":"litellm/*"}}}]}',
         }
 
         # Add ExternalId parameter if provided


### PR DESCRIPTION
## Relevant issues

Using OIDC and sts assume role does currently not support the usage of rerank models in AWS bedrock as the policy is not containing the required permissions and cannot be configured by users. Our assume role has the bedrock rerank permissions, but the session policy is missing it.

      "error": "{\"Message\":\"User: arn:aws:sts::12345678:assumed-role/my-role/litellm-session is not authorized to perform: bedrock:Rerank because no identity-based policy allows the bedrock:Rerank action\"}\nstack trace: Traceback (most recent call last):\n  File \"/usr/lib/python3.13/site-packages/litellm/llms/bedrock/rerank/handler.py\", line 38, in arerank\n    response = await client.post(\n               ^^^^^^^^^^^^^^^^^^\n    ...<4 lines>...\n    )\n    ^\n  File \"/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/logging_utils.py\", line 297, in async_wrapper\n    result = await func(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3.13/site-packages/litellm/llms/custom_httpx/http_handler.py\", line 513, in post\n    raise e\n  File \"/usr/lib/python3.13/site-packages/litellm/llms/custom_httpx/http_handler.py\", line 469, in post\n    response.raise_for_status()\n    ~~~~~~~~~~~~~~~~~~~~~~~~~^^\n  File \"/usr/lib/python3.13/site-packages/httpx/_models.py\", line 829, in raise_for_status\n    raise HTTPStatusError(message, request=request, response=self)\nhttpx.HTTPStatusError: Client error '403 Forbidden' for url 'https://bedrock-agent-runtime.eu-central-1.amazonaws.com/reran",

## Type

🐛 Bug Fix

## Changes

Add additional permission "bedrock:Rerank" to Azure policy for STS