### PR TITLE
fix(oci): dynamic max_tokens default and filter empty Cohere chat history

### DIFF
--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -671,15 +671,25 @@ class OCIChatConfig(BaseConfig):
         Uses litellm's model cost map for a dynamic lookup, falling back to
         DEFAULT_MAX_TOKENS (configurable via the DEFAULT_MAX_TOKENS env var)
         when the model is not found.
+
+        The model cost map stores OCI entries under ``oci/`` prefixed keys
+        (e.g. ``oci/cohere.command-a-03-2025``), but litellm strips the
+        provider prefix before calling ``transform_request``.  We therefore
+        try the bare name first and, if that misses, retry with the
+        ``oci/`` prefix.
         """
         if model is None:
             return DEFAULT_MAX_TOKENS
-        try:
-            max_tokens = get_max_tokens(model)
-            if max_tokens is not None:
-                return max_tokens
-        except Exception:
-            pass
+        # Try the bare model name first, then with the oci/ provider prefix
+        # since the cost map keys are prefixed but transform_request receives
+        # the name without the prefix.
+        for candidate in (model, f"oci/{model}"):
+            try:
+                max_tokens = get_max_tokens(candidate)
+                if max_tokens is not None:
+                    return max_tokens
+            except Exception:
+                continue
         return DEFAULT_MAX_TOKENS
 
     def _get_optional_params(
@@ -907,8 +917,15 @@ class OCIChatConfig(BaseConfig):
         # Build request based on vendor type
         if vendor == OCIVendors.COHERE:
             # For Cohere, we need to use the specific Cohere format
-            # Extract the last user message as the main message
-            user_messages = [msg for msg in messages if msg.get("role") == "user"]
+            # Extract the last user message as the main message.
+            # Filter out user messages with empty content — the Cohere API
+            # requires the main message field to be non-empty.
+            user_messages = [
+                msg
+                for msg in messages
+                if msg.get("role") == "user"
+                and self._extract_text_content(msg.get("content", "")).strip()
+            ]
             if not user_messages:
                 raise Exception("No user message found for Cohere model")
 

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -60,10 +60,12 @@ from litellm.types.utils import (
     ModelResponseStream,
     StreamingChoices,
 )
+from litellm.constants import DEFAULT_MAX_TOKENS
 from litellm.utils import (
     ChatCompletionMessageToolCall,
     CustomStreamWrapper,
     Usage,
+    get_max_tokens,
 )
 
 if TYPE_CHECKING:
@@ -661,7 +663,28 @@ class OCIChatConfig(BaseConfig):
         oci_region = optional_params.get("oci_region", "us-ashburn-1")
         return f"https://inference.generativeai.{oci_region}.oci.oraclecloud.com/20231130/actions/chat"
 
-    def _get_optional_params(self, vendor: OCIVendors, optional_params: dict) -> Dict:
+    @staticmethod
+    def _get_max_tokens_for_model(model: Optional[str] = None) -> int:
+        """
+        Get the max output tokens for a given OCI model.
+
+        Uses litellm's model cost map for a dynamic lookup, falling back to
+        DEFAULT_MAX_TOKENS (configurable via the DEFAULT_MAX_TOKENS env var)
+        when the model is not found.
+        """
+        if model is None:
+            return DEFAULT_MAX_TOKENS
+        try:
+            max_tokens = get_max_tokens(model)
+            if max_tokens is not None:
+                return max_tokens
+        except Exception:
+            pass
+        return DEFAULT_MAX_TOKENS
+
+    def _get_optional_params(
+        self, vendor: OCIVendors, optional_params: dict, model: Optional[str] = None
+    ) -> Dict:
         selected_params = {}
         if vendor == OCIVendors.COHERE:
             open_ai_to_oci_param_map = self.openai_to_oci_cohere_param_map
@@ -669,7 +692,7 @@ class OCIChatConfig(BaseConfig):
             open_ai_to_oci_param_map.pop("tool_choice")
             # Add default values for Cohere API
             selected_params = {
-                "maxTokens": 600,
+                "maxTokens": self._get_max_tokens_for_model(model),
                 "temperature": 1,
                 "topK": 0,
                 "topP": 0.75,
@@ -780,6 +803,13 @@ class OCIChatConfig(BaseConfig):
                             parameters=arguments,
                         )
                     )
+
+            # Cohere requires all chat history elements to have a non-empty
+            # message.  Upstream callers (e.g. Open WebUI) may include
+            # assistant placeholders or empty system messages.  Skip them
+            # to avoid a 400 "all elements in history must have a message".
+            if not content and not tool_calls:
+                continue
 
             if role == "user":
                 chat_history.append(CohereMessage(role="USER", message=content))
@@ -895,7 +925,7 @@ class OCIChatConfig(BaseConfig):
 
             # Create Cohere-specific chat request
             optional_cohere_params = self._get_optional_params(
-                OCIVendors.COHERE, optional_params
+                OCIVendors.COHERE, optional_params, model=model
             )
             chat_request = CohereChatRequest(
                 apiFormat="COHERE",
@@ -918,7 +948,7 @@ class OCIChatConfig(BaseConfig):
                 chatRequest=OCIChatRequestPayload(
                     apiFormat=vendor.value,
                     messages=adapt_messages_to_generic_oci_standard(messages),
-                    **self._get_optional_params(vendor, optional_params),
+                    **self._get_optional_params(vendor, optional_params, model=model),
                 ),
             )
 

--- a/tests/test_litellm/llms/oci/chat/test_oci_cohere_max_tokens_and_empty_messages.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_cohere_max_tokens_and_empty_messages.py
@@ -1,0 +1,194 @@
+"""
+Tests for OCI Cohere chat fixes:
+1. Dynamic maxTokens default via model cost map lookup
+2. Filtering empty messages from Cohere chat history
+"""
+
+import os
+import sys
+
+import pytest
+
+# Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm.llms.oci.chat.transformation import OCIChatConfig
+from litellm.types.llms.oci import OCIVendors
+from litellm.constants import DEFAULT_MAX_TOKENS
+
+
+TEST_COMPARTMENT_ID = "ocid1.compartment.oc1..xxxxxx"
+BASE_OCI_PARAMS = {
+    "oci_region": "us-ashburn-1",
+    "oci_user": "ocid1.user.oc1..xxxxxxEXAMPLExxxxxx",
+    "oci_fingerprint": "4f:29:77:cc:b1:3e:55:ab:61:2a:de:47:f1:38:4c:90",
+    "oci_tenancy": "ocid1.tenancy.oc1..xxxxxxEXAMPLExxxxxx",
+    "oci_compartment_id": TEST_COMPARTMENT_ID,
+    "oci_key": "<private_key.pem as string>",
+}
+
+
+class TestOCICohereMaxTokens:
+    """Tests for dynamic maxTokens default lookup."""
+
+    def test_max_tokens_uses_model_cost_map(self):
+        """When a model is in the cost map, maxTokens should use its max_output_tokens."""
+        config = OCIChatConfig()
+
+        # oci/cohere.command-a-03-2025 has max_output_tokens=4000 in the cost map
+        params = config._get_optional_params(
+            OCIVendors.COHERE, BASE_OCI_PARAMS, model="oci/cohere.command-a-03-2025"
+        )
+
+        assert params["maxTokens"] == 4000
+
+    def test_max_tokens_falls_back_to_default(self):
+        """When a model is NOT in the cost map, maxTokens should fall back to DEFAULT_MAX_TOKENS."""
+        config = OCIChatConfig()
+
+        params = config._get_optional_params(
+            OCIVendors.COHERE, BASE_OCI_PARAMS, model="oci/cohere.nonexistent-model"
+        )
+
+        assert params["maxTokens"] == DEFAULT_MAX_TOKENS
+
+    def test_max_tokens_falls_back_when_model_is_none(self):
+        """When model is None, maxTokens should fall back to DEFAULT_MAX_TOKENS."""
+        config = OCIChatConfig()
+
+        params = config._get_optional_params(
+            OCIVendors.COHERE, BASE_OCI_PARAMS, model=None
+        )
+
+        assert params["maxTokens"] == DEFAULT_MAX_TOKENS
+
+    def test_user_provided_max_tokens_overrides_default(self):
+        """User-provided max_tokens should override the dynamic default."""
+        config = OCIChatConfig()
+
+        params_with_override = {**BASE_OCI_PARAMS, "max_tokens": 1024}
+        params = config._get_optional_params(
+            OCIVendors.COHERE, params_with_override, model="oci/cohere.command-a-03-2025"
+        )
+
+        assert params["maxTokens"] == 1024
+
+    def test_get_max_tokens_for_model_known_model(self):
+        """_get_max_tokens_for_model should return the correct value for a known model."""
+        result = OCIChatConfig._get_max_tokens_for_model("oci/cohere.command-a-03-2025")
+        assert result == 4000
+
+    def test_get_max_tokens_for_model_unknown_model(self):
+        """_get_max_tokens_for_model should return DEFAULT_MAX_TOKENS for an unknown model."""
+        result = OCIChatConfig._get_max_tokens_for_model("oci/unknown-model-xyz")
+        assert result == DEFAULT_MAX_TOKENS
+
+    def test_get_max_tokens_for_model_none(self):
+        """_get_max_tokens_for_model should return DEFAULT_MAX_TOKENS when model is None."""
+        result = OCIChatConfig._get_max_tokens_for_model(None)
+        assert result == DEFAULT_MAX_TOKENS
+
+
+class TestOCICohereEmptyMessages:
+    """Tests for filtering empty messages from Cohere chat history.
+
+    Note: adapt_messages_to_cohere_standard() processes messages[:-1]
+    (all messages except the last one, which is the current user message).
+    The returned CohereMessage objects are Pydantic models with .role and
+    .message attributes.
+    """
+
+    def test_empty_assistant_message_is_filtered(self):
+        """An assistant message with empty content should be excluded from chat history."""
+        config = OCIChatConfig()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "How are you?"},
+        ]
+
+        # messages[:-1] = ["Hello" (user), "" (assistant)]
+        # Empty assistant is filtered, so only "Hello" remains
+        history = config.adapt_messages_to_cohere_standard(messages)
+
+        assert len(history) == 1
+        assert history[0].role == "USER"
+        assert history[0].message == "Hello"
+
+    def test_empty_system_message_is_filtered(self):
+        """A system message with empty content should be excluded from chat history."""
+        config = OCIChatConfig()
+        messages = [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": "Hello"},
+            {"role": "user", "content": "Last message"},
+        ]
+
+        # messages[:-1] = ["" (system), "Hello" (user)]
+        # Empty system is filtered, so only "Hello" remains
+        history = config.adapt_messages_to_cohere_standard(messages)
+
+        assert len(history) == 1
+        assert history[0].role == "USER"
+        assert history[0].message == "Hello"
+
+    def test_none_content_message_is_filtered(self):
+        """A message with None content should be excluded from chat history."""
+        config = OCIChatConfig()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": None},
+            {"role": "user", "content": "Last message"},
+        ]
+
+        # messages[:-1] = ["Hello" (user), None (assistant)]
+        # None assistant is filtered, so only "Hello" remains
+        history = config.adapt_messages_to_cohere_standard(messages)
+
+        assert len(history) == 1
+        assert history[0].role == "USER"
+        assert history[0].message == "Hello"
+
+    def test_non_empty_messages_are_preserved(self):
+        """Non-empty messages should be included in chat history normally."""
+        config = OCIChatConfig()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "Last message"},
+        ]
+
+        # messages[:-1] = ["Hello" (user), "Hi there!" (assistant)]
+        history = config.adapt_messages_to_cohere_standard(messages)
+
+        assert len(history) == 2
+        assert history[0].role == "USER"
+        assert history[0].message == "Hello"
+        assert history[1].role == "CHATBOT"
+        assert history[1].message == "Hi there!"
+
+    def test_mixed_empty_and_nonempty_messages(self):
+        """Only empty messages should be filtered; non-empty ones kept."""
+        config = OCIChatConfig()
+        messages = [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "Second question"},
+            {"role": "assistant", "content": "A real answer"},
+            {"role": "user", "content": "Last message"},
+        ]
+
+        # messages[:-1] excludes "Last message"
+        # Empty system and empty assistant are filtered
+        # Remaining: "First question" (user), "Second question" (user), "A real answer" (chatbot)
+        history = config.adapt_messages_to_cohere_standard(messages)
+
+        assert len(history) == 3
+        assert history[0].role == "USER"
+        assert history[0].message == "First question"
+        assert history[1].role == "USER"
+        assert history[1].message == "Second question"
+        assert history[2].role == "CHATBOT"
+        assert history[2].message == "A real answer"

--- a/tests/test_litellm/llms/oci/chat/test_oci_cohere_max_tokens_and_empty_messages.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_cohere_max_tokens_and_empty_messages.py
@@ -74,9 +74,18 @@ class TestOCICohereMaxTokens:
 
         assert params["maxTokens"] == 1024
 
-    def test_get_max_tokens_for_model_known_model(self):
-        """_get_max_tokens_for_model should return the correct value for a known model."""
+    def test_get_max_tokens_for_model_with_oci_prefix(self):
+        """_get_max_tokens_for_model should work with the oci/ prefix."""
         result = OCIChatConfig._get_max_tokens_for_model("oci/cohere.command-a-03-2025")
+        assert result == 4000
+
+    def test_get_max_tokens_for_model_without_oci_prefix(self):
+        """_get_max_tokens_for_model should also work without the oci/ prefix.
+
+        litellm strips the provider prefix before calling transform_request,
+        so the method must retry with the oci/ prefix to find the cost map entry.
+        """
+        result = OCIChatConfig._get_max_tokens_for_model("cohere.command-a-03-2025")
         assert result == 4000
 
     def test_get_max_tokens_for_model_unknown_model(self):


### PR DESCRIPTION
## Summary

Two fixes for the OCI Cohere chat integration in `litellm/llms/oci/chat/transformation.py`:

### 1. Dynamic `maxTokens` default instead of hardcoded 600

**Problem:** The Cohere default `maxTokens` was hardcoded to `600`, causing responses to be silently truncated well before the model's actual output limit (e.g. `4000` for `cohere.command-a-03-2025`). Users sending `max_tokens` in their requests were unaffected, but anyone relying on defaults got very short outputs.

**Fix:** Replace the hardcoded value with a dynamic lookup via `get_max_tokens()`, following the same pattern used by the Anthropic provider (`get_max_tokens_for_model()`). This reads from litellm's `model_cost_map` where OCI models already have correct `max_output_tokens` entries. Falls back to `DEFAULT_MAX_TOKENS` (configurable via env var, default `4096`) when the model is not found.

### 2. Filter empty messages from Cohere chat history

**Problem:** The Cohere API requires all chat history elements to have a non-empty `message` field. When upstream callers like Open WebUI send messages with empty content (e.g. empty assistant placeholders or system messages during multi-turn conversations), the API returns a `400` error:
```
invalid request: all elements in history must have a message
```

**Fix:** Skip history entries with empty content (and no tool calls) in `adapt_messages_to_cohere_standard()` before sending to the API.

## Test plan

- [ ] Verify `maxTokens` defaults to the model's `max_output_tokens` from the cost map (e.g. `4000` for `oci/cohere.command-a-03-2025`) instead of `600`
- [ ] Verify user-provided `max_tokens` still overrides the default
- [ ] Verify that requests with empty messages in chat history no longer return 400 errors
- [ ] Verify that non-empty messages are still included in history correctly
- [ ] Verify generic (non-Cohere) OCI models are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)