### PR TITLE
docs: add docstrings to SensitiveDataMasker

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -1,3 +1,5 @@
+"""Utilities for masking sensitive data (API keys, tokens, passwords) in dicts."""
+
 from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Set
 
@@ -5,6 +7,25 @@ from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
 
 
 class SensitiveDataMasker:
+    """Masks sensitive values (API keys, tokens, passwords) in dictionaries.
+
+    Recursively traverses nested dicts/lists and replaces string values whose
+    keys match known sensitive patterns with partially-redacted versions, e.g.
+    ``"sk-1234567890abcdef"`` becomes ``"sk-1****cdef"``.
+
+    Args:
+        sensitive_patterns: Set of key-name substrings that indicate a sensitive
+            field (matched against underscore-split segments of each key).
+            Defaults to common secret-related terms like ``"key"``, ``"token"``,
+            ``"password"``, etc.
+        non_sensitive_overrides: Set of key-name substrings that, when present,
+            override a sensitive match.  For example ``"cost"`` prevents
+            ``"input_cost_per_token"`` from being treated as sensitive.
+        visible_prefix: Number of leading characters to leave unmasked.
+        visible_suffix: Number of trailing characters to leave unmasked.
+        mask_char: Character used for the masked portion of the value.
+    """
+
     def __init__(
         self,
         sensitive_patterns: Optional[Set[str]] = None,
@@ -37,6 +58,12 @@ class SensitiveDataMasker:
         self.mask_char = mask_char
 
     def _mask_value(self, value: str) -> str:
+        """Return *value* with its middle characters replaced by ``mask_char``.
+
+        Characters at the start (``visible_prefix``) and end (``visible_suffix``)
+        are preserved; the rest is replaced.  Values shorter than
+        ``visible_prefix + visible_suffix`` are returned unchanged.
+        """
         if not value or len(str(value)) < (self.visible_prefix + self.visible_suffix):
             return value
 
@@ -52,6 +79,20 @@ class SensitiveDataMasker:
     def is_sensitive_key(
         self, key: str, excluded_keys: Optional[Set[str]] = None
     ) -> bool:
+        """Determine whether *key* refers to a sensitive field.
+
+        The key is split on underscores/hyphens into segments and each segment
+        is checked against ``sensitive_patterns``.  If any segment also appears
+        in ``non_sensitive_overrides``, the key is treated as non-sensitive.
+
+        Args:
+            key: The dictionary key to evaluate.
+            excluded_keys: Optional set of keys to unconditionally treat as
+                non-sensitive (exact match).
+
+        Returns:
+            ``True`` if the key is considered sensitive, ``False`` otherwise.
+        """
         # Check if key is in excluded_keys first (exact match)
         if excluded_keys and key in excluded_keys:
             return False
@@ -79,6 +120,18 @@ class SensitiveDataMasker:
         excluded_keys: Optional[Set[str]],
         key_is_sensitive: bool,
     ) -> List[Any]:
+        """Recursively mask sensitive string items within a list.
+
+        Args:
+            values: The list to process.
+            depth: Current recursion depth.
+            max_depth: Maximum recursion depth to prevent infinite loops.
+            excluded_keys: Keys to skip when evaluating nested dicts.
+            key_is_sensitive: Whether the parent key was classified as sensitive.
+
+        Returns:
+            A new list with sensitive string items masked.
+        """
         masked_items: List[Any] = []
         if depth >= max_depth:
             return values
@@ -111,6 +164,22 @@ class SensitiveDataMasker:
         max_depth: int = DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER,
         excluded_keys: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
+        """Return a copy of *data* with sensitive values masked.
+
+        Recursively walks nested dicts, lists, and objects with ``__dict__``.
+        String values under keys that match ``sensitive_patterns`` are redacted
+        via ``_mask_value``.  Non-serialisable values are converted to strings.
+
+        Args:
+            data: The dictionary to mask.
+            depth: Current recursion depth (used internally).
+            max_depth: Maximum recursion depth to prevent infinite loops.
+            excluded_keys: Optional set of key names to skip when checking
+                sensitivity (passed through to ``is_sensitive_key``).
+
+        Returns:
+            A new dictionary with sensitive values masked.
+        """
         if depth >= max_depth:
             return data
 


### PR DESCRIPTION
## Summary

- Add module-level docstring to `sensitive_data_masker.py`
- Add class-level docstring to `SensitiveDataMasker` describing its purpose, constructor parameters, and masking behavior
- Add method-level docstrings to `_mask_value`, `is_sensitive_key`, `_mask_sequence`, and `mask_dict` documenting args, return values, and behavior

## Motivation

`SensitiveDataMasker` is used throughout LiteLLM to redact API keys, tokens, and passwords from logging output, but none of its methods had docstrings. This makes it harder for contributors to understand the masking logic (e.g., segment-based key matching, non-sensitive overrides) without reading the implementation.

## Changes

Documentation only -- no logic, behavior, or test changes. Docstrings follow the Google style used elsewhere in the codebase.

## Test plan

- [ ] Verify no functional changes via `git diff` (69 added lines, all docstrings)
- [ ] Existing tests continue to pass (no code changes)