### PR TITLE
feat: add auto-queue middleware with per-model concurrency control

### DIFF
--- a/litellm/proxy/middleware/auto_queue_middleware.py
+++ b/litellm/proxy/middleware/auto_queue_middleware.py
@@ -419,6 +419,17 @@ class AutoQueueMiddleware:
                     queue.wake_next()
                 # If re_acquired fails, waiter stays queued until another release
 
+    def shutdown(self) -> None:
+        """Trigger graceful shutdown -- reject new requests, wake all queued."""
+        self._shutting_down = True
+        for q in self._queues.values():
+            q.wake_all()
+
+    def register_signal_handlers(self) -> None:
+        """Register SIGTERM handler. Call once after event loop is running."""
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGTERM, self.shutdown)
+
     async def _handle_status(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Respond to GET /queue/status with model queue info."""
         models_info: Dict[str, Any] = {}

--- a/litellm/proxy/middleware/auto_queue_middleware.py
+++ b/litellm/proxy/middleware/auto_queue_middleware.py
@@ -192,3 +192,128 @@ class ModelQueue:
             entry.event.set()
         self._entries.clear()
         self._heap.clear()
+
+
+# -- Path Matching -------------------------------------------------------------
+
+_QUEUED_PATHS = {
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/chat/completions",
+    "/completions",
+    "/embeddings",
+}
+
+
+def _should_queue(scope: Scope) -> bool:
+    if scope["type"] != "http":
+        return False
+    method = scope.get("method", "")
+    path = scope.get("path", "")
+    return method == "POST" and path in _QUEUED_PATHS
+
+
+# -- Body Buffering ------------------------------------------------------------
+
+async def _buffer_body(receive: Receive) -> bytes:
+    """Read the full ASGI request body, handling chunked transfer."""
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+    return body
+
+
+def _replay_receive(body: bytes) -> Receive:
+    """Create a receive callable that replays the buffered body once."""
+    sent = False
+
+    async def receive() -> dict:
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        # After body is consumed, wait for disconnect
+        await asyncio.sleep(3600)
+        return {"type": "http.disconnect"}
+
+    return receive
+
+
+# -- ASGI Middleware -----------------------------------------------------------
+
+class AutoQueueMiddleware:
+    """ASGI middleware providing per-model concurrency control and request queuing."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        aqr: Optional[AutoQueueRedis] = None,
+        max_queue_depth: int = MAX_QUEUE_DEPTH,
+    ):
+        self.app = app
+        self._aqr = aqr  # injected in tests; created lazily in production
+        self._max_queue_depth = max_queue_depth
+        self._queues: Dict[str, ModelQueue] = {}
+        self._shutting_down = False
+
+    def _ensure_aqr(self) -> AutoQueueRedis:
+        """Lazy-init Redis connection on first use (production path)."""
+        if self._aqr is None:
+            r = aioredis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
+            self._aqr = AutoQueueRedis(redis=r)
+        return self._aqr
+
+    def _get_queue(self, model: str) -> ModelQueue:
+        if model not in self._queues:
+            self._queues[model] = ModelQueue(max_depth=self._max_queue_depth)
+        return self._queues[model]
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Handle /queue/status
+        if scope["type"] == "http" and scope.get("path") == "/queue/status" and scope.get("method") == "GET":
+            await self._handle_status(scope, receive, send)
+            return
+
+        if not _should_queue(scope):
+            await self.app(scope, receive, send)
+            return
+
+        # Buffer body and extract model
+        body = await _buffer_body(receive)
+        try:
+            data = json.loads(body)
+            model = data.get("model", "unknown")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # Not JSON -- pass through without queuing
+            await self.app(scope, _replay_receive(body), send)
+            return
+
+        # Pass through with replayed body (queuing added in Task 4)
+        await self._process_request(scope, body, model, send, original_receive=receive)
+
+    async def _process_request(
+        self, scope: Scope, body: bytes, model: str, send: Send,
+        original_receive: Optional[Receive] = None,
+    ) -> None:
+        """Acquire slot, forward, release. Queuing logic added in Task 4."""
+        await self.app(scope, _replay_receive(body), send)
+
+    async def _handle_status(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Respond to GET /queue/status with model queue info."""
+        models_info: Dict[str, Any] = {}
+        if self._aqr:
+            for model, q in self._queues.items():
+                info = await self._aqr.get_model_info(model)
+                info["queued"] = q.depth
+                models_info[model] = info
+        body = json.dumps({"models": models_info}).encode()
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"application/json"]],
+        })
+        await send({"type": "http.response.body", "body": body})

--- a/litellm/proxy/middleware/auto_queue_middleware.py
+++ b/litellm/proxy/middleware/auto_queue_middleware.py
@@ -137,3 +137,58 @@ class AutoQueueRedis:
             "queued": 0,  # filled by middleware, not Redis
             "ceiling": int(ceiling_raw or self.ceiling),
         }
+
+
+# -- In-Memory Priority Queue -------------------------------------------------
+
+@dataclass(order=True)
+class _QueueEntry:
+    priority: int
+    seq: int  # tie-breaker for FIFO within same priority
+    request_id: str = field(compare=False)
+    event: asyncio.Event = field(compare=False)
+
+
+class ModelQueue:
+    """Per-model priority queue of waiting requests."""
+
+    def __init__(self, max_depth: int = MAX_QUEUE_DEPTH):
+        self._heap: List[_QueueEntry] = []
+        self._entries: Dict[str, _QueueEntry] = {}  # request_id -> entry
+        self._seq = 0
+        self.max_depth = max_depth
+
+    @property
+    def depth(self) -> int:
+        return len(self._entries)
+
+    @property
+    def is_full(self) -> bool:
+        return self.depth >= self.max_depth
+
+    def add(self, request_id: str, event: asyncio.Event, priority: int = 10) -> None:
+        entry = _QueueEntry(priority=priority, seq=self._seq, request_id=request_id, event=event)
+        self._seq += 1
+        heapq.heappush(self._heap, entry)
+        self._entries[request_id] = entry
+
+    def remove(self, request_id: str) -> None:
+        entry = self._entries.pop(request_id, None)
+        if entry is not None:
+            # Lazy deletion -- mark as removed, skip during wake_next
+            entry.request_id = ""
+
+    def wake_next(self) -> bool:
+        while self._heap:
+            entry = heapq.heappop(self._heap)
+            if entry.request_id and entry.request_id in self._entries:
+                del self._entries[entry.request_id]
+                entry.event.set()
+                return True
+        return False
+
+    def wake_all(self) -> None:
+        for entry in self._entries.values():
+            entry.event.set()
+        self._entries.clear()
+        self._heap.clear()

--- a/litellm/proxy/middleware/auto_queue_middleware.py
+++ b/litellm/proxy/middleware/auto_queue_middleware.py
@@ -243,6 +243,39 @@ def _replay_receive(body: bytes) -> Receive:
     return receive
 
 
+async def _send_json_error(send: Send, status: int, message: str) -> None:
+    body = json.dumps({"error": message}).encode()
+    await send({
+        "type": "http.response.start",
+        "status": status,
+        "headers": [[b"content-type", b"application/json"]],
+    })
+    await send({"type": "http.response.body", "body": body})
+
+
+def _get_key_config(scope: Scope) -> Tuple[int, int]:
+    """Extract queue_timeout and priority from LiteLLM's key cache. Best-effort."""
+    timeout = DEFAULT_TIMEOUT
+    priority = 10
+    try:
+        from litellm.proxy.proxy_server import user_api_key_cache
+        from litellm.proxy._types import hash_token
+
+        headers = dict(scope.get("headers", []))
+        auth = headers.get(b"authorization", b"").decode()
+        if auth.startswith("Bearer "):
+            token = auth[7:]
+            hashed = hash_token(token)
+            cached = user_api_key_cache.get_cache(key=hashed)
+            if cached and hasattr(cached, "metadata") and cached.metadata:
+                meta = cached.metadata
+                timeout = meta.get("queue_timeout_seconds", timeout)
+                priority = meta.get("queue_priority", priority)
+    except Exception:
+        pass  # Fall back to defaults if LiteLLM internals aren't available
+    return timeout, priority
+
+
 # -- ASGI Middleware -----------------------------------------------------------
 
 class AutoQueueMiddleware:
@@ -299,8 +332,92 @@ class AutoQueueMiddleware:
         self, scope: Scope, body: bytes, model: str, send: Send,
         original_receive: Optional[Receive] = None,
     ) -> None:
