### PR TITLE
fix(anthropic): auto-detect image media_type from magic bytes to prevent API rejection

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -898,25 +898,35 @@ def convert_to_anthropic_image_obj(
         else:
             media_type = media_type.replace("\\/", "/")
 
-        # Anthropic rejects requests where the declared media_type mismatches the actual
-        # image bytes. Auto-detect from magic bytes and override the declared type when needed.
-        try:
-            from litellm.litellm_core_utils.token_counter import get_image_type
+            # Anthropic rejects requests where the declared media_type mismatches the actual
+            # image bytes. Auto-detect from magic bytes and override only when the detected
+            # type is one Anthropic actually supports (jpeg/png/gif/webp). Falling back to
+            # "image/" + detected would produce "image/heic" for any ISO Base Media File
+            # Format container (MP4, MOV, …), making the failure mode worse than before.
+            # Skip detection when caller supplied an explicit `format` — that is authoritative.
+            _ANTHROPIC_SUPPORTED_MIME = {
+                "jpeg": "image/jpeg",
+                "png": "image/png",
+                "gif": "image/gif",
+                "webp": "image/webp",
+            }
+            try:
+                from litellm.litellm_core_utils.token_counter import get_image_type
 
-            image_bytes = base64.b64decode(base64_data[:128])
-            detected = get_image_type(image_bytes)
-            if detected is not None:
-                detected_mime = "image/{}".format(detected)
-                if detected_mime != media_type:
-                    verbose_logger.debug(
-                        "convert_to_anthropic_image_obj: declared media_type=%s does not match "
-                        "detected type=%s; using detected type.",
-                        media_type,
-                        detected_mime,
-                    )
-                    media_type = detected_mime
-        except Exception:
-            pass
+                image_bytes = base64.b64decode(base64_data[:128])
+                detected = get_image_type(image_bytes)
+                if detected is not None:
+                    detected_mime = _ANTHROPIC_SUPPORTED_MIME.get(detected)
+                    if detected_mime is not None and detected_mime != media_type:
+                        verbose_logger.debug(
+                            "convert_to_anthropic_image_obj: declared media_type=%s does not match "
+                            "detected type=%s; using detected type.",
+                            media_type,
+                            detected_mime,
+                        )
+                        media_type = detected_mime
+            except Exception:
+                pass
 
         return GenericImageParsingChunk(
             type="base64",

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -898,6 +898,26 @@ def convert_to_anthropic_image_obj(
         else:
             media_type = media_type.replace("\\/", "/")
 
+        # Anthropic rejects requests where the declared media_type mismatches the actual
+        # image bytes. Auto-detect from magic bytes and override the declared type when needed.
+        try:
+            from litellm.litellm_core_utils.token_counter import get_image_type
+
+            image_bytes = base64.b64decode(base64_data[:128])
+            detected = get_image_type(image_bytes)
+            if detected is not None:
+                detected_mime = "image/{}".format(detected)
+                if detected_mime != media_type:
+                    verbose_logger.debug(
+                        "convert_to_anthropic_image_obj: declared media_type=%s does not match "
+                        "detected type=%s; using detected type.",
+                        media_type,
+                        detected_mime,
+                    )
+                    media_type = detected_mime
+        except Exception:
+            pass
+
         return GenericImageParsingChunk(
             type="base64",
             media_type=media_type,

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -288,6 +288,10 @@ def _fix_image_media_types_in_messages(messages: List[Dict]) -> List[Dict]:
     from litellm import verbose_logger
     from litellm.litellm_core_utils.token_counter import get_image_type
 
+    # Only override with types Anthropic actually accepts. Using a fallback like
+    # "image/" + detected would produce "image/heic" for any ISO Base Media File
+    # Format container (MP4, MOV, …) since get_image_type() returns "heic" for
+    # all ftyp-box files — making the failure mode worse than before.
     _MIME_MAP = {"jpeg": "image/jpeg", "png": "image/png", "gif": "image/gif", "webp": "image/webp"}
 
     def _fix_source(source: dict) -> None:
@@ -301,7 +305,10 @@ def _fix_image_media_types_in_messages(messages: List[Dict]) -> List[Dict]:
             detected = get_image_type(raw)
             if detected is None:
                 return
-            detected_mime = _MIME_MAP.get(detected, "image/" + detected)
+            detected_mime = _MIME_MAP.get(detected)
+            if detected_mime is None:
+                # Detected type is not supported by Anthropic; keep declared type.
+                return
             declared = source.get("media_type", "")
             if detected_mime != declared:
                 verbose_logger.debug(

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -273,6 +273,68 @@ async def anthropic_messages(
     return response
 
 
+def _fix_image_media_types_in_messages(messages: List[Dict]) -> List[Dict]:
+    """
+    Walk Anthropic-native messages and correct any image source whose declared
+    media_type does not match the actual image bytes.
+
+    Anthropic rejects requests where declared media_type mismatches the bytes
+    (e.g. 'image/png' header on a JPEG payload).  This can happen when the
+    calling client mislabels images.  We detect the real format from magic
+    bytes and silently correct it.
+    """
+    import base64
+
+    from litellm import verbose_logger
+    from litellm.litellm_core_utils.token_counter import get_image_type
+
+    _MIME_MAP = {"jpeg": "image/jpeg", "png": "image/png", "gif": "image/gif", "webp": "image/webp"}
+
+    def _fix_source(source: dict) -> None:
+        if source.get("type") != "base64":
+            return
+        data = source.get("data", "")
+        if not data:
+            return
+        try:
+            raw = base64.b64decode(data[:128])
+            detected = get_image_type(raw)
+            if detected is None:
+                return
+            detected_mime = _MIME_MAP.get(detected, "image/" + detected)
+            declared = source.get("media_type", "")
+            if detected_mime != declared:
+                verbose_logger.debug(
+                    "_fix_image_media_types_in_messages: declared=%s detected=%s; correcting.",
+                    declared,
+                    detected_mime,
+                )
+                source["media_type"] = detected_mime
+        except Exception:
+            pass
+
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "image":
+                source = block.get("source")
+                if isinstance(source, dict):
+                    _fix_source(source)
+            elif block.get("type") == "tool_result":
+                inner = block.get("content")
+                if isinstance(inner, list):
+                    for inner_block in inner:
+                        if isinstance(inner_block, dict) and inner_block.get("type") == "image":
+                            source = inner_block.get("source")
+                            if isinstance(source, dict):
+                                _fix_source(source)
+    return messages
+
+
 def validate_anthropic_api_metadata(metadata: Optional[Dict] = None) -> Optional[Dict]:
     """
     Validate Anthropic API metadata - This is done to ensure only allowed `metadata` fields are passed to Anthropic API
@@ -318,6 +380,7 @@ def anthropic_messages_handler(
     """
     from litellm.types.utils import LlmProviders
 
+    messages = _fix_image_media_types_in_messages(messages)
     metadata = validate_anthropic_api_metadata(metadata)
 
     local_vars = locals()

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3399,3 +3399,151 @@ def test_extract_response_content_thinking_block_null_thinking():
     assert len(thinking_blocks) == 1
     assert thinking_blocks[0]["thinking"] == "Let me think..."
     assert "Done" in text
+
+
+_JPEG_B64 = "/9j/4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_PNG_B64 = "iVBORw0KGgoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+_FTYP_B64 = "AAAAGGZ0eXBtcDQyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+
+class TestConvertToAnthropicImageObjMediaTypeDetection:
+    def test_jpeg_bytes_with_png_declaration_corrected(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="jpeg",
+        ):
+            from litellm.litellm_core_utils.prompt_templates.factory import (
+                convert_to_anthropic_image_obj,
+            )
+
+            result = convert_to_anthropic_image_obj(
+                f"data:image/png;base64,{_JPEG_B64}", format=None
+            )
+            assert result["media_type"] == "image/jpeg"
+
+    def test_png_bytes_with_jpeg_declaration_corrected(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="png",
+        ):
+            from litellm.litellm_core_utils.prompt_templates.factory import (
+                convert_to_anthropic_image_obj,
+            )
+
+            result = convert_to_anthropic_image_obj(
+                f"data:image/jpeg;base64,{_PNG_B64}", format=None
+            )
+            assert result["media_type"] == "image/png"
+
+    def test_correct_declaration_not_overridden(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="jpeg",
+        ):
+            from litellm.litellm_core_utils.prompt_templates.factory import (
+                convert_to_anthropic_image_obj,
+            )
+
+            result = convert_to_anthropic_image_obj(
+                f"data:image/jpeg;base64,{_JPEG_B64}", format=None
+            )
+            assert result["media_type"] == "image/jpeg"
+
+    def test_heic_false_positive_keeps_declared_type(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="heic",
+        ):
+            from litellm.litellm_core_utils.prompt_templates.factory import (
+                convert_to_anthropic_image_obj,
+            )
+
+            result = convert_to_anthropic_image_obj(
+                f"data:image/jpeg;base64,{_FTYP_B64}", format=None
+            )
+            assert result["media_type"] == "image/jpeg"
+
+    def test_explicit_format_not_overridden_by_detection(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="jpeg",
+        ):
+            from litellm.litellm_core_utils.prompt_templates.factory import (
+                convert_to_anthropic_image_obj,
+            )
+
+            result = convert_to_anthropic_image_obj(
+                f"data:image/png;base64,{_JPEG_B64}", format="image/png"
+            )
+            assert result["media_type"] == "image/png"
+
+
+class TestFixImageMediaTypesInMessages:
+    def _make_messages(self, declared: str, b64_data: str) -> list:
+        return [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": declared,
+                            "data": b64_data,
+                        },
+                    }
+                ],
+            }
+        ]
+
+    def test_jpeg_bytes_with_png_declaration_corrected(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="jpeg",
+        ):
+            from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+                _fix_image_media_types_in_messages,
+            )
+
+            messages = self._make_messages("image/png", _JPEG_B64)
+            result = _fix_image_media_types_in_messages(messages)
+            assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+    def test_correct_declaration_unchanged(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="jpeg",
+        ):
+            from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+                _fix_image_media_types_in_messages,
+            )
+
+            messages = self._make_messages("image/jpeg", _JPEG_B64)
+            result = _fix_image_media_types_in_messages(messages)
+            assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+    def test_heic_false_positive_keeps_declared_type(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value="heic",
+        ):
+            from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+                _fix_image_media_types_in_messages,
+            )
+
+            messages = self._make_messages("image/jpeg", _FTYP_B64)
+            result = _fix_image_media_types_in_messages(messages)
+            assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+    def test_none_detection_keeps_declared_type(self):
+        with patch(
+            "litellm.litellm_core_utils.token_counter.get_image_type",
+            return_value=None,
+        ):
+            from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+                _fix_image_media_types_in_messages,
+            )
+
+            messages = self._make_messages("image/png", _JPEG_B64)
+            result = _fix_image_media_types_in_messages(messages)
+            assert result[0]["content"][0]["source"]["media_type"] == "image/png"


