### PR TITLE
fix(vertex_ai): support pluggable (executable) credential_source for WIF auth

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -136,6 +136,11 @@ class VertexBase:
                             json_obj,
                             scopes=["https://www.googleapis.com/auth/cloud-platform"],
                         )
+                elif isinstance(credential_source, dict) and "executable" in credential_source:
+                    creds = self._credentials_from_pluggable(
+                        json_obj,
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                    )
                 else:
                     creds = self._credentials_from_identity_pool(
                         json_obj,
@@ -186,6 +191,17 @@ class VertexBase:
             raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
 
         creds = identity_pool.Credentials.from_info(json_obj)
+        if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
+            creds = creds.with_scopes(scopes)
+        return creds
+
+    def _credentials_from_pluggable(self, json_obj, scopes):
+        try:
+            from google.auth import pluggable
+        except ImportError:
+            raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
+
+        creds = pluggable.Credentials.from_info(json_obj)
         if scopes and hasattr(creds, "requires_scopes") and creds.requires_scopes:
             creds = creds.with_scopes(scopes)
         return creds

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -1050,6 +1050,85 @@ class TestVertexBase:
             mock_creds.with_scopes.assert_called_once_with(scopes)
             assert result == "scoped_creds"
 
+    def test_credentials_from_pluggable_implementation(self):
+        """Test _credentials_from_pluggable dispatches to pluggable.Credentials"""
+        vertex_base = VertexBase()
+        json_obj = {
+            "type": "external_account",
+            "credential_source": {
+                "executable": {"command": "/path/to/executable", "timeout_millis": 5000}
+            },
+        }
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+        mock_creds = MagicMock()
+        mock_creds.requires_scopes = True
+        mock_creds.with_scopes.return_value = "scoped_creds"
+
+        with patch("google.auth.pluggable.Credentials") as MockCredentials:
+            MockCredentials.from_info.return_value = mock_creds
+
+            result = vertex_base._credentials_from_pluggable(json_obj, scopes)
+
+            MockCredentials.from_info.assert_called_once_with(json_obj)
+            mock_creds.with_scopes.assert_called_once_with(scopes)
+            assert result == "scoped_creds"
+
+    def test_credentials_from_pluggable_no_scopes_needed(self):
+        """Test _credentials_from_pluggable when scopes are not needed"""
+        vertex_base = VertexBase()
+        json_obj = {
+            "type": "external_account",
+            "credential_source": {
+                "executable": {"command": "/path/to/executable"}
+            },
+        }
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+        mock_creds = MagicMock()
+        mock_creds.requires_scopes = False
+
+        with patch("google.auth.pluggable.Credentials") as MockCredentials:
+            MockCredentials.from_info.return_value = mock_creds
+
+            result = vertex_base._credentials_from_pluggable(json_obj, scopes)
+
+            MockCredentials.from_info.assert_called_once_with(json_obj)
+            mock_creds.with_scopes.assert_not_called()
+            assert result == mock_creds
+
+    def test_load_auth_dispatches_to_pluggable_for_executable(self):
+        """Test that load_auth routes executable credential_source to _credentials_from_pluggable"""
+        vertex_base = VertexBase()
+        json_obj = {
+            "type": "external_account",
+            "credential_source": {
+                "executable": {"command": "/path/to/executable", "timeout_millis": 5000}
+            },
+        }
+
+        mock_creds = MagicMock()
+        mock_creds.project_id = "test-project"
+
+        with patch.object(
+            vertex_base, "_credentials_from_pluggable", return_value=mock_creds
+        ) as mock_pluggable, patch.object(
+            vertex_base, "_credentials_from_identity_pool"
+        ) as mock_identity_pool, patch.object(
+            vertex_base, "refresh_auth"
+        ):
+            creds, project_id = vertex_base.load_auth(
+                credentials=json.dumps(json_obj), project_id=None
+            )
+
+            mock_pluggable.assert_called_once_with(
+                json_obj,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            mock_identity_pool.assert_not_called()
+            assert creds == mock_creds
+            assert project_id == "test-project"
+
     def test_extract_aws_params(self):
         """Test _extract_aws_params: extraction, empty case, and unrecognized keys."""
         # Case 1: Extracts recognized aws_* keys, ignores GCP-standard fields


### PR DESCRIPTION
The WIF credential dispatch in load_auth() only handled identity_pool and aws credential types. When credential_source.executable was present (used for Azure Managed Identity via Workload Identity Federation), it fell through to identity_pool.Credentials which rejected it with MalformedError.

Add dispatch to google.auth.pluggable.Credentials for executable-type credential sources, following the same pattern as the existing identity_pool and aws helpers.

Fixes authentication for Azure Container Apps → GCP Vertex AI via WIF with executable credential sources.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- **`litellm/llms/vertex_ai/vertex_llm_base.py`**: Added `elif` branch in the WIF dispatch logic (inside `load_auth()`) to check for `credential_source.executable` and route to new `_credentials_from_pluggable()` helper, which calls `google.auth.pluggable.Credentials.from_info()`. Follows the same pattern as the existing `_credentials_from_identity_pool()` and `_credentials_from_identity_pool_with_aws()` helpers.
- **`tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py`**: Added 3 unit tests:
  - `test_credentials_from_pluggable_implementation` — verifies helper dispatches to `pluggable.Credentials` with scopes
  - `test_credentials_from_pluggable_no_scopes_needed` — verifies helper works when scopes not required
  - `test_load_auth_dispatches_to_pluggable_for_executable` — verifies `load_auth()` routes executable credential_source to pluggable (not identity_pool)