### PR TITLE
fix: tool_choice none not working with messages API

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -743,6 +743,8 @@ class LiteLLMAnthropicMessagesAdapter:
             return "required"
         elif tool_choice["type"] == "auto":
             return "auto"
+        elif tool_choice["type"] == "none":
+            return "none"
         elif tool_choice["type"] == "tool":
             # Truncate tool name if it exceeds OpenAI's 64-char limit
             original_name = tool_choice.get("name", "")

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1984,3 +1984,76 @@ def test_translate_anthropic_to_openai_with_mixed_tools():
 
     # tool_name_mapping should be empty for short tool names
     assert tool_name_mapping == {}
+
+
+def test_translate_anthropic_tool_choice_none():
+    """
+    Test that tool_choice {"type": "none"} is correctly translated to OpenAI "none".
+
+    This is a regression test for:
+    https://github.com/BerriAI/litellm/issues/24443
+
+    When passing `tool_choice = {"type": "none"}` to the Anthropic /v1/messages
+    API via LiteLLM proxy, it was returning a 500 error:
+    "Incompatible tool choice param submitted - {'type': 'none'}"
+    """
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hi"}],
+        tool_choice={"type": "none"},
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=anthropic_request
+    )
+
+    assert "tool_choice" in openai_request
+    assert openai_request["tool_choice"] == "none"
+
+
+def test_translate_anthropic_tool_choice_auto():
+    """
+    Test that tool_choice {"type": "auto"} is correctly translated to OpenAI "auto".
+    """
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hi"}],
+        tool_choice={"type": "auto"},
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=anthropic_request
+    )
+
+    assert "tool_choice" in openai_request
+    assert openai_request["tool_choice"] == "auto"
+
+
+def test_translate_anthropic_tool_choice_any():
+    """
+    Test that tool_choice {"type": "any"} is correctly translated to OpenAI "required".
+    """
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hi"}],
+        tool_choice={"type": "any"},
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=anthropic_request
+    )
+
+    assert "tool_choice" in openai_request
+    assert openai_request["tool_choice"] == "required"


### PR DESCRIPTION
## Summary

When passing `tool_choice = {"type": "none"}` to the Anthropic `/v1/messages` API via LiteLLM proxy, it returned a 500 error:

```
Incompatible tool choice param submitted - {'type': 'none'}
```

## Root Cause

`LiteLLMAnthropicMessagesAdapter.translate_anthropic_tool_choice_to_openai()` was missing a case for `tool_choice["type"] == "none"`. The function handled `any`, `auto`, and `tool` but fell through to raising `ValueError` for `none`.

## Fix

Added the missing `tool_choice["type"] == "none"` case that returns the OpenAI-equivalent `"none"` string, which is a valid `ChatCompletionToolChoiceStringValues` literal.

## Testing

Added 3 new tests covering all tool_choice type translations:
- `test_translate_anthropic_tool_choice_none`: verifies `{"type": "none"}` -> `"none"`
- `test_translate_anthropic_tool_choice_auto`: verifies `{"type": "auto"}` -> `"auto"`  
- `test_translate_anthropic_tool_choice_any`: verifies `{"type": "any"}` -> `"required"`

Fixes #24443