### PR TITLE
fix: add openrouter/minimax/minimax-m2.7 model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25394,6 +25394,23 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.7": {
+        "input_cost_per_token": 3.0e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6.0e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.7",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
+    },
     "openrouter/openrouter/auto": {
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25394,6 +25394,23 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.7": {
+        "input_cost_per_token": 3.0e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6.0e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.7",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
+    },
     "openrouter/openrouter/auto": {
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,


### PR DESCRIPTION
## Summary
- Adds the `openrouter/minimax/minimax-m2.7` model to the model prices JSON file
- Includes input/output token costs, context window, and feature support

## Changes
- `model_prices_and_context_window.json`: Added minimax-m2.7 entry
- `litellm/model_prices_and_context_window_backup.json`: Same entry in backup

## Test plan
- [x] JSON validation passed
- [x] Follows alphabetical ordering in the JSON  
- [x] Matches format of adjacent minimax models (m2, m2.1, m2.5)

Fixes #24601

