### PR TITLE
Fix for preventing double count tokens for models like haiku

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -724,21 +724,23 @@ def generic_cost_per_token(  # noqa: PLR0915
     # 2. If there's a breakdown (reasoning/audio/image tokens), calculate text_tokens as the remainder
     # 3. If no breakdown at all, assume all completion_tokens are text_tokens
     has_token_breakdown = image_tokens > 0 or audio_tokens > 0 or reasoning_tokens > 0
-    if text_tokens == 0:
-        if has_token_breakdown:
-            # Calculate text tokens as remainder when we have a breakdown
-            # This handles cases like OpenAI's reasoning models where text_tokens isn't provided
-            text_tokens = max(
-                0,
-                usage.completion_tokens
-                - reasoning_tokens
-                - audio_tokens
-                - image_tokens,
-            )
-        else:
-            # No breakdown at all, all tokens are text tokens
-            text_tokens = usage.completion_tokens
-            is_text_tokens_total = True
+    
+    if has_token_breakdown:
+        # Calculate text tokens as remainder when we have a breakdown
+        # This handles cases like OpenAI's reasoning models where text_tokens isn't provided
+        #This simply checks for double counting reasoning or audio tokens when these are already included in text_tokens like in haiku 4.5 response by writing this check with only when text_tokens were 0 , we were skipping to check that case in which text_tokens are there and other like reasoning tokens are embedded in that number
+        text_tokens = max(
+            0,
+            usage.completion_tokens
+            - reasoning_tokens
+            - audio_tokens
+            - image_tokens,
+        )
+    else:
+        # No breakdown at all, all tokens are text tokens
+        # Also it doesn't matter text tokens is 0 or not if has_token_breakdown isn't true  then text_tokens = completion_tokens
+        text_tokens = usage.completion_tokens
+        is_text_tokens_total = True
     ## TEXT COST
     completion_cost = float(text_tokens) * completion_base_cost
 

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -529,7 +529,7 @@ def test_string_cost_values_edge_cases():
     # Prompt: 1000 * 1e-6 + 100 * 0 (invalid string becomes 0)
     # Completion: 500 * 2e-6 + 50 * 2e-6 (audio tokens fall back to base cost when output_cost_per_audio_token is None)
     expected_prompt_cost = 1000 * 1e-6
-    expected_completion_cost = 500 * 2e-6 + 50 * 2e-6
+    expected_completion_cost = 450 * 2e-6 + 50 * 2e-6
 
     assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
     assert round(completion_cost, 12) == round(expected_completion_cost, 12)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_utils.py
@@ -1,18 +1,14 @@
-from unittest.mock import patch
 import os
 import sys
-from litellm.types.utils import (
-    CompletionTokensDetailsWrapper,
-    PromptTokensDetailsWrapper
-)
-
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
-
-from litellm.litellm_core_utils.llm_cost_calc.utils import (
-    generic_cost_per_token
+from unittest.mock import patch
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    PromptTokensDetailsWrapper,
 )
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
 
 def test_completion_breakdown_ignores_inflated_text_tokens():

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_utils.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+import os
+import sys
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    PromptTokensDetailsWrapper
+)
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    generic_cost_per_token
+)
+from litellm.types.utils import Usage
+
+def test_completion_breakdown_ignores_inflated_text_tokens():
+    """
+    Some providers set text_tokens to the full completion count while also reporting
+    reasoning/audio/image. Billing must use remainder text:
+    max(0, completion_tokens - reasoning - audio - image).
+    """
+    mock_model_info = {
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 2e-6,
+        "output_cost_per_audio_token": 3e-6,
+        "output_cost_per_reasoning_token": 5e-6,
+        "output_cost_per_image_token": 7e-6,
+    }
+    usage = Usage(
+        prompt_tokens=400,
+        completion_tokens=1000,
+        total_tokens=1400,
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            accepted_prediction_tokens=None,
+            audio_tokens=50,
+            reasoning_tokens=100,
+            rejected_prediction_tokens=None,
+            text_tokens=1000,
+            image_tokens=200,
+        ),
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            audio_tokens=None, cached_tokens=None, text_tokens=400, image_tokens=None
+        ),
+    )
+    with patch(
+        "litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info",
+        return_value=mock_model_info,
+    ):
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model="test-model", usage=usage, custom_llm_provider="anthropic"
+        )
+    # Expected prompt: 400 * 1e-6 = 0.0004
+    # Expected completion: text 650 (1000-100-50-200) * 2e-6 + 50*3e-6 + 100*5e-6 + 200*7e-6 = 0.00335
+    expected_prompt_cost = 400 * 1e-6
+    expected_completion_cost = (
+        (1000 - 100 - 50 - 200) * 2e-6 + 50 * 3e-6 + 100 * 5e-6 + 200 * 7e-6
+    )
+    assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
+    assert round(completion_cost, 12) == round(expected_completion_cost, 12)


### PR DESCRIPTION
## Relevant issues #24574

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ *] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ *] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [* ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ *] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request --> Bug Fixes


## Changes
Remove redundant check for text_tokens equals 0 that. was stopping from preventing duplicate counting of reasoning or audio or image tokens in text_tokens like in - 
  "usage_object": {
    "total_tokens": 46190,
    "prompt_tokens": 45731,
    "completion_tokens": 459,
    "prompt_tokens_details": {
      "text_tokens": null,
      "audio_tokens": null,
      "image_tokens": null,
      "cached_tokens": 41305,
      "cache_creation_tokens": 0
    },
    "cache_read_input_tokens": 41305,
    "completion_tokens_details": {
      "text_tokens": 459,
      "audio_tokens": null,
      "image_tokens": null,
      "reasoning_tokens": 20,
      "accepted_prediction_tokens": null,
      "rejected_prediction_tokens": null
    },
here as text_tokens is not 0 it doesn't go to check double counting before and counts text_tokens as 459 but it should be 459-20=439 , this is an example of haiku model usage object, without this change it would charge reasoning tokens with reasoning_cost_per_token and output_cost_per_token both.