### PR TITLE
fix(bedrock/converse): forward first delta when contentBlockStart events are absent

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -151,9 +151,9 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     # finish-reason chunks, and translate_streaming_openai_response_to_anthropic
                     # only emits MessageBlockDelta for finish-reason chunks — so
                     # processed_chunk is always a ContentBlockDelta here.
-                    assert processed_chunk.get("type") == "content_block_delta", (
-                        f"Expected content_block_delta, got {processed_chunk.get('type')}"
-                    )
+                    assert (
+                        processed_chunk.get("type") == "content_block_delta"
+                    ), f"Expected content_block_delta, got {processed_chunk.get('type')}"
                     self.chunk_queue.append(processed_chunk)
                     return self.chunk_queue.popleft()
 
@@ -292,16 +292,16 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         hasattr(chunk.usage, "_cache_creation_input_tokens")
                         and chunk.usage._cache_creation_input_tokens > 0
                     ):
-                        usage_dict[
-                            "cache_creation_input_tokens"
-                        ] = chunk.usage._cache_creation_input_tokens
+                        usage_dict["cache_creation_input_tokens"] = (
+                            chunk.usage._cache_creation_input_tokens
+                        )
                     if (
                         hasattr(chunk.usage, "_cache_read_input_tokens")
                         and chunk.usage._cache_read_input_tokens > 0
                     ):
-                        usage_dict[
-                            "cache_read_input_tokens"
-                        ] = chunk.usage._cache_read_input_tokens
+                        usage_dict["cache_read_input_tokens"] = (
+                            chunk.usage._cache_read_input_tokens
+                        )
                     merged_chunk["usage"] = usage_dict
 
                     # Queue the merged chunk and reset
@@ -344,9 +344,9 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         # finish-reason chunks, and translate_streaming_openai_response_to_anthropic
                         # only emits MessageBlockDelta for finish-reason chunks — so
                         # processed_chunk is always a ContentBlockDelta here.
-                        assert processed_chunk.get("type") == "content_block_delta", (
-                            f"Expected content_block_delta, got {processed_chunk.get('type')}"
-                        )
+                        assert (
+                            processed_chunk.get("type") == "content_block_delta"
+                        ), f"Expected content_block_delta, got {processed_chunk.get('type')}"
                         self.chunk_queue.append(processed_chunk)
 
                         # Return the first queued item

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -129,8 +129,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 if should_start_new_block and not self.sent_content_block_finish:
                     # Queue the sequence: content_block_stop -> content_block_start
-                    # The trigger chunk itself is not emitted as a delta since the
-                    # content_block_start already carries the relevant information.
                     self.chunk_queue.append(
                         {
                             "type": "content_block_stop",
@@ -145,6 +143,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         }
                     )
                     self.sent_content_block_finish = False
+                    # Also forward the triggering delta if it has content.
+                    # When Bedrock omits contentBlockStart events (e.g. for marketplace
+                    # models), the first delta for a new block arrives without a prior
+                    # start event. Dropping it causes the first characters of each block
+                    # to be silently lost.
+                    if processed_chunk.get("type") == "content_block_delta":
+                        self.chunk_queue.append(processed_chunk)
                     return self.chunk_queue.popleft()
 
                 if (
@@ -305,8 +310,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if not self.queued_usage_chunk:
                     if should_start_new_block and not self.sent_content_block_finish:
                         # Queue the sequence: content_block_stop -> content_block_start
-                        # The trigger chunk itself is not emitted as a delta since the
-                        # content_block_start already carries the relevant information.
 
                         # 1. Stop current content block
                         self.chunk_queue.append(
@@ -327,6 +330,14 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                         # Reset state for new block
                         self.sent_content_block_finish = False
+
+                        # Also forward the triggering delta if it has content.
+                        # When Bedrock omits contentBlockStart events (e.g. for marketplace
+                        # models), the first delta for a new block arrives without a prior
+                        # start event. Dropping it causes the first characters of each block
+                        # to be silently lost.
+                        if processed_chunk.get("type") == "content_block_delta":
+                            self.chunk_queue.append(processed_chunk)
 
                         # Return the first queued item
                         return self.chunk_queue.popleft()

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -143,13 +143,18 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         }
                     )
                     self.sent_content_block_finish = False
