### PR TITLE
Fix overlong S3 logging object keys

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -21,6 +21,24 @@ def _long_filename_suffix(s3_file_name: str) -> str:
     )
 
 
+def _truncate_to_utf8_bytes(value: str, max_bytes: int) -> str:
+    if max_bytes <= 0:
+        return ""
+
+    encoded_value = value.encode("utf-8")
+    if len(encoded_value) <= max_bytes:
+        return value
+
+    truncated_value = encoded_value[:max_bytes]
+    while truncated_value:
+        try:
+            return truncated_value.decode("utf-8")
+        except UnicodeDecodeError:
+            truncated_value = truncated_value[:-1]
+
+    return ""
+
+
 class S3Logger:
     # Class variables or attributes
     def __init__(
@@ -197,10 +215,14 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
-    if len(s3_file_name) > MAX_S3_FILENAME_STEM_LENGTH:
+    if len(s3_file_name.encode("utf-8")) > MAX_S3_FILENAME_STEM_LENGTH:
         suffix = _long_filename_suffix(s3_file_name)
-        prefix_length = MAX_S3_FILENAME_STEM_LENGTH - len(suffix) - 1
-        s3_file_name = f"{s3_file_name[:prefix_length]}_{suffix}"
+        prefix_byte_length = max(
+            MAX_S3_FILENAME_STEM_LENGTH - len(suffix.encode("utf-8")) - 1,
+            0,
+        )
+        truncated_prefix = _truncate_to_utf8_bytes(s3_file_name, prefix_byte_length)
+        s3_file_name = f"{truncated_prefix}_{suffix}"
 
     s3_object_key = (
         (s3_path.rstrip("/") + "/" if s3_path else "")

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -9,7 +9,7 @@ import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.types.utils import StandardLoggingPayload
 
-MAX_S3_FILENAME_COMPONENT_LENGTH = 250
+MAX_S3_FILENAME_STEM_LENGTH = 250
 
 
 class S3Logger:
@@ -188,9 +188,9 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
-    if len(s3_file_name) > MAX_S3_FILENAME_COMPONENT_LENGTH:
+    if len(s3_file_name) > MAX_S3_FILENAME_STEM_LENGTH:
         digest = hashlib.sha256(s3_file_name.encode("utf-8")).hexdigest()[:16]
-        prefix_length = MAX_S3_FILENAME_COMPONENT_LENGTH - len(digest) - 1
+        prefix_length = MAX_S3_FILENAME_STEM_LENGTH - len(digest) - 1
         s3_file_name = f"{s3_file_name[:prefix_length]}_{digest}"
 
     s3_object_key = (

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -1,7 +1,7 @@
 #### What this does ####
 #    On success + failure, log events to Supabase
 
-import hashlib
+import zlib
 from datetime import datetime
 from typing import Optional, cast
 
@@ -10,6 +10,15 @@ from litellm._logging import print_verbose, verbose_logger
 from litellm.types.utils import StandardLoggingPayload
 
 MAX_S3_FILENAME_STEM_LENGTH = 250
+
+
+def _long_filename_suffix(s3_file_name: str) -> str:
+    encoded_file_name = s3_file_name.encode("utf-8")
+    # Keep the suffix deterministic for collision avoidance without using a cryptographic hash.
+    return (
+        f"{zlib.crc32(encoded_file_name) & 0xFFFFFFFF:08x}"
+        f"{zlib.adler32(encoded_file_name) & 0xFFFFFFFF:08x}"
+    )
 
 
 class S3Logger:
@@ -189,9 +198,9 @@ def get_s3_object_key(
     s3_file_name: str,
 ) -> str:
     if len(s3_file_name) > MAX_S3_FILENAME_STEM_LENGTH:
-        digest = hashlib.sha256(s3_file_name.encode("utf-8")).hexdigest()[:16]
-        prefix_length = MAX_S3_FILENAME_STEM_LENGTH - len(digest) - 1
-        s3_file_name = f"{s3_file_name[:prefix_length]}_{digest}"
+        suffix = _long_filename_suffix(s3_file_name)
+        prefix_length = MAX_S3_FILENAME_STEM_LENGTH - len(suffix) - 1
+        s3_file_name = f"{s3_file_name[:prefix_length]}_{suffix}"
 
     s3_object_key = (
         (s3_path.rstrip("/") + "/" if s3_path else "")

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -1,12 +1,15 @@
 #### What this does ####
 #    On success + failure, log events to Supabase
 
+import hashlib
 from datetime import datetime
 from typing import Optional, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.types.utils import StandardLoggingPayload
+
+MAX_S3_FILENAME_COMPONENT_LENGTH = 250
 
 
 class S3Logger:
@@ -185,6 +188,11 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
+    if len(s3_file_name) > MAX_S3_FILENAME_COMPONENT_LENGTH:
+        digest = hashlib.sha256(s3_file_name.encode("utf-8")).hexdigest()[:16]
+        prefix_length = MAX_S3_FILENAME_COMPONENT_LENGTH - len(digest) - 1
+        s3_file_name = f"{s3_file_name[:prefix_length]}_{digest}"
+
     s3_object_key = (
         (s3_path.rstrip("/") + "/" if s3_path else "")
         + prefix

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs["structured_messages"] = (
-                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
-                )
+                inputs[
+                    "structured_messages"
+                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -904,6 +904,24 @@ def test_get_s3_object_key_truncates_long_filename_components():
     assert filename.startswith(f"time-{start_time.strftime('%H-%M-%S-%f')}_resp_")
 
 
+def test_get_s3_object_key_uses_deterministic_suffixes_for_long_filename_components():
+    start_time = datetime(2026, 3, 26, 12, 51, 27, 995047)
+    shared_prefix = "resp_" + ("a" * 400)
+    first_file_name = f"time-{start_time.strftime('%H-%M-%S-%f')}_{shared_prefix}first"
+    second_file_name = (
+        f"time-{start_time.strftime('%H-%M-%S-%f')}_{shared_prefix}second"
+    )
+
+    first_key = get_s3_object_key("", "", start_time, first_file_name)
+    first_key_again = get_s3_object_key("", "", start_time, first_file_name)
+    second_key = get_s3_object_key("", "", start_time, second_file_name)
+
+    assert first_key == first_key_again
+    assert first_key != second_key
+    assert len(first_key.split("/")[-1]) <= 255
+    assert len(second_key.split("/")[-1]) <= 255
+
+
 def test_create_s3_batch_logging_element_limits_long_ids():
     start_time = datetime(2026, 3, 26, 12, 51, 27, 995047)
     long_response_id = "resp_" + ("a" * 400)

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from litellm.integrations.s3 import get_s3_object_key
 from litellm.integrations.s3_v2 import S3Logger
 from litellm.types.utils import StandardLoggingPayload
 
@@ -25,8 +26,8 @@ class TestS3V2UnitTests:
             "json.dumps(" not in source_code
         ), "S3 v2 should not use json.dumps directly"
 
-    @patch('asyncio.create_task')
-    @patch('litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush')
+    @patch("asyncio.create_task")
+    @patch("litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush")
     def test_s3_v2_endpoint_url(self, mock_periodic_flush, mock_create_task):
         """testing s3 endpoint url"""
         from unittest.mock import AsyncMock, MagicMock
@@ -46,7 +47,7 @@ class TestS3V2UnitTests:
         test_element = s3BatchLoggingElement(
             s3_object_key="2025-09-14/test-key.json",
             payload={"test": "data"},
-            s3_object_download_filename="test-file.json"
+            s3_object_download_filename="test-file.json",
         )
 
         # Test 1: Custom endpoint URL with bucket name
@@ -55,7 +56,7 @@ class TestS3V2UnitTests:
             s3_endpoint_url="https://s3.amazonaws.com",
             s3_aws_access_key_id="test-key",
             s3_aws_secret_access_key="test-secret",
-            s3_region_name="us-east-1"
+            s3_region_name="us-east-1",
         )
 
         s3_logger.async_httpx_client = AsyncMock()
@@ -75,7 +76,7 @@ class TestS3V2UnitTests:
             s3_endpoint_url="https://minio.example.com:9000",
             s3_aws_access_key_id="minio-key",
             s3_aws_secret_access_key="minio-secret",
-            s3_region_name="us-east-1"
+            s3_region_name="us-east-1",
         )
 
         s3_logger_minio.async_httpx_client = AsyncMock()
@@ -86,15 +87,19 @@ class TestS3V2UnitTests:
         call_args_minio = s3_logger_minio.async_httpx_client.put.call_args
         assert call_args_minio is not None
         url_minio = call_args_minio[0][0]
-        expected_minio_url = "https://minio.example.com:9000/litellm-logs/2025-09-14/test-key.json"
-        assert url_minio == expected_minio_url, f"Expected MinIO URL {expected_minio_url}, got {url_minio}"
+        expected_minio_url = (
+            "https://minio.example.com:9000/litellm-logs/2025-09-14/test-key.json"
+        )
+        assert (
+            url_minio == expected_minio_url
+        ), f"Expected MinIO URL {expected_minio_url}, got {url_minio}"
 
         # Test 3: Custom endpoint without bucket name (should fall back to default)
         s3_logger_no_bucket = S3Logger(
             s3_endpoint_url="https://s3.amazonaws.com",
             s3_aws_access_key_id="test-key",
             s3_aws_secret_access_key="test-secret",
-            s3_region_name="us-east-1"
+            s3_region_name="us-east-1",
         )
 
         s3_logger_no_bucket.async_httpx_client = AsyncMock()
@@ -117,20 +122,27 @@ class TestS3V2UnitTests:
             s3_endpoint_url="https://custom.s3.endpoint.com",
             s3_aws_access_key_id="sync-key",
             s3_aws_secret_access_key="sync-secret",
-            s3_region_name="us-east-1"
+            s3_region_name="us-east-1",
         )
 
         mock_sync_client = MagicMock()
         mock_sync_client.put.return_value = mock_response
 
-        with patch('litellm.integrations.s3_v2._get_httpx_client', return_value=mock_sync_client):
+        with patch(
+            "litellm.integrations.s3_v2._get_httpx_client",
+            return_value=mock_sync_client,
+        ):
             s3_logger_sync.upload_data_to_s3(test_element)
 
             call_args_sync = mock_sync_client.put.call_args
             assert call_args_sync is not None
             url_sync = call_args_sync[0][0]
-            expected_sync_url = "https://custom.s3.endpoint.com/sync-bucket/2025-09-14/test-key.json"
-            assert url_sync == expected_sync_url, f"Expected sync URL {expected_sync_url}, got {url_sync}"
+            expected_sync_url = (
+                "https://custom.s3.endpoint.com/sync-bucket/2025-09-14/test-key.json"
+            )
+            assert (
+                url_sync == expected_sync_url
+            ), f"Expected sync URL {expected_sync_url}, got {url_sync}"
 
         # Test 5: Download method with custom endpoint
         s3_logger_download = S3Logger(
@@ -138,7 +150,7 @@ class TestS3V2UnitTests:
             s3_endpoint_url="https://download.s3.endpoint.com",
             s3_aws_access_key_id="download-key",
             s3_aws_secret_access_key="download-secret",
-            s3_region_name="us-east-1"
+            s3_region_name="us-east-1",
         )
 
         mock_download_response = MagicMock()
@@ -147,18 +159,24 @@ class TestS3V2UnitTests:
         s3_logger_download.async_httpx_client = AsyncMock()
         s3_logger_download.async_httpx_client.get.return_value = mock_download_response
 
-        result = asyncio.run(s3_logger_download._download_object_from_s3("2025-09-14/download-test-key.json"))
+        result = asyncio.run(
+            s3_logger_download._download_object_from_s3(
+                "2025-09-14/download-test-key.json"
+            )
+        )
 
         call_args_download = s3_logger_download.async_httpx_client.get.call_args
         assert call_args_download is not None
         url_download = call_args_download[0][0]
         expected_download_url = "https://download.s3.endpoint.com/download-bucket/2025-09-14/download-test-key.json"
-        assert url_download == expected_download_url, f"Expected download URL {expected_download_url}, got {url_download}"
+        assert (
+            url_download == expected_download_url
+        ), f"Expected download URL {expected_download_url}, got {url_download}"
 
         assert result == {"downloaded": "data"}
 
-    @patch('asyncio.create_task')
-    @patch('litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush')
+    @patch("asyncio.create_task")
+    @patch("litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush")
     def test_s3_v2_virtual_hosted_style(self, mock_periodic_flush, mock_create_task):
         """Test s3_use_virtual_hosted_style parameter for virtual-hosted-style URLs"""
         from unittest.mock import AsyncMock, MagicMock
@@ -178,7 +196,7 @@ class TestS3V2UnitTests:
         test_element = s3BatchLoggingElement(
             s3_object_key="2025-09-14/test-key.json",
             payload={"test": "data"},
-            s3_object_download_filename="test-file.json"
+            s3_object_download_filename="test-file.json",
         )
 
         # Test 1: Virtual-hosted-style with custom endpoint
@@ -188,7 +206,7 @@ class TestS3V2UnitTests:
             s3_aws_access_key_id="test-key",
             s3_aws_secret_access_key="test-secret",
             s3_region_name="us-east-1",
-            s3_use_virtual_hosted_style=True
+            s3_use_virtual_hosted_style=True,
         )
 
         s3_logger_virtual.async_httpx_client = AsyncMock()
@@ -199,8 +217,12 @@ class TestS3V2UnitTests:
         call_args = s3_logger_virtual.async_httpx_client.put.call_args
         assert call_args is not None
         url = call_args[0][0]
-        expected_url = "https://test-bucket.s3.custom-endpoint.com/2025-09-14/test-key.json"
-        assert url == expected_url, f"Expected virtual-hosted-style URL {expected_url}, got {url}"
+        expected_url = (
+            "https://test-bucket.s3.custom-endpoint.com/2025-09-14/test-key.json"
+        )
+        assert (
+            url == expected_url
+        ), f"Expected virtual-hosted-style URL {expected_url}, got {url}"
 
         # Test 2: Path-style (default behavior with s3_use_virtual_hosted_style=False)
         s3_logger_path = S3Logger(
@@ -209,7 +231,7 @@ class TestS3V2UnitTests:
             s3_aws_access_key_id="test-key",
             s3_aws_secret_access_key="test-secret",
             s3_region_name="us-east-1",
-            s3_use_virtual_hosted_style=False
+            s3_use_virtual_hosted_style=False,
         )
 
         s3_logger_path.async_httpx_client = AsyncMock()
@@ -220,8 +242,12 @@ class TestS3V2UnitTests:
         call_args_path = s3_logger_path.async_httpx_client.put.call_args
         assert call_args_path is not None
         url_path = call_args_path[0][0]
-        expected_path_url = "https://s3.custom-endpoint.com/test-bucket/2025-09-14/test-key.json"
-        assert url_path == expected_path_url, f"Expected path-style URL {expected_path_url}, got {url_path}"
+        expected_path_url = (
+            "https://s3.custom-endpoint.com/test-bucket/2025-09-14/test-key.json"
+        )
+        assert (
+            url_path == expected_path_url
+        ), f"Expected path-style URL {expected_path_url}, got {url_path}"
 
         # Test 3: Virtual-hosted-style with http protocol
         s3_logger_http = S3Logger(
@@ -230,7 +256,7 @@ class TestS3V2UnitTests:
             s3_aws_access_key_id="minio-key",
             s3_aws_secret_access_key="minio-secret",
             s3_region_name="us-east-1",
-            s3_use_virtual_hosted_style=True
+            s3_use_virtual_hosted_style=True,
         )
 
         s3_logger_http.async_httpx_client = AsyncMock()
@@ -241,8 +267,12 @@ class TestS3V2UnitTests:
         call_args_http = s3_logger_http.async_httpx_client.put.call_args
         assert call_args_http is not None
         url_http = call_args_http[0][0]
-        expected_http_url = "http://http-bucket.minio.local:9000/2025-09-14/test-key.json"
-        assert url_http == expected_http_url, f"Expected virtual-hosted-style URL with http {expected_http_url}, got {url_http}"
+        expected_http_url = (
+            "http://http-bucket.minio.local:9000/2025-09-14/test-key.json"
+        )
+        assert (
+            url_http == expected_http_url
+        ), f"Expected virtual-hosted-style URL with http {expected_http_url}, got {url_http}"
 
         # Test 4: Sync upload method with virtual-hosted-style
         s3_logger_sync_virtual = S3Logger(
@@ -251,20 +281,27 @@ class TestS3V2UnitTests:
             s3_aws_access_key_id="sync-key",
             s3_aws_secret_access_key="sync-secret",
             s3_region_name="us-east-1",
-            s3_use_virtual_hosted_style=True
+            s3_use_virtual_hosted_style=True,
         )
 
         mock_sync_client = MagicMock()
         mock_sync_client.put.return_value = mock_response
 
-        with patch('litellm.integrations.s3_v2._get_httpx_client', return_value=mock_sync_client):
+        with patch(
+            "litellm.integrations.s3_v2._get_httpx_client",
+            return_value=mock_sync_client,
+        ):
             s3_logger_sync_virtual.upload_data_to_s3(test_element)
 
             call_args_sync = mock_sync_client.put.call_args
             assert call_args_sync is not None
             url_sync = call_args_sync[0][0]
-            expected_sync_url = "https://sync-bucket.storage.example.com/2025-09-14/test-key.json"
-            assert url_sync == expected_sync_url, f"Expected virtual-hosted-style sync URL {expected_sync_url}, got {url_sync}"
+            expected_sync_url = (
+                "https://sync-bucket.storage.example.com/2025-09-14/test-key.json"
+            )
+            assert (
+                url_sync == expected_sync_url
+            ), f"Expected virtual-hosted-style sync URL {expected_sync_url}, got {url_sync}"
 
         # Test 5: Download method with virtual-hosted-style
         s3_logger_download_virtual = S3Logger(
@@ -273,24 +310,33 @@ class TestS3V2UnitTests:
             s3_aws_access_key_id="download-key",
             s3_aws_secret_access_key="download-secret",
             s3_region_name="us-east-1",
-            s3_use_virtual_hosted_style=True
+            s3_use_virtual_hosted_style=True,
         )
 
         mock_download_response = MagicMock()
         mock_download_response.status_code = 200
         mock_download_response.json = MagicMock(return_value={"downloaded": "data"})
         s3_logger_download_virtual.async_httpx_client = AsyncMock()
-        s3_logger_download_virtual.async_httpx_client.get.return_value = mock_download_response
+        s3_logger_download_virtual.async_httpx_client.get.return_value = (
+            mock_download_response
+        )
 
-        result = asyncio.run(s3_logger_download_virtual._download_object_from_s3("2025-09-14/download-test-key.json"))
+        result = asyncio.run(
+            s3_logger_download_virtual._download_object_from_s3(
+                "2025-09-14/download-test-key.json"
+            )
+        )
 
         call_args_download = s3_logger_download_virtual.async_httpx_client.get.call_args
         assert call_args_download is not None
         url_download = call_args_download[0][0]
         expected_download_url = "https://download-bucket.download.endpoint.com/2025-09-14/download-test-key.json"
-        assert url_download == expected_download_url, f"Expected virtual-hosted-style download URL {expected_download_url}, got {url_download}"
+        assert (
+            url_download == expected_download_url
+        ), f"Expected virtual-hosted-style download URL {expected_download_url}, got {url_download}"
 
         assert result == {"downloaded": "data"}
+
 
 @pytest.mark.asyncio
 async def test_async_log_event_skips_when_standard_logging_object_missing():
@@ -334,7 +380,9 @@ async def test_async_log_event_skips_when_standard_logging_object_missing():
 
     # Nothing should have been queued (catches the case where code falls
     # through without returning and appends None to the queue)
-    assert len(logger.log_queue) == 0, "log_queue should be empty when standard_logging_object is missing"
+    assert (
+        len(logger.log_queue) == 0
+    ), "log_queue should be empty when standard_logging_object is missing"
 
 
 @pytest.mark.asyncio
@@ -347,15 +395,24 @@ async def test_strip_base64_removes_file_and_nontext_entries():
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "Hello world"},
-                    {"type": "image", "file": {"file_data": "data:image/png;base64,AAAA"}},
-                    {"type": "file", "file": {"file_data": "data:application/pdf;base64,BBBB"}},
+                    {
+                        "type": "image",
+                        "file": {"file_data": "data:image/png;base64,AAAA"},
+                    },
+                    {
+                        "type": "file",
+                        "file": {"file_data": "data:application/pdf;base64,BBBB"},
+                    },
                 ],
             },
             {
                 "role": "assistant",
                 "content": [
                     {"type": "text", "text": "Response"},
-                    {"type": "audio", "file": {"file_data": "data:audio/wav;base64,CCCC"}},
+                    {
+                        "type": "audio",
+                        "file": {"file_data": "data:audio/wav;base64,CCCC"},
+                    },
                 ],
             },
         ]
