### PR TITLE
[Fix] Pin Prisma Node.js dependency in CI workflows

### DIFF
--- a/.github/workflows/test-litellm-matrix.yml
+++ b/.github/workflows/test-litellm-matrix.yml
@@ -156,7 +156,10 @@ jobs:
           poetry run pip install --force-reinstall --no-deps -e enterprise/
 
       - name: Generate Prisma client
+        env:
+          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
+          poetry run pip install nodejs-wheel-binaries==24.13.1
           poetry run prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Run tests - ${{ matrix.test-group.name }}

--- a/.github/workflows/test-proxy-e2e-azure-batches.yml
+++ b/.github/workflows/test-proxy-e2e-azure-batches.yml
@@ -68,7 +68,10 @@ jobs:
           poetry run pip install --force-reinstall --no-deps -e enterprise/
 
       - name: Generate Prisma client
+        env:
+          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
+          poetry run pip install nodejs-wheel-binaries==24.13.1
           poetry run prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Run Prisma migrations


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

`prisma generate` internally runs `npm install prisma@5.4.2` against the npm registry at runtime. In CI, there is no pre-installed Node.js, so prisma falls back to `nodeenv` which downloads Node, then runs an unpinned `npm install`. This causes:
- `ECONNRESET` errors from flaky npm registry connections on GitHub Actions runners
- An unpinned npm transitive dependency tree resolved at runtime

### Fix

Pre-install `nodejs-wheel-binaries==24.13.1` (a Python package that bundles Node.js + npm locally) before running `prisma generate`. This matches the approach already used in the Dockerfiles. When prisma detects `nodejs-wheel-binaries` is available, it uses the bundled Node/npm instead of downloading from the internet.

## Testing

- Verified that the Dockerfiles (`Dockerfile.non_root`) already use `nodejs-wheel-binaries==24.13.1` with `prisma==0.11.0`
- The prisma Python client (v0.11.0) checks for `nodejs-wheel-binaries` before falling back to `nodeenv`/global npm

## Type

🐛 Bug Fix
🚄 Infrastructure