-                    # Also forward the triggering delta if it has content.
-                    # When Bedrock omits contentBlockStart events (e.g. for marketplace
-                    # models), the first delta for a new block arrives without a prior
-                    # start event. Dropping it causes the first characters of each block
-                    # to be silently lost.
-                    if processed_chunk.get("type") == "content_block_delta":
-                        self.chunk_queue.append(processed_chunk)
+                    # Forward the triggering delta. When Bedrock omits contentBlockStart
+                    # events (e.g. for marketplace models), the first delta for a new
+                    # block arrives without a prior start event. Dropping it causes the
+                    # first characters of each block to be silently lost.
+                    # Invariant: _should_start_new_content_block returns False for
+                    # finish-reason chunks, and translate_streaming_openai_response_to_anthropic
+                    # only emits MessageBlockDelta for finish-reason chunks — so
+                    # processed_chunk is always a ContentBlockDelta here.
+                    assert processed_chunk.get("type") == "content_block_delta", (
+                        f"Expected content_block_delta, got {processed_chunk.get('type')}"
+                    )
+                    self.chunk_queue.append(processed_chunk)
                     return self.chunk_queue.popleft()
 
                 if (
@@ -331,13 +336,18 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                         # Reset state for new block
                         self.sent_content_block_finish = False
 
-                        # Also forward the triggering delta if it has content.
-                        # When Bedrock omits contentBlockStart events (e.g. for marketplace
-                        # models), the first delta for a new block arrives without a prior
-                        # start event. Dropping it causes the first characters of each block
-                        # to be silently lost.
-                        if processed_chunk.get("type") == "content_block_delta":
-                            self.chunk_queue.append(processed_chunk)
+                        # Forward the triggering delta. When Bedrock omits contentBlockStart
+                        # events (e.g. for marketplace models), the first delta for a new
+                        # block arrives without a prior start event. Dropping it causes the
+                        # first characters of each block to be silently lost.
+                        # Invariant: _should_start_new_content_block returns False for
+                        # finish-reason chunks, and translate_streaming_openai_response_to_anthropic
+                        # only emits MessageBlockDelta for finish-reason chunks — so
+                        # processed_chunk is always a ContentBlockDelta here.
+                        assert processed_chunk.get("type") == "content_block_delta", (
+                            f"Expected content_block_delta, got {processed_chunk.get('type')}"
+                        )
+                        self.chunk_queue.append(processed_chunk)
 
                         # Return the first queued item
                         return self.chunk_queue.popleft()

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2111,3 +2111,196 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
         assert self.adapter.translate_anthropic_output_format_to_openai("invalid") is None
         assert self.adapter.translate_anthropic_output_format_to_openai({"type": "text"}) is None
         assert self.adapter.translate_anthropic_output_format_to_openai({"type": "json_schema"}) is None
+
+
+# ---------------------------------------------------------------------------
+# AnthropicStreamWrapper tests
+# ---------------------------------------------------------------------------
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+    AnthropicStreamWrapper,
+)
+from litellm.types.utils import ModelResponseStream
+
+
+def _make_text_chunk(text: str, finish_reason=None) -> ModelResponseStream:
+    """Build a minimal streaming ModelResponseStream with a text delta."""
+    return ModelResponseStream(
+        id="chatcmpl-test",
+        object="chat.completion.chunk",
+        created=0,
+        model="test-model",
+        choices=[
+            StreamingChoices(
+                finish_reason=finish_reason,
+                index=0,
+                delta=Delta(content=text, role="assistant"),
+                logprobs=None,
+            )
+        ],
+    )
+
+
+def _make_finish_chunk(finish_reason: str = "stop") -> ModelResponseStream:
+    return _make_text_chunk("", finish_reason=finish_reason)
+
+
+def _collect_sync(stream) -> list:
+    chunks = []
+    while True:
+        try:
+            chunks.append(next(stream))
+        except StopIteration:
+            break
+    return chunks
+
+
+class TestAnthropicStreamWrapperNoContentBlockStart:
+    """
+    Verify that AnthropicStreamWrapper correctly handles streams that omit
+    contentBlockStart events (e.g. AWS Bedrock Marketplace models).
+
+    In a well-formed stream the sequence is:
+        messageStart → contentBlockStart → contentBlockDelta* → contentBlockStop → messageDelta → messageStop
+
+    When contentBlockStart is absent the deltas arrive back-to-back:
+        messageStart → contentBlockDelta* → messageDelta → messageStop
+
+    The wrapper must synthesise the missing start/stop events and, critically,
+    must NOT drop the first delta of each content block.
+    """
+
+    def _make_wrapper(self, raw_chunks) -> AnthropicStreamWrapper:
+        return AnthropicStreamWrapper(
+            completion_stream=iter(raw_chunks),
+            model="test-model",
+        )
+
+    def test_first_delta_not_dropped(self):
+        """The very first text delta must appear in the output."""
+        raw = [
+            _make_text_chunk("Hello"),
+            _make_text_chunk(", world"),
+            _make_finish_chunk(),
+        ]
+        wrapper = self._make_wrapper(raw)
+        chunks = _collect_sync(wrapper)
+
+        types = [c["type"] for c in chunks]
+        assert "content_block_delta" in types
+
+        text_deltas = [
+            c["delta"]["text"]
+            for c in chunks
+            if c["type"] == "content_block_delta"
+            and c.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert text_deltas, "No text deltas received"
+        full_text = "".join(text_deltas)
+        assert "Hello" in full_text, f"First delta dropped; got: {full_text!r}"
+
+    def test_multi_block_first_deltas_not_dropped(self):
+        """
+        When the stream transitions from text → tool_use without contentBlockStart,
+        the first delta of the tool_use block must not be dropped.
+        """
+        raw = [
+            _make_text_chunk("Sure, "),
+            _make_text_chunk("calling tool."),
+            # Tool call chunk — triggers a new content block
+            ModelResponseStream(
+                id="chatcmpl-test",
+                object="chat.completion.chunk",
+                created=0,
+                model="test-model",
+                choices=[
+                    StreamingChoices(
+                        finish_reason=None,
+                        index=0,
+                        delta=Delta(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[
+                                ChatCompletionDeltaToolCall(
+                                    id="call_abc",
+                                    function=Function(
+                                        name="get_weather",
+                                        arguments='{"city"',
+                                    ),
+                                    type="function",
+                                    index=0,
+                                )
+                            ],
+                        ),
+                        logprobs=None,
+                    )
+                ],
+            ),
+            ModelResponseStream(
+                id="chatcmpl-test",
+                object="chat.completion.chunk",
+                created=0,
+                model="test-model",
+                choices=[
+                    StreamingChoices(
+                        finish_reason=None,
+                        index=0,
+                        delta=Delta(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[
+                                ChatCompletionDeltaToolCall(
+                                    id=None,
+                                    function=Function(
+                                        name=None,
+                                        arguments=': "Boston"}',
+                                    ),
+                                    type="function",
+                                    index=0,
+                                )
+                            ],
+                        ),
+                        logprobs=None,
+                    )
+                ],
+            ),
+            _make_finish_chunk("tool_calls"),
+        ]
+        wrapper = self._make_wrapper(raw)
+        chunks = _collect_sync(wrapper)
+
+        types = [c["type"] for c in chunks]
+        assert types.count("content_block_start") >= 2, (
+            f"Expected at least 2 content_block_start events, got: {types}"
+        )
+
+        json_deltas = "".join(
+            c["delta"]["partial_json"]
+            for c in chunks
+            if c["type"] == "content_block_delta"
+            and c.get("delta", {}).get("type") == "input_json_delta"
+        )
+        assert '{"city"' in json_deltas, (
+            f"First tool delta dropped; accumulated json: {json_deltas!r}"
+        )
+
+    def test_event_sequence_is_valid(self):
+        """Output must follow the Anthropic SSE protocol ordering."""
+        raw = [
+            _make_text_chunk("Hi"),
+            _make_finish_chunk(),
+        ]
+        wrapper = self._make_wrapper(raw)
+        chunks = _collect_sync(wrapper)
+
+        types = [c["type"] for c in chunks]
+        assert types[0] == "message_start"
+        assert types[-1] == "message_stop"
+        assert "content_block_start" in types
+        assert "content_block_stop" in types
+        # content_block_start must precede content_block_delta
+        start_idx = types.index("content_block_start")
+        delta_idx = types.index("content_block_delta")
+        assert start_idx < delta_idx, (
+            f"content_block_start ({start_idx}) must come before content_block_delta ({delta_idx})"
+        )


### PR DESCRIPTION
## Checklist

- [x] Sign the Contributor License Agreement (CLA)
- [x] Keep scope isolated (fixes one specific bug)
- [x] Added tests (`TestAnthropicStreamWrapperNoContentBlockStart` — 3 unit tests, no real API calls)
- [x] Passes linting (`black`, `ruff`)

---

## Problem

When using `bedrock/converse/<model>` with models that emit reasoning/thinking blocks (e.g. `minimax.minimax-m2.5` on AWS Bedrock Marketplace), streaming responses are **empty or truncated**.

### Root cause

AWS Bedrock's `converse-stream` API does not always emit `contentBlockStart` events — for some models it goes directly from `messageStart` to `contentBlockDelta`. When `AnthropicStreamWrapper` detects a new content block boundary from the first delta, it correctly emits `content_block_stop` + `content_block_start`, but then **returns immediately without queuing the triggering `processed_chunk`**. The comment at that line says:

> _The trigger chunk itself is not emitted as a delta since the content_block_start already carries the relevant information._

This assumption holds for tool use (where the tool name is in the start event), but **not for text or thinking blocks** where the content lives entirely in the delta.

### Impact

- Single-delta text blocks (short responses) → **completely empty**
- Multi-delta text blocks → **first N characters silently dropped**
- Affects any Bedrock Converse model that omits `contentBlockStart` events (confirmed with `minimax.minimax-m2.5`)

## Fix

After queuing `content_block_start`, also queue `processed_chunk` if it is a `content_block_delta`. Applied to both `__next__` (sync) and `__anext__` (async) paths.

## Repro

```python
# litellm proxy config:
# model_list:
#   - model_name: minimax
#     litellm_params:
#       model: bedrock/converse/minimax.minimax-m2.5

import anthropic
client = anthropic.Anthropic(base_url="http://localhost:4000", api_key="fake")

with client.messages.stream(
    model="minimax",
    max_tokens=128,
    messages=[{"role": "user", "content": "What is 2+2?"}],
) as stream:
    print(stream.get_final_message().content)
# Before fix: [TextBlock(text='', type='text')]
# After fix:  [TextBlock(text='4', type='text')]
```

The Bedrock `converse-stream` event sequence for affected models (no `contentBlockStart`):
```
messageStart
contentBlockDelta  {"contentBlockIndex": 0, "delta": {"text": ""}}
contentBlockStop   {"contentBlockIndex": 0}
contentBlockDelta  {"contentBlockIndex": 1, "delta": {"reasoningContent": {...}}}
contentBlockStop   {"contentBlockIndex": 1}
contentBlockDelta  {"contentBlockIndex": 2, "delta": {"text": "4"}}   ← was dropped
contentBlockStop   {"contentBlockIndex": 2}
messageStop
```