### PR TITLE
fix: stop logging credential values in debug/error messages

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -26,6 +26,12 @@ _REDACTED = "REDACTED"
 
 def _build_secret_patterns() -> re.Pattern:
     patterns: List[str] = [
+        # ── PEM private key / certificate blocks ──
+        r"-----BEGIN[A-Z \-]*PRIVATE KEY-----[\s\S]*?-----END[A-Z \-]*PRIVATE KEY-----",
+        # ── GCP OAuth2 access tokens (ya29.*) ──
+        r"\bya29\.[A-Za-z0-9_.~+/-]+",
+        # ── Credential %s formatting (space separator, no key= prefix) ──
+        r"(?:client_secret|azure_password|azure_username)\s+[^\s,'\"})\]{}>]+",
         # AWS access key IDs
         r"(?:AKIA|ASIA)[0-9A-Z]{16}",
         # AWS secrets / session tokens / access key IDs (key=value)
@@ -46,7 +52,8 @@ def _build_secret_patterns() -> re.Pattern:
         # Google API keys
         r"AIza[0-9A-Za-z\-_]{35}",
         # Password / secret params (handles key=value and 'key': 'value')
-        r"\w*(?:password|passwd|client_secret|secret_key|_secret)"
+        # Word boundary prevents O(n^2) backtracking on long word-char runs.
+        r"(?:^|(?<=\W))\w*(?:password|passwd|client_secret|secret_key|_secret)"
         r"['\"]?\s*[:=]\s*['\"]?[^\s,'\"})\]{}>]+",
         # Database connection string credentials (scheme://user:pass@host)
         r"(?<=://)[^\s'\"]*:[^\s'\"@]+(?=@)",
@@ -56,13 +63,21 @@ def _build_secret_patterns() -> re.Pattern:
         # Catches secrets inside dicts/config dumps by matching on the KEY name
         # regardless of what the value looks like.
         # e.g. 'master_key': 'any-value-here', "database_url": "postgres://..."
+        # private_key with PEM-aware value capture
+        r"""private_key['\"]?\s*[:=]\s*['\"]?(?:-----BEGIN[A-Z \-]*PRIVATE KEY-----[\s\S]*?-----END[A-Z \-]*PRIVATE KEY-----|[^\s,'\"})\]{}>]+)""",
         r"(?:master_key|database_url|db_url|connection_string|"
-        r"private_key|signing_key|encryption_key|"
+        r"signing_key|encryption_key|"
         r"auth_token|access_token|refresh_token|"
         r"slack_webhook_url|webhook_url|"
         r"database_connection_string|"
         r"huggingface_token|jwt_secret)"
         r"""['\"]?\s*[:=]\s*['\"]?[^\s,'\"})\]{}>]+""",
+        # ── Raw JWTs (without Bearer prefix) ──
+        r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*",
+        # ── Azure SAS tokens in URLs ──
+        r"[?&]sig=[A-Za-z0-9%+/=]+",
+        # ── Full JSON service-account blobs (single-line and multi-line) ──
+        r'\{[^{}]*"type"\s*:\s*"service_account"[^{}]*(?:\{[^{}]*\}[^{}]*)*\}',
     ]
     return re.compile("|".join(patterns), re.IGNORECASE)
 
@@ -72,6 +87,23 @@ _SECRET_RE = _build_secret_patterns()
 
 def _redact_string(value: str) -> str:
     return _SECRET_RE.sub(_REDACTED, value)
+
+
+def redact_secrets(value: str) -> str:
+    """Public API: redact known secret/credential patterns from an arbitrary string.
+
+    Use this for code paths that bypass the logging system — e.g. Slack/Teams
+    alerting, HTTP error response bodies, or any other string that may contain
+    secrets and will be sent to an external sink.
+
+    Not to be confused with redact_message_input_output_from_logging() in
+    litellm_core_utils/redact_messages.py, which redacts LLM prompt/response
+    content for privacy — this function redacts credential patterns (API keys,
+    PEM blocks, tokens, etc.) by shape.
+    """
+    if not _ENABLE_SECRET_REDACTION:
+        return value
+    return _redact_string(value)
 
 
 class SecretRedactionFilter(logging.Filter):
