### PR TITLE
fix: bill unaccounted prompt tokens at base rate (Gemini PDF attachments, #24375)

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -686,6 +686,20 @@ def generic_cost_per_token(  # noqa: PLR0915
         )
         prompt_tokens_details["text_tokens"] = text_tokens
 
+    ## EDGE CASE - partial token breakdown (e.g. Gemini PDF attachments)
+    ## When prompt_tokens_details subcategories don't sum to prompt_tokens,
+    ## the unaccounted tokens (e.g. PDF document tokens) are billed at the
+    ## base text rate to avoid silent under-billing.
+    ## Ref: https://github.com/BerriAI/litellm/issues/24375
+    else:
+        total_accounted = (
+            text_tokens + cache_hit + audio_tokens + cache_creation + image_tokens
+        )
+        unaccounted_tokens = usage.prompt_tokens - total_accounted
+        if unaccounted_tokens > 0:
+            text_tokens += unaccounted_tokens
+            prompt_tokens_details["text_tokens"] = text_tokens
+
     (
         prompt_base_cost,
         completion_base_cost,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -332,6 +332,121 @@ def test_custom_pricing_with_router_model_id():
     assert model_info["cache_read_input_token_cost"] == 0.0000006
 
 
+def test_custom_pricing_cost_calc_uses_router_model_id_from_litellm_metadata():
+    """When custom pricing is in litellm_metadata.model_info,
+    use_custom_pricing_for_model should return True and
+    _select_model_name_for_cost_calc should use router_model_id.
+
+    This tests the full chain that was broken for /messages and /responses
+    endpoints. Regression test for #23185.
+    """
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+    from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
+
+    custom_model_id = "claude-sonnet-4-custom-pricing-test"
+    custom_pricing_info = {
+        "input_cost_per_token": 0.0003,
+        "output_cost_per_token": 0.0015,
+        "max_tokens": 8192,
+        "litellm_provider": "anthropic",
+    }
+    litellm.register_model(model_cost={custom_model_id: custom_pricing_info})
+
+    litellm_params = {
+        "litellm_metadata": {
+            "model_info": {
+                "id": custom_model_id,
+                "input_cost_per_token": 0.0003,
+                "output_cost_per_token": 0.0015,
+            },
+        },
+    }
+
+    custom_pricing = use_custom_pricing_for_model(litellm_params)
+    assert custom_pricing is True
+
+    # _select_model_name_for_cost_calc appends provider prefix to the
+    # selected router_model_id, so the result is "anthropic/<model_id>"
+    selected_model = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=None,
+        custom_pricing=custom_pricing,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert selected_model is not None
+    assert custom_model_id in selected_model
+
+    # Without custom_pricing, the router_model_id is NOT selected
+    selected_model_no_custom = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=None,
+        custom_pricing=False,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert custom_model_id not in (selected_model_no_custom or "")
+
+
+def test_per_request_custom_pricing_with_router():
+    """When custom pricing is passed as per-request kwargs (not in model_list),
+    _select_model_name_for_cost_calc should fall back to the model name
+    (where register_model stored the pricing) instead of the router_model_id
+    (which has no pricing data).
+
+    Regression test for the bug where response._hidden_params["response_cost"]
+    returned 0.0 for per-request custom pricing via Router.
+    """
+    from litellm import Router
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "openai/gpt-3.5-turbo",
+                "litellm_params": {
+                    "model": "openai/gpt-3.5-turbo",
+                    "api_key": "test_api_key",
+                },
+            },
+        ]
+    )
+
+    # Get the deployment's model_id (hash) that the router registered
+    deployment = router.model_list[0]
+    router_model_id = deployment["model_info"]["id"]
+
+    # The router registered this hash in model_cost but without custom pricing
+    assert router_model_id in litellm.model_cost
+    entry = litellm.model_cost[router_model_id]
+    # No custom pricing was set in model_list, so these should be None
+    assert entry.get("input_cost_per_token") is None
+
+    # Now simulate what completion() does: register custom pricing under the model name
+    litellm.register_model(
+        {
+            "openai/gpt-3.5-turbo": {
+                "input_cost_per_token": 2.0,
+                "output_cost_per_token": 2.0,
+                "litellm_provider": "openai",
+            }
+        }
+    )
+
+    # _select_model_name_for_cost_calc should pick the model name (which has pricing),
+    # NOT the router_model_id (which has no pricing)
+    selected = _select_model_name_for_cost_calc(
+        model="openai/gpt-3.5-turbo",
+        completion_response=None,
+        custom_pricing=True,
+        custom_llm_provider="openai",
+        router_model_id=router_model_id,
+    )
+    assert selected is not None
+    assert router_model_id not in selected
+    assert "gpt-3.5-turbo" in selected
+
+
 def test_azure_realtime_cost_calculator():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -365,11 +480,7 @@ def test_azure_audio_output_cost_calculation():
     Audio tokens should be charged at output_cost_per_audio_token rate,
     not at the text token rate (output_cost_per_token).
     """
-    from litellm.types.utils import (
-        Choices,
-        CompletionTokensDetailsWrapper,
-        Message,
-    )
+    from litellm.types.utils import Choices, CompletionTokensDetailsWrapper, Message
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -471,11 +582,7 @@ def test_default_image_cost_calculator(monkeypatch):
 
 def test_cost_calculator_with_cache_creation():
     from litellm import completion_cost
-    from litellm.types.utils import (
-        Choices,
-        Message,
-        Usage,
-    )
+    from litellm.types.utils import Choices, Message, Usage
 
     litellm_model_response = ModelResponse(
         id="chatcmpl-cc5638bc-fdfe-48e4-8884-57c8f4fb7c63",
@@ -896,10 +1003,7 @@ def test_azure_ai_cache_cost_calculation():
     applied correctly.
     """
     from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-    from litellm.types.utils import (
-        PromptTokensDetailsWrapper,
-        Usage,
-    )
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -1866,3 +1970,72 @@ def test_additional_costs_only_for_azure_ai():
         completion_tokens=50,
     )
     assert result is None, "Vertex AI should have no additional costs"
