### PR TITLE
fix(auth): update CLI JWT token spend/budget from DB during auth

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -922,9 +922,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         route=route,
                     )
                 if _end_user_object is not None:
-                    end_user_params[
-                        "allowed_model_region"
-                    ] = _end_user_object.allowed_model_region
+                    end_user_params["allowed_model_region"] = (
+                        _end_user_object.allowed_model_region
+                    )
                     if _end_user_object.litellm_budget_table is not None:
                         _apply_budget_limits_to_end_user_params(
                             end_user_params=end_user_params,
@@ -1258,6 +1258,12 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             # Check 2a. Check if model has zero cost - if so, skip all budget checks
             model = get_model_from_request(request_data, route)
             skip_budget_checks = False
+
+            # CLI JWT tokens have no real key-level budget (the $0.25 is a
+            # session default). Token-level checks are meaningless; real
+            # enforcement happens at user/team level in common_checks.
+            if valid_token.token == CLI_JWT_TOKEN_NAME:
+                skip_budget_checks = True
             if model is not None and llm_router is not None:
                 from litellm.proxy.auth.auth_checks import _is_model_cost_zero
 
@@ -1424,18 +1430,16 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             # CLI JWT tokens carry frozen spend/budget from the encrypted blob.
             # Replace with real DB values so response headers are accurate.
+            # max_budget is set to the team budget (or user budget as fallback)
+            # because that is the effective constraint for CLI JWT users.
+            # Token-level budget checks are skipped above; real enforcement
+            # uses _team_obj / user_obj directly in common_checks.
             if valid_token.token == CLI_JWT_TOKEN_NAME:
                 if user_obj is not None and user_obj.spend is not None:
                     valid_token.spend = user_obj.spend
-                if (
-                    _team_obj is not None
-                    and _team_obj.max_budget is not None
-                ):
+                if _team_obj is not None and _team_obj.max_budget is not None:
                     valid_token.max_budget = _team_obj.max_budget
-                elif (
-                    user_obj is not None
-                    and user_obj.max_budget is not None
-                ):
+                elif user_obj is not None and user_obj.max_budget is not None:
                     valid_token.max_budget = user_obj.max_budget
 
             # Fetch project object if key belongs to a project
@@ -1518,9 +1522,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             if _end_user_object is not None:
                 valid_token_dict.update(end_user_params)
-                valid_token_dict[
-                    "end_user_object_permission"
-                ] = _end_user_object.object_permission
+                valid_token_dict["end_user_object_permission"] = (
+                    _end_user_object.object_permission
+                )
 
         # check if token is from litellm-ui, litellm ui makes keys to allow users to login with sso. These keys can only be used for LiteLLM UI functions
         # sso/login, ui/login, /key functions and /user functions

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -22,6 +22,7 @@ from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
 from litellm.caching import DualCache
 from litellm.litellm_core_utils.dd_tracing import tracer
+from litellm.constants import CLI_JWT_TOKEN_NAME
 from litellm.litellm_core_utils.dot_notation_indexing import get_nested_value
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import (
@@ -1420,6 +1421,22 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             await user_api_key_cache.async_set_cache(
                 key=valid_token.team_id, value=_team_obj
             )  # save team table in cache - used for tpm/rpm limiting - tpm_rpm_limiter.py
+
+            # CLI JWT tokens carry frozen spend/budget from the encrypted blob.
+            # Replace with real DB values so response headers are accurate.
+            if valid_token.token == CLI_JWT_TOKEN_NAME:
+                if user_obj is not None and user_obj.spend is not None:
+                    valid_token.spend = user_obj.spend
+                if (
+                    _team_obj is not None
+                    and _team_obj.max_budget is not None
+                ):
+                    valid_token.max_budget = _team_obj.max_budget
+                elif (
+                    user_obj is not None
+                    and user_obj.max_budget is not None
+                ):
+                    valid_token.max_budget = user_obj.max_budget
 
             # Fetch project object if key belongs to a project
             _project_obj = None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1258,13 +1258,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             # Check 2a. Check if model has zero cost - if so, skip all budget checks
             model = get_model_from_request(request_data, route)
             skip_budget_checks = False
-
-            # CLI JWT tokens have no real key-level budget (the $0.25 is a
-            # session default). Token-level checks are meaningless; real
-            # enforcement happens at user/team level in common_checks.
-            if valid_token.token == CLI_JWT_TOKEN_NAME:
-                skip_budget_checks = True
-            if model is not None and llm_router is not None and not skip_budget_checks:
+            if model is not None and llm_router is not None:
                 from litellm.proxy.auth.auth_checks import _is_model_cost_zero
 
                 skip_budget_checks = _is_model_cost_zero(
@@ -1430,10 +1424,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             # CLI JWT tokens carry frozen spend/budget from the encrypted blob.
             # Replace with real DB values so response headers are accurate.
-            # max_budget is set to the team budget (or user budget as fallback)
-            # because that is the effective constraint for CLI JWT users.
-            # Token-level budget checks are skipped above; real enforcement
-            # uses _team_obj / user_obj directly in common_checks.
+            # Note: token-level budget checks (lines above) see the frozen
+            # values and are a no-op (0.0 >= 0.25 = False). This is fine —
+            # real budget enforcement happens in common_checks() below,
+            # which uses _team_obj and user_obj directly, not valid_token.
             if valid_token.token == CLI_JWT_TOKEN_NAME:
                 if user_obj is not None and user_obj.spend is not None:
                     valid_token.spend = user_obj.spend

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1264,7 +1264,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             # enforcement happens at user/team level in common_checks.
             if valid_token.token == CLI_JWT_TOKEN_NAME:
                 skip_budget_checks = True
-            if model is not None and llm_router is not None:
+            if model is not None and llm_router is not None and not skip_budget_checks:
                 from litellm.proxy.auth.auth_checks import _is_model_cost_zero
 
                 skip_budget_checks = _is_model_cost_zero(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -59,9 +59,9 @@ def reset_constants_module():
     # Reload modules before test
     importlib.reload(constants)
     importlib.reload(auth_checks)
-    
+
     yield
-    
+
     # Reload modules after test to clean up
     importlib.reload(constants)
     importlib.reload(auth_checks)
@@ -154,9 +154,9 @@ def test_experimental_ui_token_ignores_litellm_ui_session_duration(
     expires = datetime.fromisoformat(token_data["expires"].replace("Z", "+00:00"))
     now = get_utc_datetime()
     # Must be ~10 min, NOT 24h. If LITELLM_UI_SESSION_DURATION were incorrectly used, this would fail.
-    assert expires <= now + timedelta(minutes=11), (
-        "Experimental UI must use 10-min expiry, not LITELLM_UI_SESSION_DURATION"
-    )
+    assert expires <= now + timedelta(
+        minutes=11
+    ), "Experimental UI must use 10-min expiry, not LITELLM_UI_SESSION_DURATION"
 
 
 def test_get_experimental_ui_login_jwt_auth_token_invalid(
@@ -290,13 +290,15 @@ def test_get_cli_jwt_auth_token_custom_expiration(
 
     # Set custom expiration to 48 hours
     monkeypatch.setenv("LITELLM_CLI_JWT_EXPIRATION_HOURS", "48")
-    
+
     # Reload the constants module to pick up the new env var
     importlib.reload(constants)
     # Also reload auth_checks to pick up the new constant value
     importlib.reload(auth_checks)
-    
-    token = auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token(valid_sso_user_defined_values)
+
+    token = auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
 
     # Decrypt and verify token contents
     decrypted_token = decrypt_value_helper(
@@ -315,7 +317,8 @@ def test_get_cli_jwt_auth_token_custom_expiration(
 @pytest.mark.asyncio
 async def test_cli_jwt_auth_flow_updates_spend_and_budget(monkeypatch):
     """Integration test: CLI JWT tokens get real spend/budget through the actual auth builder."""
-    from starlette.datastructures import URL
+    import asyncio
+
     from starlette.requests import Request
 
     from litellm.proxy._types import LiteLLM_TeamTableCachedObj
@@ -387,8 +390,15 @@ async def test_cli_jwt_auth_flow_updates_spend_and_budget(monkeypatch):
         for attr, val in attrs_to_set.items():
             setattr(_proxy_server_mod, attr, val)
 
-        request = Request(scope={"type": "http"})
-        request._url = URL(url="/chat/completions")
+        request = Request(
+            scope={
+                "type": "http",
+                "method": "POST",
+                "path": "/chat/completions",
+                "query_string": b"",
+                "headers": [],
+            }
+        )
 
         with patch(
             "litellm.proxy.auth.user_api_key_auth.get_key_object",
@@ -422,6 +432,9 @@ async def test_cli_jwt_auth_flow_updates_spend_and_budget(monkeypatch):
         assert (
             result.max_budget == 1000.0
         ), f"Expected max_budget=1000.0, got {result.max_budget}"
+
+        # Drain fire-and-forget tasks spawned by _user_api_key_auth_builder
+        await asyncio.sleep(0)
     finally:
         for attr, val in original_values.items():
             setattr(_proxy_server_mod, attr, val)
@@ -430,7 +443,8 @@ async def test_cli_jwt_auth_flow_updates_spend_and_budget(monkeypatch):
 @pytest.mark.asyncio
 async def test_cli_jwt_auth_flow_fallback_to_user_budget(monkeypatch):
     """Integration test: CLI JWT falls back to user budget when no team is assigned."""
-    from starlette.datastructures import URL
+    import asyncio
+
     from starlette.requests import Request
 
     from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
@@ -491,8 +505,15 @@ async def test_cli_jwt_auth_flow_fallback_to_user_budget(monkeypatch):
         for attr, val in attrs_to_set.items():
             setattr(_proxy_server_mod, attr, val)
 
-        request = Request(scope={"type": "http"})
-        request._url = URL(url="/chat/completions")
+        request = Request(
+            scope={
+                "type": "http",
+                "method": "POST",
+                "path": "/chat/completions",
+                "query_string": b"",
+                "headers": [],
+            }
+        )
 
         with patch(
             "litellm.proxy.auth.user_api_key_auth.get_key_object",
@@ -525,6 +546,9 @@ async def test_cli_jwt_auth_flow_fallback_to_user_budget(monkeypatch):
         assert (
             result.max_budget == 200.0
         ), f"Expected max_budget=200.0 (user fallback), got {result.max_budget}"
+
+        # Drain fire-and-forget tasks spawned by _user_api_key_auth_builder
+        await asyncio.sleep(0)
     finally:
         for attr, val in original_values.items():
             setattr(_proxy_server_mod, attr, val)
@@ -650,7 +674,9 @@ async def test_get_user_object_upsert_includes_user_email():
     mock_prisma_client.db.litellm_usertable.create.assert_called_once()
     creation_args = mock_prisma_client.db.litellm_usertable.create.call_args[1]["data"]
 
-    assert "user_email" in creation_args, "user_email should be included when upserting a new user"
+    assert (
+        "user_email" in creation_args
+    ), "user_email should be included when upserting a new user"
     assert creation_args["user_email"] == "test@example.com"
     assert creation_args["user_id"] == "new_test_user"
 
@@ -677,7 +703,9 @@ def test_log_budget_lookup_failure_skips_user_not_found():
 
 
 @pytest.mark.asyncio
-@patch("litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock)
+@patch(
+    "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
+)
 async def test_get_team_db_check_calls_new_team_on_upsert(mock_new_team, monkeypatch):
     """
     Test that _get_team_db_check correctly calls the `new_team` function
@@ -711,8 +739,12 @@ async def test_get_team_db_check_calls_new_team_on_upsert(mock_new_team, monkeyp
 
 
 @pytest.mark.asyncio
-@patch("litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock)
-async def test_get_team_db_check_does_not_call_new_team_if_exists(mock_new_team, monkeypatch):
+@patch(
+    "litellm.proxy.management_endpoints.team_endpoints.new_team", new_callable=AsyncMock
+)
+async def test_get_team_db_check_does_not_call_new_team_if_exists(
+    mock_new_team, monkeypatch
+):
     """
     Test that _get_team_db_check does NOT call the `new_team` function
     if the team already exists in the database.

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -312,6 +312,193 @@ def test_get_cli_jwt_auth_token_custom_expiration(
     assert expires <= get_utc_datetime() + timedelta(hours=48, minutes=1)
 
 
+@pytest.mark.asyncio
+async def test_cli_jwt_auth_flow_updates_spend_and_budget(monkeypatch):
+    """Integration test: CLI JWT tokens get real spend/budget through the actual auth builder."""
+    from starlette.datastructures import URL
+    from starlette.requests import Request
+
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN", "True")
+
+    # Create a CLI JWT token for an internal_user with a team
+    user_info = LiteLLM_UserTable(
+        user_id="test_user_spend",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        models=[],
+        max_budget=100.0,
+        teams=["test_team_budget"],
+    )
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(user_info)
+
+    # Mock DB objects with real spend/budget
+    mock_user_obj = LiteLLM_UserTable(
+        user_id="test_user_spend",
+        spend=42.50,
+        max_budget=100.0,
+    )
+    mock_team_obj = LiteLLM_TeamTableCachedObj(
+        team_id="test_team_budget",
+        max_budget=1000.0,
+        spend=150.0,
+        last_refreshed_at=None,
+    )
+
+    # Set up module globals
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.async_set_cache = AsyncMock()
+    mock_cache.set_cache = MagicMock()
+
+    mock_prisma = MagicMock()
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.internal_usage_cache = MagicMock()
+    mock_proxy_logging.internal_usage_cache.dual_cache = MagicMock()
+    mock_proxy_logging.internal_usage_cache.dual_cache.async_get_cache = AsyncMock(
+        return_value=None
+    )
+    mock_proxy_logging.budget_alerts = AsyncMock()
+    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
+
+    attrs_to_set = {
+        "prisma_client": mock_prisma,
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging,
+        "master_key": "sk-master-key-test",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in attrs_to_set
+    }
+    try:
+        for attr, val in attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with patch(
+            "litellm.proxy.auth.user_api_key_auth.get_key_object",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.get_user_object",
+            new_callable=AsyncMock,
+            return_value=mock_user_obj,
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team_obj,
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.common_checks",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {token}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        # The returned UserAPIKeyAuth should have real DB values
+        assert result.spend == 42.50, f"Expected spend=42.50, got {result.spend}"
+        assert (
+            result.max_budget == 1000.0
+        ), f"Expected max_budget=1000.0, got {result.max_budget}"
+    finally:
+        for attr, val in original_values.items():
+            setattr(_proxy_server_mod, attr, val)
+
+
+def test_cli_jwt_token_spend_and_budget_from_db(valid_sso_user_defined_values):
+    """Test that CLI JWT tokens get real spend/budget from DB objects, not frozen blob values."""
+    from litellm.constants import CLI_JWT_TOKEN_NAME
+
+    # Generate a CLI JWT token (will have spend=0.0, max_budget=0.25)
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
+
+    # Decrypt to get the UserAPIKeyAuth object
+    key_obj = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(token)
+    assert key_obj is not None
+    assert key_obj.token == CLI_JWT_TOKEN_NAME
+    assert key_obj.spend == 0.0  # frozen in blob
+    assert key_obj.max_budget == litellm.max_ui_session_budget  # $0.25
+
+    # Simulate what the auth flow does after fetching user/team from DB:
+    # Create mock DB objects with real spend/budget
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        spend=42.50,
+        max_budget=100.0,
+    )
+    team_obj = LiteLLM_TeamTable(
+        team_id="test_team",
+        max_budget=1000.0,
+        spend=150.0,
+    )
+
+    # Apply the fix logic (same as in user_api_key_auth.py)
+    if key_obj.token == CLI_JWT_TOKEN_NAME:
+        if user_obj is not None and user_obj.spend is not None:
+            key_obj.spend = user_obj.spend
+        if team_obj is not None and team_obj.max_budget is not None:
+            key_obj.max_budget = team_obj.max_budget
+
+    # Verify corrected values
+    assert key_obj.spend == 42.50  # real user spend, not 0.0
+    assert key_obj.max_budget == 1000.0  # real team budget, not $0.25
+
+
+def test_cli_jwt_token_fallback_to_user_budget_when_no_team(
+    valid_sso_user_defined_values,
+):
+    """Test that CLI JWT falls back to user budget when no team object is available."""
+    from litellm.constants import CLI_JWT_TOKEN_NAME
+
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
+        valid_sso_user_defined_values
+    )
+    key_obj = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(token)
+    assert key_obj is not None
+
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        spend=10.0,
+        max_budget=200.0,
+    )
+    _team_obj = None
+
+    # Apply the fix logic
+    if key_obj.token == CLI_JWT_TOKEN_NAME:
+        if user_obj is not None and user_obj.spend is not None:
+            key_obj.spend = user_obj.spend
+        if _team_obj is not None and _team_obj.max_budget is not None:
+            key_obj.max_budget = _team_obj.max_budget
+        elif user_obj is not None and user_obj.max_budget is not None:
+            key_obj.max_budget = user_obj.max_budget
+
+    assert key_obj.spend == 10.0
+    assert key_obj.max_budget == 200.0  # user budget, not session $0.25
+
 
 @pytest.mark.asyncio
 async def test_default_internal_user_params_with_get_user_object(monkeypatch):

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -427,77 +427,107 @@ async def test_cli_jwt_auth_flow_updates_spend_and_budget(monkeypatch):
             setattr(_proxy_server_mod, attr, val)
 
 
-def test_cli_jwt_token_spend_and_budget_from_db(valid_sso_user_defined_values):
-    """Test that CLI JWT tokens get real spend/budget from DB objects, not frozen blob values."""
-    from litellm.constants import CLI_JWT_TOKEN_NAME
+@pytest.mark.asyncio
+async def test_cli_jwt_auth_flow_fallback_to_user_budget(monkeypatch):
+    """Integration test: CLI JWT falls back to user budget when no team is assigned."""
+    from starlette.datastructures import URL
+    from starlette.requests import Request
 
-    # Generate a CLI JWT token (will have spend=0.0, max_budget=0.25)
-    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
-        valid_sso_user_defined_values
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    monkeypatch.setenv("EXPERIMENTAL_UI_LOGIN", "True")
+
+    # Create a CLI JWT token for an internal_user WITHOUT a team
+    user_info = LiteLLM_UserTable(
+        user_id="test_user_no_team",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        models=[],
+        max_budget=200.0,
     )
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(user_info)
 
-    # Decrypt to get the UserAPIKeyAuth object
-    key_obj = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(token)
-    assert key_obj is not None
-    assert key_obj.token == CLI_JWT_TOKEN_NAME
-    assert key_obj.spend == 0.0  # frozen in blob
-    assert key_obj.max_budget == litellm.max_ui_session_budget  # $0.25
-
-    # Simulate what the auth flow does after fetching user/team from DB:
-    # Create mock DB objects with real spend/budget
-    user_obj = LiteLLM_UserTable(
-        user_id="test_user",
-        spend=42.50,
-        max_budget=100.0,
-    )
-    team_obj = LiteLLM_TeamTable(
-        team_id="test_team",
-        max_budget=1000.0,
-        spend=150.0,
-    )
-
-    # Apply the fix logic (same as in user_api_key_auth.py)
-    if key_obj.token == CLI_JWT_TOKEN_NAME:
-        if user_obj is not None and user_obj.spend is not None:
-            key_obj.spend = user_obj.spend
-        if team_obj is not None and team_obj.max_budget is not None:
-            key_obj.max_budget = team_obj.max_budget
-
-    # Verify corrected values
-    assert key_obj.spend == 42.50  # real user spend, not 0.0
-    assert key_obj.max_budget == 1000.0  # real team budget, not $0.25
-
-
-def test_cli_jwt_token_fallback_to_user_budget_when_no_team(
-    valid_sso_user_defined_values,
-):
-    """Test that CLI JWT falls back to user budget when no team object is available."""
-    from litellm.constants import CLI_JWT_TOKEN_NAME
-
-    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
-        valid_sso_user_defined_values
-    )
-    key_obj = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(token)
-    assert key_obj is not None
-
-    user_obj = LiteLLM_UserTable(
-        user_id="test_user",
+    # Mock DB: user with real spend/budget, no team
+    mock_user_obj = LiteLLM_UserTable(
+        user_id="test_user_no_team",
         spend=10.0,
         max_budget=200.0,
     )
-    _team_obj = None
 
-    # Apply the fix logic
-    if key_obj.token == CLI_JWT_TOKEN_NAME:
-        if user_obj is not None and user_obj.spend is not None:
-            key_obj.spend = user_obj.spend
-        if _team_obj is not None and _team_obj.max_budget is not None:
-            key_obj.max_budget = _team_obj.max_budget
-        elif user_obj is not None and user_obj.max_budget is not None:
-            key_obj.max_budget = user_obj.max_budget
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.async_set_cache = AsyncMock()
+    mock_cache.set_cache = MagicMock()
 
-    assert key_obj.spend == 10.0
-    assert key_obj.max_budget == 200.0  # user budget, not session $0.25
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.internal_usage_cache = MagicMock()
+    mock_proxy_logging.internal_usage_cache.dual_cache = MagicMock()
+    mock_proxy_logging.internal_usage_cache.dual_cache.async_get_cache = AsyncMock(
+        return_value=None
+    )
+    mock_proxy_logging.budget_alerts = AsyncMock()
+    mock_proxy_logging.post_call_failure_hook = AsyncMock(return_value=None)
+
+    attrs_to_set = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging,
+        "master_key": "sk-master-key-test",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in attrs_to_set
+    }
+    try:
+        for attr, val in attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with patch(
+            "litellm.proxy.auth.user_api_key_auth.get_key_object",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.get_user_object",
+            new_callable=AsyncMock,
+            return_value=mock_user_obj,
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.get_team_object",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.common_checks",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {token}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert result.spend == 10.0, f"Expected spend=10.0, got {result.spend}"
+        assert (
+            result.max_budget == 200.0
+        ), f"Expected max_budget=200.0 (user fallback), got {result.max_budget}"
+    finally:
+        for attr, val in original_values.items():
+            setattr(_proxy_server_mod, attr, val)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
CLI SSO JWT tokens carry frozen spend/budget from the encrypted blob. Overwrite with real DB values after fetching user_obj and team_obj so response headers report accurate data.

## Design Decisions

### Why the fix is placed after token-level budget checks

The token-level budget checks (`_virtual_key_max_budget_check`, `_virtual_key_max_budget_alert_check`, `_virtual_key_soft_budget_check`) run before `_team_obj` is fetched. Since `_team_obj` is needed to determine the real `max_budget`, the overwrite block must be placed after the team fetch. The token-level checks see frozen values (`0.0 >= 0.25 = False`) and are a pre-existing no-op for CLI JWT tokens — this PR does not change that behavior. Real budget enforcement happens in `common_checks()` which receives `_team_obj` and `user_obj` as separate arguments and uses them directly, not `valid_token.max_budget`.

### Why `valid_token.max_budget` is set to the team budget

For CLI JWT tokens, there is no DB-backed key-level budget — the `$0.25` is a meaningless session default. The team budget is the effective constraint. `common_checks()` enforces team/user budgets via `_team_obj` and `user_obj` directly, so overwriting `valid_token.max_budget` does not affect enforcement. The only downstream consumer of this field after the fix point is `get_custom_headers()`, which uses it for the `x-litellm-key-max-budget` response header.

### Why tests use `monkeypatch.setenv` without `importlib.reload`

`EXPERIMENTAL_UI_LOGIN` is read at runtime via `get_secret_bool()` → `get_secret()` → `os.environ.get()`. It is NOT cached in a module-level constant. This is different from `LITELLM_CLI_JWT_EXPIRATION_HOURS` (which IS read at module load into `litellm.constants` and requires reload). `monkeypatch.setenv` is sufficient here.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

**Problem**: CLI SSO JWT tokens (generated via `/sso/key/generate`) embed `spend=0.0` and `max_budget=0.25` inside an AES-encrypted blob. These values are never refreshed from the database, so response headers `x-litellm-key-spend` and `x-litellm-key-max-budget` always report stale data — regardless of the user's actual accumulated spend or their team's real budget.

**Fix**: In `user_api_key_auth.py`, after the auth flow fetches `user_obj` and `team_obj` from the DB, overwrite the frozen values on `valid_token` with the real ones. This is a targeted check for `valid_token.token == CLI_JWT_TOKEN_NAME` only — no other token types are affected.

**Changes**:
- `litellm/proxy/auth/user_api_key_auth.py` — Add `CLI_JWT_TOKEN_NAME` import + block that replaces frozen spend/budget with DB values for CLI JWT tokens
- `tests/test_litellm/proxy/auth/test_auth_checks.py` — 2 integration tests calling `_user_api_key_auth_builder` end-to-end:
  - `test_cli_jwt_auth_flow_updates_spend_and_budget` — verifies team budget + user spend override
  - `test_cli_jwt_auth_flow_fallback_to_user_budget` — verifies fallback to user budget when no team