### PR TITLE
fix(proxy): clarify managed files error when target_model_names lacks Enterprise hook

### DIFF
--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -213,7 +213,14 @@ async def route_create_file(
         managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
         if managed_files_obj is None:
             raise ProxyException(
-                message="Managed files hook not found",
+                message=(
+                    "The `target_model_names` form field requires LiteLLM Enterprise managed files "
+                    "(the `litellm-enterprise` package). This image or environment does not load that hook—"
+                    "use a LiteLLM Enterprise Docker image or `pip install litellm-enterprise`, set "
+                    "`LITELLM_LICENSE`, and restart. On open-source-only deployments, omit "
+                    "`target_model_names` and use the `model` form field to route uploads to one model. "
+                    + CommonProxyErrors.not_premium_user.value
+                ),
                 type="None",
                 param="None",
                 code=500,

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
 import pytest
 import respx
@@ -14,7 +14,12 @@ sys.path.insert(
 
 import litellm
 from litellm import Router
-from litellm.proxy._types import LiteLLM_UserTableFiltered, UserAPIKeyAuth
+from litellm.proxy._types import (
+    CommonProxyErrors,
+    LiteLLM_UserTableFiltered,
+    ProxyException,
+    UserAPIKeyAuth,
+)
 from litellm.proxy.hooks import get_proxy_hook
 from litellm.proxy.management_endpoints.internal_user_endpoints import ui_view_users
 from litellm.proxy.proxy_server import app
@@ -99,6 +104,34 @@ def test_invalid_purpose(mocker: MockerFixture, monkeypatch, llm_router: Router)
     assert response.status_code == 400
     print(f"response: {response.json()}")
     assert "Invalid purpose: my-bad-purpose" in response.json()["error"]["message"]
+
+
+async def test_route_create_file_without_managed_files_hook_message():
+    """OSS deployments omit the managed_files hook; error should explain Enterprise + alternatives."""
+    from litellm.proxy.openai_files_endpoints.files_endpoints import route_create_file
+
+    proxy_logging = ProxyLogging(user_api_key_cache=DualCache(default_in_memory_ttl=1))
+    user = UserAPIKeyAuth(api_key="sk-test")
+
+    with pytest.raises(ProxyException) as exc_info:
+        await route_create_file(
+            llm_router=MagicMock(),
+            _create_file_request={"file": b"x", "purpose": "batch"},
+            purpose="batch",
+            proxy_logging_obj=proxy_logging,
+            user_api_key_dict=user,
+            target_model_names_list=["gpt-3.5-turbo"],
+            is_router_model=False,
+            router_model=None,
+            custom_llm_provider="openai",
+            model=None,
+            target_storage="default",
+        )
+
+    msg = exc_info.value.message
+    assert "target_model_names" in msg
+    assert "litellm-enterprise" in msg
+    assert CommonProxyErrors.not_premium_user.value in msg
 
 
 def test_mock_create_audio_file(mocker: MockerFixture, monkeypatch, llm_router: Router):


### PR DESCRIPTION
When `target_model_names` is sent but the managed files hook is not loaded (e.g. community Docker without `litellm-enterprise`), the previous message was opaque ("Managed files hook not found").

This change explains that the feature requires LiteLLM Enterprise (`litellm-enterprise`, `LITELLM_LICENSE`, Enterprise Docker) and points OSS users to omit `target_model_names` and use the `model` form field instead. Appends `CommonProxyErrors.not_premium_user` for consistency with other Enterprise gates.

**Test:** `poetry run pytest tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py::test_route_create_file_without_managed_files_hook_message -v`

Made with [Cursor](https://cursor.com)