### PR TITLE
fix(gemini): filter out thought=true image parts in LiteLLM vertex parser

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1431,6 +1431,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         """Extract image response from parts if present"""
         images: List[ImageURLListItem] = []
         for part in parts:
+            if isinstance(part, dict) and part.get("thought") is True:
+                continue
             if "inlineData" in part:
                 inline_data = part.get("inlineData", {})
                 mime_type = inline_data.get("mimeType", "")


### PR DESCRIPTION
## Background

When using Gemini image-preview models (e.g. gemini-3.x-flash-image-preview),
the model may generate intermediate images as part of its reasoning process.
These intermediate outputs are marked with `"thought": true` in the response.

LiteLLM currently extracts all `inlineData` image parts without filtering
these reasoning artifacts, which causes multiple images to be returned in
the final response.

## Root Cause

In `vertex_and_google_ai_studio_gemini.py`,
`_extract_image_response_from_parts()` iterates over all parts and collects
image data whenever `inlineData` is present, without checking the `thought` flag.

As a result, both:
- final output images
- intermediate reasoning images (`thought=true`)

are included in the response.

## Fix

Added a filter to skip parts where:

```python
isinstance(part, dict) and part.get("thought") is True