### PR TITLE
fix(mcp): add STS AssumeRole support for MCP SigV4 authentication

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -278,7 +278,8 @@ mcp_servers:
     url: "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/<url-encoded-ARN>/invocations"
     transport: "http"
     auth_type: "aws_sigv4"
-    aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+    aws_role_name: os.environ/AWS_ROLE_ARN          # optional — IAM role to assume
+    aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID  # optional — falls back to IAM role
     aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
     aws_region_name: us-east-1
     aws_service_name: bedrock-agentcore

--- a/docs/my-website/docs/mcp_aws_sigv4.md
+++ b/docs/my-website/docs/mcp_aws_sigv4.md
@@ -36,6 +36,8 @@ LiteLLM's `aws_sigv4` auth type handles this automatically: every outgoing MCP r
 | **AWS Access Key ID** | No | Falls back to boto3 credential chain if blank |
 | **AWS Secret Access Key** | No | Required if Access Key ID is provided |
 | **AWS Session Token** | No | Only needed for temporary STS credentials |
+| **AWS Role ARN** | No | IAM role ARN for STS AssumeRole (e.g., `arn:aws:iam::123456789012:role/MyRole`). If set, LiteLLM assumes this role before signing |
+| **AWS Session Name** | No | Session name for the AssumeRole call — appears in CloudTrail. Auto-generated if omitted |
 
 Once created, LiteLLM will sign every outgoing MCP request with SigV4. The server's tools appear automatically in the MCP Tools list.
 
@@ -66,8 +68,8 @@ mcp_servers:
     url: "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/<url-encoded-ARN>/invocations"
     transport: "http"
     auth_type: "aws_sigv4"
-    aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
-    aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+    aws_role_name: os.environ/AWS_ROLE_ARN          # IAM role to assume (recommended)
+    aws_session_name: "litellm-prod"                 # optional — for CloudTrail auditing
     aws_region_name: "us-east-1"
     aws_service_name: "bedrock-agentcore"
 ```
@@ -128,6 +130,8 @@ curl http://localhost:4000/mcp-rest/tools/call \
 | `aws_region_name` | Yes | AWS region (e.g., `us-east-1`) |
 | `aws_service_name` | No | AWS service name for signing. Defaults to `bedrock-agentcore` |
 | `aws_session_token` | No | AWS session token for temporary credentials. Supports `os.environ/VAR_NAME` |
+| `aws_role_name` | No | IAM role ARN for STS AssumeRole. Supports `os.environ/VAR_NAME`. When set, LiteLLM calls `sts:AssumeRole` to get temporary credentials before signing |
+| `aws_session_name` | No | Session name for the AssumeRole call (appears in CloudTrail). Auto-generated if omitted. Supports `os.environ/VAR_NAME` |
 
 ## How It Works
 
@@ -157,6 +161,42 @@ mcp_servers:
     aws_service_name: "bedrock-agentcore"
 ```
 
+## Using IAM Role Assumption (AssumeRole)
+
+For production environments where your LiteLLM instance authenticates via an IAM role (e.g., EKS pod role, EC2 instance profile), you can configure `aws_role_name` to have LiteLLM call `sts:AssumeRole` before signing MCP requests:
+
+```yaml title="config.yaml with AssumeRole" showLineNumbers
+mcp_servers:
+  my_agentcore_mcp:
+    url: "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/<url-encoded-ARN>/invocations"
+    transport: "http"
+    auth_type: "aws_sigv4"
+    aws_role_name: "arn:aws:iam::123456789012:role/BedrockAgentCoreRole"
+    aws_session_name: "litellm-prod"    # optional
+    aws_region_name: "us-east-1"
+    aws_service_name: "bedrock-agentcore"
+```
+
+LiteLLM uses the ambient credentials (pod role, instance profile, or env vars) to call `sts:AssumeRole`, then signs MCP requests with the assumed role's temporary credentials.
+
+You can also combine `aws_role_name` with explicit access keys — the keys are then used as the source identity for the AssumeRole call:
+
+```yaml title="config.yaml with AssumeRole + explicit source keys" showLineNumbers
+mcp_servers:
+  my_agentcore_mcp:
+    url: "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/<url-encoded-ARN>/invocations"
+    transport: "http"
+    auth_type: "aws_sigv4"
+    aws_role_name: os.environ/AWS_ROLE_ARN
+    aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+    aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+    aws_region_name: "us-east-1"
+```
+
+:::tip
+For most Kubernetes deployments, you only need `aws_role_name` and `aws_region_name` — the pod's IAM role provides the source credentials automatically.
+:::
+
 ## Troubleshooting
 
 ### 403 Forbidden from AWS
