### PR TITLE
False "guardrails feature unavailable" error when guardrails are not configured in LiteLLM 1.82.3 #24734

### DIFF
--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -338,7 +338,9 @@ def _set_object_metadata_field(
         value: Value to set for the field
     """
     if field_name in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
-        _premium_user_check(field_name)
+        # Skip the premium check for empty collections ([] or {}).
+        if value is not None and value != [] and value != {}:
+            _premium_user_check(field_name)
 
     object_data.metadata = object_data.metadata or {}
     object_data.metadata[field_name] = value

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1487,7 +1487,8 @@ def prepare_metadata_fields(
             if k in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
                 from litellm.proxy.utils import _premium_user_check
 
-                _premium_user_check(k)
+                if v is not None and v != [] and v != {}:
+                    _premium_user_check(k)
                 casted_metadata[k] = v
 
     except Exception as e:


### PR DESCRIPTION
I have updated the metadata parser helpers across backend endpoints to ignore and bypass the proxy enterprise premium check specifically when the received values are empty collections (like [] or {}).

This effectively ensures that users without premium privileges can safely clear out premium fields or have the UI send default empty collections safely without encountering false-positive Feature Unavailable backend errors.

The following files have been updated:

litellm/proxy/management_endpoints/key_management_endpoints.py -> Updated prepare_metadata_fields to verify v != [] and v != {} before raising the enterprise check.
litellm/proxy/management_endpoints/common_utils.py -> Updated _set_object_metadata_field so backend validation logic acts consistently for updating API Keys, Projects, and Teams.