@@ -451,7 +508,7 @@ async def test_strip_base64_mixed_nested_objects():
 async def test_s3_verify_false_handling():
     """
     Test that s3_verify=False is properly handled and not treated as None.
-    
+
     This is a regression test for the bug where s3_verify=False was being
     ignored because 'False or s3_verify' would evaluate to s3_verify (None).
     """
@@ -469,25 +526,35 @@ async def test_s3_verify_false_handling():
         "s3_verify": False,  # This should NOT be ignored
         "s3_use_ssl": False,  # This should also NOT be ignored
     }
-    
-    with patch('asyncio.create_task'):
-        with patch('litellm.integrations.s3_v2.get_async_httpx_client') as mock_get_client:
+
+    with patch("asyncio.create_task"):
+        with patch(
+            "litellm.integrations.s3_v2.get_async_httpx_client"
+        ) as mock_get_client:
             mock_client = AsyncMock()
             mock_get_client.return_value = mock_client
-            
+
             # Create logger
             logger = S3Logger()
-            
+
             # Verify s3_verify is False, not None
-            assert logger.s3_verify is False, f"Expected s3_verify=False, got {logger.s3_verify}"
-            assert logger.s3_use_ssl is False, f"Expected s3_use_ssl=False, got {logger.s3_use_ssl}"
-            
+            assert (
+                logger.s3_verify is False
+            ), f"Expected s3_verify=False, got {logger.s3_verify}"
+            assert (
+                logger.s3_use_ssl is False
+            ), f"Expected s3_use_ssl=False, got {logger.s3_use_ssl}"
+
             # Verify that get_async_httpx_client was called with ssl_verify=False
             mock_get_client.assert_called_once()
             call_kwargs = mock_get_client.call_args.kwargs