@@ -165,6 +205,15 @@ mcp_servers:
 - Check that `aws_region_name` matches the region in your AgentCore URL
 - Ensure `aws_service_name` is set to `bedrock-agentcore`
 - If using STS credentials, confirm `aws_session_token` is set and not expired
+
+### AssumeRole AccessDenied
+
+If you get `AccessDenied` when using `aws_role_name`:
+
+- Verify the role ARN is correct
+- Check that the trust policy on the target role allows your source identity to assume it
+- If running on EKS, ensure the pod's service account is annotated with the correct IAM role
+- Check CloudTrail for the failed `sts:AssumeRole` call to see the exact error
 
 ### Health check errors on startup
 

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -82,6 +82,8 @@ class MCPSigV4Auth(httpx.Auth):
         aws_session_token: Optional[str] = None,
         aws_region_name: Optional[str] = None,
         aws_service_name: Optional[str] = None,
+        aws_role_name: Optional[str] = None,
+        aws_session_name: Optional[str] = None,
     ):
         try:
             from botocore.credentials import Credentials
@@ -97,7 +99,16 @@ class MCPSigV4Auth(httpx.Auth):
         # Note: os.environ/ prefixed values are already resolved by
         # ProxyConfig._check_for_os_environ_vars() at config load time.
         # Values arrive here as plain strings.
-        if aws_access_key_id and aws_secret_access_key:
+        if aws_role_name:
+            self.credentials = self._assume_role(
+                aws_role_name=aws_role_name,
+                aws_session_name=aws_session_name,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+                aws_region_name=self.region_name,
+            )
+        elif aws_access_key_id and aws_secret_access_key:
             self.credentials = Credentials(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
@@ -115,6 +126,41 @@ class MCPSigV4Auth(httpx.Auth):
                     "aws_secret_access_key, or configure default credentials "
                     "(env vars, ~/.aws/credentials, instance profile)."
                 )
+
+    @staticmethod
+    def _assume_role(
+        aws_role_name: str,
+        aws_session_name: Optional[str],
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[str],
+        aws_session_token: Optional[str],
+        aws_region_name: str,
+    ):
+        """Call STS AssumeRole and return temporary credentials."""
+        import boto3
+        from botocore.credentials import Credentials
+
+        session_name = aws_session_name or f"litellm-mcp-{int(__import__('time').time())}"
+
+        sts_kwargs: dict = {"region_name": aws_region_name}
+        if aws_access_key_id and aws_secret_access_key:
+            sts_kwargs["aws_access_key_id"] = aws_access_key_id
+            sts_kwargs["aws_secret_access_key"] = aws_secret_access_key
+            if aws_session_token:
+                sts_kwargs["aws_session_token"] = aws_session_token
+
+        sts_client = boto3.client("sts", **sts_kwargs)
+        sts_response = sts_client.assume_role(
+            RoleArn=aws_role_name,
+            RoleSessionName=session_name,
+        )
+
+        sts_creds = sts_response["Credentials"]
+        return Credentials(
+            access_key=sts_creds["AccessKeyId"],
+            secret_key=sts_creds["SecretAccessKey"],
+            token=sts_creds["SessionToken"],
+        )
 
     def auth_flow(
         self, request: httpx.Request

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -346,6 +346,8 @@ class MCPServerManager:
                 aws_session_token=server_config.get("aws_session_token", None),
                 aws_region_name=server_config.get("aws_region_name", None),
                 aws_service_name=server_config.get("aws_service_name", None),
+                aws_role_name=server_config.get("aws_role_name", None),
+                aws_session_name=server_config.get("aws_session_name", None),
             )
             self.config_mcp_servers[server_id] = new_server
 
