### PR TITLE
feat(models): add openrouter/minimax/minimax-m2.7 model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25394,6 +25394,23 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.7",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
+    },
     "openrouter/openrouter/auto": {
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25394,6 +25394,23 @@
         "supports_prompt_caching": true,
         "supports_computer_use": false
     },
+    "openrouter/minimax/minimax-m2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 204800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://openrouter.ai/minimax/minimax-m2.7",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": false,
+        "supports_prompt_caching": true,
+        "supports_computer_use": false
+    },
     "openrouter/openrouter/auto": {
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,


### PR DESCRIPTION
## Summary

Adds `openrouter/minimax/minimax-m2.7` to `model_prices_and_context_window.json` and the backup file, as requested in #24601.

## Model Details (from [OpenRouter](https://openrouter.ai/minimax/minimax-m2.7))

| Field | Value |
|-------|-------|
| Input cost | $0.30 / 1M tokens (`3e-07` per token) |
| Output cost | $1.20 / 1M tokens (`1.2e-06` per token) |
| Cache read cost | $0.06 / 1M tokens (`6e-08` per token) |
| Max input tokens | 204,800 |
| Max output tokens | 131,072 |
| Function calling | ✅ |
| Tool choice | ✅ |
| Reasoning | ✅ |
| Vision | ❌ |
| Prompt caching | ✅ |

## Changes

- Updated `model_prices_and_context_window.json`
- Updated `litellm/model_prices_and_context_window_backup.json`

Closes #24601