### PR TITLE
[Fix] WatsonX Tests Failing on CI Due to Missing Env Vars

### DIFF
--- a/tests/llm_translation/test_watsonx.py
+++ b/tests/llm_translation/test_watsonx.py
@@ -13,6 +13,16 @@ import pytest
 from typing import Optional
 
 
+@pytest.fixture(autouse=True)
+def watsonx_env_vars(monkeypatch):
+    """Set required WatsonX env vars so the provider passes validation.
+    Also clear WATSONX_ZENAPIKEY/WATSONX_TOKEN so they don't bypass the IAM token mock."""
+    monkeypatch.setenv("WATSONX_URL", "https://us-south.ml.cloud.ibm.com")
+    monkeypatch.setenv("WATSONX_PROJECT_ID", "test-project-id")
+    monkeypatch.delenv("WATSONX_ZENAPIKEY", raising=False)
+    monkeypatch.delenv("WATSONX_TOKEN", raising=False)
+
+
 @pytest.fixture
 def watsonx_chat_completion_call():
     def _call(


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
WatsonX tests in `tests/llm_translation/test_watsonx.py` fail on CI with `assert mock_post.call_count == 0 == 1`. The tests are fully mocked but the WatsonX provider requires `WATSONX_URL` and `WATSONX_PROJECT_ID` env vars to pass validation before reaching the mocked HTTP client. Without them, a validation error is raised and silently swallowed by the fixture's `except` block.

### Fix
Added an `autouse` fixture that sets dummy `WATSONX_URL` and `WATSONX_PROJECT_ID` via `monkeypatch`, and clears `WATSONX_ZENAPIKEY`/`WATSONX_TOKEN` to prevent env leakage from `.env` files loaded by `dotenv.load_dotenv()`. No real API keys or CI/CD env var changes needed.

## Testing
All 11 tests in `tests/llm_translation/test_watsonx.py` pass locally.

## Type
🐛 Bug Fix
✅ Test