### PR TITLE
feat: add environment and user tracking to prompt management

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260331000000_add_prompt_environment_and_created_by/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260331000000_add_prompt_environment_and_created_by/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_PromptTable" ADD COLUMN "environment" TEXT NOT NULL DEFAULT 'development';
+ALTER TABLE "LiteLLM_PromptTable" ADD COLUMN "created_by" TEXT;
+
+-- DropIndex (old unique constraint)
+DROP INDEX IF EXISTS "LiteLLM_PromptTable_prompt_id_version_key";
+
+-- CreateIndex (new unique constraint)
+CREATE UNIQUE INDEX "LiteLLM_PromptTable_prompt_id_version_environment_key" ON "LiteLLM_PromptTable"("prompt_id", "version", "environment");
+
+-- CreateIndex (new composite index)
+CREATE INDEX "LiteLLM_PromptTable_prompt_id_environment_idx" ON "LiteLLM_PromptTable"("prompt_id", "environment");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -1002,12 +1002,15 @@ model LiteLLM_PromptTable {
   id String @id @default(uuid())
   prompt_id String
   version Int @default(1)
+  environment String @default("development")
+  created_by String?
   litellm_params Json
   prompt_info Json?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
-  @@unique([prompt_id, version])
+  @@unique([prompt_id, version, environment])
+  @@index([prompt_id, environment])
   @@index([prompt_id])
 }
 

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -464,6 +464,7 @@ async def get_prompt_versions(
             prompt
             for prompt in all_prompts
             if get_base_prompt_id(prompt_id=prompt.prompt_id) == base_prompt_id
+            and (environment is None or prompt.environment == environment)
         ]
         for prompt in prompt_versions:
             version_number = get_version_number(prompt_id=prompt.prompt_id)

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -192,19 +192,22 @@ def get_latest_prompt_versions(prompts: List[PromptSpec]) -> List[PromptSpec]:
     return list(latest_prompts.values())
 
 
-async def get_next_version_for_prompt(prisma_client, prompt_id: str) -> int:
+async def get_next_version_for_prompt(
+    prisma_client, prompt_id: str, environment: str = "development"
+) -> int:
     """
-    Get the next version number for a prompt.
+    Get the next version number for a prompt in a specific environment.
 
     Args:
         prisma_client: Prisma database client
         prompt_id: Base prompt ID
+        environment: The environment to check versions for
 
     Returns:
         Next version number (1 if no versions exist, max_version + 1 otherwise)
     """
     existing_prompts = await prisma_client.db.litellm_prompttable.find_many(
-        where={"prompt_id": prompt_id}
+        where={"prompt_id": prompt_id, "environment": environment}
     )
 
     if existing_prompts:
@@ -231,6 +234,8 @@ def create_versioned_prompt_spec(db_prompt) -> PromptSpec:
     prompt_dict = db_prompt.model_dump()
     base_prompt_id = prompt_dict["prompt_id"]
     version = prompt_dict.get("version", 1)
+    environment = prompt_dict.get("environment", "development")
+    created_by = prompt_dict.get("created_by")
 
     # Parse litellm_params
     litellm_params_data = prompt_dict.get("litellm_params")
@@ -256,6 +261,8 @@ def create_versioned_prompt_spec(db_prompt) -> PromptSpec:
         prompt_info=prompt_info,
         created_at=prompt_dict.get("created_at"),
         updated_at=prompt_dict.get("updated_at"),
+        environment=environment,
+        created_by=created_by,
     )
 
 