### PR DESCRIPTION
## Summary

Fixes #24900

Anthropic API strictly validates that the declared `media_type` in a base64 image source matches the actual image bytes. When they mismatch (e.g. a client sends a JPEG with a `data:image/png;base64,...` URI, or passes an Anthropic-native message with a wrong `media_type`), Anthropic returns a 400:

```
invalid_request_error: messages.92.content.0.tool_result.content.1.image.source.base64:
The image was specified using the image/png media type, but the image appears to be a image/jpeg image
```

## Root Cause

There are **two separate code paths** that need fixing:

### Path 1 — `/chat/completions` (OpenAI format)
`convert_to_anthropic_image_obj()` in `factory.py` extracted `media_type` directly from the data URI prefix and passed it through without byte-level verification:

```python
# Before: trusted declared type blindly
media_type, base64_data = openai_image_url.split("data:")[1].split(";base64,")
```

### Path 2 — `/v1/messages` (Anthropic native format)
When clients use the Anthropic-native `/v1/messages` API, images arrive already in Anthropic format:
```json
{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "..."}}
```
These messages bypass `factory.py` entirely — `anthropic_messages_handler()` forwards them directly to Anthropic without any media_type validation.

## Fix

### Fix 1 — `factory.py` (`convert_to_anthropic_image_obj`)
After extracting the declared `media_type`, decode the first 128 bytes and run them through the existing `get_image_type()` magic-byte detector. Override the declared type if there's a mismatch:

