### PR TITLE
fix: filter Anthropic-only output_config from non-Anthropic providers

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4656,6 +4656,16 @@ def get_optional_params(  # noqa: PLR0915
     return optional_params
 
 
+_ANTHROPIC_ONLY_EXTRA_PARAMS: List[str] = [
+    "output_config",  # Anthropic output_config (effort control) — not a standard OpenAI param
+]
+"""
+Params that are Anthropic-specific and must NOT be forwarded to other providers.
+Used in add_provider_specific_params_to_optional_params to prevent silent breakage
+when a user mixes Anthropic-specific kwargs with non-Anthropic model calls.
+"""
+
+
 def add_provider_specific_params_to_optional_params(
     optional_params: dict,
     passed_params: dict,
@@ -4706,11 +4716,21 @@ def add_provider_specific_params_to_optional_params(
                 extra_body=processed_extra_body
             )
     else:
+        _is_anthropic_provider = custom_llm_provider in (
+            "anthropic",
+            "anthropic_text",
+            "bedrock",
+            "vertex_ai",
+            "vertex_ai_beta",
+        )
         for k in passed_params.keys():
             if k not in openai_params and passed_params[k] is not None:
                 if _should_drop_param(
                     k=k, additional_drop_params=additional_drop_params
                 ):
+                    continue
+                # Skip Anthropic-only params for providers that don't support them
+                if not _is_anthropic_provider and k in _ANTHROPIC_ONLY_EXTRA_PARAMS:
                     continue
                 optional_params[k] = passed_params[k]
     return optional_params

--- a/tests/test_litellm/llms/openai_like/test_xiaomi_mimo.py
+++ b/tests/test_litellm/llms/openai_like/test_xiaomi_mimo.py
@@ -148,3 +148,49 @@ if __name__ == "__main__":
     print("\n" + "="*50)
     print("✓ All configuration tests passed!")
     print("="*50)
+
+
+class TestXiaomiMiMoOutputConfigFiltering:
+    """Tests for output_config filtering in non-Anthropic providers.
+    Related to issue #24549.
+    """
+
+    def test_output_config_not_forwarded_to_xiaomi_mimo(self):
+        """output_config is an Anthropic-specific param and must not be passed
+        through to xiaomi_mimo (or any other non-Anthropic provider).
+        See: https://github.com/BerriAI/litellm/issues/24549
+        """
+        from litellm.utils import get_optional_params
+
+        optional_params = get_optional_params(
+            model="mimo-v2-pro",
+            custom_llm_provider="xiaomi_mimo",
+            # Anthropic-specific: should be silently dropped for MiMo
+            output_config={"effort": "medium"},
+            temperature=0.7,
+        )
+
+        assert "output_config" not in optional_params, (
+            "output_config must not be forwarded to xiaomi_mimo — "
+            "it is an Anthropic-only parameter and causes "
+            "AsyncCompletions.create() to raise an unexpected-keyword-argument error."
+        )
+        # Standard params should still pass through
+        assert optional_params.get("temperature") == 0.7
+
+    def test_output_config_forwarded_to_anthropic(self):
+        """output_config must still be forwarded when the provider IS Anthropic."""
+        from litellm.utils import get_optional_params
+
+        optional_params = get_optional_params(
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+            output_config={"effort": "medium"},
+            temperature=1.0,
+        )
+
+        # output_config should reach the Anthropic request transformer
+        has_output_config = "output_config" in optional_params or any(
+            "effort" in str(v) for v in optional_params.values()
+        )
+        assert has_output_config, "output_config must reach the Anthropic request transformer"


### PR DESCRIPTION
## Summary

Fixes #24549

`output_config` (Anthropic-specific reasoning effort parameter) leaked into optional_params for non-Anthropic providers like `xiaomi_mimo`, causing:
```
AsyncCompletions.create() got an unexpected keyword argument 'output_config'
```

## Root Cause

In `add_provider_specific_params_to_optional_params()`, the `else` branch blindly copied all non-standard kwargs into `optional_params`, including Anthropic-only params.

## Fix

- Added `_ANTHROPIC_ONLY_EXTRA_PARAMS = ["output_config"]`
- In the `else` branch, skip these params for non-Anthropic providers
- Verified `output_config` still reaches Anthropic transformers correctly

## Tests

Added `TestXiaomiMiMoOutputConfigFiltering` in `tests/test_litellm/llms/openai_like/test_xiaomi_mimo.py`