### PR TITLE
fix: deep copy kwargs in run_async_fallback to prevent mutation across providers

### DIFF
--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -124,13 +124,13 @@ async def run_async_fallback(
         if mg == original_model_group:
             continue
         try:
-        # Deep copy kwargs to prevent mutations from one provider
+            # Deep copy kwargs to prevent mutations from one provider
             # (e.g., Bedrock popping 'tools' from optional_params)
             # from corrupting kwargs for subsequent fallback providers.
             # See: https://github.com/BerriAI/litellm/issues/24764
-                kwargs = safe_deep_copy(kwargs)
-            
-        # LOGGING
+            kwargs = safe_deep_copy(kwargs)
+
+            # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
             verbose_router_logger.info(f"Falling back to model_group = {mg}")
             if isinstance(mg, str):
@@ -262,3 +262,4 @@ def run_non_standard_fallback_format(
     fallbacks: Union[List[str], List[Dict[str, Any]]], model_group: str
 ):
     pass
+

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -8,6 +8,7 @@ from litellm.router_utils.add_retry_fallback_headers import (
     add_fallback_headers_to_response,
 )
 from litellm.types.router import LiteLLMParamsTypedDict
+from litellm.litellm_core_utils.core_helpers import safe_deep_copy
 
 if TYPE_CHECKING:
     from litellm.router import Router as _Router
@@ -123,7 +124,13 @@ async def run_async_fallback(
         if mg == original_model_group:
             continue
         try:
-            # LOGGING
+        # Deep copy kwargs to prevent mutations from one provider
+            # (e.g., Bedrock popping 'tools' from optional_params)
+            # from corrupting kwargs for subsequent fallback providers.
+            # See: https://github.com/BerriAI/litellm/issues/24764
+                kwargs = safe_deep_copy(kwargs)
+            
+        # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
             verbose_router_logger.info(f"Falling back to model_group = {mg}")
             if isinstance(mg, str):

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -8,7 +8,6 @@ from litellm.router_utils.add_retry_fallback_headers import (
     add_fallback_headers_to_response,
 )
 from litellm.types.router import LiteLLMParamsTypedDict
-from litellm.litellm_core_utils.core_helpers import safe_deep_copy
 
 if TYPE_CHECKING:
     from litellm.router import Router as _Router
@@ -120,15 +119,21 @@ async def run_async_fallback(
 
     error_from_fallbacks = original_exception
 
+    # Snapshot original kwargs before the fallback loop so that each
+    # iteration starts from a clean, unmutated copy.
+    from litellm.litellm_core_utils.core_helpers import safe_deep_copy
+
+    base_kwargs = safe_deep_copy(kwargs)
+
     for mg in fallback_model_group:
         if mg == original_model_group:
             continue
         try:
-            # Deep copy kwargs to prevent mutations from one provider
-            # (e.g., Bedrock popping 'tools' from optional_params)
-            # from corrupting kwargs for subsequent fallback providers.
-            # See: https://github.com/BerriAI/litellm/issues/24764
-            kwargs = safe_deep_copy(kwargs)
+            # Each iteration gets a fresh copy from the clean original
+            # to prevent provider-specific mutations (e.g., Bedrock
+            # popping 'tools' from optional_params) from corrupting
+            # subsequent fallback calls. See: #24764
+            kwargs = safe_deep_copy(base_kwargs)
 
             # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)

--- a/tests/test_litellm/test_fallback_kwargs_mutation.py
+++ b/tests/test_litellm/test_fallback_kwargs_mutation.py
@@ -1,0 +1,183 @@
+"""
+Tests that run_async_fallback deep-copies kwargs before each fallback attempt,
+preventing provider-specific mutations (e.g., Bedrock popping 'tools' from
+optional_params) from corrupting subsequent fallback calls.
+
+See: https://github.com/BerriAI/litellm/issues/24764
+"""
+
+import copy
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.router_utils.fallback_event_handlers import run_async_fallback
+
+def _make_router_mock() -> MagicMock:
+    """Create a minimal mock that behaves like a LiteLLM Router."""
+    router = MagicMock()
+    router.log_retry = MagicMock(side_effect=lambda kwargs, e: kwargs)
+    return router
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_does_not_mutate_kwargs():
+    """
+    Simulate a scenario where the first fallback provider mutates kwargs
+    (e.g., pops 'tools' from optional_params) and verify that the second
+    fallback provider still receives the original kwargs with 'tools' intact.
+
+    This reproduces the bug where Bedrock's converse_handler pops 'tools'
+    and 'tool_choice' from optional_params, causing the Azure OpenAI
+    fallback to receive tool_choice without tools.
+    """
+    router = _make_router_mock()
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                    },
+                },
+            },
+        }
+    ]
+
+    original_kwargs = {
+        "model": "bedrock-model",
+        "messages": [{"role": "user", "content": "What is the weather?"}],
+        "optional_params": {
+            "tools": copy.deepcopy(tools),
+            "tool_choice": "auto",
+            "stream": False,
+        },
+        "litellm_params": {
+            "metadata": {"previous_models": ["bedrock-model"]},
+        },
+        "metadata": {"previous_models": ["bedrock-model"]},
+        "original_function": AsyncMock(),
+    }
+
+    call_count = 0
+    captured_kwargs: List[Dict[str, Any]] = []
+
+    async def mock_function_with_fallbacks(*args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        # Capture a deep copy of what was received so we can inspect later
+        captured_kwargs.append(copy.deepcopy(kwargs))
+
+        if call_count == 1:
+            # Simulate Bedrock-like mutation: pop tools and tool_choice
+            kwargs.get("optional_params", {}).pop("tools", None)
+            kwargs.get("optional_params", {}).pop("tool_choice", None)
+            raise litellm.exceptions.InternalServerError(
+                message="Simulated Bedrock timeout",
+                llm_provider="bedrock",
+                model="bedrock-model",
+            )
+        # Second call succeeds
+        mock_response = MagicMock()
+        mock_response._hidden_params = {}
+        return mock_response
+
+    router.async_function_with_fallbacks = AsyncMock(
+        side_effect=mock_function_with_fallbacks
+    )
+
+    original_exception = litellm.exceptions.InternalServerError(
+        message="Simulated Bedrock timeout",
+        llm_provider="bedrock",
+        model="bedrock-model",
+    )
+
+    await run_async_fallback(
+        litellm_router=router,
+        fallback_model_group=["azure-model-1", "azure-model-2"],
+        original_model_group="bedrock-model",
+        original_exception=original_exception,
+        max_fallbacks=5,
+        fallback_depth=0,
+        **original_kwargs,
+    )
+
+    # Both fallback attempts should have been called
+    assert call_count == 2, f"Expected 2 calls, got {call_count}"
+
+    # The second fallback call should still have 'tools' in optional_params
+    second_call_kwargs = captured_kwargs[1]
+    optional_params = second_call_kwargs.get("optional_params", {})
+
+    assert "tools" in optional_params, (
+        "Second fallback lost 'tools' from optional_params. "
+        "This means kwargs were mutated by the first fallback attempt."
+    )
+    assert "tool_choice" in optional_params, (
+        "Second fallback lost 'tool_choice' from optional_params. "
+        "This means kwargs were mutated by the first fallback attempt."
+    )
+    assert optional_params["tool_choice"] == "auto"
+    assert len(optional_params["tools"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_original_kwargs_unchanged():
+    """
+    Verify that the original kwargs dict passed to run_async_fallback
+    is not modified, even if fallback providers mutate their copy.
+    """
+    router = _make_router_mock()
+
+    original_optional_params = {
+        "tools": [{"type": "function", "function": {"name": "test_fn"}}],
+        "tool_choice": "auto",
+    }
+
+    kwargs = {
+        "model": "primary-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "optional_params": copy.deepcopy(original_optional_params),
+        "metadata": {"previous_models": ["primary-model"]},
+        "original_function": AsyncMock(),
+    }
+
+    # Keep a reference to the original optional_params dict
+    kwargs_optional_params_ref = kwargs["optional_params"]
+
+    async def mock_function_with_fallbacks(*args: Any, **kwargs: Any) -> Any:
+        # Simulate mutation
+        kwargs.get("optional_params", {}).pop("tools", None)
+        mock_response = MagicMock()
+        mock_response._hidden_params = {}
+        return mock_response
+
+    router.async_function_with_fallbacks = AsyncMock(
+        side_effect=mock_function_with_fallbacks
+    )
+
+    original_exception = Exception("Simulated error")
+
+    await run_async_fallback(
+        litellm_router=router,
+        fallback_model_group=["fallback-model"],
+        original_model_group="primary-model",
+        original_exception=original_exception,
+        max_fallbacks=5,
+        fallback_depth=0,
+        **kwargs,
+    )
+
+    # The original optional_params reference should still have 'tools'
+    assert "tools" in kwargs_optional_params_ref, (
+        "Original kwargs['optional_params'] was mutated by fallback. "
+        "safe_deep_copy should protect the caller's kwargs."
+    )
+


### PR DESCRIPTION
## Relevant issues

Fixes #24764

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix

## Changes

When `run_async_fallback` iterates over fallback model groups, provider-specific transformations (e.g., Bedrock's `converse_handler` popping `tools` and `tool_choice` from `optional_params`) mutate the shared `kwargs` dict in place. This causes subsequent fallback providers (e.g., Azure OpenAI) to receive corrupted kwargs — specifically, `tool_choice` without `tools`, triggering a 400 error.

This PR adds a `safe_deep_copy(kwargs)` call at the start of each fallback attempt inside `run_async_fallback`, ensuring each provider gets a clean copy of kwargs. This follows the same pattern already used in `litellm/litellm_core_utils/fallback_utils.py`.

**Files changed:**
- **`litellm/router_utils/fallback_event_handlers.py`**: Import `safe_deep_copy` and call `kwargs = safe_deep_copy(kwargs)` at the beginning of the `try` block in the fallback loop.
- **`tests/test_litellm/test_fallback_kwargs_mutation.py`**: Two new mocked tests verifying that kwargs are not mutated between fallback attempts and that the caller's original kwargs remain unchanged.

**Related issues:**
- #24051 — Gemini schema mutation in `add_object_type` breaks fallback to OpenAI (same family of bug, different provider)
- #10136 — LiteLLM Router carries over completion parameters across requests