### PR TITLE
[Infra] Bump Version to 1.83.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3219,15 +3219,15 @@ files = [
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.61"
+version = "0.4.62"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 optional = true
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-    {file = "litellm_proxy_extras-0.4.61-py3-none-any.whl", hash = "sha256:9bd1e57ef51972cacff52172ef5d70b0ff689f57f3d240877667301ab8f8590e"},
-    {file = "litellm_proxy_extras-0.4.61.tar.gz", hash = "sha256:dce8e39b1547abf90d912ddd0f2a876beadf789d700ef04c165362d78ad56aee"},
+    {file = "litellm_proxy_extras-0.4.62-py3-none-any.whl", hash = "sha256:cf91c1a83d94000b8997ee29d9e8d505d1ad80c26f111803bef5365174c97de0"},
+    {file = "litellm_proxy_extras-0.4.62.tar.gz", hash = "sha256:0d87db1cda9851717e5294f2fa2c7ae1f34d7476d99e24e6462702e11a2cdd88"},
 ]
 
 [[package]]
@@ -8009,4 +8009,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "8dad0e86d75e574f12c57c9f32614b7b4ea2181e931874046d43a398aef1e998"
+content-hash = "b238a24abf451e3a7ce954d2f565fb95172cedfb2f1b56d6ed985b67e23fed36"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "1.82.6"
+version = "1.83.0"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
@@ -61,7 +61,7 @@ boto3 = { version = "^1.40.76", optional = true }
 redisvl = {version = "^0.4.1", optional = true, markers = "python_version >= '3.9' and python_version < '3.14'"}
 mcp = {version = ">=1.25.0,<2.0.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "^0.3.22", optional = true, python = ">=3.10"}
-litellm-proxy-extras = {version = "^0.4.61", optional = true}
+litellm-proxy-extras = {version = "^0.4.62", optional = true}
 rich = {version = "^13.7.1", optional = true}
 litellm-enterprise = {version = "0.1.35", optional = true}
 diskcache = {version = "^5.6.1", optional = true}
@@ -184,7 +184,7 @@ requires = ["poetry-core", "wheel"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.82.6"
+version = "1.83.0"
 version_files = [
     "pyproject.toml:^version"
 ]


### PR DESCRIPTION
## Summary

- Bump litellm version from 1.82.6 to 1.83.0
- Bump litellm-proxy-extras dependency from ^0.4.61 to ^0.4.62

## Changes

Version bump only — no code changes.

## Type
🚄 Infrastructure