### PR TITLE
fix(guardrails): return HTTP 400 instead of 500 for Model Armor streaming blocks

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -221,16 +221,21 @@ async def create_response(
             f"Error consuming first chunk from generator: {e}"
         )
 
-        # Fallback to a generic error stream
+        # Preserve status code from HTTPException (e.g., guardrail blocks)
+        error_status = getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR)
+        error_detail = getattr(e, "detail", "Error processing stream start")
+        if not isinstance(error_detail, str):
+            error_detail = str(error_detail)
+
         async def error_gen_message() -> AsyncGenerator[str, None]:
-            yield f"data: {json.dumps({'error': {'message': 'Error processing stream start', 'code': status.HTTP_500_INTERNAL_SERVER_ERROR}})}\n\n"
+            yield f"data: {json.dumps({'error': {'message': error_detail, 'code': error_status}})}\n\n"
             yield "data: [DONE]\n\n"
 
         return StreamingResponse(
             error_gen_message(),
             media_type=media_type,
             headers=headers,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=error_status,
         )
 
     async def combined_generator() -> AsyncGenerator[str, None]:

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -14,6 +14,8 @@ from fastapi import HTTPException
 if TYPE_CHECKING:
     from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 
+import json
+
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
@@ -203,8 +205,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                 response.text,
             )
             raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Model Armor API error: {response.text}",
+                status_code=400,
+                detail=f"Model Armor API error (upstream {response.status_code}): {response.text}",
             )
 
         json_response = response.json()
@@ -746,8 +748,21 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                                 yield chunk
                             return
 
-                except HTTPException:
-                    raise
+                except HTTPException as e:
+                    # Yield error as SSE event so create_response() detects it and
+                    # returns a proper JSON error response with the correct status code.
+                    # (Raising from a generator hits create_response's generic except → 500.)
+                    detail = (
+                        e.detail if isinstance(e.detail, dict) else {"message": str(e.detail)}
+                    )
+                    error_value = detail.get("error", detail)
+                    if isinstance(error_value, dict):
+                        error_obj = dict(error_value)
+                    else:
+                        error_obj = {"message": str(error_value)}
+                    error_obj["code"] = e.status_code
+                    yield f"data: {json.dumps({'error': error_obj})}\n\n"
+                    return
                 except Exception as e:
                     verbose_proxy_logger.error(
                         "Model Armor streaming error: %s", str(e), exc_info=True

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -380,8 +380,9 @@ async def test_model_armor_api_error_handling():
                 call_type="completion"
             )
 
-        assert exc_info.value.status_code == 500
+        assert exc_info.value.status_code == 400
         assert "Model Armor API error" in str(exc_info.value.detail)
+        assert "upstream 500" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
@@ -484,6 +485,128 @@ async def test_model_armor_streaming_response():
         # Should have processed the chunks through Model Armor
         assert len(result_chunks) > 0
         mock_post.assert_called()
