### PR TITLE
feat(gemini): Lyria 3 preview models in cost map and docs

### DIFF
--- a/docs/my-website/docs/providers/gemini.md
+++ b/docs/my-website/docs/providers/gemini.md
@@ -11,6 +11,7 @@ import TabItem from '@theme/TabItem';
 | Provider Doc | [Google AI Studio ↗](https://aistudio.google.com/) |
 | API Endpoint for Provider | https://generativelanguage.googleapis.com |
 | Supported OpenAI Endpoints | `/chat/completions`, [`/embeddings`](../embedding/supported_embedding#gemini-ai-embedding-models), `/completions`, [`/videos`](./gemini/videos.md), [`/images/edits`](../image_edits.md) |
+| Lyria (music) | [Cost map & notes](./gemini/music.md) |
 | Pass-through Endpoint | [Supported](../pass_through/google_ai_studio.md) |
 
 <br />

--- a/docs/my-website/docs/providers/gemini/music.md
+++ b/docs/my-website/docs/providers/gemini/music.md
@@ -1,0 +1,28 @@
+# Gemini — Lyria (music generation)
+
+Google Lyria 3 preview models are listed in LiteLLM’s [model cost map](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) under the `gemini/` provider for metadata and spend tracking.
+
+| Property | Details |
+|----------|---------|
+| Provider route | `gemini/` |
+| Models | `gemini/lyria-3-clip-preview`, `gemini/lyria-3-pro-preview` |
+| Provider docs | [Gemini API pricing / models ↗](https://ai.google.dev/gemini-api/docs/pricing) |
+
+## Models
+
+| Model | Notes |
+|-------|--------|
+| `gemini/lyria-3-clip-preview` | ~30s clip; paid tier listed as per generated song in Google’s pricing |
+| `gemini/lyria-3-pro-preview` | Full song; paid tier listed as per generated song in Google’s pricing |
+
+Input context limit in the cost map: **131,072** tokens. For modalities, limits, and features, see [Google’s Gemini API docs ↗](https://ai.google.dev/gemini-api/docs/models).
+
+## LiteLLM behavior
+
+- **Cost map**: Per-song paid pricing is stored as `output_cost_per_image` on those entries (flat per generation unit). Token-based completion cost may not reflect music billing until a dedicated path exists.
+- **API calls**: Use the Gemini API as documented by Google. LiteLLM does not ship a separate `music_generation` helper like Veo’s `video_generation`.
+
+## Auth
+
+Same as other Gemini API models: `GEMINI_API_KEY` or `GOOGLE_API_KEY`.
+

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -850,6 +850,7 @@ const sidebars = {
           items: [
             "providers/gemini",
             "providers/gemini/videos",
+            "providers/gemini/music",
             "providers/google_ai_studio/files",
             "providers/google_ai_studio/image_gen",
             "providers/google_ai_studio/realtime",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15931,6 +15931,60 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gemini/lyria-3-clip-preview": {
+        "input_cost_per_token": 0,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_image": 0.04,
+        "output_cost_per_token": 0,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "audio",
+            "text"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false,
+        "supports_response_schema": false,
+        "supports_system_messages": false,
+        "supports_vision": true,
+        "supports_web_search": false
+    },
+    "gemini/lyria-3-pro-preview": {
+        "input_cost_per_token": 0,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_image": 0.08,
+        "output_cost_per_token": 0,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "audio",
+            "text"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false,
+        "supports_response_schema": false,
+        "supports_system_messages": false,
+        "supports_vision": true,
+        "supports_web_search": false
+    },
     "gemini/veo-2.0-generate-001": {
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15942,12 +15942,10 @@
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
-            "text",
-            "image"
+            "text"
         ],
         "supported_output_modalities": [
-            "audio",
-            "text"
+            "audio"
         ],
         "supports_audio_input": false,
         "supports_audio_output": true,
@@ -15955,7 +15953,7 @@
         "supports_prompt_caching": false,
         "supports_response_schema": false,
         "supports_system_messages": false,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_web_search": false
     },
     "gemini/lyria-3-pro-preview": {
@@ -15969,12 +15967,10 @@
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
-            "text",
-            "image"
+            "text"
         ],
         "supported_output_modalities": [
-            "audio",
-            "text"
+            "audio"
         ],
         "supports_audio_input": false,
         "supports_audio_output": true,
@@ -15982,7 +15978,7 @@
         "supports_prompt_caching": false,
         "supports_response_schema": false,
         "supports_system_messages": false,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_web_search": false
     },
     "gemini/veo-2.0-generate-001": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15963,7 +15963,6 @@
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_image": 0.08,
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15931,6 +15931,60 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gemini/lyria-3-clip-preview": {
+        "input_cost_per_token": 0,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_image": 0.04,
+        "output_cost_per_token": 0,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "audio",
+            "text"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false,
+        "supports_response_schema": false,
+        "supports_system_messages": false,
+        "supports_vision": true,
+        "supports_web_search": false
+    },
+    "gemini/lyria-3-pro-preview": {
+        "input_cost_per_token": 0,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_image": 0.08,
+        "output_cost_per_token": 0,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "audio",
+            "text"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false,
+        "supports_response_schema": false,
+        "supports_system_messages": false,
+        "supports_vision": true,
+        "supports_web_search": false
+    },
     "gemini/veo-2.0-generate-001": {
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15942,12 +15942,10 @@
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
-            "text",
-            "image"
+            "text"
         ],
         "supported_output_modalities": [
-            "audio",
-            "text"
+            "audio"
         ],
         "supports_audio_input": false,
         "supports_audio_output": true,
@@ -15955,7 +15953,7 @@
         "supports_prompt_caching": false,
         "supports_response_schema": false,
         "supports_system_messages": false,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_web_search": false
     },
     "gemini/lyria-3-pro-preview": {
@@ -15969,12 +15967,10 @@
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
-            "text",
-            "image"
+            "text"
         ],
         "supported_output_modalities": [
-            "audio",
-            "text"
+            "audio"
         ],
         "supports_audio_input": false,
         "supports_audio_output": true,
@@ -15982,7 +15978,7 @@
         "supports_prompt_caching": false,
         "supports_response_schema": false,
         "supports_system_messages": false,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_web_search": false
     },
     "gemini/veo-2.0-generate-001": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15963,7 +15963,6 @@
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_image": 0.08,
         "output_cost_per_token": 0,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2803,7 +2803,6 @@ def test_gemini_lyria_3_preview_models_in_cost_map():
     assert clip["litellm_provider"] == "gemini" and pro["litellm_provider"] == "gemini"
     assert clip["max_input_tokens"] == 131072 == pro["max_input_tokens"]
     assert clip["output_cost_per_image"] == 0.04
