### PR TITLE
fix: use actual start_time for failed request spend logs

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -112,6 +112,14 @@ class _ProxyDBLogger(CustomLogger):
                     _litellm_logging_obj, "litellm_trace_id", None
                 )
 
+        # Use the actual request start time from the logging object so that
+        # failed requests record the real duration instead of 0.
+        actual_start_time = datetime.now()
+        if _litellm_logging_obj is not None:
+            obj_start = getattr(_litellm_logging_obj, "start_time", None)
+            if obj_start is not None:
+                actual_start_time = obj_start
+
         await proxy_logging_obj.db_spend_update_writer.update_database(
             token=user_api_key_dict.api_key,
             response_cost=0.0,
@@ -120,7 +128,7 @@ class _ProxyDBLogger(CustomLogger):
             team_id=user_api_key_dict.team_id,
             kwargs=request_data,
             completion_response=original_exception,
-            start_time=datetime.now(),
+            start_time=actual_start_time,
             end_time=datetime.now(),
             org_id=user_api_key_dict.org_id,
         )

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -479,3 +479,67 @@ async def test_track_cost_callback_skips_for_falsy_model_and_no_slo(model_value)
         )
 
         mock_proxy_logging.failed_tracking_alert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_uses_actual_start_time():
+    """
+    Verify that failed requests record the actual request start time
+    instead of datetime.now(), so the spend log shows the real duration.
+
+    Previously both start_time and end_time were set to datetime.now()
+    at failure-logging time, resulting in duration=0 for all failures.
+    """
+    from datetime import timedelta
+
+    logger = _ProxyDBLogger()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+        team_id="test_team_id",
+        org_id="test_org_id",
+        end_user_id="test_end_user_id",
+    )
+
+    # Simulate a request that started 60 seconds ago
+    simulated_start = datetime.now() - timedelta(seconds=60)
+
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.start_time = simulated_start
+    mock_logging_obj.model_call_details = {}
+    mock_logging_obj.litellm_trace_id = None
+
+    request_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {},
+        "proxy_server_request": {},
+        "litellm_logging_obj": mock_logging_obj,
+    }
+
+    original_exception = Exception("Timeout error")
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=original_exception,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        mock_update_database.assert_called_once()
+        call_args = mock_update_database.call_args[1]
+
+        # start_time should be the simulated start, not datetime.now()
+        assert call_args["start_time"] == simulated_start
+
+        # end_time should be close to now (within a few seconds)
+        time_diff = (datetime.now() - call_args["end_time"]).total_seconds()
+        assert time_diff < 5, f"end_time should be close to now, was {time_diff}s ago"
+
+        # Duration should be approximately 60 seconds, not 0
+        duration = (call_args["end_time"] - call_args["start_time"]).total_seconds()
+        assert duration >= 55, f"Duration should be ~60s, got {duration}s"


### PR DESCRIPTION
## Relevant issues

Fixes #24888

## Summary

`async_post_call_failure_hook` in `proxy_track_cost_callback.py` set both `start_time` and `end_time` to `datetime.now()` when logging failed requests to the spend database. This caused all failed requests (timeouts, auth errors, etc.) to show `Duration: 0.000s` in the UI, making it impossible to determine how long the request actually ran before failing.

The fix extracts the actual request start time from `litellm_logging_obj.start_time` (which is set when the request first arrives) and uses `datetime.now()` only for `end_time`.

**Before:** Failed requests show `Start Time == End Time`, duration 0.
**After:** Failed requests show the real duration from request arrival to failure.

## Pre-Submission checklist

- [x] I have Added testing — 1 new test verifying start_time comes from logging obj, not datetime.now()
- [x] My PR passes all unit tests — 13/13 tests pass in `test_proxy_track_cost_callback.py`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/hooks/proxy_track_cost_callback.py` — Extract `start_time` from `litellm_logging_obj` instead of calling `datetime.now()` for both timestamps
- `tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py` — New test `test_async_post_call_failure_hook_uses_actual_start_time` verifying duration > 0 for simulated 60s request