### PR TITLE
fix: add image_config support in map_openai_params for Gemini image models

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -318,6 +318,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "parallel_tool_calls",
             "web_search_options",
             "include_server_side_tool_invocations",
+            "image_config",
         ]
 
         # Add penalty parameters only for non-preview models
@@ -1022,6 +1023,16 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 optional_params["candidate_count"] = value
             elif param == "audio" and isinstance(value, dict):
                 optional_params["speechConfig"] = self._map_audio_params(value)
+            elif param == "image_config" and isinstance(value, dict):
+                image_config = {}
+                aspect_ratio = value.get("aspect_ratio") or value.get("aspectRatio")
+                image_size = value.get("image_size") or value.get("imageSize")
+                if aspect_ratio is not None:
+                    image_config["aspectRatio"] = aspect_ratio
+                if image_size is not None:
+                    image_config["imageSize"] = image_size
+                if image_config:
+                    optional_params["imageConfig"] = image_config
             elif param == "stop":
                 if isinstance(value, str):
                     optional_params["stop_sequences"] = [value]

--- a/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -288,3 +288,35 @@ def test_map_function_enterprise_web_search_snake_case():
 
     assert len(result) == 1
     assert "enterpriseWebSearch" in result[0]
+
+
+def test_map_openai_params_image_config_snake_case():
+    """Test that image_config with snake_case keys is mapped to camelCase imageConfig."""
+    config = VertexGeminiConfig()
+    result = config.map_openai_params(
+        non_default_params={
+            "image_config": {"image_size": "2K", "aspect_ratio": "16:9"}
+        },
+        optional_params={},
+        model="gemini-3.1-flash-image-preview",
+        drop_params=False,
+    )
+    assert "imageConfig" in result
+    assert result["imageConfig"]["imageSize"] == "2K"
+    assert result["imageConfig"]["aspectRatio"] == "16:9"
+
+
+def test_map_openai_params_image_config_camel_case():
+    """Test that image_config with camelCase keys is passed through to imageConfig."""
+    config = VertexGeminiConfig()
+    result = config.map_openai_params(
+        non_default_params={
+            "image_config": {"imageSize": "4K", "aspectRatio": "9:16"}
+        },
+        optional_params={},
+        model="gemini-3.1-flash-image-preview",
+        drop_params=False,
+    )
+    assert "imageConfig" in result
+    assert result["imageConfig"]["imageSize"] == "4K"
+    assert result["imageConfig"]["aspectRatio"] == "9:16"


### PR DESCRIPTION
## Relevant issues

Fixes #17075
Fixes #18656

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem
`image_config` with `imageSize` and `aspectRatio` is not passed to the Gemini API through `map_openai_params()`, making it impossible to control output resolution (1K/2K/4K) and aspect ratio (e.g. 16:9, 9:16) when using Gemini image models.

### Solution
- Added `image_config` to `get_supported_openai_params()`
- Added `imageConfig` mapping logic in `map_openai_params()`, supporting both snake_case (`image_size`, `aspect_ratio`) and camelCase (`imageSize`, `aspectRatio`)

### Testing
- Added unit tests for snake_case and camelCase key handling