### PR TITLE
fix(streaming): ensure completion_tokens >= reasoning_tokens in streaming usage

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -467,6 +467,7 @@ cost_margin_config: Dict[
 # Combined: {"vertex_ai": {"percentage": 0.08, "fixed_amount": 0.0005}}
 custom_prompt_dict: Dict[str, dict] = {}
 check_provider_endpoint = False
+enforce_openai_completion_token_invariant: bool = True
 
 
 ####### THREAD-SPECIFIC DATA ####################

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -717,6 +717,26 @@ class ChunkProcessor:
                     web_search_requests
                 )
 
+        # Ensure completion_tokens >= reasoning_tokens (OpenAI spec compliance).
+        # Some backends (e.g., vLLM) report reasoning_tokens and
+        # completion_tokens separately instead of including reasoning tokens
+        # in the completion_tokens total.  When reasoning_tokens exceeds
+        # completion_tokens it is clear that the backend excluded them from
+        # the total, so we add them to produce a spec-compliant value.
+        if (
+            returned_usage.completion_tokens_details is not None
+            and returned_usage.completion_tokens_details.reasoning_tokens is not None
+            and returned_usage.completion_tokens_details.reasoning_tokens
+            > returned_usage.completion_tokens
+        ):
+            returned_usage.completion_tokens = (
+                returned_usage.completion_tokens
+                + returned_usage.completion_tokens_details.reasoning_tokens
+            )
+            returned_usage.total_tokens = (
+                returned_usage.prompt_tokens + returned_usage.completion_tokens
+            )
+
         # Return a new usage object with the new values
 
         returned_usage = Usage(**returned_usage.model_dump())

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -728,7 +728,7 @@ class ChunkProcessor:
         # Gate behind litellm.enforce_openai_completion_token_invariant so
         # operators who rely on raw backend values can opt out.
         if (
-            getattr(litellm, "enforce_openai_completion_token_invariant", True)
+            litellm.enforce_openai_completion_token_invariant
             and returned_usage.completion_tokens_details is not None
             and returned_usage.completion_tokens_details.reasoning_tokens is not None
             and returned_usage.completion_tokens_details.reasoning_tokens

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -2,6 +2,8 @@ import base64
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
+import litellm
+
 from litellm.types.llms.openai import (
     ChatCompletionAssistantContentValue,
     ChatCompletionAudioDelta,
@@ -723,8 +725,11 @@ class ChunkProcessor:
         # in the completion_tokens total.  When reasoning_tokens exceeds
         # completion_tokens it is clear that the backend excluded them from
         # the total, so we add them to produce a spec-compliant value.
+        # Gate behind litellm.enforce_openai_completion_token_invariant so
+        # operators who rely on raw backend values can opt out.
         if (
-            returned_usage.completion_tokens_details is not None
+            getattr(litellm, "enforce_openai_completion_token_invariant", True)
+            and returned_usage.completion_tokens_details is not None
             and returned_usage.completion_tokens_details.reasoning_tokens is not None
             and returned_usage.completion_tokens_details.reasoning_tokens
             > returned_usage.completion_tokens
@@ -733,8 +738,13 @@ class ChunkProcessor:
                 returned_usage.completion_tokens
                 + returned_usage.completion_tokens_details.reasoning_tokens
             )
+            # Recompute total_tokens from all known sub-totals so we don't
+            # lose cache-related tokens that some backends include.
             returned_usage.total_tokens = (
-                returned_usage.prompt_tokens + returned_usage.completion_tokens
+                returned_usage.prompt_tokens
+                + returned_usage.completion_tokens
+                + (returned_usage._cache_creation_input_tokens or 0)
+                + (returned_usage._cache_read_input_tokens or 0)
             )
 
         # Return a new usage object with the new values

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs["structured_messages"] = (
-                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
-                )
+                inputs[
+                    "structured_messages"
+                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProces
 from litellm.types.utils import (
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
+    CompletionTokensDetailsWrapper,
     Delta,
     Function,
     ModelResponseStream,
@@ -603,3 +604,121 @@ def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
     response = stream_chunk_builder(chunks=[chunk_dict])
     assert response is not None
     assert response._hidden_params["provider_specific_fields"]["traffic_type"] == "default"
+
+
+def test_streaming_reasoning_tokens_exceeds_completion_tokens():
+    """
+    Validate that when a backend (e.g. vLLM) reports reasoning_tokens
+    separately from completion_tokens such that reasoning_tokens >
+    completion_tokens, calculate_usage adjusts completion_tokens to include
+    reasoning_tokens so that the OpenAI invariant
+    completion_tokens >= reasoning_tokens is maintained.
+
+    Reproduces: https://github.com/BerriAI/litellm/issues/24526
+    """
+    # Simulate vLLM streaming usage: completion_tokens=64 (text only),
+    # reasoning_tokens=79 (thinking tokens reported separately).
+    chunk = ModelResponseStream(
+        id="chatcmpl-vllm-reasoning",
+        created=1745513206,
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content=None,
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=64,
+            prompt_tokens=100,
+            total_tokens=164,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=79
+            ),
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunks = [chunk]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks,
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        completion_output="",
+    )
+
+    # completion_tokens must be >= reasoning_tokens per OpenAI spec.
+    # Since vLLM reported them separately (64 text + 79 reasoning),
+    # the fix should set completion_tokens = 64 + 79 = 143.
+    assert usage.completion_tokens >= usage.completion_tokens_details.reasoning_tokens
+    assert usage.completion_tokens == 64 + 79  # 143
+    assert usage.completion_tokens_details.reasoning_tokens == 79
+    assert usage.total_tokens == 100 + 143  # prompt + adjusted completion
+
+
+def test_streaming_reasoning_tokens_within_completion_tokens_unchanged():
+    """
+    When reasoning_tokens <= completion_tokens (the backend already follows
+    the OpenAI convention), calculate_usage must NOT inflate completion_tokens.
+    """
+    chunk = ModelResponseStream(
+        id="chatcmpl-openai-normal",
+        created=1745513206,
+        model="gpt-4o",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content=None,
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=150,
+            prompt_tokens=50,
+            total_tokens=200,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=80
+            ),
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunks = [chunk]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks,
+        model="gpt-4o",
+        completion_output="",
+    )
+
+    # Already compliant — should stay unchanged.
+    assert usage.completion_tokens == 150
+    assert usage.completion_tokens_details.reasoning_tokens == 80
+    assert usage.total_tokens == 200

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -184,7 +184,11 @@ def test_get_combined_thinking_content_preserves_interleaved_blocks():
         make_chunk(role="assistant", content=None),
         make_chunk(
             thinking_blocks=[
-                {"type": "thinking", "thinking": "Step 1 analysis...", "signature": None}
+                {
+                    "type": "thinking",
+                    "thinking": "Step 1 analysis...",
+                    "signature": None,
+                }
             ]
         ),
         make_chunk(
@@ -202,7 +206,11 @@ def test_get_combined_thinking_content_preserves_interleaved_blocks():
         ),
         make_chunk(
             thinking_blocks=[
-                {"type": "thinking", "thinking": "Step 2 analysis...", "signature": None}
+                {
+                    "type": "thinking",
+                    "thinking": "Step 2 analysis...",
+                    "signature": None,
+                }
             ]
         ),
         make_chunk(
@@ -403,7 +411,7 @@ def test_stream_chunk_builder_litellm_usage_chunks():
 def test_get_model_from_chunks_azure_model_router():
     """
     Test that _get_model_from_chunks finds the actual model from Azure Model Router chunks.
-    
+
     Azure Model Router returns the request model (e.g., 'azure-model-router') in the first chunk,
     but subsequent chunks contain the actual model (e.g., 'gpt-4.1-nano-2025-04-14').
     This is important for accurate cost calculation.
@@ -414,24 +422,24 @@ def test_get_model_from_chunks_azure_model_router():
         {"model": "gpt-4.1-nano-2025-04-14", "id": "chatcmpl-123", "choices": []},
         {"model": "gpt-4.1-nano-2025-04-14", "id": "chatcmpl-123", "choices": []},
     ]
-    
+
     result = ChunkProcessor._get_model_from_chunks(
         chunks=chunks, first_chunk_model="azure-model-router"
     )
-    
+
     # Should return the actual model, not the request model
     assert result == "gpt-4.1-nano-2025-04-14"
-    
+
     # Test when all chunks have the same model (non-router case)
     chunks_same_model = [
         {"model": "gpt-4", "id": "chatcmpl-456", "choices": []},
         {"model": "gpt-4", "id": "chatcmpl-456", "choices": []},
     ]
-    
+
     result_same = ChunkProcessor._get_model_from_chunks(
         chunks=chunks_same_model, first_chunk_model="gpt-4"
     )
-    
+
     # Should return the first chunk's model when all are the same
     assert result_same == "gpt-4"
 
@@ -512,8 +520,8 @@ def test_stream_chunk_builder_anthropic_web_search():
 
     assert usage.prompt_tokens == 50
     assert usage.completion_tokens == 27
-    assert usage.total_tokens == 77    
-    assert usage.server_tool_use['web_search_requests'] == 2
+    assert usage.total_tokens == 77
+    assert usage.server_tool_use["web_search_requests"] == 2
 
 
 def test_sort_chunks_handles_dict_hidden_params_created_at():
@@ -603,7 +611,9 @@ def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
 
     response = stream_chunk_builder(chunks=[chunk_dict])
     assert response is not None
-    assert response._hidden_params["provider_specific_fields"]["traffic_type"] == "default"
+    assert (
+        response._hidden_params["provider_specific_fields"]["traffic_type"] == "default"
+    )
 
 
 def test_streaming_reasoning_tokens_exceeds_completion_tokens():
@@ -722,3 +732,120 @@ def test_streaming_reasoning_tokens_within_completion_tokens_unchanged():
     assert usage.completion_tokens == 150
     assert usage.completion_tokens_details.reasoning_tokens == 80
     assert usage.total_tokens == 200
+
+
+def test_streaming_reasoning_tokens_opt_out_flag(monkeypatch):
+    """
+    When enforce_openai_completion_token_invariant is False, the raw backend
+    values must be preserved even when reasoning_tokens > completion_tokens.
+    """
+    import litellm
+
+    monkeypatch.setattr(litellm, "enforce_openai_completion_token_invariant", False)
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-vllm-opt-out",
+        created=1745513206,
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content=None,
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=64,
+            prompt_tokens=100,
+            total_tokens=164,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=79
+            ),
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunks = [chunk]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks,
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        completion_output="",
+    )
+
+    # With opt-out, raw backend values should be preserved.
+    assert usage.completion_tokens == 64
+    assert usage.completion_tokens_details.reasoning_tokens == 79
+    assert usage.total_tokens == 164
+
+
+def test_streaming_reasoning_tokens_preserves_cache_tokens_in_total():
+    """
+    When the adjustment fires and the response includes cache creation/read
+    tokens, total_tokens must account for those extra token categories.
+    """
+    usage = Usage(
+        completion_tokens=64,
+        prompt_tokens=100,
+        total_tokens=264,
+        completion_tokens_details=CompletionTokensDetailsWrapper(reasoning_tokens=79),
+        prompt_tokens_details=None,
+    )
+    # Simulate Anthropic-style cache tokens by adding them as public
+    # attributes the way the provider transformation layer does.
+    setattr(usage, "cache_creation_input_tokens", 50)
+    setattr(usage, "cache_read_input_tokens", 50)
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-cache-reasoning",
+        created=1745513206,
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content=None,
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=usage,
+    )
+
+    chunks = [chunk]
+    processor = ChunkProcessor(chunks=chunks)
+
+    result = processor.calculate_usage(
+        chunks=chunks,
+        model="openai/Qwen/Qwen3.5-397B-A17B-FP8",
+        completion_output="",
+    )
+
+    # completion_tokens adjusted: 64 + 79 = 143
+    assert result.completion_tokens == 143
+    # total_tokens must include prompt + adjusted completion + cache tokens
+    # 100 + 143 + 50 + 50 = 343
+    assert result.total_tokens == 100 + 143 + 50 + 50


### PR DESCRIPTION
## Summary

Fixes #24526

Some backends like vLLM report `reasoning_tokens` and `completion_tokens` separately in streaming responses instead of including reasoning tokens in the `completion_tokens` total. This violates the OpenAI API standard where `completion_tokens` should always be >= `reasoning_tokens` (since reasoning tokens are a subset of completion tokens).

**Example from the issue** (vLLM serving Qwen3.5-397B):
```
completion_tokens=64, reasoning_tokens=79   # reasoning_tokens > completion_tokens!
completion_tokens=68, reasoning_tokens=71
completion_tokens=135, reasoning_tokens=152
```

**Root cause:** `ChunkProcessor.calculate_usage()` in `streaming_chunk_builder_utils.py` passes through the backend-reported `completion_tokens` and `reasoning_tokens` values without validating that `completion_tokens >= reasoning_tokens`.

**Fix:** After assembling the usage object, if `reasoning_tokens > completion_tokens`, add `reasoning_tokens` to `completion_tokens` (since the backend clearly excluded them from the total) and recalculate `total_tokens`.

- When `reasoning_tokens > completion_tokens`: adjusts `completion_tokens = completion_tokens + reasoning_tokens` and updates `total_tokens`
- When `reasoning_tokens <= completion_tokens`: no change (backend already follows OpenAI convention)

## Test plan

- [x] Added `test_streaming_reasoning_tokens_exceeds_completion_tokens` — verifies that when vLLM reports `completion_tokens=64, reasoning_tokens=79`, the fix produces `completion_tokens=143` (64+79) with correct `total_tokens`
- [x] Added `test_streaming_reasoning_tokens_within_completion_tokens_unchanged` — verifies that when the backend already reports `completion_tokens >= reasoning_tokens` (e.g., OpenAI), values are left unchanged
- [x] All 11 tests in `test_streaming_chunk_builder_utils.py` pass