### PR TITLE
fix(proxy): load team member RPM/TPM from membership budget in combined_view

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2970,6 +2970,8 @@ class PrismaClient:
                             t.organization_id as org_id,
                             p.project_alias AS project_alias,
                             tm.spend AS team_member_spend,
+                            b_tm.tpm_limit AS team_member_tpm_limit,
+                            b_tm.rpm_limit AS team_member_rpm_limit,
                             m.aliases AS team_model_aliases,
                             -- Added comma to separate b.* columns
                             b.max_budget AS litellm_budget_table_max_budget,
@@ -2984,6 +2986,7 @@ class PrismaClient:
                         FROM "LiteLLM_VerificationToken" AS v
                         LEFT JOIN "LiteLLM_TeamTable" AS t ON v.team_id = t.team_id
                         LEFT JOIN "LiteLLM_TeamMembership" AS tm ON v.team_id = tm.team_id AND tm.user_id = v.user_id
+                        LEFT JOIN "LiteLLM_BudgetTable" AS b_tm ON tm.budget_id = b_tm.budget_id
                         LEFT JOIN "LiteLLM_ModelTable" m ON t.model_id = m.id
                         LEFT JOIN "LiteLLM_BudgetTable" AS b ON v.budget_id = b.budget_id
                         LEFT JOIN "LiteLLM_ProjectTable" AS p ON v.project_id = p.project_id

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -1030,6 +1030,83 @@ async def test_team_member_rate_limits_v3():
 
 
 @pytest.mark.asyncio
+async def test_team_member_rate_limits_v3_raises_429_when_over_limit():
+    """
+    When should_rate_limit reports OVER_LIMIT for the team_member descriptor, the
+    pre-call hook raises HTTP 429 with rate_limit headers — same contract as
+    test_rpm_api_key_rate_limits_v3 / test_tpm_api_key_rate_limits_v3.
+    """
+    _api_key = hash_token("sk-12345")
+    _team_id = "team_123"
+    _user_id = "user_456"
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        team_id=_team_id,
+        user_id=_user_id,
+        team_member_rpm_limit=10,
+        team_member_tpm_limit=1000,
+    )
+
+    local_cache = DualCache()
+    parallel_request_handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    captured_descriptors = None
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        nonlocal captured_descriptors
+        captured_descriptors = descriptors
+        return {
+            "overall_code": "OVER_LIMIT",
+            "statuses": [
+                {
+                    "code": "OVER_LIMIT",
+                    "current_limit": 10,
+                    "limit_remaining": -1,
+                    "rate_limit_type": "requests",
+                    "descriptor_key": "team_member",
+                },
+                {
+                    "code": "OK",
+                    "current_limit": 1000,
+                    "limit_remaining": 500,
+                    "rate_limit_type": "tokens",
+                    "descriptor_key": "team_member",
+                },
+            ],
+        }
+
+    parallel_request_handler.should_rate_limit = mock_should_rate_limit
+
+    error = None
+    try:
+        await parallel_request_handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data={"model": "gpt-3.5-turbo"},
+            call_type="",
+        )
+    except HTTPException as e:
+        error = e
+        assert e.status_code == 429
+        assert "rate_limit_type" in e.headers
+        assert e.headers.get("rate_limit_type") == "requests"
+        assert "retry-after" in e.headers
+
+    assert error is not None, "An Exception must be thrown"
+    assert captured_descriptors is not None, "Rate limit descriptors should be captured"
+    team_member_descriptor = None
+    for descriptor in captured_descriptors:
+        if descriptor["key"] == "team_member":
+            team_member_descriptor = descriptor
+            break
+    assert team_member_descriptor is not None
+    assert team_member_descriptor["value"] == f"{_team_id}:{_user_id}"
+
+
+@pytest.mark.asyncio
 async def test_dynamic_rate_limiting_v3():
     """
     Test that dynamic rate limiting only enforces limits when model has failures.


### PR DESCRIPTION
## Relevant issues

N/A — fixes virtual keys not receiving per-team-member RPM/TPM from `combined_view` when those limits are stored on the team membership budget row (`LiteLLM_TeamMembership.budget_id` → `LiteLLM_BudgetTable`).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

✅ Test

## Changes

**Problem:** The proxy `combined_view` query joined `LiteLLM_TeamMembership` for spend but did not join the membership budget table. Per-team-member RPM/TPM configured on the membership budget were not selected, so `team_member_rpm_limit` / `team_member_tpm_limit` were not populated on virtual key auth and `parallel_request_limiter_v3` did not enforce those limits.

**Fix:** Add `LEFT JOIN "LiteLLM_BudgetTable" AS b_tm ON tm.budget_id = b_tm.budget_id` and select `b_tm.tpm_limit AS team_member_tpm_limit`, `b_tm.rpm_limit AS team_member_rpm_limit` in `litellm/proxy/utils.py` (`PrismaClient` combined view SQL).

**Tests:** Add `test_team_member_rate_limits_v3_raises_429_when_over_limit` in `tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py`, matching the existing pattern for key RPM limits (mock `should_rate_limit` → `OVER_LIMIT` for `team_member` descriptor → assert HTTP 429 and headers).
