### PR TITLE
fix(logging): honour metadata log_raw_request flag per request

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -969,12 +969,13 @@ class Logging(LiteLLMLoggingBaseClass):
                 additional_args=additional_args,
             )
             # log raw request to provider (like LangFuse) -- if opted in.
+            _litellm_params = self.model_call_details.get("litellm_params", {})
+            _metadata = _litellm_params.get("metadata", {}) or {}
             if (
                 self.log_raw_request_response is True
                 or log_raw_request_response is True
+                or _metadata.get("log_raw_request") is True
             ):
-                _litellm_params = self.model_call_details.get("litellm_params", {})
-                _metadata = _litellm_params.get("metadata", {}) or {}
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2299,3 +2299,69 @@ def test_merge_hidden_params_from_response_into_metadata_no_op_when_empty():
     assert "hidden_params" not in logging_obj.model_call_details["litellm_params"][
         "metadata"
     ]
+
+
+def test_pre_call_log_raw_request_via_metadata():
+    """metadata={'log_raw_request': True} should trigger raw request logging."""
+    import time
+    from unittest.mock import MagicMock, patch
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+    logging_obj = LiteLLMLoggingObj(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="acompletion",
+        start_time=time.time(),
+        litellm_call_id="test-raw-req",
+        function_id="test-fn",
+    )
+    logging_obj.model_call_details = {
+        "litellm_params": {"metadata": {"log_raw_request": True}},
+    }
+
+    with patch.object(
+        logging_obj, "_get_request_curl_command", return_value="curl -X POST ..."
+    ) as mock_curl, patch.object(
+        logging_obj, "_print_llm_call_debugging_log"
+    ), patch.object(
+        logging_obj, "_pre_call"
+    ):
+        logging_obj.pre_call(input="hi", api_key="sk-test", additional_args={})
+
+    mock_curl.assert_called_once()
+    assert (
+        logging_obj.model_call_details["litellm_params"]["metadata"].get("raw_request")
+        == "curl -X POST ..."
+    )
+
+
+def test_pre_call_no_raw_request_without_flag():
+    """Without log_raw_request in metadata, raw request should not be logged."""
+    import time
+    from unittest.mock import MagicMock, patch
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+    logging_obj = LiteLLMLoggingObj(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="acompletion",
+        start_time=time.time(),
+        litellm_call_id="test-no-raw-req",
+        function_id="test-fn",
+    )
+    logging_obj.model_call_details = {
+        "litellm_params": {"metadata": {}},
+    }
+
+    with patch.object(
+        logging_obj, "_get_request_curl_command", return_value="curl -X POST ..."
+    ) as mock_curl, patch.object(
+        logging_obj, "_print_llm_call_debugging_log"
+    ), patch.object(
+        logging_obj, "_pre_call"
+    ):
+        logging_obj.pre_call(input="hi", api_key="sk-test", additional_args={})
+
+    mock_curl.assert_not_called()

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2304,7 +2304,7 @@ def test_merge_hidden_params_from_response_into_metadata_no_op_when_empty():
 def test_pre_call_log_raw_request_via_metadata():
     """metadata={'log_raw_request': True} should trigger raw request logging."""
     import time
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
     logging_obj = LiteLLMLoggingObj(
@@ -2339,7 +2339,8 @@ def test_pre_call_log_raw_request_via_metadata():
 def test_pre_call_no_raw_request_without_flag():
     """Without log_raw_request in metadata, raw request should not be logged."""
     import time
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
+    import litellm.litellm_core_utils.litellm_logging as logging_module
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
     logging_obj = LiteLLMLoggingObj(
@@ -2355,13 +2356,10 @@ def test_pre_call_no_raw_request_without_flag():
         "litellm_params": {"metadata": {}},
     }
 
-    with patch.object(
-        logging_obj, "_get_request_curl_command", return_value="curl -X POST ..."
-    ) as mock_curl, patch.object(
-        logging_obj, "_print_llm_call_debugging_log"
-    ), patch.object(
-        logging_obj, "_pre_call"
-    ):
+    with patch.object(logging_module, "log_raw_request_response", False), \
+         patch.object(logging_obj, "_get_request_curl_command", return_value="curl -X POST ...") as mock_curl, \
+         patch.object(logging_obj, "_print_llm_call_debugging_log"), \
+         patch.object(logging_obj, "_pre_call"):
         logging_obj.pre_call(input="hi", api_key="sk-test", additional_args={})
 
     mock_curl.assert_not_called()


### PR DESCRIPTION
metadata: {"log_raw_request": true} was documented but never wired up. The raw-request logging block in pre_call only checked the global litellm.log_raw_request_response flag and the Logging instance flag, never the per-request metadata key.

Move the metadata extraction before the guard and add _metadata.get("log_raw_request") is True to the condition so callers can opt in per-request without touching global config.

Fixes #23442

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix