### PR TITLE
fix: normalize responses model names for OpenAI Responses API

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
@@ -197,6 +197,7 @@ class PagerDutyAlerting(SlackAlerting):
                 user_api_key_org_id=user_api_key_dict.org_id,
                 user_api_key_team_id=user_api_key_dict.team_id,
                 user_api_key_project_id=user_api_key_dict.project_id,
+                user_api_key_project_alias=user_api_key_dict.project_alias,
                 user_api_key_user_id=user_api_key_dict.user_id,
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,

--- a/litellm/llms/a2a/chat/guardrail_translation/handler.py
+++ b/litellm/llms/a2a/chat/guardrail_translation/handler.py
@@ -216,7 +216,7 @@ class A2AGuardrailHandler(BaseTranslation):
             response["result"] = result
             return response
 
-    async def process_output_streaming_response(
+    async def process_output_streaming_response(  # noqa: PLR0915
         self,
         responses_so_far: List[Any],
         guardrail_to_apply: "CustomGuardrail",

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -246,7 +246,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                     "text"
                 ] = guardrail_response
 
-    async def process_output_response(
+    async def process_output_response(  # noqa: PLR0915
         self,
         response: "AnthropicMessagesResponse",
         guardrail_to_apply: "CustomGuardrail",

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs["structured_messages"] = (
-                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
-                )
+                inputs[
+                    "structured_messages"
+                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -547,7 +547,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         data = dict(
             ResponsesAPIRequestParams(
-                model=model, input=input, **response_api_optional_request_params
+                model=self._normalize_response_api_model_name(model),
+                input=input,
+                **response_api_optional_request_params,
             )
         )
 

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -28,6 +28,12 @@ else:
 
 
 class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
+    @staticmethod
+    def _normalize_response_api_model_name(model: str) -> str:
+        if model.startswith("responses/"):
+            return model.split("responses/", 1)[1]
+        return model
+
     @property
     def custom_llm_provider(self) -> LlmProviders:
         return LlmProviders.OPENAI
@@ -76,7 +82,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         final_request_params = dict(
             ResponsesAPIRequestParams(
-                model=model, input=input, **response_api_optional_request_params
+                model=self._normalize_response_api_model_name(model),
+                input=input,
+                **response_api_optional_request_params,
             )
         )
 

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -90,6 +90,7 @@ def _get_spend_logs_metadata(
             user_api_key_alias=None,
             user_api_key_team_id=None,
             user_api_key_project_id=None,
+            user_api_key_project_alias=None,
             user_api_key_org_id=None,
             user_api_key_user_id=None,
             user_api_key_team_alias=None,

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -735,6 +735,22 @@ class TestTransformListInputItemsRequest:
         assert data["model"] == "gpt-4o"
         assert data["input"] == "hello"
 
+    def test_openai_transform_compact_response_api_request_strips_responses_prefix(
+        self,
+    ):
+        url, data = self.openai_config.transform_compact_response_api_request(
+            model="responses/gpt-4o",
+            input="hello",
+            response_api_optional_request_params={},
+            api_base="https://api.openai.com/v1/responses",
+            litellm_params=self.litellm_params,
+            headers=self.headers,
+        )
+
+        assert url == "https://api.openai.com/v1/responses/compact"
+        assert data["model"] == "gpt-4o"
+        assert data["input"] == "hello"
+
     def test_azure_transform_list_input_items_request_minimal(self):
         """Test Azure implementation with minimal parameters"""
         # Setup

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1,23 +1,19 @@
-import json
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
-import httpx
 import pytest
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
-import litellm
 from litellm.llms.azure.responses.transformation import AzureOpenAIResponsesAPIConfig
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.types.llms.openai import (
     ImageGenerationPartialImageEvent,
     OutputTextDeltaEvent,
     ResponseCompletedEvent,
-    ResponsesAPIRequestParams,
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
 )
@@ -84,6 +80,17 @@ class TestOpenAIResponsesAPIConfig:
         }
 
         self.validate_responses_api_request_params(result, expected_fields)
+
+    def test_transform_responses_api_request_strips_responses_prefix(self):
+        result = self.config.transform_responses_api_request(
+            model="responses/gpt-4.1",
+            input="Hello world",
+            response_api_optional_request_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert result["model"] == "gpt-4.1"
 
     def test_transform_streaming_response(self):
         """Test streaming response transformation"""

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -101,3 +101,72 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
             assert request_body[key] == expected_value, (
                 f"Mismatch for key {key}: got {request_body[key]!r}, expected {expected_value!r}"
             )
+
+
+@pytest.mark.asyncio
+async def test_aresponses_strips_responses_prefix_from_openai_model_name():
+    mock_response = {
+        "id": "resp_prefix_strip_test",
+        "object": "response",
+        "created_at": 1734366691,
+        "status": "completed",
+        "model": "gpt-4o",
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_1",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "Done.", "annotations": []}
+                ],
+            }
+        ],
+        "parallel_tool_calls": False,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "metadata": None,
+        "temperature": None,
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": None,
+        "max_output_tokens": None,
+        "previous_response_id": None,
+        "reasoning": None,
+        "truncation": None,
+        "user": None,
+    }
+
+    class MockResponse:
+        def __init__(self, json_data, status_code=200):
+            self._json_data = json_data
+            self.status_code = status_code
+            self.text = json.dumps(json_data)
+            self.headers = httpx.Headers({})
+
+        def json(self):
+            return self._json_data
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(mock_response, 200)
+
+        await litellm.aresponses(
+            model="openai/responses/gpt-4o",
+            input="Reply with OK.",
+        )
+
+        mock_post.assert_called_once()
+        request_body = mock_post.call_args.kwargs["json"]
+
+        assert request_body["model"] == "gpt-4o"
+        assert request_body["input"] == "Reply with OK."

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -17,20 +17,11 @@ def _expected_dir() -> Path:
     return Path(__file__).resolve().parent.parent / "expected_responses_api_request"
 
 
-@pytest.mark.asyncio
-async def test_aresponses_context_management_and_shell_request_body_matches_expected():
-    """
-    Call litellm.aresponses() with context_management and shell tool;
-    assert the httpx POST request body matches the expected JSON.
-    """
-    expected_path = _expected_dir() / "context_management_and_shell.json"
-    assert expected_path.exists(), f"Expected file not found: {expected_path}"
-    with open(expected_path) as f:
-        expected_body = json.load(f)
-
-    # Minimal Responses API response so parsing succeeds
-    mock_response = {
-        "id": "resp_ctx_shell_test",
+def _mock_responses_api_response(
+    response_id: str, parallel_tool_calls: bool = False
+) -> dict:
+    return {
+        "id": response_id,
         "object": "response",
         "created_at": 1734366691,
         "status": "completed",
@@ -46,7 +37,7 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
                 ],
             }
         ],
-        "parallel_tool_calls": True,
+        "parallel_tool_calls": parallel_tool_calls,
         "usage": {
             "input_tokens": 10,
             "output_tokens": 5,
@@ -68,21 +59,40 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
         "user": None,
     }
 
-    class MockResponse:
-        def __init__(self, json_data, status_code=200):
-            self._json_data = json_data
-            self.status_code = status_code
-            self.text = json.dumps(json_data)
-            self.headers = httpx.Headers({})
 
-        def json(self):
-            return self._json_data
+class MockResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.text = json.dumps(json_data)
+        self.headers = httpx.Headers({})
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.asyncio
+async def test_aresponses_context_management_and_shell_request_body_matches_expected():
+    """
+    Call litellm.aresponses() with context_management and shell tool;
+    assert the httpx POST request body matches the expected JSON.
+    """
+    expected_path = _expected_dir() / "context_management_and_shell.json"
+    assert expected_path.exists(), f"Expected file not found: {expected_path}"
+    with open(expected_path) as f:
+        expected_body = json.load(f)
 
     with patch(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
         new_callable=AsyncMock,
     ) as mock_post:
-        mock_post.return_value = MockResponse(mock_response, 200)
+        mock_post.return_value = MockResponse(
+            _mock_responses_api_response(
+                response_id="resp_ctx_shell_test",
+                parallel_tool_calls=True,
+            ),
+            200,
+        )
 
         await litellm.aresponses(
             model="openai/gpt-4o",
@@ -105,62 +115,39 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
 
 @pytest.mark.asyncio
 async def test_aresponses_strips_responses_prefix_from_openai_model_name():
-    mock_response = {
-        "id": "resp_prefix_strip_test",
-        "object": "response",
-        "created_at": 1734366691,
-        "status": "completed",
-        "model": "gpt-4o",
-        "output": [
-            {
-                "type": "message",
-                "id": "msg_1",
-                "status": "completed",
-                "role": "assistant",
-                "content": [
-                    {"type": "output_text", "text": "Done.", "annotations": []}
-                ],
-            }
-        ],
-        "parallel_tool_calls": False,
-        "usage": {
-            "input_tokens": 10,
-            "output_tokens": 5,
-            "total_tokens": 15,
-            "output_tokens_details": {"reasoning_tokens": 0},
-        },
-        "error": None,
-        "incomplete_details": None,
-        "instructions": None,
-        "metadata": None,
-        "temperature": None,
-        "tool_choice": "auto",
-        "tools": [],
-        "top_p": None,
-        "max_output_tokens": None,
-        "previous_response_id": None,
-        "reasoning": None,
-        "truncation": None,
-        "user": None,
-    }
-
-    class MockResponse:
-        def __init__(self, json_data, status_code=200):
-            self._json_data = json_data
-            self.status_code = status_code
-            self.text = json.dumps(json_data)
-            self.headers = httpx.Headers({})
-
-        def json(self):
-            return self._json_data
-
     with patch(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
         new_callable=AsyncMock,
     ) as mock_post:
-        mock_post.return_value = MockResponse(mock_response, 200)
+        mock_post.return_value = MockResponse(
+            _mock_responses_api_response(response_id="resp_prefix_strip_test"),
+            200,
+        )
 
         await litellm.aresponses(
+            model="openai/responses/gpt-4o",
+            input="Reply with OK.",
+        )
+
+        mock_post.assert_called_once()
+        request_body = mock_post.call_args.kwargs["json"]
+
+        assert request_body["model"] == "gpt-4o"
+        assert request_body["input"] == "Reply with OK."
+
+
+@pytest.mark.asyncio
+async def test_acompact_responses_strips_responses_prefix_from_openai_model_name():
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(
+            _mock_responses_api_response(response_id="resp_compact_prefix_strip_test"),
+            200,
+        )
+
+        await litellm.acompact_responses(
             model="openai/responses/gpt-4o",
             input="Reply with OK.",
         )


### PR DESCRIPTION
## Relevant issues

Fixes #24505

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Strip a leading `responses/` prefix before LiteLLM builds an explicit OpenAI Responses API request body.
- Apply the same model-name normalization in the compact Responses request transformation path.
- Add focused transformation tests for both explicit and compact response request builders.
- Add request-body regression tests covering `litellm.aresponses(model="openai/responses/gpt-4o", ...)`.

## Validation

- `python -m pytest -q tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py tests/test_litellm/responses/test_responses_api_request_body.py`
- `python -m ruff check litellm/llms/openai/responses/transformation.py tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py tests/test_litellm/responses/test_responses_api_request_body.py`
- Latest GitHub CI for commit `9317c0f` is green, including `lint` and the LiteLLM unit-test matrix.
