### PR TITLE
fix(proxy): allow JWT auth for /v1/mcp/server sub-paths

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -432,6 +432,7 @@ class LiteLLMRoutes(enum.Enum):
         "/mcp-rest/tools/list",
         "/mcp-rest/tools/call",
         "/v1/mcp/server",
+        "/v1/mcp/server/{path:path}",
     ]
 
     agent_routes = [

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_jwt_mcp_enforcement.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_jwt_mcp_enforcement.py
@@ -160,6 +160,32 @@ async def test_mcp_route_check_passes_for_team():
 
 
 @pytest.mark.asyncio
+async def test_mcp_route_check_passes_for_team_server_subpaths():
+    """
+    Verify that allowed_routes_check returns True for /v1/mcp/server sub-paths with default settings.
+    Regression test for JWT users accessing /v1/mcp/server/register and similar endpoints.
+    """
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.auth.auth_checks import allowed_routes_check
+
+    jwt_auth = LiteLLM_JWTAuth()
+
+    for route in [
+        "/v1/mcp/server/register",
+        "/v1/mcp/server/health",
+        "/v1/mcp/server/abc/approve",
+    ]:
+        is_allowed = allowed_routes_check(
+            user_role=LitellmUserRoles.TEAM,
+            user_route=route,
+            litellm_proxy_roles=jwt_auth,
+        )
+        assert is_allowed is True, (
+            f"Route {route} should be allowed for TEAM role with default settings"
+        )
+
+
+@pytest.mark.asyncio
 async def test_e2e_jwt_team_mcp_permissions_enforced(monkeypatch):
     """
     End-to-end test verifying that team MCP permissions are properly enforced

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -124,6 +124,34 @@ def test_virtual_key_mcp_routes_allows_v1_mcp_server():
     assert result is True
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/v1/mcp/server/register",
+        "/v1/mcp/server/health",
+        "/v1/mcp/server/submissions",
+        "/v1/mcp/server/abc123",
+        "/v1/mcp/server/abc123/approve",
+        "/v1/mcp/server/oauth/session",
+        "/v1/mcp/server/oauth/abc123/authorize",
+    ],
+)
+def test_virtual_key_mcp_routes_allows_v1_mcp_server_subpaths(route):
+    """Regression test: mcp_routes must allow /v1/mcp/server sub-paths (register, health, oauth, etc.)."""
+
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        allowed_routes=["mcp_routes"],
+    )
+
+    result = RouteChecks.is_virtual_key_allowed_to_call_route(
+        route=route,
+        valid_token=valid_token,
+    )
+
+    assert result is True
+
+
 def test_virtual_key_allowed_routes_with_litellm_routes_member_name_denied():
     """Test that virtual key is denied when route is not in the allowed LiteLLMRoutes group"""
 


### PR DESCRIPTION
mcp_routes only contained "/v1/mcp/server" (exact match). Starlette's compile_path produces an end-anchored regex, so sub-paths like /register, /health, /submissions, /oauth/* all failed the JWT allowed_routes_check. Add a {path:path} wildcard entry so all sub-paths are covered.

## Relevant issues

Reported by community member — JWT-authenticated users denied access to all `/v1/mcp/server/*` sub-paths (register, health, submissions, approve, reject, oauth, credentials).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

`mcp_routes` in `LiteLLMRoutes` only contains `"/v1/mcp/server"` (exact match). Starlette's `compile_path` produces `^/v1/mcp/server$`, so all sub-paths fail the JWT `_allowed_routes_check`:

- `/v1/mcp/server/register`
- `/v1/mcp/server/health`
- `/v1/mcp/server/submissions`
- `/v1/mcp/server/{server_id}/approve`
- `/v1/mcp/server/oauth/*`
- etc.

This only affects **JWT auth users** — virtual-key users have a separate bypass at `route_checks.py:231`.

For JWT users with team group memberships, the route check failure inside `find_team_with_model_access` also prevents team_id resolution, causing downstream 400 errors from endpoints that require a team-scoped key.

### Fix

Add `"/v1/mcp/server/{path:path}"` to `mcp_routes` — same `{name:path}` Starlette path converter pattern used by `google_routes`.

### Tests added

- **`test_route_checks.py`**: 7-case parametrized test for virtual-key access to `/v1/mcp/server/*` sub-paths
- **`test_jwt_mcp_enforcement.py`**: Test verifying `allowed_routes_check` returns True for sub-paths with TEAM role + default JWT settings

All 8 new tests pass, existing exact-match test still passes.