### PR TITLE
[Fix] Update gemini-2.0-flash to gemini-2.5-flash in test_gemini

### DIFF
--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -532,7 +532,7 @@ def test_gemini_with_grounding():
     ## Check streaming
 
     response = completion(
-        model="gemini/gemini-2.0-flash",
+        model="gemini/gemini-2.5-flash",
         messages=[{"role": "user", "content": "What is the capital of France?"}],
         tools=tools,
         stream=True,
@@ -566,7 +566,7 @@ def test_gemini_with_empty_function_call_arguments():
         }
     ]
     response = completion(
-        model="gemini/gemini-2.0-flash",
+        model="gemini/gemini-2.5-flash",
         messages=[{"role": "user", "content": "What is the capital of France?"}],
         tools=tools,
     )
@@ -775,7 +775,7 @@ def test_gemini_tool_use():
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What's the weather like in Lima, Peru today?"},
         ],
-        "model": "gemini/gemini-2.0-flash",
+        "model": "gemini/gemini-2.5-flash",
         "tools": [
             {
                 "type": "function",


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

Integration tests in `llm_translation_testing` (`test_gemini`) using `gemini/gemini-2.0-flash` fail with a 404 error because `gemini-2.0-flash` is no longer available to new users.

### Fix

Updated all 3 instances of `gemini/gemini-2.0-flash` to `gemini/gemini-2.5-flash` in `tests/llm_translation/test_gemini.py`:
- `test_gemini_with_grounding` (streaming call)
- `test_gemini_with_empty_function_call_arguments`
- `test_gemini_tool_use`

## Testing

- `llm_translation_testing` with `test_gemini`

## Type

🐛 Bug Fix
✅ Test