### PR TITLE
fix(proxy): invalidate cached end-user object on budget reset

### DIFF
--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -86,9 +86,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if tool_calls_to_check:
                 inputs["tool_calls"] = tool_calls_to_check  # type: ignore
             if messages:
-                inputs["structured_messages"] = (
-                    messages  # pass the openai /chat/completions messages to the guardrail, as-is
-                )
+                inputs[
+                    "structured_messages"
+                ] = messages  # pass the openai /chat/completions messages to the guardrail, as-is
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
             if tools:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3078,10 +3078,7 @@ async def _team_max_budget_check(
         BudgetExceededError if the team is over it's max budget.
         Triggers a budget alert if the team is over it's max budget.
     """
-    if (
-        team_object is not None
-        and team_object.max_budget is not None
-    ):
+    if team_object is not None and team_object.max_budget is not None:
         from litellm.proxy.proxy_server import get_current_spend
 
         # Read spend from cross-pod counter (Redis-first) or cached object (fallback)

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -66,10 +66,8 @@ class ResetBudgetJob:
         try:
             from litellm.proxy.proxy_server import spend_counter_cache
 
-            memberships = (
-                await self.prisma_client.db.litellm_teammembership.find_many(
-                    where={"budget_id": {"in": budget_ids}}
-                )
+            memberships = await self.prisma_client.db.litellm_teammembership.find_many(
+                where={"budget_id": {"in": budget_ids}}
             )
             for m in memberships:
                 counter_key = f"spend:team_member:{m.user_id}:{m.team_id}"
@@ -574,7 +572,11 @@ class ResetBudgetJob:
             counter_key = None
             if item_type == "key" and hasattr(item, "token") and item.token is not None:
                 counter_key = f"spend:key:{item.token}"
-            elif item_type == "team" and hasattr(item, "team_id") and item.team_id is not None:
+            elif (
+                item_type == "team"
+                and hasattr(item, "team_id")
+                and item.team_id is not None
+            ):
                 counter_key = f"spend:team:{item.team_id}"
 
             if counter_key is not None:
@@ -637,6 +639,25 @@ class ResetBudgetJob:
     ) -> Optional[LiteLLM_EndUserTable]:
         try:
             enduser.spend = 0.0
+
+            # Invalidate the cached end-user object so auth checks pick up
+            # the reset spend instead of reading a stale value until TTL
+            # expires.  Uses the same cache key format as get_end_user_object
+            # in litellm/proxy/auth/auth_checks.py.
+            if enduser.user_id is not None:
+                try:
+                    from litellm.proxy.proxy_server import user_api_key_cache
+
+                    await user_api_key_cache.async_delete_cache(
+                        key="end_user_id:{}".format(enduser.user_id)
+                    )
+                except Exception as cache_err:
+                    verbose_proxy_logger.warning(
+                        "Failed to invalidate cached end-user object for %s: %s. "
+                        "Budget may be over-enforced until cache entry expires.",
+                        enduser.user_id,
+                        cache_err,
+                    )
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Error resetting budget for enduser: %s. Item: %s", e, enduser

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -827,7 +827,9 @@ async def get_generic_sso_response(
     ],  # sso specific jwt handler - used for restricted sso group access control
     generic_client_id: str,
     redirect_url: str,
-) -> Tuple[Union[OpenID, dict], Optional[dict], Optional[dict]]:  # (result, received_response, access_token_payload)
+) -> Tuple[
+    Union[OpenID, dict], Optional[dict], Optional[dict]
+]:  # (result, received_response, access_token_payload)
     # make generic sso provider
     from fastapi_sso.sso.base import DiscoveryDocument
     from fastapi_sso.sso.generic import create_provider
@@ -1369,7 +1371,11 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
         )
 
     elif generic_client_id is not None:
-        result, received_response, access_token_payload = await get_generic_sso_response(
+        (
+            result,
+            received_response,
+            access_token_payload,
+        ) = await get_generic_sso_response(
             request=request,
             jwt_handler=jwt_handler,
             generic_client_id=generic_client_id,

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -51,7 +51,11 @@ def _build_audit_log_payload(
     if request_data.updated_at is not None:
         updated_at = request_data.updated_at.isoformat()
 
-    table_name_str: str = request_data.table_name.value if isinstance(request_data.table_name, LitellmTableNames) else str(request_data.table_name)
+    table_name_str: str = (
+        request_data.table_name.value
+        if isinstance(request_data.table_name, LitellmTableNames)
+        else str(request_data.table_name)
+    )
 
     return StandardAuditLogPayload(
         id=request_data.id,
@@ -89,7 +93,9 @@ async def _dispatch_audit_log_to_callbacks(
 
     for callback in litellm.audit_log_callbacks:
         try:
-            resolved: Optional[CustomLogger] = callback if isinstance(callback, CustomLogger) else None
+            resolved: Optional[CustomLogger] = (
+                callback if isinstance(callback, CustomLogger) else None
+            )
             if isinstance(callback, str):
                 resolved = _resolve_audit_log_callback(callback)
                 if resolved is None:
@@ -138,9 +144,7 @@ async def create_object_audit_log(
         return
 
     _changed_by = (
-        litellm_changed_by
-        or user_api_key_dict.user_id
-        or litellm_proxy_admin_name
+        litellm_changed_by or user_api_key_dict.user_id or litellm_proxy_admin_name
     )
 
     await create_audit_log_for_update(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1714,9 +1714,7 @@ async def get_current_spend(counter_key: str, fallback_spend: float) -> float:
     # 1. Try Redis first (cross-pod authoritative)
     if spend_counter_cache.redis_cache is not None:
         try:
-            val = await spend_counter_cache.redis_cache.async_get_cache(
-                key=counter_key
-            )
+            val = await spend_counter_cache.redis_cache.async_get_cache(key=counter_key)
             if val is not None:
                 return float(val)
         except Exception as e:
@@ -1820,9 +1818,7 @@ async def _init_and_increment_spend_counter(
                 key=counter_key, value=base_spend
             )
 
-    await spend_counter_cache.async_increment_cache(
-        key=counter_key, value=increment
-    )
+    await spend_counter_cache.async_increment_cache(key=counter_key, value=increment)
 
 
 async def update_cache(  # noqa: PLR0915

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import sys
-import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
@@ -11,9 +10,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm._logging import verbose_proxy_logger
 from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
-from litellm.proxy.utils import ProxyLogging
 
 
 # Mock classes for testing
@@ -393,7 +390,7 @@ def test_enduser_budget_reset_reproduces_stale_cache_bug():
     This test simulates the full flow using real LiteLLM_EndUserTable and
     LiteLLM_BudgetTable Pydantic objects.
     """
-    from unittest.mock import AsyncMock, patch
+    from unittest.mock import patch
 
     from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_EndUserTable
 
@@ -596,8 +593,6 @@ def test_reset_budget_for_keys_linked_to_budgets(reset_budget_job, mock_prisma_c
     This covers the case where keys were created with budget_id but
     budget_duration was not inherited to the key (pre-fix keys).
     """
-    from litellm.proxy._types import LiteLLM_BudgetTableFull
-
     now = datetime.now(timezone.utc)
 
     # Create a budget tier that is due for reset

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -269,23 +269,20 @@ def test_reset_budget_for_enduser_invalidates_cache():
     mock_cache.async_delete_cache = AsyncMock()
 
     async def _run():
-        with patch(
-            "litellm.proxy.common_utils.reset_budget_job.user_api_key_cache",
-            mock_cache,
-            create=True,
+        # Patch sys.modules so the lazy import inside _reset_budget_for_enduser
+        # (`from litellm.proxy.proxy_server import user_api_key_cache`)
+        # picks up our mock cache.
+        with patch.dict(
+            "sys.modules",
+            {
+                "litellm.proxy.proxy_server": type(
+                    "module", (), {"user_api_key_cache": mock_cache}
+                )()
+            },
         ):
-            # Patch the import inside the function
-            with patch.dict(
-                "sys.modules",
-                {
-                    "litellm.proxy.proxy_server": type(
-                        "module", (), {"user_api_key_cache": mock_cache}
-                    )()
-                },
-            ):
-                result = await ResetBudgetJob._reset_budget_for_enduser(
-                    enduser=test_enduser
-                )
+            result = await ResetBudgetJob._reset_budget_for_enduser(
+                enduser=test_enduser
+            )
 
         assert result is not None
         assert result.spend == 0.0

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -252,6 +252,53 @@ def test_reset_budget_for_enduser(reset_budget_job, mock_prisma_client):
     assert updated_budget.budget_reset_at > now
 
 
+def test_reset_budget_for_enduser_invalidates_cache():
+    """
+    Test that _reset_budget_for_enduser invalidates the cached end-user object
+    so auth checks pick up the reset spend instead of a stale cached value.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    test_enduser = type(
+        "LiteLLM_EndUserTable",
+        (),
+        {
+            "spend": 45.0,
+            "user_id": "cached-enduser-1",
+        },
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_delete_cache = AsyncMock()
+
+    async def _run():
+        with patch(
+            "litellm.proxy.common_utils.reset_budget_job.user_api_key_cache",
+            mock_cache,
+            create=True,
+        ):
+            # Patch the import inside the function
+            with patch.dict(
+                "sys.modules",
+                {
+                    "litellm.proxy.proxy_server": type(
+                        "module", (), {"user_api_key_cache": mock_cache}
+                    )()
+                },
+            ):
+                result = await ResetBudgetJob._reset_budget_for_enduser(
+                    enduser=test_enduser
+                )
+
+        assert result is not None
+        assert result.spend == 0.0
+        mock_cache.async_delete_cache.assert_called_once_with(
+            key="end_user_id:cached-enduser-1"
+        )
+
+    asyncio.run(_run())
+
+
 def test_reset_budget_all(reset_budget_job, mock_prisma_client):
     # Setup test data with timezone-aware datetime
     now = datetime.now(timezone.utc)
@@ -434,9 +481,7 @@ def test_reset_budget_for_keys_linked_to_budgets_empty(
     """
     # Run with empty list
     asyncio.run(
-        reset_budget_job.reset_budget_for_keys_linked_to_budgets(
-            budgets_to_reset=[]
-        )
+        reset_budget_job.reset_budget_for_keys_linked_to_budgets(budgets_to_reset=[])
     )
 
     # Verify no update_many calls were made

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -299,6 +299,212 @@ def test_reset_budget_for_enduser_invalidates_cache():
     asyncio.run(_run())
 
 
+def test_reset_budget_for_enduser_cache_failure_does_not_block_reset():
+    """
+    Test that if cache invalidation fails (e.g. Redis down), the spend reset
+    still succeeds. The cache failure should be logged as a warning, not
+    propagated as an exception.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    test_enduser = type(
+        "LiteLLM_EndUserTable",
+        (),
+        {
+            "spend": 30.0,
+            "user_id": "enduser-cache-fail",
+        },
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_delete_cache = AsyncMock(
+        side_effect=ConnectionError("Redis connection refused")
+    )
+
+    async def _run():
+        with patch.dict(
+            "sys.modules",
+            {
+                "litellm.proxy.proxy_server": type(
+                    "module", (), {"user_api_key_cache": mock_cache}
+                )()
+            },
+        ):
+            result = await ResetBudgetJob._reset_budget_for_enduser(
+                enduser=test_enduser
+            )
+
+        # Spend should still be reset even though cache invalidation failed
+        assert result is not None
+        assert result.spend == 0.0
+        # Cache delete was attempted
+        mock_cache.async_delete_cache.assert_called_once()
+
+    asyncio.run(_run())
+
+
+def test_reset_budget_for_enduser_with_none_user_id():
+    """
+    Test that _reset_budget_for_enduser handles end users with user_id=None
+    gracefully - spend is reset but cache invalidation is skipped.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    test_enduser = type(
+        "LiteLLM_EndUserTable",
+        (),
+        {
+            "spend": 15.0,
+            "user_id": None,
+        },
+    )
+
+    mock_cache = AsyncMock()
+
+    async def _run():
+        with patch.dict(
+            "sys.modules",
+            {
+                "litellm.proxy.proxy_server": type(
+                    "module", (), {"user_api_key_cache": mock_cache}
+                )()
+            },
+        ):
+            result = await ResetBudgetJob._reset_budget_for_enduser(
+                enduser=test_enduser
+            )
+
+        assert result is not None
+        assert result.spend == 0.0
+        # Cache delete should NOT be called when user_id is None
+        mock_cache.async_delete_cache.assert_not_called()
+
+    asyncio.run(_run())
+
+
+def test_enduser_budget_reset_reproduces_stale_cache_bug():
+    """
+    Reproduce the exact bug from issue #24675:
+    1. End user has spend=45 cached, budget=50
+    2. Cron job resets spend=0 in DB
+    3. Without fix: auth check reads stale cache (spend=45), user appears near limit
+    4. With fix: cache is invalidated, next read gets fresh spend=0
+
+    This test simulates the full flow using real LiteLLM_EndUserTable and
+    LiteLLM_BudgetTable Pydantic objects.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_EndUserTable
+
+    # Step 1: Create an end user near their budget limit
+    budget = LiteLLM_BudgetTable(
+        budget_id="monthly-50",
+        max_budget=50.0,
+        budget_duration="1mo",
+    )
+    end_user = LiteLLM_EndUserTable(
+        user_id="customer-123",
+        blocked=False,
+        spend=45.0,
+        litellm_budget_table=budget,
+    )
+
+    # Simulate the cache holding stale data
+    from litellm.caching.caching import DualCache
+
+    cache = DualCache()
+
+    async def _run():
+        # Put the end user in cache (simulating what get_end_user_object does)
+        await cache.async_set_cache(
+            key="end_user_id:customer-123",
+            value=end_user.dict(),
+        )
+
+        # Verify stale data is in cache
+        cached = await cache.async_get_cache(key="end_user_id:customer-123")
+        assert cached is not None
+        assert cached["spend"] == 45.0  # stale!
+
+        # Step 2: Cron job runs _reset_budget_for_enduser WITH our fix
+        with patch.dict(
+            "sys.modules",
+            {
+                "litellm.proxy.proxy_server": type(
+                    "module", (), {"user_api_key_cache": cache}
+                )()
+            },
+        ):
+            result = await ResetBudgetJob._reset_budget_for_enduser(enduser=end_user)
+
+        # Step 3: Verify spend is reset
+        assert result.spend == 0.0
+
+        # Step 4: Verify cache was invalidated (the key fix)
+        cached_after_reset = await cache.async_get_cache(key="end_user_id:customer-123")
+        assert cached_after_reset is None, (
+            "Cache should be invalidated after budget reset, but stale entry "
+            f"still exists with spend={cached_after_reset.get('spend') if cached_after_reset else 'N/A'}"
+        )
+
+    asyncio.run(_run())
+
+
+def test_multiple_endusers_budget_reset_invalidates_all_caches():
+    """
+    When multiple end users are linked to the same budget and the budget
+    resets, ALL of their cache entries should be invalidated.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    mock_cache = AsyncMock()
+    mock_cache.async_delete_cache = AsyncMock()
+    deleted_keys = []
+
+    async def track_delete(key):
+        deleted_keys.append(key)
+
+    mock_cache.async_delete_cache = AsyncMock(side_effect=track_delete)
+
+    endusers = []
+    for i in range(5):
+        endusers.append(
+            type(
+                "LiteLLM_EndUserTable",
+                (),
+                {
+                    "spend": 10.0 * (i + 1),
+                    "user_id": f"user-{i}",
+                },
+            )
+        )
+
+    async def _run():
+        with patch.dict(
+            "sys.modules",
+            {
+                "litellm.proxy.proxy_server": type(
+                    "module", (), {"user_api_key_cache": mock_cache}
+                )()
+            },
+        ):
+            for enduser in endusers:
+                await ResetBudgetJob._reset_budget_for_enduser(enduser=enduser)
+
+        # All 5 users should have spend reset
+        for enduser in endusers:
+            assert enduser.spend == 0.0
+
+        # All 5 cache entries should be invalidated
+        assert len(deleted_keys) == 5
+        expected_keys = [f"end_user_id:user-{i}" for i in range(5)]
+        for key in expected_keys:
+            assert key in deleted_keys, f"Cache key {key} was not invalidated"
+
+    asyncio.run(_run())
+
+
 def test_reset_budget_all(reset_budget_job, mock_prisma_client):
     # Setup test data with timezone-aware datetime
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

Fixes #24675

`_reset_budget_for_enduser()` only reset `spend=0.0` on the DB object but did not invalidate the in-memory/Redis cached end-user entry (keyed as `end_user_id:{id}`). This caused auth checks in `_check_end_user_budget` to read stale spend values from cache until TTL expired, making budget resets appear to have no effect - spend continuously accumulated, rendering the `max_end_user_budget_id` feature unusable.

### Root Cause

The budget reset cron job resets end-user spend to 0 in the DB, but `get_end_user_object()` in `auth_checks.py` reads from cache first (line 950):

~~~~python
cached_user_obj = await user_api_key_cache.async_get_cache(key=_key)
~~~~

The cached object still holds the pre-reset spend value. The auth check (line 540):

~~~~python
if end_user_budget is not None and end_user_object.spend > end_user_budget:
~~~~

then compares stale cached spend against max_budget and continues rejecting requests.

Keys and teams don't have this issue because `_reset_budget_common()` already resets their Redis/in-memory spend counters. End users were missing this cache invalidation.

### Fix

- Updated `_reset_budget_for_enduser()` to call `user_api_key_cache.async_delete_cache()` after resetting spend, using the same cache key format (`end_user_id:{id}`) as `get_end_user_object()`
- Graceful error handling - if cache invalidation fails (e.g. Redis down), the DB reset still proceeds and a warning is logged
- Cleaned up pre-existing unused imports in the test file to fix ruff F401 lint errors

## Test plan

- [x] `test_reset_budget_for_enduser` - existing test still passes
- [x] `test_reset_budget_for_enduser_invalidates_cache` - verifies cache delete called with correct key
- [x] `test_reset_budget_for_enduser_cache_failure_does_not_block_reset` - Redis failure doesn't crash the reset
- [x] `test_reset_budget_for_enduser_with_none_user_id` - null user_id handled gracefully
- [x] `test_enduser_budget_reset_reproduces_stale_cache_bug` - full bug reproduction with real Pydantic models and DualCache
- [x] `test_multiple_endusers_budget_reset_invalidates_all_caches` - batch reset of 5 users invalidates all caches
- [x] `make lint` checks pass (Black, Ruff)
