### PR TITLE
Fix broken codeql-action SHA in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@c10b806170c8ee63ea24152429041b5624f0baf5 # v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

The scorecard workflow was failing with:

> Unable to resolve action `github/codeql-action/upload-sarif@c10b806170c8ee63ea24152429041b5624f0baf5`

The SHA was invalid. Updated to the correct immutable SHA for `v4.35.1`.

## Test plan
- [ ] Scorecard workflow passes on next scheduled or push run