### PR TITLE
fix(openrouter): strip routing prefix for wildcard proxy deployments

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -158,12 +158,15 @@ def get_llm_provider(  # noqa: PLR0915
         ):  # handle scenario where model="azure/*" and custom_llm_provider="azure"
             model = custom_llm_provider + "/" + model
 
-        # Native OpenRouter models have IDs like "openrouter/free" where the
-        # "openrouter/" prefix is part of the actual model name on the API.
-        # When called from a bridge (e.g. anthropic_messages adapter),
-        # custom_llm_provider is already resolved, so return early to prevent
-        # the provider-list stripping below from removing the prefix.
+        # OpenRouter: when the router/proxy already set custom_llm_provider,
+        # the model may still carry LiteLLM's "openrouter/" routing prefix.
+        # Native IDs like "openrouter/auto" must stay intact for the API; IDs
+        # like "openrouter/anthropic/claude-3.5-sonnet" must become
+        # "anthropic/claude-3.5-sonnet" (OpenRouter expects provider/model).
         if custom_llm_provider == "openrouter" and model.startswith("openrouter/"):
+            remainder = model[len("openrouter/") :]
+            if "/" in remainder:
+                return remainder, custom_llm_provider, dynamic_api_key, api_base
             return model, custom_llm_provider, dynamic_api_key, api_base
 
         if api_key and api_key.startswith("os.environ/"):

--- a/tests/test_litellm/llms/openrouter/test_openrouter_provider_routing.py
+++ b/tests/test_litellm/llms/openrouter/test_openrouter_provider_routing.py
@@ -80,7 +80,10 @@ class TestOpenRouterNativeModelRouting:
         "input_model,expected_model",
         [
             ("openrouter/anthropic/claude-3-haiku", "anthropic/claude-3-haiku"),
-            ("openrouter/meta-llama/llama-3-70b-instruct", "meta-llama/llama-3-70b-instruct"),
+            (
+                "openrouter/meta-llama/llama-3-70b-instruct",
+                "meta-llama/llama-3-70b-instruct",
+            ),
         ],
     )
     def test_regular_models_still_strip_normally(self, input_model, expected_model):
@@ -88,3 +91,12 @@ class TestOpenRouterNativeModelRouting:
         result_model, provider, _, _ = litellm.get_llm_provider(model=input_model)
         assert provider == "openrouter"
         assert result_model == expected_model
+
+    def test_wildcard_deployment_strips_routing_prefix(self):
+        """openrouter/* proxy deployments pass custom_llm_provider; strip LiteLLM prefix."""
+        result_model, provider, _, _ = litellm.get_llm_provider(
+            model="openrouter/anthropic/claude-3.5-sonnet",
+            custom_llm_provider="openrouter",
+        )
+        assert provider == "openrouter"
+        assert result_model == "anthropic/claude-3.5-sonnet"


### PR DESCRIPTION
## Problem
Proxy deployments using `openrouter/*` set `custom_llm_provider=openrouter` while the request model stays `openrouter/provider/model`. `get_llm_provider` returned early and never stripped the LiteLLM routing prefix, so OpenRouter received the wrong model id. Direct SDK calls worked because `custom_llm_provider` was unset and the normal strip path ran.

## Change
When `custom_llm_provider == "openrouter"` and the model starts with `openrouter/`, strip that prefix only if the remainder contains `/` (upstream `provider/model`). Single-segment remainders keep the full `openrouter/...` id for native OpenRouter models (e.g. `openrouter/auto`).

## Test
`test_wildcard_deployment_strips_routing_prefix` in `tests/test_litellm/llms/openrouter/test_openrouter_provider_routing.py`.