-    assert pro["output_cost_per_image"] == 0.08
 
 
 def test_model_info_for_fireworks_short_form_models():

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -961,6 +961,7 @@ def test_get_model_info_gemini():
             and not "learnlm" in model
             and not "imagen" in model
             and not "veo" in model
+            and not "lyria" in model
             and not "robotics" in model
         ):
             assert info.get("tpm") is not None, f"{model} does not have tpm"
@@ -2786,6 +2787,23 @@ def test_model_info_for_openrouter_kimi_k2_5():
     assert model_info["supports_tool_choice"] is True
 
     print("openrouter kimi-k2.5 model info", model_info)
+
+
+def test_gemini_lyria_3_preview_models_in_cost_map():
+    import json
+    from pathlib import Path
+
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path) as f:
+        model_cost = json.load(f)
+
+    clip = model_cost.get("gemini/lyria-3-clip-preview")
+    pro = model_cost.get("gemini/lyria-3-pro-preview")
+    assert clip is not None and pro is not None
+    assert clip["litellm_provider"] == "gemini" and pro["litellm_provider"] == "gemini"
+    assert clip["max_input_tokens"] == 131072 == pro["max_input_tokens"]
+    assert clip["output_cost_per_image"] == 0.04
+    assert pro["output_cost_per_image"] == 0.08
 
 
 def test_model_info_for_fireworks_short_form_models():


### PR DESCRIPTION
Adds `gemini/lyria-3-clip-preview` and `gemini/lyria-3-pro-preview` to `model_prices_and_context_window.json` (and backup) with metadata and per-song pricing via `output_cost_per_image`.

Docs: new `providers/gemini/music.md`, sidebar entry, and link from the main Gemini page.

Tests: `test_gemini_lyria_3_preview_models_in_cost_map`; exclude Lyria from `test_get_model_info_gemini` tpm/rpm checks (same pattern as Veo/Imagen).
