### PR TITLE
feat(bedrock): add nova canvas image edit support

### DIFF
--- a/docs/my-website/docs/providers/bedrock_image_gen.md
+++ b/docs/my-website/docs/providers/bedrock_image_gen.md
@@ -111,6 +111,29 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/images/generations' \
 </TabItem>
 </Tabs>
 
+## Amazon Nova Canvas - Image Edit
+
+Use OpenAI-compatible `image_edit()` with Bedrock Nova Canvas (`amazon.nova-canvas-v1:0`). Requests use the same `InvokeModel` API as generation; LiteLLM maps inputs to [Nova Canvas task types](https://docs.aws.amazon.com/nova/latest/userguide/image-gen-access.html):
+
+| Scenario | `taskType` sent to Bedrock |
+|----------|----------------------------|
+| Image + prompt (no mask) | `IMAGE_VARIATION` |
+| Image + prompt + mask | `INPAINTING` (`inPaintingParams.image`, `maskImage` or `maskPrompt`) |
+| `taskType: OUTPAINTING` + `mask` or `maskPrompt` | `OUTPAINTING` (Bedrock requires one; LiteLLM raises a clear error if both are missing) |
+| `taskType: BACKGROUND_REMOVAL` | `BACKGROUND_REMOVAL` |
+
+```python
+from litellm import image_edit
+
+response = image_edit(
+    image=open("photo.png", "rb"),
+    prompt="Add soft sunset lighting",
+    model="bedrock/amazon.nova-canvas-v1:0",
+)
+```
+
+For **`BACKGROUND_REMOVAL`**, the AWS request must not include `imageGenerationConfig`; LiteLLM omits it for that task even if you pass `size`, `n`, `seed`, etc. Additional Nova Canvas inference IDs for image edit should set **`supports_nova_canvas_image_edit`: true** in `model_prices_and_context_window.json` (see `amazon.nova-canvas-v1:0`).
+
 ## Using Inference Profiles with Image Generation
 
 For AWS Bedrock Application Inference Profiles with image generation, use the `model_id` parameter to specify the inference profile ARN:
@@ -147,4 +170,3 @@ model_list:
 ## Authentication
 
 All standard Bedrock authentication methods are supported for image generation. See [Bedrock Authentication](./bedrock#boto3---authentication) for details.
-

--- a/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
+++ b/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
@@ -13,6 +13,7 @@ Refs:
 from __future__ import annotations
 
 import base64
+import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import httpx
@@ -140,6 +141,9 @@ def _file_types_to_b64(image: Optional[FileTypes]) -> str:
         return base64.b64encode(image).decode("utf-8")
     if isinstance(image, str):
         return image
+    if isinstance(image, os.PathLike):
+        with open(image, "rb") as f:
+            return base64.b64encode(f.read()).decode("utf-8")
     if isinstance(image, tuple):
         raise ValueError(
             "Nova Canvas image edit does not support tuple FileTypes. "

--- a/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
+++ b/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
@@ -1,0 +1,511 @@
+"""
+Amazon Nova Canvas image edit on Bedrock (InvokeModel).
+
+Maps OpenAI-style image edit (image + prompt, optional mask) to Nova Canvas task types:
+- With mask: INPAINTING (inPaintingParams per AWS docs)
+- Without mask: IMAGE_VARIATION (imageVariationParams)
+
+Refs:
+- https://docs.aws.amazon.com/nova/latest/userguide/image-gen-access.html
+- https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import httpx
+
+from litellm._logging import verbose_logger
+from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
+from litellm.types.images.main import ImageEditOptionalRequestParams
+from litellm.types.router import GenericLiteLLMParams
+from litellm.types.utils import FileTypes, ImageObject, ImageResponse
+from litellm.utils import (
+    _get_model_cost_key,
+    _get_potential_model_names,
+    get_model_info,
+)
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+def _nova_canvas_task_body(
+    *,
+    image_b64: str,
+    mask_b64: Optional[str],
+    text: str,
+    negative_text: Optional[str],
+    similarity_strength: Optional[float],
+    task_type: Optional[str],
+    mask_prompt: Optional[str],
+    out_painting_mode: Optional[str],
+) -> Dict[str, Any]:
+    """Build InvokeModel body task section (without imageGenerationConfig)."""
+    if task_type == "BACKGROUND_REMOVAL":
+        return {
+            "taskType": "BACKGROUND_REMOVAL",
+            "backgroundRemovalParams": {"image": image_b64},
+        }
+    if task_type == "OUTPAINTING":
+        if mask_prompt is None and mask_b64 is None:
+            raise ValueError(
+                "OUTPAINTING requires either a mask image or a mask prompt. "
+                "Pass mask=<file> or maskPrompt=<str> in the request."
+            )
+        out_params: Dict[str, Any] = {
+            "image": image_b64,
+            "text": text,
+        }
+        if mask_prompt is not None:
+            out_params["maskPrompt"] = mask_prompt
+        elif mask_b64 is not None:
+            out_params["maskImage"] = mask_b64
+        if negative_text is not None:
+            out_params["negativeText"] = negative_text
+        if out_painting_mode is not None:
+            out_params["outPaintingMode"] = out_painting_mode
+        return {
+            "taskType": "OUTPAINTING",
+            "outPaintingParams": out_params,
+        }
+    # Honour explicit IMAGE_VARIATION even when a mask is present (mask is ignored
+    # for this task type; callers use INPAINTING when they want mask semantics).
+    if task_type == "IMAGE_VARIATION":
+        var_params_explicit: Dict[str, Any] = {
+            "images": [image_b64],
+            "text": text,
+        }
+        if negative_text is not None:
+            var_params_explicit["negativeText"] = negative_text
+        if similarity_strength is not None:
+            var_params_explicit["similarityStrength"] = similarity_strength
+        return {
+            "taskType": "IMAGE_VARIATION",
+            "imageVariationParams": var_params_explicit,
+        }
+    # Explicit taskType must be INPAINTING or omitted from here on; anything else is invalid.
+    if task_type is not None and str(task_type).strip() != "":
+        if task_type != "INPAINTING":
+            raise ValueError(
+                f"Unsupported Amazon Nova Canvas taskType: {task_type!r}. "
+                "Use BACKGROUND_REMOVAL, OUTPAINTING, IMAGE_VARIATION, INPAINTING, "
+                "or omit taskType for automatic routing (mask → INPAINTING, else IMAGE_VARIATION)."
+            )
+    if mask_b64 is not None or mask_prompt is not None or task_type == "INPAINTING":
+        in_params: Dict[str, Any] = {"image": image_b64, "text": text}
+        if mask_prompt is not None:
+            in_params["maskPrompt"] = mask_prompt
+        elif mask_b64 is not None:
+            in_params["maskImage"] = mask_b64
+        if negative_text is not None:
+            in_params["negativeText"] = negative_text
+        if "maskPrompt" not in in_params and "maskImage" not in in_params:
+            raise ValueError(
+                "Amazon Nova Canvas INPAINTING requires either maskPrompt or maskImage "
+                "(use OpenAI mask= for maskImage, or pass maskPrompt in optional params). "
+                "See https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html"
+            )
+        return {"taskType": "INPAINTING", "inPaintingParams": in_params}
+    var_params: Dict[str, Any] = {
+        "images": [image_b64],
+        "text": text,
+    }
+    if negative_text is not None:
+        var_params["negativeText"] = negative_text
+    if similarity_strength is not None:
+        var_params["similarityStrength"] = similarity_strength
+    return {
+        "taskType": "IMAGE_VARIATION",
+        "imageVariationParams": var_params,
+    }
+
+
+def _file_types_to_b64(image: Optional[FileTypes]) -> str:
+    """Encode OpenAI image input to base64 string for Nova Canvas."""
+    if image is None:
+        raise ValueError("Nova Canvas image edit requires an image input")
+    if hasattr(image, "read") and callable(getattr(image, "read", None)):
+        if hasattr(image, "seek"):
+            image.seek(0)  # type: ignore[union-attr]
+        image_bytes = image.read()  # type: ignore[union-attr]
+        return base64.b64encode(image_bytes).decode("utf-8")
+    if isinstance(image, bytes):
+        return base64.b64encode(image).decode("utf-8")
+    if isinstance(image, str):
+        return image
+    if isinstance(image, tuple):
+        raise ValueError(
+            "Nova Canvas image edit does not support tuple FileTypes. "
+            "Pass a file-like object, bytes, or a base64-encoded string."
+        )
+    return base64.b64encode(bytes(image)).decode("utf-8")  # type: ignore[arg-type]
+
+
+def _supports_nova_canvas_image_edit_from_model_cost(model: str) -> bool:
+    """
+    True when model_cost has supports_nova_canvas_image_edit for a resolved catalog key.
+
+    get_model_info / ModelInfoBase omit arbitrary JSON keys, so we read model_cost
+    directly (same idea as supports_* bare_entry fallback).
+    """
+    import litellm as _litellm
+
+    if not model:
+        return False
+
+    seen: set[str] = set()
+    candidates: List[str] = []
+
+    def _add(name: Optional[str]) -> None:
+        if name and name not in seen:
+            seen.add(name)
+            candidates.append(name)
+
+    _add(model)
+    if "/" in model:
+        suffix = model.split("/")[-1]
+        _add(suffix)
+        _add(f"bedrock/{suffix}")
+
+    # Cross-region inference ids (e.g. us.amazon.nova-canvas-v1:0) share pricing with
+    # the base model id (amazon.nova-canvas-v1:0) in model_cost.
+    try:
+        from litellm.llms.bedrock.common_utils import BedrockModelInfo
+
+        base_model = BedrockModelInfo.get_base_model(model)
+        if base_model and base_model != model:
+            _add(base_model)
+            _add(f"bedrock/{base_model}")
+    except Exception:
+        pass
+
+    try:
+        potential = _get_potential_model_names(model=model, custom_llm_provider=None)
+        for field in (
+            "combined_model_name",
+            "combined_stripped_model_name",
+            "stripped_model_name",
+            "split_model",
+        ):
+            raw = potential.get(field)
+            if isinstance(raw, str):
+                _add(raw)
+    except Exception:
+        pass
+
+    for name in candidates:
+        key = _get_model_cost_key(name)
+        if key is None:
+            continue
+        entry = _litellm.model_cost.get(key) or {}
+        if entry.get("supports_nova_canvas_image_edit") is True:
+            return True
+    return False
+
+
+class BedrockAmazonNovaCanvasImageEditConfig(BaseImageEditConfig):
+    """
+    Bedrock InvokeModel image edit for amazon.nova-canvas-v1:0 and regional variants.
+    """
+
+    @classmethod
+    def _is_nova_canvas_image_edit_model(cls, model: Optional[str] = None) -> bool:
+        """
+        Use model_cost.supports_nova_canvas_image_edit so new Nova Canvas inference IDs
+        are added via model_prices_and_context_window.json only (not get_model_info, which
+        drops keys not on ModelInfoBase).
+        """
+        return _supports_nova_canvas_image_edit_from_model_cost(model or "")
+
+    def get_supported_openai_params(self, model: str) -> list:
+        return [
+            "n",
+            "size",
+            "response_format",
+            "mask",
+            "negativeText",
+            "similarityStrength",
+            "cfgScale",
+            "seed",
+            "quality",
+            "taskType",
+            "maskPrompt",
+            "outPaintingMode",
+            "imageGenerationConfig",
+        ]
+
+    def map_openai_params(
+        self,
+        image_edit_optional_params: ImageEditOptionalRequestParams,
+        model: str,
+        drop_params: bool,
+    ) -> Dict[str, Any]:
+        supported = set(self.get_supported_openai_params(model))
+        mapped: Dict[str, Any] = dict(image_edit_optional_params)
+        _size = mapped.pop("size", None)
+        if _size is not None and isinstance(_size, str) and "x" in _size:
+            w, h = _size.split("x", 1)
+            try:
+                mapped["width"], mapped["height"] = int(w), int(h)
+            except ValueError:
+                pass
+        _n = mapped.pop("n", None)
+        if _n is not None:
+            mapped["numberOfImages"] = _n
+        _quality = mapped.pop("quality", None)
+        if _quality is not None:
+            if _quality in ("hd", "premium"):
+                mapped["quality"] = "premium"
+            elif _quality == "standard":
+                mapped["quality"] = "standard"
+            else:
+                # Re-emit unknown values (e.g. OpenAI "auto") so transform_image_edit_request
+                # forwards them and the API can reject, or drop_params can still apply upstream.
+                mapped["quality"] = _quality
+        # Accepted for OpenAI compatibility but ignored for Nova Canvas image edit;
+        # Bedrock returns base64 images only (no URL mode).
+        response_format = mapped.pop("response_format", None)
+        if response_format not in (None, "b64_json"):
+            verbose_logger.debug(
+                "Nova Canvas image edit ignores response_format=%s and returns base64 images",
+                response_format,
+            )
+        # Drop unknown keys if drop_params
+        if drop_params:
+            for k in list(mapped.keys()):
+                if k.startswith("_"):
+                    continue
+                if k not in supported and k not in (
+                    "width",
+                    "height",
+                    "numberOfImages",
+                    "mask",
+                ):
+                    mapped.pop(k, None)
+        return mapped
+
+    def transform_image_edit_request(
+        self,
+        model: str,
+        prompt: Optional[str],
+        image: Optional[FileTypes],
+        image_edit_optional_request_params: Dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Tuple[Dict, Any]:
+        op = dict(image_edit_optional_request_params)
+        image_b64 = _file_types_to_b64(image)
+
+        mask_raw = op.pop("mask", None)
+        mask_b64: Optional[str] = None
+        if mask_raw is not None:
+            mask_b64 = _file_types_to_b64(mask_raw)  # type: ignore[arg-type]
+
+        _size = op.pop("size", None)
+        width = op.pop("width", None)
+        height = op.pop("height", None)
+        if (
+            width is None
+            and height is None
+            and _size is not None
+            and isinstance(_size, str)
+            and "x" in _size
+        ):
+            w, h = _size.split("x", 1)
+            try:
+                width, height = int(w), int(h)
+            except ValueError:
+                pass
+
+        number_of_images = op.pop("numberOfImages", None)
+        quality = op.pop("quality", None)
+        cfg_scale = op.pop("cfgScale", None)
+        seed = op.pop("seed", None)
+
+        image_generation_config: Dict[str, Any] = {}
+        nested_igc = op.pop("imageGenerationConfig", None)
+        if isinstance(nested_igc, dict):
+            image_generation_config.update(nested_igc)
+        if width is not None:
+            image_generation_config["width"] = width
+        if height is not None:
+            image_generation_config["height"] = height
+        if number_of_images is not None:
+            image_generation_config["numberOfImages"] = number_of_images
+        if quality is not None:
+            image_generation_config["quality"] = quality
+        if cfg_scale is not None:
+            image_generation_config["cfgScale"] = cfg_scale
+        if seed is not None:
+            image_generation_config["seed"] = seed
+
+        task_type = op.pop("taskType", None)
+        if (prompt is None or prompt == "") and task_type in (
+            "INPAINTING",
+            "OUTPAINTING",
+        ):
+            raise ValueError(
+                f"Amazon Nova Canvas {task_type} requires a text prompt. "
+                "Pass a non-empty `prompt` in your request."
+            )
+        text = prompt if prompt is not None and prompt != "" else " "
+        negative_text = op.pop("negativeText", None)
+        similarity_strength = op.pop("similarityStrength", None)
+        mask_prompt = op.pop("maskPrompt", None)
+        out_painting_mode = op.pop("outPaintingMode", None)
+
+        body = _nova_canvas_task_body(
+            image_b64=image_b64,
+            mask_b64=mask_b64,
+            text=text,
+            negative_text=negative_text,
+            similarity_strength=similarity_strength,
+            task_type=task_type,
+            mask_prompt=mask_prompt,
+            out_painting_mode=out_painting_mode,
+        )
+
+        # BACKGROUND_REMOVAL InvokeModel body must not include imageGenerationConfig (AWS rejects it).
+        if image_generation_config and body.get("taskType") != "BACKGROUND_REMOVAL":
+            body["imageGenerationConfig"] = image_generation_config
+
+        return body, {}
+
+    def transform_image_edit_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ImageResponse:
+        try:
+            response_data = raw_response.json()
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=f"Error parsing Nova Canvas image edit response: {e}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        if raw_response.status_code not in (200,):
+            raise self.get_error_class(
+                error_message=f"Nova Canvas image edit error: {response_data}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        images: List[str] = response_data.get("images") or []
+
+        if "errors" in response_data and not images:
+            raise self.get_error_class(
+                error_message=f"Nova Canvas image edit error: {response_data['errors']}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        # Nova Canvas InvokeModel success body uses "images" and optional "error" (AWS docs);
+        # it does not use Stability-style "finish_reasons".
+        error_msg = response_data.get("message") or response_data.get("error")
+        if error_msg and not images:
+            if not isinstance(error_msg, str):
+                error_msg = str(error_msg)
+            raise self.get_error_class(
+                error_message=f"Nova Canvas image edit error: {error_msg}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        model_response = ImageResponse()
+        model_response.data = []
+        for image_b64 in images:
+            if image_b64:
+                model_response.data.append(
+                    ImageObject(
+                        b64_json=image_b64,
+                        url=None,
+                        revised_prompt=None,
+                    )
+                )
+
+        if not model_response.data:
+            raise self.get_error_class(
+                error_message="Nova Canvas image edit returned no images",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        if not hasattr(model_response, "_hidden_params"):
+            model_response._hidden_params = {}
+        if "additional_headers" not in model_response._hidden_params:
+            model_response._hidden_params["additional_headers"] = {}
+
+        try:
+            model_info = get_model_info(model, custom_llm_provider="bedrock")
+            cost_per_image = model_info.get("output_cost_per_image", 0)
+            if cost_per_image is not None and model_response.data:
+                model_response._hidden_params["additional_headers"][
+                    "llm_provider-x-litellm-response-cost"
+                ] = float(cost_per_image) * len(model_response.data)
+        except Exception:
+            pass
+
+        return model_response
+
+    def use_multipart_form_data(self) -> bool:
+        return False
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: Optional[str],
+        litellm_params: dict,
+    ) -> str:
+        raise NotImplementedError(
+            "Nova Canvas image edit URLs are built in BedrockImageEdit._prepare_request "
+            "(AWS runtime endpoint + model invoke path). Do not use get_complete_url for "
+            "this config."
+        )
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: Optional[str] = None,
+    ) -> dict:
+        if headers is None:
+            headers = {}
+        if "Content-Type" not in headers:
+            headers["Content-Type"] = "application/json"
+        return headers
+
+
+def get_bedrock_image_edit_config_for_model(
+    model: str,
+) -> BaseImageEditConfig:
+    """
+    Return the correct Bedrock image-edit config for the model id.
+
+    Same routing as ``BedrockImageEdit.get_config_class``: Stability edit models,
+    Nova Canvas when marked in model_cost; otherwise raises ``ValueError``.
+    """
+    from litellm.llms.bedrock.image_edit.stability_transformation import (
+        BedrockStabilityImageEditConfig,
+    )
+
+    if BedrockStabilityImageEditConfig._is_stability_edit_model(model):
+        return BedrockStabilityImageEditConfig()
+    if BedrockAmazonNovaCanvasImageEditConfig._is_nova_canvas_image_edit_model(model):
+        return BedrockAmazonNovaCanvasImageEditConfig()
+    raise ValueError(
+        f"Unsupported Bedrock image-edit model: {model!r}. "
+        "Use a stability.* image-edit model id or add supports_nova_canvas_image_edit "
+        "in model_prices for this id."
+    )

--- a/litellm/llms/bedrock/image_edit/handler.py
+++ b/litellm/llms/bedrock/image_edit/handler.py
@@ -15,6 +15,9 @@ from pydantic import BaseModel
 import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+from litellm.llms.bedrock.image_edit.amazon_nova_canvas_image_edit_transformation import (
+    BedrockAmazonNovaCanvasImageEditConfig,
+)
 from litellm.llms.bedrock.image_edit.stability_transformation import (
     BedrockStabilityImageEditConfig,
 )
@@ -55,8 +58,15 @@ class BedrockImageEdit(BaseAWSLLM):
     def get_config_class(cls, model: str | None):
         if BedrockStabilityImageEditConfig._is_stability_edit_model(model):
             return BedrockStabilityImageEditConfig
-        else:
-            raise ValueError(f"Unsupported model for bedrock image edit: {model}")
+        if BedrockAmazonNovaCanvasImageEditConfig._is_nova_canvas_image_edit_model(
+            model
+        ):
+            return BedrockAmazonNovaCanvasImageEditConfig
+        raise ValueError(
+            f"Unsupported Bedrock image-edit model: {model!r}. "
+            "Use a stability.* image-edit model id or add supports_nova_canvas_image_edit "
+            "in model_prices for this id."
+        )
 
     def image_edit(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -277,7 +277,15 @@
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
-        "output_cost_per_image": 0.06
+        "output_cost_per_image": 0.06,
+        "supports_nova_canvas_image_edit": true
+    },
+    "us.amazon.nova-canvas-v1:0": {
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 2600,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.06,
+        "supports_nova_canvas_image_edit": true
     },
     "us.writer.palmyra-x4-v1:0": {
         "input_cost_per_token": 2.5e-06,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9034,11 +9034,11 @@ class ProviderConfigManager:
 
             return get_stability_image_edit_config(model)
         elif LlmProviders.BEDROCK == provider:
-            from litellm.llms.bedrock.image_edit.stability_transformation import (
-                BedrockStabilityImageEditConfig,
+            from litellm.llms.bedrock.image_edit.amazon_nova_canvas_image_edit_transformation import (
+                get_bedrock_image_edit_config_for_model,
             )
 
-            return BedrockStabilityImageEditConfig()
+            return get_bedrock_image_edit_config_for_model(model)
         elif LlmProviders.OPENROUTER == provider:
             from litellm.llms.openrouter.image_edit import (
                 get_openrouter_image_edit_config,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -277,7 +277,15 @@
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
-        "output_cost_per_image": 0.06
+        "output_cost_per_image": 0.06,
+        "supports_nova_canvas_image_edit": true
+    },
+    "us.amazon.nova-canvas-v1:0": {
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 2600,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.06,
+        "supports_nova_canvas_image_edit": true
     },
     "us.writer.palmyra-x4-v1:0": {
         "input_cost_per_token": 2.5e-06,

--- a/tests/test_litellm/llms/bedrock/image_edit/test_amazon_nova_canvas_image_edit.py
+++ b/tests/test_litellm/llms/bedrock/image_edit/test_amazon_nova_canvas_image_edit.py
@@ -1,0 +1,634 @@
+"""Unit tests for Bedrock Amazon Nova Canvas image edit (issue #24267)."""
+
+import io
+from typing import cast
+
+import httpx
+import pytest
+
+import litellm
+from litellm.llms.bedrock.image_edit.amazon_nova_canvas_image_edit_transformation import (
+    BedrockAmazonNovaCanvasImageEditConfig,
+    get_bedrock_image_edit_config_for_model,
+)
+from litellm.llms.bedrock.image_edit.handler import BedrockImageEdit
+from litellm.llms.bedrock.image_edit.stability_transformation import (
+    BedrockStabilityImageEditConfig,
+)
+from litellm.types.images.main import ImageEditOptionalRequestParams
+
+
+@pytest.fixture(autouse=True)
+def ensure_nova_canvas_image_edit_model_cost_flags(monkeypatch):
+    """Routing uses ``supports_nova_canvas_image_edit`` on ``litellm.model_cost``.
+
+    Full ``model_prices_and_context_window.json`` includes these flags, but CI or
+    alternate cost maps may omit them—merge minimal entries so tests match production.
+    """
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    for key in (
+        "amazon.nova-canvas-v1:0",
+        "us.amazon.nova-canvas-v1:0",
+    ):
+        entry = litellm.model_cost.get(key) or {}
+        if entry.get("supports_nova_canvas_image_edit") is True:
+            continue
+        monkeypatch.setitem(
+            litellm.model_cost,
+            key,
+            {
+                **entry,
+                "litellm_provider": entry.get("litellm_provider", "bedrock"),
+                "mode": entry.get("mode", "image_generation"),
+                "supports_nova_canvas_image_edit": True,
+            },
+        )
+        _invalidate_model_cost_lowercase_map()
+
+    yield
+
+    _invalidate_model_cost_lowercase_map()
+
+
+def test_get_config_class_nova_canvas():
+    """Nova Canvas model resolves to BedrockAmazonNovaCanvasImageEditConfig."""
+    cls = BedrockImageEdit.get_config_class("amazon.nova-canvas-v1:0")
+    assert cls is BedrockAmazonNovaCanvasImageEditConfig
+
+
+def test_get_config_class_us_cross_region_nova_canvas():
+    """Cross-region inference id us.amazon.nova-canvas-v1:0 maps via model_prices."""
+    cls = BedrockImageEdit.get_config_class("us.amazon.nova-canvas-v1:0")
+    assert cls is BedrockAmazonNovaCanvasImageEditConfig
+
+
+def test_get_config_class_stability_unchanged():
+    """Stability edit models still use stability config."""
+    cls = BedrockImageEdit.get_config_class(
+        "stability.stable-image-inpaint-v1:0",
+    )
+    assert cls is BedrockStabilityImageEditConfig
+
+
+def test_provider_config_router_returns_nova_for_canvas():
+    """ProviderConfigManager routes Nova Canvas to Nova image-edit config."""
+    cfg = get_bedrock_image_edit_config_for_model("amazon.nova-canvas-v1:0")
+    assert isinstance(cfg, BedrockAmazonNovaCanvasImageEditConfig)
+
+
+def test_provider_config_router_returns_stability_for_sd():
+    """Non-Nova Bedrock image edit still uses Stability config."""
+    cfg = get_bedrock_image_edit_config_for_model(
+        "stability.stable-image-inpaint-v1:0",
+    )
+    assert isinstance(cfg, BedrockStabilityImageEditConfig)
+
+
+def test_get_bedrock_helper_matches_handler_get_config_class():
+    """Handler and get_bedrock_image_edit_config_for_model must agree."""
+    for model in (
+        "amazon.nova-canvas-v1:0",
+        "stability.stable-image-inpaint-v1:0",
+    ):
+        handler_cls = BedrockImageEdit.get_config_class(model)
+        helper_cfg = get_bedrock_image_edit_config_for_model(model)
+        assert isinstance(helper_cfg, handler_cls)
+
+
+def test_get_config_class_unknown_bedrock_image_model_raises():
+    with pytest.raises(ValueError, match="Unsupported Bedrock image-edit model"):
+        BedrockImageEdit.get_config_class("amazon.titan-image-generator-v1")
+
+
+def test_get_bedrock_image_edit_config_unknown_raises():
+    with pytest.raises(ValueError, match="Unsupported Bedrock image-edit model"):
+        get_bedrock_image_edit_config_for_model("amazon.titan-image-generator-v1")
+
+
+def test_provider_config_manager_bedrock_nova_canvas():
+    """ProviderConfigManager.get_provider_image_edit_config matches handler routing."""
+    from litellm.utils import ProviderConfigManager
+
+    cfg = ProviderConfigManager.get_provider_image_edit_config(
+        "amazon.nova-canvas-v1:0",
+        litellm.LlmProviders.BEDROCK,
+    )
+    assert isinstance(cfg, BedrockAmazonNovaCanvasImageEditConfig)
+
+
+def test_provider_config_manager_bedrock_stability_inpaint():
+    """ProviderConfigManager returns Stability config for Stability edit models."""
+    from litellm.utils import ProviderConfigManager
+
+    cfg = ProviderConfigManager.get_provider_image_edit_config(
+        "stability.stable-image-inpaint-v1:0",
+        litellm.LlmProviders.BEDROCK,
+    )
+    assert isinstance(cfg, BedrockStabilityImageEditConfig)
+
+
+def test_provider_config_manager_bedrock_unknown_raises():
+    from litellm.utils import ProviderConfigManager
+
+    with pytest.raises(ValueError, match="Unsupported Bedrock image-edit model"):
+        ProviderConfigManager.get_provider_image_edit_config(
+            "amazon.titan-image-generator-v1",
+            litellm.LlmProviders.BEDROCK,
+        )
+
+
+def test_provider_config_manager_bedrock_dispatches_to_nova_transform_outpainting():
+    """
+    Full dispatch: utils.ProviderConfigManager -> get_bedrock_image_edit_config_for_model
+    -> Nova config.transform_image_edit_request (not only direct helper calls).
+    """
+    from litellm.utils import ProviderConfigManager
+
+    cfg = ProviderConfigManager.get_provider_image_edit_config(
+        "amazon.nova-canvas-v1:0",
+        litellm.LlmProviders.BEDROCK,
+    )
+    assert cfg is not None
+    img = io.BytesIO(b"scene")
+    mask = io.BytesIO(b"mask-bytes")
+    body, _ = cfg.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="expand left",
+        image=img,
+        image_edit_optional_request_params={
+            "taskType": "OUTPAINTING",
+            "mask": mask,
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "OUTPAINTING"
+    assert "maskImage" in body["outPaintingParams"]
+
+
+def test_transform_request_image_variation_without_mask():
+    """No mask -> IMAGE_VARIATION with images + text."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"fake-png")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="make it warmer",
+        image=img,
+        image_edit_optional_request_params={},
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "IMAGE_VARIATION"
+    assert body["imageVariationParams"]["text"] == "make it warmer"
+    assert len(body["imageVariationParams"]["images"]) == 1
+
+
+def test_transform_request_inpainting_with_mask():
+    """Mask present -> INPAINTING with inPaintingParams (AWS field names)."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    main = io.BytesIO(b"img-bytes")
+    mask = io.BytesIO(b"mask-bytes")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="add a hat",
+        image=main,
+        image_edit_optional_request_params={"mask": mask},
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "INPAINTING"
+    ip = body["inPaintingParams"]
+    assert ip["text"] == "add a hat"
+    assert "maskImage" in ip
+    assert ip["image"]  # base64
+
+
+def test_transform_request_explicit_image_variation_with_mask_honors_task_type():
+    """Explicit taskType=IMAGE_VARIATION must not be overridden by mask presence."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    main = io.BytesIO(b"img-bytes")
+    mask = io.BytesIO(b"mask-bytes")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="vary style",
+        image=main,
+        image_edit_optional_request_params={
+            "taskType": "IMAGE_VARIATION",
+            "mask": mask,
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "IMAGE_VARIATION"
+    assert "imageVariationParams" in body
+    assert body["imageVariationParams"]["text"] == "vary style"
+    assert len(body["imageVariationParams"]["images"]) == 1
+
+
+def test_transform_request_outpainting_with_mask():
+    """OUTPAINTING with OpenAI mask -> outPaintingParams.maskImage."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    main = io.BytesIO(b"img")
+    mask = io.BytesIO(b"mask")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="extend the sky",
+        image=main,
+        image_edit_optional_request_params={
+            "taskType": "OUTPAINTING",
+            "mask": mask,
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "OUTPAINTING"
+    assert "maskImage" in body["outPaintingParams"]
+    assert body["outPaintingParams"]["text"] == "extend the sky"
+
+
+def test_transform_request_outpainting_with_mask_prompt():
+    """OUTPAINTING with maskPrompt only (no binary mask)."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"img")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="new background",
+        image=img,
+        image_edit_optional_request_params={
+            "taskType": "OUTPAINTING",
+            "maskPrompt": "the area behind the subject",
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "OUTPAINTING"
+    assert body["outPaintingParams"]["maskPrompt"] == "the area behind the subject"
+
+
+def test_transform_request_outpainting_prefers_mask_prompt_over_binary_mask():
+    """OUTPAINTING chooses maskPrompt over maskImage when both are set (_nova_canvas_task_body)."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    main = io.BytesIO(b"img")
+    mask = io.BytesIO(b"mask")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="extend scene",
+        image=main,
+        image_edit_optional_request_params={
+            "taskType": "OUTPAINTING",
+            "mask": mask,
+            "maskPrompt": "sky region",
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "OUTPAINTING"
+    op = body["outPaintingParams"]
+    assert op["maskPrompt"] == "sky region"
+    assert "maskImage" not in op
+
+
+def test_transform_request_outpainting_with_out_painting_mode():
+    """OUTPAINTING forwards outPaintingMode into outPaintingParams."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"img")
+    mask = io.BytesIO(b"m")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="widen",
+        image=img,
+        image_edit_optional_request_params={
+            "taskType": "OUTPAINTING",
+            "mask": mask,
+            "outPaintingMode": "PRECISE",
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "OUTPAINTING"
+    assert body["outPaintingParams"]["outPaintingMode"] == "PRECISE"
+
+
+def test_get_supported_openai_params_includes_outpainting_fields():
+    """Documented OUTPAINTING-related optional params are advertised for routing/UI."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    supported = config.get_supported_openai_params("amazon.nova-canvas-v1:0")
+    assert "taskType" in supported
+    assert "maskPrompt" in supported
+    assert "outPaintingMode" in supported
+    assert "mask" in supported
+
+
+def test_transform_request_outpainting_without_mask_raises():
+    """OUTPAINTING without maskPrompt or maskImage must fail fast with a clear error."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"img")
+    with pytest.raises(
+        ValueError,
+        match="OUTPAINTING requires either a mask image or a mask prompt",
+    ):
+        config.transform_image_edit_request(
+            model="amazon.nova-canvas-v1:0",
+            prompt="extend",
+            image=img,
+            image_edit_optional_request_params={"taskType": "OUTPAINTING"},
+            litellm_params={},  # type: ignore[arg-type]
+            headers={},
+        )
+
+
+def test_transform_request_inpainting_explicit_task_without_mask_raises():
+    """INPAINTING taskType without mask or maskPrompt must fail fast."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"img")
+    with pytest.raises(
+        ValueError, match="INPAINTING requires either maskPrompt or maskImage"
+    ):
+        config.transform_image_edit_request(
+            model="amazon.nova-canvas-v1:0",
+            prompt="fix it",
+            image=img,
+            image_edit_optional_request_params={"taskType": "INPAINTING"},
+            litellm_params={},  # type: ignore[arg-type]
+            headers={},
+        )
+
+
+def test_transform_request_unknown_task_type_raises():
+    """Unknown taskType must not silently map to IMAGE_VARIATION or INPAINTING."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"img")
+    with pytest.raises(ValueError, match="Unsupported Amazon Nova Canvas taskType"):
+        config.transform_image_edit_request(
+            model="amazon.nova-canvas-v1:0",
+            prompt="x",
+            image=img,
+            image_edit_optional_request_params={"taskType": "TEXT_IMAGE"},
+            litellm_params={},  # type: ignore[arg-type]
+            headers={},
+        )
+
+
+def test_transform_request_background_removal():
+    """taskType BACKGROUND_REMOVAL builds minimal body."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"x")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="ignored",
+        image=img,
+        image_edit_optional_request_params={"taskType": "BACKGROUND_REMOVAL"},
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "BACKGROUND_REMOVAL"
+    assert "image" in body["backgroundRemovalParams"]
+
+
+def test_transform_request_background_removal_omits_image_generation_config():
+    """AWS Nova Canvas does not allow imageGenerationConfig on BACKGROUND_REMOVAL."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"x")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="ignored",
+        image=img,
+        image_edit_optional_request_params={
+            "taskType": "BACKGROUND_REMOVAL",
+            "size": "512x512",
+            "seed": 42,
+            "quality": "standard",
+            "cfgScale": 7.5,
+            "n": 2,
+        },
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "BACKGROUND_REMOVAL"
+    assert "imageGenerationConfig" not in body
+
+
+def test_transform_request_image_variation_includes_image_generation_config():
+    """Non-BACKGROUND_REMOVAL tasks may include imageGenerationConfig when params are set."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"x")
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="warm",
+        image=img,
+        image_edit_optional_request_params={"size": "1024x1024", "seed": 1},
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["taskType"] == "IMAGE_VARIATION"
+    assert "imageGenerationConfig" in body
+    assert body["imageGenerationConfig"]["width"] == 1024
+    assert body["imageGenerationConfig"]["height"] == 1024
+    assert body["imageGenerationConfig"]["seed"] == 1
+
+
+def test_map_openai_params_unknown_quality_not_silently_dropped():
+    """Non-Nova quality strings (e.g. OpenAI 'auto') must remain for downstream handling."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    mapped = config.map_openai_params(
+        cast(ImageEditOptionalRequestParams, {"quality": "auto"}),
+        model="amazon.nova-canvas-v1:0",
+        drop_params=False,
+    )
+    assert mapped.get("quality") == "auto"
+
+
+def test_transform_request_unknown_quality_reaches_image_generation_config():
+    """Unknown quality after map_openai_params is forwarded so callers are not silently ignored."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    img = io.BytesIO(b"x")
+    op = config.map_openai_params(
+        cast(ImageEditOptionalRequestParams, {"quality": "auto"}),
+        model="amazon.nova-canvas-v1:0",
+        drop_params=False,
+    )
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="x",
+        image=img,
+        image_edit_optional_request_params=op,
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+    assert body["imageGenerationConfig"]["quality"] == "auto"
+
+
+def test_is_nova_canvas_image_edit_model_uses_model_cost_flag(monkeypatch):
+    """Routing uses supports_nova_canvas_image_edit in model_cost, not a hardcoded name substring."""
+    fake_id = "amazon.custom-bedrock-image-edit-v99:0"
+    monkeypatch.setitem(
+        litellm.model_cost,
+        fake_id,
+        {
+            "litellm_provider": "bedrock",
+            "mode": "image_generation",
+            "supports_nova_canvas_image_edit": True,
+        },
+    )
+    assert (
+        BedrockAmazonNovaCanvasImageEditConfig._is_nova_canvas_image_edit_model(fake_id)
+        is True
+    )
+
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "amazon.not-nova-canvas-v1:0",
+        {
+            "litellm_provider": "bedrock",
+            "mode": "image_generation",
+        },
+    )
+    assert (
+        BedrockAmazonNovaCanvasImageEditConfig._is_nova_canvas_image_edit_model(
+            "amazon.not-nova-canvas-v1:0"
+        )
+        is False
+    )
+
+    # Name-shaped ids do not route without supports_nova_canvas_image_edit (no substring heuristic).
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "amazon.nova-canvas-v2:0",
+        {
+            "litellm_provider": "bedrock",
+            "mode": "image_generation",
+        },
+    )
+    assert (
+        BedrockAmazonNovaCanvasImageEditConfig._is_nova_canvas_image_edit_model(
+            "amazon.nova-canvas-v2:0"
+        )
+        is False
+    )
+
+
+def test_transform_response_to_openai_format():
+    """Response maps images[] to ImageResponse.data b64_json."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        200,
+        json={"images": ["YmFzZTY0X2E=", "YmFzZTY0X2I="]},
+    )
+    model_response = config.transform_image_edit_response(
+        model="amazon.nova-canvas-v1:0",
+        raw_response=resp,
+        logging_obj=None,  # type: ignore[arg-type]
+    )
+    assert model_response.data is not None
+    assert len(model_response.data) == 2
+    assert model_response.data[0].b64_json == "YmFzZTY0X2E="
+
+
+def test_transform_response_non_200_raises():
+    """HTTP 4xx/5xx with JSON body surfaces a structured error."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        400,
+        json={"message": "ValidationException: invalid input"},
+    )
+    with pytest.raises(Exception, match="Nova Canvas image edit error"):
+        config.transform_image_edit_response(
+            model="amazon.nova-canvas-v1:0",
+            raw_response=resp,
+            logging_obj=None,  # type: ignore[arg-type]
+        )
+
+
+def test_transform_response_errors_field_raises():
+    """Align with Bedrock Stability: top-level ``errors`` in body."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        200,
+        json={"errors": ["upstream failure"]},
+    )
+    with pytest.raises(Exception, match="Nova Canvas image edit error"):
+        config.transform_image_edit_response(
+            model="amazon.nova-canvas-v1:0",
+            raw_response=resp,
+            logging_obj=None,  # type: ignore[arg-type]
+        )
+
+
+def test_transform_response_allows_errors_field_with_images():
+    """Do not treat ``errors`` as fatal when ``images`` is present."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        200,
+        json={"errors": ["non-fatal warning"], "images": ["YmFzZTY0X2E="]},
+    )
+    model_response = config.transform_image_edit_response(
+        model="amazon.nova-canvas-v1:0",
+        raw_response=resp,
+        logging_obj=None,  # type: ignore[arg-type]
+    )
+    assert model_response.data is not None
+    assert len(model_response.data) == 1
+    assert model_response.data[0].b64_json == "YmFzZTY0X2E="
+
+
+def test_transform_response_message_or_error_field_raises():
+    """API-level error payload when there are no images (status 200)."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        200,
+        json={"message": "ValidationException: task rejected"},
+    )
+    with pytest.raises(Exception, match="Nova Canvas image edit error"):
+        config.transform_image_edit_response(
+            model="amazon.nova-canvas-v1:0",
+            raw_response=resp,
+            logging_obj=None,  # type: ignore[arg-type]
+        )
+
+
+def test_transform_response_allows_informational_message_with_images():
+    """Do not treat ``message`` as fatal when ``images`` is present (SDK wrappers)."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        200,
+        json={
+            "message": "ok",
+            "images": ["YmFzZTY0X2E="],
+        },
+    )
+    model_response = config.transform_image_edit_response(
+        model="amazon.nova-canvas-v1:0",
+        raw_response=resp,
+        logging_obj=None,  # type: ignore[arg-type]
+    )
+    assert model_response.data is not None
+    assert len(model_response.data) == 1
+    assert model_response.data[0].b64_json == "YmFzZTY0X2E="
+
+
+def test_transform_response_content_filtered_via_error_field():
+    """AWS Nova Canvas signals failures (e.g. content filter) via top-level ``error``, not ``finish_reasons``."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(
+        200,
+        json={"images": [], "error": "CONTENT_FILTERED"},
+    )
+    with pytest.raises(Exception, match="Nova Canvas image edit error"):
+        config.transform_image_edit_response(
+            model="amazon.nova-canvas-v1:0",
+            raw_response=resp,
+            logging_obj=None,  # type: ignore[arg-type]
+        )
+
+
+def test_transform_response_empty_images_without_error_raises():
+    """200 with empty ``images`` and no error fields must not return silent empty ImageResponse."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    resp = httpx.Response(200, json={"images": []})
+    with pytest.raises(Exception, match="returned no images"):
+        config.transform_image_edit_response(
+            model="amazon.nova-canvas-v1:0",
+            raw_response=resp,
+            logging_obj=None,  # type: ignore[arg-type]
+        )

--- a/tests/test_litellm/llms/bedrock/image_edit/test_amazon_nova_canvas_image_edit.py
+++ b/tests/test_litellm/llms/bedrock/image_edit/test_amazon_nova_canvas_image_edit.py
@@ -1,5 +1,6 @@
 """Unit tests for Bedrock Amazon Nova Canvas image edit (issue #24267)."""
 
+import base64
 import io
 from typing import cast
 
@@ -182,6 +183,28 @@ def test_transform_request_image_variation_without_mask():
     assert body["taskType"] == "IMAGE_VARIATION"
     assert body["imageVariationParams"]["text"] == "make it warmer"
     assert len(body["imageVariationParams"]["images"]) == 1
+
+
+def test_transform_request_image_pathlike_input(tmp_path):
+    """PathLike image input should be read and base64-encoded."""
+    config = BedrockAmazonNovaCanvasImageEditConfig()
+    image_path = tmp_path / "img.bin"
+    image_bytes = b"pathlike-image-bytes"
+    image_path.write_bytes(image_bytes)
+
+    body, _ = config.transform_image_edit_request(
+        model="amazon.nova-canvas-v1:0",
+        prompt="pathlike",
+        image=image_path,
+        image_edit_optional_request_params={},
+        litellm_params={},  # type: ignore[arg-type]
+        headers={},
+    )
+
+    assert body["taskType"] == "IMAGE_VARIATION"
+    assert body["imageVariationParams"]["images"][0] == base64.b64encode(
+        image_bytes
+    ).decode("utf-8")
 
 
 def test_transform_request_inpainting_with_mask():

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -752,6 +752,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_file_search": {"type": "boolean"},
                 "supports_function_calling": {"type": "boolean"},
                 "supports_image_input": {"type": "boolean"},
+                "supports_nova_canvas_image_edit": {"type": "boolean"},
                 "supports_parallel_function_calling": {"type": "boolean"},
                 "supports_pdf_input": {"type": "boolean"},
                 "supports_prompt_caching": {"type": "boolean"},


### PR DESCRIPTION
## Relevant issues

Fixes #24267

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [tests/test_litellm/](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code) *(scoped tests for touched files are passing)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature  
✅ Test  
📖 Documentation

## Changes

### Summary
Add Bedrock Nova Canvas image-edit support to LiteLLM SDK, addressing the unsupported model error for `amazon.nova-canvas-v1:0`.

### What this PR includes
- Added Nova Canvas image-edit transformation:
  - `litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py`
- Updated Bedrock image-edit routing:
  - `litellm/llms/bedrock/image_edit/handler.py`
  - `litellm/utils.py`
- Added model capability flags for routing:
  - `model_prices_and_context_window.json`
  - `litellm/model_prices_and_context_window_backup.json`
  - `supports_nova_canvas_image_edit: true`
- Updated provider docs:
  - `docs/my-website/docs/providers/bedrock_image_gen.md`
- Added and updated tests:
  - `tests/test_litellm/llms/bedrock/image_edit/test_amazon_nova_canvas_image_edit.py`
  - `tests/test_litellm/test_utils.py` (schema allowlist for new capability key)

### Behavior changes
- `image_edit()` now supports Bedrock Nova Canvas models.
- OpenAI-style inputs are mapped to Nova task types:
  - `IMAGE_VARIATION`
  - `INPAINTING`
  - `OUTPAINTING`
  - `BACKGROUND_REMOVAL`
- Includes task-specific validation (required prompt/mask conditions).
- Parses Nova Canvas response format and propagates provider-side errors clearly.
