### PR TITLE
fix(anthropic): strip undocumented keys from metadata before sending to API

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1421,6 +1421,16 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         ):
             optional_params["metadata"] = {"user_id": _litellm_metadata["user_id"]}
 
+        ## Ensure metadata only contains user_id (only documented field in Anthropic Messages API)
+        if "metadata" in optional_params and isinstance(
+            optional_params["metadata"], dict
+        ):
+            _user_id = optional_params["metadata"].get("user_id")
+            if _user_id is not None:
+                optional_params["metadata"] = {"user_id": _user_id}
+            else:
+                optional_params.pop("metadata")
+
         # Remove internal LiteLLM parameters that should not be sent to Anthropic API
         optional_params.pop("is_vertex_request", None)
 

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -1800,3 +1800,81 @@ def test_anthropic_structured_output_chat_completion_api():
     )
     assert response is not None
     print(f"response: {response}")
+
+
+def _make_transform_request(optional_params: dict, litellm_params: dict) -> dict:
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    return AnthropicConfig().transform_request(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params=litellm_params,
+        headers={},
+    )
+
+
+def test_metadata_only_user_id_passes_through():
+    """metadata with only user_id is forwarded as-is."""
+    data = _make_transform_request(
+        optional_params={"metadata": {"user_id": "abc123"}},
+        litellm_params={},
+    )
+    assert data.get("metadata") == {"user_id": "abc123"}
+
+
+def test_metadata_extra_keys_are_stripped():
+    """Extra keys in metadata are removed; only user_id is sent."""
+    data = _make_transform_request(
+        optional_params={"metadata": {"user_id": "abc123", "extra_key": "val"}},
+        litellm_params={},
+    )
+    assert data.get("metadata") == {"user_id": "abc123"}
+
+
+def test_metadata_without_user_id_is_dropped():
+    """metadata with no user_id is removed entirely."""
+    data = _make_transform_request(
+        optional_params={"metadata": {"only_other_key": "val"}},
+        litellm_params={},
+    )
+    assert "metadata" not in data
+
+
+def test_metadata_user_id_from_litellm_params_strips_extras():
+    """user_id from litellm_params metadata is extracted; extra keys are not forwarded."""
+    data = _make_transform_request(
+        optional_params={},
+        litellm_params={"metadata": {"user_id": "abc123", "trace_id": "xyz"}},
+    )
+    assert data.get("metadata") == {"user_id": "abc123"}
+
+
+def test_metadata_filter_applies_to_vertex_anthropic():
+    """VertexAIAnthropicConfig inherits the metadata filter."""
+    from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.transformation import (
+        VertexAIAnthropicConfig,
+    )
+
+    data = VertexAIAnthropicConfig().transform_request(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"metadata": {"user_id": "u1", "extra": "drop_me"}},
+        litellm_params={},
+        headers={},
+    )
+    assert data.get("metadata") == {"user_id": "u1"}
+
+
+def test_metadata_filter_applies_to_azure_anthropic():
+    """AzureAnthropicConfig inherits the metadata filter."""
+    from litellm.llms.azure_ai.anthropic.transformation import AzureAnthropicConfig
+
+    data = AzureAnthropicConfig().transform_request(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"metadata": {"user_id": "u2", "extra": "drop_me"}},
+        litellm_params={},
+        headers={},
+    )
+    assert data.get("metadata") == {"user_id": "u2"}


### PR DESCRIPTION
## Summary

The Anthropic Messages API **only supports `user_id`** as a field inside the `metadata` object (per [official documentation](https://docs.anthropic.com/en/api/messages)). Passing any other key causes the API to return an error. The same constraint applies to Vertex AI Anthropic and Azure AI Anthropic, which share the same API contract.

This PR adds a final filter in `AnthropicConfig.transform_request()` that runs after all metadata sources are merged, ensuring only `{"user_id": <value>}` is forwarded — or `metadata` is dropped entirely if no `user_id` is present.

**Why this is needed:**
- The Anthropic API throws an error if any key other than `user_id` is present in `metadata`
- The official Anthropic documentation states only `user_id` is a valid field
- Previously, if `metadata` entered `optional_params` via any path other than the litellm-params handler (e.g., direct Anthropic param pass-through), extra keys would be forwarded unfiltered

**Providers covered:** Anthropic, Vertex AI Anthropic, Azure AI Anthropic — all three inherit from `AnthropicConfig`, so the single fix covers all of them.

<img width="1085" height="372" alt="image" src="https://github.com/user-attachments/assets/d21a5984-fcc5-4773-9e3b-bb904e03e940" />
<img width="1182" height="372" alt="image" src="https://github.com/user-attachments/assets/f943a6cf-db9d-4e5e-aa94-eb19e24f5283" />
