### PR TITLE
fix(bedrock): return `"tool"` fallback for empty `toolSpec` name in `make_valid_bedrock_tool_name`

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4731,9 +4731,11 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
             return char
         return "_"
 
-    # If the string is empty, return a default valid identifier
+    # If the string is empty, return a default valid identifier.
+    # Bedrock requires toolSpec.name to be non-empty and match [a-zA-Z][a-zA-Z0-9_]*
+    # (see https://github.com/BerriAI/litellm/issues/24668)
     if input_tool_name is None or len(input_tool_name) == 0:
-        return input_tool_name
+        return "tool" 
     bedrock_tool_name = copy.copy(input_tool_name)
     # If it doesn't start with a letter, prepend 'a'
     if not bedrock_tool_name[0].isalpha():


### PR DESCRIPTION
## Summary

Fixes #24668

### Problem

`make_valid_bedrock_tool_name()` has a comment that says *"If the string is empty, return a default valid identifier"*, but the implementation just returns `input_tool_name` — which is `None` or `""`:

```python
# Before:
if input_tool_name is None or len(input_tool_name) == 0:
    return input_tool_name  # ← returns "" or None !
```

Bedrock's Converse API enforces that `toolSpec.name` must be non-empty and match `[a-zA-Z][a-zA-Z0-9_]*`, so any tool that enters `_bedrock_tools_pt` with an empty `function.name` (e.g., Knowledge Base / `vector_store` tools generated by the LiteLLM proxy) produces a 400 ValidationException:

```
BedrockException: toolSpec.name must be non-empty
```

### Fix

Return the safe fallback `"tool"` instead of the empty string:

```python
# After:
if input_tool_name is None or len(input_tool_name) == 0:
    return "tool"
```

The existing description fallback (`description = name`) in `_bedrock_tools_pt` then resolves to `"tool"` as well, satisfying Bedrock's non-empty description requirement.

### Reproduction

```python
from litellm.litellm_core_utils.prompt_templates.factory import make_valid_bedrock_tool_name

# Before: returns "" — causes 400 from Bedrock
assert make_valid_bedrock_tool_name("") == ""  # fails after fix

# After: returns "tool"
assert make_valid_bedrock_tool_name("") == "tool"
assert make_valid_bedrock_tool_name(None) == "tool"
```

Closes #24668

Signed-off-by: NIK-TIGER-BILL <nik.tiger.bill@github.com>