### PR TITLE
fix(oci): sync streaming missing split_chunks causes JSONDecodeError

### DIFF
--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     AsyncIterator,
     Dict,
+    Iterator,
     List,
     Optional,
     Protocol,
@@ -188,6 +189,13 @@ def get_vendor_from_model(model: str) -> OCIVendors:
 
 # 5 minute timeout (models may need to load)
 STREAMING_TIMEOUT = 60 * 5
+
+
+def _split_sse_text(text: str) -> Iterator[str]:
+    """Split a possibly-batched SSE text block into individual event strings."""
+    for chunk in text.split("\n\n"):
+        if chunk:
+            yield chunk.strip()
 
 
 class OCIChatConfig(BaseConfig):
@@ -1110,8 +1118,12 @@ class OCIChatConfig(BaseConfig):
 
         completion_stream = response.iter_text()
 
+        def split_chunks(stream: Iterator[str]) -> Iterator[str]:
+            for item in stream:
+                yield from _split_sse_text(item)
+
         streaming_response = OCIStreamWrapper(
-            completion_stream=completion_stream,
+            completion_stream=split_chunks(completion_stream),
             model=model,
             custom_llm_provider=custom_llm_provider,
             logging_obj=logging_obj,
@@ -1155,12 +1167,10 @@ class OCIChatConfig(BaseConfig):
 
         completion_stream = response.aiter_text()
 
-        async def split_chunks(completion_stream: AsyncIterator[str]):
-            async for item in completion_stream:
-                for chunk in item.split("\n\n"):
-                    if not chunk:
-                        continue
-                    yield chunk.strip()
+        async def split_chunks(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+            async for item in stream:
+                for chunk in _split_sse_text(item):
+                    yield chunk
 
         streaming_response = OCIStreamWrapper(
             completion_stream=split_chunks(completion_stream),

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -11,7 +11,7 @@ import litellm
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 from litellm import ModelResponse
-from litellm.llms.oci.chat.transformation import OCIChatConfig, OCIRequestWrapper, version
+from litellm.llms.oci.chat.transformation import OCIChatConfig, OCIRequestWrapper, version, _split_sse_text
 
 TEST_MODEL_NAME = "xai.grok-4"
 TEST_MODEL = f"oci/{TEST_MODEL_NAME}"
@@ -741,3 +741,73 @@ class TestOCISignerSupport:
         )
 
         assert wrapper.path_url == "/api/v1/chat"
+
+
+class TestSplitSseText:
+    """Tests for the _split_sse_text helper used by both sync and async streaming."""
+
+    def test_single_event(self):
+        result = list(_split_sse_text("data: {\"id\": \"1\"}"))
+        assert result == ["data: {\"id\": \"1\"}"]
+
+    def test_multiple_events(self):
+        text = "data: {\"id\": \"1\"}\n\ndata: {\"id\": \"2\"}"
+        result = list(_split_sse_text(text))
+        assert result == ["data: {\"id\": \"1\"}", "data: {\"id\": \"2\"}"]
+
+    def test_empty_string(self):
+        assert list(_split_sse_text("")) == []
+
+    def test_only_separators(self):
+        assert list(_split_sse_text("\n\n\n\n")) == []
+
+    def test_strips_whitespace(self):
+        text = "  data: {\"id\": \"1\"}  \n\n  data: {\"id\": \"2\"}  "
+        result = list(_split_sse_text(text))
+        assert result == ["data: {\"id\": \"1\"}", "data: {\"id\": \"2\"}"]
+
+    def test_three_events(self):
+        text = "data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: {\"c\":3}"
+        result = list(_split_sse_text(text))
+        assert len(result) == 3
+
+
+class TestSyncStreamSplitChunks:
+    """Tests that the sync streaming path correctly splits batched SSE chunks."""
+
+    def test_sync_stream_wrapper_splits_batched_chunks(self):
+        """Verify get_sync_custom_stream_wrapper splits multi-event HTTP chunks."""
+        from unittest.mock import MagicMock, patch
+
+        config = OCIChatConfig()
+
+        # Simulate an HTTP response whose iter_text() yields a batched chunk
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.iter_text.return_value = iter([
+            "data: {\"id\":\"1\"}\n\ndata: {\"id\":\"2\"}",
+            "data: {\"id\":\"3\"}",
+        ])
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("litellm.llms.oci.chat.transformation.track_llm_api_timing", lambda: lambda f: f):
+            result = config.get_sync_custom_stream_wrapper(
+                model=TEST_MODEL_NAME,
+                custom_llm_provider="oci",
+                logging_obj=MagicMock(),
+                api_base="https://example.com/chat",
+                headers={},
+                data={"test": "data"},
+                messages=[],
+                client=mock_client,
+            )
+
+        # Consume the stream wrapper's completion_stream to verify splitting
+        chunks = list(result.completion_stream)
+        assert chunks == [
+            "data: {\"id\":\"1\"}",
+            "data: {\"id\":\"2\"}",
+            "data: {\"id\":\"3\"}",
+        ]

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -777,7 +777,7 @@ class TestSyncStreamSplitChunks:
 
     def test_sync_stream_wrapper_splits_batched_chunks(self):
         """Verify get_sync_custom_stream_wrapper splits multi-event HTTP chunks."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         config = OCIChatConfig()
 
@@ -792,17 +792,16 @@ class TestSyncStreamSplitChunks:
         mock_client = MagicMock()
         mock_client.post.return_value = mock_response
 
-        with patch("litellm.llms.oci.chat.transformation.track_llm_api_timing", lambda: lambda f: f):
-            result = config.get_sync_custom_stream_wrapper(
-                model=TEST_MODEL_NAME,
-                custom_llm_provider="oci",
-                logging_obj=MagicMock(),
-                api_base="https://example.com/chat",
-                headers={},
-                data={"test": "data"},
-                messages=[],
-                client=mock_client,
-            )
+        result = config.get_sync_custom_stream_wrapper(
+            model=TEST_MODEL_NAME,
+            custom_llm_provider="oci",
+            logging_obj=MagicMock(),
+            api_base="https://example.com/chat",
+            headers={},
+            data={"test": "data"},
+            messages=[],
+            client=mock_client,
+        )
 
         # Consume the stream wrapper's completion_stream to verify splitting
         chunks = list(result.completion_stream)


### PR DESCRIPTION
## Relevant issues

Fixes #24819

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Type

🐛 Bug Fix

## Changes

The **sync** streaming path in `OCIChatConfig.get_sync_custom_stream_wrapper` is missing the `split_chunks` logic that the **async** path already has. When the OCI endpoint batches multiple SSE events into a single HTTP chunk, `chunk_creator` receives a multi-line string and `json.loads()` fails with:

```
json.decoder.JSONDecodeError: Extra data: line 3 column 1 (char 123)
```

### Fix

- Extract a shared `_split_sse_text()` helper that splits batched SSE text on `"\n\n"` boundaries
- Add a sync `split_chunks` generator to `get_sync_custom_stream_wrapper` using the helper
- Refactor the existing async `split_chunks` in `get_async_custom_stream_wrapper` to use the same helper
- Add 7 unit tests covering the helper and the sync streaming path