### PR TITLE
fix(models): correct supports_service_tier flags for Azure models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -2724,7 +2724,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": false
+        "supports_web_search": false,
+        "supports_service_tier": true
     },
     "azure/gpt-4.1-2025-04-14": {
         "deprecation_date": "2026-11-04",
@@ -2758,7 +2759,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": false
+        "supports_web_search": false,
+        "supports_service_tier": true
     },
     "azure/gpt-4.1-mini": {
         "cache_read_input_token_cost": 1e-07,
@@ -4190,7 +4192,6 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true
     },
     "azure/gpt-5.3-codex": {
@@ -4469,7 +4470,6 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
         "supports_none_reasoning_effort": false,
@@ -4505,7 +4505,6 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
         "supports_none_reasoning_effort": false,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2724,7 +2724,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": false
+        "supports_web_search": false,
+        "supports_service_tier": true
     },
     "azure/gpt-4.1-2025-04-14": {
         "deprecation_date": "2026-11-04",
@@ -2758,7 +2759,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": false
+        "supports_web_search": false,
+        "supports_service_tier": true
     },
     "azure/gpt-4.1-mini": {
         "cache_read_input_token_cost": 1e-07,
@@ -4190,7 +4192,6 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true
     },
     "azure/gpt-5.3-codex": {
@@ -4469,7 +4470,6 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
         "supports_none_reasoning_effort": false,
@@ -4505,7 +4505,6 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true,
         "supports_web_search": true,
         "supports_none_reasoning_effort": false,

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -892,6 +892,47 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         raise AssertionError(error_message)
 
 
+def test_azure_supports_service_tier_flags():
+    """
+    Verify that supports_service_tier is set correctly for Azure models
+    based on Azure's priority processing documentation.
+
+    Ref: https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/priority-processing
+    """
+    import json
+    from pathlib import Path
+
+    config_path = (
+        Path(__file__).parent.parent.parent / "model_prices_and_context_window.json"
+    )
+    with open(config_path, "r") as f:
+        models = json.load(f)
+
+    # Models that Azure officially supports for priority processing
+    should_have = [
+        "azure/gpt-4.1",
+        "azure/gpt-4.1-2025-04-14",
+    ]
+    # Models that should NOT have the flag
+    should_not_have = [
+        "azure/gpt-5.3-chat",
+        "azure/gpt-5.4-mini",
+        "azure/gpt-5.4-nano",
+    ]
+
+    for model in should_have:
+        assert model in models, f"{model} not found in model config"
+        assert models[model].get("supports_service_tier") is True, (
+            f"{model} should have supports_service_tier=true"
+        )
+
+    for model in should_not_have:
+        assert model in models, f"{model} not found in model config"
+        assert "supports_service_tier" not in models[model], (
+            f"{model} should not have supports_service_tier"
+        )
+
+
 def test_max_tokens_consistency():
     """
     Test that max_tokens == max_output_tokens for all models.


### PR DESCRIPTION
Add supports_service_tier to azure/gpt-4.1 and azure/gpt-4.1-2025-04-14 per Azure's priority processing docs. Remove the flag from azure/gpt-5.3-chat, azure/gpt-5.4-mini, and azure/gpt-5.4-nano which are not in Azure's supported list.

## Relevant issues

Per [Azure's priority processing documentation](https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/priority-processing?tabs=global-standard#global-standard-model-availability), the supported models are:
- gpt-5.4 (2026-03-05)
- gpt-5.2 (2025-12-11)
- gpt-5.1 (2025-11-13)
- gpt-4.1 (2025-04-14)

`azure/gpt-4.1` and `azure/gpt-4.1-2025-04-14` were missing the `supports_service_tier` flag, while `azure/gpt-5.3-chat`, `azure/gpt-5.4-mini`, and `azure/gpt-5.4-nano` had it set incorrectly.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

- **`model_prices_and_context_window.json`** + **backup**: Added `"supports_service_tier": true` to `azure/gpt-4.1` and `azure/gpt-4.1-2025-04-14`. Removed the flag from `azure/gpt-5.3-chat`, `azure/gpt-5.4-mini`, and `azure/gpt-5.4-nano`.
- **`tests/test_litellm/test_utils.py`**: Added `test_azure_supports_service_tier_flags` to verify the flags match Azure's official priority processing model list.