### PR TITLE
fix(gemini): merge extra_body into generationConfig for image preview

### DIFF
--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -189,7 +189,11 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
                 for k, v in extra_body.items():
                     if k in {"cache", "tags"}:
                         continue
-                    if k in request_body and isinstance(request_body[k], dict) and isinstance(v, dict):
+                    if (
+                        k in request_body
+                        and isinstance(request_body[k], dict)
+                        and isinstance(v, dict)
+                    ):
                         request_body[k].update(v)
                     else:
                         request_body[k] = v

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -184,6 +184,15 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
                 "contents": [{"parts": [{"text": prompt}]}],
                 "generationConfig": {"response_modalities": ["IMAGE", "TEXT"]},
             }
+            extra_body: Optional[dict] = optional_params.pop("extra_body", None)
+            if extra_body is not None:
+                for k, v in extra_body.items():
+                    if k in {"cache", "tags"}:
+                        continue
+                    if k in request_body and isinstance(request_body[k], dict) and isinstance(v, dict):
+                        request_body[k].update(v)
+                    else:
+                        request_body[k] = v
             return request_body
         else:
             # For other Imagen models, use the original Imagen format

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation.py
@@ -1,4 +1,3 @@
-import pytest
 from litellm.llms.gemini.image_generation.transformation import GoogleImageGenConfig
 
 def test_gemini_flash_image_generation_extra_body():

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation.py
@@ -1,0 +1,44 @@
+import pytest
+import litellm
+from litellm.llms.gemini.image_generation.transformation import GoogleImageGenConfig
+
+def test_gemini_flash_image_generation_extra_body():
+    """
+    Test that extra_body is properly extracted and deep merged into the
+    generationConfig for Gemini 3.1 Flash Image Preview requests.
+    """
+    config = GoogleImageGenConfig()
+    model = "gemini-3.1-flash-image-preview"
+    prompt = "A realistic, high-quality close-up..."
+    
+    # User's optional parameters, containing the extra_body we want to inject
+    optional_params = {
+        "extra_body": {
+            "generationConfig": {
+                "imageConfig": {
+                    "imageSize": "2K"
+                }
+            }
+        }
+    }
+    litellm_params = {}
+    headers = {}
+    
+    request_body = config.transform_image_generation_request(
+        model=model,
+        prompt=prompt,
+        optional_params=optional_params,
+        litellm_params=litellm_params,
+        headers=headers
+    )
+    
+    assert "generationConfig" in request_body
+    gen_config = request_body["generationConfig"]
+    
+    # Should contain original hardcoded item
+    assert "response_modalities" in gen_config
+    assert gen_config["response_modalities"] == ["IMAGE", "TEXT"]
+    
+    # Should contain the extra_body injected item
+    assert "imageConfig" in gen_config
+    assert gen_config["imageConfig"] == {"imageSize": "2K"}

--- a/tests/test_litellm/llms/gemini/test_gemini_image_generation.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_image_generation.py
@@ -1,5 +1,4 @@
 import pytest
-import litellm
 from litellm.llms.gemini.image_generation.transformation import GoogleImageGenConfig
 
 def test_gemini_flash_image_generation_extra_body():


### PR DESCRIPTION
## Relevant issues

Fixes #24621

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes
- Updated `GoogleImageGenConfig.transform_image_generation_request()` to properly deep-merge the `extra_body` configuration onto the target `generationConfig` rather than strictly dropping it.
- Enabled `imageSize: 2K` generation parameters for `gemini/gemini-3.1-flash-image-preview`.
- Created `test_gemini_image_generation.py` unit test to explicitly assert deep-merged components map properly alongside the standard `response_modalities`.