-            assert 'params' in call_kwargs, "params should be passed to get_async_httpx_client"
-            assert call_kwargs['params'] == {'ssl_verify': False}, f"Expected ssl_verify=False in params, got {call_kwargs.get('params')}"
-    
+            assert (
+                "params" in call_kwargs
+            ), "params should be passed to get_async_httpx_client"
+            assert call_kwargs["params"] == {
+                "ssl_verify": False
+            }, f"Expected ssl_verify=False in params, got {call_kwargs.get('params')}"
+
     # Clean up
     litellm.s3_callback_params = None
 
@@ -508,27 +575,31 @@ async def test_s3_verify_none_handling():
         "s3_aws_secret_access_key": "test-secret",
         "s3_region_name": "us-east-1",
     }
-    
-    with patch('asyncio.create_task'):
-        with patch('litellm.integrations.s3_v2.get_async_httpx_client') as mock_get_client:
+
+    with patch("asyncio.create_task"):
+        with patch(
+            "litellm.integrations.s3_v2.get_async_httpx_client"
+        ) as mock_get_client:
             mock_client = AsyncMock()
             mock_get_client.return_value = mock_client
-            
+
             # Create logger without explicit s3_verify
             logger = S3Logger()
-            
+
             # Verify s3_verify is None (default)
