### PR TITLE
fix(bedrock): handle document content blocks in Converse API message conversion

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4741,7 +4741,9 @@ class BedrockConverseMessagesProcessor:
         source = element["source"]
         media_type: str = source["media_type"]
         data: str = source["data"]
-        doc_format = media_type.split("/")[1]
+        doc_format = BedrockImageProcessor._validate_format(
+            mime_type=media_type, image_format=media_type.split("/")[1]
+        )
 
         # Deterministic name using the same hashing pattern as _create_bedrock_block
         HASH_SAMPLE_BYTES = 64 * 1024

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4739,6 +4739,12 @@ class BedrockConverseMessagesProcessor:
         {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}
         """
         source = element["source"]
+        source_type = source.get("type")
+        if source_type != "base64":
+            raise ValueError(
+                f"Bedrock Converse only supports base64-encoded document sources, got '{source_type}'. "
+                "Please convert the document to base64 before sending to Bedrock."
+            )
         media_type: str = source["media_type"]
         data: str = source["data"]
         doc_format = BedrockImageProcessor._validate_format(

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3984,6 +3984,14 @@ def _convert_to_bedrock_tool_call_result(
                     tool_result_content_blocks.append(
                         BedrockToolResultContentBlock(image=_block["image"])
                     )
+            elif content["type"] == "document":
+                _doc_block = BedrockConverseMessagesProcessor._process_document_message(
+                    content
+                )
+                if "document" in _doc_block:
+                    tool_result_content_blocks.append(
+                        BedrockToolResultContentBlock(document=_doc_block["document"])
+                    )
 
     message.get("name", "")
     id = str(message.get("tool_call_id", str(uuid.uuid4())))
@@ -4439,6 +4447,11 @@ class BedrockConverseMessagesProcessor:
                                     message=cast(ChatCompletionFileObject, element)
                                 )
                                 _parts.append(_part)
+                            elif element["type"] == "document":
+                                _part = BedrockConverseMessagesProcessor._process_document_message(
+                                    element
+                                )
+                                _parts.append(_part)
                             _cache_point_block = (
                                 litellm.AmazonConverseConfig()._get_cache_point_block(
                                     message_block=cast(
@@ -4719,6 +4732,36 @@ class BedrockConverseMessagesProcessor:
         )
 
     @staticmethod
+    def _process_document_message(element: dict) -> BedrockContentBlock:
+        """Convert a document content block to a Bedrock DocumentBlock.
+
+        Handles the Anthropic-style document format:
+        {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "..."}}
+        """
+        source = element["source"]
+        media_type: str = source["media_type"]
+        data: str = source["data"]
+        doc_format = media_type.split("/")[1]
+
+        # Deterministic name using the same hashing pattern as _create_bedrock_block
+        HASH_SAMPLE_BYTES = 64 * 1024
+        normalized = "".join(data.split()).encode("utf-8")
+        sample = normalized[:HASH_SAMPLE_BYTES]
+        hasher = hashlib.sha256()
+        hasher.update(sample)
+        hasher.update(str(len(normalized)).encode("utf-8"))
+        content_hash = hasher.hexdigest()[:16]
+        document_name = f"Document_{content_hash}_{doc_format}"
+
+        return BedrockContentBlock(
+            document=BedrockDocumentBlock(
+                source=BedrockSourceBlock(bytes=data),
+                format=doc_format,
+                name=document_name,
+            )
+        )
+
+    @staticmethod
     def add_thinking_blocks_to_assistant_content(
         thinking_blocks: List[BedrockContentBlock],
         assistant_parts: List[BedrockContentBlock],
@@ -4813,6 +4856,11 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                                 BedrockConverseMessagesProcessor._process_file_message(
                                     message=cast(ChatCompletionFileObject, element)
                                 )
+                            )
+                            _parts.append(_part)
+                        elif element["type"] == "document":
+                            _part = BedrockConverseMessagesProcessor._process_document_message(
+                                element
                             )
                             _parts.append(_part)
                         _cache_point_block = (

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2508,3 +2508,26 @@ def test_bedrock_converse_messages_pt_document_deterministic_name():
     name1 = result1[0]["content"][0]["document"]["name"]
     name2 = result2[0]["content"][0]["document"]["name"]
     assert name1 == name2
+
+
+def test_bedrock_converse_messages_pt_document_rejects_url_source():
+    """Test that a URL-type document source raises a clear error instead of KeyError."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "url",
+                        "url": "https://example.com/doc.pdf",
+                    },
+                },
+            ],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="only supports base64-encoded"):
+        _bedrock_converse_messages_pt(
+            messages, "anthropic.claude-sonnet-4-6", "bedrock"
+        )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2444,9 +2444,11 @@ def test_bedrock_converse_messages_pt_document_various_formats():
         ("application/pdf", "pdf"),
         ("text/csv", "csv"),
         ("text/html", "html"),
