### PR TITLE
[Fix] Mypy Type Errors in Responses Transformation, Spend Tracking, and PagerDuty

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
@@ -197,6 +197,7 @@ class PagerDutyAlerting(SlackAlerting):
                 user_api_key_org_id=user_api_key_dict.org_id,
                 user_api_key_team_id=user_api_key_dict.team_id,
                 user_api_key_project_id=user_api_key_dict.project_id,
+                user_api_key_project_alias=user_api_key_dict.project_alias,
                 user_api_key_user_id=user_api_key_dict.user_id,
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,

--- a/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
@@ -116,6 +116,7 @@ class PagerDutyAlerting(SlackAlerting):
                 user_api_key_org_id=_meta.get("user_api_key_org_id"),
                 user_api_key_team_id=_meta.get("user_api_key_team_id"),
                 user_api_key_project_id=_meta.get("user_api_key_project_id"),
+                user_api_key_project_alias=_meta.get("user_api_key_project_alias"),
                 user_api_key_user_id=_meta.get("user_api_key_user_id"),
                 user_api_key_team_alias=_meta.get("user_api_key_team_alias"),
                 user_api_key_end_user_id=_meta.get("user_api_key_end_user_id"),

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -56,6 +56,16 @@ if TYPE_CHECKING:
     )
 
 
+def _get_reasoning_items(
+    msg: "AllMessageValues",
+) -> List[ChatCompletionReasoningItem]:
+    """Extract reasoning_items from a message dict with proper typing."""
+    items = msg.get("reasoning_items")  # type: ignore[union-attr]
+    if items:
+        return items  # type: ignore[return-value]
+    return []
+
+
 def _build_reasoning_item(
     item_id: str,
     encrypted_content: Optional[str],
@@ -86,7 +96,7 @@ def _build_reasoning_item(
     }
 
 
-def _reasoning_item_to_response_input(r_item: Dict[str, Any]) -> Dict[str, Any]:
+def _reasoning_item_to_response_input(r_item: Union[ChatCompletionReasoningItem, Dict[str, Any]]) -> Dict[str, Any]:
     """Convert a stored ChatCompletionReasoningItem back to a Responses API input item."""
     r_input: Dict[str, Any] = {
         "type": "reasoning",
@@ -246,7 +256,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     }
                 )
             elif role == "assistant" and tool_calls and isinstance(tool_calls, list):
-                for r_item in cast(list, msg.get("reasoning_items") or []):
+                for r_item in _get_reasoning_items(msg):
                     input_items.append(_reasoning_item_to_response_input(r_item))
                 for tool_call in tool_calls:
                     function = tool_call.get("function")
@@ -264,7 +274,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         raise ValueError(f"tool call not supported: {tool_call}")
             elif content is not None:
                 if role == "assistant":
-                    for r_item in cast(list, msg.get("reasoning_items") or []):
+                    for r_item in _get_reasoning_items(msg):
                         input_items.append(_reasoning_item_to_response_input(r_item))
                 input_items.append(
                     {

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -246,7 +246,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     }
                 )
             elif role == "assistant" and tool_calls and isinstance(tool_calls, list):
-                for r_item in msg.get("reasoning_items") or []:
+                for r_item in cast(list, msg.get("reasoning_items") or []):
                     input_items.append(_reasoning_item_to_response_input(r_item))
                 for tool_call in tool_calls:
                     function = tool_call.get("function")
@@ -264,7 +264,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         raise ValueError(f"tool call not supported: {tool_call}")
             elif content is not None:
                 if role == "assistant":
-                    for r_item in msg.get("reasoning_items") or []:
+                    for r_item in cast(list, msg.get("reasoning_items") or []):
                         input_items.append(_reasoning_item_to_response_input(r_item))
                 input_items.append(
                     {

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -90,6 +90,7 @@ def _get_spend_logs_metadata(
             user_api_key_alias=None,
             user_api_key_team_id=None,
             user_api_key_project_id=None,
+            user_api_key_project_alias=None,
             user_api_key_org_id=None,
             user_api_key_user_id=None,
             user_api_key_team_alias=None,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -747,6 +747,7 @@ class ChatCompletionAssistantMessage(OpenAIChatCompletionAssistantMessage, total
     thinking_blocks: Optional[
         List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]
     ]
+    reasoning_items: Optional[List[ChatCompletionReasoningItem]]
 
 
 class ChatCompletionToolMessage(TypedDict):


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
`mypy` reports 4 errors across 3 files:
- `transformation.py:249,267` — `msg.get("reasoning_items")` returns `object` which mypy considers not iterable
- `spend_tracking_utils.py:88` — Missing required `user_api_key_project_alias` key in `SpendLogsMetadata` TypedDict constructor
- `pagerduty.py:182` — Missing required `user_api_key_project_alias` key in `PagerDutyInternalEvent` TypedDict constructor

### Fix
- Added `cast(list, ...)` around `msg.get("reasoning_items") or []` — this is a no-op at runtime, only satisfies mypy
- Added `user_api_key_project_alias=None` to the default `SpendLogsMetadata` return
- Added `user_api_key_project_alias=user_api_key_dict.project_alias` to the `PagerDutyInternalEvent` constructor

## Testing
- Verified `mypy` passes on all 3 files with zero new errors

## Type
🐛 Bug Fix