### PR TITLE
[Fix] Remove NLP_CLOUD_API_KEY requirement from test_exceptions

### DIFF
--- a/tests/local_testing/test_exceptions.py
+++ b/tests/local_testing/test_exceptions.py
@@ -185,7 +185,6 @@ def invalid_auth(model):  # set the model key to an invalid key, depending on th
             temporary_key = os.environ["ALEPH_ALPHA_API_KEY"]
             os.environ["ALEPH_ALPHA_API_KEY"] = "bad-key"
         elif model in litellm.nlp_cloud_models:
-            temporary_key = os.environ["NLP_CLOUD_API_KEY"]
             os.environ["NLP_CLOUD_API_KEY"] = "bad-key"
         elif (
             model
@@ -230,7 +229,7 @@ def invalid_auth(model):  # set the model key to an invalid key, depending on th
         elif model in litellm.aleph_alpha_models:
             os.environ["ALEPH_ALPHA_API_KEY"] = temporary_key
         elif model in litellm.nlp_cloud_models:
-            os.environ["NLP_CLOUD_API_KEY"] = temporary_key
+            os.environ.pop("NLP_CLOUD_API_KEY", None)
         elif "bedrock" in model:
             os.environ["AWS_ACCESS_KEY_ID"] = temporary_aws_access_key
             os.environ["AWS_REGION_NAME"] = temporary_aws_region_name


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
`test_exceptions.py::invalid_auth` reads `os.environ["NLP_CLOUD_API_KEY"]` to save/restore the real key, but this key is never provisioned in CI and no other tests use it — the read would `KeyError` if the NLP Cloud branch is hit.

### Fix
Remove the read of the real key. The test only needs `"bad-key"` set to verify `AuthenticationError` handling. On cleanup, pop the env var instead of restoring a value that was never needed.

## Testing
- Verified `NLP_CLOUD_API_KEY` is not referenced in any other test file
- Verified it's not provisioned in any `.github/workflows/` file
- All other `nlp_cloud` test references are commented out or `@pytest.mark.skip`

## Type
🐛 Bug Fix
✅ Test