@@ -686,6 +688,8 @@ class MCPServerManager:
             aws_session_token=aws_creds.get("aws_session_token"),
             aws_region_name=aws_creds.get("aws_region_name"),
             aws_service_name=aws_creds.get("aws_service_name"),
+            aws_role_name=aws_creds.get("aws_role_name"),
+            aws_session_name=aws_creds.get("aws_session_name"),
         )
         return new_server
 
@@ -1011,6 +1015,8 @@ class MCPServerManager:
                     aws_session_token=server.aws_session_token,
                     aws_region_name=server.aws_region_name,
                     aws_service_name=server.aws_service_name,
+                    aws_role_name=server.aws_role_name,
+                    aws_session_name=server.aws_session_name,
                 )
 
             return MCPClient(
@@ -1571,6 +1577,8 @@ class MCPServerManager:
             ),
             "aws_region_name": credentials_dict.get("aws_region_name"),
             "aws_service_name": credentials_dict.get("aws_service_name"),
+            "aws_role_name": credentials_dict.get("aws_role_name"),
+            "aws_session_name": credentials_dict.get("aws_session_name"),
         }
 
     def _extract_scopes(self, scopes_value: Any) -> Optional[List[str]]:

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -111,6 +111,12 @@ class MCPCredentials(TypedDict, total=False):
     aws_service_name: Optional[str]
     """AWS service name for SigV4 signing (e.g., 'bedrock-agentcore'). Not a secret — stored unencrypted."""
 
+    aws_role_name: Optional[str]
+    """IAM role ARN for STS AssumeRole (e.g., 'arn:aws:iam::123456789012:role/MyRole'). Not a secret — stored unencrypted."""
+
+    aws_session_name: Optional[str]
+    """Session name for STS AssumeRole (used in CloudTrail). Not a secret — stored unencrypted."""
+
 
 class MCPServerCostInfo(TypedDict, total=False):
     default_cost_per_query: Optional[float]

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -54,6 +54,8 @@ class MCPServer(BaseModel):
     aws_session_token: Optional[str] = None
     aws_region_name: Optional[str] = None
     aws_service_name: Optional[str] = None  # defaults to "bedrock-agentcore"
+    aws_role_name: Optional[str] = None  # IAM role ARN for STS AssumeRole
+    aws_session_name: Optional[str] = None  # session name for CloudTrail auditing
     # Stdio-specific fields
     command: Optional[str] = None
     args: Optional[List[str]] = None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
@@ -162,6 +162,140 @@ class TestMCPSigV4Auth:
         assert "x-amz-security-token" in signed_request.headers
 
 
