### PR TITLE
feat(models): add openrouter/minimax/minimax-m2.7 to model pricing registry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25394,6 +25394,23 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.7",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
+    },
     "openrouter/openrouter/auto": {
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25394,6 +25394,23 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.7",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
+    },
     "openrouter/openrouter/auto": {
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,


### PR DESCRIPTION
## New Model — openrouter/minimax/minimax-m2.7

Adds the `openrouter/minimax/minimax-m2.7` model to the pricing and context window registry. This is the latest model in the MiniMax M2 series (successor to `minimax-m2.5`) and is currently available on OpenRouter.

Without this entry, routing a request to `openrouter/minimax/minimax-m2.7` will throw an unknown model error during cost calculation even though the underlying API call would succeed.

Both the main file (`model_prices_and_context_window.json`) and the backup file (`litellm/model_prices_and_context_window_backup.json`) have been updated, as required.

## Checklist

- [x] Added to both the main and backup pricing JSON files
- [x] JSON is valid (verified with `python3 -c "import json; json.load(open(...))"`)
- [x] Entry follows the same structure as adjacent models in the M2 series
- [x] Closes #24601

Signed-off-by: Sakthi Harish <sakthi.harish@edgeverve.com>