### PR TITLE
fix(proxy): use actual request start_time for failed spend logs

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -112,6 +112,11 @@ class _ProxyDBLogger(CustomLogger):
                     _litellm_logging_obj, "litellm_trace_id", None
                 )
 
+        actual_start_time = (
+            _litellm_logging_obj.start_time
+            if _litellm_logging_obj is not None
+            else datetime.now()
+        )
         await proxy_logging_obj.db_spend_update_writer.update_database(
             token=user_api_key_dict.api_key,
             response_cost=0.0,
@@ -120,7 +125,7 @@ class _ProxyDBLogger(CustomLogger):
             team_id=user_api_key_dict.team_id,
             kwargs=request_data,
             completion_response=original_exception,
-            start_time=datetime.now(),
+            start_time=actual_start_time,
             end_time=datetime.now(),
             org_id=user_api_key_dict.org_id,
         )

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -449,6 +449,94 @@ async def test_async_post_call_failure_hook_enriches_missing_team_alias():
 
 
 @pytest.mark.asyncio
+async def test_async_post_call_failure_hook_uses_actual_start_time():
+    """
+    Regression test for: failed requests logging 0 duration because both
+    start_time and end_time were set to datetime.now().
+
+    When litellm_logging_obj is present in request_data, start_time passed to
+    update_database should be litellm_logging_obj.start_time, not datetime.now().
+    """
+    logger = _ProxyDBLogger()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+        team_id="test_team_id",
+    )
+
+    actual_start = datetime(2026, 1, 1, 12, 0, 0)
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.start_time = actual_start
+    mock_logging_obj.litellm_trace_id = None
+    mock_logging_obj.model_call_details = {}
+
+    request_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {},
+        "litellm_params": {},
+        "litellm_logging_obj": mock_logging_obj,
+    }
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=Exception("Timeout after 300s"),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        mock_update_database.assert_called_once()
+        call_args = mock_update_database.call_args[1]
+        assert (
+            call_args["start_time"] == actual_start
+        ), "start_time should be the actual request start, not the failure timestamp"
+        assert (
+            call_args["end_time"] > actual_start
+        ), "end_time should be after start_time"
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_falls_back_start_time_when_no_logging_obj():
+    """
+    When litellm_logging_obj is absent from request_data, start_time should
+    fall back to datetime.now() without raising.
+    """
+    logger = _ProxyDBLogger()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+    )
+
+    request_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "metadata": {},
+        "litellm_params": {},
+        # no litellm_logging_obj
+    }
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=Exception("Auth error"),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        mock_update_database.assert_called_once()
+        call_args = mock_update_database.call_args[1]
+        assert isinstance(call_args["start_time"], datetime)
+        assert isinstance(call_args["end_time"], datetime)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("model_value", [None, ""])
 async def test_track_cost_callback_skips_for_falsy_model_and_no_slo(model_value):
     """


### PR DESCRIPTION
## Relevant issues

Fixes #24888 — failed requests logging `Duration: 0.000s` because both `start_time` and `end_time` were set to `datetime.now()` at failure time.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

✅ Test

## Changes

**Problem:** `async_post_call_failure_hook` in `litellm/proxy/hooks/proxy_track_cost_callback.py` (lines 123–124) called `datetime.now()` for both `start_time` and `end_time` when writing the spend log for a failed request. Both timestamps end up identical, so every failed request shows `Duration: 0.000s` regardless of how long the request actually ran.

**Fix:** `_litellm_logging_obj` is already fetched earlier in the same method (for trace ID propagation). Use `_litellm_logging_obj.start_time` as `actual_start_time`, with a `datetime.now()` fallback when the logging object is absent, and pass `actual_start_time` as `start_time` to `update_database`.

**Tests added** in `tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py`:
- `test_async_post_call_failure_hook_uses_actual_start_time` — asserts `start_time` equals `litellm_logging_obj.start_time` and `end_time > start_time`
- `test_async_post_call_failure_hook_falls_back_start_time_when_no_logging_obj` — asserts the fallback path (`datetime.now()`) works cleanly when no logging object is present