### PR TITLE
fix(bedrock): prevent empty toolSpec name/description when tool has no function.name

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5039,7 +5039,7 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
 
     # If the string is empty, return a default valid identifier
     if input_tool_name is None or len(input_tool_name) == 0:
-        return input_tool_name
+        return "tool"
     bedrock_tool_name = copy.copy(input_tool_name)
     # If it doesn't start with a letter, prepend 'a'
     if not bedrock_tool_name[0].isalpha():
@@ -5156,7 +5156,9 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
         parameters = tool.get("function", {}).get(
             "parameters", {"type": "object", "properties": {}}
         )
-        name = tool.get("function", {}).get("name", "")
+        # Use function.name if present; fall back to the tool's "type" field
+        # (e.g. "file_search") so non-function tool types still get a valid name.
+        name = tool.get("function", {}).get("name", "") or tool.get("type", "")
 
         # related issue: https://github.com/BerriAI/litellm/issues/5007
         # Bedrock tool names must satisfy regular expression pattern: [a-zA-Z][a-zA-Z0-9_]* ensure this is true


### PR DESCRIPTION
## Description

Fixes #24668.

When LiteLLM converts tools to Bedrock's `toolSpec` format via `_bedrock_tools_pt`, non-function tool types (such as `{"type": "file_search", "vector_store_ids": [...]}`) don't have a `function.name` field. This produces an empty `name = ""`, which then propagates to an empty `description` via the `description = name` fallback. Bedrock rejects both with a 400 validation error:

> `toolSpec.name must be non-empty` / `toolSpec.description must be non-empty`

### Root cause (two places)

**1. `make_valid_bedrock_tool_name`** — the comment says *"return a default valid identifier"* but the code returns the empty string unchanged:

```python
# Before (comment says one thing, code does another):
if input_tool_name is None or len(input_tool_name) == 0:
    return input_tool_name  # ← returns ""

# After:
if input_tool_name is None or len(input_tool_name) == 0:
    return "tool"  # ← safe default satisfying [a-zA-Z0-9_]+
```

**2. `_bedrock_tools_pt`** — name extraction only looks at `function.name`, ignoring non-function tool types:

```python
# Before:
name = tool.get("function", {}).get("name", "")

# After:
name = tool.get("function", {}).get("name", "") or tool.get("type", "")
```

For a `{"type": "file_search", ...}` tool this now produces `"file_search"` as the name, which `make_valid_bedrock_tool_name` passes through unchanged (all chars valid).

## Test plan

- [ ] `_bedrock_tools_pt([{"type": "file_search", "vector_store_ids": ["kb-123"]}])` → `toolSpec.name == "file_search"`, `toolSpec.description == "file_search"` (no 400)
- [ ] `make_valid_bedrock_tool_name("")` → `"tool"`
- [ ] `make_valid_bedrock_tool_name(None)` → `"tool"`
- [ ] Standard `{"type": "function", "function": {"name": "get_weather", ...}}` tools unaffected