### PR TITLE
fix(router): include Bedrock batch/S3 fields and model in deployment credentials

### DIFF
--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -373,7 +373,7 @@ def get_team_provider_credentials(
     def _provider_credentials(model_id: str) -> dict | None:
         credentials: Final = llm_router.get_deployment_credentials_with_provider(model_id=model_id, team_id=team_id)
         if credentials is not None and credentials.get("custom_llm_provider") == custom_llm_provider:
-            return credentials
+            return {key: value for key, value in credentials.items() if key != "model"}
         return None
 
     # 1. Prefer the team's own BYOK deployment, matched by model_info.team_id.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8738,7 +8738,7 @@ class Router:
 
         Example:
             credentials = router.get_deployment_credentials_with_provider("gpt-4o-litellm")
-            # Returns: {"api_key": "sk-...", "custom_llm_provider": "openai", ...}
+            # Returns: {"api_key": "sk-...", "custom_llm_provider": "openai", "model": "gpt-4o", ...}
         """
         # Try to get deployment by model_id first
         deployment = self.get_deployment(model_id=model_id)
@@ -8796,6 +8796,8 @@ class Router:
             credentials.update(credential_values)
             # Remove the credential name since we've resolved it
             credentials.pop("litellm_credential_name", None)
+
+        credentials["model"] = deployment.litellm_params.model
 
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -200,6 +200,9 @@ class CredentialLiteLLMParams(BaseModel):
     aws_bedrock_runtime_endpoint: str | None = None
     aws_bedrock_project_id: str | None = None
     s3_bucket_name: str | None = None
+    s3_region_name: str | None = None
+    s3_encryption_key_id: str | None = None
+    aws_batch_role_arn: str | None = None
     ## IBM WATSONX ##
     watsonx_region_name: str | None = None
 
@@ -271,11 +274,6 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     # quality-router params
     quality_router_config: dict | None = None
     quality_router_default_model: str | None = None
-
-    # Batch/File API Params
-    s3_bucket_name: str | None = None
-    s3_encryption_key_id: str | None = None
-    gcs_bucket_name: str | None = None
 
     # Vector Store Params
     vector_store_id: str | None = None

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4024,6 +4024,42 @@ def test_get_deployment_credentials_with_provider_resolves_credential_name():
     litellm.credential_list = []
 
 
+def test_get_deployment_credentials_with_provider_bedrock_batch_fields():
+    """
+    Test that get_deployment_credentials_with_provider returns the deployment's
+    model and the Bedrock batch/S3 fields (s3_region_name, s3_encryption_key_id,
+    aws_batch_role_arn) instead of silently dropping them (#25104).
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock-batch-model",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "aws_region_name": "us-west-2",
+                    "s3_bucket_name": "my-batch-bucket",
+                    "s3_region_name": "us-east-1",
+                    "s3_encryption_key_id": "arn:aws:kms:us-west-2:123:key/abc",
+                    "aws_batch_role_arn": "arn:aws:iam::123:role/batch-role",
+                },
+            }
+        ],
+    )
+
+    credentials = router.get_deployment_credentials_with_provider(
+        model_id="bedrock-batch-model"
+    )
+
+    assert credentials is not None
+    assert credentials["custom_llm_provider"] == "bedrock"
+    assert credentials["model"] == "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    assert credentials["aws_region_name"] == "us-west-2"
+    assert credentials["s3_bucket_name"] == "my-batch-bucket"
+    assert credentials["s3_region_name"] == "us-east-1"
+    assert credentials["s3_encryption_key_id"] == "arn:aws:kms:us-west-2:123:key/abc"
+    assert credentials["aws_batch_role_arn"] == "arn:aws:iam::123:role/batch-role"
+
+
 def _team_wildcard_model(api_key: str, model_id: str = "team-wildcard-id") -> dict:
     return {
         "model_name": f"model_name_team-1_{model_id}",

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26716,6 +26716,8 @@ export interface components {
             auto_router_max_input_chars?: number | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
+            /** Aws Batch Role Arn */
+            aws_batch_role_arn?: string | null;
             /** Aws Bedrock Project Id */
             aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
@@ -26949,6 +26951,8 @@ export interface components {
             s3_bucket_name?: string | null;
             /** S3 Encryption Key Id */
             s3_encryption_key_id?: string | null;
+            /** S3 Region Name */
+            s3_region_name?: string | null;
             /** Search Context Cost Per Query */
             search_context_cost_per_query?: {
                 [key: string]: unknown;
@@ -35316,6 +35320,8 @@ export interface components {
             auto_router_max_input_chars?: number | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
+            /** Aws Batch Role Arn */
+            aws_batch_role_arn?: string | null;
             /** Aws Bedrock Project Id */
             aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
@@ -35549,6 +35555,8 @@ export interface components {
             s3_bucket_name?: string | null;
             /** S3 Encryption Key Id */
             s3_encryption_key_id?: string | null;
+            /** S3 Region Name */
+            s3_region_name?: string | null;
             /** Search Context Cost Per Query */
             search_context_cost_per_query?: {
                 [key: string]: unknown;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock batch creation through the proxy failed even with correct config
- Credential resolution silently dropped the batch/S3 fields and the model

How it solves it:

- Declares s3_region_name, s3_encryption_key_id, aws_batch_role_arn on CredentialLiteLLMParams
- Returns the deployment's model from get_deployment_credentials_with_provider
- Provider-only calls still get no model kwarg injected

## User Flow

Before: the flow dies at batch creation, with a different error depending on whether the model is repeated in the create body

1. POST https://litellm-domain/v1/files (multipart: the 100-request JSONL, purpose=batch, model=bedrock-haiku-batch) returns 200 with a long scrambled file id and status "uploaded"
2. POST https://litellm-domain/v1/batches with {"input_file_id": "<that id>", "endpoint": "/v1/chat/completions", "completion_window": "24h"} returns 400: "LiteLLM doesn't support custom_llm_provider=bedrock for 'create_batch'"
3. Retrying with "model": "bedrock-haiku-batch" added to the body returns 500: "AWS IAM role ARN is required for Bedrock batch jobs. Set 'aws_batch_role_arn' in litellm_params or AWS_BATCH_ROLE_ARN env var", even though config.yaml sets exactly that field
4. No batch job ever appears in the AWS account

After: the same upload plus the minimal create body produce a real Bedrock batch job whose results can be downloaded once it finishes

1. POST https://litellm-domain/v1/files (multipart: the 100-request JSONL, purpose=batch, model=bedrock-haiku-batch) returns 200 with a long scrambled file id and status "uploaded"
2. POST https://litellm-domain/v1/batches with {"input_file_id": "<that id>", "endpoint": "/v1/chat/completions", "completion_window": "24h"} returns 200 with a batch id and status "validating"
3. GET https://litellm-domain/v1/batches/{batch_id} shows the job progressing and eventually "completed" with an output_file_id
4. GET https://litellm-domain/v1/files/{output_file_id}/content downloads the 100 model replies

## Relevant issues

Fixes #25104

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, real Bedrock spend in us-west-2. Config pins a Claude Haiku 4.5 deployment with aws_region_name, s3_bucket_name, and aws_batch_role_arn in litellm_params. Before runs at commit 0659738b3e, after runs at 3d275d97fe

Before, upload succeeds:

```
$ curl -s http://localhost:51672/v1/files -H "Authorization: Bearer sk-1234" \
    -F "file=@batch100.jsonl" -F "purpose=batch" -F "model=bedrock-haiku-batch"
{"id":"file-bGl0ZWxsbTpzMzovL2xpdGVsbG0tcHJveHkvbGl0ZWxsbS1iZWRyb2NrLWZpbGVzLW...","status":"uploaded",...}
```

Before, create fails without a body model (the file id already encodes it):

```
$ curl -s http://localhost:51672/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"input_file_id":"<file id>","endpoint":"/v1/chat/completions","completion_window":"24h"}'
{"error":{"message":"litellm.BadRequestError: LiteLLM doesn't support custom_llm_provider=bedrock for 'create_batch'","type":"internal_server_error","param":null,"code":"400"}}
```

Before, create still fails with the body model because the role ARN was dropped from credentials:

```
$ curl -s http://localhost:51672/v1/batches ... -d '{"input_file_id":"<file id>",...,"model":"bedrock-haiku-batch"}'
{"error":{"message":"AWS IAM role ARN is required for Bedrock batch jobs. Set 'aws_batch_role_arn' in litellm_params or AWS_BATCH_ROLE_ARN env var","type":"internal_server_error","param":"None","code":"500"}}
```

After, the same upload plus the minimal create body submit a real job:

```
$ curl -s http://localhost:51873/v1/batches -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"input_file_id":"<file id>","endpoint":"/v1/chat/completions","completion_window":"24h"}'
{"id":"batch_bGl0ZWxsbTphcm46YXdzOmJlZHJvY2s6dXMtd2VzdC0yOjg4ODYwMjIyMzQyODptb2RlbC1pbnZvY2F0aW9uLWpvYi85NXVzYjE0eHJrNGo7...","status":"validating",...}
```

AWS confirms the job exists with the configured role and bucket:

```
$ aws bedrock get-model-invocation-job --region us-west-2 --job-identifier arn:aws:bedrock:us-west-2:...:model-invocation-job/95usb14xrk4j \
    --query '{status:status,modelId:modelId,roleArn:roleArn,inputS3:inputDataConfig.s3InputDataConfig.s3Uri}'
{
    "status": "Submitted",
    "modelId": "arn:aws:bedrock:us-west-2:...:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
    "roleArn": "arn:aws:iam::...:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV",
    "inputS3": "s3://litellm-proxy/litellm-bedrock-files-us.anthropic.claude-haiku-4-5-20251001-v1-0-....jsonl"
}
```

After, retrieve and results download once the job completes:

```
$ curl -s http://localhost:51873/v1/batches/<batch id> -H "Authorization: Bearer sk-1234"
{"id":"batch_...","status":"completed","output_file_id":"file-...",...}

$ curl -s http://localhost:51873/v1/files/<output file id>/content -H "Authorization: Bearer sk-1234" | head -1
{"modelInput":{"messages":[{"role":"user","content":[{"type":"text","text":"Reply with exactly: pong 94"}]}],"max_tokens":16,"anthropic_version":"bedrock-2023-05-31"},"modelOutput":{"model":"claude-haiku-4-5-20251001","id":"msg_bdrk_018xyfL6nQhtuiLmSEotGSD5","type":"message","role":"assistant","content":[{"type":"text","text":"pong 94"}],"stop_reason":"end_turn",...},"recordId":"req-94"}
```

All 100 records completed with the exact requested reply

The issue's third symptom (inference-profile ARNs stripped to a bare model name) no longer reproduces at head: a deployment whose model is bedrock/arn:aws:bedrock:...:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0 created job dteqa9v1zg5p and AWS shows modelId as the full ARN, since job names no longer embed the model and the modelId passes through verbatim

## Type

🐛 Bug Fix

## Changes

`CredentialLiteLLMParams` is the credential whitelist that `get_deployment_credentials_with_provider()` filters `litellm_params` through for the model-scoped files, batches, and vector-store endpoints; any field it doesn't declare is silently dropped. `s3_bucket_name` and `gcs_bucket_name` were promoted to it earlier, but `s3_region_name`, `s3_encryption_key_id`, and `aws_batch_role_arn` were still missing, so Bedrock batch creation failed asking for a role ARN the config already set. This PR declares the three fields there and removes the now redundant redeclarations on `GenericLiteLLMParams`

`get_deployment_credentials_with_provider()` also never returned the deployment's `model`, so the proxy's model-encoded-file-id path called `litellm.acreate_batch()` without one, skipped the provider-config dispatch that loads `BedrockBatchesConfig`, and 400'd with "LiteLLM doesn't support custom_llm_provider=bedrock for 'create_batch'". The credentials dict now carries `model`. Provider-only calls keep their existing no-model contract: `get_team_provider_credentials()` strips the key so a provider-scoped request is not silently pinned to whichever deployment happened to match, which the existing scenario tests continue to assert

Regression test: `test_get_deployment_credentials_with_provider_bedrock_batch_fields` asserts the resolved credentials for a Bedrock deployment include the model and all three batch/S3 fields

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