-            assert logger.s3_verify is None, f"Expected s3_verify=None, got {logger.s3_verify}"
-            
+            assert (
+                logger.s3_verify is None
+            ), f"Expected s3_verify=None, got {logger.s3_verify}"
+
             # Verify that get_async_httpx_client was called
             mock_get_client.assert_called_once()
             call_kwargs = mock_get_client.call_args.kwargs
             # When s3_verify is None, params={'ssl_verify': None} which is fine - uses default behavior
             # The important thing is it's not False
-            if 'params' in call_kwargs and call_kwargs['params'] is not None:
-                assert call_kwargs['params'].get('ssl_verify') is None
+            if "params" in call_kwargs and call_kwargs["params"] is not None:
+                assert call_kwargs["params"].get("ssl_verify") is None
             # Either params is None or params={'ssl_verify': None} is acceptable
-    
+
     # Clean up
     litellm.s3_callback_params = None
 
@@ -537,7 +608,7 @@ async def test_s3_verify_none_handling():
 async def test_s3_verify_false_creates_httpx_client_with_verify_false():
     """
     Test that when s3_verify=False, the actual httpx client has verify=False.
-    
+
     This validates that ssl_verify=False flows through to the httpx.AsyncClient.
     """
     from unittest.mock import patch
@@ -553,22 +624,24 @@ async def test_s3_verify_false_creates_httpx_client_with_verify_false():
         "s3_region_name": "us-east-1",
         "s3_verify": False,
     }
