### PR TITLE
feat(models): add NVIDIA Nemotron 3 Super 120B on Bedrock

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23094,6 +23094,19 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "nvidia.nemotron-3-super-120b-a12b-v1": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 6.5e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23094,7 +23094,7 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
-    "nvidia.nemotron-3-super-120b-a12b-v1": {
+    "nvidia.nemotron-super-3-120b": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 256000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23094,6 +23094,19 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "nvidia.nemotron-3-super-120b-a12b-v1": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 6.5e-07,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "o1": {
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23094,7 +23094,7 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
-    "nvidia.nemotron-3-super-120b-a12b-v1": {
+    "nvidia.nemotron-super-3-120b": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 256000,

--- a/tests/litellm/test_bedrock_nemotron_super.py
+++ b/tests/litellm/test_bedrock_nemotron_super.py
@@ -1,0 +1,51 @@
+"""
+Test suite for NVIDIA Nemotron Super 3 120B on AWS Bedrock
+Verifies model configuration, pricing, and regional availability.
+"""
+
+import os
+
+os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "true"
+
+import pytest
+
+from litellm import get_model_info
+
+
+MODEL_NAME = "nvidia.nemotron-super-3-120b"
+
+
+class TestNemotronSuper3120B:
+    """Test model definition for nvidia.nemotron-super-3-120b"""
+
+    def test_model_info_primary_region(self):
+        """Test model resolves in us-east-1"""
+        model_info = get_model_info(f"bedrock/us-east-1/{MODEL_NAME}")
+
+        assert model_info is not None, f"Model {MODEL_NAME} not found"
+        assert model_info["max_input_tokens"] == 256000
+        assert model_info["max_output_tokens"] == 32000
+        assert model_info["litellm_provider"] == "bedrock_converse"
+        assert model_info["mode"] == "chat"
+        assert model_info["supports_function_calling"] is True
+
+    def test_pricing_configured(self):
+        """Verify pricing matches AWS Bedrock rates"""
+        model_info = get_model_info(f"bedrock/us-east-1/{MODEL_NAME}")
+
+        assert model_info["input_cost_per_token"] == 1.5e-07
+        assert model_info["output_cost_per_token"] == 6.5e-07
+
+    def test_context_window(self):
+        """Nemotron Super 3 120B has 256K input, 32K output on Bedrock"""
+        model_info = get_model_info(f"bedrock/us-east-1/{MODEL_NAME}")
+
+        assert model_info["max_input_tokens"] == 256000
+        assert model_info["max_output_tokens"] == 32000
+
+    def test_resolves_without_region(self):
+        """Test model resolves with just bedrock/ prefix"""
+        model_info = get_model_info(f"bedrock/{MODEL_NAME}")
+
+        assert model_info is not None, f"Model {MODEL_NAME} not found without region"
+        assert model_info["max_input_tokens"] == 256000


### PR DESCRIPTION
Add model definition for nvidia.nemotron-3-super-120b-a12b-v1 via Bedrock Converse API with pricing, context window (256k/32k), and capability flags (function calling, tool choice, system messages).

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

- Added `nvidia.nemotron-3-super-120b-a12b-v1` to `model_prices_and_context_window.json` and backup
- Provider: `bedrock_converse` (routes through Bedrock Converse API — same path as existing Nemotron Nano models)
- Pricing: $0.15/1M input tokens, $0.65/1M output tokens (US regions, source: AWS Bedrock pricing)
- Context window: 256K input, 32K output
- Capabilities: function calling, tool choice, system messages
- No vision, no structured output (per AWS model card)