### PR TITLE
Add coverage reporting to reusable unit test base workflows

### DIFF
--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -132,7 +132,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
           directory: coverage-reports

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -93,4 +93,44 @@ jobs:
             --reruns "${RERUNS}" \
             --reruns-delay 1 \
             --dist=loadscope \
-            --durations=20
+            --durations=20 \
+            --cov=litellm \
+            --cov-report=xml:coverage.xml \
+            --cov-config=pyproject.toml
+
+      - name: Save coverage report
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage.xml
+          retention-days: 1
+
+  upload-coverage:
+    name: Upload coverage to Codecov
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage-reports
+          merge-multiple: true
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          root_dir: ${{ github.workspace }}
+          fail_ci_if_error: false

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: number
         default: 10
+      artifact-name:
+        description: "Unique name for the coverage artifact (must be unique per run)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -102,7 +106,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          name: coverage-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage.xml
           retention-days: 1
 
@@ -123,7 +127,7 @@ jobs:
       - name: Download coverage report
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          pattern: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: coverage-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage-reports
           merge-multiple: true
 

--- a/.github/workflows/_test-unit-services-base.yml
+++ b/.github/workflows/_test-unit-services-base.yml
@@ -151,7 +151,10 @@ jobs:
               --maxfail="${MAX_FAILURES}" \
               --reruns "${RERUNS}" \
               --reruns-delay 1 \
-              --durations=20
+              --durations=20 \
+              --cov=litellm \
+              --cov-report=xml:coverage.xml \
+              --cov-config=pyproject.toml
           else
             poetry run pytest ${TEST_PATH:?} \
               --tb=short -vv \
@@ -160,5 +163,45 @@ jobs:
               --reruns "${RERUNS}" \
               --reruns-delay 1 \
               --dist=loadscope \
-              --durations=20
+              --durations=20 \
+              --cov=litellm \
+              --cov-report=xml:coverage.xml \
+              --cov-config=pyproject.toml
           fi
+
+      - name: Save coverage report
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: coverage-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage.xml
+          retention-days: 1
+
+  upload-coverage:
+    name: Upload coverage to Codecov
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          pattern: coverage-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage-reports
+          merge-multiple: true
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          use_oidc: true
+          directory: coverage-reports
+          root_dir: ${{ github.workspace }}
+          fail_ci_if_error: false

--- a/.github/workflows/_test-unit-services-base.yml
+++ b/.github/workflows/_test-unit-services-base.yml
@@ -204,7 +204,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
           directory: coverage-reports

--- a/.github/workflows/_test-unit-services-base.yml
+++ b/.github/workflows/_test-unit-services-base.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Download coverage report
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          pattern: coverage-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: coverage-run-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage-reports
           merge-multiple: true
 

--- a/.github/workflows/_test-unit-services-base.yml
+++ b/.github/workflows/_test-unit-services-base.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Download coverage report
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          pattern: coverage-run-${{ github.run_id }}-${{ github.run_attempt }}
+          pattern: coverage-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage-reports
           merge-multiple: true
 

--- a/.github/workflows/_test-unit-services-base.yml
+++ b/.github/workflows/_test-unit-services-base.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      artifact-name:
+        description: "Unique name for the coverage artifact (must be unique per run)"
+        required: false
+        type: string
+        default: "run"
     secrets:
       REDIS_HOST:
         required: false
@@ -173,7 +178,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: coverage-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: coverage-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage.xml
           retention-days: 1
 

--- a/.github/workflows/test-litellm-matrix.yml
+++ b/.github/workflows/test-litellm-matrix.yml
@@ -206,7 +206,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
           directory: coverage-reports

--- a/.github/workflows/test-unit-caching-redis.yml
+++ b/.github/workflows/test-unit-caching-redis.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-unit-core-utils.yml
+++ b/.github/workflows/test-unit-core-utils.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,3 +20,4 @@ jobs:
       test-path: "tests/test_litellm/litellm_core_utils"
       workers: 2
       reruns: 1
