### PR TITLE
fix(proxy): eliminate race condition in streaming guardrail_information logging

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2174,12 +2174,16 @@ class CustomStreamWrapper:
                     None,
                 )
                 if _deferred_cb is not None:
-                    # Proxy has post-call guardrails — let the closure
-                    # run guardrails on the assembled response, then
-                    # fire logging with guardrail_information populated.
-                    self.logging_obj._on_deferred_stream_complete = None  # type: ignore[attr-defined]
-                    asyncio.create_task(
-                        _deferred_cb(complete_streaming_response, cache_hit)
+                    # Proxy has post-call guardrails. Store the assembled
+                    # response so the outer streaming consumer
+                    # (ProxyLogging.async_post_call_streaming_iterator_hook)
+                    # can fire the deferred callback AFTER all guardrail
+                    # end-of-stream blocks complete.  Scheduling here via
+                    # create_task would race with unified_guardrail's
+                    # end-of-stream block for short-stream providers.
+                    self.logging_obj._deferred_stream_complete_args = (  # type: ignore[attr-defined]
+                        complete_streaming_response,
+                        cache_hit,
                     )
                 else:
                     asyncio.create_task(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1059,11 +1059,13 @@ class ProxyBaseLLMRequestProcessing:
                         "_litellm_client_requested_model"
                     ] = requested_model_from_client
 
-                # Streaming: attach a closure that CSW.__anext__ will call
-                # at stream end instead of firing logging directly.  The
-                # closure runs ONLY guardrail hooks (not all callbacks) on
-                # the assembled response so guardrail_information is
-                # populated, then fires both logging handlers.
+                # Streaming: attach a closure that fires after all guardrail
+                # end-of-stream blocks complete.  CSW.__anext__ stores the
+                # assembled response on logging_obj; the outer consumer
+                # (ProxyLogging._fire_deferred_stream_logging) fires the
+                # closure after the full streaming pipeline finishes.
+                # The closure runs non-apply_guardrail hooks on the
+                # assembled response, then fires both logging handlers.
                 # Only for CustomStreamWrapper — raw async generators from
                 # passthrough routes bypass CSW and would orphan the closure.
                 from litellm.litellm_core_utils.streaming_handler import (
@@ -1383,16 +1385,19 @@ class ProxyBaseLLMRequestProcessing:
         cache_hit: Any,
     ) -> None:
         """
-        Run only post-call guardrail hooks on an assembled streaming response,
-        then fire both async and sync logging handlers.
+        Run non-streaming post-call guardrail hooks on an assembled streaming
+        response, then fire both async and sync logging handlers.
 
-        Called by CSW.__anext__ at stream end via a closure stored on
-        logging_obj._on_deferred_stream_complete.
+        Called by ProxyLogging._fire_deferred_stream_logging after the full
+        streaming pipeline (including unified_guardrail end-of-stream blocks)
+        has completed.
+
+        Guardrails with apply_guardrail are skipped — they already ran via
+        unified_guardrail's streaming iterator.  Only guardrails that override
+        async_post_call_success_hook directly (without apply_guardrail) run
+        here.
 
         This is audit-only — content has already been delivered to the client.
-        Blocking guardrails that raise HTTPException cannot prevent content
-        delivery for streaming.  Per-chunk filtering should use
-        async_post_call_streaming_hook instead.
 
         Extracted as a static method so tests can call the production
         implementation directly rather than reimplementing the closure.
@@ -1405,7 +1410,6 @@ class ProxyBaseLLMRequestProcessing:
             from litellm.proxy.utils import (
                 _check_and_merge_model_level_guardrails,
             )
-            from litellm.proxy.utils import unified_guardrail as _unified_guardrail
 
             guardrail_data = _check_and_merge_model_level_guardrails(
                 data=captured_data, llm_router=_global_llm_router
@@ -1421,14 +1425,12 @@ class ProxyBaseLLMRequestProcessing:
                 try:
                     guardrail_result = None
                     if "apply_guardrail" in type(cb).__dict__:
-                        guardrail_data["guardrail_to_apply"] = cb
-                        guardrail_result = (
-                            await _unified_guardrail.async_post_call_success_hook(
-                                user_api_key_dict=captured_user_api_key_dict,
-                                data=guardrail_data,
-                                response=_response,
-                            )
-                        )
+                        # Skip — apply_guardrail guardrails already ran via
+                        # unified_guardrail's end-of-stream block in the
+                        # streaming iterator pipeline.  Running them again
+                        # here would duplicate the guardrail API call
+                        # (e.g. double OpenAI Moderation charges).
+                        continue
                     else:
                         guardrail_result = await cb.async_post_call_success_hook(
                             user_api_key_dict=captured_user_api_key_dict,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2235,6 +2235,32 @@ class ProxyLogging:
         async for chunk in current_response:
             yield chunk
 
+        # Fire deferred logging AFTER all guardrail end-of-stream blocks
+        # completed.  unified_guardrail writes guardrail_information during
+        # its end-of-stream block (inside current_response), so by the time
+        # we reach this point the metadata is fully populated.
+        ProxyLogging._fire_deferred_stream_logging(request_data)
+
+    @staticmethod
+    def _fire_deferred_stream_logging(request_data: dict) -> None:
+        """
+        Fire the deferred streaming logging callback after the full streaming
+        pipeline (including guardrail end-of-stream blocks) has completed.
+
+        CSW.__anext__ stores the callback and args on logging_obj instead of
+        scheduling via create_task (which would race with unified_guardrail's
+        end-of-stream block).  This method retrieves and fires them.
+        """
+        logging_obj = request_data.get("litellm_logging_obj")
+        if logging_obj is None:
+            return
+        _deferred_cb = getattr(logging_obj, "_on_deferred_stream_complete", None)
+        _args = getattr(logging_obj, "_deferred_stream_complete_args", None)
+        if _deferred_cb is not None and _args is not None:
+            logging_obj._on_deferred_stream_complete = None
+            logging_obj._deferred_stream_complete_args = None
+            asyncio.create_task(_deferred_cb(*_args))
+
     def _init_response_taking_too_long_task(self, data: Optional[dict] = None):
         """
         Initialize the response taking too long task if user is using slack alerting

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -8,9 +8,10 @@ is built with guardrail_information populated.
 Non-streaming: create_task in wrapper_async is replaced by a closure that
     the proxy fires in a try/finally after post_call_success_hook.
 
-Streaming: a closure on logging_obj is called by CSW.__anext__ at stream end.
-    The closure runs ONLY guardrail hooks (not all callbacks), then fires
-    both logging handlers.
+Streaming: CSW.__anext__ stores args on logging_obj at stream end.
+    ProxyLogging._fire_deferred_stream_logging fires the closure AFTER all
+    guardrail end-of-stream blocks complete. apply_guardrail guardrails are
+    skipped (they already ran in unified_guardrail's streaming iterator).
 """
 
 import asyncio
@@ -288,19 +289,11 @@ async def test_deferred_logging_fires_on_guardrail_exception():
 
 class TestDeferredStreamingClosure:
     @pytest.mark.asyncio
-    async def test_streaming_closure_defers_logging(self):
-        """When _on_deferred_stream_complete is set, CSW calls the closure
-        instead of firing async_success_handler directly."""
+    async def test_streaming_stores_deferred_args(self):
+        """When _on_deferred_stream_complete is set, CSW stores the assembled
+        response args on logging_obj instead of calling the closure directly."""
         mock_logging_obj = MagicMock()
-        callback_called = False
-        callback_args = {}
-
-        async def mock_callback(assembled_response, cache_hit):
-            nonlocal callback_called, callback_args
-            callback_called = True
-            callback_args = {"response": assembled_response, "cache_hit": cache_hit}
-
-        mock_logging_obj._on_deferred_stream_complete = mock_callback
+        mock_logging_obj._on_deferred_stream_complete = MagicMock()
 
         resp = await litellm.acompletion(
             model="gpt-3.5-turbo",
@@ -312,11 +305,12 @@ class TestDeferredStreamingClosure:
         async for _ in resp:
             pass
 
-        await asyncio.sleep(0)
-
-        assert callback_called is True, "Closure should be called at stream end"
-        assert callback_args["response"] is not None
-        assert mock_logging_obj._on_deferred_stream_complete is None
+        # CSW should store args, NOT call the closure
+        assert hasattr(mock_logging_obj, "_deferred_stream_complete_args")
+        args = mock_logging_obj._deferred_stream_complete_args
+        assert args is not None, "Deferred args should be stored"
+        assert len(args) == 2, "Should be (assembled_response, cache_hit)"
+        assert args[0] is not None, "Assembled response should not be None"
 
     @pytest.mark.asyncio
     async def test_streaming_no_closure_fires_normally(self):
@@ -415,6 +409,10 @@ class TestDeferredStreamingClosure:
             )
             async for _ in resp:
                 pass
+
+            # CSW stored args; now simulate what ProxyLogging does
+            request_data = {"litellm_logging_obj": mock_logging_obj}
+            ProxyLogging._fire_deferred_stream_logging(request_data)
 
             await asyncio.sleep(0)
             await asyncio.sleep(0)
@@ -570,9 +568,8 @@ class TestDeferredStreamingClosure:
 
     @pytest.mark.asyncio
     async def test_production_closure_integration(self):
-        """Integration test: calls the real _run_deferred_stream_guardrails
-        static method and verifies it calls guardrail hooks and passes
-        the modified response to logging."""
+        """Integration test: CSW stores args, then _fire_deferred_stream_logging
+        fires the closure which calls _run_deferred_stream_guardrails."""
         hook_called = False
         logged_response = None
         modified_response = MagicMock()
@@ -625,6 +622,10 @@ class TestDeferredStreamingClosure:
             async for _ in resp:
                 pass
 
+            # CSW stored args; now simulate what ProxyLogging does
+            request_data = {"litellm_logging_obj": mock_logging_obj}
+            ProxyLogging._fire_deferred_stream_logging(request_data)
+
             await asyncio.sleep(0)
             await asyncio.sleep(0)
 
@@ -634,13 +635,13 @@ class TestDeferredStreamingClosure:
         ), "Production closure must pass guardrail-modified response to logging"
 
     @pytest.mark.asyncio
-    async def test_apply_guardrail_path_uses_unified_guardrail(self):
-        """Guardrails that define apply_guardrail should be dispatched through
-        UnifiedLLMGuardrails.async_post_call_success_hook via the real
-        _run_deferred_stream_guardrails static method."""
+    async def test_apply_guardrail_skipped_in_deferred_path(self):
+        """Guardrails that define apply_guardrail should be SKIPPED in
+        _run_deferred_stream_guardrails (they already ran via unified_guardrail's
+        streaming end-of-stream block)."""
         from litellm.types.utils import GenericGuardrailAPIInputs
 
-        unified_hook_called = False
+        apply_guardrail_called = False
 
         class ApplyGuardrailType(CustomGuardrail):
             def __init__(self):
@@ -653,53 +654,34 @@ class TestDeferredStreamingClosure:
             async def apply_guardrail(
                 self, inputs, request_data, input_type, logging_obj=None
             ) -> GenericGuardrailAPIInputs:
-                nonlocal unified_hook_called
-                unified_hook_called = True
+                nonlocal apply_guardrail_called
+                apply_guardrail_called = True
                 return inputs
 
         mock_logging_obj = MagicMock()
         mock_logging_obj.model_call_details = {"metadata": {}}
-        logged_response = None
 
         async def track_async_success(*args, **kwargs):
-            nonlocal logged_response
-            logged_response = args[0] if args else None
+            pass
 
         mock_logging_obj.async_success_handler = track_async_success
 
         guardrail = ApplyGuardrailType()
 
-        async def _on_deferred_stream_complete(assembled_response, cache_hit):
+        with patch("litellm.callbacks", [guardrail]):
             await ProxyBaseLLMRequestProcessing._run_deferred_stream_guardrails(
                 captured_data={"model": "gpt-4", "metadata": {}},
                 captured_user_api_key_dict=UserAPIKeyAuth(api_key="test"),
                 captured_logging_obj=mock_logging_obj,
-                assembled_response=assembled_response,
-                cache_hit=cache_hit,
+                assembled_response=MagicMock(),
+                cache_hit=False,
             )
 
-        mock_logging_obj._on_deferred_stream_complete = _on_deferred_stream_complete
-
-        with patch("litellm.callbacks", [guardrail]):
-            resp = await litellm.acompletion(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": "hi"}],
-                mock_response="Hello!",
-                stream=True,
-                litellm_logging_obj=mock_logging_obj,
-            )
-            async for _ in resp:
-                pass
-
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
         assert (
-            unified_hook_called is True
-        ), "apply_guardrail guardrails must be dispatched through UnifiedLLMGuardrails"
-        assert (
-            logged_response is not None
-        ), "Logging must fire after unified guardrail path"
+            apply_guardrail_called is False
+        ), "apply_guardrail guardrails must be SKIPPED in deferred path"
 
     @pytest.mark.asyncio
     async def test_hooks_receive_merged_guardrail_data(self):
@@ -771,91 +753,6 @@ class TestDeferredStreamingClosure:
         assert "model-guardrail" in hook_received_data.get("metadata", {}).get(
             "guardrails", []
         ), "Hook data must contain model-level guardrails"
-
-    @pytest.mark.asyncio
-    async def test_apply_guardrail_path_receives_merged_guardrail_data(self):
-        """The apply_guardrail path (through UnifiedLLMGuardrails) must also
-        receive guardrail_data so that the inner should_run_guardrail re-check
-        inside UnifiedLLMGuardrails sees model-level guardrails.
-
-        This is the specific scenario Greptile flagged: a default_on=False
-        guardrail configured at the model level would pass the outer gate but
-        be silently skipped at execution time if captured_data (unmerged) were
-        passed instead of guardrail_data (merged)."""
-        import copy
-
-        from litellm.types.utils import GenericGuardrailAPIInputs
-
-        unified_received_data = None
-
-        class ModelLevelApplyGuardrail(CustomGuardrail):
-            def __init__(self):
-                super().__init__(
-                    guardrail_name="model-apply-guardrail",
-                    default_on=True,
-                    event_hook=GuardrailEventHooks.post_call,
-                )
-
-            async def apply_guardrail(
-                self, inputs, request_data, input_type, logging_obj=None
-            ) -> GenericGuardrailAPIInputs:
-                return inputs
-
-        mock_logging_obj = MagicMock()
-        mock_logging_obj.model_call_details = {"metadata": {}}
-
-        async def track_async_success(*args, **kwargs):
-            pass
-
-        mock_logging_obj.async_success_handler = track_async_success
-
-        guardrail = ModelLevelApplyGuardrail()
-        captured_data = {"model": "gpt-4", "metadata": {}}
-
-        def mock_merge(data, llm_router):
-            merged = copy.deepcopy(data)
-            merged["metadata"]["guardrails"] = ["model-apply-guardrail"]
-            merged["_merged_marker"] = True
-            return merged
-
-        # Capture what UnifiedLLMGuardrails.async_post_call_success_hook receives
-        original_unified_hook = None
-        from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
-            UnifiedLLMGuardrails,
-        )
-
-        original_unified_hook = UnifiedLLMGuardrails.async_post_call_success_hook
-
-        async def tracking_unified_hook(self, user_api_key_dict, data, response):
-            nonlocal unified_received_data
-            unified_received_data = data
-            return response
-
-        with patch("litellm.callbacks", [guardrail]), patch(
-            "litellm.proxy.utils._check_and_merge_model_level_guardrails",
-            side_effect=mock_merge,
-        ), patch.object(
-            UnifiedLLMGuardrails,
-            "async_post_call_success_hook",
-            tracking_unified_hook,
-        ):
-            await ProxyBaseLLMRequestProcessing._run_deferred_stream_guardrails(
-                captured_data=captured_data,
-                captured_user_api_key_dict=UserAPIKeyAuth(api_key="test"),
-                captured_logging_obj=mock_logging_obj,
-                assembled_response=MagicMock(),
-                cache_hit=False,
-            )
-
-        assert (
-            unified_received_data is not None
-        ), "UnifiedLLMGuardrails must be called for apply_guardrail guardrails"
-        assert (
-            unified_received_data.get("_merged_marker") is True
-        ), "UnifiedLLMGuardrails must receive guardrail_data (merged), not captured_data"
-        assert "model-apply-guardrail" in unified_received_data.get("metadata", {}).get(
-            "guardrails", []
-        ), "UnifiedLLMGuardrails data must contain model-level guardrails"
 
     @pytest.mark.asyncio
     async def test_multiple_guardrails_all_receive_merged_data(self):
@@ -953,3 +850,112 @@ class TestDeferredStreamingClosure:
         assert (
             logging_called is True
         ), "Logging must fire even when guardrail initialization raises"
+
+
+# ---------------------------------------------------------------------------
+# 7. _fire_deferred_stream_logging
+# ---------------------------------------------------------------------------
+
+
+class TestFireDeferredStreamLogging:
+    @pytest.mark.asyncio
+    async def test_fires_callback_with_stored_args(self):
+        """_fire_deferred_stream_logging should call the deferred callback
+        with the stored args."""
+        callback_called = False
+        callback_args = {}
+
+        async def mock_callback(assembled_response, cache_hit):
+            nonlocal callback_called, callback_args
+            callback_called = True
+            callback_args = {"response": assembled_response, "cache_hit": cache_hit}
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj._on_deferred_stream_complete = mock_callback
+        mock_logging_obj._deferred_stream_complete_args = ("test_response", True)
+
+        request_data = {"litellm_logging_obj": mock_logging_obj}
+        ProxyLogging._fire_deferred_stream_logging(request_data)
+
+        await asyncio.sleep(0)
+
+        assert callback_called is True
+        assert callback_args["response"] == "test_response"
+        assert callback_args["cache_hit"] is True
+        # Attributes should be cleared
+        assert mock_logging_obj._on_deferred_stream_complete is None
+        assert mock_logging_obj._deferred_stream_complete_args is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_deferred_args(self):
+        """_fire_deferred_stream_logging should be a no-op when no deferred
+        args are stored."""
+        mock_logging_obj = MagicMock()
+        mock_logging_obj._on_deferred_stream_complete = None
+
+        request_data = {"litellm_logging_obj": mock_logging_obj}
+        # Should not raise
+        ProxyLogging._fire_deferred_stream_logging(request_data)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_logging_obj(self):
+        """_fire_deferred_stream_logging should be a no-op when
+        litellm_logging_obj is missing from request_data."""
+        request_data = {}
+        # Should not raise
+        ProxyLogging._fire_deferred_stream_logging(request_data)
+
+    @pytest.mark.asyncio
+    async def test_short_stream_guardrail_info_populated(self):
+        """Verify that _run_deferred_stream_guardrails populates
+        guardrail_information for guardrails using async_post_call_success_hook
+        (non-apply_guardrail path) even with short streams."""
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {"metadata": {}}
+
+        logged_response = None
+
+        async def track_async_success(*args, **kwargs):
+            nonlocal logged_response
+            logged_response = args[0] if args else None
+
+        mock_logging_obj.async_success_handler = track_async_success
+
+        class InfoWritingGuardrail(CustomGuardrail):
+            def __init__(self):
+                super().__init__(
+                    guardrail_name="info-writer",
+                    default_on=True,
+                    event_hook=GuardrailEventHooks.post_call,
+                )
+
+            async def async_post_call_success_hook(
+                self, data: dict, user_api_key_dict: UserAPIKeyAuth, response: Any
+            ) -> Any:
+                # Simulate writing guardrail_information
+                metadata = data.setdefault("metadata", {})
+                info_list = metadata.setdefault(
+                    "standard_logging_guardrail_information", []
+                )
+                info_list.append({"guardrail_name": "info-writer", "status": "success"})
+                return response
+
+        guardrail = InfoWritingGuardrail()
+        captured_data = {"model": "gpt-4", "metadata": {}}
+
+        with patch("litellm.callbacks", [guardrail]):
+            await ProxyBaseLLMRequestProcessing._run_deferred_stream_guardrails(
+                captured_data=captured_data,
+                captured_user_api_key_dict=UserAPIKeyAuth(api_key="test"),
+                captured_logging_obj=mock_logging_obj,
+                assembled_response=MagicMock(),
+                cache_hit=False,
+            )
+
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        info = captured_data["metadata"].get("standard_logging_guardrail_information")
+        assert info is not None, "guardrail_information should be populated"
+        assert len(info) == 1
+        assert info[0]["guardrail_name"] == "info-writer"


### PR DESCRIPTION
asyncio.create_task in CSW.__anext__ scheduled the deferred logging callback as an independent task that raced with unified_guardrail's end-of-stream block. For short-stream providers (Vertex AI, Azure, Anthropic), the logging fired before guardrail_information was written, causing post_call guardrail entries to be missing from StandardLoggingPayload.

Move the deferred callback trigger from CSW.__anext__ to ProxyLogging.async_post_call_streaming_iterator_hook (after the full streaming pipeline completes). CSW now stores the assembled response args; the outer consumer fires the callback after all guardrail end-of-stream blocks finish. Also skip apply_guardrail guardrails in _run_deferred_stream_guardrails to eliminate duplicate API calls.

## Relevant issues

Fixes guardrail_information missing post_call entries for non-OpenAI streaming providers (Vertex AI/Gemini, Azure, Anthropic). Related to #23910 and #24135.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### `litellm/litellm_core_utils/streaming_handler.py`
- CSW.__anext__ no longer calls `asyncio.create_task` for the deferred callback. Instead, it stores `(assembled_response, cache_hit)` on `logging_obj._deferred_stream_complete_args` for the outer consumer to pick up.

### `litellm/proxy/utils.py`
- Added `ProxyLogging._fire_deferred_stream_logging()` static method that retrieves the stored callback and args from `logging_obj`, then fires `asyncio.create_task`.
- Called after the `async for` loop in `async_post_call_streaming_iterator_hook`, ensuring all guardrail end-of-stream blocks (including unified_guardrail) have fully completed before logging fires.

### `litellm/proxy/common_request_processing.py`
- `_run_deferred_stream_guardrails` now skips guardrails that define `apply_guardrail` — these already ran via unified_guardrail's streaming iterator end-of-stream block. Running them again would duplicate the guardrail API call (e.g., double OpenAI Moderation charges).
- Updated docstring and closure comment to reflect the new flow.
- Removed unused `unified_guardrail` import.

### `tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py`
- Updated `test_streaming_closure_defers_logging` → `test_streaming_stores_deferred_args`: verifies CSW stores args instead of calling the closure.
- Updated `test_apply_guardrail_path_uses_unified_guardrail` → `test_apply_guardrail_skipped_in_deferred_path`: verifies apply_guardrail guardrails are skipped in the deferred path.
- Updated integration tests to use `_fire_deferred_stream_logging` after CSW iteration.
- Added `TestFireDeferredStreamLogging` class with 4 new tests: fires callback with stored args, no-op when no args, no-op when no logging_obj, short-stream guardrail info populated.
- 25 tests total, all passing.