### PR TITLE
[Infra] Improve CodeQL scanning coverage and schedule

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,22 +1,21 @@
 name: "LiteLLM CodeQL config"
 
-# Use security-extended suite instead of security-and-quality to avoid
-# result sets > 2 GiB on this codebase that cause fatal OOM failures.
 queries:
-  - uses: security-extended
+  - uses: security-and-quality
 
-# These two queries are security queries included in security-extended that
-# individually produce result sets > 2 GiB on this codebase, causing fatal
-# OOM failures. Exclude them as a safety net until CI confirms they no longer
-# OOM; drop these exclusions in a follow-up once verified.
+# Known OOM queries on large Python codebases:
+# CodeQL builds a full data flow graph in memory. These two queries trace
+# sensitive data through every log call / regex pattern, causing combinatorial
+# path explosion on codebases with extensive logging like LiteLLM (>2 GiB
+# result sets). This is a known CodeQL scaling limitation, not a code issue.
+# Re-test periodically as CodeQL improves or the codebase refactors logging.
 query-filters:
   - exclude:
-      id: py/clear-text-logging-sensitive-data  # CWE-312 — > 2 GiB result set
+      id: py/clear-text-logging-sensitive-data  # CWE-312
   - exclude:
-      id: py/polynomial-redos                   # CWE-730 — > 2 GiB result set
+      id: py/polynomial-redos                   # CWE-730
 
 paths-ignore:
   - tests
   - docs
   - "**/*.md"
-  - litellm/proxy/_experimental/out

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run weekly on Sundays at 04:00 UTC
-    - cron: "0 4 * * 0"
+    # Run daily at 04:00 UTC
+    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

### Problem
CodeQL was configured with `security-extended` query suite, which provides less coverage than the default GitHub Advanced Security setup (`security-and-quality`). The build output directory (`_experimental/out`) was excluded, hiding duplicate alerts. Scheduled scans ran only weekly.

### Fix
- Switch to `security-and-quality` query suite to match default GHAS coverage
- Run scheduled scans daily instead of weekly
- Remove `_experimental/out` from paths-ignore so build artifacts are scanned
- Keep two known OOM-causing Python queries excluded (`py/clear-text-logging-sensitive-data`, `py/polynomial-redos`) with documentation explaining the CodeQL scaling limitation

## Testing
- Verified locally that CodeQL JS/TS scan now detects the same alerts reported by users running default GHAS setup
- OOM-excluded queries are documented with context for periodic re-evaluation

## Type

🚄 Infrastructure