+      artifact-name: core-utils

--- a/.github/workflows/test-unit-enterprise-routing.yml
+++ b/.github/workflows/test-unit-enterprise-routing.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -22,3 +24,4 @@ jobs:
         tests/test_litellm/router_strategy
       workers: 2
       reruns: 2
+      artifact-name: enterprise-routing

--- a/.github/workflows/test-unit-integrations.yml
+++ b/.github/workflows/test-unit-integrations.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,3 +20,4 @@ jobs:
       test-path: "tests/test_litellm/integrations"
       workers: 2
       reruns: 3
+      artifact-name: integrations

--- a/.github/workflows/test-unit-llm-providers.yml
+++ b/.github/workflows/test-unit-llm-providers.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +21,7 @@ jobs:
       test-path: "tests/test_litellm/llms/vertex_ai"
       workers: 1
       reruns: 2
+      artifact-name: llm-vertex-ai
 
   other-providers:
     name: All Other Providers
@@ -27,3 +30,4 @@ jobs:
       test-path: "tests/test_litellm/llms --ignore=tests/test_litellm/llms/vertex_ai"
       workers: 2
       reruns: 2
+      artifact-name: llm-other-providers

--- a/.github/workflows/test-unit-misc.yml
+++ b/.github/workflows/test-unit-misc.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -29,3 +31,4 @@ jobs:
         tests/test_litellm/test_*.py
       workers: 2
       reruns: 2
+      artifact-name: misc

--- a/.github/workflows/test-unit-proxy-auth.yml
+++ b/.github/workflows/test-unit-proxy-auth.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,3 +20,4 @@ jobs:
       test-path: "tests/test_litellm/proxy/auth tests/test_litellm/proxy/hooks tests/test_litellm/proxy/policy_engine tests/test_litellm/proxy/client"
       workers: 2
       reruns: 2
+      artifact-name: proxy-auth

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -41,6 +41,7 @@ jobs:
       timeout-minutes: ${{ matrix.timeout }}
       enable-redis: false
       enable-postgres: true
+      artifact-name: proxy-db-${{ matrix.test-group }}
     secrets:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       POSTGRES_USER: ${{ secrets.POSTGRES_USER }}

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-unit-proxy-endpoints.yml
+++ b/.github/workflows/test-unit-proxy-endpoints.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -33,3 +35,4 @@ jobs:
         tests/test_litellm/proxy/ui_crud_endpoints
       workers: 2
       reruns: 2
+      artifact-name: proxy-endpoints

--- a/.github/workflows/test-unit-proxy-infra.yml
+++ b/.github/workflows/test-unit-proxy-infra.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,3 +28,4 @@ jobs:
         tests/test_litellm/proxy/test_*.py
       workers: 2
       reruns: 2
+      artifact-name: proxy-infra

--- a/.github/workflows/test-unit-responses-caching-types.yml
+++ b/.github/workflows/test-unit-responses-caching-types.yml
@@ -6,6 +6,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,3 +20,4 @@ jobs:
       test-path: "tests/test_litellm/responses tests/test_litellm/caching tests/test_litellm/types"
       workers: 2
       reruns: 2
+      artifact-name: responses-caching-types

--- a/.github/workflows/test-unit-security.yml
+++ b/.github/workflows/test-unit-security.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `--cov=litellm`, `--cov-report`, and `--cov-config` flags to `_test-unit-base.yml` and `_test-unit-services-base.yml`
- Adds isolated `upload-coverage` job (OIDC, no secrets in test job) to both base workflows
- Covers 11 GHA workflows that call these templates (caching-redis, core-utils, llm-providers, integrations, misc, proxy-auth, proxy-db, proxy-infra, proxy-endpoints, responses-caching-types, security, enterprise-routing)

## Test plan

- [ ] Verify coverage appears on Codecov for a PR that triggers one of the affected workflows