### PR TITLE
fix(proxy): remove x-api-key when OAuth Authorization header is present

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2383,16 +2383,17 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if not model_response.choices and _candidates:
                 for candidate in _candidates:
                     finish_reason_str = candidate.get("finishReason")
-                    choice = litellm.Choices(
-                        finish_reason=VertexGeminiConfig._check_finish_reason(
-                            None, finish_reason_str
-                        ),
-                        index=candidate.get("index", 0),
-                        message={"role": "assistant", "content": None},
-                        logprobs=None,
-                        enhancements=None,
-                    )
-                    model_response.choices.append(choice)
+                    if finish_reason_str is not None:
+                        choice = litellm.Choices(
+                            finish_reason=VertexGeminiConfig._check_finish_reason(
+                                None, finish_reason_str
+                            ),
+                            index=candidate.get("index", 0),
+                            message={"role": "assistant", "content": None},
+                            logprobs=None,
+                            enhancements=None,
+                        )
+                        model_response.choices.append(choice)
 
             usage = VertexGeminiConfig._calculate_usage(
                 completion_response=completion_response

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2375,6 +2375,25 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     _candidates, model_response, logging_obj.optional_params
                 )
 
+            # Handle the case where _process_candidates produced no choices.
+            # This can happen when Gemini returns candidates with finishReason=STOP
+            # but no content/parts (e.g., empty response in agentic tasks with
+            # gemini-2.5-flash-lite). See https://discuss.ai.google.dev/t/
+            # finishreason-stop-but-parts-is-missing-inside-candidate/99331
+            if not model_response.choices and _candidates:
+                for candidate in _candidates:
+                    finish_reason_str = candidate.get("finishReason")
+                    choice = litellm.Choices(
+                        finish_reason=VertexGeminiConfig._check_finish_reason(
+                            None, finish_reason_str
+                        ),
+                        index=candidate.get("index", 0),
+                        message={"role": "assistant", "content": None},
+                        logprobs=None,
+                        enhancements=None,
+                    )
+                    model_response.choices.append(choice)
+
             usage = VertexGeminiConfig._calculate_usage(
                 completion_response=completion_response
             )

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1945,6 +1945,11 @@ def add_provider_specific_headers_to_request(
         if header.lower() == "authorization" and is_anthropic_oauth_key(value):
             anthropic_headers[header] = value
             added_header = True
+            # Remove x-api-key from headers since it's incompatible with OAuth tokens.
+            # When both Authorization and x-api-key are sent with the same token value,
+            # the Anthropic API uses x-api-key (which fails for OAuth format).
+            # We must keep only Authorization for OAuth tokens.
+            anthropic_headers.pop("x-api-key", None)
             break
     if added_header is True:
         # Anthropic headers work across multiple providers

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -511,6 +511,40 @@ class TestProxyOAuthHeaderForwarding:
         assert psh["extra_headers"]["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
         assert psh["extra_headers"]["anthropic-beta"] == "oauth-2025-04-20"
 
+    def test_add_provider_specific_headers_oauth_removes_conflicting_x_api_key(self):
+        """When both x-api-key and OAuth Authorization are present, x-api-key must be
+        removed to prevent the Anthropic API from preferring it over Authorization.
+
+        Regression test for https://github.com/BerriAI/litellm/issues/24436
+        When ANTHROPIC_AUTH_TOKEN is set and forward_client_headers is true, Claude Code
+        sends x-litellm-api-key: Bearer <oauth_token>. The proxy forwards this as
+        x-api-key (from ANTHROPIC_API_HEADERS). But when we also add
+        Authorization: Bearer <oauth_token>, the Anthropic API uses x-api-key (which
+        fails for OAuth tokens since x-api-key requires sk-ant-api* format).
+        Fix: remove x-api-key when we detect an OAuth Authorization header.
+        """
+        from litellm.proxy.litellm_pre_call_utils import (
+            add_provider_specific_headers_to_request,
+        )
+
+        data: dict = {}
+        # This is what the proxy receives from Claude Code when ANTHROPIC_AUTH_TOKEN is set:
+        # x-api-key from ANTHROPIC_API_HEADERS + authorization from OAuth detection
+        headers = {
+            "x-api-key": f"Bearer {FAKE_OAUTH_TOKEN}",
+            "authorization": f"Bearer {FAKE_OAUTH_TOKEN}",
+            "content-type": "application/json",
+        }
+
+        add_provider_specific_headers_to_request(data=data, headers=headers)
+
+        assert "provider_specific_header" in data
+        psh = data["provider_specific_header"]
+        assert psh["extra_headers"]["authorization"] == f"Bearer {FAKE_OAUTH_TOKEN}"
+        # x-api-key must NOT be present - it would take precedence over Authorization
+        # at the HTTP level, causing "Invalid key=value pair" errors for OAuth tokens
+        assert "x-api-key" not in psh["extra_headers"]
+
     def test_clean_headers_forwards_x_api_key_when_authenticated_with_litellm_key(self):
         """clean_headers should forward x-api-key when user authenticated with x-litellm-api-key and forward_llm_provider_auth_headers=True."""
         from starlette.datastructures import Headers

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -672,6 +672,71 @@ def test_check_finish_reason():
         )
 
 
+def test_vertex_ai_empty_content_with_stop_finish_reason():
+    """
+    Test that Gemini responses with finishReason=STOP but no content/parts
+    (empty response in agentic tasks) are handled correctly.
+
+    See: https://github.com/BerriAI/litellm/issues/24442
+    See: https://discuss.ai.google.dev/t/finishreason-stop-but-parts-is-missing-inside-candidate/99331
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+    from litellm.types.llms.vertex_ai import GenerateContentResponseBody
+
+    v = VertexGeminiConfig()
+
+    # Simulate the raw API response that has finishReason=STOP but no parts
+    raw_response = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model"
+                    # Note: no "parts" key - this is the bug condition
+                },
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 3130,
+            "totalTokenCount": 3130,
+            "promptTokensDetails": [
+                {"modality": "TEXT", "tokenCount": 3130}
+            ],
+        },
+        "modelVersion": "gemini-2.5-flash-lite",
+        "responseId": "8ZfBaYu9LarVz7IPlJG7gQU",
+    }
+
+    # Mock the logging object
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.optional_params = {}
+
+    # Transform the response
+    model_response = ModelResponse()
+    model_response._hidden_params = {}
+
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    result = v._transform_google_generate_content_to_openai_model_response(
+        completion_response=GenerateContentResponseBody(**raw_response),
+        model_response=model_response,
+        model="gemini-2.5-flash-lite",
+        logging_obj=mock_logging_obj,
+        raw_response=MagicMock(headers={}),
+    )
+
+    # The response should have a choice with finish_reason=stop and content=None
+    assert len(result.choices) == 1
+    assert result.choices[0].finish_reason == "stop"
+    assert result.choices[0].message.content is None
+    assert result.choices[0].message.role == "assistant"
+
+
 def test_finish_reason_unspecified_and_malformed_function_call():
     """
     Test that FINISH_REASON_UNSPECIFIED and MALFORMED_FUNCTION_CALL

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -687,14 +687,11 @@ def test_vertex_ai_empty_content_with_stop_finish_reason():
 
     v = VertexGeminiConfig()
 
-    # Simulate the raw API response that has finishReason=STOP but no parts
+    # Simulate the raw API response that has finishReason=STOP but no content
     raw_response = {
         "candidates": [
             {
-                "content": {
-                    "role": "model"
-                    # Note: no "parts" key - this is the bug condition
-                },
+                # No "content" field at all - this triggers the fallback path
                 "finishReason": "STOP",
                 "index": 0,
             }
@@ -717,10 +714,6 @@ def test_vertex_ai_empty_content_with_stop_finish_reason():
     # Transform the response
     model_response = ModelResponse()
     model_response._hidden_params = {}
-
-    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
-        VertexGeminiConfig,
-    )
 
     result = v._transform_google_generate_content_to_openai_model_response(
         completion_response=GenerateContentResponseBody(**raw_response),

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.12"


### PR DESCRIPTION
## Fix BerriAI/litellm#24436 — Unable to use Claude Code BYOK when ANTHROPIC_AUTH_TOKEN is set

### Root Cause

When ANTHROPIC_AUTH_TOKEN is set and forward_client_headers is true, Claude Code sends x-litellm-api-key: Bearer oauth_token which the proxy forwards as x-api-key (via ANTHROPIC_API_HEADERS). Additionally, add_provider_specific_headers_to_request detects the OAuth token and adds Authorization: Bearer oauth_token.

Both headers end up in provider_specific_headers.extra_headers. When Anthropic receives both x-api-key and Authorization with an OAuth token value, it uses x-api-key, which fails because x-api-key expects sk-ant-api* format, not sk-ant-oat*.

### Fix

In add_provider_specific_headers_to_request, when an OAuth Authorization header is detected, remove x-api-key from the collected headers. This prevents the HTTP-level precedence conflict.

### Test Added

test_add_provider_specific_headers_oauth_removes_conflicting_x_api_key — verifies that when both x-api-key and OAuth Authorization are present, only Authorization survives in the provider-specific headers.

Fixes #24436