### PR TITLE
fix(vertex_ai/gemini): raise BadRequestError when image_url or url fi…

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -351,15 +351,28 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                             img_element = element
                             format: Optional[str] = None
                             media_resolution_enum: Optional[Dict[str, str]] = None
-                            if isinstance(img_element["image_url"], dict):
-                                image_url = img_element["image_url"]["url"]
-                                format = img_element["image_url"].get("format")
-                                detail = img_element["image_url"].get("detail")
+                            raw_image_url = img_element.get("image_url")
+                            if raw_image_url is None:
+                                raise litellm.BadRequestError(
+                                    message="Invalid message content: element type is 'image_url' but 'image_url' field is missing ",
+                                    model=model,
+                                    llm_provider="vertex_ai",
+                                )
+                            if isinstance(raw_image_url, dict):
+                                image_url = raw_image_url.get("url")
+                                if image_url is None:
+                                    raise litellm.BadRequestError(
+                                        message="Invalid message content: element type is 'image_url' but 'url' field is missing inside 'image_url' ",
+                                        model=model,
+                                        llm_provider="vertex_ai",
+                                    )
+                                format = raw_image_url.get("format")
+                                detail = raw_image_url.get("detail")
                                 media_resolution_enum = (
                                     _convert_detail_to_media_resolution_enum(detail)
                                 )
                             else:
-                                image_url = img_element["image_url"]
+                                image_url = raw_image_url
                             _part = _process_gemini_media(
                                 image_url=image_url,
                                 format=format,

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
@@ -1,0 +1,30 @@
+import pytest
+from typing import List, cast
+
+import litellm
+from litellm.llms.vertex_ai.gemini.transformation import (
+    _gemini_convert_messages_with_history,
+)
+from litellm.types.llms.openai import AllMessageValues
+
+
+def test_missing_image_url_field_raises_bad_request_error():
+    """When element type is 'image_url' but 'image_url' field is missing, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url"}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'image_url' field is missing" in str(exc_info.value)
+
+
+def test_missing_url_inside_image_url_dict_raises_bad_request_error():
+    """When image_url is a dict but 'url' key is absent, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": {"detail": "high"}}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'url' field is missing inside" in str(exc_info.value)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py
@@ -28,3 +28,25 @@ def test_missing_url_inside_image_url_dict_raises_bad_request_error():
     with pytest.raises(litellm.BadRequestError) as exc_info:
         _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
     assert "'url' field is missing inside" in str(exc_info.value)
+
+
+def test_explicit_null_image_url_raises_bad_request_error():
+    """When image_url key is present but explicitly null, a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": None}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'image_url' field is missing" in str(exc_info.value)
+
+
+def test_empty_dict_image_url_raises_bad_request_error():
+    """When image_url is an empty dict (no url), a BadRequestError is raised."""
+    messages = cast(
+        List[AllMessageValues],
+        [{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}],
+    )
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _gemini_convert_messages_with_history(messages, model="gemini-1.5-pro")
+    assert "'url' field is missing inside" in str(exc_info.value)


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

Two adjacent `KeyError` bugs in the `image_url` element handling of `_gemini_convert_messages_with_history`:

1. **Missing `image_url` field** — when an element has `type: "image_url"` but no `image_url` key at all, direct access `img_element["image_url"]` raised an unhandled `KeyError`, resulting in a 500 `APIConnectionError`.

2. **Missing `url` inside `image_url` dict** — when `image_url` is a dict but the `url` key is absent (e.g. `{"detail": "high"}`), direct access `raw_image_url["url"]` raised another bare `KeyError`.

**Error trace (case 1):**
```
KeyError: 'image_url'
  File "litellm/llws/vertex_ai/gemini/transformation.py"
    if isinstance(img_element["image_url"], dict):
                  ~~~~~~~~~~~^^^^^^^^^^^^^
```

### Fix

In `litellm/llms/vertex_ai/gemini/transformation.py`:
- Use `.get("image_url")` and raise `BadRequestError` (400) when the field is `None`
- Use `.get("url")` and raise `BadRequestError` (400) when `url` is absent inside the dict

### Tests

Added `tests/test_litellm/llms/vertex_ai/gemini/test_gemini_image_url_missing_field.py` with two tests:
- `test_missing_image_url_field_raises_bad_request_error` — element has `type: "image_url"` but no `image_url` key
- `test_missing_url_inside_image_url_dict_raises_bad_request_error` — `image_url` is a dict with no `url` key (e.g. `{"detail": "high"}`)

<img width="1396" height="294" alt="image" src="https://github.com/user-attachments/assets/cf267148-56e7-402b-a087-95a10a387291" />