+class TestMCPSigV4AssumeRole:
+    """Tests for STS AssumeRole credential resolution in MCPSigV4Auth."""
+
+    def test_assume_role_with_ambient_credentials(self):
+        """MCPSigV4Auth calls STS AssumeRole when aws_role_name is provided (no explicit keys)."""
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASSUMED_KEY",
+                "SecretAccessKey": "ASSUMED_SECRET",
+                "SessionToken": "ASSUMED_TOKEN",
+                "Expiration": "2026-03-30T12:00:00Z",
+            }
+        }
+
+        with patch("boto3.client", return_value=mock_sts) as mock_boto3:
+            auth = MCPSigV4Auth(
+                aws_role_name="arn:aws:iam::123456789012:role/TestRole",
+                aws_region_name="us-east-1",
+            )
+
+        mock_boto3.assert_called_once_with("sts", region_name="us-east-1")
+        mock_sts.assume_role.assert_called_once()
+        call_kwargs = mock_sts.assume_role.call_args[1]
+        assert call_kwargs["RoleArn"] == "arn:aws:iam::123456789012:role/TestRole"
+        assert call_kwargs["RoleSessionName"].startswith("litellm-mcp-")
+        assert auth.credentials.access_key == "ASSUMED_KEY"
+        assert auth.credentials.secret_key == "ASSUMED_SECRET"
+        assert auth.credentials.token == "ASSUMED_TOKEN"
+
+    def test_assume_role_with_explicit_source_credentials(self):
+        """When aws_role_name + explicit keys are provided, keys are used as STS source identity."""
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASSUMED_KEY",
+                "SecretAccessKey": "ASSUMED_SECRET",
+                "SessionToken": "ASSUMED_TOKEN",
+                "Expiration": "2026-03-30T12:00:00Z",
+            }
+        }
+
+        with patch("boto3.client", return_value=mock_sts) as mock_boto3:
+            auth = MCPSigV4Auth(
+                aws_role_name="arn:aws:iam::123456789012:role/TestRole",
+                aws_access_key_id="SOURCE_KEY",
+                aws_secret_access_key="SOURCE_SECRET",
+                aws_region_name="us-west-2",
+            )
+
+        mock_boto3.assert_called_once_with(
+            "sts",
+            region_name="us-west-2",
+            aws_access_key_id="SOURCE_KEY",
+            aws_secret_access_key="SOURCE_SECRET",
+        )
+        assert auth.credentials.access_key == "ASSUMED_KEY"
+
+    def test_assume_role_with_custom_session_name(self):
+        """Custom aws_session_name is used in the AssumeRole call."""
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASSUMED_KEY",
+                "SecretAccessKey": "ASSUMED_SECRET",
+                "SessionToken": "ASSUMED_TOKEN",
+                "Expiration": "2026-03-30T12:00:00Z",
+            }
+        }
+
+        with patch("boto3.client", return_value=mock_sts):
+            MCPSigV4Auth(
+                aws_role_name="arn:aws:iam::123456789012:role/TestRole",
+                aws_session_name="regeneron-litellm-prod",
+            )
+
+        call_kwargs = mock_sts.assume_role.call_args[1]
+        assert call_kwargs["RoleSessionName"] == "regeneron-litellm-prod"
+
+    def test_assume_role_signing_works(self):
+        """Requests are signed correctly with STS-derived credentials."""
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+                "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "SessionToken": "STS_SESSION_TOKEN",
+                "Expiration": "2026-03-30T12:00:00Z",
+            }
+        }
+
+        with patch("boto3.client", return_value=mock_sts):
+            auth = MCPSigV4Auth(
+                aws_role_name="arn:aws:iam::123456789012:role/TestRole",
+                aws_region_name="us-east-1",
+                aws_service_name="bedrock-agentcore",
+            )
+
+        request = httpx.Request(
+            method="POST",
+            url="https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/test/invocations",
+            headers={"Content-Type": "application/json"},
+            content=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+        )
+
+        signed_request = next(auth.auth_flow(request))
+        assert "Authorization" in signed_request.headers
+        assert "AWS4-HMAC-SHA256" in signed_request.headers["Authorization"]
+        assert "x-amz-security-token" in signed_request.headers
+
+    def test_assume_role_takes_precedence_over_explicit_keys(self):
+        """When both aws_role_name and explicit keys are provided, AssumeRole is used (keys become source identity)."""
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASSUMED_KEY",
+                "SecretAccessKey": "ASSUMED_SECRET",
+                "SessionToken": "ASSUMED_TOKEN",
+                "Expiration": "2026-03-30T12:00:00Z",
+            }
+        }
+
+        with patch("boto3.client", return_value=mock_sts):
+            auth = MCPSigV4Auth(
+                aws_role_name="arn:aws:iam::123456789012:role/TestRole",
+                aws_access_key_id="EXPLICIT_KEY",
+                aws_secret_access_key="EXPLICIT_SECRET",
+            )
+
+        # Credentials should be from AssumeRole, not the explicit keys
+        assert auth.credentials.access_key == "ASSUMED_KEY"
+        assert auth.credentials.secret_key == "ASSUMED_SECRET"
+
+
 class TestMCPClientSigV4Integration:
     """Tests for MCPClient with SigV4 auth wired through."""
 
