### PR TITLE
fix(cohere): strip index from tool_calls and name from tool results i…

### DIFF
--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -182,14 +182,14 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
         sanitized: List[AllMessageValues] = []
         for message in data.get("messages", []):
             if hasattr(message, "model_dump"):
-                message = message.model_dump(exclude_none=True)
+                message = message.model_dump(exclude_unset=True)
             if isinstance(message, dict):
                 role = message.get("role")
                 if role == "assistant" and message.get("tool_calls"):
                     cleaned_tool_calls = [
                         {k: v for k, v in tc.items() if k != "index"}
                         if isinstance(tc, dict)
-                        else {k: v for k, v in tc.model_dump(exclude_none=True).items() if k != "index"}
+                        else {k: v for k, v in tc.model_dump(exclude_unset=True).items() if k != "index"}
                         for tc in message["tool_calls"]
                     ]
                     message = {**message, "tool_calls": cleaned_tool_calls}

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -176,6 +176,27 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             model, messages, optional_params, litellm_params, headers
         )
 
+        # Cohere v2 rejects fields that are valid in OpenAI but not in Cohere:
+        # 1. 'index' in assistant tool_calls
+        # 2. 'name' in tool result messages
+        sanitized: List[AllMessageValues] = []
+        for message in data.get("messages", []):
+            if hasattr(message, "model_dump"):
+                message = message.model_dump(exclude_none=True)
+            if isinstance(message, dict):
+                role = message.get("role")
+                if role == "assistant" and message.get("tool_calls"):
+                    cleaned_tool_calls = [
+                        {k: v for k, v in tc.items() if k != "index"}
+                        if isinstance(tc, dict)
+                        else {k: v for k, v in tc.model_dump(exclude_none=True).items() if k != "index"}
+                        for tc in message["tool_calls"]
+                    ]
+                    message = {**message, "tool_calls": cleaned_tool_calls}
+                elif role == "tool":
+                    message = {k: v for k, v in message.items() if k != "name"}
+            sanitized.append(message)  # type: ignore
+        data["messages"] = sanitized
         return data
 
     def transform_response(

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -179,8 +179,10 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
         # Cohere v2 rejects fields that are valid in OpenAI but not in Cohere:
         # 1. 'index' in assistant tool_calls
         # 2. 'name' in tool result messages
+        if "messages" not in data:
+            return data
         sanitized: List[AllMessageValues] = []
-        for message in data.get("messages", []):
+        for message in data["messages"]:
             if hasattr(message, "model_dump"):
                 message = message.model_dump(exclude_unset=True)
             if isinstance(message, dict):
@@ -190,6 +192,8 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
                         {k: v for k, v in tc.items() if k != "index"}
                         if isinstance(tc, dict)
                         else {k: v for k, v in tc.model_dump(exclude_unset=True).items() if k != "index"}
+                        if hasattr(tc, "model_dump")
+                        else tc
                         for tc in message["tool_calls"]
                     ]
                     message = {**message, "tool_calls": cleaned_tool_calls}

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -8,6 +8,7 @@ sys.path.insert(
 
 from litellm.llms.cohere.chat.transformation import CohereChatConfig
 from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
 class TestCohereTransform:
@@ -59,7 +60,7 @@ class TestCohereV2Transform:
 
     def _make_transform_request(self, messages):
         with patch.object(
-            self.config.__class__.__bases__[0],
+            OpenAIGPTConfig,
             "transform_request",
             return_value={"model": self.model, "messages": messages},
         ):
@@ -109,6 +110,29 @@ class TestCohereV2Transform:
         assert "name" not in tool_msg
         assert tool_msg["tool_call_id"] == "call_abc"
         assert tool_msg["content"] == "12:00"
+
+    def test_strips_index_from_pydantic_tool_calls(self):
+        """Pydantic model tool call objects also have index stripped."""
+        from litellm.types.utils import ChatCompletionMessageToolCall, Function
+
+        tool_call_obj = ChatCompletionMessageToolCall(
+            index=0,
+            id="call_abc",
+            type="function",
+            function=Function(name="get_time", arguments="{}"),
+        )
+        messages = [
+            {"role": "user", "content": "What time is it?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [tool_call_obj],
+            },
+        ]
+        result = self._make_transform_request(messages)
+        assistant_msg = result["messages"][1]
+        assert "index" not in assistant_msg["tool_calls"][0]
+        assert assistant_msg["tool_calls"][0]["id"] == "call_abc"
 
     def test_preserves_messages_without_offending_fields(self):
         """Messages that don't have index or name are passed through unchanged."""

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -1,12 +1,13 @@
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
 from litellm.llms.cohere.chat.transformation import CohereChatConfig
+from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
 
 
 class TestCohereTransform:
@@ -49,3 +50,71 @@ class TestCohereTransform:
 
         # The function should properly map max_tokens if max_completion_tokens is not provided
         assert result == {"temperature": 0.7, "max_tokens": 200}
+
+
+class TestCohereV2Transform:
+    def setup_method(self):
+        self.config = CohereV2ChatConfig()
+        self.model = "command-r-08-2024"
+
+    def _make_transform_request(self, messages):
+        with patch.object(
+            self.config.__class__.__bases__[0],
+            "transform_request",
+            return_value={"model": self.model, "messages": messages},
+        ):
+            return self.config.transform_request(
+                model=self.model,
+                messages=messages,
+                optional_params={},
+                litellm_params={},
+                headers={},
+            )
+
+    def test_strips_index_from_assistant_tool_calls(self):
+        """Cohere v2 rejects 'index' in tool_calls — it must be stripped before sending."""
+        messages = [
+            {"role": "user", "content": "What time is it?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "get_time", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        result = self._make_transform_request(messages)
+        assistant_msg = result["messages"][1]
+        assert "index" not in assistant_msg["tool_calls"][0]
+        assert assistant_msg["tool_calls"][0]["id"] == "call_abc"
+
+    def test_strips_name_from_tool_result_messages(self):
+        """Cohere v2 rejects 'name' in tool result messages — it must be stripped."""
+        messages = [
+            {"role": "user", "content": "What time is it?"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_abc",
+                "name": "get_time",
+                "content": "12:00",
+            },
+        ]
+        result = self._make_transform_request(messages)
+        tool_msg = result["messages"][1]
+        assert "name" not in tool_msg
+        assert tool_msg["tool_call_id"] == "call_abc"
+        assert tool_msg["content"] == "12:00"
+
+    def test_preserves_messages_without_offending_fields(self):
+        """Messages that don't have index or name are passed through unchanged."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        result = self._make_transform_request(messages)
+        assert result["messages"] == messages

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -133,6 +133,8 @@ class TestCohereV2Transform:
         assistant_msg = result["messages"][1]
         assert "index" not in assistant_msg["tool_calls"][0]
         assert assistant_msg["tool_calls"][0]["id"] == "call_abc"
+        assert assistant_msg["tool_calls"][0]["type"] == "function"
+        assert assistant_msg["tool_calls"][0]["function"]["name"] == "get_time"
 
     def test_preserves_messages_without_offending_fields(self):
         """Messages that don't have index or name are passed through unchanged."""


### PR DESCRIPTION

Cohere v2 API rejects two fields that are valid in OpenAI format:
- `index` in assistant tool_calls (added by LiteLLM when building responses)
- `name` in tool result messages (commonly added by users following OpenAI patterns)

Override transform_request in CohereV2ChatConfig to sanitize messages before sending, handling both dict and Pydantic model message objects.

Fixes #24031

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix