### PR TITLE
[Fix] Correct kwarg name in test_user_api_key_auth tests

### DIFF
--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -28,7 +28,7 @@ def test_get_api_key():
     assert get_api_key(
         custom_litellm_key_header=None,
         api_key=bearer_token,
-        AZURE_AI_API_KEY_header=None,
+        azure_api_key_header=None,
         anthropic_api_key_header=None,
         google_ai_studio_api_key_header=None,
         azure_apim_header=None,
@@ -59,7 +59,7 @@ def test_get_api_key_with_custom_litellm_key_header(
     assert get_api_key(
         custom_litellm_key_header=custom_litellm_key_header,
         api_key=None,
-        AZURE_AI_API_KEY_header=None,
+        azure_api_key_header=None,
         anthropic_api_key_header=None,
         google_ai_studio_api_key_header=None,
         azure_apim_header=None,
@@ -371,7 +371,7 @@ async def test_proxy_admin_expired_key_from_cache():
                 await _user_api_key_auth_builder(
                     request=request,
                     api_key=f"Bearer {api_key}",  # Add Bearer prefix
-                    AZURE_AI_API_KEY_header="",
+                    azure_api_key_header="",
                     anthropic_api_key_header=None,
                     google_ai_studio_api_key_header=None,
                     azure_apim_header=None,
@@ -842,7 +842,7 @@ async def test_user_api_key_auth_builder_no_blocking_calls():
             await _user_api_key_auth_builder(
                 request=request,
                 api_key=f"Bearer {api_key}",
-                AZURE_AI_API_KEY_header="",
+                azure_api_key_header="",
                 anthropic_api_key_header=None,
                 google_ai_studio_api_key_header=None,
                 azure_apim_header=None,


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)

`test_get_api_key_with_custom_litellm_key_header` and related tests in `test_user_api_key_auth.py` fail with `TypeError: get_api_key() got an unexpected keyword argument 'AZURE_AI_API_KEY_header'`.

PR #24755 renamed `azure_api_key_header` to `AZURE_AI_API_KEY_header` in the test file but did not update the actual function signatures of `get_api_key()` and `_user_api_key_auth_builder()`, which still use `azure_api_key_header`.

### Fix

Reverts the 4 kwarg name changes in the test file back to `azure_api_key_header` to match the function signatures.

## Testing

```
pytest tests/test_litellm/proxy/auth/test_user_api_key_auth.py::test_get_api_key -v
pytest tests/test_litellm/proxy/auth/test_user_api_key_auth.py::test_get_api_key_with_custom_litellm_key_header -v
```

All 6 tests pass.

## Type

🐛 Bug Fix
✅ Test