### PR TITLE
fix(cost): pass service_tier through azure and azure_ai cost calculation

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -512,7 +512,8 @@ def cost_per_token(  # noqa: PLR0915
         return fireworks_ai_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "azure":
         return azure_openai_cost_per_token(
-            model=model, usage=usage_block, response_time_ms=response_time_ms
+            model=model, usage=usage_block, response_time_ms=response_time_ms,
+            service_tier=service_tier,
         )
     elif custom_llm_provider == "gemini":
         return gemini_cost_per_token(
@@ -538,6 +539,7 @@ def cost_per_token(  # noqa: PLR0915
             usage=usage_block,
             response_time_ms=response_time_ms,
             request_model=request_model,
+            service_tier=service_tier,
         )
     else:
         model_info = _cached_get_model_info_helper(

--- a/litellm/llms/azure/cost_calculation.py
+++ b/litellm/llms/azure/cost_calculation.py
@@ -12,7 +12,8 @@ from litellm.utils import get_model_info
 
 
 def cost_per_token(
-    model: str, usage: Usage, response_time_ms: Optional[float] = 0.0
+    model: str, usage: Usage, response_time_ms: Optional[float] = 0.0,
+    service_tier: Optional[str] = None,
 ) -> Tuple[float, float]:
     """
     Calculates the cost per token for a given model, prompt tokens, and completion tokens.
@@ -47,4 +48,5 @@ def cost_per_token(
         model=model,
         usage=usage,
         custom_llm_provider="azure",
+        service_tier=service_tier,
     )

--- a/litellm/llms/azure_ai/cost_calculator.py
+++ b/litellm/llms/azure_ai/cost_calculator.py
@@ -65,6 +65,7 @@ def cost_per_token(
     usage: Usage,
     response_time_ms: Optional[float] = 0.0,
     request_model: Optional[str] = None,
+    service_tier: Optional[str] = None,
 ) -> Tuple[float, float]:
     """
     Calculate the cost per token for Azure AI models.
@@ -102,6 +103,7 @@ def cost_per_token(
             model=model,
             usage=usage,
             custom_llm_provider="azure_ai",
+            service_tier=service_tier,
         )
     except Exception as e:
         # For Model Router, the model name (e.g., "azure-model-router") may not be in the cost map

--- a/tests/test_litellm/llms/azure/test_azure_cost_calculation.py
+++ b/tests/test_litellm/llms/azure/test_azure_cost_calculation.py
@@ -1,0 +1,75 @@
+"""
+Test Azure OpenAI cost calculator — service_tier pricing.
+"""
+
+import pytest
+
+import litellm
+from litellm.llms.azure.cost_calculation import cost_per_token
+from litellm.types.utils import Usage
+
+
+# Register a test model with tier-specific pricing
+TEST_MODEL = "test-azure-gpt-4.1"
+TEST_MODEL_COST = {
+    TEST_MODEL: {
+        "input_cost_per_token": 0.001,
+        "output_cost_per_token": 0.002,
+        "input_cost_per_token_priority": 0.01,
+        "output_cost_per_token_priority": 0.02,
+        "input_cost_per_token_flex": 0.0005,
+        "output_cost_per_token_flex": 0.001,
+        "litellm_provider": "azure",
+        "max_tokens": 8192,
+    }
+}
+
+
+class TestAzureServiceTierCostCalculation:
+    """Test that service_tier is passed through Azure cost calculation."""
+
+    @pytest.fixture(autouse=True)
+    def register_test_model(self):
+        litellm.register_model(model_cost=TEST_MODEL_COST)
+
+    def test_service_tier_priority_higher_cost(self):
+        """Priority tier should cost more than standard."""
+        usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
+        standard_prompt, standard_completion = cost_per_token(
+            model=TEST_MODEL, usage=usage
+        )
+        priority_prompt, priority_completion = cost_per_token(
+            model=TEST_MODEL, usage=usage, service_tier="priority"
+        )
+
+        assert priority_prompt > standard_prompt
+        assert priority_completion > standard_completion
+
+    def test_service_tier_flex_lower_cost(self):
+        """Flex tier should cost less than standard."""
+        usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
+        standard_prompt, standard_completion = cost_per_token(
+            model=TEST_MODEL, usage=usage
+        )
+        flex_prompt, flex_completion = cost_per_token(
+            model=TEST_MODEL, usage=usage, service_tier="flex"
+        )
+
+        assert flex_prompt < standard_prompt
+        assert flex_completion < standard_completion
+
+    def test_service_tier_none_returns_standard(self):
+        """service_tier=None should return standard pricing."""
+        usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
+        none_prompt, none_completion = cost_per_token(
+            model=TEST_MODEL, usage=usage, service_tier=None
+        )
+        standard_prompt, standard_completion = cost_per_token(
+            model=TEST_MODEL, usage=usage, service_tier="standard"
+        )
+
+        assert abs(none_prompt - standard_prompt) < 1e-10
+        assert abs(none_completion - standard_completion) < 1e-10

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_cost_calculator.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_cost_calculator.py
@@ -428,3 +428,51 @@ class TestAzureModelRouterCostBreakdown:
         assert logging_obj.cost_breakdown["additional_costs"]["Azure Model Router Flat Cost"] == pytest.approx(
             expected_flat_cost, rel=1e-9
         )
+
+
+class TestAzureAIServiceTierCostCalculation:
+    """Test that service_tier is passed through Azure AI cost calculation."""
+
+    @pytest.fixture(autouse=True)
+    def register_test_model(self):
+        import litellm
+        litellm.register_model(model_cost={
+            "test-azure-ai-model": {
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+                "input_cost_per_token_priority": 0.01,
+                "output_cost_per_token_priority": 0.02,
+                "input_cost_per_token_flex": 0.0005,
+                "output_cost_per_token_flex": 0.001,
+                "litellm_provider": "azure_ai",
+                "max_tokens": 8192,
+            }
+        })
+
+    def test_service_tier_priority_higher_cost(self):
+        """Priority tier should cost more than standard for azure_ai."""
+        usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
+        standard_prompt, standard_completion = cost_per_token(
+            model="test-azure-ai-model", usage=usage
+        )
+        priority_prompt, priority_completion = cost_per_token(
+            model="test-azure-ai-model", usage=usage, service_tier="priority"
+        )
+
+        assert priority_prompt > standard_prompt
+        assert priority_completion > standard_completion
+
+    def test_service_tier_flex_lower_cost(self):
+        """Flex tier should cost less than standard for azure_ai."""
+        usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
+        standard_prompt, standard_completion = cost_per_token(
+            model="test-azure-ai-model", usage=usage
+        )
+        flex_prompt, flex_completion = cost_per_token(
+            model="test-azure-ai-model", usage=usage, service_tier="flex"
+        )
+
+        assert flex_prompt < standard_prompt
+        assert flex_completion < standard_completion


### PR DESCRIPTION
service_tier (priority/flex) was not forwarded to generic_cost_per_token for azure and azure_ai providers, so tier-specific pricing was ignored and standard pricing was always returned. Other providers (openai, bedrock, gemini, vertex_ai) already pass it correctly.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

Wire `service_tier` through the cost calculation chain for `azure` and `azure_ai` providers, matching the pattern already used by `openai`, `bedrock`, `gemini`, and `vertex_ai`.

**3 production files changed (6 one-line additions):**

1. **`litellm/cost_calculator.py`** — pass `service_tier=service_tier` to `azure_openai_cost_per_token()` and `azure_ai_cost_per_token()` in the central dispatcher
2. **`litellm/llms/azure/cost_calculation.py`** — add `service_tier: Optional[str] = None` parameter, forward to `generic_cost_per_token()`
3. **`litellm/llms/azure_ai/cost_calculator.py`** — add `service_tier: Optional[str] = None` parameter, forward to `generic_cost_per_token()`

**Tests added (5 new tests):**

- `tests/test_litellm/llms/azure/test_azure_cost_calculation.py` (new file) — 3 tests: priority > standard, flex < standard, None == standard
- `tests/test_litellm/llms/azure_ai/test_azure_ai_cost_calculator.py` — 2 tests: priority > standard, flex < standard