@@ -318,6 +452,86 @@ class TestMCPServerManagerSigV4:
         client = await manager._create_mcp_client(server=server)
 
         assert client._aws_auth is None
+
+    @pytest.mark.asyncio
+    async def test_load_config_with_aws_role_name(self):
+        """Config loading correctly parses aws_role_name and aws_session_name."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+
+        config = {
+            "agentcore_tools": {
+                "url": "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/test/invocations",
+                "transport": "http",
+                "auth_type": "aws_sigv4",
+                "aws_role_name": "arn:aws:iam::123456789012:role/TestRole",
+                "aws_session_name": "litellm-prod",
+                "aws_region_name": "us-east-1",
+            }
+        }
+
+        manager = MCPServerManager()
+        await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        assert server.aws_role_name == "arn:aws:iam::123456789012:role/TestRole"
+        assert server.aws_session_name == "litellm-prod"
+
+    @pytest.mark.asyncio
+    async def test_create_mcp_client_with_role_assumption(self):
+        """_create_mcp_client passes aws_role_name to MCPSigV4Auth."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASSUMED_KEY",
+                "SecretAccessKey": "ASSUMED_SECRET",
+                "SessionToken": "ASSUMED_TOKEN",
+                "Expiration": "2026-03-30T12:00:00Z",
+            }
+        }
+
+        server = MCPServer(
+            server_id="test-sigv4-role",
+            name="test_sigv4_role",
+            server_name="test_sigv4_role",
+            url="https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/test/invocations",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.aws_sigv4,
+            aws_role_name="arn:aws:iam::123456789012:role/TestRole",
+            aws_region_name="us-east-1",
+        )
+
+        manager = MCPServerManager()
+        with patch("boto3.client", return_value=mock_sts):
+            client = await manager._create_mcp_client(server=server)
+
+        assert client._aws_auth is not None
+        assert isinstance(client._aws_auth, MCPSigV4Auth)
+        mock_sts.assume_role.assert_called_once()
+
+    def test_extract_aws_credentials_includes_role_fields(self):
+        """_extract_aws_credentials extracts aws_role_name and aws_session_name."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+
+        manager = MCPServerManager()
+        creds = {
+            "aws_access_key_id": "KEY",
+            "aws_region_name": "us-east-1",
+            "aws_role_name": "arn:aws:iam::123456789012:role/TestRole",
+            "aws_session_name": "my-session",
+        }
+
+        result = manager._extract_aws_credentials(creds, credentials_are_encrypted=False)
+        assert result["aws_role_name"] == "arn:aws:iam::123456789012:role/TestRole"
+        assert result["aws_session_name"] == "my-session"
 
 
 class TestSigV4CredentialEncryption:

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -933,6 +933,38 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                     className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                   />
                 </Form.Item>
+                <Form.Item
+                  label={
+                    <span className="text-sm font-medium text-gray-700 flex items-center">
+                      AWS Role ARN
+                      <Tooltip title="Optional. IAM role ARN to assume via STS before signing. If set, LiteLLM calls sts:AssumeRole to get temporary credentials. Uses ambient credentials (IAM role, env vars) as the source identity unless explicit keys are also provided.">
+                        <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                      </Tooltip>
+                    </span>
+                  }
+                  name={["credentials", "aws_role_name"]}
+                >
+                  <Input
+                    placeholder="arn:aws:iam::123456789012:role/MyRole (optional)"
+                    className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                  />
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <span className="text-sm font-medium text-gray-700 flex items-center">
+                      AWS Session Name
+                      <Tooltip title="Optional. Session name for the AssumeRole call — appears in CloudTrail logs. Auto-generated if omitted.">
+                        <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                      </Tooltip>
+                    </span>
+                  }
+                  name={["credentials", "aws_session_name"]}
+                >
+                  <Input
+                    placeholder="litellm-prod (optional, auto-generated if blank)"
+                    className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                  />
+                </Form.Item>
               </>
             )}
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -976,6 +976,38 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                   />
                 </Form.Item>
+                <Form.Item
+                  label={
+                    <span className="text-sm font-medium text-gray-700 flex items-center">
+                      AWS Role ARN
+                      <Tooltip title="Optional. IAM role ARN to assume via STS before signing. If set, LiteLLM calls sts:AssumeRole to get temporary credentials.">
+                        <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                      </Tooltip>
+                    </span>
+                  }
+                  name={["credentials", "aws_role_name"]}
+                >
+                  <Input
+                    placeholder="Leave blank to keep existing"
+                    className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                  />
+                </Form.Item>
+                <Form.Item
+                  label={
+                    <span className="text-sm font-medium text-gray-700 flex items-center">
+                      AWS Session Name
+                      <Tooltip title="Optional. Session name for the AssumeRole call — appears in CloudTrail logs. Auto-generated if omitted.">
+                        <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                      </Tooltip>
+                    </span>
+                  }
+                  name={["credentials", "aws_session_name"]}
+                >
+                  <Input
+                    placeholder="Leave blank to keep existing"
+                    className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                  />
+                </Form.Item>
               </>
             )}
 


### PR DESCRIPTION
MCPSigV4Auth only supported static AWS credentials or the boto3 default credential chain. Production Kubernetes environments typically authenticate via IAM role assumption (sts:AssumeRole), which was not possible.

Add aws_role_name and aws_session_name parameters to the MCP SigV4 auth stack. When aws_role_name is provided, MCPSigV4Auth calls sts:AssumeRole to obtain temporary credentials before signing requests. Explicit keys, if also provided, are used as the source identity for the STS call; otherwise ambient credentials (pod role, instance profile) are used.

## Relevant issues

Related to PR #22782 (original MCP SigV4 support) — extends it with AssumeRole capability.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

### Core — `MCPSigV4Auth` AssumeRole credential path
- **`litellm/experimental_mcp_client/client.py`** — Added `aws_role_name` and `aws_session_name` parameters to `MCPSigV4Auth.__init__()`. When `aws_role_name` is provided, a new `_assume_role()` static method calls `sts:AssumeRole` to obtain temporary credentials before creating the SigV4 signer. Follows the same STS pattern as `BaseAWSLLM._auth_with_aws_role()`.

### Types — New fields on models
- **`litellm/types/mcp_server/mcp_server_manager.py`** — Added `aws_role_name` and `aws_session_name` to the `MCPServer` Pydantic model.
- **`litellm/types/mcp.py`** — Added `aws_role_name` and `aws_session_name` to the `MCPCredentials` TypedDict.

### Manager — Wire fields through all code paths
- **`litellm/proxy/_experimental/mcp_server/mcp_server_manager.py`** — Passed new fields through `load_servers_from_config()`, `_create_mcp_client()`, `_extract_aws_credentials()`, and `build_mcp_server_from_table()`.

### UI — Create and Edit forms
- **`ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx`** — Added AWS Role ARN and AWS Session Name form fields (plain `<Input>`, not secrets) inside the SigV4 auth section.
- **`ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx`** — Same fields for the edit form.

### Docs
- **`docs/my-website/docs/mcp_aws_sigv4.md`** — Added UI field table rows, updated Quick Start config example, added Config Reference rows, added "Using IAM Role Assumption (AssumeRole)" section, added AssumeRole troubleshooting entry.
- **`docs/my-website/docs/mcp.md`** — Updated the `aws_sigv4` YAML snippet to show `aws_role_name`.

### Tests — 8 new tests
- **`tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py`**:
  - `TestMCPSigV4AssumeRole` (5 tests): ambient credentials, explicit source credentials, custom session name, signing with STS-derived creds, precedence over explicit keys.
  - `TestMCPServerManagerSigV4` (3 tests): config loading with role name, client creation with role assumption, credential extraction includes role fields.
  - All 38 tests pass (30 existing + 8 new).