### PR TITLE
fix(s3): truncate long object-key components to avoid 255-byte POSIX filename limit

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -1,12 +1,34 @@
 #### What this does ####
 #    On success + failure, log events to Supabase
 
+import hashlib
 from datetime import datetime
 from typing import Optional, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.types.utils import StandardLoggingPayload
+
+# Some S3-compatible servers with a filesystem backend (e.g. rustfs, MinIO on
+# Windows/Linux) enforce the 255-byte POSIX filename limit on individual path
+# components.  Standard AWS S3 supports keys up to 1 024 bytes total, so we
+# leave plenty of headroom while staying well within the POSIX limit.
+_MAX_S3_KEY_COMPONENT_LEN = 200
+
+
+def _truncate_s3_component(name: str) -> str:
+    """Shorten *name* to at most ``_MAX_S3_KEY_COMPONENT_LEN`` characters.
+
+    When truncation is needed the last 32 characters are replaced with the
+    MD5 hex-digest of the *full* original name so that the shortened key
+    remains unique.
+    """
+    if len(name) <= _MAX_S3_KEY_COMPONENT_LEN:
+        return name
+    digest = hashlib.md5(name.encode()).hexdigest()  # 32 hex chars
+    # Keep as much of the original prefix as possible, then append the digest.
+    prefix_len = _MAX_S3_KEY_COMPONENT_LEN - 33  # 32 digest + 1 separator
+    return name[:prefix_len] + "-" + digest
 
 
 class S3Logger:
@@ -146,11 +168,14 @@ class S3Logger:
                 s3_file_name,
             )
 
+            # Truncate the download filename so it fits within the 255-byte
+            # POSIX limit used by filesystem-backed S3-compatible servers.
+            payload_id = _truncate_s3_component(payload["id"])
             s3_object_download_filename = (
                 "time-"
                 + start_time.strftime("%Y-%m-%dT%H-%M-%S-%f")
                 + "_"
-                + payload["id"]
+                + payload_id
                 + ".json"
             )
 
@@ -185,12 +210,23 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
+    """Build the S3 object key for a logging payload.
+
+    The ``s3_file_name`` component is automatically shortened when it exceeds
+    ``_MAX_S3_KEY_COMPONENT_LEN`` characters.  Filesystem-backed S3-compatible
+    servers (e.g. rustfs, MinIO on Windows/Linux) enforce the 255-byte POSIX
+    filename limit on individual path components, while standard AWS S3
+    supports keys up to 1 024 bytes total.  Shortening only the file-name
+    segment keeps the key unique and human-readable while staying safely
+    within both limits.
+    """
+    safe_file_name = _truncate_s3_component(s3_file_name)
     s3_object_key = (
         (s3_path.rstrip("/") + "/" if s3_path else "")
         + prefix
         + start_time.strftime("%Y-%m-%d")
         + "/"
-        + s3_file_name
+        + safe_file_name
     )  # we need the s3 key to include the time, so we log cache hits too
     s3_object_key += ".json"
     return s3_object_key


### PR DESCRIPTION
## Summary

Fixes #24628

### Problem

Some S3-compatible servers with a filesystem backend (e.g. **rustfs**, MinIO on Windows/Linux) enforce the **255-byte POSIX filename limit** on individual path components. The `s3_file_name` generated by `get_logging_id()` can easily exceed this when the request ID or JWT token is embedded, producing a 300+ char key component and a `500 Internal Server Error`.

### Fix

Added a `_truncate_s3_component()` helper that:
- Returns the name unchanged if `len(name) <= 200`
- Otherwise keeps the first 167 chars and appends `-` + 32-char MD5 hex-digest, so the key stays unique **and** within the 200-char budget

Applied in two places:
1. `get_s3_object_key` — for the file-name segment of the S3 object key
2. `S3Logger.log_event` — for the `payload["id"]` used in `ContentDisposition: filename=`

### Why 200 chars?

| Limit | Value |
|---|---|
| AWS S3 max key length | 1 024 bytes |
| POSIX filename limit (most OSes) | 255 bytes |
| Our budget per component | 200 chars |

200 chars leaves 55 bytes for prefix + date path components while staying well within the 255-byte POSIX limit.

## Testing

```python
from litellm.integrations.s3 import _truncate_s3_component, get_s3_object_key
from datetime import datetime

# Short names pass through unchanged
assert _truncate_s3_component("short") == "short"

# Long names are shortened but remain unique
long_name = "x" * 300
truncated = _truncate_s3_component(long_name)
assert len(truncated) == 200
assert truncated != _truncate_s3_component("y" * 300)  # different content → different digest

# get_s3_object_key no longer produces >255-char components
key = get_s3_object_key("", "", datetime.now(), "z" * 300)
final_component = key.rsplit("/", 1)[-1]  # includes .json suffix
assert len(final_component) <= 210  # 200 + len(".json")
```

Closes #24628

Signed-off-by: NIK-TIGER-BILL <nik.tiger.bill@github.com>