### PR TITLE
fix: allow hashed token_id in /key/update endpoint

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -942,9 +942,9 @@ async def _check_team_key_limits(
         where={"team_id": team_table.team_id},
     )
     # Exclude the key being updated to avoid double-counting its limits.
-    # key.token is the SHA-256 hash stored in DB; data.key is the raw key string.
+    # data.key may be a raw key (sk-...) or a pre-hashed token_id.
     if isinstance(data, UpdateKeyRequest):
-        hashed_key = hash_token(data.key)
+        hashed_key = _hash_token_if_needed(data.key)
         keys = [key for key in keys if key.token != hashed_key]
     check_team_key_model_specific_limits(
         keys=keys,
@@ -1101,9 +1101,9 @@ async def _check_org_key_limits(
         where={"organization_id": org_table.organization_id},
     )
     # Exclude the key being updated to avoid double-counting its limits.
-    # key.token is the SHA-256 hash stored in DB; data.key is the raw key string.
+    # data.key may be a raw key (sk-...) or a pre-hashed token_id.
     if isinstance(data, UpdateKeyRequest):
-        hashed_key = hash_token(data.key)
+        hashed_key = _hash_token_if_needed(data.key)
         keys = [key for key in keys if key.token != hashed_key]
     check_org_key_model_specific_limits(
         keys=keys,
@@ -2157,7 +2157,7 @@ async def update_key_fn(
         # Delete - key from cache, since it's been updated!
         # key updated - a new model could have been added to this key. it should not block requests after this is done
         await _delete_cache_key_object(
-            hashed_token=hash_token(key),
+            hashed_token=_hash_token_if_needed(key),
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )


### PR DESCRIPTION
## Summary

`/key/update` currently calls `hash_token()` directly on the `key` field, which assumes the value is always a raw key (starting with `sk-`). This breaks when a pre-hashed `token_id` is passed instead.

This change replaces three `hash_token()` calls with `_hash_token_if_needed()`, which already exists and is already used consistently in `/key/info`, `/key/delete`, and the internal `_get_and_validate_existing_key` and `update_data` helpers.

## Changes

- `_check_team_key_limits`: use `_hash_token_if_needed(data.key)` when excluding the current key from limit checks
- `_check_org_key_limits`: same
- `update_key_fn`: use `_hash_token_if_needed(key)` for cache invalidation after update

## Why

This is required to support write-only key attributes in the Terraform provider (BerriAI/terraform-provider-litellm#27). The provider stores the SHA-256 `token_id` as the Terraform resource ID (safe to store in state) rather than the raw key, and passes it to `/key/update` as the identifier. Without this fix, updates to managed keys fail.