### PR TITLE
fix: [Bug]: Lastest helm chart is pointing towards a non-existing image (#22173)

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: {{ include "litellm.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "main-latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HOST

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }} 
       containers:
         - name: prisma-migrations
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "main-latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -3,6 +3,12 @@ templates:
   - deployment.yaml
   - configmap-litellm.yaml
 tests:
+  - it: should use main-latest tag by default
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/berriai/litellm-database:main-latest
   - it: should work
     template: deployment.yaml
     set:

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -2,6 +2,15 @@ suite: test migrations job
 templates:
   - migrations-job.yaml
 tests:
+  - it: should use main-latest image tag by default
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/berriai/litellm-database:main-latest
   - it: should work with envVars
     template: migrations-job.yaml
     set:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -9,9 +9,8 @@ image:
   # Use "ghcr.io/berriai/litellm-database" for optimized image with database
   repository: ghcr.io/berriai/litellm-database
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  # tag: "main-latest"
-  tag: ""
+  # Overrides the image tag whose default is "main-latest".
+  tag: "main-latest"
 
 imagePullSecrets: []
 nameOverride: "litellm"

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -9,7 +9,9 @@ image:
   # Use "ghcr.io/berriai/litellm-database" for optimized image with database
   repository: ghcr.io/berriai/litellm-database
   pullPolicy: Always
-  # Overrides the image tag whose default is "main-latest".
+  # Overrides the image tag. Defaults to "main-latest" (the latest main-branch build).
+  # For production use, override this with a specific version tag (e.g. "v1.x.y") to
+  # ensure reproducible deployments, since "main-latest" is a mutable tag.
   tag: "main-latest"
 
 imagePullSecrets: []


### PR DESCRIPTION
## Relevant issues

Fixes #22173

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ X] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Summary
Updates Helm chart to use a valid and stable image tag (`main-latest`) instead of dynamically constructing a potentially non-existent image tag from the chart version.

### Problem
The previous implementation used `printf "main-%s" .Chart.AppVersion` as the default image tag, which could reference image tags that don't exist in the container registry. This caused Helm deployments to fail when attempting to pull a non-existent image.

### Solution
- Updated `deployment.yaml` to default to the stable `main-latest` tag
- Updated `migrations-job.yaml` to use the same stable tag
- Changed `values.yaml` to explicitly set `tag: "main-latest"` instead of leaving it empty, ensuring consistency and making the default image tag discoverable in the values configuration

### Affected files
- `deploy/charts/litellm-helm/templates/deployment.yaml`
- `deploy/charts/litellm-helm/templates/migrations-job.yaml`
- `deploy/charts/litellm-helm/values.yaml`

Users can still override the image tag by setting `image.tag` in their Helm values if they need a different version.