### PR TITLE
fix(bedrock_guardrails): handle explicit None in guardrail assessment policy fields

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -540,7 +540,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # Check topic policy
             topic_policy = assessment.get("topicPolicy")
             if topic_policy:
-                topics = topic_policy.get("topics", [])
+                topics = topic_policy.get("topics") or []
                 for topic in topics:
                     if topic.get("action") == "BLOCKED":
                         return True
@@ -548,7 +548,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # Check content policy
             content_policy = assessment.get("contentPolicy")
             if content_policy:
-                filters = content_policy.get("filters", [])
+                filters = content_policy.get("filters") or []
                 for filter_item in filters:
                     if filter_item.get("action") == "BLOCKED":
                         return True
@@ -556,11 +556,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # Check word policy
             word_policy = assessment.get("wordPolicy")
             if word_policy:
-                custom_words = word_policy.get("customWords", [])
+                custom_words = word_policy.get("customWords") or []
                 for custom_word in custom_words:
                     if custom_word.get("action") == "BLOCKED":
                         return True
-                managed_words = word_policy.get("managedWordLists", [])
+                managed_words = word_policy.get("managedWordLists") or []
                 for managed_word in managed_words:
                     if managed_word.get("action") == "BLOCKED":
                         return True
@@ -568,12 +568,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # Check sensitive information policy
             sensitive_info_policy = assessment.get("sensitiveInformationPolicy")
             if sensitive_info_policy:
-                pii_entities = sensitive_info_policy.get("piiEntities", [])
+                pii_entities = sensitive_info_policy.get("piiEntities") or []
                 if pii_entities:
                     for pii_entity in pii_entities:
                         if pii_entity.get("action") == "BLOCKED":
                             return True
-                regexes = sensitive_info_policy.get("regexes", [])
+                regexes = sensitive_info_policy.get("regexes") or []
                 if regexes:
                     for regex in regexes:
                         if regex.get("action") == "BLOCKED":
@@ -582,7 +582,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # Check contextual grounding policy
             contextual_grounding_policy = assessment.get("contextualGroundingPolicy")
             if contextual_grounding_policy:
-                grounding_filters = contextual_grounding_policy.get("filters", [])
+                grounding_filters = contextual_grounding_policy.get("filters") or []
                 for grounding_filter in grounding_filters:
                     if grounding_filter.get("action") == "BLOCKED":
                         return True


### PR DESCRIPTION
## Summary

- Fix `TypeError: 'NoneType' object is not iterable` in `_should_raise_guardrail_blocked_exception` when Bedrock Guardrail API returns explicit `null` for policy list fields
- Replace `.get("key", [])` with `.get("key") or []` for all iterable policy fields in assessment parsing

## Problem

The Bedrock Guardrail API returns explicit `null` (Python `None`) for policy list fields when they have no entries, rather than omitting the key or returning an empty list.

`dict.get("key", [])` only returns the default `[]` when the key is **missing**. When the key **exists** with value `None`, `.get()` returns `None`, causing:

```
File "litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py", line 709, in _should_raise_guardrail_blocked_exception
    for custom_word in custom_words:
                       ^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

This means any Bedrock guardrail configuration where one word policy type fires but the other is `null` (e.g. profanity filter enabled but no custom words, or custom words but no profanity filter) will crash instead of correctly processing the block.

## Example Bedrock API responses that reproduce the issue

**Profanity filter triggered** (`customWords: null` crashes on iteration):

```python
{
  "action": "GUARDRAIL_INTERVENED",
  "assessments": [{
    "wordPolicy": {
      "customWords": None,  # <-- causes TypeError when iterated
      "managedWordLists": [
        {"action": "BLOCKED", "detected": True, "match": "shit", "type": "PROFANITY"},
        {"action": "BLOCKED", "detected": True, "match": "asshole", "type": "PROFANITY"}
      ]
    },
    "contentPolicy": {
      "filters": [{"action": "BLOCKED", "confidence": "HIGH", "detected": True, "filterStrength": "HIGH", "type": "INSULTS"}]
    },
    "topicPolicy": None,
    "sensitiveInformationPolicy": None,
    "contextualGroundingPolicy": None
  }]
}
```

**Custom word filter triggered** (`managedWordLists: null` crashes on iteration):

```python
{
  "action": "GUARDRAIL_INTERVENED",
  "assessments": [{
    "wordPolicy": {
      "customWords": [{"action": "BLOCKED", "detected": True, "match": "system prompt"}],
      "managedWordLists": None  # <-- causes TypeError when iterated
    },
    "contentPolicy": None,
    "topicPolicy": None,
    "sensitiveInformationPolicy": None,
    "contextualGroundingPolicy": None
  }]
}
```

## Fix

Replace all `.get("field", [])` calls with `.get("field") or []` in `_should_raise_guardrail_blocked_exception`. The `or []` pattern handles both missing keys **and** explicit `None` values.

### Affected fields

All iterable fields in the method are patched:
- `topicPolicy.topics`
- `contentPolicy.filters`
- `wordPolicy.customWords`
- `wordPolicy.managedWordLists`
- `sensitiveInformationPolicy.piiEntities`
- `sensitiveInformationPolicy.regexes`
- `contextualGroundingPolicy.filters`

## Test plan

- [x] Verified fix with Bedrock guardrail that has profanity filter enabled but no custom words (`customWords: null`)
- [x] Verified fix with Bedrock guardrail that has custom words but no profanity filter (`managedWordLists: null`)
- [x] Verified existing behavior unchanged when fields are present with valid lists
- [x] Verified existing behavior unchanged when policy keys are missing entirely