@@ -441,7 +473,7 @@ def _enable_debugging():
 def print_verbose(print_statement):
     try:
         if set_verbose:
-            print(print_statement)  # noqa
+            print(redact_secrets(str(print_statement)))  # noqa
     except Exception:
         pass
 

--- a/litellm/integrations/azure_storage/azure_storage.py
+++ b/litellm/integrations/azure_storage/azure_storage.py
@@ -275,12 +275,11 @@ class AzureBlobStorageLogger(CustomBatchLogger):
         """
         Gets Azure AD token to use for Azure Storage API requests
         """
-        verbose_logger.debug("Getting Azure AD Token from Azure Storage")
         verbose_logger.debug(
-            "tenant_id %s, client_id %s, client_secret %s",
+            "Getting Azure AD Token from Azure Storage, tenant_id=%s, client_id=%s, client_secret=[set=%s]",
             tenant_id,
             client_id,
-            client_secret,
+            client_secret is not None,
         )
         if tenant_id is None:
             raise ValueError(

--- a/litellm/integrations/gcs_bucket/gcs_bucket_base.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket_base.py
@@ -70,7 +70,9 @@ class GCSBucketBase(CustomBatchLogger):
             custom_llm_provider="vertex_ai",
             api_base=None,
         )
-        verbose_logger.debug("constructed auth_header %s", auth_header)
+        verbose_logger.debug(
+            "constructed auth_header [set=%s]", auth_header is not None
+        )
         headers = {
             "Authorization": f"Bearer {auth_header}",  # auth_header
             "Content-Type": "application/json",
@@ -106,7 +108,9 @@ class GCSBucketBase(CustomBatchLogger):
             custom_llm_provider="vertex_ai",
             api_base=None,
         )
