### PR TITLE
feat(ci): add coverage reporting to reusable unit test base workflows

### DIFF
--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -93,4 +93,44 @@ jobs:
             --reruns "${RERUNS}" \
             --reruns-delay 1 \
             --dist=loadscope \
-            --durations=20
+            --durations=20 \
+            --cov=litellm \
+            --cov-report=xml:coverage.xml \
+            --cov-config=pyproject.toml
+
+      - name: Save coverage report
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage.xml
+          retention-days: 1
+
+  upload-coverage:
+    name: Upload coverage to Codecov
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage-reports
+          merge-multiple: true
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          root_dir: ${{ github.workspace }}
+          fail_ci_if_error: false

--- a/.github/workflows/_test-unit-services-base.yml
+++ b/.github/workflows/_test-unit-services-base.yml
@@ -151,7 +151,10 @@ jobs:
               --maxfail="${MAX_FAILURES}" \
               --reruns "${RERUNS}" \
               --reruns-delay 1 \
-              --durations=20
+              --durations=20 \
+              --cov=litellm \
+              --cov-report=xml:coverage.xml \
+              --cov-config=pyproject.toml
           else
             poetry run pytest ${TEST_PATH:?} \
               --tb=short -vv \
@@ -160,5 +163,45 @@ jobs:
               --reruns "${RERUNS}" \
               --reruns-delay 1 \
               --dist=loadscope \
-              --durations=20
+              --durations=20 \
+              --cov=litellm \
+              --cov-report=xml:coverage.xml \
+              --cov-config=pyproject.toml
           fi
+
+      - name: Save coverage report
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: coverage-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage.xml
+          retention-days: 1
+
+  upload-coverage:
+    name: Upload coverage to Codecov
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: coverage-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage-reports
+          merge-multiple: true
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          root_dir: ${{ github.workspace }}
+          fail_ci_if_error: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@c10b806170c8ee63ea24152429041b5624f0baf5 # v4.35.1
+        uses: github/codeql-action/upload-sarif@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Extends Codecov coverage reporting to all workflows that use the two reusable base templates.

- Add `--cov=litellm --cov-report=xml --cov-config=pyproject.toml` to pytest invocations in `_test-unit-base.yml` and `_test-unit-services-base.yml`
- Save coverage XML as a GitHub Actions artifact after each test run
- Add isolated `upload-coverage` job (no secrets in scope during tests) that checks out the repo, downloads the artifact, and uploads to Codecov via OIDC

This covers all workflows that inherit from these templates:
- `test-unit-core-utils`, `test-unit-enterprise-routing`, `test-unit-integrations`
- `test-unit-llm-providers`, `test-unit-misc`, `test-unit-proxy-auth`
- `test-unit-proxy-db`, `test-unit-proxy-endpoints`, `test-unit-proxy-infra`
- `test-unit-responses-caching-types`, `test-unit-security`, `test-unit-caching-redis`

Depends on PR #24804 (base Codecov setup).

## Test plan
- [ ] Coverage uploads successfully on next PR run
- [ ] No secrets in scope during test execution