### PR TITLE
fix: strip ollama/ prefix from model name in embedding requests

### DIFF
--- a/litellm/llms/ollama/completion/handler.py
+++ b/litellm/llms/ollama/completion/handler.py
@@ -13,6 +13,8 @@ from litellm.types.utils import EmbeddingResponse
 def _prepare_ollama_embedding_payload(
     model: str, prompts: List[str], optional_params: Dict[str, Any]
 ) -> Dict[str, Any]:
+    if model.startswith("ollama/"):
+        model = model[len("ollama/"):]
     data: Dict[str, Any] = {"model": model, "input": prompts}
     special_optional_params = ["truncate", "options", "keep_alive", "dimensions"]
 

--- a/tests/test_litellm/llms/ollama/test_ollama_embedding.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_embedding.py
@@ -2,7 +2,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from litellm.llms.ollama.completion.handler import ollama_aembeddings, ollama_embeddings
+from litellm.llms.ollama.completion.handler import (
+    _prepare_ollama_embedding_payload,
+    ollama_aembeddings,
+    ollama_embeddings,
+)
 from litellm.types.utils import EmbeddingResponse
 
 
@@ -51,6 +55,52 @@ def test_ollama_embeddings(mock_response_data, mock_embedding_response, mock_enc
         assert response.usage.total_tokens == 5
 
 
+def test_prepare_ollama_embedding_payload_strips_ollama_prefix():
+    payload = _prepare_ollama_embedding_payload(
+        model="ollama/nomic-embed-text",
+        prompts=["hello"],
+        optional_params={},
+    )
+
+    assert payload["model"] == "nomic-embed-text"
+    assert payload["input"] == ["hello"]
+
+
+def test_prepare_ollama_embedding_payload_keeps_unprefixed_model():
+    payload = _prepare_ollama_embedding_payload(
+        model="nomic-embed-text",
+        prompts=["hello"],
+        optional_params={},
+    )
+
+    assert payload["model"] == "nomic-embed-text"
+    assert payload["input"] == ["hello"]
+
+
+def test_ollama_embeddings_strips_prefix_in_embed_payload(
+    mock_response_data, mock_embedding_response, mock_encoding
+):
+    with patch("litellm.module_level_client.post") as mock_post, patch(
+        "litellm.OllamaConfig.get_config", return_value={"truncate": 512}
+    ):
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_response_data
+        mock_post.return_value = mock_response
+
+        ollama_embeddings(
+            api_base="http://localhost:11434",
+            model="ollama/nomic-embed-text",
+            prompts=["hello", "world"],
+            optional_params={},
+            model_response=mock_embedding_response,
+            logging_obj=None,
+            encoding=mock_encoding,
+        )
+
+        assert mock_post.call_args.kwargs["json"]["model"] == "nomic-embed-text"
+        assert mock_post.call_args.kwargs["json"]["input"] == ["hello", "world"]
+
+
 @pytest.mark.asyncio
 async def test_ollama_aembeddings(
     mock_response_data, mock_embedding_response, mock_encoding
@@ -78,6 +128,31 @@ async def test_ollama_aembeddings(
         assert response.object == "list"
         assert isinstance(response.data, list)
         assert response.usage.total_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_ollama_aembeddings_strips_prefix_in_embed_payload(
+    mock_response_data, mock_embedding_response, mock_encoding
+):
+    mock_response = AsyncMock()
+    mock_response.json = MagicMock(return_value=mock_response_data)
+    with patch(
+        "litellm.module_level_aclient.post", return_value=mock_response
+    ) as mock_post, patch(
+        "litellm.OllamaConfig.get_config", return_value={"truncate": 512}
+    ):
+        await ollama_aembeddings(
+            api_base="http://localhost:11434",
+            model="ollama/nomic-embed-text",
+            prompts=["hello", "world"],
+            optional_params={},
+            model_response=mock_embedding_response,
+            logging_obj=None,
+            encoding=mock_encoding,
+        )
+
+        assert mock_post.call_args.kwargs["json"]["model"] == "nomic-embed-text"
+        assert mock_post.call_args.kwargs["json"]["input"] == ["hello", "world"]
 
 
 def test_prompt_eval_fallback_when_missing(mock_embedding_response, mock_encoding):


### PR DESCRIPTION
## Summary

Fixes Ollama embedding requests failing with `400 Bad Request` because the `ollama/` provider prefix is not stripped from the model name before sending to Ollama's `/api/embed` endpoint.

## Root Cause

`_prepare_ollama_embedding_payload()` in `litellm/llms/ollama/completion/handler.py` passes the full LiteLLM model identifier (e.g., `ollama/nomic-embed-text`) directly to Ollama. Ollama expects just the model name (`nomic-embed-text`), so the request fails with "model not found".

The chat completion path strips this prefix correctly, but the embedding handler does not.

## Fix

Strip the `ollama/` prefix at the top of `_prepare_ollama_embedding_payload()`:

```python
if model.startswith("ollama/"):
    model = model[len("ollama/"):]
```

## Reproduction

```python
import litellm

# Fails on v1.82.6 with: OllamaException - Client error '400 Bad Request'
response = litellm.embedding(model="ollama/nomic-embed-text", input=["hello world"])
```

Ollama returns: `{"error":"model \"ollama/nomic-embed-text\" not found, try pulling it first"}`

## Test plan

- [x] Verified `ollama/nomic-embed-text` embedding requests succeed after fix
- [x] Verified direct Ollama calls work with stripped model name
- [ ] Verify models without the prefix still work
- [ ] Verify non-Ollama embedding providers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)