-        """Acquire slot, forward, release. Queuing logic added in Task 4."""
-        await self.app(scope, _replay_receive(body), send)
+        """Acquire slot (or queue), forward request, release slot, auto-scale."""
+        aqr = self._ensure_aqr()
+        request_id = f"{model}-{time.monotonic_ns()}"
+        queue = self._get_queue(model)
+
+        # Try to acquire a slot
+        acquired = await aqr.try_acquire(model)
+        if not acquired:
+            # Check shutdown
+            if self._shutting_down:
+                await _send_json_error(send, 503, "Server shutting down")
+                return
+
+            # Check queue depth
+            if queue.is_full:
+                await _send_json_error(send, 503, f"Queue full for model {model}")
+                return
+
+            # Read per-key timeout/priority (best-effort from LiteLLM cache)
+            timeout, priority = _get_key_config(scope)
+
+            # Enqueue and wait with disconnect detection
+            event = asyncio.Event()
+            disconnected = False
+            queue.add(request_id, event, priority)
+
+            async def _watch_disconnect():
+                nonlocal disconnected
+                if original_receive is None:
+                    return
+                try:
+                    msg = await original_receive()
+                    if msg.get("type") == "http.disconnect":
+                        disconnected = True
+                        queue.remove(request_id)
+                        event.set()
+                except Exception:
+                    pass
+
+            disconnect_task = asyncio.create_task(_watch_disconnect())
+
+            try:
+                await asyncio.wait_for(event.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                queue.remove(request_id)
+                disconnect_task.cancel()
+                await _send_json_error(
+                    send, 504, f"Queue timeout after {timeout}s for model {model}"
+                )
+                return
+
+            disconnect_task.cancel()
+
+            # If woken by disconnect, exit silently
+            if disconnected:
+                return
+
+            # Slot was pre-acquired for us by release_and_wake_next()
+
+        # Slot acquired -- forward request and intercept response status
+        response_status = 0
+
+        async def send_wrapper(message: dict) -> None:
+            nonlocal response_status
+            if message["type"] == "http.response.start":
+                response_status = message.get("status", 0)
+            await send(message)
+
+        try:
+            await self.app(scope, _replay_receive(body), send_wrapper)
+        finally:
+            # Release slot and wake next queued request
+            await aqr.release(model)
+
+            # Auto-scale based on response
+            if response_status == 429:
+                await aqr.on_429(model)
+            elif 200 <= response_status < 400:
+                await aqr.on_success(model)
+
+            # Try to acquire for next waiter, then wake them
+            if queue.depth > 0:
+                re_acquired = await aqr.try_acquire(model)
+                if re_acquired:
+                    queue.wake_next()
+                # If re_acquired fails, waiter stays queued until another release
 
     async def _handle_status(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Respond to GET /queue/status with model queue info."""

--- a/litellm/proxy/middleware/auto_queue_middleware.py
+++ b/litellm/proxy/middleware/auto_queue_middleware.py
@@ -1,0 +1,139 @@
+"""litellm/proxy/middleware/auto_queue_middleware.py"""
+import asyncio
+import heapq
+import json
+import os
+import signal
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import redis.asyncio as aioredis
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+# -- Configuration ------------------------------------------------------------
+
+DEFAULT_MAX_CONCURRENT = int(os.environ.get("AUTOQ_DEFAULT_MAX_CONCURRENT", "20"))
+SCALE_UP_THRESHOLD = int(os.environ.get("AUTOQ_SCALE_UP_THRESHOLD", "20"))
+SCALE_DOWN_STEP = int(os.environ.get("AUTOQ_SCALE_DOWN_STEP", "1"))
+CEILING = int(os.environ.get("AUTOQ_CEILING", "50"))
+DEFAULT_TIMEOUT = int(os.environ.get("AUTOQ_DEFAULT_TIMEOUT", "300"))
+MAX_QUEUE_DEPTH = int(os.environ.get("AUTOQ_MAX_QUEUE_DEPTH", "100"))
+REDIS_HOST = os.environ.get("AUTOQ_REDIS_HOST", os.environ.get("REDIS_HOST", "localhost"))
+REDIS_PORT = int(os.environ.get("AUTOQ_REDIS_PORT", os.environ.get("REDIS_PORT", "6379")))
+REDIS_DB = int(os.environ.get("AUTOQ_REDIS_DB", "3"))
+ACTIVE_KEY_TTL = 600  # seconds
+
+
+# -- Lua Scripts ---------------------------------------------------------------
+
+_LUA_ACQUIRE = """
+local active = tonumber(redis.call('GET', KEYS[1])) or 0
+local limit = tonumber(redis.call('GET', KEYS[2])) or tonumber(ARGV[1])
+if active < limit then
+    redis.call('INCR', KEYS[1])
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+    return 1
+end
+return 0
+"""
+
+_LUA_RELEASE = """
+local active = tonumber(redis.call('GET', KEYS[1])) or 0
+if active > 0 then
+    redis.call('DECR', KEYS[1])
+end
+return math.max(0, active - 1)
+"""
+
+_LUA_SCALE_UP = """
+local count = redis.call('INCR', KEYS[1])
+local threshold = tonumber(ARGV[1])
+local ceiling = tonumber(redis.call('GET', KEYS[3])) or tonumber(ARGV[2])
+if tonumber(count) >= threshold then
+    local current = tonumber(redis.call('GET', KEYS[2])) or tonumber(ARGV[3])
+    if current < ceiling then
+        redis.call('SET', KEYS[2], current + 1)
+    end
+    redis.call('SET', KEYS[1], 0)
+end
+return 0
+"""
+
+_LUA_SCALE_DOWN = """
+local current = tonumber(redis.call('GET', KEYS[1])) or tonumber(ARGV[1])
+local step = tonumber(ARGV[2])
+if current - step >= 1 then
+    redis.call('SET', KEYS[1], current - step)
+else
+    redis.call('SET', KEYS[1], 1)
+end
+redis.call('SET', KEYS[2], 0)
+return tonumber(redis.call('GET', KEYS[1]))
+"""
+
+
+# -- Redis Helper --------------------------------------------------------------
+
+class AutoQueueRedis:
+    """Atomic Redis operations for concurrency control and auto-scaling."""
+
+    def __init__(
+        self,
+        redis: aioredis.Redis,
+        default_max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+        ceiling: int = CEILING,
+        scale_up_threshold: int = SCALE_UP_THRESHOLD,
+        scale_down_step: int = SCALE_DOWN_STEP,
+    ):
+        self.redis = redis
+        self.default_max_concurrent = default_max_concurrent
+        self.ceiling = ceiling
+        self.scale_up_threshold = scale_up_threshold
+        self.scale_down_step = scale_down_step
+        self._acquire_script = redis.register_script(_LUA_ACQUIRE)
+        self._release_script = redis.register_script(_LUA_RELEASE)
+        self._scale_up_script = redis.register_script(_LUA_SCALE_UP)
+        self._scale_down_script = redis.register_script(_LUA_SCALE_DOWN)
+
+    async def try_acquire(self, model: str) -> bool:
+        result = await self._acquire_script(
+            keys=[f"autoq:active:{model}", f"autoq:limit:{model}"],
+            args=[self.default_max_concurrent, ACTIVE_KEY_TTL],
+        )
+        return bool(result)
+
+    async def release(self, model: str) -> int:
+        result = await self._release_script(
+            keys=[f"autoq:active:{model}"],
+        )
+        return int(result)
+
+    async def on_success(self, model: str) -> None:
+        await self._scale_up_script(
+            keys=[
+                f"autoq:success:{model}",
+                f"autoq:limit:{model}",
+                f"autoq:ceiling:{model}",
+            ],
+            args=[self.scale_up_threshold, self.ceiling, self.default_max_concurrent],
+        )
+
+    async def on_429(self, model: str) -> None:
+        await self._scale_down_script(
+            keys=[f"autoq:limit:{model}", f"autoq:success:{model}"],
+            args=[self.default_max_concurrent, self.scale_down_step],
+        )
+
+    async def get_model_info(self, model: str) -> dict:
+        pipe = self.redis.pipeline()
+        pipe.get(f"autoq:active:{model}")
+        pipe.get(f"autoq:limit:{model}")
+        pipe.get(f"autoq:ceiling:{model}")
+        active_raw, limit_raw, ceiling_raw = await pipe.execute()
+        return {
+            "active": int(active_raw or 0),
+            "limit": int(limit_raw or self.default_max_concurrent),
+            "queued": 0,  # filled by middleware, not Redis
+            "ceiling": int(ceiling_raw or self.ceiling),
+        }

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -441,6 +441,7 @@ from litellm.proxy.middleware.in_flight_requests_middleware import (
     InFlightRequestsMiddleware,
 )
 from litellm.proxy.middleware.prometheus_auth_middleware import PrometheusAuthMiddleware
+from litellm.proxy.middleware.auto_queue_middleware import AutoQueueMiddleware
 from litellm.proxy.ocr_endpoints.endpoints import router as ocr_router
 from litellm.proxy.openai_evals_endpoints.endpoints import router as evals_router
 from litellm.proxy.openai_files_endpoints.files_endpoints import (
@@ -1476,6 +1477,7 @@ app.add_middleware(
 
 app.add_middleware(PrometheusAuthMiddleware)
 app.add_middleware(InFlightRequestsMiddleware)
+app.add_middleware(AutoQueueMiddleware)
 
 
 def mount_swagger_ui():

--- a/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
@@ -114,3 +114,73 @@ async def test_scale_down_resets_success_counter(aqr):
     # Limit was default 5, 429 brought to 4, then 3 successes -> 5
     info = await aqr.get_model_info("gpt-4")
     assert info["limit"] == 5
+
+
+from litellm.proxy.middleware.auto_queue_middleware import ModelQueue
+
+
+# -- In-memory priority queue --------------------------------------------------
+
+
+@pytest.fixture
+def queue():
+    return ModelQueue(max_depth=3)
+
+
+@pytest.mark.asyncio
+async def test_queue_add_and_wake(queue):
+    event = asyncio.Event()
+    queue.add("req-1", event, priority=10)
+    assert queue.depth == 1
+    woken = queue.wake_next()
+    assert woken is True
+    assert event.is_set()
+    assert queue.depth == 0
+
+
+@pytest.mark.asyncio
+async def test_queue_priority_ordering(queue):
+    low = asyncio.Event()
+    high = asyncio.Event()
+    queue.add("req-low", low, priority=10)
+    queue.add("req-high", high, priority=1)
+    queue.wake_next()
+    assert high.is_set()  # higher priority (lower number) woken first
+    assert not low.is_set()
+
+
+@pytest.mark.asyncio
+async def test_queue_fifo_within_same_priority(queue):
+    first = asyncio.Event()
+    second = asyncio.Event()
+    queue.add("req-1", first, priority=10)
+    queue.add("req-2", second, priority=10)
+    queue.wake_next()
+    assert first.is_set()
+    assert not second.is_set()
+
+
+@pytest.mark.asyncio
+async def test_queue_max_depth_exceeded(queue):
+    for i in range(3):
+        queue.add(f"req-{i}", asyncio.Event(), priority=10)
+    assert queue.is_full is True
+
+
+@pytest.mark.asyncio
+async def test_queue_remove_by_id(queue):
+    event = asyncio.Event()
+    queue.add("req-1", event, priority=10)
+    queue.remove("req-1")
+    assert queue.depth == 0
+    assert queue.wake_next() is False
+
+
+@pytest.mark.asyncio
+async def test_queue_wake_all_sets_all_events(queue):
+    events = [asyncio.Event() for _ in range(3)]
+    for i, e in enumerate(events):
+        queue.add(f"req-{i}", e, priority=10)
+    queue.wake_all()
+    assert all(e.is_set() for e in events)
+    assert queue.depth == 0

--- a/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
@@ -380,3 +380,83 @@ async def test_shutdown_wakes_all_queued(redis, aqr_for_middleware):
     mw.shutdown()
     assert event.is_set()
     assert mw._shutting_down is True
+
+
+# -- Integration: concurrent requests -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_queued_and_served(redis):
+    """3 concurrent requests with max_concurrent=1: served sequentially."""
+    aqr = AutoQueueRedis(redis=redis, default_max_concurrent=1, ceiling=5,
+                          scale_up_threshold=100, scale_down_step=1)
+
+    call_order = []
+
+    async def ordered_handler(request: Request):
+        body = await request.body()
+        data = json.loads(body)
+        call_order.append(data["id"])
+        await asyncio.sleep(0.05)
+        return JSONResponse({"id": data["id"]})
+
+    inner = Starlette(routes=[
+        Route("/v1/chat/completions", ordered_handler, methods=["POST"]),
+    ])
+    mw = AutoQueueMiddleware(inner, aqr=aqr)
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=mw), base_url="http://test") as client:
+        tasks = [
+            asyncio.create_task(
+                client.post("/v1/chat/completions",
+                            json={"model": "gpt-4", "messages": [], "id": i})
+            )
+            for i in range(3)
+        ]
+        responses = await asyncio.gather(*tasks)
+
+    assert all(r.status_code == 200 for r in responses)
+    # All 3 should have been served (order may vary due to async scheduling)
+    assert sorted(call_order) == [0, 1, 2]
+
+    # Verify all slots released
+    active = int(await redis.get("autoq:active:gpt-4") or 0)
+    assert active == 0
+
+
+@pytest.mark.asyncio
+async def test_queue_status_reflects_active_requests(redis):
+    aqr = AutoQueueRedis(redis=redis, default_max_concurrent=1, ceiling=5,
+                          scale_up_threshold=100, scale_down_step=1)
+    hold = asyncio.Event()
+
+    async def blocking_handler(request: Request):
+        body = await request.body()
+        await hold.wait()
+        return JSONResponse({"ok": True})
+
+    inner = Starlette(routes=[
+        Route("/v1/chat/completions", blocking_handler, methods=["POST"]),
+    ])
+    mw = AutoQueueMiddleware(inner, aqr=aqr)
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=mw), base_url="http://test") as client:
+        # Start a request that blocks
+        task = asyncio.create_task(
+            client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+        )
+        await asyncio.sleep(0.05)
+
+        # Check status
+        status_resp = await client.get("/queue/status")
+        assert status_resp.status_code == 200
+        models = status_resp.json()["models"]
+        assert "gpt-4" in models
+        assert models["gpt-4"]["active"] == 1
+
+        hold.set()
+        await task

--- a/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
@@ -184,3 +184,73 @@ async def test_queue_wake_all_sets_all_events(queue):
     queue.wake_all()
     assert all(e.is_set() for e in events)
     assert queue.depth == 0
+
+
+import json
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from litellm.proxy.middleware.auto_queue_middleware import AutoQueueMiddleware
+
+
+# -- Middleware helpers --------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def aqr_for_middleware(redis):
+    return AutoQueueRedis(
+        redis=redis,
+        default_max_concurrent=2,
+        ceiling=10,
+        scale_up_threshold=3,
+        scale_down_step=1,
+    )
+
+
+def _make_echo_app(aqr_instance):
+    """App that echoes back the request body, proving body replay works."""
+    async def echo(request: Request):
+        body = await request.body()
+        data = json.loads(body) if body else {}
+        return JSONResponse({"model": data.get("model", "none"), "echoed": True})
+
+    async def health(request: Request):
+        return JSONResponse({"status": "ok"})
+
+    app = Starlette(routes=[
+        Route("/v1/chat/completions", echo, methods=["POST"]),
+        Route("/health", health),
+    ])
+    app.add_middleware(AutoQueueMiddleware, aqr=aqr_instance)
+    return app
+
+
+# -- Passthrough ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_llm_routes_pass_through(aqr_for_middleware):
+    client = TestClient(_make_echo_app(aqr_for_middleware))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_body_is_replayed_to_downstream(aqr_for_middleware):
+    client = TestClient(_make_echo_app(aqr_for_middleware))
+    resp = client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+    assert resp.status_code == 200
+    assert resp.json()["model"] == "gpt-4"
+    assert resp.json()["echoed"] is True
+
+
+@pytest.mark.asyncio
+async def test_queue_status_endpoint(aqr_for_middleware):
+    client = TestClient(_make_echo_app(aqr_for_middleware))
+    resp = client.get("/queue/status")
+    assert resp.status_code == 200
+    assert "models" in resp.json()

--- a/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
@@ -254,3 +254,95 @@ async def test_queue_status_endpoint(aqr_for_middleware):
     resp = client.get("/queue/status")
     assert resp.status_code == 200
     assert "models" in resp.json()
+
+
+import time
+
+
+# -- Full flow -----------------------------------------------------------------
+
+
+def _make_slow_app(aqr_instance, delay: float = 0.1, status: int = 200):
+    """App that takes `delay` seconds and returns `status`."""
+    async def handler(request: Request):
+        body = await request.body()
+        await asyncio.sleep(delay)
+        return JSONResponse({"ok": True}, status_code=status)
+
+    app = Starlette(routes=[
+        Route("/v1/chat/completions", handler, methods=["POST"]),
+    ])
+    app.add_middleware(AutoQueueMiddleware, aqr=aqr_instance)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_request_acquires_and_releases_slot(redis, aqr_for_middleware):
+    app = _make_slow_app(aqr_for_middleware, delay=0.0)
+    client = TestClient(app)
+    client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+    # After request completes, slot should be released
+    active = int(await redis.get("autoq:active:gpt-4") or 0)
+    assert active == 0
+
+
+@pytest.mark.asyncio
+async def test_429_response_triggers_scale_down(redis, aqr_for_middleware):
+    app = _make_slow_app(aqr_for_middleware, delay=0.0, status=429)
+    client = TestClient(app)
+    await redis.set("autoq:limit:gpt-4", 10)
+    client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+    limit = int(await redis.get("autoq:limit:gpt-4") or 0)
+    assert limit == 9
+
+
+@pytest.mark.asyncio
+async def test_success_response_increments_success_counter(redis, aqr_for_middleware):
+    app = _make_slow_app(aqr_for_middleware, delay=0.0, status=200)
+    client = TestClient(app)
+    client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+    count = int(await redis.get("autoq:success:gpt-4") or 0)
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_queue_full_returns_503(redis):
+    """When max_concurrent=1 and max_queue_depth=1, third request gets 503."""
+    aqr = AutoQueueRedis(
+        redis=redis, default_max_concurrent=1, ceiling=10,
+        scale_up_threshold=3, scale_down_step=1,
+    )
+    hold_event = asyncio.Event()
+
+    async def slow_handler(request: Request):
+        body = await request.body()
+        await hold_event.wait()
+        return JSONResponse({"ok": True})
+
+    app = Starlette(routes=[
+        Route("/v1/chat/completions", slow_handler, methods=["POST"]),
+    ])
+    mw = AutoQueueMiddleware(app, aqr=aqr, max_queue_depth=1)
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=mw), base_url="http://test") as client:
+        # Fill the slot
+        task1 = asyncio.create_task(
+            client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+        )
+        await asyncio.sleep(0.05)
+
+        # Fill the queue (1 deep)
+        task2 = asyncio.create_task(
+            client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+        )
+        await asyncio.sleep(0.05)
+
+        # This should get 503 -- queue full
+        resp = await client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+        assert resp.status_code == 503
+
+        hold_event.set()
+        await task1
+        await task2

--- a/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
@@ -1,0 +1,116 @@
+"""tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py"""
+import asyncio
+import os
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+
+from litellm.proxy.middleware.auto_queue_middleware import AutoQueueRedis
+
+
+@pytest_asyncio.fixture
+async def redis():
+    r = fakeredis.aioredis.FakeRedis(db=3)
+    yield r
+    await r.flushdb()
+    await r.aclose()
+
+
+@pytest.fixture
+def aqr(redis):
+    return AutoQueueRedis(
+        redis=redis,
+        default_max_concurrent=5,
+        ceiling=20,
+        scale_up_threshold=3,
+        scale_down_step=1,
+    )
+
+
+# -- Slot acquire / release ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acquire_slot_succeeds_when_under_limit(aqr):
+    assert await aqr.try_acquire("gpt-4") is True
+
+
+@pytest.mark.asyncio
+async def test_acquire_slot_fails_when_at_limit(aqr):
+    for _ in range(5):
+        await aqr.try_acquire("gpt-4")
+    assert await aqr.try_acquire("gpt-4") is False
+
+
+@pytest.mark.asyncio
+async def test_release_slot_frees_capacity(aqr):
+    for _ in range(5):
+        await aqr.try_acquire("gpt-4")
+    await aqr.release("gpt-4")
+    assert await aqr.try_acquire("gpt-4") is True
+
+
+@pytest.mark.asyncio
+async def test_release_never_goes_negative(aqr):
+    await aqr.release("gpt-4")
+    await aqr.release("gpt-4")
+    info = await aqr.get_model_info("gpt-4")
+    assert info["active"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_model_info_defaults(aqr):
+    info = await aqr.get_model_info("gpt-4")
+    assert info == {"active": 0, "limit": 5, "queued": 0, "ceiling": 20}
+
+
+# -- Auto-scale ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scale_up_after_threshold_successes(aqr):
+    for _ in range(3):  # threshold = 3
+        await aqr.on_success("gpt-4")
+    info = await aqr.get_model_info("gpt-4")
+    assert info["limit"] == 6  # 5 + 1
+
+
+@pytest.mark.asyncio
+async def test_scale_up_capped_at_ceiling(aqr):
+    # Set limit just below ceiling
+    await aqr.redis.set("autoq:limit:gpt-4", 20)
+    for _ in range(3):
+        await aqr.on_success("gpt-4")
+    info = await aqr.get_model_info("gpt-4")
+    assert info["limit"] == 20  # stays at ceiling
+
+
+@pytest.mark.asyncio
+async def test_scale_down_on_429(aqr):
+    # First set a known limit
+    await aqr.redis.set("autoq:limit:gpt-4", 10)
+    await aqr.on_429("gpt-4")
+    info = await aqr.get_model_info("gpt-4")
+    assert info["limit"] == 9
+
+
+@pytest.mark.asyncio
+async def test_scale_down_never_below_1(aqr):
+    await aqr.redis.set("autoq:limit:gpt-4", 1)
+    await aqr.on_429("gpt-4")
+    info = await aqr.get_model_info("gpt-4")
+    assert info["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_scale_down_resets_success_counter(aqr):
+    await aqr.on_success("gpt-4")
+    await aqr.on_success("gpt-4")
+    await aqr.on_429("gpt-4")
+    # Next 3 successes should trigger scale up (counter was reset)
+    for _ in range(3):
+        await aqr.on_success("gpt-4")
+    # Limit was default 5, 429 brought to 4, then 3 successes -> 5
+    info = await aqr.get_model_info("gpt-4")
+    assert info["limit"] == 5

--- a/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py
@@ -346,3 +346,37 @@ async def test_queue_full_returns_503(redis):
         hold_event.set()
         await task1
         await task2
+
+
+# -- Disconnect and shutdown ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shutdown_rejects_new_requests(redis, aqr_for_middleware):
+    inner_app = Starlette(routes=[
+        Route("/v1/chat/completions", lambda r: JSONResponse({"ok": True}), methods=["POST"]),
+    ])
+    mw = AutoQueueMiddleware(inner_app, aqr=aqr_for_middleware)
+    mw._shutting_down = True
+
+    from httpx import ASGITransport, AsyncClient
+    async with AsyncClient(transport=ASGITransport(app=mw), base_url="http://test") as client:
+        # Fill the only slots so the next request tries to queue
+        await redis.set("autoq:active:gpt-4", 2)  # at limit
+        resp = await client.post("/v1/chat/completions", json={"model": "gpt-4", "messages": []})
+        assert resp.status_code == 503
+        assert "shutting down" in resp.json()["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_wakes_all_queued(redis, aqr_for_middleware):
+    inner_app = Starlette(routes=[
+        Route("/v1/chat/completions", lambda r: JSONResponse({"ok": True}), methods=["POST"]),
+    ])
+    mw = AutoQueueMiddleware(inner_app, aqr=aqr_for_middleware)
+    q = mw._get_queue("gpt-4")
+    event = asyncio.Event()
+    q.add("req-1", event, priority=10)
+    mw.shutdown()
+    assert event.is_set()
+    assert mw._shutting_down is True


### PR DESCRIPTION
## Summary
- Add ASGI middleware (`AutoQueueMiddleware`) that provides per-model request queuing with auto-scaling concurrency limits
- Redis Lua scripts handle atomic slot acquire/release; in-memory priority queue manages waiting requests
- Auto-scales concurrency limits up on sustained success, down on 429 responses
- Includes graceful shutdown (SIGTERM), client disconnect detection, queue-full 503s, and `/queue/status` endpoint
- Registered in `proxy_server.py` wrapping outside `InFlightRequestsMiddleware`

## Files Changed
- **New:** `litellm/proxy/middleware/auto_queue_middleware.py` (~350 lines)
- **New:** `tests/test_litellm/proxy/middleware/test_auto_queue_middleware.py` (27 tests)
- **Modified:** `litellm/proxy/proxy_server.py` (2 lines: import + middleware registration)

## Test Plan
- [x] 10 Redis slot acquire/release/auto-scale unit tests
- [x] 6 in-memory priority queue unit tests
- [x] 3 middleware passthrough/body-buffering tests
- [x] 4 full queue flow tests (acquire, release, 429 scale-down, 503 queue-full)
- [x] 2 shutdown/disconnect tests
- [x] 2 integration smoke tests (concurrent requests, queue status)
- [x] Existing `InFlightRequestsMiddleware` tests still pass