### PR TITLE
feat(proxy): Optional on_error for guardrail pipeline (API / technical failures)

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/guardrail_policies.md
+++ b/docs/my-website/docs/proxy/guardrails/guardrail_policies.md
@@ -311,7 +311,7 @@ Response:
 
 ## Policy Flow Builder
 
-For conditional execution (e.g., run a second guardrail only if the first fails), use the [Policy Flow Builder](./policy_flow_builder) to define pipelines with per-step pass/fail actions.
+For conditional execution (e.g., run a second guardrail only if the first fails), use the [Policy Flow Builder](./policy_flow_builder) to define pipelines with per-step **pass**, **fail**, and optional **error** actions (`on_pass`, `on_fail`, `on_error`).
 
 ## Config Reference
 
@@ -337,7 +337,7 @@ policies:
 | `guardrails.add` | `list[string]` | Guardrails to enable. |
 | `guardrails.remove` | `list[string]` | Guardrails to disable (useful with inheritance). |
 | `condition.model` | `string` or `list[string]` | Optional. Only apply when model matches. Supports regex. |
-| `pipeline` | `object` | Optional. Ordered guardrail execution with per-step actions. See [Policy Flow Builder](./policy_flow_builder). |
+| `pipeline` | `object` | Optional. Ordered guardrail execution with per-step actions (`on_pass`, `on_fail`, optional `on_error`). See [Policy Flow Builder](./policy_flow_builder). |
 
 ### `policy_attachments`
 

--- a/docs/my-website/docs/proxy/guardrails/policy_flow_builder.md
+++ b/docs/my-website/docs/proxy/guardrails/policy_flow_builder.md
@@ -1,8 +1,8 @@
 # Policy Flow Builder
 
-The Policy Flow Builder lets you design guardrail pipelines with **conditional execution**. Instead of running guardrails independently, you chain them into ordered steps and control what happens when each guardrail passes or fails.
+The Policy Flow Builder lets you design guardrail pipelines with **conditional execution**. Instead of running guardrails independently, you chain them into ordered steps and control what happens when each guardrail **passes**, **fails a policy check** (content intervention), or hits a **technical error** (e.g. timeout, unreachable provider, missing guardrail).
 
-Two powerful patterns it enables: **guardrail fallbacks** (try a different guardrail when one fails) and **retrying the same guardrail** (run the same guardrail again if it fails, e.g. to handle transient errors).
+Two powerful patterns it enables: **guardrail fallbacks** (try a different guardrail when one fails) and **retrying the same guardrail** (run the same guardrail again if it fails, e.g. to handle transient errors). With **`on_error`**, you can treat **technical** failures differently from **policy** failures—for example, fall back to another provider when the primary API errors, while still blocking on flagged content.
 
 ## When to use the Flow Builder
 
@@ -19,6 +19,7 @@ Use the Flow Builder when you need:
 - **Custom responses** — return a specific message when a guardrail fails instead of a generic block
 - **Data chaining** — pass modified data (e.g., PII-masked content) from one step to the next
 - **Fine-grained control** — different actions on pass vs. fail per step
+- **Technical-error routing** — set `on_error` separately from `on_fail` so outages or timeouts can **allow**, **block**, **go to the next step**, or return a **custom response** without conflating them with content violations
 
 ## Concepts
 
@@ -29,24 +30,37 @@ A pipeline has:
 - **Mode**: `pre_call` (before the LLM) or `post_call` (after the LLM)
 - **Steps**: Ordered list of guardrail steps
 
+### Outcomes: pass, fail, and error
+
+Each step run produces one of three outcomes:
+
+| Outcome | Meaning | Typical cause |
+|--------|---------|----------------|
+| **pass** | Guardrail completed without blocking | Content allowed, or data was modified and returned |
+| **fail** | Policy intervention | Guardrail raised an intervention (e.g. flagged content, blocked request) |
+| **error** | Technical failure | Timeouts, network errors, guardrail not registered, or other non-intervention exceptions |
+
+`on_pass` and `on_fail` apply to **pass** and **fail** respectively. **`on_error`** applies only to **error**. If `on_error` is omitted, the pipeline uses **`on_fail`** for error outcomes (backward compatible).
+
 ### Step actions
 
-Each step defines what happens when the guardrail **passes** and when it **fails**:
+For each step you choose an action for **pass**, **fail**, and optionally **error**. Allowed values are: `next`, `allow`, `block`, `modify_response`.
 
 | Action | Description |
 |--------|-------------|
