### PR TITLE
fix: support WARNING/ERROR/CRITICAL levels for LITELLM_LOG env var

### DIFF
--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -826,6 +826,19 @@ def init_verbose_loggers():
                     verbose_proxy_logger.setLevel(
                         level=logging.DEBUG
                     )  # set proxy logs to debug
+                elif litellm_log_setting.upper() in ("WARNING", "ERROR", "CRITICAL"):
+                    import logging
+
+                    from litellm._logging import (
+                        verbose_logger,
+                        verbose_proxy_logger,
+                        verbose_router_logger,
+                    )
+
+                    _level = getattr(logging, litellm_log_setting.upper())
+                    verbose_logger.setLevel(level=_level)
+                    verbose_router_logger.setLevel(level=_level)
+                    verbose_proxy_logger.setLevel(level=_level)
     except Exception as e:
         import logging
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5586,6 +5586,19 @@ async def initialize(  # noqa: PLR0915
                 verbose_proxy_logger.setLevel(
                     level=logging.DEBUG
                 )  # set proxy logs to debug
+            elif litellm_log_setting.upper() in ("WARNING", "ERROR", "CRITICAL"):
+                import logging
+
+                from litellm._logging import (
+                    verbose_logger,
+                    verbose_proxy_logger,
+                    verbose_router_logger,
+                )
+
+                _level = getattr(logging, litellm_log_setting.upper())
+                verbose_logger.setLevel(level=_level)
+                verbose_router_logger.setLevel(level=_level)
+                verbose_proxy_logger.setLevel(level=_level)
     dynamic_config = {"general": {}, user_model: {}}
     if config:
         (

--- a/tests/test_litellm/proxy/common_utils/test_debug_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_debug_utils.py
@@ -1,0 +1,70 @@
+"""
+Tests for LITELLM_LOG env var handling in debug_utils.init_verbose_loggers().
+
+Verifies that WARNING, ERROR, and CRITICAL levels are respected in addition
+to the previously-supported DEBUG and INFO levels.
+"""
+
+import json
+import logging
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm._logging import (
+    verbose_logger,
+    verbose_proxy_logger,
+    verbose_router_logger,
+)
+from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_levels():
+    """Save and restore logger levels around each test."""
+    orig = (
+        verbose_logger.level,
+        verbose_proxy_logger.level,
+        verbose_router_logger.level,
+    )
+    yield
+    verbose_logger.setLevel(orig[0])
+    verbose_proxy_logger.setLevel(orig[1])
+    verbose_router_logger.setLevel(orig[2])
+
+
+def _worker_config_json(debug=False, detailed_debug=False):
+    """Return a WORKER_CONFIG JSON string with debug flags set to False."""
+    return json.dumps({"debug": debug, "detailed_debug": detailed_debug})
+
+
+@pytest.mark.parametrize(
+    "log_level_str, expected_level",
+    [
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("CRITICAL", logging.CRITICAL),
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+    ],
+)
+def test_litellm_log_env_sets_logger_levels(
+    monkeypatch, log_level_str, expected_level
+):
+    """Test that LITELLM_LOG env var correctly sets logger levels."""
+    monkeypatch.setenv("LITELLM_LOG", log_level_str)
+
+    with patch(
+        "litellm.proxy.common_utils.debug_utils.get_secret_str",
+        return_value=_worker_config_json(),
+    ):
+        init_verbose_loggers()
+
+    assert verbose_router_logger.level == expected_level
+    assert verbose_proxy_logger.level == expected_level


### PR DESCRIPTION
## Relevant issues

Fixes #10788 and also adds tests unlike #21752 

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The `LITELLM_LOG` env var only handles `INFO` and `DEBUG`. Setting it to `WARNING`, `ERROR`, or `CRITICAL` silently does nothing — the loggers stay at `INFO`.

The env var handling in both `proxy_server.py` and `debug_utils.py` uses a hardcoded `if/elif` that only matches those two values:

```python
if litellm_log_setting.upper() == "INFO":
    ...
elif litellm_log_setting.upper() == "DEBUG":
    ...
# ← any other value falls through silently
```

This adds an `elif` branch for the remaining standard Python log levels (`WARNING`, `ERROR`, `CRITICAL`) to both locations, matching the existing code style.

**Files changed:**
- `litellm/proxy/proxy_server.py` — added `elif` branch (+13 lines)
- `litellm/proxy/common_utils/debug_utils.py` — added `elif` branch (+13 lines)
- `tests/test_litellm/proxy/common_utils/test_debug_utils.py` — new test file, parametrized across all 5 levels