### PR TITLE
feat(bedrock): add MiniMax M2.5 model pricing and tool support metadata

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7436,6 +7436,45 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "minimax.minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/minimax.minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/us-east-1/minimax.minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/us-east-1/minimax.minimax-m2.1": {
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",


### PR DESCRIPTION
## Summary

Add MiniMax M2.5 (`minimax.minimax-m2.5`) model entries to `model_prices_and_context_window.json` following the same pattern as existing Bedrock models (e.g., `moonshotai.kimi-k2.5`, `minimax.minimax-m2.1`).

**Data-only change** — no code modifications.

## Problem

MiniMax M2.5 on Amazon Bedrock supports tool calling via the Converse API ([AWS model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html)), but LiteLLM rejects `tools` and `tool_choice` parameters because the model has no entries in `model_prices_and_context_window.json`.

```
litellm.UnsupportedParamsError: bedrock does not support parameters: ['tools'],
for model=converse/minimax.minimax-m2.5
```

## Changes

**File:** `model_prices_and_context_window.json`

Added 3 entries following existing conventions:

| Key | `litellm_provider` | Purpose |
|-----|---------------------|---------|
| `minimax.minimax-m2.5` | `bedrock_converse` | Converse route (bare name lookup) |
| `bedrock/minimax.minimax-m2.5` | `bedrock` | Invoke route (base) |
| `bedrock/us-east-1/minimax.minimax-m2.5` | `bedrock` | Region-specific |

All with `supports_function_calling: true` and `supports_tool_choice: true`.

This matches the pattern used by `moonshotai.kimi-k2.5` and `minimax.minimax-m2.1`.

## Verification

- `supports_function_calling()` returns `True` for `converse/minimax.minimax-m2.5` with `bedrock_converse` provider
- LiteLLM proxy `/model/info` shows `supports_function_calling=True`
- Proxy returns `200 OK` for requests with `tools` parameter
- Direct Bedrock Converse API calls return `stopReason: "tool_use"` with valid tool call responses

## Test plan

- [x] `validate-model-prices-json` passes
- [x] `supports_function_calling()` returns `True` for the new model
- [x] LiteLLM proxy accepts `tools` parameter without `UnsupportedParamsError`
- [x] End-to-end test with Claude Code CLI through LiteLLM proxy

Fixes #24970