-| **Next Step** | Continue to the next guardrail in the pipeline |
-| **Allow** | Stop the pipeline and allow the request to proceed |
-| **Block** | Stop the pipeline and block the request |
-| **Custom Response** | Return a custom message instead of the default block |
+| **Next Step** (`next`) | Continue to the next guardrail in the pipeline |
+| **Allow** (`allow`) | Stop the pipeline and allow the request to proceed |
+| **Block** (`block`) | Stop the pipeline and block the request |
+| **Custom Response** (`modify_response`) | Return a custom message instead of the default block |
 
 ### Step options
 
 | Field | Type | Description |
 |-------|------|--------------|
 | `guardrail` | `string` | Name of the guardrail to run |
-| `on_pass` | `string` | Action when guardrail passes: `next`, `allow`, `block`, `modify_response` |
-| `on_fail` | `string` | Action when guardrail fails: `next`, `allow`, `block`, `modify_response` |
+| `on_pass` | `string` | Action when outcome is **pass**: `next`, `allow`, `block`, `modify_response` |
+| `on_fail` | `string` | Action when outcome is **fail** (policy intervention): `next`, `allow`, `block`, `modify_response` |
+| `on_error` | `string` (optional) | Action when outcome is **error** (technical). If omitted, **error** uses `on_fail`. |
 | `pass_data` | `boolean` | Forward modified request data (e.g., PII-masked) to the next step |
 | `modify_response_message` | `string` | Custom message when using `modify_response` action |
 
@@ -57,7 +71,7 @@ Each step defines what happens when the guardrail **passes** and when it **fails
 3. Select **Flow Builder** (instead of the simple form)
 4. Design your flow:
    - **Trigger** — Incoming LLM request (runs when the policy matches)
-   - **Steps** — Add guardrails, set ON PASS and ON FAIL actions per step
+   - **Steps** — Add guardrails, set **ON PASS**, **ON FAIL**, and **ON ERROR** actions per step (ON ERROR is optional; when unset, errors follow ON FAIL)
    - **End** — Request proceeds to the LLM
 5. Use the **+** between steps to insert new steps
 6. Use the **Test** panel to run sample messages through the pipeline before saving
