### PR TITLE
fix: add /user/bulk_update to management routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -525,6 +525,7 @@ class LiteLLMRoutes(enum.Enum):
         # user
         "/user/new",
         "/user/update",
+        "/user/bulk_update",
         "/user/delete",
         "/user/info",
         "/user/list",

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -629,6 +629,7 @@ class RouteChecks:
                 in [
                     "/user/new",
                     "/user/delete",
+                    "/user/bulk_update",
                     "/team/new",
                     "/team/update",
                     "/team/delete",

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -6,6 +6,7 @@ These are members of a Team on LiteLLM
 
 /user/new
 /user/update
+/user/bulk_update
 /user/delete
 /user/info
 /user/list


### PR DESCRIPTION
## Summary
- Adds `/user/bulk_update` to `management_routes` so proxy admins can access the endpoint
- Adds `/user/bulk_update` to the `PROXY_ADMIN_VIEW_ONLY` write-block list to prevent read-only admins from using it
- Updates the module docstring in `internal_user_endpoints.py` to include `/user/bulk_update`
<img width="700" height="818" alt="Screenshot 2026-03-27 at 6 03 47 PM" src="https://github.com/user-attachments/assets/70f5e6a9-26e6-4027-8a4e-8245999766ea" />