+
+@pytest.mark.asyncio
+async def test_model_armor_streaming_block_yields_sse_error():
+    """Test that streaming content block yields SSE error event instead of raising HTTPException."""
+    mock_user_api_key_dict = UserAPIKeyAuth()
+
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        location="us-central1",
+        guardrail_name="model-armor-test",
+    )
+
+    # Mock Model Armor API response that triggers a block (SDP MATCH_FOUND)
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "sanitizationResult": {
+                "filterMatchState": "MATCH_FOUND",
+                "filterResults": {
+                    "sdp": {
+                        "sdpFilterResult": {
+                            "inspectResult": {
+                                "matchState": "MATCH_FOUND",
+                                "findings": [
+                                    {
+                                        "infoType": "PASSWORD",
+                                        "likelihood": "VERY_LIKELY",
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    guardrail._ensure_access_token_async = AsyncMock(
+        return_value=("test-token", "test-project")
+    )
+
+    with patch.object(
+        guardrail.async_handler, "post", AsyncMock(return_value=mock_response)
+    ):
+
+        async def mock_stream():
+            chunks = [
+                litellm.ModelResponseStream(
+                    choices=[
+                        litellm.types.utils.StreamingChoices(
+                            delta=litellm.types.utils.Delta(
+                                content="My password is "
+                            )
+                        )
+                    ]
+                ),
+                litellm.ModelResponseStream(
+                    choices=[
+                        litellm.types.utils.StreamingChoices(
+                            delta=litellm.types.utils.Delta(content="hunter2")
+                        )
+                    ]
+                ),
+            ]
+            for chunk in chunks:
+                yield chunk
+
+        request_data = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "What's your password?"}],
+            "metadata": {"guardrails": ["model-armor-test"]},
+        }
+
+        result_chunks = []
+        async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=mock_user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            result_chunks.append(chunk)
+
+        # Should yield exactly one SSE error event (not raise HTTPException)
+        assert len(result_chunks) == 1
+        error_data = json.loads(result_chunks[0].removeprefix("data: "))
+        assert "error" in error_data
+        assert error_data["error"]["code"] == 400
+
+
+@pytest.mark.asyncio
+async def test_model_armor_api_failure_returns_400():
+    """Test that Model Armor API failures raise HTTP 400, not the upstream status code."""
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        location="us-central1",
+        guardrail_name="model-armor-test",
+    )
+
+    # Mock a 500 response from the Model Armor GCP API
+    mock_response = AsyncMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+
+    guardrail._ensure_access_token_async = AsyncMock(
+        return_value=("test-token", "test-project")
+    )
+
+    with patch.object(
+        guardrail.async_handler, "post", AsyncMock(return_value=mock_response)
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.make_model_armor_request(
+                content="test content",
+                source="user_prompt",
+            )
+
+        # Should be 400, NOT the upstream 500
+        assert exc_info.value.status_code == 400
+        assert "upstream 500" in str(exc_info.value.detail)
+
 
 def test_model_armor_ui_friendly_name():
     """Test the UI-friendly name of the Model Armor guardrail"""

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import Request, status
+from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 
 import litellm
@@ -896,6 +896,33 @@ class TestCommonRequestProcessingHelpers:
         # Use json.dumps to match the formatting in create_streaming_response's exception handler
         import json
 
+        assert content[0] == f"data: {json.dumps(expected_error_data)}\n\n"
+        assert content[1] == "data: [DONE]\n\n"
+
+    async def test_create_streaming_response_generator_raises_http_exception(
+        self,
+    ):
+        """
+        Test that when a generator raises HTTPException, the response preserves
+        the original status code instead of hardcoding 500.
+        """
+        mock_gen = AsyncMock()
+        mock_gen.__anext__.side_effect = HTTPException(
+            status_code=400, detail="Content blocked by guardrail"
+        )
+
+        response = await create_response(mock_gen, "text/event-stream", {})
+        assert response.status_code == 400
+        content = await self.consume_stream(response)
+        import json
+
+        expected_error_data = {
+            "error": {
+                "message": "Content blocked by guardrail",
+                "code": 400,
+            }
+        }
+        assert len(content) == 2
         assert content[0] == f"data: {json.dumps(expected_error_data)}\n\n"
         assert content[1] == "data: [DONE]\n\n"
 


### PR DESCRIPTION
When Model Armor blocks a streaming response, it correctly raises HTTPException(status_code=400) but create_response() catches it with a bare except Exception and hardcodes a 500 response, discarding the original status code.

Fix create_response() to preserve status_code from HTTPException instead of hardcoding 500. Also update Model Armor's streaming hook to yield an SSE error event instead of raising (matching the Prisma Airs pattern), and fix make_model_armor_request() to return 400 for upstream API failures instead of passing through the upstream status code.

## Relevant issues

Fixes #24348

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

### `litellm/proxy/common_request_processing.py`
- **`create_response()`**: Replace hardcoded `HTTP_500_INTERNAL_SERVER_ERROR` in the `except Exception` handler with `getattr(e, "status_code", 500)`. This preserves the original status code from `HTTPException` (e.g., 400 from guardrail blocks) while still defaulting to 500 for unexpected exceptions. Also extracts `e.detail` for the error message instead of the generic "Error processing stream start".

### `litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py`
- **Streaming hook** (`async_post_call_streaming_iterator_hook`): Replace `except HTTPException: raise` with a yield-error pattern that emits the error as an SSE data event. This follows the existing Prisma Airs convention and allows `create_response()` to detect the error via `_parse_event_data_for_error()` and return a proper `JSONResponse` with the correct status code.
- **`make_model_armor_request()`**: Change `status_code=response.status_code` to `status_code=400` so upstream Model Armor API failures (e.g., 500, 503) are reported as 400 to the client instead of leaking the upstream status code. The original upstream code is preserved in the detail message for debugging.

### Tests added
- `test_create_streaming_response_generator_raises_http_exception` — verifies `create_response()` preserves HTTPException status code (400) instead of hardcoding 500
- `test_model_armor_streaming_block_yields_sse_error` — verifies streaming content block yields SSE error event with code 400 instead of raising
- `test_model_armor_api_failure_returns_400` — verifies upstream API failures return 400, not the passthrough status code
- Updated `test_model_armor_api_error_handling` assertion to match new 400 behavior