### PR TITLE
fix(docker): load enterprise hooks in non-root runtime image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -133,6 +133,9 @@ COPY --from=builder /app/requirements.txt /app/requirements.txt
 COPY --from=builder /app/docker/entrypoint.sh /app/docker/prod_entrypoint.sh /app/docker/
 COPY --from=builder /app/docker/supervisord.conf /etc/supervisord.conf
 COPY --from=builder /app/schema.prisma /app/
+# Keep enterprise bridge module in runtime so `enterprise.enterprise_hooks`
+# can load and register managed enterprise hooks (e.g. managed_files).
+COPY --from=builder /app/enterprise /app/enterprise
 # Copy prisma_migration.py for Helm migrations job compatibility
 COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/prisma_migration.py
 COPY --from=builder /wheels/ /wheels/


### PR DESCRIPTION
## Summary
- Copy `/app/enterprise` from builder to runtime in `docker/Dockerfile.non_root`.
- This restores the `enterprise.enterprise_hooks` bridge import in non-root images so enterprise hooks (including `managed_files`) are registered.
- Keeps behavior aligned with root image runtime where managed files hook is available.

## Test plan
- [x] Build non-root image locally from this branch.
- [x] Run `python -c \"from litellm.proxy.hooks import PROXY_HOOKS; print('managed_files' in PROXY_HOOKS, sorted(PROXY_HOOKS.keys()))\"` inside container.
- [x] Verify output includes `managed_files` (previously missing on `litellm-non_root:v1.83.0-nightly`).

