### PR TITLE
fix(logging_worker): wait for in-flight tasks during flush

### DIFF
--- a/litellm/litellm_core_utils/logging_worker.py
+++ b/litellm/litellm_core_utils/logging_worker.py
@@ -370,11 +370,10 @@ class LoggingWorker:
         self._running_tasks.clear()
 
     async def flush(self) -> None:
-        """Flush the logging queue."""
+        """Flush queued and in-flight logging work."""
         if self._queue is None:
             return
-        while not self._queue.empty():
-            await self._queue.join()
+        await self._queue.join()
 
     async def clear_queue(self):
         """

--- a/tests/test_litellm/litellm_core_utils/test_logging_worker.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_worker.py
@@ -360,3 +360,34 @@ class TestLoggingWorker:
         assert worker2._bound_loop is not None
 
         await worker2.stop()
+
+    @pytest.mark.asyncio
+    async def test_flush_waits_for_in_flight_task_after_queue_is_empty(self):
+        """Flush must wait for dequeued work that has not called task_done() yet."""
+        worker = LoggingWorker(timeout=1.0, max_queue_size=10, concurrency=1)
+        worker.start()
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_task():
+            started.set()
+            await release.wait()
+
+        worker.enqueue(slow_task())
+
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        # The worker has already dequeued the item, so qsize() can be zero
+        # even though the logging coroutine is still running.
+        assert worker._queue is not None
+        assert worker._queue.empty() is True
+
+        flush_task = asyncio.create_task(worker.flush())
+        await asyncio.sleep(0.05)
+
+        assert flush_task.done() is False
+
+        release.set()
+        await asyncio.wait_for(flush_task, timeout=2.0)
+        await worker.stop()


### PR DESCRIPTION
## Summary

This is a follow-up to [#24733](https://github.com/BerriAI/litellm/pull/24733).

- `#24733` fixes orphaned `LoggingWorker` tasks when the event loop changes or the process exits.
- This PR fixes a separate steady-state race in `LoggingWorker.flush()` during normal concurrent operation.

Today `flush()` does:

```python
while not self._queue.empty():
    await self._queue.join()
```

That looks reasonable, but it misses the case where the worker has already dequeued the final item and started running it. In that window:

- `self._queue.empty()` is `True`
- the corresponding logging coroutine is still running
- `task_done()` has not been called yet

So `flush()` can return early even though one logging task is still in flight.

If the caller then shuts the worker down, that last logging coroutine can be cancelled or discarded during teardown. Downstream this shows up as warnings like:

- `RuntimeWarning: coroutine 'Logging.async_success_handler' was never awaited`
- `PytestUnraisableExceptionWarning`

## Why this is different from #24733

`#24733` covers the "old event loop / orphaned task" half:

- loop changes between `asyncio.run()` calls
- test suites with per-test loops
- process-exit cleanup

This PR covers the "current event loop / in-flight task" half:

- queue is empty because work has already been dequeued
- the final logging task is still running
- `flush()` returns before that task finishes

Both fixes are useful together:

- `#24733` prevents warnings from orphaned tasks on loop transitions and exit
- this PR makes `flush()` accurately wait for unfinished logging work on the active loop

## Fix

Use `await self._queue.join()` directly.

`asyncio.Queue.join()` already tracks unfinished tasks, not just items currently visible in the queue, so it correctly waits for:

- queued items
- dequeued items that are still running
- extracted items that have not called `task_done()` yet

## Small repro

This reproduces the race without needing any provider integrations:

```python
worker = LoggingWorker(timeout=1.0, max_queue_size=10, concurrency=1)
worker.start()

started = asyncio.Event()
release = asyncio.Event()

async def slow_task():
    started.set()
    await release.wait()

worker.enqueue(slow_task())
await started.wait()

assert worker._queue.empty() is True

flush_task = asyncio.create_task(worker.flush())
await asyncio.sleep(0.05)

# Before this PR: flush_task is already done here.
# After this PR: it stays pending until slow_task calls task_done().
assert flush_task.done() is False

release.set()
await flush_task
await worker.stop()
```

## Test plan

- Added `test_flush_waits_for_in_flight_task_after_queue_is_empty`
- Ran:

```bash
PYTHONPATH=/tmp/litellm-pr-26253 /tmp/osoji-venv/bin/pytest -q /tmp/litellm-pr-26253/tests/test_litellm/litellm_core_utils/test_logging_worker.py -k "flush_waits_for_in_flight_task_after_queue_is_empty or event_loop_change_handling or graceful_shutdown_with_clear_queue or clear_queue_processes_remaining_items"
```

Result: `4 passed`

I also verified this removes the remaining downstream warning path in Osoji's live concurrent prompt-regression tests after `#24733`-style orphan cleanup was already in place.