-    
-    with patch('asyncio.create_task'):
+
+    with patch("asyncio.create_task"):
         # Create logger - this creates the httpx client
         logger = S3Logger()
-        
+
         # Verify the logger has s3_verify=False
         assert logger.s3_verify is False
-        
+
         # Check the actual httpx client has verify=False
         # The async_httpx_client.client is the actual httpx.AsyncClient
-        if hasattr(logger.async_httpx_client, 'client'):
+        if hasattr(logger.async_httpx_client, "client"):
             httpx_client = logger.async_httpx_client.client
             # Check the _verify attribute (httpx internal)
-            if hasattr(httpx_client, '_verify'):
-                assert httpx_client._verify is False, f"Expected httpx client _verify=False, got {httpx_client._verify}"
-    
+            if hasattr(httpx_client, "_verify"):
+                assert (
+                    httpx_client._verify is False
+                ), f"Expected httpx client _verify=False, got {httpx_client._verify}"
+
     # Clean up
     litellm.s3_callback_params = None
 
@@ -592,38 +665,40 @@ async def test_s3_verify_false_async_client():
         "s3_region_name": "us-east-1",
         "s3_verify": False,
     }
-    
-    with patch('asyncio.create_task'):
+
+    with patch("asyncio.create_task"):
         logger = S3Logger()