```python
try:
    from litellm.litellm_core_utils.token_counter import get_image_type
    image_bytes = base64.b64decode(base64_data[:128])
    detected = get_image_type(image_bytes)
    if detected is not None:
        detected_mime = "image/{}".format(detected)
        if detected_mime != media_type:
            media_type = detected_mime
except Exception:
    pass
```

### Fix 2 — `messages/handler.py` (`anthropic_messages_handler`)
Add `_fix_image_media_types_in_messages()` called before the request is sent. It walks all content blocks (including nested `tool_result` content) and applies the same magic-byte correction:

```python
def _fix_image_media_types_in_messages(messages):
    # Walk all blocks including tool_result nested content
    # Detect from magic bytes, correct media_type if mismatched
    ...

def anthropic_messages_handler(...):
    messages = _fix_image_media_types_in_messages(messages)
    ...
```

## Why This Approach

- **Zero overhead for correct images**: only 128 bytes decoded for magic-byte check
- **Reuses existing infrastructure**: `get_image_type()` already used by `BedrockImageProcessor` and `get_image_dimensions()`
- **Graceful degradation**: detection wrapped in try/except; any failure preserves original behavior
- **No breaking changes**: only changes behavior when declared and actual types mismatch
- **Covers both API formats**: `/chat/completions` (OpenAI) and `/v1/messages` (Anthropic native)