### PR TITLE
fix: MCP OAuth PKCE — persist credentials and preserve sessionStorage

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -213,53 +213,6 @@ model LiteLLM_DeletedTeamTable {
     @@index([created_at])
 }
 
-// Audit table for deleted teams - preserves spend and team information for historical tracking
-model LiteLLM_DeletedTeamTable {
-    id                      String   @id @default(uuid())
-    team_id                 String   // Original team_id
-    team_alias              String?
-    organization_id         String?
-    object_permission_id    String?
-    admins                  String[]
-    members                 String[]
-    members_with_roles      Json     @default("{}")
-    metadata                Json     @default("{}")
-    max_budget              Float?
-    soft_budget             Float?
-    spend                   Float    @default(0.0)
-    models                  String[]
-    max_parallel_requests   Int?
-    tpm_limit               BigInt?
-    rpm_limit               BigInt?
-    budget_duration         String?
-    budget_reset_at         DateTime?
-    blocked                 Boolean  @default(false)
-    model_spend             Json     @default("{}")
-    model_max_budget        Json     @default("{}")
-    router_settings  Json? @default("{}")
-    team_member_permissions String[] @default([])
-    access_group_ids String[] @default([])
-    policies                String[] @default([])
-    model_id                Int?     // id for LiteLLM_ModelTable -> stores team-level model aliases
-    allow_team_guardrail_config Boolean @default(false)
-
-    // Original timestamps from team creation/updates
-    created_at              DateTime? @map("created_at")
-    updated_at              DateTime? @map("updated_at")
-    
-    // Deletion metadata
-    deleted_at              DateTime  @default(now()) @map("deleted_at")
-    deleted_by              String?   @map("deleted_by") // User who deleted the team
-    deleted_by_api_key      String?   @map("deleted_by_api_key") // API key hash that performed the deletion
-    litellm_changed_by      String?   @map("litellm_changed_by") // From litellm-changed-by header if provided
-    
-    @@index([team_id])
-    @@index([deleted_at])
-    @@index([organization_id])
-    @@index([team_alias])
-    @@index([created_at])
-}
-
 // Track spend, rate limit, budget Users
 model LiteLLM_UserTable {
 		user_id    String @id

--- a/litellm/caching/llm_caching_handler.py
+++ b/litellm/caching/llm_caching_handler.py
@@ -8,25 +8,6 @@ from .in_memory_cache import InMemoryCache
 
 
 class LLMClientCache(InMemoryCache):
-    def _remove_key(self, key: str) -> None:
-        """Close async clients before evicting them to prevent connection pool leaks."""
-        value = self.cache_dict.get(key)
-        super()._remove_key(key)
-        if value is not None:
-            close_fn = getattr(value, "aclose", None) or getattr(
-                value, "close", None
-            )
-            if close_fn and asyncio.iscoroutinefunction(close_fn):
-                try:
-                    asyncio.get_running_loop().create_task(close_fn())
-                except RuntimeError:
-                    pass
-            elif close_fn and callable(close_fn):
-                try:
-                    close_fn()
-                except Exception:
-                    pass
-
     def update_cache_key_with_event_loop(self, key):
         """
         Add the event loop to the cache key, to prevent event loop closed errors.

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -86,6 +86,12 @@ def encrypt_credentials(
             value=client_secret,
             new_encryption_key=encryption_key,
         )
+    refresh_token = credentials.get("refresh_token")
+    if refresh_token is not None:
+        credentials["refresh_token"] = encrypt_value_helper(
+            value=refresh_token,
+            new_encryption_key=encryption_key,
+        )
     return credentials
 
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1,10 +1,12 @@
 import json
+import time
 from typing import Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from litellm._logging import verbose_logger
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -255,7 +257,94 @@ async def exchange_token_with_server(
     if "scope" in token_response and token_response["scope"]:
         result["scope"] = token_response["scope"]
 
+    # Persist OAuth credentials and discovery URLs to the database
+    await _persist_oauth_credentials(
+        mcp_server=mcp_server,
+        client_id=token_data["client_id"],
+        client_secret=token_data.get("client_secret"),
+        access_token=access_token,
+        refresh_token=token_response.get("refresh_token"),
+        expires_in=token_response.get("expires_in"),
+    )
+
     return JSONResponse(result)
+
+
+async def _persist_oauth_credentials(
+    mcp_server: MCPServer,
+    client_id: Optional[str],
+    client_secret: Optional[str],
+    access_token: str,
+    refresh_token: Optional[str],
+    expires_in: Optional[int],
+) -> None:
+    """
+    Persist OAuth credentials and discovery URLs to the MCP server record
+    in the database after a successful token exchange.
+    """
+    try:
+        from litellm.proxy.proxy_server import prisma_client
+
+        if prisma_client is None:
+            verbose_logger.warning(
+                "Cannot persist OAuth credentials: no database connected"
+            )
+            return
+
+        from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
+        from litellm.proxy._experimental.mcp_server.db import encrypt_credentials
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import _get_salt_key
+
+        # Build credentials dict with OAuth tokens and client registration
+        credentials = {}
+        if client_id:
+            credentials["client_id"] = client_id
+        if client_secret:
+            credentials["client_secret"] = client_secret
+        credentials["auth_value"] = access_token
+        if refresh_token:
+            credentials["refresh_token"] = refresh_token
+        if expires_in is not None:
+            credentials["expires_at"] = int(time.time()) + expires_in
+        credentials["type"] = "oauth2"
+
+        encrypted_credentials = encrypt_credentials(
+            credentials=credentials,
+            encryption_key=_get_salt_key(),
+        )
+
+        # Build the update data — persist credentials and discovery URLs
+        update_data: dict = {
+            "auth_type": "oauth2",
+            "credentials": safe_dumps(encrypted_credentials),
+            "updated_by": "oauth_token_exchange",
+        }
+
+        # Persist discovery URLs if they were found during the flow
+        if mcp_server.token_url:
+            update_data["token_url"] = mcp_server.token_url
+        if mcp_server.authorization_url:
+            update_data["authorization_url"] = mcp_server.authorization_url
+        if mcp_server.registration_url:
+            update_data["registration_url"] = mcp_server.registration_url
+
+        await prisma_client.db.litellm_mcpservertable.update(
+            where={"server_id": mcp_server.server_id},
+            data=update_data,
+        )
+
+        verbose_logger.info(
+            "Persisted OAuth credentials for MCP server %s (%s)",
+            mcp_server.name,
+            mcp_server.server_id,
+        )
+    except Exception as e:
+        verbose_logger.error(
+            "Failed to persist OAuth credentials for MCP server %s: %s",
+            mcp_server.server_id,
+            e,
+        )
 
 
 async def register_client_with_server(

--- a/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/daily_spend_update_queue.py
@@ -86,6 +86,11 @@ class DailySpendUpdateQueue(BaseUpdateQueue):
     ) -> Dict[str, BaseDailySpendTransaction]:
         """Get all updates from the queue and return all updates aggregated by daily_transaction_key. Works for both user and team spend updates."""
         updates = await self.flush_all_updates_from_in_memory_queue()
+        if len(updates) > 0:
+            verbose_proxy_logger.info(
+                "Spend tracking - flushed %d daily spend update items from in-memory queue",
+                len(updates),
+            )
         aggregated_daily_spend_update_transactions = (
             DailySpendUpdateQueue.get_aggregated_daily_spend_update_transactions(
                 updates

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -80,6 +80,14 @@ class PodLockManager:
                         )
                         self._emit_acquired_lock_event(cronjob_id, self.pod_id)
                         return True
+                    else:
+                        verbose_proxy_logger.info(
+                            "Spend tracking - pod %s could not acquire lock for cronjob_id=%s, "
+                            "held by pod %s. Spend updates in Redis will wait for the leader pod to commit.",
+                            self.pod_id,
+                            cronjob_id,
+                            current_value,
+                        )
             return False
         except Exception as e:
             verbose_proxy_logger.error(
@@ -124,10 +132,12 @@ class PodLockManager:
                             pod_id=self.pod_id,
                         )
                     else:
-                        verbose_proxy_logger.debug(
-                            "Pod %s failed to release Redis lock for cronjob_id=%s",
+                        verbose_proxy_logger.warning(
+                            "Spend tracking - pod %s failed to release Redis lock for cronjob_id=%s. "
+                            "Lock will expire after TTL=%ds.",
                             self.pod_id,
                             cronjob_id,
+                            DEFAULT_CRON_JOB_LOCK_TTL_SECONDS,
                         )
                 else:
                     verbose_proxy_logger.debug(

--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -31,6 +31,11 @@ class SpendUpdateQueue(BaseUpdateQueue):
     ) -> DBSpendUpdateTransactions:
         """Flush all updates from the queue and return all updates aggregated by entity type."""
         updates = await self.flush_all_updates_from_in_memory_queue()
+        if len(updates) > 0:
+            verbose_proxy_logger.info(
+                "Spend tracking - flushed %d spend update items from in-memory queue",
+                len(updates),
+            )
         verbose_proxy_logger.debug("Aggregating updates by entity type: %s", updates)
         return self.get_aggregated_db_spend_update_transactions(updates)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1758,8 +1758,14 @@ async def update_cache(  # noqa: PLR0915
                     ("{}:spend".format(litellm_proxy_admin_name), increment)
                 )
         except Exception as e:
-            verbose_proxy_logger.debug(
-                f"An error occurred updating user cache: {str(e)}\n\n{traceback.format_exc()}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update user spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "user_id=%s, response_cost=%s - %s\n%s",
+                user_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
 
     ### UPDATE END-USER SPEND ###
@@ -1796,8 +1802,14 @@ async def update_cache(  # noqa: PLR0915
                 existing_spend_obj.spend = new_spend
                 values_to_update_in_cache.append((_id, existing_spend_obj.json()))
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"An error occurred updating end user cache: {str(e)}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update end user spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "end_user_id=%s, response_cost=%s - %s\n%s",
+                end_user_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
 
     ### UPDATE TEAM SPEND ###
@@ -1838,8 +1850,14 @@ async def update_cache(  # noqa: PLR0915
                 existing_spend_obj.spend = new_spend
                 values_to_update_in_cache.append((_id, existing_spend_obj))
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"An error occurred updating end user cache: {str(e)}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update team spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "team_id=%s, response_cost=%s - %s\n%s",
+                team_id,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
 
     ### UPDATE TAG SPEND ###
@@ -1884,8 +1902,14 @@ async def update_cache(  # noqa: PLR0915
                     existing_tag_obj.spend = new_spend
                     values_to_update_in_cache.append((cache_key, existing_tag_obj))
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"An error occurred updating tag cache: {str(e)}"
+            verbose_proxy_logger.warning(
+                "Spend tracking - failed to update tag spend in cache. "
+                "Budget enforcement may use stale spend values. "
+                "tags=%s, response_cost=%s - %s\n%s",
+                tags,
+                response_cost,
+                str(e),
+                traceback.format_exc(),
             )
 
     if token is not None and response_cost is not None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4226,9 +4226,17 @@ class ProxyUpdateSpend:
                             f"{len(logs_to_process)} logs processed. Remaining in queue: {remaining_count}"
                         )
                     break
-                except DB_CONNECTION_ERROR_TYPES:
+                except DB_CONNECTION_ERROR_TYPES as e:
                     if i is None:
                         i = 0
+                    verbose_proxy_logger.warning(
+                        "Spend tracking - DB connection error writing spend logs, "
+                        "retry %d/%d. logs_count=%d, error=%s",
+                        i + 1,
+                        n_retry_times,
+                        len(logs_to_process),
+                        str(e),
+                    )
                     if i >= n_retry_times:
                         raise
                     await asyncio.sleep(2**i)
@@ -4324,6 +4332,23 @@ async def update_spend_logs_job(
         db_writer_client=db_writer_client,
     )
 
+<<<<<<< HEAD
+=======
+    # Guardrail/policy usage tracking (same batch, outside spend-logs update)
+    try:
+        from litellm.proxy.guardrails.usage_tracking import \
+            process_spend_logs_guardrail_usage
+        await process_spend_logs_guardrail_usage(
+            prisma_client=prisma_client,
+            logs_to_process=logs_to_process,
+        )
+    except Exception as guardrail_tracking_err:
+        verbose_proxy_logger.warning(
+            "Spend tracking - guardrail usage tracking failed (non-fatal): %s",
+            guardrail_tracking_err,
+        )
+
+>>>>>>> 80ebe722d9 (Merge pull request #22029 from BerriAI/litellm_spend_tracking_logging)
 
 async def _monitor_spend_logs_queue(
     prisma_client: PrismaClient,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4332,23 +4332,6 @@ async def update_spend_logs_job(
         db_writer_client=db_writer_client,
     )
 
-<<<<<<< HEAD
-=======
-    # Guardrail/policy usage tracking (same batch, outside spend-logs update)
-    try:
-        from litellm.proxy.guardrails.usage_tracking import \
-            process_spend_logs_guardrail_usage
-        await process_spend_logs_guardrail_usage(
-            prisma_client=prisma_client,
-            logs_to_process=logs_to_process,
-        )
-    except Exception as guardrail_tracking_err:
-        verbose_proxy_logger.warning(
-            "Spend tracking - guardrail usage tracking failed (non-fatal): %s",
-            guardrail_tracking_err,
-        )
-
->>>>>>> 80ebe722d9 (Merge pull request #22029 from BerriAI/litellm_spend_tracking_logging)
 
 async def _monitor_spend_logs_queue(
     prisma_client: PrismaClient,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1582,11 +1582,17 @@ async def test_token_exchange_persists_credentials_to_db():
     assert update_data["registration_url"] == "https://auth.example.com/register"
     assert update_data["updated_by"] == "oauth_token_exchange"
 
-    # Verify credentials are stored (encrypted, so check it's a non-empty JSON string)
+    # Verify credentials are stored and sensitive fields are encrypted
     credentials_json = json.loads(update_data["credentials"])
     assert "auth_value" in credentials_json
     assert "client_id" in credentials_json
+    assert "refresh_token" in credentials_json
     assert "type" in credentials_json
+
+    # Verify sensitive fields are NOT stored as plaintext (they should be encrypted)
+    assert credentials_json["auth_value"] != "test_access_token_123"
+    assert credentials_json["client_id"] != "test-client-id"
+    assert credentials_json["refresh_token"] != "test_refresh_token_456"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1487,3 +1487,183 @@ async def test_discovery_root_includes_server_name_prefix():
         assert response["scopes_supported"] == ["read", "write"]
     finally:
         global_mcp_server_manager.registry.clear()
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_persists_credentials_to_db():
+    """Test that token exchange persists OAuth credentials and discovery URLs to the database."""
+    try:
+        import json
+
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            exchange_token_with_server,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    # Create mock OAuth2 server with discovery URLs
+    oauth2_server = MCPServer(
+        server_id="test-persist-server",
+        name="test_persist",
+        server_name="test_persist",
+        alias="test_persist",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        token_url="https://auth.example.com/token",
+        authorization_url="https://auth.example.com/authorize",
+        registration_url="https://auth.example.com/register",
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm-proxy.example.com/"
+    mock_request.headers = {}
+
+    # Mock the token endpoint response
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "access_token": "test_access_token_123",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "refresh_token": "test_refresh_token_456",
+        "scope": "tools",
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    # Mock prisma client
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_mcpservertable.update = AsyncMock(return_value=None)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
+    ) as mock_get_client, patch(
+        "litellm.proxy.proxy_server.prisma_client",
+        mock_prisma,
+    ), patch(
+        "litellm.proxy.common_utils.encrypt_decrypt_utils._get_salt_key",
+        return_value="test-salt-key",
+    ):
+        mock_async_client = MagicMock()
+        mock_async_client.post = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_async_client
+
+        response = await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=oauth2_server,
+            grant_type="authorization_code",
+            code="test_auth_code",
+            redirect_uri="https://litellm-proxy.example.com/callback",
+            client_id="test-client-id",
+            client_secret=None,
+            code_verifier="test_verifier",
+        )
+
+    # Verify token response is correct
+    response_data = json.loads(response.body)
+    assert response_data["access_token"] == "test_access_token_123"
+    assert response_data["refresh_token"] == "test_refresh_token_456"
+
+    # Verify DB update was called
+    mock_prisma.db.litellm_mcpservertable.update.assert_called_once()
+    update_call = mock_prisma.db.litellm_mcpservertable.update.call_args
+
+    # Verify the where clause targets our server
+    assert update_call[1]["where"]["server_id"] == "test-persist-server"
+
+    # Verify the update data
+    update_data = update_call[1]["data"]
+    assert update_data["auth_type"] == "oauth2"
+    assert update_data["token_url"] == "https://auth.example.com/token"
+    assert update_data["authorization_url"] == "https://auth.example.com/authorize"
+    assert update_data["registration_url"] == "https://auth.example.com/register"
+    assert update_data["updated_by"] == "oauth_token_exchange"
+
+    # Verify credentials are stored (encrypted, so check it's a non-empty JSON string)
+    credentials_json = json.loads(update_data["credentials"])
+    assert "auth_value" in credentials_json
+    assert "client_id" in credentials_json
+    assert "type" in credentials_json
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_persists_without_optional_fields():
+    """Test that token exchange persists correctly when refresh_token and expires_in are absent."""
+    try:
+        import json
+
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            exchange_token_with_server,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    oauth2_server = MCPServer(
+        server_id="test-persist-minimal",
+        name="test_minimal",
+        server_name="test_minimal",
+        alias="test_minimal",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        token_url="https://auth.example.com/token",
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.example.com/"
+    mock_request.headers = {}
+
+    # Response without refresh_token or expires_in
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "access_token": "minimal_token",
+        "token_type": "Bearer",
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_mcpservertable.update = AsyncMock(return_value=None)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client"
+    ) as mock_get_client, patch(
+        "litellm.proxy.proxy_server.prisma_client",
+        mock_prisma,
+    ), patch(
+        "litellm.proxy.common_utils.encrypt_decrypt_utils._get_salt_key",
+        return_value="test-salt-key",
+    ):
+        mock_async_client = MagicMock()
+        mock_async_client.post = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_async_client
+
+        response = await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=oauth2_server,
+            grant_type="authorization_code",
+            code="test_code",
+            redirect_uri="https://proxy.example.com/callback",
+            client_id="test-client",
+            client_secret=None,
+            code_verifier=None,
+        )
+
+    response_data = json.loads(response.body)
+    assert response_data["access_token"] == "minimal_token"
+    assert "refresh_token" not in response_data
+
+    # Verify DB was still updated
+    mock_prisma.db.litellm_mcpservertable.update.assert_called_once()
+    update_data = mock_prisma.db.litellm_mcpservertable.update.call_args[1]["data"]
+    assert update_data["auth_type"] == "oauth2"
+    assert update_data["token_url"] == "https://auth.example.com/token"
+    # authorization_url and registration_url should not be in update if not set on server
+    assert "authorization_url" not in update_data
+    assert "registration_url" not in update_data

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -96,10 +96,26 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
   // check if window is not undefined
   if (typeof window !== "undefined") {
     window.addEventListener("beforeunload", function () {
-      // Clear session storage
+      // Preserve MCP OAuth flow state across page unloads (OAuth redirects)
+      const mcpKeysToPreserve = [
+        "litellm-mcp-oauth-flow-state",
+        "litellm-mcp-oauth-return-url",
+        "litellm-mcp-oauth-result",
+        "litellm-user-mcp-oauth-flow-state",
+        "litellm-user-mcp-oauth-return-url",
+        "litellm-user-mcp-oauth-result",
+      ];
+      const saved: Record<string, string> = {};
+      mcpKeysToPreserve.forEach(function(key) {
+        const val = sessionStorage.getItem(key);
+        if (val) saved[key] = val;
+      });
+
       sessionStorage.clear();
-      // Note: MCP auth tokens are persistent and should not be cleared on page refresh
-      // They are only cleared on logout
+
+      Object.entries(saved).forEach(function([key, val]) {
+        sessionStorage.setItem(key, val);
+      });
     });
   }
 


### PR DESCRIPTION
## Relevant issues

Fixes #19821 — Cannot Add OAuth2.1 MCP - Missing OAuth session state
Fixes #20493 — MCP OAuth token not saved to credentials after successful OAuth flow

## Summary

Two bugs prevent the MCP OAuth PKCE (3-legged) flow from completing end-to-end:

**Bug 1 — sessionStorage loss (#19821):** The `beforeunload` handler in `user_dashboard.tsx` calls `sessionStorage.clear()`, which wipes the OAuth flow state (code_verifier, state, serverId) when the browser redirects to the OAuth provider. On return, `resumeOAuthFlow()` finds no flow state and errors with "Missing OAuth session state".

**Fix:** Preserve MCP OAuth sessionStorage keys across the clear by saving and restoring them.

**Bug 2 — Token not persisted (#20493):** `exchange_token_with_server()` exchanges the auth code for an access token but never saves it to the database. The token lives only in React state and is lost on page refresh or pod restart. OAuth discovery URLs (token_url, authorization_url, registration_url) and DCR client_id are also not persisted.

**Fix:** Add `_persist_oauth_credentials()` that encrypts and saves credentials + discovery URLs to the MCP server DB record after successful token exchange.

## Important note

**This PR is based on `v1.81.14-stable` to verify the direction and validity of the fix.** The `exchange_token_with_server` function has been refactored on `main` (added refresh_token grant type support). If this approach is accepted, I will rebase and reimplement against `main`.

## Testing

- 2 new unit tests added to `test_discoverable_endpoints.py`
- `test_token_exchange_persists_credentials_to_db` — verifies credentials, token_url, authorization_url, registration_url are persisted after token exchange
- `test_token_exchange_persists_without_optional_fields` — verifies correct behavior when refresh_token and expires_in are absent
- All 37 existing tests in the file continue to pass
- Manually verified end-to-end against a live Postern MCP server

## Pre-Submission checklist

- [x] I have Added testing — 2 new tests for token persistence
- [ ] My PR passes all unit tests on `make test-unit` — tested locally, CI pending
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py` — Added `_persist_oauth_credentials()`, called after successful token exchange
- `ui/litellm-dashboard/src/components/user_dashboard.tsx` — Preserve MCP OAuth keys in `beforeunload` handler
- `tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py` — 2 new tests