@@ -150,6 +164,37 @@ policies:
 ```
 
 First attempt passes → allow. First attempt fails → retry the same guardrail; second pass → allow, second fail → block.
+
+## Technical errors vs policy failures (`on_error`)
+
+Use **`on_error`** when you want different behavior for **API/infra problems** than for **content policy** violations.
+
+- **`on_fail`** — Runs when the guardrail **intervenes** (e.g. toxic content, PII detected).
+- **`on_error`** — Runs when the step ends in **error** (timeout, connection failure, guardrail not loaded, etc.). If you omit `on_error`, **error** outcomes use **`on_fail`**.
+
+Example: block on bad content, but if the primary scanner is down, fall back to a second guardrail instead of blocking every request:
+
+```yaml
+policies:
+  error-fallback-policy:
+    guardrails:
+      add:
+        - primary_scanner
+        - backup_scanner
+    pipeline:
+      mode: pre_call
+      steps:
+        - guardrail: primary_scanner
+          on_pass: allow
+          on_fail: block
+          on_error: next
+        - guardrail: backup_scanner
+          on_pass: allow
+          on_fail: block
+          on_error: allow
+```
+
+If `primary_scanner` errors → run `backup_scanner`. If `backup_scanner` errors → allow the request (set `on_error` to `block` if you prefer fail-closed).
 
 ## Example: Custom response on fail
 

--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -74,7 +74,7 @@ class PipelineExecutor:
 
             duration = time.perf_counter() - start_time
 
-            action = step.on_pass if outcome == "pass" else step.on_fail
+            action = _pipeline_action_for_outcome(step, outcome)
 
             step_result = PipelineStepResult(
                 guardrail_name=step.guardrail,
@@ -204,6 +204,23 @@ class PipelineExecutor:
                 if callback.guardrail_name == guardrail_name:
                     return callback
         return None
+
+
+def _pipeline_action_for_outcome(step: PipelineStep, outcome: str) -> str:
+    """
+    Map pipeline step outcome to the configured action.
+
+    - pass -> on_pass
+    - fail -> on_fail (content/policy intervention)
+    - error -> on_error if set, else on_fail (backward compatible)
+    """
+    if outcome == "pass":
+        return step.on_pass
+    if outcome == "fail":
+        return step.on_fail
+    if step.on_error is not None:
+        return step.on_error
+    return step.on_fail
 
 
 def _extract_error_message(e: Exception) -> str:

--- a/litellm/types/proxy/policy_engine/pipeline_types.py
+++ b/litellm/types/proxy/policy_engine/pipeline_types.py
@@ -18,17 +18,23 @@ class PipelineStep(BaseModel):
     """
     A single step in a guardrail pipeline.
 
-    Each step runs a guardrail and takes an action based on pass/fail.
+    Each step runs a guardrail and takes an action based on pass, policy fail,
+    or technical/API error (see pipeline executor outcome types).
     """
 
     guardrail: str = Field(description="Name of the guardrail to run.")
     on_fail: str = Field(
         default="block",
-        description="Action when guardrail rejects: next | block | allow | modify_response",
+        description="Action when guardrail rejects content (policy intervention): next | block | allow | modify_response",
     )
     on_pass: str = Field(
         default="allow",
         description="Action when guardrail passes: next | block | allow | modify_response",
+    )
+    on_error: Optional[str] = Field(
+        default=None,
+        description="Action when the guardrail raises a technical error (timeouts, "
+        "unreachable provider, non-intervention HTTP errors). If omitted, uses on_fail.",
     )
     pass_data: bool = Field(
         default=False,
@@ -41,9 +47,11 @@ class PipelineStep(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    @field_validator("on_fail", "on_pass")
+    @field_validator("on_fail", "on_pass", "on_error")
     @classmethod
-    def validate_action(cls, v: str) -> str:
+    def validate_action(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
         if v not in VALID_PIPELINE_ACTIONS:
             raise ValueError(
                 f"Invalid action '{v}'. Must be one of: {sorted(VALID_PIPELINE_ACTIONS)}"

--- a/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
+++ b/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
@@ -46,6 +46,28 @@ class AlwaysFailGuardrail(CustomGuardrail):
         raise HTTPException(status_code=400, detail="Content policy violation")
 
 
+class HttpStatusGuardrail(CustomGuardrail):
+    """Raises HTTPException with a configurable status (e.g. 503 for API outage)."""
+
+    def __init__(self, guardrail_name: str, status_code: int):
+        super().__init__(
+            guardrail_name=guardrail_name,
+            event_hook="pre_call",
+            default_on=True,
+        )
+        self.status_code = status_code
+        self.calls = 0
+
+    def should_run_guardrail(self, data, event_type) -> bool:
+        return True
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        self.calls += 1
+        raise HTTPException(
+            status_code=self.status_code, detail="Simulated HTTP error"
+        )
+
+
 class AlwaysPassGuardrail(CustomGuardrail):
     """Mock guardrail that always passes."""
 
@@ -346,6 +368,125 @@ async def test_guardrail_not_found_uses_on_fail():
         assert result.terminal_action == "block"
         assert result.step_results[0].outcome == "error"
         assert "not found" in result.step_results[0].error_detail
+    finally:
+        litellm.callbacks = original_callbacks
+
+
+@pytest.mark.skipif(HTTPException is None, reason="fastapi not installed")
+@pytest.mark.asyncio
+async def test_on_error_next_fallback_on_api_outage_on_fail_blocks_content():
+    """
+    Policy intervention (400) uses on_fail; technical error (503) uses on_error.
+
+    Primary returns 503 -> on_error: next -> fallback runs -> allow.
+    """
+    primary = HttpStatusGuardrail("primary-mod", status_code=503)
+    fallback = AlwaysPassGuardrail("fallback-filter")
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[
+            PipelineStep(
+                guardrail="primary-mod",
+                on_fail="block",
+                on_error="next",
+                on_pass="allow",
+            ),
+            PipelineStep(
+                guardrail="fallback-filter",
+                on_fail="block",
+                on_pass="allow",
+            ),
+        ],
+    )
+
+    original_callbacks = litellm.callbacks.copy()
+    litellm.callbacks = [primary, fallback]
+
+    try:
+        result = await PipelineExecutor.execute_steps(
+            steps=pipeline.steps,
+            mode=pipeline.mode,
+            data={"messages": [{"role": "user", "content": "any"}]},
+            user_api_key_dict=MagicMock(),
+            call_type="completion",
+            policy_name="mod-fallback",
+        )
+
+        assert primary.calls == 1
+        assert fallback.calls == 1
+        assert result.terminal_action == "allow"
+        assert result.step_results[0].outcome == "error"
+        assert result.step_results[0].action_taken == "next"
+        assert result.step_results[1].outcome == "pass"
+    finally:
+        litellm.callbacks = original_callbacks
+
+
+@pytest.mark.skipif(HTTPException is None, reason="fastapi not installed")
+@pytest.mark.asyncio
+async def test_on_fail_next_on_content_on_error_block_stops_api_fallback():
+    """
+    Content policy fail (400) uses on_fail: next; API error uses on_error: block (no second step).
+    """
+    primary_content = AlwaysFailGuardrail("strict-mod")
+    primary_api = HttpStatusGuardrail("strict-mod", status_code=503)
+    fallback = AlwaysPassGuardrail("fallback-filter")
+
+    # Content violation: on_fail next -> would reach fallback if we had two steps
+    pipeline_content = GuardrailPipeline(
+        mode="pre_call",
+        steps=[
+            PipelineStep(
+                guardrail="strict-mod",
+                on_fail="next",
+                on_error="block",
+                on_pass="allow",
+            ),
+            PipelineStep(
+                guardrail="fallback-filter",
+                on_fail="block",
+                on_pass="allow",
+            ),
+        ],
+    )
+
+    original_callbacks = litellm.callbacks.copy()
+    litellm.callbacks = [primary_content, fallback]
+
+    try:
+        result = await PipelineExecutor.execute_steps(
+            steps=pipeline_content.steps,
+            mode=pipeline_content.mode,
+            data={"messages": [{"role": "user", "content": "bad"}]},
+            user_api_key_dict=MagicMock(),
+            call_type="completion",
+            policy_name="test",
+        )
+        assert result.terminal_action == "allow"
+        assert primary_content.calls == 1
+        assert fallback.calls == 1
+    finally:
+        litellm.callbacks = original_callbacks
+
+    # API outage: on_error block -> do not run fallback
+    fallback.calls = 0
+    original_callbacks = litellm.callbacks.copy()
+    litellm.callbacks = [primary_api, fallback]
+    try:
+        result = await PipelineExecutor.execute_steps(
+            steps=pipeline_content.steps,
+            mode=pipeline_content.mode,
+            data={"messages": [{"role": "user", "content": "ok"}]},
+            user_api_key_dict=MagicMock(),
+            call_type="completion",
+            policy_name="test",
+        )
+        assert result.terminal_action == "block"
+        assert primary_api.calls == 1
+        assert fallback.calls == 0
+        assert result.step_results[0].outcome == "error"
+        assert result.step_results[0].action_taken == "block"
     finally:
         litellm.callbacks = original_callbacks
 

--- a/tests/test_litellm/types/proxy/policy_engine/test_pipeline_types.py
+++ b/tests/test_litellm/types/proxy/policy_engine/test_pipeline_types.py
@@ -21,6 +21,7 @@ def test_pipeline_step_defaults():
     step = PipelineStep(guardrail="my-guard")
     assert step.on_fail == "block"
     assert step.on_pass == "allow"
+    assert step.on_error is None
     assert step.pass_data is False
     assert step.modify_response_message is None
 
@@ -33,9 +34,10 @@ def test_pipeline_step_valid_actions():
 
 def test_pipeline_step_all_action_types():
     for action in ("allow", "block", "next", "modify_response"):
-        step = PipelineStep(guardrail="g", on_fail=action, on_pass=action)
+        step = PipelineStep(guardrail="g", on_fail=action, on_pass=action, on_error=action)
         assert step.on_fail == action
         assert step.on_pass == action
+        assert step.on_error == action
 
 
 def test_pipeline_step_invalid_action_rejected():
@@ -46,6 +48,16 @@ def test_pipeline_step_invalid_action_rejected():
 def test_pipeline_step_invalid_on_pass_rejected():
     with pytest.raises(ValidationError):
         PipelineStep(guardrail="my-guard", on_pass="skip")
+
+
+def test_pipeline_step_on_error_valid():
+    step = PipelineStep(guardrail="g", on_error="next", on_fail="block", on_pass="allow")
+    assert step.on_error == "next"
+
+
+def test_pipeline_step_invalid_on_error_rejected():
+    with pytest.raises(ValidationError):
+        PipelineStep(guardrail="my-guard", on_error="invalid")
 
 
 def test_pipeline_requires_at_least_one_step():

--- a/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
+++ b/ui/litellm-dashboard/src/components/policies/pipeline_flow_builder.tsx
@@ -155,6 +155,14 @@ const FailIcon: React.FC = () => (
   </svg>
 );
 
+const ApiFailureIcon: React.FC = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#d97706" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Connector
 // ─────────────────────────────────────────────────────────────────────────────
@@ -337,6 +345,41 @@ const StepCard: React.FC<StepCardProps> = ({
           options={ACTION_OPTIONS}
         />
         {step.on_fail === "modify_response" && (
+          <div style={{ marginTop: 8 }}>
+            <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+              Custom Response Message
+            </label>
+            <TextInput
+              placeholder="Enter custom response..."
+              value={step.modify_response_message || ""}
+              onChange={(e) => onChange({ modify_response_message: e.target.value || null })}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* ON API FAILURE (technical / provider outage) — optional; defaults to ON FAIL */}
+      <div style={{ borderTop: "1px solid #f0f0f0", padding: "14px 20px" }}>
+        <div className="flex items-center gap-2" style={{ marginBottom: 8 }}>
+          <ApiFailureIcon />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "#374151" }}>ON API FAILURE</span>
+        </div>
+        <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
+          Action
+        </label>
+        <Select
+          style={{ width: "100%" }}
+          placeholder="Same as ON FAIL"
+          allowClear
+          value={step.on_error ?? undefined}
+          onChange={(value) =>
+            onChange({
+              on_error: value === undefined || value === null ? undefined : (value as PipelineStep["on_error"]),
+            })
+          }
+          options={ACTION_OPTIONS}
+        />
+        {step.on_error === "modify_response" && step.on_fail !== "modify_response" && (
           <div style={{ marginTop: 8 }}>
             <label style={{ fontSize: 12, fontWeight: 500, color: "#6b7280", display: "block", marginBottom: 6 }}>
               Custom Response Message
@@ -566,13 +609,19 @@ export const PipelineInfoDisplay: React.FC<PipelineInfoDisplayProps> = ({ pipeli
           {/* Divider */}
           <div style={{ borderTop: "1px solid #f3f4f6", marginBottom: 10 }} />
 
-          {/* Pass / Fail */}
-          <div className="flex items-center gap-6" style={{ fontSize: 13, color: "#374151" }}>
+          {/* Pass / Fail / API failure */}
+          <div className="flex flex-col gap-2" style={{ fontSize: 13, color: "#374151" }}>
             <span className="flex items-center gap-1.5">
               <PassIcon /> Pass &#8594; {ACTION_LABELS[step.on_pass] || step.on_pass}
             </span>
             <span className="flex items-center gap-1.5">
-              <FailIcon /> Fail &#8594; {ACTION_LABELS[step.on_fail] || step.on_fail}
+              <FailIcon /> On fail &#8594; {ACTION_LABELS[step.on_fail] || step.on_fail}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <ApiFailureIcon /> On API failure &#8594;{" "}
+              {step.on_error != null
+                ? ACTION_LABELS[step.on_error] || step.on_error
+                : `${ACTION_LABELS[step.on_fail] || step.on_fail} (same as on fail)`}
             </span>
           </div>
         </div>

--- a/ui/litellm-dashboard/src/components/policies/types.ts
+++ b/ui/litellm-dashboard/src/components/policies/types.ts
@@ -24,6 +24,8 @@ export interface PipelineStep {
   guardrail: string;
   on_fail: "block" | "allow" | "next" | "modify_response";
   on_pass: "allow" | "block" | "next" | "modify_response";
+  /** If unset, API/technical errors use on_fail (backward compatible). */
+  on_error?: "block" | "allow" | "next" | "modify_response" | null;
   pass_data?: boolean;
   modify_response_message?: string | null;
 }


### PR DESCRIPTION
## Relevant issues

Cause

Guardrail pipelines only exposed on_pass and on_fail. The executor already distinguishes policy intervention (fail, e.g. HTTP 400) from technical errors (error, e.g. timeouts, 503, missing callback), but both used on_fail. You could not configure “fallback to another guardrail only when the provider is down” without also affecting what happens on real content-policy failures.


<img width="1474" height="785" alt="Screenshot 2026-04-04 at 12 23 03 PM" src="https://github.com/user-attachments/assets/57e80940-f025-49c8-bc89-eb6028b60730" />
<img width="1487" height="779" alt="Screenshot 2026-04-04 at 12 25 19 PM" src="https://github.com/user-attachments/assets/e183a1d3-a02e-44e6-8ac0-d71249ae95ee" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🆕 New Feature
✅ Test

## Changes
Add optional on_error on PipelineStep (same action set as on_pass / on_fail). If omitted, error outcomes still follow on_fail (no behavior change for existing configs).
pipeline_executor: choose action via outcome — pass → on_pass, fail → on_fail, error → on_error if set, else on_fail.
Dashboard: policy flow builder + types — ON API FAILURE control (clearable; default = same as ON FAIL).
Tests: executor + Pydantic types cover fallback vs content-block paths.