### PR TITLE
fix(bedrock): promote cache usage to message_delta for Claude Code

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
@@ -208,13 +208,29 @@ class FakeAnthropicMessagesStreamIterator:
                     )
 
         # 5. message_delta event (with final usage and stop_reason)
+        # Include cache usage fields so clients that only read message_delta
+        # (like Claude Code's SDK) see the full input token breakdown.
+        delta_usage: Dict[str, Any] = {
+            "output_tokens": usage.get("output_tokens", 0) if usage else 0,
+        }
+        if usage:
+            if usage.get("input_tokens") is not None:
+                delta_usage["input_tokens"] = usage["input_tokens"]
+            if usage.get("cache_creation_input_tokens") is not None:
+                delta_usage["cache_creation_input_tokens"] = usage[
+                    "cache_creation_input_tokens"
+                ]
+            if usage.get("cache_read_input_tokens") is not None:
+                delta_usage["cache_read_input_tokens"] = usage[
+                    "cache_read_input_tokens"
+                ]
         message_delta = {
             "type": "message_delta",
             "delta": {
                 "stop_reason": response_dict.get("stop_reason"),
                 "stop_sequence": response_dict.get("stop_sequence"),
             },
-            "usage": {"output_tokens": usage.get("output_tokens", 0) if usage else 0},
+            "usage": delta_usage,
         }
         chunks.append(
             f"event: message_delta\ndata: {json.dumps(message_delta)}\n\n".encode()

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -498,6 +498,12 @@ class AmazonAnthropicClaudeMessagesConfig(
     ):
         """
         Bedrock invoke does not return SSE formatted data. This function is a wrapper to ensure litellm chunks are SSE formatted.
+
+        Bedrock's Anthropic-compatible streaming puts cache usage fields
+        (cache_creation_input_tokens, cache_read_input_tokens) only on
+        message_stop, not on message_start or message_delta. Claude Code's
+        SDK only merges usage from message_delta, so we promote those fields
+        from message_stop onto message_delta before yielding.
         """
         from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
             BaseAnthropicMessagesStreamingIterator,
@@ -508,8 +514,80 @@ class AmazonAnthropicClaudeMessagesConfig(
             request_body=request_body,
         )
 
-        async for chunk in handler.async_sse_wrapper(completion_stream):
+        patched_stream = self._promote_message_stop_usage(completion_stream)
+
+        async for chunk in handler.async_sse_wrapper(patched_stream):
             yield chunk
+
+    @staticmethod
+    async def _promote_message_stop_usage(
+        completion_stream: AsyncIterator[
+            Union[bytes, GenericStreamingChunk, ModelResponseStream, dict]
+        ],
+    ) -> AsyncIterator[Union[bytes, GenericStreamingChunk, ModelResponseStream, dict]]:
+        """
+        Promote cache usage fields from message_stop onto message_delta.
+
+        Bedrock reports input_tokens (uncached only) on message_start, and
+        the full breakdown (input_tokens, cache_creation_input_tokens,
+        cache_read_input_tokens) only on message_stop. Claude Code's SDK
+        merges usage from message_start and message_delta but ignores
+        message_stop. This method buffers message_delta and, when
+        message_stop arrives with cache usage, merges those fields into the
+        message_delta usage and also updates the input_tokens on
+        message_delta to include the full count (uncached + cache_creation +
+        cache_read).
+        """
+        _CACHE_FIELDS = ("cache_creation_input_tokens", "cache_read_input_tokens")
+        pending_delta = None
+
+        async for chunk in completion_stream:
+            if not isinstance(chunk, dict):
+                if pending_delta is not None:
+                    yield pending_delta
+                    pending_delta = None
+                yield chunk
+                continue
+
+            chunk_type = chunk.get("type")
+
+            if chunk_type == "message_delta":
+                pending_delta = chunk
+                continue
+
+            if chunk_type == "message_stop" and pending_delta is not None:
+                stop_usage = dict(chunk.get("usage") or {})
+                delta_usage = dict(pending_delta.get("usage") or {})
+
+                for field in _CACHE_FIELDS:
+                    if field in stop_usage:
+                        delta_usage[field] = stop_usage[field]
+
+                raw_input = stop_usage.get("input_tokens")
+                if raw_input is not None:
+                    uncached = raw_input if isinstance(raw_input, int) else 0
+                    raw_cc = delta_usage.get("cache_creation_input_tokens", 0)
+                    cache_creation = raw_cc if isinstance(raw_cc, int) else 0
+                    raw_cr = delta_usage.get("cache_read_input_tokens", 0)
+                    cache_read = raw_cr if isinstance(raw_cr, int) else 0
+                    delta_usage["input_tokens"] = uncached + cache_creation + cache_read
+
+                if delta_usage:
+                    pending_delta["usage"] = delta_usage  # type: ignore[assignment]
+
+                yield pending_delta
+                pending_delta = None
+                yield chunk
+                continue
+
+            if pending_delta is not None:
+                yield pending_delta
+                pending_delta = None
+
+            yield chunk
+
+        if pending_delta is not None:
+            yield pending_delta
 
 
 class AmazonAnthropicClaudeMessagesStreamDecoder(AWSEventStreamDecoder):

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -34,7 +34,9 @@ async def test_bedrock_sse_wrapper_encodes_dict_chunks():
         _dummy_stream(),
         litellm_logging_obj=LiteLLMLoggingObj(
             model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
-            messages=[{"role": "user", "content": "Hello, can you tell me a short joke?"}],
+            messages=[
+                {"role": "user", "content": "Hello, can you tell me a short joke?"}
+            ],
             stream=True,
             call_type="chat",
             start_time=datetime.now(),
@@ -56,6 +58,74 @@ async def test_bedrock_sse_wrapper_encodes_dict_chunks():
 
     # Second chunk should be forwarded unchanged
     assert collected[1] == b"raw-bytes"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_sse_wrapper_keeps_usage_in_message_start_and_message_delta():
+    """Regression test: usage should be available on both message_start and message_delta SSE events."""
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    async def _dummy_stream():  # type: ignore[return-type]
+        yield {
+            "type": "message_start",
+            "message": {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 1,
+                },
+            },
+        }
+        yield {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 8,
+            },
+        }
+        yield {
+            "type": "message_stop",
+            "usage": {
+                "input_tokens": 3,
+                "cache_creation_input_tokens": 1562,
+                "cache_read_input_tokens": 32392,
+            },
+        }
+
+    collected: list[bytes] = []
+    async for chunk in cfg.bedrock_sse_wrapper(
+        _dummy_stream(),
+        litellm_logging_obj=LiteLLMLoggingObj(
+            model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+            call_type="chat",
+            start_time=datetime.now(),
+            litellm_call_id="test_bedrock_sse_wrapper_keeps_usage_in_both_events",
+            function_id="test_bedrock_sse_wrapper_keeps_usage_in_both_events",
+        ),
+        request_body={},
+    ):
+        collected.append(chunk)
+
+    start_chunk = next(c for c in collected if b"event: message_start\n" in c)
+    delta_chunk = next(c for c in collected if b"event: message_delta\n" in c)
+
+    start_json = json.loads(start_chunk.decode("utf-8").split("data: ", 1)[1].strip())
+    delta_json = json.loads(delta_chunk.decode("utf-8").split("data: ", 1)[1].strip())
+
+    assert "usage" in start_json["message"]
+    assert start_json["message"]["usage"]["input_tokens"] == 3
+
+    assert "usage" in delta_json
+    assert delta_json["usage"]["cache_creation_input_tokens"] == 1562
+    assert delta_json["usage"]["cache_read_input_tokens"] == 32392
+    assert delta_json["usage"]["input_tokens"] == 3 + 1562 + 32392
 
 
 def test_chunk_parser_usage_transformation():
