### PR TITLE
fix: use redis_kwargs host/port in cache ping health check (#24636)

### DIFF
--- a/litellm/proxy/caching_routes.py
+++ b/litellm/proxy/caching_routes.py
@@ -40,6 +40,11 @@ def _extract_cache_params() -> Dict[str, Any]:
         return {}
     try:
         cache_params = vars(litellm.cache.cache)
+        if cache_params.get("redis_kwargs"):
+            if not cache_params.get("host"):
+                cache_params["host"] = cache_params["redis_kwargs"].get("host")
+            if not cache_params.get("port"):
+                cache_params["port"] = cache_params["redis_kwargs"].get("port")
         cleaned_params = (
             HealthCheckCacheParams(**cache_params).model_dump() if cache_params else {}
         )

--- a/litellm/proxy/caching_routes.py
+++ b/litellm/proxy/caching_routes.py
@@ -39,7 +39,7 @@ def _extract_cache_params() -> Dict[str, Any]:
     if litellm.cache is None:
         return {}
     try:
-        cache_params = vars(litellm.cache.cache)
+        cache_params = dict(vars(litellm.cache.cache))
         if cache_params.get("redis_kwargs"):
             if not cache_params.get("host"):
                 cache_params["host"] = cache_params["redis_kwargs"].get("host")


### PR DESCRIPTION
Fixes #24636. The `/cache/ping` endpoint was returning `None` for `host` and `port` because it didn't fall back to the settings configured in `redis_kwargs`. This ensures the actual Redis host/port are displayed in the Admin UI.\n\n*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*\n\n