### PR TITLE
[Infra] Add release workflow with cosign verification

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,7 +52,7 @@ jobs:
               ``,
               '```bash',
               `cosign verify \\`,
-              `  --key https://raw.githubusercontent.com/BerriAI/litellm/main/cosign.pub \\`,
+              `  --key https://raw.githubusercontent.com/BerriAI/litellm/${tag}/cosign.pub \\`,
               `  ghcr.io/berriai/litellm:${tag}`,
               '```',
               ``,
@@ -70,7 +70,7 @@ jobs:
 
             try {
               const response = await github.rest.repos.createRelease({
-                draft: false,
+                draft: true,
                 generate_release_notes: true,
                 target_commitish: commitHash,
                 name: tag,
@@ -80,12 +80,13 @@ jobs:
                 tag_name: tag,
               });
 
-              const updatedBody = cosignSection + response.data.body;
+              const updatedBody = cosignSection + (response.data.body ?? '');
               await github.rest.repos.updateRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: response.data.id,
                 body: updatedBody,
+                draft: false,
               });
             } catch (error) {
               core.setFailed(error.message);

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,8 +44,32 @@ jobs:
           script: |
             const tag = process.env.TAG;
             const commitHash = process.env.COMMIT_HASH;
+
+            const cosignSection = [
+              `## Verify Docker Image Signature`,
+              ``,
+              `All LiteLLM Docker images are signed with [cosign](https://docs.sigstore.dev/cosign/overview/). To verify the integrity of an image before deploying:`,
+              ``,
+              '```bash',
+              `cosign verify \\`,
+              `  --key https://raw.githubusercontent.com/BerriAI/litellm/main/cosign.pub \\`,
+              `  ghcr.io/berriai/litellm:${tag}`,
+              '```',
+              ``,
+              `Expected output:`,
+              ``,
+              '```',
+              `The following checks were performed on each of these signatures:`,
+              `  - The cosign claims were validated`,
+              `  - The signatures were verified against the specified public key`,
+              '```',
+              ``,
+              `---`,
+              ``,
+            ].join('\n');
+
             try {
-              await github.rest.repos.createRelease({
+              const response = await github.rest.repos.createRelease({
                 draft: false,
                 generate_release_notes: true,
                 target_commitish: commitHash,
@@ -54,6 +78,14 @@ jobs:
                 prerelease: false,
                 repo: context.repo.repo,
                 tag_name: tag,
+              });
+
+              const updatedBody = cosignSection + response.data.body;
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: response.data.id,
+                body: updatedBody,
               });
             } catch (error) {
               core.setFailed(error.message);


### PR DESCRIPTION
## Summary

### Problem
No automated way to create GitHub releases after Docker images are built. No cosign verification instructions in release notes for users to verify image signatures.

### Fix
- Add `create-release.yml` workflow (triggered via `workflow_dispatch`) that creates a GitHub release with auto-generated notes
- Prepend cosign signature verification instructions to each release, dynamically using the release tag
- Add `cosign.pub` public key for container image signature verification

## Testing
- Verified `generate_release_notes: true` produces identical output to existing releases (e.g. v1.82.3-stable.patch.2)
- Inputs validated (40-char hex SHA, vX.Y.Z tag format)
- Security hardened: inputs passed via `env:`/`process.env` (no script injection), action pinned to full SHA, minimal permissions

## Type

🚄 Infrastructure