### PR TITLE
fix(responses): translate `developer` role to `system` in Responses→Chat bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -206,7 +206,7 @@ class LiteLLMCompletionResponsesConfig:
             "parallel_tool_calls": responses_api_request.get("parallel_tool_calls"),
             "max_tokens": responses_api_request.get("max_output_tokens"),
             "stream": stream,
-            "metadata": kwargs.get("metadata"),
+            # NOTE: Responses API 'metadata' is for LiteLLM tracking only, not forwarded to providers
             "service_tier": kwargs.get("service_tier"),
             "web_search_options": web_search_options,
             "response_format": response_format,
@@ -922,9 +922,13 @@ class LiteLLMCompletionResponsesConfig:
             # Since guardrails skip None content anyway, we return empty list to exclude it from structured messages
             if content is None:
                 return []
+            _raw_role = input_item.get("role") or "user"
+            # The Responses API uses "developer" as the equivalent of "system".
+            # Non-OpenAI providers only understand "system", so translate it here.
+            _chat_role = "system" if _raw_role == "developer" else _raw_role
             return [
                 GenericChatCompletionMessage(
-                    role=input_item.get("role") or "user",
+                    role=_chat_role,
                     content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
                         content
                     ),


### PR DESCRIPTION
## Summary

Fixes #24664

When a Responses API request (`/v1/responses`) contains messages with `role: "developer"` (the standard Responses API equivalent of `system`), the bridge now correctly normalises it to `"system"` before forwarding to Chat Completions.

Previously, providers like vLLM would reject the request with `"Unexpected message role: developer"` because they only recognise `system`, `user`, `assistant`, and `tool`.

Additionally, the `metadata` field from the Responses API request is no longer forwarded as a top-level param to downstream Chat Completions calls — this prevents `UnexpectedKwarg` errors on strict providers.

## Changes

- `litellm/responses/litellm_completion_transformation/transformation.py`:
  - `_transform_responses_api_input_item_to_chat_completion_message`: map `role=developer` → `role=system`
  - `transform_responses_api_request_to_completion`: remove `metadata` from Chat Completions forwarding

## Testing

Manual repro before fix:
```python
import litellm
resp = litellm.responses(
    model="hosted_vllm/meta-llama/Llama-3.1-8B",
    input=[{"role": "developer", "content": "You are a helpful assistant."},
           {"role": "user", "content": "Hello"}],
    api_base="http://localhost:8000"
)
# Before: raises BadRequestError: Unexpected message role: developer
# After: works correctly
```

Closes #24664

Signed-off-by: NIK-TIGER-BILL <nik.tiger.bill@github.com>