### PR TITLE
fix(bedrock): preserve document content blocks for Converse API (#24641)

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1727,9 +1727,9 @@ def convert_to_anthropic_tool_result(
                     text_content["cache_control"] = cache_control_value
                 anthropic_content_list.append(text_content)
             elif content["type"] == "document":
-                tool_result_content_blocks.append(
-                    BedrockToolResultContentBlock(document=content) # Assume it matches Bedrock structure or Anthropic fallback
-                )
+                # Remove 'type' key from content dict to pass to Anthropic / Bedrock block
+                doc_content = {k: v for k, v in content.items() if k != "type"}
+                anthropic_content_list.append(doc_content)
             elif content["type"] == "image_url":
                 format = (
                     content["image_url"].get("format")
@@ -3974,9 +3974,9 @@ def _convert_to_bedrock_tool_call_result(
                     BedrockToolResultContentBlock(text=content["text"])
                 )
             elif content["type"] == "document":
-                tool_result_content_blocks.append(
-                    BedrockToolResultContentBlock(document=content) # Assume it matches Bedrock structure or Anthropic fallback
-                )
+                # Remove 'type' key from content dict to pass to Anthropic / Bedrock block
+                doc_content = {k: v for k, v in content.items() if k != "type"}
+                anthropic_content_list.append(doc_content)
             elif content["type"] == "image_url":
                 format: Optional[str] = None
                 if isinstance(content["image_url"], dict):
@@ -4432,7 +4432,8 @@ class BedrockConverseMessagesProcessor:
                                 )
                                 _parts.append(_part)
                             elif element["type"] == "document":
-                                _part = BedrockContentBlock(document=element) # Pass it through since element already has format, name, source
+                                doc_content = {k: v for k, v in element.items() if k != "type"}
+                                _part = BedrockContentBlock(document=doc_content)
                                 _parts.append(_part)
                             elif element["type"] == "image_url":
                                 format: Optional[str] = None
@@ -4604,7 +4605,8 @@ class BedrockConverseMessagesProcessor:
                                     )
                                     assistants_parts.append(assistants_part)
                             elif element["type"] == "document":
-                                _part = BedrockContentBlock(document=element) # Pass it through since element already has format, name, source
+                                doc_content = {k: v for k, v in element.items() if k != "type"}
+                                _part = BedrockContentBlock(document=doc_content)
                                 _parts.append(_part)
                             elif element["type"] == "image_url":
                                 if isinstance(element["image_url"], dict):

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1727,8 +1727,8 @@ def convert_to_anthropic_tool_result(
                     text_content["cache_control"] = cache_control_value
                 anthropic_content_list.append(text_content)
             elif content["type"] == "document":
-                doc_content = {k: v for k, v in content.items() if k != "type"}
-                anthropic_content_list.append(doc_content)
+                # Do NOT strip type for Anthropic; it is Required
+                anthropic_content_list.append(content)
             elif content["type"] == "image_url":
                 format = (
                     content["image_url"].get("format")
@@ -3974,7 +3974,9 @@ def _convert_to_bedrock_tool_call_result(
                 )
             elif content["type"] == "document":
                 doc_content = {k: v for k, v in content.items() if k != "type"}
-                anthropic_content_list.append(doc_content)
+                tool_result_content_blocks.append(
+                    BedrockToolResultContentBlock(document=doc_content)
+                )
             elif content["type"] == "image_url":
                 format: Optional[str] = None
                 if isinstance(content["image_url"], dict):

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1727,9 +1727,10 @@ def convert_to_anthropic_tool_result(
                     text_content["cache_control"] = cache_control_value
                 anthropic_content_list.append(text_content)
             elif content["type"] == "document":
-                # Remove 'type' key from content dict to pass to Anthropic / Bedrock block
                 doc_content = {k: v for k, v in content.items() if k != "type"}
-                anthropic_content_list.append(doc_content)
+                tool_result_content_blocks.append(
+                    BedrockToolResultContentBlock(document=doc_content)
+                )
             elif content["type"] == "image_url":
                 format = (
                     content["image_url"].get("format")
@@ -3974,9 +3975,10 @@ def _convert_to_bedrock_tool_call_result(
                     BedrockToolResultContentBlock(text=content["text"])
                 )
             elif content["type"] == "document":
-                # Remove 'type' key from content dict to pass to Anthropic / Bedrock block
                 doc_content = {k: v for k, v in content.items() if k != "type"}
-                anthropic_content_list.append(doc_content)
+                tool_result_content_blocks.append(
+                    BedrockToolResultContentBlock(document=doc_content)
+                )
             elif content["type"] == "image_url":
                 format: Optional[str] = None
                 if isinstance(content["image_url"], dict):
@@ -4433,8 +4435,8 @@ class BedrockConverseMessagesProcessor:
                                 _parts.append(_part)
                             elif element["type"] == "document":
                                 doc_content = {k: v for k, v in element.items() if k != "type"}
-                                _part = BedrockContentBlock(document=doc_content)
-                                _parts.append(_part)
+                                assistants_part = BedrockContentBlock(document=doc_content)
+                                assistants_parts.append(assistants_part)
                             elif element["type"] == "image_url":
                                 format: Optional[str] = None
                                 if isinstance(element["image_url"], dict):
@@ -4606,8 +4608,8 @@ class BedrockConverseMessagesProcessor:
                                     assistants_parts.append(assistants_part)
                             elif element["type"] == "document":
                                 doc_content = {k: v for k, v in element.items() if k != "type"}
-                                _part = BedrockContentBlock(document=doc_content)
-                                _parts.append(_part)
+                                assistants_part = BedrockContentBlock(document=doc_content)
+                                assistants_parts.append(assistants_part)
                             elif element["type"] == "image_url":
                                 if isinstance(element["image_url"], dict):
                                     image_url = element["image_url"]["url"]

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1726,6 +1726,10 @@ def convert_to_anthropic_tool_result(
                 if cache_control_value is not None:
                     text_content["cache_control"] = cache_control_value
                 anthropic_content_list.append(text_content)
+            elif content["type"] == "document":
+                tool_result_content_blocks.append(
+                    BedrockToolResultContentBlock(document=content) # Assume it matches Bedrock structure or Anthropic fallback
+                )
             elif content["type"] == "image_url":
                 format = (
                     content["image_url"].get("format")
@@ -3969,6 +3973,10 @@ def _convert_to_bedrock_tool_call_result(
                 tool_result_content_blocks.append(
                     BedrockToolResultContentBlock(text=content["text"])
                 )
+            elif content["type"] == "document":
+                tool_result_content_blocks.append(
+                    BedrockToolResultContentBlock(document=content) # Assume it matches Bedrock structure or Anthropic fallback
+                )
             elif content["type"] == "image_url":
                 format: Optional[str] = None
                 if isinstance(content["image_url"], dict):
@@ -4423,6 +4431,9 @@ class BedrockConverseMessagesProcessor:
                                     guardContent={"text": {"text": element["text"]}}
                                 )
                                 _parts.append(_part)
+                            elif element["type"] == "document":
+                                _part = BedrockContentBlock(document=element) # Pass it through since element already has format, name, source
+                                _parts.append(_part)
                             elif element["type"] == "image_url":
                                 format: Optional[str] = None
                                 if isinstance(element["image_url"], dict):
@@ -4592,6 +4603,9 @@ class BedrockConverseMessagesProcessor:
                                         text=element["text"]
                                     )
                                     assistants_parts.append(assistants_part)
+                            elif element["type"] == "document":
+                                _part = BedrockContentBlock(document=element) # Pass it through since element already has format, name, source
+                                _parts.append(_part)
                             elif element["type"] == "image_url":
                                 if isinstance(element["image_url"], dict):
                                     image_url = element["image_url"]["url"]

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1728,9 +1728,7 @@ def convert_to_anthropic_tool_result(
                 anthropic_content_list.append(text_content)
             elif content["type"] == "document":
                 doc_content = {k: v for k, v in content.items() if k != "type"}
-                tool_result_content_blocks.append(
-                    BedrockToolResultContentBlock(document=doc_content)
-                )
+                anthropic_content_list.append(doc_content)
             elif content["type"] == "image_url":
                 format = (
                     content["image_url"].get("format")
@@ -3976,9 +3974,7 @@ def _convert_to_bedrock_tool_call_result(
                 )
             elif content["type"] == "document":
                 doc_content = {k: v for k, v in content.items() if k != "type"}
-                tool_result_content_blocks.append(
-                    BedrockToolResultContentBlock(document=doc_content)
-                )
+                anthropic_content_list.append(doc_content)
             elif content["type"] == "image_url":
                 format: Optional[str] = None
                 if isinstance(content["image_url"], dict):
@@ -4435,8 +4431,8 @@ class BedrockConverseMessagesProcessor:
                                 _parts.append(_part)
                             elif element["type"] == "document":
                                 doc_content = {k: v for k, v in element.items() if k != "type"}
-                                assistants_part = BedrockContentBlock(document=doc_content)
-                                assistants_parts.append(assistants_part)
+                                _part = BedrockContentBlock(document=doc_content)
+                                _parts.append(_part)
                             elif element["type"] == "image_url":
                                 format: Optional[str] = None
                                 if isinstance(element["image_url"], dict):


### PR DESCRIPTION
Fixes #24641.\n\nLiteLLM currently drops `document` content blocks when converting messages to the Bedrock Converse API format because `_bedrock_converse_messages_pt` and `_convert_to_bedrock_tool_call_result` only process `text`, `guarded_text`, and `image_url` types. This prevents the model from accessing passed PDF attachments.\n\nThis patch explicitly checks for and passes through `document` type blocks by wrapping them into valid Bedrock Content structures, both for standard user messages and within tool results.