### PR TITLE
fix(security): migrate PyPI publishing to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/publish_enterprise.yml
+++ b/.github/workflows/publish_enterprise.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
+    environment: pypi-enterprise
     defaults:
       run:
         working-directory: enterprise
@@ -86,9 +88,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_ENTERPRISE }}
-        run: |
-          pip install twine
-          twine upload dist/litellm_enterprise-${{ steps.bump.outputs.new }}*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: enterprise/dist/
+        # No token needed — uses OIDC Trusted Publisher

--- a/.github/workflows/publish_proxy_extras.yml
+++ b/.github/workflows/publish_proxy_extras.yml
@@ -19,6 +19,8 @@ jobs:
     if: github.repository == 'BerriAI/litellm'
     permissions:
       contents: write
+      id-token: write
+    environment: pypi-proxy-extras
     defaults:
       run:
         working-directory: litellm-proxy-extras
@@ -66,9 +68,7 @@ jobs:
           git push
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PUBLISH_PASSWORD }}
-        run: |
-          pip install twine
-          twine upload dist/litellm_proxy_extras-${{ steps.bump.outputs.new }}*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: litellm-proxy-extras/dist/
+        # No token needed — uses OIDC Trusted Publisher

--- a/.github/workflows/simple_pypi_publish.yml
+++ b/.github/workflows/simple_pypi_publish.yml
@@ -8,14 +8,16 @@ on:
         required: true
         type: string
 
-env:
-  TWINE_USERNAME: __token__
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     if: github.repository == 'BerriAI/litellm'
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,21 +30,21 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install toml build wheel twine
+          pip install toml build wheel
 
       - name: Update version in pyproject.toml
         run: |
           python -c "
           import toml
-          
+
           with open('pyproject.toml', 'r') as f:
               data = toml.load(f)
-          
+
           data['tool']['poetry']['version'] = '${{ github.event.inputs.version }}'
-          
+
           with open('pyproject.toml', 'w') as f:
               toml.dump(data, f)
-          
+
           print(f'Updated version to ${{ github.event.inputs.version }}')
           "
 
@@ -56,12 +58,10 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        env:
-          TWINE_PASSWORD: ${{ secrets.PYPI_PUBLISH_PASSWORD }}
-        run: |
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No token needed — uses OIDC Trusted Publisher
 
       - name: Output success
         run: |
-          echo "✅ Successfully published litellm v${{ github.event.inputs.version }} to PyPI"
-          echo "📦 Package: https://pypi.org/project/litellm/${{ github.event.inputs.version }}/" 
+          echo "Successfully published litellm v${{ github.event.inputs.version }} to PyPI"
+          echo "Package: https://pypi.org/project/litellm/${{ github.event.inputs.version }}/"


### PR DESCRIPTION
## Summary

Closes #24542

Migrates all three PyPI publishing workflows from stored API tokens (`PYPI_PUBLISH_PASSWORD` / `PYPI_ENTERPRISE`) to [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (OIDC-based authentication).

**This eliminates the attack vector used in the March 24 incident** — there is no longer a stored token that can be stolen and used to publish malicious packages.

## Changes

- **`simple_pypi_publish.yml`** (main `litellm` package):
  - Removed `TWINE_USERNAME` env and `TWINE_PASSWORD` secret reference
  - Removed `twine` from installed dependencies
  - Added top-level `permissions: id-token: write, contents: read`
  - Added `environment: pypi` for deployment protection rules
  - Replaced `twine upload` step with `pypa/gh-action-pypi-publish@release/v1`

- **`publish_enterprise.yml`** (`litellm-enterprise` package):
  - Added `id-token: write` to job permissions
  - Added `environment: pypi-enterprise`
  - Replaced `twine upload` with `pypa/gh-action-pypi-publish@release/v1` (with `packages-dir: enterprise/dist/`)

- **`publish_proxy_extras.yml`** (`litellm-proxy-extras` package):
  - Added `id-token: write` to job permissions
  - Added `environment: pypi-proxy-extras`
  - Replaced `twine upload` with `pypa/gh-action-pypi-publish@release/v1` (with `packages-dir: litellm-proxy-extras/dist/`)

All existing build, version update, and non-publish steps are unchanged.

## Admin Setup Required

Before merging, a PyPI project admin needs to configure Trusted Publishers on pypi.org. For each package:

1. Go to **pypi.org** → the package → **Publishing** → **Add a new publisher**
2. Configure the trusted publisher:

| Package | Workflow | Environment |
|---|---|---|
| `litellm` | `simple_pypi_publish.yml` | `pypi` |
| `litellm-enterprise` | `publish_enterprise.yml` | `pypi-enterprise` |
| `litellm-proxy-extras` | `publish_proxy_extras.yml` | `pypi-proxy-extras` |

3. Create the corresponding GitHub environments (`pypi`, `pypi-enterprise`, `pypi-proxy-extras`) in repo Settings → Environments
4. After verifying Trusted Publishers work, delete the `PYPI_PUBLISH_PASSWORD` and `PYPI_ENTERPRISE` secrets from GitHub repo settings

## How It Works

Instead of authenticating with a stored API token, the workflow:
1. Requests a short-lived OIDC token from GitHub (via `id-token: write` permission)
2. Sends the OIDC token to PyPI
3. PyPI verifies the token was issued by GitHub for the correct repo/workflow/environment
4. PyPI authorizes the publish — no stored secret involved

## References

- [PyPI Trusted Publishers docs](https://docs.pypi.org/trusted-publishers/)
- [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)
- Complementary to #24524 (cosign signing for container images)