### PR TITLE
feat(router): health-check-driven failover v2 — stricter cooldown qualification

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9914,10 +9914,13 @@ class Router:
         parent_otel_span: Optional[Span] = None,
     ) -> List[Dict]:
         """
-        Filter out deployments marked unhealthy by background health checks.
+        Background health check integration for routing.
+
+        V2 (enable_health_check_routing=True): visibility only — logs unhealthy
+        deployments for operators but does NOT filter routing candidates.
+        The cooldown filter handles routing exclusion based on request-path failures.
+
         No-op when enable_health_check_routing is False.
-        Returns all deployments if health state is unavailable, stale, or would
-        exclude every candidate (safety net).
         """
         if not self.enable_health_check_routing:
             return healthy_deployments
@@ -9927,20 +9930,12 @@ class Router:
                 parent_otel_span=parent_otel_span
             )
         )
-        if not unhealthy_ids:
-            return healthy_deployments
-
-        filtered = [
-            d for d in healthy_deployments if d["model_info"]["id"] not in unhealthy_ids
-        ]
-
-        if not filtered:
-            verbose_router_logger.warning(
-                "All deployments marked unhealthy by health checks, bypassing health filter"
+        if unhealthy_ids:
+            verbose_router_logger.info(
+                "health_check_visibility unhealthy_deployment_ids=%s",
+                unhealthy_ids,
             )
-            return healthy_deployments
-
-        return filtered
+        return healthy_deployments
 
     def _filter_health_check_unhealthy_deployments(
         self,
@@ -9954,20 +9949,12 @@ class Router:
         unhealthy_ids = self.health_state_cache.get_unhealthy_deployment_ids(
             parent_otel_span=parent_otel_span
         )
-        if not unhealthy_ids:
-            return healthy_deployments
-
-        filtered = [
-            d for d in healthy_deployments if d["model_info"]["id"] not in unhealthy_ids
-        ]
-
-        if not filtered:
-            verbose_router_logger.warning(
-                "All deployments marked unhealthy by health checks, bypassing health filter"
+        if unhealthy_ids:
+            verbose_router_logger.info(
+                "health_check_visibility unhealthy_deployment_ids=%s",
+                unhealthy_ids,
             )
-            return healthy_deployments
-
-        return filtered
+        return healthy_deployments
 
     def _filter_pass_through_deployments(
         self, healthy_deployments: List[Dict]

--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -37,6 +37,33 @@ else:
     Span = Any
 
 
+def _is_qualifying_failure_for_v2(
+    exception_status: Union[str, int],
+    exception_str: Optional[str] = None,
+) -> bool:
+    """
+    V2 failure qualification: only hard failures qualify for cooldown.
+
+    Qualifying: 5xx (server errors), 401 (auth/credential failure), 404 (deleted deployment).
+    Not qualifying: 429 (rate limit) and 408 (timeout) — these are transient.
+
+    Used when enable_health_check_routing=True.
+    """
+    try:
+        if isinstance(exception_status, str):
+            if len(exception_status) == 0:
+                return False
+            exception_status = int(exception_status)
+
+        if exception_status >= 500:
+            return True
+        if exception_status in (401, 404):
+            return True
+        return False
+    except Exception:
+        return True
+
+
 def _is_cooldown_required(
     litellm_router_instance: LitellmRouter,
     model_id: str,
@@ -54,6 +81,12 @@ def _is_cooldown_required(
         bool: True if a cooldown is required, False otherwise.
     """
     try:
+        # V2: stricter failure qualification — only 5xx + hard 4xx (401, 404)
+        if getattr(litellm_router_instance, "enable_health_check_routing", False):
+            return _is_qualifying_failure_for_v2(
+                exception_status=exception_status,
+                exception_str=exception_str,
+            )
         ignored_strings = ["APIConnectionError"]
         if (
             exception_str is not None

--- a/tests/test_litellm/router_utils/test_health_check_routing.py
+++ b/tests/test_litellm/router_utils/test_health_check_routing.py
@@ -3,6 +3,7 @@ Tests for health-check-driven routing filter in the Router.
 """
 
 import time
+from typing import Any, Optional
 
 import pytest
 
@@ -20,7 +21,7 @@ def _make_deployment(model_id: str, model_name: str = "gpt-4") -> dict:
 
 
 def _make_health_cache(
-    unhealthy_ids: set = None, staleness_threshold: float = 60.0
+    unhealthy_ids: Optional[set] = None, staleness_threshold: float = 60.0
 ) -> DeploymentHealthCache:
     """Create a health cache pre-populated with unhealthy deployment IDs."""
     cache = DualCache()
@@ -43,26 +44,28 @@ def _make_health_cache(
 class TestFilterHealthCheckUnhealthyDeployments:
     """Test the sync filter method."""
 
-    def _make_router_like(self, enable: bool, health_cache: DeploymentHealthCache):
+    def _make_router_like(
+        self, enable: bool, health_cache: DeploymentHealthCache
+    ) -> Any:
         """Create a minimal object that behaves like Router for filter testing."""
-
-        class FakeRouter:
-            def __init__(self):
-                self.enable_health_check_routing = enable
-                self.health_state_cache = health_cache
-
-        # Import the actual method and bind it
         from litellm.router import Router
 
-        fake = FakeRouter()
-        # Use the unbound method
-        fake._filter_health_check_unhealthy_deployments = (
-            Router._filter_health_check_unhealthy_deployments.__get__(fake, FakeRouter)
-        )
-        return fake
+        class FakeRouter:
+            def __init__(self) -> None:
+                self.enable_health_check_routing = enable
+                self.health_state_cache = health_cache
+                setattr(
+                    self,
+                    "_filter_health_check_unhealthy_deployments",
+                    Router._filter_health_check_unhealthy_deployments.__get__(
+                        self, FakeRouter
+                    ),
+                )
 
-    def test_filter_removes_unhealthy_deployments(self):
-        """Unhealthy deployments should be removed from candidates."""
+        return FakeRouter()
+
+    def test_filter_is_visibility_only_when_enabled(self):
+        """V2: unhealthy deployments are logged but NOT filtered from candidates."""
         health_cache = _make_health_cache(unhealthy_ids={"deploy-2"})
         router = self._make_router_like(enable=True, health_cache=health_cache)
 
@@ -72,8 +75,7 @@ class TestFilterHealthCheckUnhealthyDeployments:
             _make_deployment("deploy-3"),
         ]
         result = router._filter_health_check_unhealthy_deployments(deployments)
-        assert len(result) == 2
-        assert all(d["model_info"]["id"] != "deploy-2" for d in result)
+        assert len(result) == 3  # all returned, visibility only
 
     def test_filter_noop_when_disabled(self):
         """When enable_health_check_routing=False, filter should be a no-op."""
@@ -88,7 +90,7 @@ class TestFilterHealthCheckUnhealthyDeployments:
         assert len(result) == 2  # no filtering
 
     def test_filter_returns_all_when_all_unhealthy(self):
-        """Safety net: if ALL deployments are unhealthy, return all (don't cause outage)."""
+        """V2: all deployments returned even when all unhealthy (visibility only)."""
         health_cache = _make_health_cache(
             unhealthy_ids={"deploy-1", "deploy-2", "deploy-3"}
         )
@@ -100,7 +102,7 @@ class TestFilterHealthCheckUnhealthyDeployments:
             _make_deployment("deploy-3"),
         ]
         result = router._filter_health_check_unhealthy_deployments(deployments)
-        assert len(result) == 3  # all returned, safety net
+        assert len(result) == 3  # all returned, visibility only
 
     def test_filter_returns_all_when_cache_empty(self):
         """When cache is empty, all deployments should pass through."""
@@ -118,25 +120,28 @@ class TestFilterHealthCheckUnhealthyDeployments:
 class TestAsyncFilterHealthCheckUnhealthyDeployments:
     """Test the async filter method."""
 
-    def _make_router_like(self, enable: bool, health_cache: DeploymentHealthCache):
+    def _make_router_like(
+        self, enable: bool, health_cache: DeploymentHealthCache
+    ) -> Any:
         from litellm.router import Router
 
         class FakeRouter:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.enable_health_check_routing = enable
                 self.health_state_cache = health_cache
+                setattr(
+                    self,
+                    "_async_filter_health_check_unhealthy_deployments",
+                    Router._async_filter_health_check_unhealthy_deployments.__get__(
+                        self, FakeRouter
+                    ),
+                )
 
-        fake = FakeRouter()
-        fake._async_filter_health_check_unhealthy_deployments = (
-            Router._async_filter_health_check_unhealthy_deployments.__get__(
-                fake, FakeRouter
-            )
-        )
-        return fake
+        return FakeRouter()
 
     @pytest.mark.asyncio
-    async def test_async_filter_removes_unhealthy(self):
-        """Async version: unhealthy deployments removed."""
+    async def test_async_filter_is_visibility_only(self):
+        """V2: async filter logs but does not remove unhealthy deployments."""
         health_cache = _make_health_cache(unhealthy_ids={"deploy-2"})
         router = self._make_router_like(enable=True, health_cache=health_cache)
 
@@ -148,12 +153,11 @@ class TestAsyncFilterHealthCheckUnhealthyDeployments:
         result = await router._async_filter_health_check_unhealthy_deployments(
             healthy_deployments=deployments
         )
-        assert len(result) == 2
-        assert all(d["model_info"]["id"] != "deploy-2" for d in result)
+        assert len(result) == 3  # all returned, visibility only
 
     @pytest.mark.asyncio
-    async def test_async_filter_safety_net(self):
-        """Async version: safety net when all unhealthy."""
+    async def test_async_filter_all_unhealthy_returns_all(self):
+        """V2: all deployments returned even when all unhealthy."""
         health_cache = _make_health_cache(unhealthy_ids={"deploy-1", "deploy-2"})
         router = self._make_router_like(enable=True, health_cache=health_cache)
 
@@ -164,7 +168,7 @@ class TestAsyncFilterHealthCheckUnhealthyDeployments:
         result = await router._async_filter_health_check_unhealthy_deployments(
             healthy_deployments=deployments
         )
-        assert len(result) == 2  # safety net
+        assert len(result) == 2  # all returned, visibility only
 
 
 class TestBuildDeploymentHealthStates:

--- a/tests/test_litellm/router_utils/test_v2_health_failover.py
+++ b/tests/test_litellm/router_utils/test_v2_health_failover.py
@@ -1,0 +1,237 @@
+"""
+Tests for V2 health-check-driven failover.
+
+Validates the production routing behavior:
+- Fail over on qualifying 5xx-style deployment failures
+- Do NOT fail over on 429 rate limits
+- Do NOT fail over on timeout errors
+- Background health checks provide visibility only, not routing exclusion
+"""
+
+import time
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_utils.cooldown_handlers import (
+    _is_cooldown_required,
+    _is_qualifying_failure_for_v2,
+)
+from litellm.router_utils.health_state_cache import DeploymentHealthCache
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_deployment(model_id: str, model_name: str = "gpt-4") -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {"model": model_name, "api_key": "fake"},
+        "model_info": {"id": model_id},
+    }
+
+
+class _FakeRouterV2:
+    """Minimal router stub with enable_health_check_routing=True."""
+
+    def __init__(self, enable_health_check_routing: bool = True):
+        self.enable_health_check_routing = enable_health_check_routing
+
+
+class _FakeRouterV1:
+    """Minimal router stub with V1 behavior (health check routing off)."""
+
+    def __init__(self):
+        self.enable_health_check_routing = False
+
+
+# ---------------------------------------------------------------------------
+# 1. Failure qualification unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsQualifyingFailureForV2:
+    """Direct unit tests for the V2 failure qualification gate."""
+
+    def test_5xx_qualifies(self):
+        assert _is_qualifying_failure_for_v2(500) is True
+        assert _is_qualifying_failure_for_v2(502) is True
+        assert _is_qualifying_failure_for_v2(503) is True
+        assert _is_qualifying_failure_for_v2(504) is True
+
+    def test_401_qualifies(self):
+        assert _is_qualifying_failure_for_v2(401) is True
+
+    def test_404_qualifies(self):
+        assert _is_qualifying_failure_for_v2(404) is True
+
+    def test_429_does_not_qualify(self):
+        assert _is_qualifying_failure_for_v2(429) is False
+
+    def test_408_timeout_does_not_qualify(self):
+        assert _is_qualifying_failure_for_v2(408) is False
+
+    def test_other_4xx_do_not_qualify(self):
+        assert _is_qualifying_failure_for_v2(400) is False
+        assert _is_qualifying_failure_for_v2(403) is False
+        assert _is_qualifying_failure_for_v2(422) is False
+
+    def test_string_status_codes(self):
+        assert _is_qualifying_failure_for_v2("503") is True
+        assert _is_qualifying_failure_for_v2("429") is False
+        assert _is_qualifying_failure_for_v2("") is False
+
+
+# ---------------------------------------------------------------------------
+# 2. _is_cooldown_required branching on V2
+# ---------------------------------------------------------------------------
+
+
+class TestIsCooldownRequiredV2Branch:
+    """Test that _is_cooldown_required uses V2 qualification when enabled."""
+
+    def test_429_does_not_trigger_cooldown_in_v2(self):
+        """Scenario: 429 handling — no failover."""
+        router = _FakeRouterV2(enable_health_check_routing=True)
+        result = _is_cooldown_required(
+            litellm_router_instance=router,
+            model_id="deploy-1",
+            exception_status=429,
+        )
+        assert result is False
+
+    def test_408_timeout_does_not_trigger_cooldown_in_v2(self):
+        """Scenario: Timeout handling — no failover."""
+        router = _FakeRouterV2(enable_health_check_routing=True)
+        result = _is_cooldown_required(
+            litellm_router_instance=router,
+            model_id="deploy-1",
+            exception_status=408,
+        )
+        assert result is False
+
+    def test_503_triggers_cooldown_in_v2(self):
+        """Scenario: True 5xx failover — 503 qualifies."""
+        router = _FakeRouterV2(enable_health_check_routing=True)
+        result = _is_cooldown_required(
+            litellm_router_instance=router,
+            model_id="deploy-1",
+            exception_status=503,
+        )
+        assert result is True
+
+    def test_401_auth_failure_triggers_cooldown_in_v2(self):
+        """Scenario: Hard auth failure qualifies."""
+        router = _FakeRouterV2(enable_health_check_routing=True)
+        result = _is_cooldown_required(
+            litellm_router_instance=router,
+            model_id="deploy-1",
+            exception_status=401,
+        )
+        assert result is True
+
+    def test_404_deleted_deployment_triggers_cooldown_in_v2(self):
+        """Scenario: Hard upstream failure (deleted deployment) — 404 qualifies."""
+        router = _FakeRouterV2(enable_health_check_routing=True)
+        result = _is_cooldown_required(
+            litellm_router_instance=router,
+            model_id="deploy-1",
+            exception_status=404,
+        )
+        assert result is True
+
+    def test_v1_behavior_preserved_when_v2_disabled(self):
+        """When enable_health_check_routing=False, V1 behavior: 429 DOES trigger cooldown."""
+        router = _FakeRouterV1()
+        result = _is_cooldown_required(
+            litellm_router_instance=router,
+            model_id="deploy-1",
+            exception_status=429,
+        )
+        assert result is True  # V1 cools down on 429
+
+
+# ---------------------------------------------------------------------------
+# 3. Health check filter is visibility-only
+# ---------------------------------------------------------------------------
+
+
+def _make_health_cache(
+    unhealthy_ids: set = None, staleness_threshold: float = 60.0
+) -> DeploymentHealthCache:
+    cache = DualCache()
+    health_cache = DeploymentHealthCache(
+        cache=cache, staleness_threshold=staleness_threshold
+    )
+    if unhealthy_ids:
+        now = time.time()
+        states = {
+            uid: {"is_healthy": False, "timestamp": now, "reason": "test"}
+            for uid in unhealthy_ids
+        }
+        health_cache.set_deployment_health_states(states)
+    return health_cache
+
+
+class TestHealthCheckFilterVisibilityOnly:
+    """Test that the health check filter is visibility-only in V2."""
+
+    def _make_router_like(self, enable: bool, health_cache: DeploymentHealthCache):
+        from litellm.router import Router
+
+        class FakeRouter:
+            def __init__(self):
+                self.enable_health_check_routing = enable
+                self.health_state_cache = health_cache
+
+        fake = FakeRouter()
+        fake._filter_health_check_unhealthy_deployments = (
+            Router._filter_health_check_unhealthy_deployments.__get__(fake, FakeRouter)
+        )
+        fake._async_filter_health_check_unhealthy_deployments = (
+            Router._async_filter_health_check_unhealthy_deployments.__get__(
+                fake, FakeRouter
+            )
+        )
+        return fake
+
+    def test_health_check_filter_visibility_only(self):
+        """Scenario: Background health visibility — no routing impact."""
+        health_cache = _make_health_cache(unhealthy_ids={"deploy-2"})
+        router = self._make_router_like(enable=True, health_cache=health_cache)
+
+        deployments = [
+            _make_deployment("deploy-1"),
+            _make_deployment("deploy-2"),
+            _make_deployment("deploy-3"),
+        ]
+        result = router._filter_health_check_unhealthy_deployments(deployments)
+        # All deployments returned — filter is visibility-only
+        assert len(result) == 3
+        ids = {d["model_info"]["id"] for d in result}
+        assert "deploy-2" in ids
+
+    @pytest.mark.asyncio
+    async def test_async_health_check_filter_visibility_only(self):
+        """Async version: visibility-only, no routing impact."""
+        health_cache = _make_health_cache(unhealthy_ids={"deploy-2"})
+        router = self._make_router_like(enable=True, health_cache=health_cache)
+
+        deployments = [
+            _make_deployment("deploy-1"),
+            _make_deployment("deploy-2"),
+        ]
+        result = await router._async_filter_health_check_unhealthy_deployments(
+            healthy_deployments=deployments
+        )
+        assert len(result) == 2  # all returned
+
+    def test_filter_noop_when_disabled(self):
+        """When disabled, filter is a no-op regardless."""
+        health_cache = _make_health_cache(unhealthy_ids={"deploy-1"})
+        router = self._make_router_like(enable=False, health_cache=health_cache)
+
+        deployments = [_make_deployment("deploy-1"), _make_deployment("deploy-2")]
+        result = router._filter_health_check_unhealthy_deployments(deployments)
+        assert len(result) == 2


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

When `enable_health_check_routing: true`, only hard failures (5xx, 401, 404) trigger deployment cooldown/failover. 429 rate-limit and 408 timeout responses are now excluded — they are transient and should not reroute traffic away from the deployment.

Background health checks are now visibility-only under this flag: unhealthy deployment IDs are logged for operator observability but no longer filter routing candidates. The existing cooldown cache (driven by request-path failures) is the sole routing exclusion mechanism.

**Files changed:**
- `litellm/router_utils/cooldown_handlers.py` — new `_is_qualifying_failure_for_v2()` + V2 branch in `_is_cooldown_required()`
- `litellm/router.py` — health check filter methods made visibility-only (log, don't exclude)
- `tests/test_litellm/router_utils/test_v2_health_failover.py` — new: 16 tests covering V2 qualification logic and filter behavior
- `tests/test_litellm/router_utils/test_health_check_routing.py` — updated to reflect V2 visibility-only behavior