### PR TITLE
fix(model): add supports_reasoning for gemini-3.1-flash-image-preview                                          

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -13807,6 +13807,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13807,6 +13807,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_3_1_flash_image_supports_reasoning.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_3_1_flash_image_supports_reasoning.py
@@ -1,0 +1,60 @@
+"""
+Tests for gemini-3.1-flash-image-preview supports_reasoning flag.
+
+Verifies that supports_reasoning returns True for all provider variants,
+including the fallback from provider-prefixed entries to the base entry.
+"""
+
+import os
+
+import pytest
+
+import litellm
+from litellm.utils import supports_reasoning
+
+
+@pytest.fixture(autouse=True)
+def load_local_model_cost():
+    """Load model cost from local JSON so that uncommitted changes are picked up."""
+    original_env = os.getenv("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = getattr(litellm, "model_cost", None)
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    yield
+
+    if original_env is None:
+        os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+    else:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_env
+
+    if original_model_cost is not None:
+        litellm.model_cost = original_model_cost
+
+
+def test_gemini_3_1_flash_image_preview_supports_reasoning_base():
+    """Test that the base entry supports reasoning."""
+    assert supports_reasoning(model="gemini-3.1-flash-image-preview") is True
+
+
+def test_gemini_3_1_flash_image_preview_supports_reasoning_gemini_provider():
+    """Test that the gemini/ prefixed entry inherits supports_reasoning via fallback."""
+    assert (
+        supports_reasoning(
+            model="gemini/gemini-3.1-flash-image-preview",
+            custom_llm_provider="gemini",
+        )
+        is True
+    )
+
+
+def test_gemini_3_1_flash_image_preview_supports_reasoning_vertex_ai_provider():
+    """Test that the vertex_ai/ prefixed entry inherits supports_reasoning via fallback."""
+    assert (
+        supports_reasoning(
+            model="gemini-3.1-flash-image-preview",
+            custom_llm_provider="vertex_ai",
+        )
+        is True
+    )


### PR DESCRIPTION
## Changes

The `gemini-3.1-flash-image-preview` model supports thinking/reasoning via the `thinkingLevel` parameter, but was missing the `supports_reasoning` flag in `model_prices_and_context_window.json`.

Added `supports_reasoning: true` to the base `gemini-3.1-flash-image-preview` entry. The `gemini/` and `vertex_ai/` prefixed entries inherit this via `_supports_factory` fallback logic
([ref](https://github.com/BerriAI/litellm/blob/main/litellm/utils.py#L2569-L2578)).

### References
- Vertex AI: https://cloud.google.com/vertex-ai/generative-ai/docs/thinking
- Google AI Studio: https://ai.google.dev/gemini-api/docs/thinking

## Type
                                                                                                               
🐛 Bug Fix                                                                                                   

## Pre-Submission checklist                                                                                    
 
- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)   
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at   
least 4/5** before requesting a maintainer review