### PR TITLE
litellm release security

### DIFF
--- a/.github/workflows/test-release-hygiene.yml
+++ b/.github/workflows/test-release-hygiene.yml
@@ -36,25 +36,4 @@ jobs:
             exit 0
           fi
 
-          mapfile -t changed_files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-
-          if [[ ${#changed_files[@]} -eq 0 ]]; then
-            echo "No changed files detected."
-            exit 0
-          fi
-
-          violating_files=()
-          for file in "${changed_files[@]}"; do
-            if [[ "$file" =~ (^|/)(dist|build)(/|$) ]] || [[ "$file" =~ \.(whl|tar\.gz)$ ]]; then
-              violating_files+=("$file")
-            fi
-          done
-
-          if [[ ${#violating_files[@]} -gt 0 ]]; then
-            echo "Build artifacts should not be committed to git."
-            echo "Publish archives from the release process instead."
-            printf ' - %s\n' "${violating_files[@]}"
-            exit 1
-          fi
-
-          echo "No committed build artifacts detected."
+          python ci_cd/check_committed_build_artifacts.py --base "$BASE_SHA" --head "$HEAD_SHA"

--- a/.github/workflows/test-release-hygiene.yml
+++ b/.github/workflows/test-release-hygiene.yml
@@ -1,0 +1,60 @@
+name: Release Hygiene
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  block-built-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block committed build artifacts
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            echo "No valid base SHA available, skipping artifact diff."
+            exit 0
+          fi
+
+          mapfile -t changed_files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if [[ ${#changed_files[@]} -eq 0 ]]; then
+            echo "No changed files detected."
+            exit 0
+          fi
+
+          violating_files=()
+          for file in "${changed_files[@]}"; do
+            if [[ "$file" =~ (^|/)(dist|build)(/|$) ]] || [[ "$file" =~ \.(whl|tar\.gz)$ ]]; then
+              violating_files+=("$file")
+            fi
+          done
+
+          if [[ ${#violating_files[@]} -gt 0 ]]; then
+            echo "Build artifacts should not be committed to git."
+            echo "Publish archives from the release process instead."
+            printf ' - %s\n' "${violating_files[@]}"
+            exit 1
+          fi
+
+          echo "No committed build artifacts detected."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Here are the core requirements for any PR submitted to LiteLLM:
 
 - [ ] **Sign the Contributor License Agreement (CLA)** - [see details](#contributor-license-agreement-cla)
 - [ ] **Keep scope isolated** - Your changes should address 1 specific problem at a time
+- [ ] **Do not commit build artifacts** - Avoid committing `dist/`, `build/`, `*.whl`, and `*.tar.gz` files. Publish generated archives from the release process, not from git.
 
 #### Proxy (Backend) PRs
 
@@ -222,6 +223,7 @@ If `make test-unit` fails:
 - **Keep PRs focused**: One feature/fix per PR
 - **Test edge cases**: Don't just test the happy path
 - **Update documentation**: If you change APIs, update docs
+- **Keep source reviewable**: Avoid checking in generated package archives or other release artifacts
 
 ## Building and Running Locally
 
@@ -319,4 +321,4 @@ Looking for ideas? Check out:
 - 🧪 Test coverage improvements
 - 🔌 New LLM provider integrations
 
-Thank you for contributing to LiteLLM! 🚀 
+Thank you for contributing to LiteLLM! 🚀

--- a/ci_cd/check_committed_build_artifacts.py
+++ b/ci_cd/check_committed_build_artifacts.py
@@ -1,0 +1,89 @@
+"""
+Fail CI when generated package artifacts are committed to git.
+
+This keeps pull requests reviewable and reduces the risk of opaque release
+artifacts being merged into source control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+def is_build_artifact_path(path: str) -> bool:
+    """Return True when a changed path points to a generated build artifact."""
+    normalized = path.replace("\\", "/")
+    pure_path = PurePosixPath(normalized)
+
+    if any(part in {"dist", "build"} for part in pure_path.parts):
+        return True
+
+    if normalized.endswith(".whl") or normalized.endswith(".tar.gz"):
+        return True
+
+    return False
+
+
+def find_build_artifact_paths(paths: list[str]) -> list[str]:
+    """Return build artifact paths from a changed-file list."""
+    return [path for path in paths if is_build_artifact_path(path)]
+
+
+def get_changed_files(base_sha: str, head_sha: str) -> list[str]:
+    """Return files changed between two git revisions."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_sha, head_sha],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the CLI parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", help="Base git SHA for diff checks")
+    parser.add_argument("--head", help="Head git SHA for diff checks")
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional explicit file paths to scan instead of using git diff",
+    )
+    return parser
+
+
+def main() -> int:
+    """CLI entrypoint."""
+    args = build_parser().parse_args()
+
+    if args.paths is not None and len(args.paths) > 0:
+        changed_files = args.paths
+    elif args.base and args.head:
+        changed_files = get_changed_files(args.base, args.head)
+    else:
+        print(
+            "Pass either --base and --head, or provide one or more paths via --paths.",
+            file=sys.stderr,
+        )
+        return 2
+
+    violating_files = find_build_artifact_paths(changed_files)
+
+    if violating_files:
+        print("Build artifacts should not be committed to git.")
+        print("Publish archives from the release process instead.")
+        for path in violating_files:
+            print(f" - {path}")
+        return 1
+
+    print("No committed build artifacts detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security.md
+++ b/security.md
@@ -5,6 +5,8 @@
 ### LiteLLM Github
 
 - All commits run through Github's CodeQL checking
+- Generated release artifacts should be published from the release process and not committed to git
+- Prefer short-lived credentials or trusted publishing for package releases whenever possible
 
 ### Self-hosted Instances LiteLLM
 
@@ -45,5 +47,6 @@ We value the security community's role in protecting our systems and users. To r
 - Email support@berri.ai with details
 - Include steps to reproduce the issue
 - Provide any relevant additional information
+- Do not disclose unpatched vulnerabilities or leaked credentials in public issues or PRs
 
 We'll review all reports promptly. Note that we don't currently offer a bug bounty program.

--- a/tests/test_litellm/test_check_committed_build_artifacts.py
+++ b/tests/test_litellm/test_check_committed_build_artifacts.py
@@ -1,0 +1,50 @@
+import importlib.util
+import os
+
+
+def _load_module():
+    script_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "ci_cd",
+            "check_committed_build_artifacts.py",
+        )
+    )
+    spec = importlib.util.spec_from_file_location(
+        "check_committed_build_artifacts", script_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_find_build_artifact_paths_detects_generated_outputs():
+    module = _load_module()
+
+    paths = [
+        "litellm-proxy-extras/dist/package.whl",
+        "build/output.txt",
+        "src/archive.tar.gz",
+        "docs/readme.md",
+    ]
+
+    assert module.find_build_artifact_paths(paths) == [
+        "litellm-proxy-extras/dist/package.whl",
+        "build/output.txt",
+        "src/archive.tar.gz",
+    ]
+
+
+def test_find_build_artifact_paths_ignores_source_files():
+    module = _load_module()
+
+    paths = [
+        ".github/workflows/test-release-hygiene.yml",
+        "litellm/proxy/proxy_server.py",
+        "tests/test_litellm/test_check_committed_build_artifacts.py",
+    ]
+
+    assert module.find_build_artifact_paths(paths) == []


### PR DESCRIPTION
## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure  
✅ Test  
📖 Documentation

## Changes

- adds a `Release Hygiene` workflow that blocks committed build artifacts in PRs and pushes to `main`
- moves the artifact detection into a small Python script so the check is easier to review and maintain
- adds targeted unit coverage for the artifact detection logic under `tests/test_litellm/`
- prevents adding or modifying `dist/`, `build/`, `*.whl`, and `*.tar.gz` in git history
- updates contributing docs to explicitly forbid committing generated release artifacts
- updates security docs with a short supply-chain hygiene note and guidance to avoid public disclosure of unpatched issues

## Verification

- `python -m pytest tests/test_litellm/test_check_committed_build_artifacts.py -q`
- result: `2 passed`