@@ -277,6 +284,7 @@ class PatchPromptRequest(BaseModel):
     response_model=ListPromptsResponse,
 )
 async def list_prompts(
+    environment: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
@@ -318,23 +326,28 @@ async def list_prompts(
     if key_metadata is not None:
         prompts = cast(Optional[List[str]], key_metadata.get("prompts", None))
         if prompts is not None:
+            all_prompts = [
+                IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[prompt_id]
+                for prompt_id in prompts
+                if prompt_id in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS
+            ]
+            if environment:
+                all_prompts = [p for p in all_prompts if p.environment == environment]
             prompt_list = []
-            for prompt_id in prompts:
-                if prompt_id in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS:
-                    original_prompt = IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[
-                        prompt_id
-                    ]
-                    # Create a copy with base prompt_id (without version suffix)
-                    prompt_copy = PromptSpec(
-                        prompt_id=get_base_prompt_id(
-                            prompt_id=original_prompt.prompt_id
-                        ),
-                        litellm_params=original_prompt.litellm_params,
-                        prompt_info=original_prompt.prompt_info,
-                        created_at=original_prompt.created_at,
-                        updated_at=original_prompt.updated_at,
-                    )
-                    prompt_list.append(prompt_copy)
+            for original_prompt in all_prompts:
+                # Create a copy with base prompt_id (without version suffix)
+                prompt_copy = PromptSpec(
+                    prompt_id=get_base_prompt_id(
+                        prompt_id=original_prompt.prompt_id
+                    ),
+                    litellm_params=original_prompt.litellm_params,
+                    prompt_info=original_prompt.prompt_info,
+                    created_at=original_prompt.created_at,
+                    updated_at=original_prompt.updated_at,
+                    environment=original_prompt.environment,
+                    created_by=original_prompt.created_by,
+                )
+                prompt_list.append(prompt_copy)
             return ListPromptsResponse(prompts=prompt_list)
     # check if user is proxy admin - show all prompts
     if user_api_key_dict.user_role is not None and (
@@ -343,6 +356,8 @@ async def list_prompts(
     ):
         # Get all prompts and filter to show only the latest version of each
         all_prompts = list(IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.values())
+        if environment:
+            all_prompts = [p for p in all_prompts if p.environment == environment]
         latest_prompts = get_latest_prompt_versions(prompts=all_prompts)
         # Create copies with base prompt_id (without version suffix) for display
         prompts_for_display = []
@@ -353,6 +368,8 @@ async def list_prompts(
                 prompt_info=original_prompt.prompt_info,
                 created_at=original_prompt.created_at,
                 updated_at=original_prompt.updated_at,
+                environment=original_prompt.environment,
+                created_by=original_prompt.created_by,
             )
             prompts_for_display.append(prompt_copy)
         return ListPromptsResponse(prompts=prompts_for_display)
@@ -368,6 +385,7 @@ async def list_prompts(
 )
 async def get_prompt_versions(
     prompt_id: str,
+    environment: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
@@ -404,6 +422,7 @@ async def get_prompt_versions(
     ```
     """
     from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
+    from litellm.proxy.proxy_server import prisma_client
 
     # Only allow proxy admins to view version history
     if user_api_key_dict.user_role is None or (
@@ -414,45 +433,56 @@ async def get_prompt_versions(
             status_code=403, detail="Only proxy admins can view prompt versions"
         )
 
-    # Strip version suffix if provided (e.g., "jack_success.v1" -> "jack_success")
     base_prompt_id = get_base_prompt_id(prompt_id=prompt_id)
 
-    # Get all prompts and filter by base_prompt_id
-    all_prompts = list(IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.values())
-    prompt_versions = [
-        prompt
-        for prompt in all_prompts
-        if get_base_prompt_id(prompt_id=prompt.prompt_id) == base_prompt_id
-    ]
+    # Query DB for versions
+    versioned_prompts = []
+    if prisma_client is not None:
+        where_clause: Dict[str, Any] = {"prompt_id": base_prompt_id}
+        if environment:
+            where_clause["environment"] = environment
+        db_prompts = await prisma_client.db.litellm_prompttable.find_many(
+            where=where_clause,
+            order={"version": "desc"},
+        )
+        for db_prompt in db_prompts:
+            spec = create_versioned_prompt_spec(db_prompt=db_prompt)
+            versioned_prompts.append(PromptSpec(
+                prompt_id=base_prompt_id,
+                litellm_params=spec.litellm_params,
+                prompt_info=spec.prompt_info,
+                created_at=spec.created_at,
+                updated_at=spec.updated_at,
+                version=get_version_number(prompt_id=spec.prompt_id),
+                environment=spec.environment,
+                created_by=spec.created_by,
+            ))
+    else:
+        # Fallback: in-memory registry (no DB)
+        all_prompts = list(IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.values())
+        prompt_versions = [
+            prompt
+            for prompt in all_prompts
+            if get_base_prompt_id(prompt_id=prompt.prompt_id) == base_prompt_id
+        ]
+        for prompt in prompt_versions:
+            version_number = get_version_number(prompt_id=prompt.prompt_id)
+            versioned_prompts.append(PromptSpec(
+                prompt_id=base_prompt_id,
+                litellm_params=prompt.litellm_params,
+                prompt_info=prompt.prompt_info,
+                created_at=prompt.created_at,
+                updated_at=prompt.updated_at,
+                version=version_number,
+                environment=prompt.environment,
+                created_by=prompt.created_by,
+            ))
+        versioned_prompts.sort(key=lambda p: p.version or 1, reverse=True)
 
-    if not prompt_versions:
+    if not versioned_prompts:
         raise HTTPException(
             status_code=404, detail=f"No versions found for prompt ID {base_prompt_id}"
         )
-
-    # Create response with explicit version field for each prompt
-    versioned_prompts = []
-    for prompt in prompt_versions:
-        # Extract version number from the root prompt_id which has version suffix
-        # (e.g., "jack-sparrow.v3" -> 3)
-        version_number = get_version_number(prompt_id=prompt.prompt_id)
-
-        # Strip version from prompt_id for clean display
-        base_prompt_id = get_base_prompt_id(prompt_id=prompt.prompt_id)
-
-        # Create a copy with explicit version field and clean prompt_id
-        versioned_prompt = PromptSpec(
-            prompt_id=base_prompt_id,  # Clean ID without version (e.g., "jack-sparrow")
-            litellm_params=prompt.litellm_params,
-            prompt_info=prompt.prompt_info,
-            created_at=prompt.created_at,
-            updated_at=prompt.updated_at,
-            version=version_number,  # Explicit version field (e.g., 3)
-        )
-        versioned_prompts.append(versioned_prompt)
-
-    # Sort by version number (descending - newest first)
-    versioned_prompts.sort(key=lambda p: p.version or 1, reverse=True)
 
     return ListPromptsResponse(prompts=versioned_prompts)
 
@@ -471,6 +501,7 @@ async def get_prompt_versions(
 )
 async def get_prompt_info(
     prompt_id: str,
+    environment: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
@@ -503,6 +534,7 @@ async def get_prompt_info(
     ```
     """
     from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
+    from litellm.proxy.proxy_server import prisma_client
 
     ## CHECK IF USER HAS ACCESS TO PROMPT
     prompts: Optional[List[str]] = None
@@ -523,68 +555,114 @@ async def get_prompt_info(
             detail=f"You are not authorized to access this prompt. Your role - {user_api_key_dict.user_role}, Your key's prompts - {prompts}",
         )
 
-    # Try to get prompt directly first
-    prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(prompt_id)
+    base_prompt_id = get_base_prompt_id(prompt_id=prompt_id)
 
-    # If not found, try to find the latest version
-    if prompt_spec is None:
-        latest_prompt_id = get_latest_version_prompt_id(
-            prompt_id=prompt_id,
-            all_prompt_ids=IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS,
+    # Query all environments this prompt exists in
+    all_environments: List[str] = []
+    if prisma_client is not None:
+        all_prompt_rows = await prisma_client.db.litellm_prompttable.find_many(
+            where={"prompt_id": base_prompt_id}
         )
-        prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(latest_prompt_id)
+        all_environments = sorted(set(
+            row.environment for row in all_prompt_rows if row.environment
+        ))
+
+    # If environment is specified, find the version in that environment from DB
+    # If prompt_id has a version suffix (e.g., "testprompt.v2"), fetch that specific version
+    # Otherwise fetch the latest version in that environment
+    prompt_spec = None
+    requested_version = get_version_number(prompt_id=prompt_id) if prompt_id != base_prompt_id else None
+    if environment and prisma_client is not None:
+        where_clause: Dict[str, Any] = {"prompt_id": base_prompt_id, "environment": environment}
+        if requested_version is not None:
+            where_clause["version"] = requested_version
+        env_prompts = await prisma_client.db.litellm_prompttable.find_many(
+            where=where_clause,
+            order={"version": "desc"},
+            take=1,
+        )
+        if env_prompts:
+            prompt_spec = create_versioned_prompt_spec(db_prompt=env_prompts[0])
+
+    # Fallback: use in-memory registry (no environment filter)
+    if prompt_spec is None and environment is None:
+        prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(prompt_id)
+        if prompt_spec is None:
+            latest_prompt_id = get_latest_version_prompt_id(
+                prompt_id=prompt_id,
+                all_prompt_ids=IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS,
+            )
+            prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(latest_prompt_id)
 
     if prompt_spec is None:
-        raise HTTPException(status_code=400, detail=f"Prompt {prompt_id} not found")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Prompt {prompt_id} not found"
+            + (f" in environment {environment}" if environment else ""),
+        )
 
     # Extract version number from the prompt_id
     version_number = get_version_number(prompt_id=prompt_spec.prompt_id)
 
     # Create a copy of the prompt spec with the base prompt ID (stripped of version)
-    # and explicit version field for consistency with list_prompts and versions endpoints
     prompt_spec_response = PromptSpec(
         prompt_id=get_base_prompt_id(prompt_id=prompt_spec.prompt_id),
-        litellm_params=prompt_spec.litellm_params,  # This preserves the versioned ID
+        litellm_params=prompt_spec.litellm_params,
         prompt_info=prompt_spec.prompt_info,
         created_at=prompt_spec.created_at,
         updated_at=prompt_spec.updated_at,
-        version=version_number,  # Explicit version field
+        version=version_number,
+        environment=prompt_spec.environment,
+        created_by=prompt_spec.created_by,
     )
 
-    # Get prompt content from the callback
+    # Get prompt content
     prompt_template: Optional[PromptTemplateBase] = None
     try:
-        prompt_callback = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id(
-            prompt_spec.prompt_id
-        )
-        if prompt_callback is not None:
-            # Extract content based on integration type
-            integration_name = prompt_callback.integration_name
+        # When fetched from DB (environment-specific), parse dotprompt_content directly
+        dotprompt_content = prompt_spec.litellm_params.dotprompt_content
+        if dotprompt_content and environment:
+            from litellm.integrations.dotprompt import (
+                _get_prompt_data_from_dotprompt_content,
+            )
 
-            if integration_name == "dotprompt":
-                # For dotprompt integration, get content from the prompt manager
-                from litellm.integrations.dotprompt.dotprompt_manager import (
-                    DotpromptManager,
+            parsed = _get_prompt_data_from_dotprompt_content(dotprompt_content)
+            if parsed:
+                prompt_template = PromptTemplateBase(
+                    litellm_prompt_id=base_prompt_id,
+                    content=parsed.get("content", ""),
+                    metadata=parsed.get("metadata"),
                 )
+        else:
+            # Fallback: use in-memory registry callback
+            prompt_callback = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id(
+                prompt_spec.prompt_id
+            )
+            if prompt_callback is not None:
+                integration_name = prompt_callback.integration_name
 
-                if isinstance(prompt_callback, DotpromptManager):
-                    template = prompt_callback.prompt_manager.get_all_prompts_as_json()
-                    if template is not None and len(template) == 1:
-                        template_id = list(template.keys())[0]
-                        prompt_template = PromptTemplateBase(
-                            litellm_prompt_id=template_id,  # id sent to prompt management tool
-                            content=template[template_id]["content"],
-                            metadata=template[template_id]["metadata"],
-                        )
+                if integration_name == "dotprompt":
+                    from litellm.integrations.dotprompt.dotprompt_manager import (
+                        DotpromptManager,
+                    )
+
+                    if isinstance(prompt_callback, DotpromptManager):
+                        template = prompt_callback.prompt_manager.get_all_prompts_as_json()
+                        if template is not None and len(template) == 1:
+                            template_id = list(template.keys())[0]
+                            prompt_template = PromptTemplateBase(
+                                litellm_prompt_id=template_id,
+                                content=template[template_id]["content"],
+                                metadata=template[template_id]["metadata"],
+                            )
 
     except Exception:
-        # If content extraction fails, continue without content
         pass
 
-    # Create response with content
     return PromptInfoResponse(
         prompt_spec=prompt_spec_response,
         raw_prompt_template=prompt_template,
+        environments=all_environments,
     )
 
 
@@ -641,9 +719,18 @@ async def create_prompt(
         )
 
     try:
+        # Extract environment from request
+        environment = (
+            request.prompt_info.environment
+            if request.prompt_info and request.prompt_info.environment
+            else "development"
+        )
+
         # Get next version number
         new_version = await get_next_version_for_prompt(
-            prisma_client=prisma_client, prompt_id=request.prompt_id
+            prisma_client=prisma_client,
+            prompt_id=request.prompt_id,
+            environment=environment,
         )
 
         # Store prompt in db with version
@@ -651,6 +738,8 @@ async def create_prompt(
             data={
                 "prompt_id": request.prompt_id,
                 "version": new_version,
+                "environment": environment,
+                "created_by": user_api_key_dict.user_id,
                 "litellm_params": request.litellm_params.model_dump_json(),
                 "prompt_info": (
                     request.prompt_info.model_dump_json()
@@ -733,14 +822,22 @@ async def update_prompt(
         # Strip version suffix from prompt_id if present (e.g., "jack_success.v1" -> "jack_success")
         base_prompt_id = get_base_prompt_id(prompt_id=prompt_id)
 
-        # Check if any version exists
+        # Extract environment from request
+        environment = (
+            request.prompt_info.environment
+            if request.prompt_info and request.prompt_info.environment
+            else "development"
+        )
+
+        # Check if any version of this prompt exists (in any environment)
         existing_prompts = await prisma_client.db.litellm_prompttable.find_many(
             where={"prompt_id": base_prompt_id}
         )
 
         if not existing_prompts:
             raise HTTPException(
-                status_code=404, detail=f"Prompt with ID {base_prompt_id} not found"
+                status_code=404,
+                detail=f"Prompt with ID {base_prompt_id} not found",
             )
 
         # Check if it's a config prompt
@@ -756,7 +853,9 @@ async def update_prompt(
 
         # Get next version number (UPDATE creates a new version)
         new_version = await get_next_version_for_prompt(
-            prisma_client=prisma_client, prompt_id=base_prompt_id
+            prisma_client=prisma_client,
+            prompt_id=base_prompt_id,
+            environment=environment,
         )
 
         # Store new version in db
@@ -764,6 +863,8 @@ async def update_prompt(
             data={
                 "prompt_id": base_prompt_id,
                 "version": new_version,
+                "environment": environment,
+                "created_by": user_api_key_dict.user_id,
                 "litellm_params": request.litellm_params.model_dump_json(),
                 "prompt_info": (
                     request.prompt_info.model_dump_json()
@@ -800,6 +901,7 @@ async def update_prompt(
 )
 async def delete_prompt(
     prompt_id: str,
+    environment: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
@@ -867,10 +969,13 @@ async def delete_prompt(
         # Get the base prompt ID (without version suffix) for database deletion
         base_prompt_id = get_base_prompt_id(prompt_id=prompt_id)
 
+        # Build delete filter; scope to environment if provided
+        delete_where: Dict[str, Any] = {"prompt_id": base_prompt_id}
+        if environment:
+            delete_where["environment"] = environment
+
         # Delete all versions of the prompt from the database
-        await prisma_client.db.litellm_prompttable.delete_many(
-            where={"prompt_id": base_prompt_id}
-        )
+        await prisma_client.db.litellm_prompttable.delete_many(where=delete_where)
 
         # Remove all versions of the prompt from memory
         IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id(base_prompt_id)
@@ -965,13 +1070,18 @@ async def patch_prompt(
         if updated_litellm_params is None:
             raise HTTPException(status_code=400, detail="litellm_params cannot be None")
 
+        # Build update data dict
+        update_data: Dict[str, Any] = {
+            "litellm_params": updated_litellm_params.model_dump_json(),
+            "prompt_info": updated_prompt_info.model_dump_json(),
+        }
+        if user_api_key_dict.user_id:
+            update_data["created_by"] = user_api_key_dict.user_id
+
         # Create updated prompt spec - cast to satisfy typing
         updated_prompt_db_entry = await prisma_client.db.litellm_prompttable.update(
             where={"prompt_id": prompt_id},
-            data={
-                "litellm_params": updated_litellm_params.model_dump_json(),
-                "prompt_info": updated_prompt_info.model_dump_json(),
-            },
+            data=update_data,
         )
 
         updated_prompt_spec = PromptSpec(**updated_prompt_db_entry.model_dump())

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -559,11 +559,12 @@ async def get_prompt_info(
 
     base_prompt_id = get_base_prompt_id(prompt_id=prompt_id)
 
-    # Query all environments this prompt exists in
+    # Query all environments this prompt exists in (lightweight: distinct on environment)
     all_environments: List[str] = []
     if prisma_client is not None:
         all_prompt_rows = await prisma_client.db.litellm_prompttable.find_many(
-            where={"prompt_id": base_prompt_id}
+            where={"prompt_id": base_prompt_id},
+            distinct=["environment"],
         )
         all_environments = sorted(
             set(row.environment for row in all_prompt_rows if row.environment)
@@ -626,9 +627,9 @@ async def get_prompt_info(
     # Get prompt content
     prompt_template: Optional[PromptTemplateBase] = None
     try:
-        # When fetched from DB (environment-specific), parse dotprompt_content directly
+        # Parse dotprompt_content directly when available (avoids stale in-memory data)
         dotprompt_content = prompt_spec.litellm_params.dotprompt_content
-        if dotprompt_content and environment:
+        if dotprompt_content:
             from litellm.integrations.dotprompt import (
                 _get_prompt_data_from_dotprompt_content,
             )
@@ -983,13 +984,26 @@ async def delete_prompt(
         if environment:
             delete_where["environment"] = environment
 
-        # Delete all versions of the prompt from the database
+        # Delete versions from the database (scoped to environment if provided)
         await prisma_client.db.litellm_prompttable.delete_many(where=delete_where)
 
-        # Remove all versions of the prompt from memory
-        IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id(base_prompt_id)
+        # Remove matching prompts from memory — scope to environment if provided
+        if environment:
+            prompts_to_delete = [
+                pid
+                for pid, prompt in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.items()
+                if get_base_prompt_id(prompt_id=pid) == base_prompt_id
+                and prompt.environment == environment
+            ]
+            for pid in prompts_to_delete:
+                del IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[pid]
+                if pid in IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt:
+                    del IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt[pid]
+        else:
+            IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id(base_prompt_id)
 
-        return {"message": f"Prompt {base_prompt_id} deleted successfully"}
+        env_msg = f" from {environment}" if environment else ""
+        return {"message": f"Prompt {base_prompt_id} deleted successfully{env_msg}"}
 
     except HTTPException as e:
         raise e

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -337,9 +337,7 @@ async def list_prompts(
             for original_prompt in all_prompts:
                 # Create a copy with base prompt_id (without version suffix)
                 prompt_copy = PromptSpec(
-                    prompt_id=get_base_prompt_id(
-                        prompt_id=original_prompt.prompt_id
-                    ),
+                    prompt_id=get_base_prompt_id(prompt_id=original_prompt.prompt_id),
                     litellm_params=original_prompt.litellm_params,
                     prompt_info=original_prompt.prompt_info,
                     created_at=original_prompt.created_at,
@@ -447,16 +445,18 @@ async def get_prompt_versions(
         )
         for db_prompt in db_prompts:
             spec = create_versioned_prompt_spec(db_prompt=db_prompt)
-            versioned_prompts.append(PromptSpec(
-                prompt_id=base_prompt_id,
-                litellm_params=spec.litellm_params,
-                prompt_info=spec.prompt_info,
-                created_at=spec.created_at,
-                updated_at=spec.updated_at,
-                version=get_version_number(prompt_id=spec.prompt_id),
-                environment=spec.environment,
-                created_by=spec.created_by,
-            ))
+            versioned_prompts.append(
+                PromptSpec(
+                    prompt_id=base_prompt_id,
+                    litellm_params=spec.litellm_params,
+                    prompt_info=spec.prompt_info,
+                    created_at=spec.created_at,
+                    updated_at=spec.updated_at,
+                    version=get_version_number(prompt_id=spec.prompt_id),
+                    environment=spec.environment,
+                    created_by=spec.created_by,
+                )
+            )
     else:
         # Fallback: in-memory registry (no DB)
         all_prompts = list(IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.values())
@@ -467,16 +467,18 @@ async def get_prompt_versions(
         ]
         for prompt in prompt_versions:
             version_number = get_version_number(prompt_id=prompt.prompt_id)
-            versioned_prompts.append(PromptSpec(
-                prompt_id=base_prompt_id,
-                litellm_params=prompt.litellm_params,
-                prompt_info=prompt.prompt_info,
-                created_at=prompt.created_at,
-                updated_at=prompt.updated_at,
-                version=version_number,
-                environment=prompt.environment,
-                created_by=prompt.created_by,
-            ))
+            versioned_prompts.append(
+                PromptSpec(
+                    prompt_id=base_prompt_id,
+                    litellm_params=prompt.litellm_params,
+                    prompt_info=prompt.prompt_info,
+                    created_at=prompt.created_at,
+                    updated_at=prompt.updated_at,
+                    version=version_number,
+                    environment=prompt.environment,
+                    created_by=prompt.created_by,
+                )
+            )
         versioned_prompts.sort(key=lambda p: p.version or 1, reverse=True)
 
     if not versioned_prompts:
@@ -563,17 +565,22 @@ async def get_prompt_info(
         all_prompt_rows = await prisma_client.db.litellm_prompttable.find_many(
             where={"prompt_id": base_prompt_id}
         )
-        all_environments = sorted(set(
-            row.environment for row in all_prompt_rows if row.environment
-        ))
+        all_environments = sorted(
+            set(row.environment for row in all_prompt_rows if row.environment)
+        )
 
     # If environment is specified, find the version in that environment from DB
     # If prompt_id has a version suffix (e.g., "testprompt.v2"), fetch that specific version
     # Otherwise fetch the latest version in that environment
     prompt_spec = None
-    requested_version = get_version_number(prompt_id=prompt_id) if prompt_id != base_prompt_id else None
+    requested_version = (
+        get_version_number(prompt_id=prompt_id) if prompt_id != base_prompt_id else None
+    )
     if environment and prisma_client is not None:
-        where_clause: Dict[str, Any] = {"prompt_id": base_prompt_id, "environment": environment}
+        where_clause: Dict[str, Any] = {
+            "prompt_id": base_prompt_id,
+            "environment": environment,
+        }
         if requested_version is not None:
             where_clause["version"] = requested_version
         env_prompts = await prisma_client.db.litellm_prompttable.find_many(
@@ -647,7 +654,9 @@ async def get_prompt_info(
                     )
 
                     if isinstance(prompt_callback, DotpromptManager):
-                        template = prompt_callback.prompt_manager.get_all_prompts_as_json()
+                        template = (
+                            prompt_callback.prompt_manager.get_all_prompts_as_json()
+                        )
                         if template is not None and len(template) == 1:
                             template_id = list(template.keys())[0]
                             prompt_template = PromptTemplateBase(

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -1021,6 +1021,7 @@ async def delete_prompt(
 async def patch_prompt(
     prompt_id: str,
     request: PatchPromptRequest,
+    environment: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
@@ -1064,30 +1065,66 @@ async def patch_prompt(
         )
 
     try:
-        # Check if prompt exists and get current data
-        existing_prompt = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(prompt_id)
-        if existing_prompt is None:
+        # Resolve the target row: find the latest version in the given environment
+        base_prompt_id = get_base_prompt_id(prompt_id=prompt_id)
+        env = environment or "development"
+        requested_version = (
+            get_version_number(prompt_id=prompt_id)
+            if prompt_id != base_prompt_id
+            else None
+        )
+
+        # Build query to find the exact row by composite unique key
+        find_where: Dict[str, Any] = {
+            "prompt_id": base_prompt_id,
+            "environment": env,
+        }
+        if requested_version is not None:
+            find_where["version"] = requested_version
+
+        db_rows = await prisma_client.db.litellm_prompttable.find_many(
+            where=find_where,
+            order={"version": "desc"},
+            take=1,
+        )
+        if not db_rows:
             raise HTTPException(
-                status_code=404, detail=f"Prompt with ID {prompt_id} not found"
+                status_code=404,
+                detail=f"Prompt with ID {base_prompt_id} not found in environment {env}",
             )
 
-        if existing_prompt.prompt_info.prompt_type == "config":
+        target_row = db_rows[0]
+
+        # Check if prompt exists in memory
+        versioned_id = f"{base_prompt_id}.v{target_row.version}"
+        existing_prompt = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(versioned_id)
+
+        if existing_prompt and existing_prompt.prompt_info.prompt_type == "config":
             raise HTTPException(
                 status_code=400,
                 detail="Cannot update config prompts.",
             )
 
+        # Use existing prompt from memory or build from DB row for field merging
+        if existing_prompt:
+            current_litellm_params = existing_prompt.litellm_params
+            current_prompt_info = existing_prompt.prompt_info
+        else:
+            current_spec = create_versioned_prompt_spec(db_prompt=target_row)
+            current_litellm_params = current_spec.litellm_params
+            current_prompt_info = current_spec.prompt_info
+
         # Update fields if provided
         updated_litellm_params = (
             request.litellm_params
             if request.litellm_params is not None
-            else existing_prompt.litellm_params
+            else current_litellm_params
         )
 
         updated_prompt_info = (
             request.prompt_info
             if request.prompt_info is not None
-            else existing_prompt.prompt_info
+            else current_prompt_info
         )
 
         # Ensure we have valid litellm_params
@@ -1102,18 +1139,21 @@ async def patch_prompt(
         if user_api_key_dict.user_id:
             update_data["created_by"] = user_api_key_dict.user_id
 
-        # Create updated prompt spec - cast to satisfy typing
+        # Update by primary key (id) to target exactly one row
         updated_prompt_db_entry = await prisma_client.db.litellm_prompttable.update(
-            where={"prompt_id": prompt_id},
+            where={"id": target_row.id},
             data=update_data,
         )
 
-        updated_prompt_spec = PromptSpec(**updated_prompt_db_entry.model_dump())
+        updated_prompt_spec = create_versioned_prompt_spec(
+            db_prompt=updated_prompt_db_entry
+        )
 
         # Remove the old prompt from memory
-        del IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[prompt_id]
-        if prompt_id in IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt:
-            del IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt[prompt_id]
+        if versioned_id in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS:
+            del IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[versioned_id]
+        if versioned_id in IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt:
+            del IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt[versioned_id]
 
         # Initialize the updated prompt
         initialized_prompt = IN_MEMORY_PROMPT_REGISTRY.initialize_prompt(

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -1002,12 +1002,15 @@ model LiteLLM_PromptTable {
   id String @id @default(uuid())
   prompt_id String
   version Int @default(1)
+  environment String @default("development")
+  created_by String?
   litellm_params Json
   prompt_info Json?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
-  @@unique([prompt_id, version])
+  @@unique([prompt_id, version, environment])
+  @@index([prompt_id, environment])
   @@index([prompt_id])
 }
 

--- a/litellm/types/prompts/init_prompts.py
+++ b/litellm/types/prompts/init_prompts.py
@@ -73,7 +73,9 @@ class PromptTemplateBase(BaseModel):
 class PromptInfoResponse(BaseModel):
     prompt_spec: PromptSpec
     raw_prompt_template: Optional[PromptTemplateBase] = None
-    environments: Optional[List[str]] = None  # All environments this prompt is deployed to
+    environments: Optional[
+        List[str]
+    ] = None  # All environments this prompt is deployed to
 
 
 class ListPromptsResponse(BaseModel):

--- a/litellm/types/prompts/init_prompts.py
+++ b/litellm/types/prompts/init_prompts.py
@@ -17,6 +17,7 @@ class SupportedPromptIntegrations(str, Enum):
 
 class PromptInfo(BaseModel):
     prompt_type: Literal["config", "db"]
+    environment: Optional[str] = "development"
 
     model_config = ConfigDict(extra="allow", protected_namespaces=())
 
@@ -48,6 +49,8 @@ class PromptSpec(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     version: Optional[int] = None  # Version number for version history
+    environment: Optional[str] = "development"
+    created_by: Optional[str] = None
 
     def __init__(self, **data):
         if "prompt_info" not in data:
@@ -70,6 +73,7 @@ class PromptTemplateBase(BaseModel):
 class PromptInfoResponse(BaseModel):
     prompt_spec: PromptSpec
     raw_prompt_template: Optional[PromptTemplateBase] = None
+    environments: Optional[List[str]] = None  # All environments this prompt is deployed to
 
 
 class ListPromptsResponse(BaseModel):

--- a/schema.prisma
+++ b/schema.prisma
@@ -1002,12 +1002,15 @@ model LiteLLM_PromptTable {
   id String @id @default(uuid())
   prompt_id String
   version Int @default(1)
+  environment String @default("development")
+  created_by String?
   litellm_params Json
   prompt_info Json?
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
-  @@unique([prompt_id, version])
+  @@unique([prompt_id, version, environment])
+  @@index([prompt_id, environment])
   @@index([prompt_id])
 }
 

--- a/tests/test_litellm/proxy/prompts/test_prompt_environment.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_environment.py
@@ -1,0 +1,223 @@
+import json
+import pytest
+from unittest.mock import MagicMock
+from litellm.types.prompts.init_prompts import (
+    PromptInfo,
+    PromptSpec,
+    PromptLiteLLMParams,
+)
+
+
+def test_prompt_info_default_environment():
+    """PromptInfo should default environment to 'development'."""
+    info = PromptInfo(prompt_type="db")
+    assert info.environment == "development"
+
+
+def test_prompt_info_custom_environment():
+    """PromptInfo should accept a custom environment."""
+    info = PromptInfo(prompt_type="db", environment="production")
+    assert info.environment == "production"
+
+
+def test_prompt_spec_includes_environment_and_created_by():
+    """PromptSpec should carry environment and created_by fields."""
+    spec = PromptSpec(
+        prompt_id="test",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="test", prompt_integration="dotprompt"
+        ),
+        prompt_info=PromptInfo(prompt_type="db", environment="staging"),
+        environment="staging",
+        created_by="user-123",
+    )
+    assert spec.environment == "staging"
+    assert spec.created_by == "user-123"
+
+
+def test_prompt_spec_default_environment():
+    """PromptSpec environment should default to 'development'."""
+    spec = PromptSpec(
+        prompt_id="test",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="test", prompt_integration="dotprompt"
+        ),
+        prompt_info=PromptInfo(prompt_type="db"),
+    )
+    assert spec.environment == "development"
+    assert spec.created_by is None
+
+
+def test_create_versioned_prompt_spec_includes_environment():
+    """create_versioned_prompt_spec should populate environment and created_by from DB row."""
+    from litellm.proxy.prompts.prompt_endpoints import create_versioned_prompt_spec
+
+    mock_db_prompt = MagicMock()
+    mock_db_prompt.model_dump.return_value = {
+        "id": "uuid-123",
+        "prompt_id": "test_prompt",
+        "version": 2,
+        "environment": "staging",
+        "created_by": "user-456",
+        "litellm_params": json.dumps({
+            "prompt_id": "test_prompt",
+            "prompt_integration": "dotprompt",
+        }),
+        "prompt_info": json.dumps({"prompt_type": "db", "environment": "staging"}),
+        "created_at": None,
+        "updated_at": None,
+    }
+    spec = create_versioned_prompt_spec(mock_db_prompt)
+    assert spec.environment == "staging"
+    assert spec.created_by == "user-456"
+    assert spec.prompt_id == "test_prompt.v2"
+
+
+@pytest.mark.asyncio
+async def test_create_prompt_stores_environment_and_created_by():
+    """create_prompt should pass environment and created_by to the DB."""
+    from unittest.mock import AsyncMock, patch
+    from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+    from litellm.proxy.prompts.prompt_endpoints import create_prompt, Prompt
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="user-789",
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_db_entry = MagicMock()
+    mock_db_entry.model_dump.return_value = {
+        "id": "uuid-1",
+        "prompt_id": "my_prompt",
+        "version": 1,
+        "environment": "staging",
+        "created_by": "user-789",
+        "litellm_params": json.dumps({
+            "prompt_id": "my_prompt",
+            "prompt_integration": "dotprompt",
+        }),
+        "prompt_info": json.dumps({"prompt_type": "db", "environment": "staging"}),
+        "created_at": None,
+        "updated_at": None,
+    }
+    mock_prisma_client.db.litellm_prompttable.create = AsyncMock(return_value=mock_db_entry)
+    mock_prisma_client.db.litellm_prompttable.find_many = AsyncMock(return_value=[])
+
+    request = Prompt(
+        prompt_id="my_prompt",
+        litellm_params=PromptLiteLLMParams(prompt_id="my_prompt", prompt_integration="dotprompt"),
+        prompt_info=PromptInfo(prompt_type="db", environment="staging"),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+            mock_registry.initialize_prompt.return_value = PromptSpec(
+                prompt_id="my_prompt.v1",
+                litellm_params=request.litellm_params,
+                prompt_info=request.prompt_info,
+                environment="staging",
+                created_by="user-789",
+            )
+            await create_prompt(request=request, user_api_key_dict=mock_user_auth)
+
+            create_call = mock_prisma_client.db.litellm_prompttable.create.call_args
+            data = create_call.kwargs["data"]
+            assert data["environment"] == "staging"
+            assert data["created_by"] == "user-789"
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_stores_environment_and_created_by():
+    """update_prompt should pass environment and created_by to new version."""
+    from unittest.mock import AsyncMock, patch
+    from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+    from litellm.proxy.prompts.prompt_endpoints import update_prompt, Prompt
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="user-update",
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_existing = MagicMock()
+    mock_existing.version = 1
+    mock_prisma_client.db.litellm_prompttable.find_many = AsyncMock(return_value=[mock_existing])
+
+    mock_db_entry = MagicMock()
+    mock_db_entry.model_dump.return_value = {
+        "id": "uuid-2",
+        "prompt_id": "my_prompt",
+        "version": 2,
+        "environment": "production",
+        "created_by": "user-update",
+        "litellm_params": json.dumps({
+            "prompt_id": "my_prompt",
+            "prompt_integration": "dotprompt",
+        }),
+        "prompt_info": json.dumps({"prompt_type": "db", "environment": "production"}),
+        "created_at": None,
+        "updated_at": None,
+    }
+    mock_prisma_client.db.litellm_prompttable.create = AsyncMock(return_value=mock_db_entry)
+
+    request = Prompt(
+        prompt_id="my_prompt",
+        litellm_params=PromptLiteLLMParams(prompt_id="my_prompt", prompt_integration="dotprompt"),
+        prompt_info=PromptInfo(prompt_type="db", environment="production"),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+            mock_registry.get_prompt_by_id.return_value = PromptSpec(
+                prompt_id="my_prompt.v1",
+                litellm_params=request.litellm_params,
+                prompt_info=PromptInfo(prompt_type="db"),
+            )
+            mock_registry.initialize_prompt.return_value = PromptSpec(
+                prompt_id="my_prompt.v2",
+                litellm_params=request.litellm_params,
+                prompt_info=request.prompt_info,
+                environment="production",
+                created_by="user-update",
+            )
+            await update_prompt(prompt_id="my_prompt", request=request, user_api_key_dict=mock_user_auth)
+
+            create_call = mock_prisma_client.db.litellm_prompttable.create.call_args
+            data = create_call.kwargs["data"]
+            assert data["environment"] == "production"
+            assert data["created_by"] == "user-update"
+
+
+@pytest.mark.asyncio
+async def test_delete_prompt_scoped_to_environment():
+    """delete_prompt with environment param should scope deletion."""
+    from unittest.mock import AsyncMock, patch
+    from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+    from litellm.proxy.prompts.prompt_endpoints import delete_prompt
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_prompttable.delete_many = AsyncMock(return_value=None)
+
+    with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+        prompt_spec = PromptSpec(
+            prompt_id="test_prompt.v1",
+            litellm_params=PromptLiteLLMParams(prompt_id="test_prompt", prompt_integration="dotprompt"),
+            prompt_info=PromptInfo(prompt_type="db"),
+            environment="staging",
+        )
+        mock_registry.get_prompt_by_id.return_value = prompt_spec
+
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+            await delete_prompt(prompt_id="test_prompt", user_api_key_dict=mock_user_auth, environment="staging")
+
+            mock_prisma_client.db.litellm_prompttable.delete_many.assert_called_once_with(
+                where={"prompt_id": "test_prompt", "environment": "staging"}
+            )

--- a/tests/test_litellm/proxy/prompts/test_prompt_environment.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_environment.py
@@ -59,10 +59,12 @@ def test_create_versioned_prompt_spec_includes_environment():
         "version": 2,
         "environment": "staging",
         "created_by": "user-456",
-        "litellm_params": json.dumps({
-            "prompt_id": "test_prompt",
-            "prompt_integration": "dotprompt",
-        }),
+        "litellm_params": json.dumps(
+            {
+                "prompt_id": "test_prompt",
+                "prompt_integration": "dotprompt",
+            }
+        ),
         "prompt_info": json.dumps({"prompt_type": "db", "environment": "staging"}),
         "created_at": None,
         "updated_at": None,
@@ -94,25 +96,33 @@ async def test_create_prompt_stores_environment_and_created_by():
         "version": 1,
         "environment": "staging",
         "created_by": "user-789",
-        "litellm_params": json.dumps({
-            "prompt_id": "my_prompt",
-            "prompt_integration": "dotprompt",
-        }),
+        "litellm_params": json.dumps(
+            {
+                "prompt_id": "my_prompt",
+                "prompt_integration": "dotprompt",
+            }
+        ),
         "prompt_info": json.dumps({"prompt_type": "db", "environment": "staging"}),
         "created_at": None,
         "updated_at": None,
     }
-    mock_prisma_client.db.litellm_prompttable.create = AsyncMock(return_value=mock_db_entry)
+    mock_prisma_client.db.litellm_prompttable.create = AsyncMock(
+        return_value=mock_db_entry
+    )
     mock_prisma_client.db.litellm_prompttable.find_many = AsyncMock(return_value=[])
 
     request = Prompt(
         prompt_id="my_prompt",
-        litellm_params=PromptLiteLLMParams(prompt_id="my_prompt", prompt_integration="dotprompt"),
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="my_prompt", prompt_integration="dotprompt"
+        ),
         prompt_info=PromptInfo(prompt_type="db", environment="staging"),
     )
 
     with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
-        with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+        with patch(
+            "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+        ) as mock_registry:
             mock_registry.initialize_prompt.return_value = PromptSpec(
                 prompt_id="my_prompt.v1",
                 litellm_params=request.litellm_params,
@@ -144,7 +154,9 @@ async def test_update_prompt_stores_environment_and_created_by():
     mock_prisma_client = MagicMock()
     mock_existing = MagicMock()
     mock_existing.version = 1
-    mock_prisma_client.db.litellm_prompttable.find_many = AsyncMock(return_value=[mock_existing])
+    mock_prisma_client.db.litellm_prompttable.find_many = AsyncMock(
+        return_value=[mock_existing]
+    )
 
     mock_db_entry = MagicMock()
     mock_db_entry.model_dump.return_value = {
@@ -153,24 +165,32 @@ async def test_update_prompt_stores_environment_and_created_by():
         "version": 2,
         "environment": "production",
         "created_by": "user-update",
-        "litellm_params": json.dumps({
-            "prompt_id": "my_prompt",
-            "prompt_integration": "dotprompt",
-        }),
+        "litellm_params": json.dumps(
+            {
+                "prompt_id": "my_prompt",
+                "prompt_integration": "dotprompt",
+            }
+        ),
         "prompt_info": json.dumps({"prompt_type": "db", "environment": "production"}),
         "created_at": None,
         "updated_at": None,
     }
-    mock_prisma_client.db.litellm_prompttable.create = AsyncMock(return_value=mock_db_entry)
+    mock_prisma_client.db.litellm_prompttable.create = AsyncMock(
+        return_value=mock_db_entry
+    )
 
     request = Prompt(
         prompt_id="my_prompt",
-        litellm_params=PromptLiteLLMParams(prompt_id="my_prompt", prompt_integration="dotprompt"),
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="my_prompt", prompt_integration="dotprompt"
+        ),
         prompt_info=PromptInfo(prompt_type="db", environment="production"),
     )
 
     with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
-        with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+        with patch(
+            "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+        ) as mock_registry:
             mock_registry.get_prompt_by_id.return_value = PromptSpec(
                 prompt_id="my_prompt.v1",
                 litellm_params=request.litellm_params,
@@ -183,7 +203,9 @@ async def test_update_prompt_stores_environment_and_created_by():
                 environment="production",
                 created_by="user-update",
             )
-            await update_prompt(prompt_id="my_prompt", request=request, user_api_key_dict=mock_user_auth)
+            await update_prompt(
+                prompt_id="my_prompt", request=request, user_api_key_dict=mock_user_auth
+            )
 
             create_call = mock_prisma_client.db.litellm_prompttable.create.call_args
             data = create_call.kwargs["data"]
@@ -206,17 +228,25 @@ async def test_delete_prompt_scoped_to_environment():
     mock_prisma_client = MagicMock()
     mock_prisma_client.db.litellm_prompttable.delete_many = AsyncMock(return_value=None)
 
-    with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+    with patch(
+        "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+    ) as mock_registry:
         prompt_spec = PromptSpec(
             prompt_id="test_prompt.v1",
-            litellm_params=PromptLiteLLMParams(prompt_id="test_prompt", prompt_integration="dotprompt"),
+            litellm_params=PromptLiteLLMParams(
+                prompt_id="test_prompt", prompt_integration="dotprompt"
+            ),
             prompt_info=PromptInfo(prompt_type="db"),
             environment="staging",
         )
         mock_registry.get_prompt_by_id.return_value = prompt_spec
 
         with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
-            await delete_prompt(prompt_id="test_prompt", user_api_key_dict=mock_user_auth, environment="staging")
+            await delete_prompt(
+                prompt_id="test_prompt",
+                user_api_key_dict=mock_user_auth,
+                environment="staging",
+            )
 
             mock_prisma_client.db.litellm_prompttable.delete_many.assert_called_once_with(
                 where={"prompt_id": "test_prompt", "environment": "staging"}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -225,6 +225,7 @@ export interface PromptTemplateBase {
 interface PromptInfoResponse {
   prompt_spec: PromptSpec;
   raw_prompt_template: PromptTemplateBase | null;
+  environments?: string[];
 }
 
 export interface ListPromptsResponse {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -202,6 +202,7 @@ export interface Model {
 
 interface PromptInfo {
   prompt_type: string;
+  environment?: string;
 }
 
 export interface PromptSpec {
@@ -211,6 +212,8 @@ export interface PromptSpec {
   created_at?: string;
   updated_at?: string;
   version?: number; // Explicit version number for version history
+  environment?: string;
+  created_by?: string;
 }
 
 export interface PromptTemplateBase {
@@ -6035,9 +6038,15 @@ export const estimateAttachmentImpactCall = async (
   }
 };
 
-export const getPromptsList = async (accessToken: string): Promise<ListPromptsResponse> => {
+export const getPromptsList = async (
+  accessToken: string,
+  environment?: string,
+): Promise<ListPromptsResponse> => {
   try {
-    const url = proxyBaseUrl ? `${proxyBaseUrl}/prompts/list` : `/prompts/list`;
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/prompts/list` : `/prompts/list`;
+    if (environment) {
+      url += `?environment=${encodeURIComponent(environment)}`;
+    }
     const response = await fetch(url, {
       method: "GET",
       headers: {
@@ -6061,9 +6070,12 @@ export const getPromptsList = async (accessToken: string): Promise<ListPromptsRe
   }
 };
 
-export const getPromptInfo = async (accessToken: string, promptId: string): Promise<PromptInfoResponse> => {
+export const getPromptInfo = async (accessToken: string, promptId: string, environment?: string): Promise<PromptInfoResponse> => {
   try {
-    const url = proxyBaseUrl ? `${proxyBaseUrl}/prompts/${promptId}/info` : `/prompts/${promptId}/info`;
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/prompts/${promptId}/info` : `/prompts/${promptId}/info`;
+    if (environment) {
+      url += `?environment=${encodeURIComponent(environment)}`;
+    }
     const response = await fetch(url, {
       method: "GET",
       headers: {
@@ -6087,9 +6099,12 @@ export const getPromptInfo = async (accessToken: string, promptId: string): Prom
   }
 };
 
-export const getPromptVersions = async (accessToken: string, promptId: string): Promise<ListPromptsResponse> => {
+export const getPromptVersions = async (accessToken: string, promptId: string, environment?: string): Promise<ListPromptsResponse> => {
   try {
-    const url = proxyBaseUrl ? `${proxyBaseUrl}/prompts/${promptId}/versions` : `/prompts/${promptId}/versions`;
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/prompts/${promptId}/versions` : `/prompts/${promptId}/versions`;
+    if (environment) {
+      url += `?environment=${encodeURIComponent(environment)}`;
+    }
     const response = await fetch(url, {
       method: "GET",
       headers: {

--- a/ui/litellm-dashboard/src/components/prompts.tsx
+++ b/ui/litellm-dashboard/src/components/prompts.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 
 import { Button } from "@tremor/react";
-import { Modal } from "antd";
+import { Modal, Select } from "antd";
 import { getPromptsList, PromptSpec, ListPromptsResponse, deletePromptCall } from "./networking";
 import PromptTable from "./prompts/prompt_table";
 import PromptInfoView from "./prompts/prompt_info";
@@ -18,6 +18,7 @@ interface PromptsProps {
 const PromptsPanel: React.FC<PromptsProps> = ({ accessToken, userRole }) => {
   const [promptsList, setPromptsList] = useState<PromptSpec[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [selectedEnvironment, setSelectedEnvironment] = useState<string | undefined>(undefined);
   const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
   const [showEditorView, setShowEditorView] = useState(false);
@@ -34,7 +35,7 @@ const PromptsPanel: React.FC<PromptsProps> = ({ accessToken, userRole }) => {
 
     setIsLoading(true);
     try {
-      const response: ListPromptsResponse = await getPromptsList(accessToken);
+      const response: ListPromptsResponse = await getPromptsList(accessToken, selectedEnvironment);
       console.log(`prompts: ${JSON.stringify(response)}`);
       setPromptsList(response.prompts);
     } catch (error) {
@@ -46,7 +47,7 @@ const PromptsPanel: React.FC<PromptsProps> = ({ accessToken, userRole }) => {
 
   useEffect(() => {
     fetchPrompts();
-  }, [accessToken]);
+  }, [accessToken, selectedEnvironment]);
 
   const handlePromptClick = (promptId: string) => {
     setSelectedPromptId(promptId);
@@ -135,13 +136,25 @@ const PromptsPanel: React.FC<PromptsProps> = ({ accessToken, userRole }) => {
         <>
           <div className="flex justify-between items-center mb-4">
             <div className="flex gap-2">
-            <Button onClick={handleAddPrompt} disabled={!accessToken}>
-              + Add New Prompt
-            </Button>
+              <Button onClick={handleAddPrompt} disabled={!accessToken}>
+                + Add New Prompt
+              </Button>
               <Button onClick={handleAddPromptFromFile} disabled={!accessToken} variant="secondary">
                 Upload .prompt File
               </Button>
             </div>
+            <Select
+              placeholder="All Environments"
+              allowClear
+              value={selectedEnvironment}
+              onChange={(value) => setSelectedEnvironment(value)}
+              style={{ width: 180 }}
+              options={[
+                { label: "Development", value: "development" },
+                { label: "Staging", value: "staging" },
+                { label: "Production", value: "production" },
+              ]}
+            />
           </div>
 
           <PromptTable

--- a/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/PromptEditorHeader.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/PromptEditorHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button as TremorButton } from "@tremor/react";
-import { Input } from "antd";
+import { Input, Select } from "antd";
 import { ArrowLeftIcon, SaveIcon, ClockIcon } from "lucide-react";
 import PromptCodeSnippets from "./PromptCodeSnippets";
 
@@ -20,6 +20,8 @@ interface PromptEditorHeaderProps {
     PROXY_BASE_URL?: string;
     LITELLM_UI_API_DOC_BASE_URL?: string | null;
   };
+  environment: string;
+  onEnvironmentChange: (env: string) => void;
 }
 
 const PromptEditorHeader: React.FC<PromptEditorHeaderProps> = ({
@@ -35,6 +37,8 @@ const PromptEditorHeader: React.FC<PromptEditorHeaderProps> = ({
   promptVariables = {},
   accessToken,
   proxySettings,
+  environment,
+  onEnvironmentChange,
 }) => {
   return (
     <div className="bg-white border-b border-gray-200 px-6 py-3 flex items-center justify-between">
@@ -53,6 +57,17 @@ const PromptEditorHeader: React.FC<PromptEditorHeaderProps> = ({
             {version}
           </span>
         )}
+        <Select
+          value={environment}
+          onChange={onEnvironmentChange}
+          style={{ width: 140 }}
+          size="small"
+          options={[
+            { label: "Development", value: "development" },
+            { label: "Staging", value: "staging" },
+            { label: "Production", value: "production" },
+          ]}
+        />
         <span className="px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded">Draft</span>
         <span className="text-xs text-gray-400">Unsaved changes</span>
       </div>

--- a/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/index.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import ToolModal from "../tool_modal";
 import NotificationsManager from "../../molecules/notifications_manager";
 import { createPromptCall, updatePromptCall, getPromptInfo } from "../../networking";

--- a/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/index.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/index.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import ToolModal from "../tool_modal";
 import NotificationsManager from "../../molecules/notifications_manager";
-import { createPromptCall, updatePromptCall } from "../../networking";
+import { createPromptCall, updatePromptCall, getPromptInfo } from "../../networking";
 import { PromptType, PromptEditorViewProps, Tool } from "./types";
 import { convertToDotPrompt, parseExistingPrompt } from "./utils";
 import PromptEditorHeader from "./PromptEditorHeader";
@@ -39,6 +39,7 @@ const PromptEditorView: React.FC<PromptEditorViewProps> = ({ onClose, onSuccess,
           content: "Enter task specifics. Use {{template_variables}} for dynamic inputs",
         },
       ],
+      environment: "development",
     };
   };
 
@@ -208,6 +209,7 @@ const PromptEditorView: React.FC<PromptEditorViewProps> = ({ onClose, onSuccess,
         },
         prompt_info: {
           prompt_type: "db",
+          environment: prompt.environment,
         },
       };
 
@@ -273,6 +275,23 @@ const PromptEditorView: React.FC<PromptEditorViewProps> = ({ onClose, onSuccess,
           promptModel={prompt.model}
           promptVariables={extractTemplateVariables()}
           accessToken={accessToken}
+          environment={prompt.environment}
+          onEnvironmentChange={async (env) => {
+            setPrompt({ ...prompt, environment: env });
+            if (editMode && accessToken && initialPromptData?.prompt_spec?.prompt_id) {
+              try {
+                const response = await getPromptInfo(accessToken, initialPromptData.prompt_spec.prompt_id, env);
+                if (response?.prompt_spec) {
+                  const loadedPrompt = parseExistingPrompt(response);
+                  setPrompt({ ...loadedPrompt, environment: env });
+                  const versionNum = response.prompt_spec.version || 1;
+                  setActiveVersionId(`${response.prompt_spec.prompt_id}.v${versionNum}`);
+                }
+              } catch {
+                // No version in this environment yet — keep current content, just change env
+              }
+            }
+          }}
         />
 
         <div className="flex-1 flex overflow-hidden">

--- a/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/types.ts
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/types.ts
@@ -20,6 +20,7 @@ export interface PromptType {
   tools: Tool[];
   developerMessage: string;
   messages: Message[];
+  environment: string;
 }
 
 export interface PromptEditorViewProps {

--- a/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/utils.ts
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_editor_view/utils.ts
@@ -246,6 +246,7 @@ export const parseExistingPrompt = (apiResponse: any): PromptType => {
       parsedBody.messages.length > 0
         ? parsedBody.messages
         : [{ role: "user", content: "Enter task specifics. Use {{template_variables}} for dynamic inputs" }],
+    environment: apiResponse?.prompt_spec?.environment || apiResponse?.prompt_spec?.prompt_info?.environment || "development",
   };
 };
 

--- a/ui/litellm-dashboard/src/components/prompts/prompt_info.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_info.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Card,
   Title,
@@ -103,12 +103,22 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
     }
   };
 
+  const isInitialMount = useRef(true);
+
   useEffect(() => {
     fetchPromptInfo();
   }, [promptId, accessToken]);
 
-  // When environment changes, re-fetch prompt info and version history
+  // When environment changes (user clicks tab), re-fetch — skip initial mount
   useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      // Still fetch version history on initial mount once selectedEnv is set
+      if (selectedEnv && accessToken) {
+        fetchVersionHistory(selectedEnv);
+      }
+      return;
+    }
     if (selectedEnv && accessToken) {
       fetchPromptInfo(selectedEnv);
       fetchVersionHistory(selectedEnv);

--- a/ui/litellm-dashboard/src/components/prompts/prompt_info.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_info.tsx
@@ -41,12 +41,6 @@ export interface PromptInfoProps {
   onEdit?: (promptData: any) => void;
 }
 
-const ENV_COLORS: Record<string, string> = {
-  production: "red",
-  staging: "yellow",
-  development: "green",
-};
-
 const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessToken, isAdmin, onDelete, onEdit }) => {
   const [promptData, setPromptData] = useState<PromptSpec | null>(null);
   const [promptTemplate, setPromptTemplate] = useState<PromptTemplateBase | null>(null);
@@ -106,6 +100,9 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
   const isInitialMount = useRef(true);
 
   useEffect(() => {
+    setSelectedEnv(null);
+    setEnvironments([]);
+    setVersionHistory([]);
     fetchPromptInfo();
   }, [promptId, accessToken]);
 

--- a/ui/litellm-dashboard/src/components/prompts/prompt_info.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_info.tsx
@@ -11,19 +11,25 @@ import {
   TabList,
   TabPanel,
   TabPanels,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
 } from "@tremor/react";
 import { Button, Modal } from "antd";
 import { ArrowLeftIcon, TrashIcon, PencilIcon } from "@heroicons/react/outline";
-import { getPromptInfo, PromptSpec, PromptTemplateBase, deletePromptCall } from "@/components/networking";
+import { getPromptInfo, getPromptVersions, PromptSpec, PromptTemplateBase, deletePromptCall } from "@/components/networking";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import NotificationsManager from "../molecules/notifications_manager";
 import PromptCodeSnippets from "./prompt_editor_view/PromptCodeSnippets";
-import { 
-  extractModel, 
-  extractTemplateVariables, 
-  getBasePromptId, 
-  getCurrentVersion 
+import {
+  extractModel,
+  extractTemplateVariables,
+  getBasePromptId,
+  getCurrentVersion
 } from "./prompt_utils";
 
 export interface PromptInfoProps {
@@ -35,6 +41,12 @@ export interface PromptInfoProps {
   onEdit?: (promptData: any) => void;
 }
 
+const ENV_COLORS: Record<string, string> = {
+  production: "red",
+  staging: "yellow",
+  development: "green",
+};
+
 const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessToken, isAdmin, onDelete, onEdit }) => {
   const [promptData, setPromptData] = useState<PromptSpec | null>(null);
   const [promptTemplate, setPromptTemplate] = useState<PromptTemplateBase | null>(null);
@@ -44,14 +56,31 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const fetchPromptInfo = async () => {
+  // Environment and version state
+  const [environments, setEnvironments] = useState<string[]>([]);
+  const [selectedEnv, setSelectedEnv] = useState<string | null>(null);
+  const [versionHistory, setVersionHistory] = useState<PromptSpec[]>([]);
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
+  const [loadingVersions, setLoadingVersions] = useState(false);
+
+  // Initial fetch — no environment filter, gets default + all environments list
+  const fetchPromptInfo = async (environment?: string) => {
     try {
       setLoading(true);
       if (!accessToken) return;
-      const response = await getPromptInfo(accessToken, promptId);
+      const response = await getPromptInfo(accessToken, promptId, environment);
       setPromptData(response.prompt_spec);
       setPromptTemplate(response.raw_prompt_template);
-      setRawApiResponse(response); // Store the raw response for the Raw JSON tab
+      setRawApiResponse(response);
+
+      // Set environments from response
+      if (response.environments && response.environments.length > 0) {
+        setEnvironments(response.environments);
+        if (!selectedEnv) {
+          setSelectedEnv(response.prompt_spec.environment || response.environments[0]);
+        }
+      }
+      setSelectedVersion(response.prompt_spec.version || null);
     } catch (error) {
       NotificationsManager.fromBackend("Failed to load prompt information");
       console.error("Error fetching prompt info:", error);
@@ -60,11 +89,33 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
     }
   };
 
+  // Fetch version history for selected environment
+  const fetchVersionHistory = async (env: string) => {
+    if (!accessToken) return;
+    setLoadingVersions(true);
+    try {
+      const response = await getPromptVersions(accessToken, promptId, env);
+      setVersionHistory(response.prompts || []);
+    } catch {
+      setVersionHistory([]);
+    } finally {
+      setLoadingVersions(false);
+    }
+  };
+
   useEffect(() => {
     fetchPromptInfo();
   }, [promptId, accessToken]);
 
-  if (loading) {
+  // When environment changes, re-fetch prompt info and version history
+  useEffect(() => {
+    if (selectedEnv && accessToken) {
+      fetchPromptInfo(selectedEnv);
+      fetchVersionHistory(selectedEnv);
+    }
+  }, [selectedEnv]);
+
+  if (loading && !promptData) {
     return <div className="p-4">Loading...</div>;
   }
 
@@ -72,7 +123,6 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
     return <div className="p-4">Prompt not found</div>;
   }
 
-  // Format date helper function
   const formatDate = (dateString?: string) => {
     if (!dateString) return "-";
     const date = new Date(dateString);
@@ -95,13 +145,12 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
 
   const handleDeleteConfirm = async () => {
     if (!accessToken || !promptData) return;
-
     setIsDeleting(true);
     try {
       await deletePromptCall(accessToken, basePromptId);
       NotificationsManager.success(`Prompt "${basePromptId}" deleted successfully`);
-      onDelete?.(); // Call the callback to refresh the parent component
-      onClose(); // Close the info view
+      onDelete?.();
+      onClose();
     } catch (error) {
       console.error("Error deleting prompt:", error);
       NotificationsManager.fromBackend("Failed to delete prompt");
@@ -115,10 +164,27 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
     setShowDeleteConfirm(false);
   };
 
-  // Use utility functions to extract prompt data
+  const handleVersionClick = async (version: PromptSpec) => {
+    if (!accessToken || !selectedEnv) return;
+    // Fetch specific version's info
+    const versionNum = version.version || 1;
+    setSelectedVersion(versionNum);
+    try {
+      const versionedId = `${promptId}.v${versionNum}`;
+      const response = await getPromptInfo(accessToken, versionedId, selectedEnv);
+      setPromptData(response.prompt_spec);
+      setPromptTemplate(response.raw_prompt_template);
+      setRawApiResponse(response);
+    } catch {
+      NotificationsManager.fromBackend(`Failed to load version v${versionNum}`);
+    }
+  };
+
   const promptModel = promptData ? extractModel(promptData) || "gpt-4o" : "gpt-4o";
   const basePromptId = getBasePromptId(promptData);
   const currentVersion = getCurrentVersion(promptData);
+  const latestVersion = versionHistory.length > 0 ? Math.max(...versionHistory.map(v => v.version || 1)) : null;
+  const isViewingOldVersion = latestVersion !== null && selectedVersion !== null && selectedVersion < latestVersion;
 
   return (
     <div className="p-4">
@@ -174,32 +240,75 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
         </div>
       </div>
 
+      {/* Environment Tabs */}
+      {environments.length > 0 && (
+        <div className="flex gap-2 mb-4">
+          {[...environments].sort((a, b) => {
+            const order: Record<string, number> = { development: 0, staging: 1, production: 2 };
+            return (order[a] ?? 99) - (order[b] ?? 99);
+          }).map((env) => (
+            <button
+              key={env}
+              onClick={() => {
+                setSelectedEnv(env);
+                setSelectedVersion(null);
+              }}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+                selectedEnv === env
+                  ? env === "production"
+                    ? "bg-red-100 text-red-800 border-2 border-red-300"
+                    : env === "staging"
+                    ? "bg-yellow-100 text-yellow-800 border-2 border-yellow-300"
+                    : "bg-green-100 text-green-800 border-2 border-green-300"
+                  : "bg-gray-100 text-gray-600 border-2 border-transparent hover:bg-gray-200"
+              }`}
+            >
+              {env}
+              {versionHistory.length > 0 && selectedEnv === env && (
+                <span className="ml-1 text-xs opacity-75">
+                  (v{latestVersion})
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Old version banner */}
+      {isViewingOldVersion && (
+        <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-center justify-between">
+          <Text className="text-amber-800">
+            Viewing v{selectedVersion} — not the latest version (v{latestVersion})
+          </Text>
+          <TremorButton
+            variant="light"
+            size="xs"
+            onClick={() => {
+              const latest = versionHistory.find(v => v.version === latestVersion);
+              if (latest) handleVersionClick(latest);
+            }}
+          >
+            Go to latest
+          </TremorButton>
+        </div>
+      )}
+
       <TabGroup>
         <TabList className="mb-4">
           <Tab key="overview">Overview</Tab>
           {promptTemplate ? <Tab key="prompt-template">Prompt Template</Tab> : <></>}
-          {isAdmin ? <Tab key="details">Details</Tab> : <></>}
           <Tab key="raw-json">Raw JSON</Tab>
         </TabList>
 
         <TabPanels>
           {/* Overview Panel */}
           <TabPanel>
-            <Grid numItems={1} numItemsSm={2} numItemsLg={3} className="gap-6">
-              <Card>
-                <Text>Prompt ID</Text>
-                <div className="mt-2">
-                  <Title className="font-mono text-sm">{basePromptId}</Title>
-                </div>
-              </Card>
-
+            <Grid numItems={1} numItemsSm={2} numItemsLg={4} className="gap-4">
               <Card>
                 <Text>Version</Text>
                 <div className="mt-2">
                   <Title>{currentVersion}</Title>
-                  <Badge color="blue" className="mt-1">
-                    v{currentVersion}
-                  </Badge>
+                  <Badge color="blue" className="mt-1">v{currentVersion}</Badge>
                 </div>
               </Card>
 
@@ -207,31 +316,98 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
                 <Text>Prompt Type</Text>
                 <div className="mt-2">
                   <Title>{promptData.prompt_info?.prompt_type || "-"}</Title>
-                  <Badge color="blue" className="mt-1">
-                    {promptData.prompt_info?.prompt_type || "Unknown"}
-                  </Badge>
+                </div>
+              </Card>
+
+              <Card>
+                <Text>Created By</Text>
+                <div className="mt-2">
+                  <Title className="text-sm">{promptData.created_by || "-"}</Title>
                 </div>
               </Card>
 
               <Card>
                 <Text>Created At</Text>
                 <div className="mt-2">
-                  <Title>{formatDate(promptData.created_at)}</Title>
-                  <Text>Last Updated: {formatDate(promptData.updated_at)}</Text>
+                  <Title className="text-sm">{formatDate(promptData.created_at)}</Title>
+                  <Text className="text-xs">Updated: {formatDate(promptData.updated_at)}</Text>
                 </div>
               </Card>
             </Grid>
 
-            {promptData.litellm_params && Object.keys(promptData.litellm_params).length > 0 && (
-              <Card className="mt-6">
-                <Text className="font-medium">LiteLLM Parameters</Text>
-                <div className="mt-2 p-3 bg-gray-50 rounded-md">
-                  <pre className="text-xs text-gray-800 whitespace-pre-wrap">
-                    {JSON.stringify(promptData.litellm_params, null, 2)}
-                  </pre>
-                </div>
-              </Card>
-            )}
+            {/* Version History Table */}
+            <Card className="mt-6">
+              <Title className="mb-3">Version History — {selectedEnv}</Title>
+              {loadingVersions ? (
+                <Text>Loading versions...</Text>
+              ) : versionHistory.length > 0 ? (
+                <Table>
+                  <TableHead>
+                    <TableRow>
+                      <TableHeaderCell>Version</TableHeaderCell>
+                      <TableHeaderCell>Created By</TableHeaderCell>
+                      <TableHeaderCell>Date</TableHeaderCell>
+                      <TableHeaderCell>Actions</TableHeaderCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {versionHistory.map((v) => {
+                      const vNum = v.version || 1;
+                      const isSelected = vNum === selectedVersion;
+                      const isLatest = vNum === latestVersion;
+                      return (
+                        <TableRow
+                          key={vNum}
+                          className={`cursor-pointer hover:bg-blue-50 transition-colors ${
+                            isSelected ? "bg-blue-50" : ""
+                          }`}
+                          onClick={() => handleVersionClick(v)}
+                        >
+                          <TableCell>
+                            <span className={isSelected ? "font-bold" : ""}>
+                              v{vNum}
+                            </span>
+                            {isLatest && (
+                              <Badge color="blue" className="ml-2" size="xs">latest</Badge>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm">{v.created_by || "-"}</span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm">{formatDate(v.created_at)}</span>
+                          </TableCell>
+                          <TableCell>
+                            <TremorButton
+                              icon={PencilIcon}
+                              variant="light"
+                              size="xs"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                // Build a response-like object for the editor
+                                const editData = {
+                                  prompt_spec: {
+                                    ...v,
+                                    prompt_id: basePromptId,
+                                    environment: selectedEnv,
+                                  },
+                                  raw_prompt_template: isSelected ? promptTemplate : null,
+                                };
+                                onEdit?.(editData);
+                              }}
+                            >
+                              Edit
+                            </TremorButton>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              ) : (
+                <Text className="text-gray-400">No versions found in {selectedEnv}</Text>
+              )}
+            </Card>
           </TabPanel>
 
           {/* Prompt Template Panel */}
@@ -278,54 +454,6 @@ const PromptInfoView: React.FC<PromptInfoProps> = ({ promptId, onClose, accessTo
                       </div>
                     </div>
                   )}
-                </div>
-              </Card>
-            </TabPanel>
-          )}
-
-          {/* Details Panel (only for admins) */}
-          {isAdmin && (
-            <TabPanel>
-              <Card>
-                <Title className="mb-4">Prompt Details</Title>
-                <div className="space-y-4">
-                  <div>
-                    <Text className="font-medium">Prompt ID</Text>
-                    <div className="font-mono text-sm bg-gray-50 p-2 rounded">{basePromptId}</div>
-                  </div>
-
-                  <div>
-                    <Text className="font-medium">Prompt Type</Text>
-                    <div>{promptData.prompt_info?.prompt_type || "-"}</div>
-                  </div>
-
-                  <div>
-                    <Text className="font-medium">Created At</Text>
-                    <div>{formatDate(promptData.created_at)}</div>
-                  </div>
-
-                  <div>
-                    <Text className="font-medium">Last Updated</Text>
-                    <div>{formatDate(promptData.updated_at)}</div>
-                  </div>
-
-                  <div>
-                    <Text className="font-medium">LiteLLM Parameters</Text>
-                    <div className="mt-2 p-3 bg-gray-50 rounded-md border">
-                      <pre className="text-xs text-gray-800 whitespace-pre-wrap overflow-auto max-h-96">
-                        {JSON.stringify(promptData.litellm_params, null, 2)}
-                      </pre>
-                    </div>
-                  </div>
-
-                  <div>
-                    <Text className="font-medium">Prompt Info</Text>
-                    <div className="mt-2 p-3 bg-gray-50 rounded-md border">
-                      <pre className="text-xs text-gray-800 whitespace-pre-wrap">
-                        {JSON.stringify(promptData.prompt_info, null, 2)}
-                      </pre>
-                    </div>
-                  </div>
                 </div>
               </Card>
             </TabPanel>

--- a/ui/litellm-dashboard/src/components/prompts/prompt_table.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_table.tsx
@@ -185,6 +185,36 @@ const PromptTable: React.FC<PromptTableProps> = ({
       },
     },
     {
+      header: "Environment",
+      accessorKey: "environment",
+      cell: ({ row }) => {
+        const prompt = row.original;
+        const env = prompt.environment || "development";
+        const colorMap: Record<string, string> = {
+          production: "text-red-600 bg-red-50",
+          staging: "text-yellow-600 bg-yellow-50",
+          development: "text-green-600 bg-green-50",
+        };
+        return (
+          <span className={`text-xs px-2 py-0.5 rounded ${colorMap[env] || "text-gray-600 bg-gray-50"}`}>
+            {env}
+          </span>
+        );
+      },
+    },
+    {
+      header: "Created By",
+      accessorKey: "created_by",
+      cell: ({ row }) => {
+        const prompt = row.original;
+        return (
+          <span className="text-xs text-gray-600">
+            {prompt.created_by || "-"}
+          </span>
+        );
+      },
+    },
+    {
       header: "Type",
       accessorKey: "prompt_info.prompt_type",
       cell: ({ row }) => {


### PR DESCRIPTION
  ## Relevant issues                                                                                 
                                                                                                     
  Fixes #24854                                               
                                                                                                     
  ## Pre-Submission checklist                                                                        
                                                                                                     
  - [x] I have Added testing in the                                                                  
  [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory,
   **Adding at least 1 test is a hard requirement** - [see                                           
  details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] My PR passes all unit tests on [`make
  test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)                                 
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence   
  Score of at least 4/5** before requesting a maintainer review                                      
                                                                                                     
  ## Delays in PR merge?                                                                             
                                                            
  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](htt
  ps://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).
                                                                                                     
  ## CI (LiteLLM team)                                                                               
  
  > **CI status guideline:**                                                                         
  >                                                         
  > - 50-55 passing tests: main is stable with minor issues.                                         
  > - 45-49 passing tests: acceptable but needs attention                                            
  > - <= 40 passing tests: unstable; be careful with your merges and assess the risk.                
                                                                                                     
  - [ ] **Branch creation CI run**                                                                   
         Link:                                                                                       
                                                                                                     
  - [ ] **CI run for the last commit**                                                               
         Link:                                                                                       
                                                                                                     
  - [ ] **Merge / cherry-pick CI run**                                                               
         Links:
                                                                                                     
  ## Type                                                                                            
  
  🆕 New Feature                                                                                     
                                                            
  ## Changes                                                                                         
                                                            
  ### Database                                                                                       
  - Add `environment` (String, default `"development"`) and `created_by` (String, nullable) columns
  to `LiteLLM_PromptTable`                                                                           
  - Change unique constraint from `[prompt_id, version]` to `[prompt_id, version, environment]`
  - Add index on `[prompt_id, environment]`                                                          
  - Prisma migration included — backfills existing rows with `environment = 'development'`           
                                                                                                     
  ### Backend (`litellm/proxy/prompts/prompt_endpoints.py`)                                          
  - All CRUD endpoints support optional `environment` query/body parameter                           
  - `created_by` set automatically from authenticated user on create/update                          
  - `get_prompt_info` and `get_prompt_versions` query DB for environment-specific data               
  - `PromptInfoResponse` includes `environments` field listing all environments a prompt is deployed 
  to                                                                                                 
  - Supports fetching specific version via versioned prompt_id (e.g.,                                
  `testprompt.v2?environment=staging`)                                                               
                                                            
  ### UI                                                                                             
  - **Prompt list**: Environment filter dropdown, Environment and Created By columns
  - **Prompt detail**: Environment tabs (development/staging/production) that switch the entire view,
   version history table with Created By and Edit action per row, old-version banner                 
  - **Prompt editor**: Environment selector dropdown, switching environments re-fetches correct      
  version     

                                
**Before**                                                       
 <img width="2208" height="1258" alt="image" src="https://github.com/user-attachments/assets/79b613a8-d508-4d43-855d-a597e9ed1bd1" />

**After**
<img width="2208" height="1258" alt="image" src="https://github.com/user-attachments/assets/07883ce4-20fe-49f1-8a39-ed5def44c027" />

                                                           
  ### Tests (`tests/test_litellm/proxy/prompts/test_prompt_environment.py`)                          
  - 8 new tests covering: model defaults, custom environments, create/update with
  environment+created_by, delete scoped to environment, versioned prompt spec creation 