### PR TITLE
Fix health check stripping bedrock/ prefix from model name

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -325,7 +325,7 @@ def _update_litellm_params_for_health_check(
                 filtered_parts.append(part)
 
         model = "/".join(filtered_parts)
-        litellm_params["model"] = model
+        litellm_params["model"] = "bedrock/" + model
 
     return litellm_params
 

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -83,7 +83,9 @@ async def test_openai_img_gen_health_check():
 # asyncio.run(test_openai_img_gen_health_check())
 
 
-@pytest.mark.skip(reason="Azure DALL-E 3 model deployment is deprecated (410 ModelDeprecated)")
+@pytest.mark.skip(
+    reason="Azure DALL-E 3 model deployment is deprecated (410 ModelDeprecated)"
+)
 @pytest.mark.asyncio
 async def test_azure_img_gen_health_check():
     """
@@ -345,7 +347,9 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
+    assert (
+        updated_params["model"] == "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
+    )
 
     # Test with Bedrock cross-region inference profile - should preserve the inference profile prefix
     # AWS requires inference profile IDs like "us.anthropic.claude..." for cross-region routing
@@ -354,7 +358,10 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    assert (
+        updated_params["model"]
+        == "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    )
 
     # Test with Bedrock model without region routing - should preserve bedrock/ prefix
     litellm_params = {
@@ -362,7 +369,9 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
+    assert (
+        updated_params["model"] == "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
+    )
 
     # Test that non-Bedrock models are not affected by Bedrock-specific logic
     litellm_params = {
@@ -383,7 +392,8 @@ def test_update_litellm_params_for_health_check():
             model_info, litellm_params
         )
         assert (
-            updated_params["model"] == f"bedrock/{prefix}anthropic.claude-3-haiku-20240307-v1:0"
+            updated_params["model"]
+            == f"bedrock/{prefix}anthropic.claude-3-haiku-20240307-v1:0"
         ), f"Failed to preserve CRIS prefix: {prefix}"
 
     # Test regional + CRIS combination - region should be stripped, CRIS preserved
@@ -392,7 +402,9 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "bedrock/us.anthropic.claude-3-haiku-20240307-v1:0"
+    assert (
+        updated_params["model"] == "bedrock/us.anthropic.claude-3-haiku-20240307-v1:0"
+    )
 
     # Test GovCloud regions
     litellm_params = {
@@ -470,7 +482,8 @@ def test_update_litellm_params_for_health_check():
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
-        updated_params["model"] == "bedrock/converse/eu.anthropic.claude-3-sonnet-20240229-v1:0"
+        updated_params["model"]
+        == "bedrock/converse/eu.anthropic.claude-3-sonnet-20240229-v1:0"
     )
 
 
@@ -500,7 +513,9 @@ async def test_perform_health_check_filters_by_model_id():
 
     async def mock_perform_health_check(m_list, details=True, **kwargs):
         captured_list.append(m_list)
-        return [{"model": "gpt-4", "api_key": m_list[0]["litellm_params"]["api_key"]}], []
+        return [
+            {"model": "gpt-4", "api_key": m_list[0]["litellm_params"]["api_key"]}
+        ], []
 
     with patch(
         "litellm.proxy.health_check._perform_health_check",
@@ -657,7 +672,8 @@ async def test_health_check_creates_only_bounded_initial_tasks():
         return real_create_task(coro)
 
     with patch("litellm.ahealth_check", side_effect=mock_health_check), patch(
-        "litellm.proxy.health_check.asyncio.create_task", side_effect=tracked_create_task
+        "litellm.proxy.health_check.asyncio.create_task",
+        side_effect=tracked_create_task,
     ):
         perform_task = real_create_task(
             _perform_health_check(model_list, max_concurrency=2)

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -337,7 +337,7 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert "voice" not in updated_params
 
-    # Test with Bedrock model with region routing - should strip bedrock/ and region/ prefix
+    # Test with Bedrock model with region routing - should strip region/ prefix and preserve bedrock/
     # Issue #15807: Fixes health checks sending "region/model" as model ID to AWS
     model_info = {}
     litellm_params = {
@@ -345,7 +345,7 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "anthropic.claude-3-7-sonnet-20250219-v1:0"
+    assert updated_params["model"] == "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
 
     # Test with Bedrock cross-region inference profile - should preserve the inference profile prefix
     # AWS requires inference profile IDs like "us.anthropic.claude..." for cross-region routing
@@ -354,15 +354,15 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    assert updated_params["model"] == "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
 
-    # Test with Bedrock model without region routing - should just strip bedrock/ prefix
+    # Test with Bedrock model without region routing - should preserve bedrock/ prefix
     litellm_params = {
         "model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    assert updated_params["model"] == "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
 
     # Test that non-Bedrock models are not affected by Bedrock-specific logic
     litellm_params = {
@@ -383,7 +383,7 @@ def test_update_litellm_params_for_health_check():
             model_info, litellm_params
         )
         assert (
-            updated_params["model"] == f"{prefix}anthropic.claude-3-haiku-20240307-v1:0"
+            updated_params["model"] == f"bedrock/{prefix}anthropic.claude-3-haiku-20240307-v1:0"
         ), f"Failed to preserve CRIS prefix: {prefix}"
 
     # Test regional + CRIS combination - region should be stripped, CRIS preserved
@@ -392,7 +392,7 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "us.anthropic.claude-3-haiku-20240307-v1:0"
+    assert updated_params["model"] == "bedrock/us.anthropic.claude-3-haiku-20240307-v1:0"
 
     # Test GovCloud regions
     litellm_params = {
@@ -400,7 +400,7 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "anthropic.claude-instant-v1"
+    assert updated_params["model"] == "bedrock/anthropic.claude-instant-v1"
 
     # Test imported models with handler prefixes - handlers should be preserved
     litellm_params = {
@@ -410,7 +410,7 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
         updated_params["model"]
-        == "llama/arn:aws:bedrock:us-east-1:123:imported-model/abc"
+        == "bedrock/llama/arn:aws:bedrock:us-east-1:123:imported-model/abc"
     )
 
     litellm_params = {
@@ -420,7 +420,7 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
         updated_params["model"]
-        == "deepseek_r1/arn:aws:bedrock:us-west-2:456:imported-model/xyz"
+        == "bedrock/deepseek_r1/arn:aws:bedrock:us-west-2:456:imported-model/xyz"
     )
 
     # Test route specifications - routes should be preserved
@@ -431,7 +431,7 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
         updated_params["model"]
-        == "converse/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        == "bedrock/converse/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
     )
 
     litellm_params = {
@@ -439,7 +439,7 @@ def test_update_litellm_params_for_health_check():
         "api_key": "fake_key",
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
-    assert updated_params["model"] == "invoke/anthropic.claude-instant-v1"
+    assert updated_params["model"] == "bedrock/invoke/anthropic.claude-instant-v1"
 
     # Test ARN formats - should be preserved
     litellm_params = {
@@ -449,7 +449,7 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
         updated_params["model"]
-        == "arn:aws:bedrock:eu-central-1:000:application-inference-profile/abc"
+        == "bedrock/arn:aws:bedrock:eu-central-1:000:application-inference-profile/abc"
     )
 
     # Test edge case: region + handler + ARN
@@ -460,7 +460,7 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
         updated_params["model"]
-        == "llama/arn:aws:bedrock:us-east-1:123:imported-model/abc"
+        == "bedrock/llama/arn:aws:bedrock:us-east-1:123:imported-model/abc"
     )
 
     # Test edge case: route + region + CRIS
@@ -470,7 +470,7 @@ def test_update_litellm_params_for_health_check():
     }
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert (
-        updated_params["model"] == "converse/eu.anthropic.claude-3-sonnet-20240229-v1:0"
+        updated_params["model"] == "bedrock/converse/eu.anthropic.claude-3-sonnet-20240229-v1:0"
     )
 
 


### PR DESCRIPTION
Fixes #24694

`_update_litellm_params_for_health_check` strips the `bedrock/` prefix from the model name to extract the base model, but never re-adds it when assigning back to `litellm_params["model"]`. This causes `get_llm_provider()` to fail for models not in the cost map since there's no provider prefix to split on.

Re-added the `bedrock/` prefix after processing so the model name retains its provider routing information.