### PR TITLE
fix: router empty deployments tag 401 misleading error

### DIFF
--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -147,6 +147,13 @@ async def get_deployments_for_tag(
         )
         return healthy_deployments
 
+    # No candidates (e.g. all in cooldown) must not be treated as tag mismatch below.
+    if isinstance(healthy_deployments, list) and len(healthy_deployments) == 0:
+        verbose_logger.debug(
+            "get_deployments_for_tag: empty candidate set; skipping tag filter"
+        )
+        return healthy_deployments
+
     verbose_logger.debug(
         "request metadata: %s", request_kwargs.get(metadata_variable_name)
     )

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -147,7 +147,7 @@ async def get_deployments_for_tag(
         )
         return healthy_deployments
 
-    # No candidates (e.g. all in cooldown) must not be treated as tag mismatch below.
+    # Tag filtering applies only when there is at least one deployment to evaluate.
     if isinstance(healthy_deployments, list) and len(healthy_deployments) == 0:
         verbose_logger.debug(
             "get_deployments_for_tag: empty candidate set; skipping tag filter"

--- a/tests/test_litellm/router_strategy/test_router_tag_regex_routing.py
+++ b/tests/test_litellm/router_strategy/test_router_tag_regex_routing.py
@@ -189,6 +189,25 @@ async def test_tag_filtering_disabled_returns_all_deployments():
 
 
 @pytest.mark.asyncio
+async def test_empty_healthy_deployments_with_request_tags_skips_misleading_tag_error():
+    """
+    Deterministic repro: cooldown (or any filter) can leave zero candidates before tag routing.
+    Request metadata tags must not trigger RouterErrors.no_deployments_with_tag_routing —
+    that implied misconfigured tags; return [] so the router can surface no-deployment / cooldown.
+    """
+    router = _make_router_mock()
+    result = await get_deployments_for_tag(
+        llm_router_instance=router,
+        model="gpt-5.2",
+        healthy_deployments=[],
+        request_kwargs={
+            "metadata": {"tags": ["client_id:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]}
+        },
+    )
+    assert result == []
+
+
+@pytest.mark.asyncio
 async def test_explicit_tag_match_takes_precedence_over_regex():
     """A deployment with both tags and tag_regex: exact tag match fires first."""
     deployment_with_both = {

--- a/tests/test_litellm/router_strategy/test_router_tag_regex_routing.py
+++ b/tests/test_litellm/router_strategy/test_router_tag_regex_routing.py
@@ -189,11 +189,12 @@ async def test_tag_filtering_disabled_returns_all_deployments():
 
 
 @pytest.mark.asyncio
-async def test_empty_healthy_deployments_with_request_tags_skips_misleading_tag_error():
+async def test_empty_healthy_deployments_with_request_tags_returns_empty_list():
     """
-    Deterministic repro: cooldown (or any filter) can leave zero candidates before tag routing.
-    Request metadata tags must not trigger RouterErrors.no_deployments_with_tag_routing —
-    that implied misconfigured tags; return [] so the router can surface no-deployment / cooldown.
+    With an empty candidate list, return [] even when the request includes metadata tags.
+
+    Tag-based filtering runs only against non-empty healthy_deployments; an empty list is
+    returned unchanged for the router's standard handling.
     """
     router = _make_router_mock()
     result = await get_deployments_for_tag(


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🧹 Refactoring

## Changes

- **`get_deployments_for_tag`:** When `healthy_deployments` is already an empty list, return immediately without running tag matching. Tag-based filtering is only applied when there is at least one deployment to evaluate; an empty candidate set is left for the router’s existing “no deployment available” handling.
- **Unit test:** Covers the case `healthy_deployments=[]` with non-empty `metadata.tags` and asserts the function returns `[]` (no tag-routing `ValueError` on an empty candidate set).

---