### PR TITLE
fix: enable Uvicorn proxy headers to fix SSO 307 redirect behind TLS-…

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -137,11 +137,15 @@ class ProxyInitializationHelpers:
         import litellm
         from litellm._logging import _get_uvicorn_json_log_config
 
-        uvicorn_args = {
+        forwarded_allow_ips = os.getenv("FORWARDED_ALLOW_IPS", None)
+        uvicorn_args: dict = {
             "app": "litellm.proxy.proxy_server:app",
             "host": host,
             "port": port,
         }
+        if forwarded_allow_ips is not None:
+            uvicorn_args["proxy_headers"] = True
+            uvicorn_args["forwarded_allow_ips"] = forwarded_allow_ips
         if log_config is not None:
             print(f"Using log_config: {log_config}")  # noqa
             uvicorn_args["log_config"] = log_config


### PR DESCRIPTION
Description:

When LiteLLM is deployed behind a TLS-terminating reverse proxy (e.g., GCP Cloud Run, AWS ALB, Nginx), the new /ui/login static page introduced in v1.81.x triggers a Starlette StaticFiles 307 redirect from /ui/login to /ui/login/. This redirect constructs the URL using the incoming request's scheme, which is http behind the proxy — sending the browser to an HTTP URL that fails or loops. This broke Generic SSO login for users upgrading from v1.80.0.

Cause:
In v1.81.x, a dedicated /ui/login page was added and the _restructure_ui_html_files startup function converts login.html into login/index.html. Starlette's StaticFiles enforces a trailing-slash 307 redirect for directory URLs, and builds the redirect URL from the ASGI scope's scheme. Since Uvicorn was not configured with proxy_headers, it never reads X-Forwarded-Proto from the upstream proxy, so scope["scheme"] stays http even when the client connected via HTTPS. This was never an issue in v1.80.0 because no static login page existed — the login was handled entirely client-side.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes
Fix:
Add support for the FORWARDED_ALLOW_IPS environment variable in Uvicorn's startup args. When set, Uvicorn enables proxy_headers mode and trusts X-Forwarded-Proto / X-Forwarded-For headers from the specified IPs, ensuring all redirects (including Starlette's StaticFiles 307) use the correct HTTPS scheme. Users behind a reverse proxy set FORWARDED_ALLOW_IPS=* in their environment.
