### PR TITLE
fix(proxy): prevent PostgreSQL deadlocks in concurrent spend updates 

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
 import httpx
+import prisma.errors
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -3571,6 +3572,17 @@ DB_CONNECTION_ERROR_TYPES = (
     httpx.ReadError,
     httpx.ReadTimeout,
 )
+
+PRISMA_DEADLOCK_CODE = "P2034"
+"""Prisma error code for PostgreSQL deadlock / write conflict."""
+
+
+def _is_deadlock_error(e: Exception) -> bool:
+    """Check if a Prisma error is a PostgreSQL deadlock / write conflict (P2034)."""
+    return (
+        isinstance(e, prisma.errors.DataError)
+        and getattr(e, "code", None) == PRISMA_DEADLOCK_CODE
+    )
 
 
 class SSOUserDefinedValues(TypedDict):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
 import httpx
-import prisma.errors
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -3579,6 +3578,10 @@ PRISMA_DEADLOCK_CODE = "P2034"
 
 def _is_deadlock_error(e: Exception) -> bool:
     """Check if a Prisma error is a PostgreSQL deadlock / write conflict (P2034)."""
+    try:
+        import prisma.errors
+    except ImportError:
+        return False
     return (
         isinstance(e, prisma.errors.DataError)
         and getattr(e, "code", None) == PRISMA_DEADLOCK_CODE

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -25,8 +25,6 @@ from typing import (
     overload,
 )
 
-import prisma.errors
-
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache, RedisCache
@@ -48,6 +46,7 @@ from litellm.proxy._types import (
     SpendLogsPayload,
     SpendUpdateQueueItem,
     ToolDiscoveryQueueItem,
+    _is_deadlock_error,
 )
 from litellm.proxy.db.db_transaction_queue.daily_spend_update_queue import (
     DailySpendUpdateQueue,
@@ -65,14 +64,6 @@ if TYPE_CHECKING:
 else:
     PrismaClient = Any
     ProxyLogging = Any
-
-PRISMA_DEADLOCK_CODE = "P2034"
-
-
-def _is_deadlock_error(e: Exception) -> bool:
-    """Check if a Prisma error is a PostgreSQL deadlock / write conflict (P2034)."""
-    return isinstance(e, prisma.errors.DataError) and getattr(e, "code", None) == PRISMA_DEADLOCK_CODE
-
 
 class DBSpendUpdateWriter:
     """
@@ -1093,6 +1084,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
+                            # Sort by ID for consistent lock ordering across pods to prevent deadlocks
                             for user_id, response_cost in sorted(user_list_transactions.items()):
                                 batcher.litellm_usertable.update_many(
                                     where={"user_id": user_id},
@@ -1148,6 +1140,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
+                            # Sort by ID for consistent lock ordering across pods to prevent deadlocks
                             for token, response_cost in sorted(key_list_transactions.items()):
                                 batcher.litellm_verificationtoken.update_many(  # 'update_many' prevents error from being raised if no row exists
                                     where={"token": token},
@@ -1192,6 +1185,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
+                            # Sort by ID for consistent lock ordering across pods to prevent deadlocks
                             for team_id, response_cost in sorted(team_list_transactions.items()):
                                 verbose_proxy_logger.debug(
                                     "Updating spend for team id={} by {}".format(
@@ -1250,6 +1244,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
+                            # Sort by ID for consistent lock ordering across pods to prevent deadlocks
                             for key, response_cost in sorted(team_member_list_transactions.items()):
                                 # key is "team_id::<value>::user_id::<value>"
                                 team_id = key.split("::")[1]
@@ -1307,6 +1302,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
+                            # Sort by ID for consistent lock ordering across pods to prevent deadlocks
                             for org_id, response_cost in sorted(org_list_transactions.items()):
                                 batcher.litellm_organizationtable.update_many(  # 'update_many' prevents error from being raised if no row exists
                                     where={"organization_id": org_id},
@@ -1395,7 +1391,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for entity_id, response_cost in sorted(transactions.items()):
+                            for entity_id, response_cost in transactions.items():
                                 verbose_proxy_logger.debug(
                                     f"Updating spend for {entity_name} {where_field}={entity_id} by {response_cost}"
                                 )
@@ -1411,12 +1407,8 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    # Randomized backoff to reduce repeated collisions across pods
-                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                    await asyncio.sleep(2**i)  # Exponential backoff
                 except Exception as e:
-                    if _is_deadlock_error(e) and i < n_retry_times:
-                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
-                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -25,6 +25,8 @@ from typing import (
     overload,
 )
 
+import prisma.errors
+
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache, RedisCache
@@ -63,6 +65,13 @@ if TYPE_CHECKING:
 else:
     PrismaClient = Any
     ProxyLogging = Any
+
+PRISMA_DEADLOCK_CODE = "P2034"
+
+
+def _is_deadlock_error(e: Exception) -> bool:
+    """Check if a Prisma error is a PostgreSQL deadlock / write conflict (P2034)."""
+    return isinstance(e, prisma.errors.DataError) and getattr(e, "code", None) == PRISMA_DEADLOCK_CODE
 
 
 class DBSpendUpdateWriter:
@@ -1084,10 +1093,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for (
-                                user_id,
-                                response_cost,
-                            ) in user_list_transactions.items():
+                            for user_id, response_cost in sorted(user_list_transactions.items()):
                                 batcher.litellm_usertable.update_many(
                                     where={"user_id": user_id},
                                     data={"spend": {"increment": response_cost}},
@@ -1102,9 +1108,12 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    # Optionally, sleep for a bit before retrying
-                    await asyncio.sleep(2**i)  # Exponential backoff
+                    # Randomized backoff to reduce repeated collisions across pods
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
                 except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
@@ -1139,10 +1148,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for (
-                                token,
-                                response_cost,
-                            ) in key_list_transactions.items():
+                            for token, response_cost in sorted(key_list_transactions.items()):
                                 batcher.litellm_verificationtoken.update_many(  # 'update_many' prevents error from being raised if no row exists
                                     where={"token": token},
                                     data={
@@ -1160,9 +1166,12 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    # Optionally, sleep for a bit before retrying
-                    await asyncio.sleep(2**i)  # Exponential backoff
+                    # Randomized backoff to reduce repeated collisions across pods
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
                 except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
@@ -1183,10 +1192,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for (
-                                team_id,
-                                response_cost,
-                            ) in team_list_transactions.items():
+                            for team_id, response_cost in sorted(team_list_transactions.items()):
                                 verbose_proxy_logger.debug(
                                     "Updating spend for team id={} by {}".format(
                                         team_id, response_cost
@@ -1206,9 +1212,12 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    # Optionally, sleep for a bit before retrying
-                    await asyncio.sleep(2**i)  # Exponential backoff
+                    # Randomized backoff to reduce repeated collisions across pods
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
                 except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
@@ -1241,10 +1250,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for (
-                                key,
-                                response_cost,
-                            ) in team_member_list_transactions.items():
+                            for key, response_cost in sorted(team_member_list_transactions.items()):
                                 # key is "team_id::<value>::user_id::<value>"
                                 team_id = key.split("::")[1]
                                 user_id = key.split("::")[3]
@@ -1264,9 +1270,12 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    # Optionally, sleep for a bit before retrying
-                    await asyncio.sleep(2**i)  # Exponential backoff
+                    # Randomized backoff to reduce repeated collisions across pods
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
                 except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
@@ -1298,10 +1307,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for (
-                                org_id,
-                                response_cost,
-                            ) in org_list_transactions.items():
+                            for org_id, response_cost in sorted(org_list_transactions.items()):
                                 batcher.litellm_organizationtable.update_many(  # 'update_many' prevents error from being raised if no row exists
                                     where={"organization_id": org_id},
                                     data={"spend": {"increment": response_cost}},
@@ -1316,16 +1322,16 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    # Optionally, sleep for a bit before retrying
-                    await asyncio.sleep(
-                        # Sleep a random amount to avoid retrying and deadlocking again: when two transactions deadlock they are
-                        # cancelled basically at the same time, so if they wait the same time they will also retry at the same time
-                        # and thus they are more likely to deadlock again.
-                        # Instead, we sleep a random amount so that they retry at slightly different times, lowering the chance of
-                        # repeated deadlocks, and therefore of exceeding the retry limit.
-                        random.uniform(2**i, 2 ** (i + 1))
-                    )
+                    # Sleep a random amount to avoid retrying and deadlocking again: when two transactions deadlock they are
+                    # cancelled basically at the same time, so if they wait the same time they will also retry at the same time
+                    # and thus they are more likely to deadlock again.
+                    # Instead, we sleep a random amount so that they retry at slightly different times, lowering the chance of
+                    # repeated deadlocks, and therefore of exceeding the retry limit.
+                    await asyncio.sleep(random.uniform(2**i, 2 ** (i + 1)))
                 except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2 ** (i + 1)))
+                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
@@ -1389,7 +1395,7 @@ class DBSpendUpdateWriter:
                         timeout=timedelta(seconds=60)
                     ) as transaction:
                         async with transaction.batch_() as batcher:
-                            for entity_id, response_cost in transactions.items():
+                            for entity_id, response_cost in sorted(transactions.items()):
                                 verbose_proxy_logger.debug(
                                     f"Updating spend for {entity_name} {where_field}={entity_id} by {response_cost}"
                                 )
@@ -1405,8 +1411,12 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    await asyncio.sleep(2**i)  # Exponential backoff
+                    # Randomized backoff to reduce repeated collisions across pods
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
                 except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                        continue
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
@@ -1709,14 +1719,17 @@ class DBSpendUpdateWriter:
                             start_time=start_time,
                             proxy_logging_obj=proxy_logging_obj,
                         )
-                    await asyncio.sleep(
-                        # Sleep a random amount to avoid retrying and deadlocking again: when two transactions deadlock they are
-                        # cancelled basically at the same time, so if they wait the same time they will also retry at the same time
-                        # and thus they are more likely to deadlock again.
-                        # Instead, we sleep a random amount so that they retry at slightly different times, lowering the chance of
-                        # repeated deadlocks, and therefore of exceeding the retry limit.
-                        random.uniform(2**i, 2 ** (i + 1))
-                    )
+                    # Sleep a random amount to avoid retrying and deadlocking again: when two transactions deadlock they are
+                    # cancelled basically at the same time, so if they wait the same time they will also retry at the same time
+                    # and thus they are more likely to deadlock again.
+                    # Instead, we sleep a random amount so that they retry at slightly different times, lowering the chance of
+                    # repeated deadlocks, and therefore of exceeding the retry limit.
+                    await asyncio.sleep(random.uniform(2**i, 2 ** (i + 1)))
+                except Exception as e:
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        await asyncio.sleep(random.uniform(2**i, 2 ** (i + 1)))
+                        continue
+                    raise
 
         except Exception as e:
             if "transactions_to_process" in locals():

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -25,8 +25,6 @@ from typing import (
     overload,
 )
 
-import prisma.errors
-
 from litellm import _custom_logger_compatible_callbacks_literal
 from litellm.constants import DEFAULT_MODEL_CREATED_AT_TIME, MAX_TEAM_LIST_LIMIT
 from litellm.proxy._types import (
@@ -36,17 +34,11 @@ from litellm.proxy._types import (
     ProxyException,
     SpendLogsMetadata,
     SpendLogsPayload,
+    _is_deadlock_error,
 )
 
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import CallTypes, CallTypesLiteral
-
-PRISMA_DEADLOCK_CODE = "P2034"
-
-
-def _is_deadlock_error(e: Exception) -> bool:
-    """Check if a Prisma error is a PostgreSQL deadlock / write conflict (P2034)."""
-    return isinstance(e, prisma.errors.DataError) and getattr(e, "code", None) == PRISMA_DEADLOCK_CODE
 
 try:
     from litellm_enterprise.enterprise_callbacks.send_emails.base_email import (
@@ -4549,6 +4541,7 @@ class ProxyUpdateSpend:
                     timeout=timedelta(seconds=60)
                 ) as transaction:
                     async with transaction.batch_() as batcher:
+                        # Sort by ID for consistent lock ordering across pods to prevent deadlocks
                         for end_user_id, response_cost in sorted(end_user_list_transactions.items()):
                             if litellm.max_end_user_budget is not None:
                                 pass

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import inspect
 import json
 import os
+import random
 import smtplib
 import sys
 import threading
@@ -24,6 +25,8 @@ from typing import (
     overload,
 )
 
+import prisma.errors
+
 from litellm import _custom_logger_compatible_callbacks_literal
 from litellm.constants import DEFAULT_MODEL_CREATED_AT_TIME, MAX_TEAM_LIST_LIMIT
 from litellm.proxy._types import (
@@ -34,8 +37,16 @@ from litellm.proxy._types import (
     SpendLogsMetadata,
     SpendLogsPayload,
 )
+
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import CallTypes, CallTypesLiteral
+
+PRISMA_DEADLOCK_CODE = "P2034"
+
+
+def _is_deadlock_error(e: Exception) -> bool:
+    """Check if a Prisma error is a PostgreSQL deadlock / write conflict (P2034)."""
+    return isinstance(e, prisma.errors.DataError) and getattr(e, "code", None) == PRISMA_DEADLOCK_CODE
 
 try:
     from litellm_enterprise.enterprise_callbacks.send_emails.base_email import (
@@ -4538,10 +4549,7 @@ class ProxyUpdateSpend:
                     timeout=timedelta(seconds=60)
                 ) as transaction:
                     async with transaction.batch_() as batcher:
-                        for (
-                            end_user_id,
-                            response_cost,
-                        ) in end_user_list_transactions.items():
+                        for end_user_id, response_cost in sorted(end_user_list_transactions.items()):
                             if litellm.max_end_user_budget is not None:
                                 pass
                             batcher.litellm_endusertable.upsert(
@@ -4562,9 +4570,12 @@ class ProxyUpdateSpend:
                     _raise_failed_update_spend_exception(
                         e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                     )
-                # Optionally, sleep for a bit before retrying
-                await asyncio.sleep(2**i)  # Exponential backoff
+                # Randomized backoff to reduce repeated collisions across pods
+                await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
             except Exception as e:
+                if _is_deadlock_error(e) and i < n_retry_times:
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                    continue
                 _raise_failed_update_spend_exception(
                     e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj
                 )
@@ -4657,7 +4668,23 @@ class ProxyUpdateSpend:
                     )
                     if i >= n_retry_times:
                         raise
-                    await asyncio.sleep(2**i)
+                    # Randomized backoff to reduce repeated collisions across pods
+                    await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                except Exception as e:
+                    if i is None:
+                        i = 0
+                    if _is_deadlock_error(e) and i < n_retry_times:
+                        verbose_proxy_logger.warning(
+                            "Spend tracking - deadlock writing spend logs, "
+                            "retry %d/%d. logs_count=%d, error=%s",
+                            i + 1,
+                            n_retry_times,
+                            len(logs_to_process),
+                            str(e),
+                        )
+                        await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
+                        continue
+                    raise
         except Exception as e:
             # Logs already removed from queue at start - don't put them back
             # This matches the original behavior where logs are removed even on error

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4664,8 +4664,6 @@ class ProxyUpdateSpend:
                     # Randomized backoff to reduce repeated collisions across pods
                     await asyncio.sleep(random.uniform(2**i, 2**(i+1)))
                 except Exception as e:
-                    if i is None:
-                        i = 0
                     if _is_deadlock_error(e) and i < n_retry_times:
                         verbose_proxy_logger.warning(
                             "Spend tracking - deadlock writing spend logs, "

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -1219,6 +1219,137 @@ async def test_commit_key_spend_updates_includes_last_active():
 
 
 @pytest.mark.asyncio
+async def test_deadlock_error_retried_on_user_spend_update():
+    """
+    Test that a PostgreSQL deadlock (Prisma P2034) is retried with backoff
+    instead of immediately failing and losing spend data.
+    """
+    import prisma.errors
+
+    db_writer = DBSpendUpdateWriter()
+
+    # First call raises a deadlock error, second call succeeds
+    deadlock_error = prisma.errors.DataError(
+        data={"user_facing_error": {"error_code": "P2034"}},
+        message="Transaction failed due to a write conflict or a deadlock",
+    )
+
+    mock_batcher = MagicMock()
+    mock_batcher.litellm_usertable = MagicMock()
+    mock_batcher.litellm_usertable.update_many = MagicMock()
+
+    mock_transaction_ok = AsyncMock()
+    mock_transaction_ok.__aenter__ = AsyncMock(return_value=mock_transaction_ok)
+    mock_transaction_ok.__aexit__ = AsyncMock(return_value=False)
+    mock_transaction_ok.batch_ = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_batcher),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+
+    mock_prisma_client = MagicMock()
+    # First call raises deadlock, second succeeds
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.tx = MagicMock(
+        side_effect=[
+            # First attempt: raise deadlock inside the transaction context
+            AsyncMock(
+                __aenter__=AsyncMock(side_effect=deadlock_error),
+                __aexit__=AsyncMock(return_value=False),
+            ),
+            # Second attempt: succeed
+            mock_transaction_ok,
+        ]
+    )
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.call_details = {}
+
+    db_spend_update_transactions = {
+        "user_list_transactions": {"user_1": 0.05},
+        "end_user_list_transactions": {},
+        "key_list_transactions": {},
+        "team_list_transactions": {},
+        "team_member_list_transactions": {},
+        "org_list_transactions": {},
+        "tag_list_transactions": {},
+        "agent_list_transactions": {},
+    }
+
+    with patch("litellm.proxy.utils._raise_failed_update_spend_exception"), \
+         patch("litellm.proxy.db.db_spend_update_writer.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        await db_writer._commit_spend_updates_to_db(
+            prisma_client=mock_prisma_client,
+            n_retry_times=3,
+            proxy_logging_obj=mock_proxy_logging,
+            db_spend_update_transactions=db_spend_update_transactions,
+        )
+
+    # Verify: tx was called twice (first deadlock, then success)
+    assert mock_prisma_client.db.tx.call_count == 2
+    # Verify: sleep was called for backoff between retries
+    mock_sleep.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_non_deadlock_prisma_error_not_retried():
+    """
+    Test that a non-deadlock Prisma error (e.g. UniqueViolationError)
+    is NOT retried — it should fail immediately.
+    """
+    import prisma.errors
+
+    db_writer = DBSpendUpdateWriter()
+
+    # A non-deadlock DataError (e.g. unique violation, code P2002)
+    non_deadlock_error = prisma.errors.DataError(
+        data={"user_facing_error": {"error_code": "P2002"}},
+        message="Unique constraint failed on the fields: (`user_id`)",
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.tx = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(side_effect=non_deadlock_error),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.call_details = {}
+
+    db_spend_update_transactions = {
+        "user_list_transactions": {"user_1": 0.05},
+        "end_user_list_transactions": {},
+        "key_list_transactions": {},
+        "team_list_transactions": {},
+        "team_member_list_transactions": {},
+        "org_list_transactions": {},
+        "tag_list_transactions": {},
+        "agent_list_transactions": {},
+    }
+
+    mock_raise = MagicMock()
+    with patch("litellm.proxy.utils._raise_failed_update_spend_exception", mock_raise), \
+         patch("litellm.proxy.db.db_spend_update_writer.asyncio.sleep", new_callable=AsyncMock):
+        await db_writer._commit_spend_updates_to_db(
+            prisma_client=mock_prisma_client,
+            n_retry_times=3,
+            proxy_logging_obj=mock_proxy_logging,
+            db_spend_update_transactions=db_spend_update_transactions,
+        )
+
+    # Verify: _raise_failed_update_spend_exception was called immediately (no retry)
+    # The first call should be for the user table non-deadlock error
+    mock_raise.assert_called()
+    first_call_error = mock_raise.call_args_list[0][1]["e"]
+    assert isinstance(first_call_error, prisma.errors.DataError)
+    assert first_call_error.code == "P2002"
+
+
+@pytest.mark.asyncio
 async def test_update_database_creates_single_task():
     """
     Test that update_database() fires exactly 1 asyncio.create_task() call


### PR DESCRIPTION
## Relevant issues

Fixes PostgreSQL deadlocks occurring under high concurrency when flushing batched spend updates to the database, without using redis

## 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

### Problem
When multiple proxy pods flush spend updates concurrently, each pod wraps updates for multiple users/keys/teams in a single Prisma transaction. Without consistent row ordering, two pods can lock
overlapping rows in different orders, causing PostgreSQL deadlocks (`ERROR: deadlock detected`). The existing retry logic only catches transport-level errors (`httpx.ConnectError`,
`httpx.ReadError`), not Prisma deadlock errors (P2034).

### Fix (3 changes)
1. **Sorted lock ordering** — iterate entity IDs in sorted order within each transaction so all pods lock rows in the same order, preventing deadlocks
2. **Deadlock detection + retry** — detect Prisma P2034 (deadlock/write conflict) errors and retry with backoff instead of failing immediately and losing spend data
3. **Randomized exponential backoff** — use `random.uniform(2**i, 2**(i+1))` instead of fixed `2**i` so retrying pods don't collide at the same time

Applied to: user, key, team, team_member, org, and end_user spend update paths. Tag/agent tables (`_update_entity_spend_in_db`) left unchanged as they are low-contention.

### Files changed
- `litellm/proxy/_types.py` — add `PRISMA_DEADLOCK_CODE` constant and `_is_deadlock_error()` helper (single source of truth)
- `litellm/proxy/db/db_spend_update_writer.py` — sorted iteration, deadlock retry, randomized backoff on 5 entity tables
- `litellm/proxy/utils.py` — same fixes for end_user spend and spend_logs paths
- `tests/test_litellm/proxy/db/test_db_spend_update_writer.py` — 2 new tests: deadlock retried, non-deadlock error not retried