-        
+
         # Verify s3_verify is False
         assert logger.s3_verify is False
-        
+
         # Create test element
         test_element = s3BatchLoggingElement(
             s3_object_key="2025-11-03/test-key.json",
             payload={"test": "data"},
-            s3_object_download_filename="test-file.json"
+            s3_object_download_filename="test-file.json",
         )
-        
+
         # Mock the async httpx client's put method
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
         logger.async_httpx_client.put = AsyncMock(return_value=mock_response)
-        
+
         # Call async upload
         await logger.async_upload_data_to_s3(test_element)
-        
+
         # Verify put was called
         assert logger.async_httpx_client.put.called
-        
+
         # Check that the async httpx client was created with verify=False
-        if hasattr(logger.async_httpx_client, 'client'):
+        if hasattr(logger.async_httpx_client, "client"):
             httpx_client = logger.async_httpx_client.client
-            if hasattr(httpx_client, '_verify'):
-                assert httpx_client._verify is False, f"Expected async httpx client _verify=False, got {httpx_client._verify}"
-    
+            if hasattr(httpx_client, "_verify"):
+                assert (
+                    httpx_client._verify is False
+                ), f"Expected async httpx client _verify=False, got {httpx_client._verify}"
+
     # Clean up
     litellm.s3_callback_params = None
 
