### PR TITLE
fix(s3): truncate and hash S3 object key filename when it exceeds 200 chars

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -185,6 +185,17 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
+    # Local filesystem adapters (e.g. MinIO/rustfs on Linux/Windows) enforce a
+    # 255-character limit on the *last* path component.  Long LiteLLM request IDs
+    # can easily exceed that.  If s3_file_name is too long, keep a short
+    # human-readable prefix and append a SHA-256 hash so the key stays unique.
+    _MAX_FILENAME_CHARS = 200  # leaves headroom for ".json" and future segments
+    if len(s3_file_name) > _MAX_FILENAME_CHARS:
+        import hashlib as _hashlib
+        _ts_prefix = s3_file_name[:40]  # preserve "time-HH-MM-SS-ffffff_resp_" prefix
+        _suffix = _hashlib.sha256(s3_file_name.encode()).hexdigest()[:16]
+        s3_file_name = f"{_ts_prefix}{_suffix}"
+
     s3_object_key = (
         (s3_path.rstrip("/") + "/" if s3_path else "")
         + prefix


### PR DESCRIPTION
## Summary

Fixes #24628

LiteLLM S3 logger generates filenames from the response ID, which can be 300+ characters long. Local filesystem adapters such as rustfs, MinIO on Linux/Windows, enforce a 255-character limit on filename components, causing `500 Internal Server Error` when uploading logs.

## Root Cause

`get_s3_object_key` constructs the object key as:
```
{date}/{time-HH-MM-SS-ffffff}_{response_id}.json
```
When `response_id` is long (e.g. ~300 chars), the last filename component exceeds OS limits.

## Fix

In `get_s3_object_key`, if `s3_file_name` exceeds 200 characters, replace it with a truncated timestamp prefix + SHA-256 hash suffix. This keeps the key:
- **Unique** – SHA-256 hash preserves uniqueness
- **Human-readable** – timestamp prefix is preserved
- **Short** – always ≤ 200 + 5 (`.json`) = 205 chars

```python
if len(s3_file_name) > 200:
    _ts_prefix = s3_file_name[:40]   # keep "time-HH-MM-SS-ffffff_resp_" prefix
    _suffix = hashlib.sha256(s3_file_name.encode()).hexdigest()[:16]
    s3_file_name = f"{_ts_prefix}{_suffix}"
```

## Before / After

```
# Before (500 error on rustfs/local S3 adapters):
2026-03-26/time-12-51-27-995047_resp_MDcGKOrxhcDkVhHHxwmHy3c1QwQeNNE9MKpL3q7DvZ2zzW4u...{300+ chars}.json

# After:
2026-03-26/time-12-51-27-995047_resp_MDcGKOrxhcd1a2b3c4d5e6f7a8.json  # 56 chars
```

Closes #24628