-        verbose_logger.debug("constructed auth_header %s", auth_header)
+        verbose_logger.debug(
+            "constructed auth_header [set=%s]", auth_header is not None
+        )
         headers = {
             "Authorization": f"Bearer {auth_header}",  # auth_header
             "Content-Type": "application/json",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -205,8 +205,8 @@ def get_llm_provider(  # noqa: PLR0915
                 )
             if dynamic_api_key is not None and not isinstance(dynamic_api_key, str):
                 raise Exception(
-                    "dynamic_api_key needs to be a string. dynamic_api_key={}".format(
-                        dynamic_api_key
+                    "dynamic_api_key needs to be a string. Got type={}".format(
+                        type(dynamic_api_key).__name__
                     )
                 )
             return model, custom_llm_provider, dynamic_api_key, api_base

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -101,16 +101,14 @@ def get_azure_ad_token_from_entra_id(
         _client_secret = client_secret
 
     verbose_logger.debug(
-        "tenant_id %s, client_id %s, client_secret %s",
+        "tenant_id=%s, client_id=%s, client_secret=[set=%s]",
         _tenant_id,
         _client_id,
-        _client_secret,
+        _client_secret is not None,
     )
     if _tenant_id is None or _client_id is None or _client_secret is None:
         raise ValueError("tenant_id, client_id, and client_secret must be provided")
     credential = ClientSecretCredential(_tenant_id, _client_id, _client_secret)
-
-    verbose_logger.debug("credential %s", credential)
 
     token_provider = get_bearer_token_provider(credential, scope)
 
@@ -140,18 +138,16 @@ def get_azure_ad_token_from_username_password(
     from azure.identity import UsernamePasswordCredential, get_bearer_token_provider
 
     verbose_logger.debug(
-        "client_id %s, azure_username %s, azure_password %s",
+        "client_id=%s, azure_username=[set=%s], azure_password=[set=%s]",
         client_id,
-        azure_username,
-        azure_password,
+        azure_username is not None,
+        azure_password is not None,
     )
     credential = UsernamePasswordCredential(
         client_id=client_id,
         username=azure_username,
         password=azure_password,
     )
-
-    verbose_logger.debug("credential %s", credential)
 
     token_provider = get_bearer_token_provider(credential, scope)
 

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -156,24 +156,24 @@ class BaseAWSLLM:
 
         verbose_logger.debug(
             "in get credentials\n"
-            "aws_access_key_id=%s\n"
-            "aws_secret_access_key=%s\n"
-            "aws_session_token=%s\n"
+            "aws_access_key_id=[set=%s]\n"
+            "aws_secret_access_key=[set=%s]\n"
+            "aws_session_token=[set=%s]\n"
             "aws_region_name=%s\n"
             "aws_session_name=%s\n"
             "aws_profile_name=%s\n"
             "aws_role_name=%s\n"
-            "aws_web_identity_token=%s\n"
+            "aws_web_identity_token=[set=%s]\n"
             "aws_sts_endpoint=%s\n"
             "aws_external_id=%s",
-            aws_access_key_id,
-            aws_secret_access_key,
-            aws_session_token,
+            aws_access_key_id is not None,
+            aws_secret_access_key is not None,
+            aws_session_token is not None,
             aws_region_name,
             aws_session_name,
             aws_profile_name,
             aws_role_name,
-            aws_web_identity_token,
+            aws_web_identity_token is not None,
             aws_sts_endpoint,
             aws_external_id,
         )

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -81,26 +81,26 @@ class VertexBase:
     ) -> Tuple[Any, str]:
         if credentials is not None:
             if isinstance(credentials, str):
+                _is_path = os.path.exists(
+                    credentials
+                )  # credentials is from server config (litellm_params), not user input
                 verbose_logger.debug(
-                    "Vertex: Loading vertex credentials from %s", credentials
-                )
-                verbose_logger.debug(
-                    "Vertex: checking if credentials is a valid path, os.path.exists(%s)=%s, current dir %s",
-                    credentials,
-                    os.path.exists(credentials),
+                    "Vertex: Loading vertex credentials, is_file_path=%s, current dir %s",
+                    _is_path,
                     os.getcwd(),
                 )
 
                 try:
-                    if os.path.exists(credentials):
-                        json_obj = json.load(open(credentials))
+                    if _is_path:
+                        with open(credentials) as f:
+                            json_obj = json.load(f)
                     else:
                         json_obj = json.loads(credentials)
-                except Exception:
+                except Exception as e:
                     raise Exception(
-                        "Unable to load vertex credentials from environment. Got={}".format(
-                            credentials
-                        )
+                        "Unable to load vertex credentials from environment. "
+                        "Ensure the JSON is valid (check for unescaped newlines in private_key). "
+                        "Parse error: {}".format(type(e).__name__)
                     )
             elif isinstance(credentials, dict):
                 json_obj = credentials
@@ -668,8 +668,8 @@ class VertexBase:
         ## VALIDATION STEP
         if _credentials.token is None or not isinstance(_credentials.token, str):
             raise ValueError(
-                "Could not resolve credentials token. Got None or non-string token - {}".format(
-                    _credentials.token
+                "Could not resolve credentials token. Got None or non-string token (type={})".format(
+                    type(_credentials.token).__name__
                 )
             )
 

--- a/litellm/proxy/auth/oauth2_check.py
+++ b/litellm/proxy/auth/oauth2_check.py
@@ -136,7 +136,9 @@ class Oauth2Handler:
                 + CommonProxyErrors.not_premium_user.value
             )
 
-        verbose_proxy_logger.debug("Oauth2 token validation for token=%s", token)
+        verbose_proxy_logger.debug(
+            "Oauth2 token validation for token=[set=%s]", token is not None
+        )
 
         # Get the token info endpoint from environment variable
         token_info_endpoint = os.getenv("OAUTH_TOKEN_INFO_ENDPOINT")

--- a/litellm/proxy/auth/oauth2_proxy_hook.py
+++ b/litellm/proxy/auth/oauth2_proxy_hook.py
@@ -37,7 +37,8 @@ async def handle_oauth2_proxy_request(request: Request) -> UserAPIKeyAuth:
             else:
                 auth_data[key] = value
     verbose_proxy_logger.debug(
-        f"Auth data before creating UserAPIKeyAuth object: {auth_data}"
+        "Auth data before creating UserAPIKeyAuth object: keys=%s",
+        list(auth_data.keys()),
     )
     user_api_key_auth = UserAPIKeyAuth(**auth_data)
     verbose_proxy_logger.debug(f"UserAPIKeyAuth object created: {user_api_key_auth}")

--- a/litellm/proxy/auth/oauth2_proxy_hook.py
+++ b/litellm/proxy/auth/oauth2_proxy_hook.py
@@ -41,6 +41,9 @@ async def handle_oauth2_proxy_request(request: Request) -> UserAPIKeyAuth:
         list(auth_data.keys()),
     )
     user_api_key_auth = UserAPIKeyAuth(**auth_data)
-    verbose_proxy_logger.debug(f"UserAPIKeyAuth object created: {user_api_key_auth}")
+    verbose_proxy_logger.debug(
+        "UserAPIKeyAuth object created with keys: %s",
+        list(user_api_key_auth.__fields_set__),
+    )
     # Create and return UserAPIKeyAuth object
     return user_api_key_auth

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -711,7 +711,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 "global_max_parallel_requests", None
             )
             user_api_key = _metadata.get("user_api_key", None)
-            self.print_verbose(f"user_api_key: {user_api_key}")
+            self.print_verbose(f"user_api_key: [set={user_api_key is not None}]")
             if user_api_key is None:
                 return
 

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1002,7 +1002,9 @@ async def get_global_spend_report(
                 "/spend/report endpoint " + CommonProxyErrors.not_premium_user.value
             )
         if api_key is not None:
-            verbose_proxy_logger.debug("Getting /spend for api_key: %s", api_key)
+            verbose_proxy_logger.debug(
+                "Getting /spend for api_key: [set=%s]", api_key is not None
+            )
             if api_key.startswith("sk-"):
                 api_key = hash_token(token=api_key)
             sql_query = """

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3267,7 +3267,7 @@ class PrismaClient:
             if update_key_values is not None:
                 update_key_values = self.jsonify_object(data=update_key_values)
             if token is not None:
-                print_verbose(f"token: {token}")
+                print_verbose(f"token: [set={token is not None}]")
                 # check if plain text or hash
                 token = _hash_token_if_needed(token=token)
                 db_data["token"] = token

--- a/litellm/router_utils/handle_error.py
+++ b/litellm/router_utils/handle_error.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from litellm._logging import verbose_router_logger
+from litellm._logging import redact_secrets, verbose_router_logger
 from litellm.constants import MAX_EXCEPTION_MESSAGE_LENGTH
 from litellm.router_utils.cooldown_handlers import (
     _async_get_cooldown_deployments_with_debug_info,
@@ -56,6 +56,9 @@ async def send_llm_exception_alert(
     if litellm_debug_info is not None:
         exception_str += litellm_debug_info
     exception_str += f"\n\n{error_traceback_str[:MAX_EXCEPTION_MESSAGE_LENGTH]}"
+
+    # Redact secrets before sending to external service (Slack / MS Teams)
+    exception_str = redact_secrets(exception_str)
 
     await litellm_router_instance.slack_alerting_logger.send_alert(
         message=f"LLM API call failed: `{exception_str}`",

--- a/litellm/secret_managers/secret_manager_handler.py
+++ b/litellm/secret_managers/secret_manager_handler.py
@@ -117,12 +117,14 @@ def get_secret_from_manager(  # noqa: PLR0915
                 secret_name=secret_name,
                 primary_secret_name=primary_secret_name,
             )
-            print_verbose(f"get_secret_value_response: {secret}")
+            print_verbose(f"get_secret_value_response: [set={secret is not None}]")
 
     elif key_manager == KeyManagementSystem.GOOGLE_SECRET_MANAGER.value:
         try:
             secret = client.get_secret_from_google_secret_manager(secret_name)
-            print_verbose(f"secret from google secret manager:  {secret}")
+            print_verbose(
+                f"secret from google secret manager: [set={secret is not None}]"
+            )
             if secret is None:
                 raise ValueError(
                     f"No secret found in Google Secret Manager for {secret_name}"

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -262,3 +262,80 @@ def test_key_name_redaction_in_general_settings_dict():
     assert "REDACTED" in output
     # Non-sensitive values should survive
     assert "enable_jwt_auth" in output
+
+
+# ── GCP service-account / Vertex credential redaction ──
+
+
+_SAMPLE_SA_JSON = (
+    '{"type": "service_account", "project_id": "my-proj-123", '
+    '"private_key_id": "abc123def", '
+    '"private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkq\\n-----END PRIVATE KEY-----\\n", '
+    '"client_email": "sa@my-proj.iam.gserviceaccount.com", '
+    '"client_id": "123456789"}'
+)
+
+
+def test_pem_private_key_redacted_in_json():
+    result = _redact_string(_SAMPLE_SA_JSON)
+    assert "MIIEvQIBADA" not in result
+    assert "-----BEGIN" not in result
+
+
+def test_pem_private_key_redacted_in_dict_repr():
+    import json
+
+    sa = json.loads(_SAMPLE_SA_JSON)
+    result = _redact_string(str(sa))
+    assert "MIIEvQIBADA" not in result
+
+
+def test_service_account_blob_fully_redacted():
+    result = _redact_string(f"Got={_SAMPLE_SA_JSON}")
+    assert "my-proj-123" not in result
+    assert "sa@my-proj.iam.gserviceaccount.com" not in result
+    assert "abc123def" not in result
+    assert "MIIEvQIBADA" not in result
+
+
+def test_vertex_error_message_no_credential_leak():
+    """The old Vertex error format leaked the full credential JSON.
+    The new format must not contain any credential material."""
+    new_msg = (
+        "Unable to load vertex credentials from environment. "
+        "Ensure the JSON is valid (check for unescaped newlines in private_key). "
+        "Parse error: JSONDecodeError"
+    )
+    result = _redact_string(new_msg)
+    assert result == new_msg  # nothing to redact
+
+
+def test_vertex_traceback_redacts_pem():
+    traceback_text = (
+        "Traceback (most recent call last):\n"
+        '  File "vertex_llm_base.py", line 95\n'
+        "    json_obj = json.loads(credentials)\n"
+        "json.decoder.JSONDecodeError: Invalid control character\n"
+        "Failed to load vertex credentials. Error: "
+        "Unable to load vertex credentials from environment. "
+        f"Got={_SAMPLE_SA_JSON}"
+    )
+    result = _redact_string(traceback_text)
+    assert "MIIEvQIBADA" not in result
+    assert "-----BEGIN" not in result
+
+
+def test_gcp_oauth_token_redacted():
+    result = _redact_string("access token ya29.c.c0ASRK0GZvXlongtokenhere")
+    assert "ya29." not in result
+    assert "REDACTED" in result
+
+
+def test_non_pem_private_key_value_redacted():
+    result = _redact_string("'private_key': 'some-non-pem-secret-value'")
+    assert "some-non-pem-secret" not in result
+
+
+def test_normal_vertex_log_not_redacted():
+    msg = "Vertex: Loading vertex credentials, is_file_path=True, current dir /app"
+    assert _redact_string(msg) == msg


### PR DESCRIPTION
## Relevant issues

Fixes credential material (GCP service account private keys, AWS secrets, Azure client secrets, OAuth tokens) being logged to stderr in debug and error messages. Specifically addresses Vertex AI credential JSON (including RSA private key) being logged on health check failures via `vertex_llm_base.py`.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Replace raw credential values in log messages with boolean presence checks (`[set=True/False]`) or type names across 14 files
- Add missing redaction patterns to `_logging.py`: PEM private key blocks, GCP OAuth tokens (`ya29.*`), raw JWTs, Azure SAS tokens, full GCP service-account JSON blobs
- Fix `vertex_llm_base.py` error handler to not include credential content in exception messages
- Fix `private_key` redaction pattern to capture full PEM blocks instead of stopping at first whitespace
- Fix backtracking risk in password pattern with word boundary anchor
- Add 9 tests covering PEM redaction, service-account blob redaction, Vertex error format, GCP OAuth tokens, and false-positive checks