### PR TITLE
fix(mcp): allow health check for OAuth2 M2M (client_credentials) servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2659,12 +2659,14 @@ class MCPServerManager:
         if server.requires_per_user_auth:
             should_skip_health_check = True
         # Skip if auth_type is not none and authentication_token is missing
-        # (except aws_sigv4 which uses its own credential fields)
+        # (except aws_sigv4 which uses its own credential fields, and OAuth2
+        # M2M servers which fetch tokens dynamically via client_credentials flow)
         elif (
             server.auth_type
             and server.auth_type != MCPAuth.none
             and server.auth_type != MCPAuth.aws_sigv4
             and not server.authentication_token
+            and not server.has_client_credentials
         ):
             should_skip_health_check = True
 


### PR DESCRIPTION
## Problem

Fixes #24709

MCP servers configured with OAuth2 `client_credentials` (M2M) auth always show `status: "unknown"` because the health check is unconditionally skipped.

### Root Cause

In `health_check_server()`, the following guard skips the health check when `authentication_token` is absent:

```python
elif (
    server.auth_type
    and server.auth_type != MCPAuth.none
    and server.auth_type != MCPAuth.aws_sigv4
    and not server.authentication_token
):  # ← skips ALL auth_type-set servers without a static token
    should_skip_health_check = True
```

For M2M OAuth2 servers (`oauth2_flow: client_credentials`), `authentication_token` is always `None` — the access token is fetched **dynamically** at request time via `token_url` / `client_id` / `client_secret`. So this condition always triggers and the health check is never run.

## Fix

Add `and not server.has_client_credentials` to the guard condition:

```python
elif (
    server.auth_type
    and server.auth_type != MCPAuth.none
    and server.auth_type != MCPAuth.aws_sigv4
    and not server.authentication_token
    and not server.has_client_credentials   # ← NEW: let M2M servers through
):
    should_skip_health_check = True
```

`server.has_client_credentials` returns `True` when `oauth2_flow == "client_credentials"`. When the guard is bypassed, `_create_mcp_client` is called as usual, and it already invokes `resolve_mcp_auth` (from `oauth2_token_cache.py`) to fetch and cache the OAuth2 token — **no additional changes needed**.

## What was tested

- M2M OAuth2 server now runs through the health check path
- Servers with static `authentication_token` still take the existing fast path
- `aws_sigv4` servers are still excluded from the guard (unchanged)
- `requires_per_user_auth` servers still skip the health check (unchanged)

## Checklist
- [x] My PR is focused on a single issue
- [x] I have read the LiteLLM contribution guidelines
- [x] DCO signed (`-s` flag on commit)
