### PR TITLE
docs: add missing Palm and Maritalk provider pages

### DIFF
--- a/docs/my-website/docs/providers/maritalk.md
+++ b/docs/my-website/docs/providers/maritalk.md
@@ -1,0 +1,65 @@
+# Maritalk
+
+| Property | Details |
+|-------|-------|
+| Description | Maritaca AI chat completions through LiteLLM's OpenAI-compatible provider path. |
+| Provider Route on LiteLLM | `maritalk` |
+| Default API Base | `https://chat.maritaca.ai/api` |
+| Required API Key | `MARITALK_API_KEY` or `api_key=...` |
+| Supported OpenAI Endpoints | `/chat/completions` |
+
+## API Key
+
+```python
+import os
+
+os.environ["MARITALK_API_KEY"] = "your-api-key"
+os.environ["MARITALK_API_BASE"] = "https://chat.maritaca.ai/api"  # optional
+```
+
+## Sample Usage
+
+```python
+import os
+
+from litellm import completion
+
+os.environ["MARITALK_API_KEY"] = "your-api-key"
+
+response = completion(
+    model="maritalk",
+    messages=[{"role": "user", "content": "Hello from LiteLLM"}],
+)
+
+print(response)
+```
+
+## Streaming
+
+```python
+from litellm import completion
+
+response = completion(
+    model="maritalk",
+    messages=[{"role": "user", "content": "Stream a short answer"}],
+    stream=True,
+)
+
+for chunk in response:
+    print(chunk)
+```
+
+## Supported OpenAI Params
+
+- `frequency_penalty`
+- `presence_penalty`
+- `top_p`
+- `top_k`
+- `temperature`
+- `max_tokens`
+- `n`
+- `stop`
+- `stream`
+- `stream_options`
+- `tools`
+- `tool_choice`

--- a/docs/my-website/docs/providers/palm.md
+++ b/docs/my-website/docs/providers/palm.md
@@ -1,0 +1,51 @@
+# Google PaLM
+
+:::warning PaLM was decommissioned
+Google decommissioned PaLM in October 2024.
+
+LiteLLM keeps the `palm/` route only to surface a clear migration error. New requests should use the `gemini/` route instead.
+:::
+
+| Property | Details |
+|-------|-------|
+| Status | Deprecated / decommissioned |
+| Legacy Provider Route on LiteLLM | `palm/` |
+| Recommended Replacement | [`gemini/`](./gemini.md) |
+| Deprecation Announcement | [Google PaLM deprecation notice](https://ai.google.dev/palm_docs/palm?hl=en) |
+
+## What happens in LiteLLM
+
+If you call LiteLLM with a `palm/` model, LiteLLM raises an error that instructs you to migrate to `gemini/`.
+
+## Migration
+
+Replace:
+
+```python
+from litellm import completion
+
+completion(
+    model="palm/chat-bison",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+With:
+
+```python
+import os
+from litellm import completion
+
+os.environ["GEMINI_API_KEY"] = "your-api-key"
+
+completion(
+    model="gemini/gemini-2.0-flash",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+:::tip Legacy API keys
+When you migrate to `gemini/`, prefer `GEMINI_API_KEY`.
+
+LiteLLM still falls back to `PALM_API_KEY` for compatibility, but `GEMINI_API_KEY` is the current env var.
+:::

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -849,6 +849,7 @@ const sidebars = {
           label: "Google AI Studio",
           items: [
             "providers/gemini",
+            "providers/palm",
             "providers/gemini/videos",
             "providers/google_ai_studio/files",
             "providers/google_ai_studio/image_gen",
@@ -935,6 +936,7 @@ const sidebars = {
         "providers/llamafile",
         "providers/llamagate",
         "providers/lm_studio",
+        "providers/maritalk",
         "providers/manus",
         "providers/meta_llama",
         "providers/milvus_vector_stores",


### PR DESCRIPTION
## Relevant issues

N/A - fixes two broken provider documentation links from the README provider matrix.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have Added testing in the `tests/test_litellm/` directory
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

Docs-only change:
- no Python or UI runtime behavior changed
- verified with `npm --prefix docs/my-website run build`

## Type

📉 Documentation

## Changes

This PR adds the missing provider docs pages for:
- `providers/palm`
- `providers/maritalk`

Why:
- the README provider matrix currently links to `https://docs.litellm.ai/docs/providers/palm` and `https://docs.litellm.ai/docs/providers/maritalk`
- both routes currently return 404

What changed:
- added a `palm` page that explains the provider is deprecated/decommissioned and points users to `gemini/`
- added a minimal `maritalk` provider page with route, API base, API key, sample usage, and supported params
- added both pages to the Docusaurus sidebar
