### PR TITLE
chore: pin Docker base images to SHA256 digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.11-alpine
+ARG LITELLM_BUILD_IMAGE=python:3.11-alpine@sha256:f07e2ace46f560f09a6eeec7b4913b80ee99546e749ef82342a419a326620856
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.11-alpine
+ARG LITELLM_RUNTIME_IMAGE=python:3.11-alpine@sha256:f07e2ace46f560f09a6eeec7b4913b80ee99546e749ef82342a419a326620856
 
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.11-slim
+ARG LITELLM_BUILD_IMAGE=python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.11-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder

--- a/docker/Dockerfile.health_check
+++ b/docker/Dockerfile.health_check
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634
 
 WORKDIR /app
 

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -1,6 +1,6 @@
 # Base images
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a5a619c1793039dcf92f02178f37c94bb3d6001403716da59d6092dfe8d9b502
 ARG PROXY_EXTRAS_SOURCE=published
 
 # -----------------

--- a/docker/build_from_pip/Dockerfile.build_from_pip
+++ b/docker/build_from_pip/Dockerfile.build_from_pip
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3.13-alpine@sha256:bb1f2fdb1065c85468775c9d680dcd344f6442a2d1181ef7916b60a623f11d40
 
 WORKDIR /app
 

--- a/litellm-js/spend-logs/Dockerfile
+++ b/litellm-js/spend-logs/Dockerfile
@@ -1,5 +1,5 @@
 # Use the specific Node.js v20.11.0 image
-FROM node:20.18.1-alpine3.20
+FROM node:20.18.1-alpine3.20@sha256:9b5af1cc895fe7231c351cc1ea653322742091fb5d1ea8f1eb404c11e2b4da56
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
## Summary

Pin all production Dockerfile base images to content-addressable SHA256 digests instead of mutable tags.

## Why

Mutable tags (e.g. `python:3.11-slim`, `cgr.dev/chainguard/wolfi-base`) can be silently republished with different content. If a registry account is compromised, an attacker can push a malicious image under the same tag and all downstream builds silently pull it. Digest pinning guarantees the exact image bytes used at build time.

This is the same class of attack as the [axios npm supply chain compromise](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan) — a compromised maintainer publishing to a mutable reference.

## Changes

| Image | Digest |
|---|---|
| `cgr.dev/chainguard/wolfi-base` | `sha256:a5a619c1...` |
| `python:3.11-slim` | `sha256:93584440...` |
| `python:3.11-alpine` | `sha256:f07e2ace...` |
| `python:3.13-alpine` | `sha256:bb1f2fdb...` |
| `node:20.18.1-alpine3.20` | `sha256:9b5af1cc...` |

### Files changed (8)
- `Dockerfile` (main production)
- `docker/Dockerfile.non_root` (hardened production)
- `docker/Dockerfile.database` (database-enabled)
- `docker/Dockerfile.dev` (development)
- `docker/Dockerfile.alpine` (alpine variant)
- `docker/Dockerfile.health_check` (health check sidecar)
- `docker/build_from_pip/Dockerfile.build_from_pip` (pip-based install)
- `litellm-js/spend-logs/Dockerfile` (JS spend logs service)

### Intentionally skipped
- `deploy/Dockerfile.ghcr_base` — references `ghcr.io/berriai/litellm:main-latest` (changes every build)
- `docker/Dockerfile.custom_ui` — references `ghcr.io/berriai/litellm:litellm_fwd_server_root_path-dev`
- `cookbook/litellm-ollama-docker-image/Dockerfile` — example code
- `docs/my-website/Dockerfile` — uses alpha Python 3.14.0a3, needs a separate fix

## Test plan

- [ ] Docker builds succeed with pinned digests
- Digests should be periodically updated via Renovate/Dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)