@@ -96,12 +166,9 @@ def test_remove_ttl_from_cache_control():
                     {
                         "type": "text",
                         "text": "Hello",
-                        "cache_control": {
-                            "type": "ephemeral",
-                            "ttl": "1h"
-                        }
+                        "cache_control": {"type": "ephemeral", "ttl": "1h"},
                     }
-                ]
+                ],
             }
         ]
     }
@@ -122,20 +189,14 @@ def test_remove_ttl_from_cache_control():
                     {
                         "type": "text",
                         "text": "Hello",
-                        "cache_control": {
-                            "type": "ephemeral",
-                            "ttl": "1h"
-                        }
+                        "cache_control": {"type": "ephemeral", "ttl": "1h"},
                     },
                     {
                         "type": "text",
                         "text": "World",
-                        "cache_control": {
-                            "type": "ephemeral",
-                            "ttl": "2h"
-                        }
-                    }
-                ]
+                        "cache_control": {"type": "ephemeral", "ttl": "2h"},
+                    },
+                ],
             }
         ]
     }
@@ -156,11 +217,9 @@ def test_remove_ttl_from_cache_control():
                     {
                         "type": "text",
                         "text": "Hello",
-                        "cache_control": {
-                            "type": "ephemeral"
-                        }
+                        "cache_control": {"type": "ephemeral"},
                     }
-                ]
+                ],
             }
         ]
     }
@@ -231,6 +290,7 @@ def test_remove_custom_field_from_tools():
     request4 = {"tools": None}
     remove_custom_field_from_tools(request4)
     assert request4["tools"] is None
+
 
 def test_remove_scope_from_cache_control():
     """Ensure scope field is removed from cache_control for Bedrock (not supported)."""
@@ -303,9 +363,9 @@ def test_bedrock_messages_strips_output_config():
         headers={},
     )
 
-    assert "output_config" not in result, (
-        "output_config should be stripped — Bedrock Invoke rejects it"
-    )
+    assert (
+        "output_config" not in result
+    ), "output_config should be stripped — Bedrock Invoke rejects it"
     # Other params should be preserved
     assert result.get("max_tokens") == 4096
 


### PR DESCRIPTION
## Summary
- promote Bedrock `message_stop` cache usage fields onto `message_delta` before SSE emission so Claude Code can read them
- recompute `message_delta.usage.input_tokens` as `uncached + cache_creation + cache_read` for accurate total context usage
- include cache/input usage fields in fake-stream `message_delta` and add a regression test that verifies usage is present in both `message_start` and `message_delta`


**Before**
<img width="701" height="341" alt="Screenshot 2026-03-31 at 12 57 24 PM" src="https://github.com/user-attachments/assets/3ff2c120-118a-4ef1-9758-6b1a9e2ffb7a" />


**After**
<img width="775" height="531" alt="image" src="https://github.com/user-attachments/assets/f2f47502-f401-4255-9dc3-ec77d79b9ee1" />
