### PR TITLE
feat(gemini): add gemini-3.1-flash-live-preview to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -36831,15 +36831,18 @@
         "supports_audio_output": true
     },
     "gemini-3.1-flash-live-preview": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 1e-06,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_video_per_second": 3.3333333333333335e-05,
         "litellm_provider": "gemini",
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -36856,7 +36859,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "supports_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-native-audio-latest": {
         "input_cost_per_audio_token": 1e-06,
@@ -36937,15 +36941,18 @@
         "rpm": 10
     },
     "gemini/gemini-3.1-flash-live-preview": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 1e-06,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_video_per_second": 3.3333333333333335e-05,
         "litellm_provider": "gemini",
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -36963,6 +36970,7 @@
         "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_vision": true,
+        "supports_web_search": true,
         "tpm": 250000,
         "rpm": 10
     },

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -36830,6 +36830,34 @@
         "supports_audio_input": true,
         "supports_audio_output": true
     },
+    "gemini-3.1-flash-live-preview": {
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
     "gemini/gemini-2.5-flash-native-audio-latest": {
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -36905,6 +36933,36 @@
         ],
         "supports_audio_input": true,
         "supports_audio_output": true,
+        "tpm": 250000,
+        "rpm": 10
+    },
+    "gemini/gemini-3.1-flash-live-preview": {
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
         "tpm": 250000,
         "rpm": 10
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36831,15 +36831,18 @@
         "supports_audio_output": true
     },
     "gemini-3.1-flash-live-preview": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 1e-06,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_video_per_second": 3.3333333333333335e-05,
         "litellm_provider": "gemini",
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -36856,7 +36859,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "supports_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-native-audio-latest": {
         "input_cost_per_audio_token": 1e-06,
@@ -36937,15 +36941,18 @@
         "rpm": 10
     },
     "gemini/gemini-3.1-flash-live-preview": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_image_token": 1e-06,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_video_per_second": 3.3333333333333335e-05,
         "litellm_provider": "gemini",
         "max_input_tokens": 131072,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 4.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -36963,6 +36970,7 @@
         "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_vision": true,
+        "supports_web_search": true,
         "tpm": 250000,
         "rpm": 10
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36830,6 +36830,34 @@
         "supports_audio_input": true,
         "supports_audio_output": true
     },
+    "gemini-3.1-flash-live-preview": {
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
     "gemini/gemini-2.5-flash-native-audio-latest": {
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -36905,6 +36933,36 @@
         ],
         "supports_audio_input": true,
         "supports_audio_output": true,
+        "tpm": 250000,
+        "rpm": 10
+    },
+    "gemini/gemini-3.1-flash-live-preview": {
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/models",
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
         "tpm": 250000,
         "rpm": 10
     },

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -10,6 +10,7 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
 from litellm.types.llms.openai import OpenAIRealtimeStreamSessionEvents
 
@@ -227,3 +228,17 @@ def test_gemini_realtime_transformation_generation_complete():
             contains_audio_delta = True
             break
     assert contains_audio_delta, "Expected audio delta event"
+
+
+def test_gemini_3_1_flash_live_preview_model_cost_map_entry():
+    for key in (
+        "gemini-3.1-flash-live-preview",
+        "gemini/gemini-3.1-flash-live-preview",
+    ):
+        assert key in litellm.model_cost
+        info = litellm.model_cost[key]
+        assert "/v1/realtime" in info.get("supported_endpoints", [])
+        assert info.get("max_input_tokens") == 131072
+        assert info.get("max_output_tokens") == 65536
+        assert "video" in info.get("supported_modalities", [])
+        assert info.get("supports_function_calling") is True


### PR DESCRIPTION
## Summary
Register `gemini-3.1-flash-live-preview` and `gemini/gemini-3.1-flash-live-preview` for Google AI Studio Live API (\`/v1/realtime\`) with 131K input / 65K output context, multimodal inputs (text, image, audio, video), and audio+text outputs per Google model card.

## Changes
- `model_prices_and_context_window.json` and backup: new entries with pricing aligned to existing Gemini 2.5 Flash native audio preview rates (update when Google publishes distinct Live 3.1 pricing).
- Unit test asserts cost map keys, limits, realtime endpoint, and modalities.

## Testing
```bash
poetry run pytest tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py::test_gemini_3_1_flash_live_preview_model_cost_map_entry -v
```