### PR TITLE
fix(docs): add missing default values to OpenAPI spec

### DIFF
--- a/litellm/proxy/openapi.json
+++ b/litellm/proxy/openapi.json
@@ -70,19 +70,23 @@
               },
               "temperature": {
                 "type": "number",
-                "description": "The sampling temperature to be used"
+                "description": "The sampling temperature to be used",
+                "default": 1
               },
               "top_p": {
                 "type": "number",
-                "description": "An alternative to sampling with temperature"
+                "description": "An alternative to sampling with temperature",
+                "default": 1
               },
               "n": {
                 "type": "integer",
-                "description": "The number of chat completion choices to generate for each input message"
+                "description": "The number of chat completion choices to generate for each input message",
+                "default": 1
               },
               "stream": {
                 "type": "boolean",
-                "description": "If set to true, it sends partial message deltas"
+                "description": "If set to true, it sends partial message deltas",
+                "default": false
               },
               "stop": {
                 "type": "array",
@@ -97,11 +101,13 @@
               },
               "presence_penalty": {
                 "type": "number",
-                "description": "It is used to penalize new tokens based on their existence in the text so far"
+                "description": "It is used to penalize new tokens based on their existence in the text so far",
+                "default": 0
               },
               "frequency_penalty": {
                 "type": "number",
-                "description": "It is used to penalize new tokens based on their frequency in the text so far"
+                "description": "It is used to penalize new tokens based on their frequency in the text so far",
+                "default": 0
               },
               "logit_bias": {
                 "type": "object",

--- a/tests/test_litellm/proxy/test_openapi_schema_validation.py
+++ b/tests/test_litellm/proxy/test_openapi_schema_validation.py
@@ -140,3 +140,73 @@ class TestCredentialEndpointsOpenAPISchema:
         assert "credential_name" in sig.parameters, (
             "get_credential_by_name must have a credential_name parameter"
         )
+
+
+class TestOpenAPISpecDefaultValues:
+    """Test that the static openapi.json has correct default values for chat completion parameters."""
+
+    @pytest.fixture
+    def openapi_spec(self):
+        """Load the static openapi.json spec."""
+        import json
+        from pathlib import Path
+
+        spec_path = (
+            Path(__file__).parents[3] / "litellm" / "proxy" / "openapi.json"
+        )
+        with open(spec_path) as f:
+            return json.load(f)
+
+    def test_temperature_has_default(self, openapi_spec):
+        """temperature should have default value 1."""
+        props = (
+            openapi_spec["paths"]["/chat/completions"]["post"]["requestBody"]
+            ["content"]["application/json"]["schema"]["properties"]
+        )
+        assert "default" in props["temperature"]
+        assert props["temperature"]["default"] == 1
+
+    def test_top_p_has_default(self, openapi_spec):
+        """top_p should have default value 1."""
+        props = (
+            openapi_spec["paths"]["/chat/completions"]["post"]["requestBody"]
+            ["content"]["application/json"]["schema"]["properties"]
+        )
+        assert "default" in props["top_p"]
+        assert props["top_p"]["default"] == 1
+
+    def test_n_has_default(self, openapi_spec):
+        """n should have default value 1."""
+        props = (
+            openapi_spec["paths"]["/chat/completions"]["post"]["requestBody"]
+            ["content"]["application/json"]["schema"]["properties"]
+        )
+        assert "default" in props["n"]
+        assert props["n"]["default"] == 1
+
+    def test_stream_has_default(self, openapi_spec):
+        """stream should have default value false."""
+        props = (
+            openapi_spec["paths"]["/chat/completions"]["post"]["requestBody"]
+            ["content"]["application/json"]["schema"]["properties"]
+        )
+        assert "default" in props["stream"]
+        assert props["stream"]["default"] is False
+
+    def test_presence_penalty_has_default(self, openapi_spec):
+        """presence_penalty should have default value 0."""
+        props = (
+            openapi_spec["paths"]["/chat/completions"]["post"]["requestBody"]
+            ["content"]["application/json"]["schema"]["properties"]
+        )
+        assert "default" in props["presence_penalty"]
+        assert props["presence_penalty"]["default"] == 0
+
+    def test_frequency_penalty_has_default(self, openapi_spec):
+        """frequency_penalty should have default value 0."""
+        props = (
+            openapi_spec["paths"]["/chat/completions"]["post"]["requestBody"]
+            ["content"]["application/json"]["schema"]["properties"]
+        )
+        assert "default" in props["frequency_penalty"]
+        assert props["frequency_penalty"]["default"] == 0


### PR DESCRIPTION
## Summary

- Added explicit `default` values to 6 parameters in `litellm/proxy/openapi.json` that had defined defaults in the proxy implementation but were missing from the spec
- Added `TestOpenAPISpecDefaultValues` test class to validate defaults are present and correct

## Parameters Updated

| Parameter | Default | Source |
|---|---|---|
| `temperature` | `1` | `litellm/main.py:1112` (docstring) |
| `top_p` | `1` | `litellm/main.py:1113` (docstring) |
| `n` | `1` | `litellm/main.py:1114` (docstring) |
| `stream` | `false` | `litellm/main.py:1115` (docstring) |
| `presence_penalty` | `0` | OpenAI API standard |
| `frequency_penalty` | `0` | OpenAI API standard |

## Test plan

- JSON syntax validation: passed
- New test class `TestOpenAPISpecDefaultValues` with 6 tests verifying each default

## Related

No runtime behavior changes. Documentation-only improvement.