+        ("text/plain", "txt"),
+        ("text/markdown", "md"),
         (
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            "vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "docx",
         ),
     ]
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -9,8 +9,10 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     BAD_MESSAGE_ERROR_STR,
     BedrockConverseMessagesProcessor,
     BedrockImageProcessor,
-    anthropic_messages_pt,
+    _bedrock_converse_messages_pt,
     _convert_to_bedrock_tool_call_invoke,
+    _convert_to_bedrock_tool_call_result,
+    anthropic_messages_pt,
     convert_to_gemini_tool_call_result,
     ollama_pt,
     sanitize_messages_for_tool_calling,
@@ -2339,3 +2341,168 @@ def test_anthropic_messages_pt_file_block_preserves_cache_control():
     assert text_block["type"] == "text"
     assert "cache_control" in text_block
     assert text_block["cache_control"]["type"] == "ephemeral"
+
+
+def test_bedrock_converse_messages_pt_document_block():
+    """Test that a document content block is converted to a Bedrock DocumentBlock."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "dGVzdA==",
+                    },
+                },
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    assert len(result) == 1
+    content = result[0]["content"]
+    assert len(content) == 1
+
+    doc_block = content[0]
+    assert "document" in doc_block
+    assert doc_block["document"]["format"] == "pdf"
+    assert doc_block["document"]["source"]["bytes"] == "dGVzdA=="
+    assert doc_block["document"]["name"].startswith("Document_")
+    assert doc_block["document"]["name"].endswith("_pdf")
+
+
+def test_bedrock_converse_messages_pt_document_and_text():
+    """Test that mixed document + text content produces both blocks."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "dGVzdA==",
+                    },
+                },
+                {"type": "text", "text": "What is the title?"},
+            ],
+        }
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    content = result[0]["content"]
+    assert len(content) == 2
+
+    doc_block = content[0]
+    assert "document" in doc_block
+    assert doc_block["document"]["format"] == "pdf"
+
+    text_block = content[1]
+    assert "text" in text_block
+    assert text_block["text"] == "What is the title?"
+
+
+def test_bedrock_converse_messages_pt_document_in_tool_result():
+    """Test that a tool result containing a document block is converted correctly."""
+    message = {
+        "role": "tool",
+        "tool_call_id": "tool_123",
+        "content": [
+            {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "dGVzdA==",
+                },
+            },
+        ],
+    }
+
+    result = _convert_to_bedrock_tool_call_result(message)
+
+    tool_result = result["toolResult"]
+    assert len(tool_result["content"]) == 1
+    assert "document" in tool_result["content"][0]
+    assert tool_result["content"][0]["document"]["format"] == "pdf"
+    assert tool_result["content"][0]["document"]["source"]["bytes"] == "dGVzdA=="
+
+
+def test_bedrock_converse_messages_pt_document_various_formats():
+    """Test that various document media types produce the correct format value."""
+    test_cases = [
+        ("application/pdf", "pdf"),
+        ("text/csv", "csv"),
+        ("text/html", "html"),
+        (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+    ]
+
+    for media_type, expected_format in test_cases:
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": "dGVzdA==",
+                        },
+                    },
+                ],
+            }
+        ]
+
+        result = _bedrock_converse_messages_pt(
+            messages, "anthropic.claude-sonnet-4-6", "bedrock"
+        )
+
+        doc_block = result[0]["content"][0]
+        assert doc_block["document"]["format"] == expected_format, (
+            f"Expected format '{expected_format}' for media_type '{media_type}', "
+            f"got '{doc_block['document']['format']}'"
+        )
+
+
+def test_bedrock_converse_messages_pt_document_deterministic_name():
+    """Test that the same document data always produces the same name."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "dGVzdA==",
+                    },
+                },
+            ],
+        }
+    ]
+
+    result1 = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+    result2 = _bedrock_converse_messages_pt(
+        messages, "anthropic.claude-sonnet-4-6", "bedrock"
+    )
+
+    name1 = result1[0]["content"][0]["document"]["name"]
+    name2 = result2[0]["content"][0]["document"]["name"]
+    assert name1 == name2


### PR DESCRIPTION
## Relevant issues

Fixes #24641

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`document` content blocks (used for PDF support via Anthropic's API format) were **silently dropped** during Bedrock Converse API message conversion. The content block processing loop in `_bedrock_converse_messages_pt()` handled `text`, `image_url`, and `file` types but had no branch for `document` — blocks were skipped without any warning.

This meant sending a PDF to `bedrock/anthropic.claude-*` would result in the model responding as if no document was provided (~24 prompt tokens instead of ~47,000), while the same message worked correctly with `anthropic/claude-*`.

### Root cause

The `for element in message_block["content"]` loop in three locations lacked an `elif element["type"] == "document"` branch:

1. **Sync user message processing** in `_bedrock_converse_messages_pt()`
2. **Async user message processing** in `_bedrock_converse_messages_pt_async()`
3. **Tool result conversion** in `_convert_to_bedrock_tool_call_result()`

### Fix

- Added `_process_document_message()` static method on `BedrockConverseMessagesProcessor` that converts `document` content blocks to Bedrock's `DocumentBlock` format (extracting `media_type` → `format`, `data` → `source.bytes`, and generating a deterministic document name using the same SHA-256 hashing pattern already used in `_create_bedrock_block()`)
- Added `elif element["type"] == "document"` branches in all three locations
- All existing Bedrock types (`DocumentBlock`, `SourceBlock`, `ContentBlock`, `ToolResultContentBlock`) already supported documents — no type changes needed

### Testing

Added 5 unit tests in `tests/test_litellm/`:

| Test | What it verifies |
|------|-----------------|
| `test_bedrock_converse_messages_pt_document_block` | Single document block produces correct `BedrockContentBlock` with `format`, `source.bytes`, and `name` |
| `test_bedrock_converse_messages_pt_document_and_text` | Mixed document + text content preserves both blocks (reproduces the exact scenario from #24641) |
| `test_bedrock_converse_messages_pt_document_in_tool_result` | Document in tool result produces correct `BedrockToolResultContentBlock` |
| `test_bedrock_converse_messages_pt_document_various_formats` | Multiple media types (`application/pdf`, `text/csv`, `text/html`, OOXML) all produce correct format values |
| `test_bedrock_converse_messages_pt_document_deterministic_name` | Same document data always produces the same deterministic name |

**Reproduction script from the issue now passes:**

```python
import litellm.litellm_core_utils.prompt_templates.factory as factory

messages = [{"role": "user", "content": [
    {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "dGVzdA=="}},
    {"type": "text", "text": "What is the title?"},
]}]

result = factory._bedrock_converse_messages_pt(messages, "anthropic.claude-sonnet-4-6", "bedrock")
print(result[0]["content"])
# Before: [{'text': 'What is the title?'}]                          — document dropped
# After:  [{'document': {'source': {'bytes': 'dGVzdA=='}, ...}},    — document preserved
#           {'text': 'What is the title?'}]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)