### PR TITLE
fix: truncate long response IDs in get_logging_id to prevent S3 filename too long errors (#24628)

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -150,7 +150,7 @@ class S3Logger:
                 "time-"
                 + start_time.strftime("%Y-%m-%dT%H-%M-%S-%f")
                 + "_"
-                + payload["id"]
+                + str(payload["id"])[:150]
                 + ".json"
             )
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7677,8 +7677,11 @@ def print_args_passed_to_litellm(original_function, args, kwargs):
 
 def get_logging_id(start_time, response_obj):
     try:
+        resp_id = response_obj.get("id")
+        if not resp_id:
+            return None
         response_id = (
-            "time-" + start_time.strftime("%H-%M-%S-%f") + "_" + str(response_obj.get("id"))[:150] if response_obj.get("id") else ""
+            "time-" + start_time.strftime("%H-%M-%S-%f") + "_" + str(resp_id)[:150]
         )
         return response_id
     except Exception:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7678,7 +7678,7 @@ def print_args_passed_to_litellm(original_function, args, kwargs):
 def get_logging_id(start_time, response_obj):
     try:
         response_id = (
-            "time-" + start_time.strftime("%H-%M-%S-%f") + "_" + response_obj.get("id")
+            "time-" + start_time.strftime("%H-%M-%S-%f") + "_" + str(response_obj.get("id"))[:150] if response_obj.get("id") else ""
         )
         return response_id
     except Exception:


### PR DESCRIPTION
Fixes #24628. When responses contain extremely long IDs, the generated S3 object key exceeds the 255-character filename limit enforced by OS/local S3 implementations like MinIO or rustfs, causing a `500 Internal Server Error`. This PR truncates the raw response ID to a maximum of 150 characters within `get_logging_id` to ensure safe, cross-platform filesystem limits.\n\n*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*