+
+
+def test_gemini_pdf_attachment_cost_no_underbilling():
+    """
+    Test that Gemini models correctly bill all tokens when PDF attachments
+    result in a partial prompt_tokens_details breakdown.
+
+    Reproduces issue #24375: when Gemini returns prompt_tokens_details with
+    only text_tokens=9 for a 783-token request (remaining 774 tokens are PDF
+    document tokens not assigned to any subcategory), LiteLLM was silently
+    under-billing by charging only for the 9 reported text tokens.
+
+    The fix ensures unaccounted tokens (prompt_tokens minus all subcategories)
+    are billed at the base input rate.
+    """
+    from litellm import completion_cost
+    from litellm.types.utils import (
+        CompletionTokensDetailsWrapper,
+        ModelResponse,
+        PromptTokensDetailsWrapper,
+        Usage,
+    )
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    # Simulate the Gemini response from the issue:
+    # 783 prompt tokens total, but prompt_tokens_details only reports 9 text tokens.
+    # The remaining 774 tokens are from the PDF attachment.
+    usage = Usage(
+        prompt_tokens=783,
+        completion_tokens=96,
+        total_tokens=879,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=9,
+        ),
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            reasoning_tokens=92,
+            text_tokens=4,
+        ),
+    )
+    model_response = ModelResponse(usage=usage, model="gemini/gemini-2.5-flash")
+
+    result = completion_cost(
+        completion_response=model_response,
+        model="gemini/gemini-2.5-flash",
+    )
+
+    model_info = litellm.model_cost.get("gemini/gemini-2.5-flash") or litellm.model_cost["gemini-2.5-flash"]
+    input_cost_per_token = model_info["input_cost_per_token"]
+    output_cost_per_token = model_info["output_cost_per_token"]
+
+    # All 783 prompt tokens should be billed (9 text + 774 unaccounted PDF tokens)
+    # Both are billed at the base input rate.
+    expected_prompt_cost = 783 * input_cost_per_token
+    expected_completion_cost = 96 * output_cost_per_token
+    expected_cost = expected_prompt_cost + expected_completion_cost
+
+    assert abs(result - expected_cost) < 1e-10, (
+        f"Expected cost {expected_cost:.12f} (all 783 prompt tokens billed), "
+        f"but got {result:.12f}. "
+        f"Under-billing by {expected_cost - result:.12f} (likely PDF tokens not counted)."
+    )
+
+    # Sanity check: cost should be much higher than if only 9 text tokens were billed
+    underbilled_cost = 9 * input_cost_per_token + 96 * output_cost_per_token
+    assert result > underbilled_cost, (
+        f"Cost {result} should be greater than under-billed amount {underbilled_cost}"
+    )


### PR DESCRIPTION
## Summary

- **Bug**: When Gemini returns `prompt_tokens_details` with only a partial subcategory breakdown (e.g. `text_tokens=9` for a 783-token request that included a PDF), the unaccounted 774 tokens were silently dropped from cost calculations, causing ~99% under-billing.
- **Fix**: After parsing `prompt_tokens_details`, compute the difference between `prompt_tokens` and all subcategory totals. Any positive remainder (unaccounted tokens) is added to `text_tokens` and billed at the base input rate.
- **Test**: `test_gemini_pdf_attachment_cost_no_underbilling` in `tests/test_litellm/test_cost_calculator.py` reproduces the exact usage object from the issue report and asserts all 783 prompt tokens are billed.

## Root Cause

In `litellm/litellm_core_utils/llm_cost_calc/utils.py`, `generic_cost_per_token()` had a fallback that recomputed `text_tokens` as `prompt_tokens - cache_hit - audio - cache_creation - image_tokens`, but only when `text_tokens == 0`. When Gemini reports `text_tokens=9` (non-zero), the condition was skipped and the 774 PDF-document tokens were never billed.

The output/completion side already handles unaccounted tokens via the `has_token_breakdown` path. This PR brings the input side to parity.

## Files Changed

- `litellm/litellm_core_utils/llm_cost_calc/utils.py` — add `else` branch to detect and bill unaccounted prompt tokens
- `tests/test_litellm/test_cost_calculator.py` — add regression test for issue #24375

## Test plan

- [ ] `pytest tests/test_litellm/test_cost_calculator.py::test_gemini_pdf_attachment_cost_no_underbilling`
- [ ] `pytest tests/test_litellm/test_cost_calculator.py` (full suite)

Fixes BerriAI/litellm#24375

🤖 Generated with [Claude Code](https://claude.com/claude-code)