@@ -636,8 +711,14 @@ async def test_strip_base64_recursive_redaction():
             {
                 "content": [
                     {"type": "text", "text": "normal text"},
-                    {"type": "text", "text": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg"},
-                    {"type": "text", "text": "Nested: {'data': 'data:application/pdf;base64,AAA...'}"},
+                    {
+                        "type": "text",
+                        "text": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg",
+                    },
+                    {
+                        "type": "text",
+                        "text": "Nested: {'data': 'data:application/pdf;base64,AAA...'}",
+                    },
                     {"file": {"file_data": "data:application/pdf;base64,AAAA"}},
                     {"metadata": {"preview": "data:audio/mp3;base64,AAAAA=="}},
                 ]
@@ -653,12 +734,12 @@ async def test_strip_base64_recursive_redaction():
 
     # Base64 redacted globally
     import json
+
     for c in content:
         if isinstance(c, dict):
             s = json.dumps(c).lower()
             # "[base64_redacted]" is fine, but raw base64 is not
             assert "base64," not in s, f"Found real base64 blob in: {s}"
-
 
 
 # --------------------------------------------------------------
@@ -667,7 +748,13 @@ async def test_strip_base64_recursive_redaction():
 @pytest.fixture(autouse=True)
 def patch_asyncio_create_task():
     """Prevent 'no running event loop' errors when S3Logger calls asyncio.create_task()."""
-    with patch("asyncio.create_task"):
+
+    def _discard_task(coro):
+        if hasattr(coro, "close"):
+            coro.close()
+        return None
+
+    with patch("asyncio.create_task", side_effect=_discard_task):
         yield
 
 
@@ -687,7 +774,7 @@ def patch_asyncio_create_task():
     ],
 )
 def test_s3_object_key_prefix_combinations(
-        use_team_prefix, use_key_prefix, team_alias, key_alias, expected_prefix
+    use_team_prefix, use_key_prefix, team_alias, key_alias, expected_prefix
 ):
     """
     Validate correct S3 prefix composition for team alias + key alias combinations.
@@ -796,3 +883,43 @@ async def test_combined_prefix_reflects_in_s3_object_key():
     result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
     key = result.s3_object_key
     assert "myteam/apikey/" in key, f"Expected both prefixes in key: {key}"
+
+
+def test_get_s3_object_key_truncates_long_filename_components():
+    start_time = datetime(2026, 3, 26, 12, 51, 27, 995047)
+    long_response_id = "resp_" + ("a" * 400)
+    original_file_name = f"time-{start_time.strftime('%H-%M-%S-%f')}_{long_response_id}"
+
+    key = get_s3_object_key(
+        s3_path="",
+        prefix="",
+        start_time=start_time,
+        s3_file_name=original_file_name,
+    )
+    filename = key.split("/")[-1]
+
+    assert len(f"{original_file_name}.json") > 255
+    assert len(filename) <= 255
+    assert filename.endswith(".json")
+    assert filename.startswith(f"time-{start_time.strftime('%H-%M-%S-%f')}_resp_")
+
+
+def test_create_s3_batch_logging_element_limits_long_ids():
+    start_time = datetime(2026, 3, 26, 12, 51, 27, 995047)
+    long_response_id = "resp_" + ("a" * 400)
+    payload = StandardLoggingPayload(
+        id=long_response_id,
+        metadata={},
+        messages=[],
+    )
+
+    with patch(
+        "litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush",
+        return_value=None,
+    ):
+        logger = S3Logger()
+        result = logger.create_s3_batch_logging_element(start_time, payload)
+
+    assert result is not None
+    assert len(result.s3_object_key.split("/")[-1]) <= 255
+    assert result.s3_object_key.endswith(".json")

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -898,8 +898,8 @@ def test_get_s3_object_key_truncates_long_filename_components():
     )
     filename = key.split("/")[-1]
 
-    assert len(f"{original_file_name}.json") > 255
-    assert len(filename) <= 255
+    assert len(f"{original_file_name}.json".encode("utf-8")) > 255
+    assert len(filename.encode("utf-8")) <= 255
     assert filename.endswith(".json")
     assert filename.startswith(f"time-{start_time.strftime('%H-%M-%S-%f')}_resp_")
 
@@ -918,8 +918,23 @@ def test_get_s3_object_key_uses_deterministic_suffixes_for_long_filename_compone
 
     assert first_key == first_key_again
     assert first_key != second_key
-    assert len(first_key.split("/")[-1]) <= 255
-    assert len(second_key.split("/")[-1]) <= 255
+    assert len(first_key.split("/")[-1].encode("utf-8")) <= 255
+    assert len(second_key.split("/")[-1].encode("utf-8")) <= 255
+
+
+def test_get_s3_object_key_truncates_non_ascii_filename_components_by_utf8_bytes():
+    start_time = datetime(2026, 3, 26, 12, 51, 27, 995047)
+    long_response_id = "resp_" + ("漢" * 120)
+    original_file_name = f"time-{start_time.strftime('%H-%M-%S-%f')}_{long_response_id}"
+
+    key = get_s3_object_key("", "", start_time, original_file_name)
+    filename = key.split("/")[-1]
+
+    assert len(original_file_name) < 250
+    assert len(f"{original_file_name}.json".encode("utf-8")) > 255
+    assert len(filename.encode("utf-8")) <= 255
+    assert filename.endswith(".json")
+    assert filename.startswith(f"time-{start_time.strftime('%H-%M-%S-%f')}_resp_")
 
 
 def test_create_s3_batch_logging_element_limits_long_ids():
@@ -939,5 +954,5 @@ def test_create_s3_batch_logging_element_limits_long_ids():
         result = logger.create_s3_batch_logging_element(start_time, payload)
 
     assert result is not None
-    assert len(result.s3_object_key.split("/")[-1]) <= 255
+    assert len(result.s3_object_key.split("/")[-1].encode("utf-8")) <= 255
     assert result.s3_object_key.endswith(".json")


### PR DESCRIPTION
Fixes #24628.

## Summary
- cap the final S3 filename component to a filesystem-safe length inside `get_s3_object_key`
- preserve the readable time/id prefix while appending a deterministic hash suffix for overlong keys
- add regression coverage for direct key generation and `S3Logger.create_s3_batch_logging_element()` with very long response ids
- update the shared `asyncio.create_task` test fixture in `test_s3_v2.py` so discarded mocked coroutines are closed cleanly during these S3 logger tests

## Validation
- `python -m poetry run pytest tests/test_litellm/integrations/test_s3_v2.py -k "truncates_long_filename_components or limits_long_ids or combined_prefix_reflects_in_s3_object_key" -vv`
- `python -m poetry run black --check litellm/integrations/s3.py tests/test_litellm/integrations/test_s3_v2.py`