### PR TITLE
fix: wrap single-image tool_result in image_url object for Bedrock Converse

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -480,7 +480,14 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 tool_call_id=content.get(
                                                     "tool_use_id", ""
                                                 ),
-                                                content=openai_image_url,
+                                                content=[
+                                                    ChatCompletionImageObject(
+                                                        type="image_url",
+                                                        image_url=ChatCompletionImageUrlObject(
+                                                            url=openai_image_url
+                                                        ),
+                                                    )
+                                                ],
                                             )
                                             self._add_cache_control_if_applicable(
                                                 content, tool_result, model

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -473,26 +473,26 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 self._translate_anthropic_image_to_openai(
                                                     cast(dict, source)
                                                 )
-                                                or ""
                                             )
-                                            tool_result = ChatCompletionToolMessage(
-                                                role="tool",
-                                                tool_call_id=content.get(
-                                                    "tool_use_id", ""
-                                                ),
-                                                content=[
-                                                    ChatCompletionImageObject(
-                                                        type="image_url",
-                                                        image_url=ChatCompletionImageUrlObject(
-                                                            url=openai_image_url
-                                                        ),
-                                                    )
-                                                ],
-                                            )
-                                            self._add_cache_control_if_applicable(
-                                                content, tool_result, model
-                                            )
-                                            tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                            if openai_image_url:
+                                                tool_result = ChatCompletionToolMessage(
+                                                    role="tool",
+                                                    tool_call_id=content.get(
+                                                        "tool_use_id", ""
+                                                    ),
+                                                    content=[
+                                                        ChatCompletionImageObject(
+                                                            type="image_url",
+                                                            image_url=ChatCompletionImageUrlObject(
+                                                                url=openai_image_url
+                                                            ),
+                                                        )
+                                                    ],
+                                                )
+                                                self._add_cache_control_if_applicable(
+                                                    content, tool_result, model
+                                                )
+                                                tool_message_list.append(tool_result)  # type: ignore[arg-type]
                                 else:
                                     # For multiple content items, combine into a single tool message
                                     # with list content to preserve all items while having one tool_use_id

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -750,10 +750,13 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_base64_image():
             break
 
     assert tool_message is not None, "Tool message not found in result"
-    # Tool messages in OpenAI format have string content (data URL), not list
-    assert isinstance(tool_message["content"], str)
-    assert tool_message["content"].startswith("data:image/jpeg;base64,")
-    assert "/9j/4AAQSkZJRgABAQAAAQABAAD" in tool_message["content"]
+    # Tool messages with images use list content with ChatCompletionImageObject
+    assert isinstance(tool_message["content"], list)
+    assert len(tool_message["content"]) == 1
+    image_obj = tool_message["content"][0]
+    assert image_obj["type"] == "image_url"
+    assert image_obj["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    assert "/9j/4AAQSkZJRgABAQAAAQABAAD" in image_obj["image_url"]["url"]
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_with_url_image():
@@ -806,10 +809,13 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_url_image():
             break
 
     assert tool_message is not None, "Tool message not found in result"
-    # Tool messages in OpenAI format have string content (URL), not list
-    assert isinstance(tool_message["content"], str)
+    # Tool messages with images use list content with ChatCompletionImageObject
+    assert isinstance(tool_message["content"], list)
+    assert len(tool_message["content"]) == 1
+    image_obj = tool_message["content"][0]
+    assert image_obj["type"] == "image_url"
     assert (
-        tool_message["content"]
+        image_obj["image_url"]["url"]
         == "https://i0.wp.com/picjumbo.com/wp-content/uploads/amazing-stone-path-in-forest-free-image.jpg"
     )
 


### PR DESCRIPTION
Fixes #24968

## Problem
When a tool result contains a single image, the Bedrock Converse adapter assigns the raw data URI string directly to `content` instead of wrapping it in a `ChatCompletionImageObject`. The multi-image code path correctly wraps images. This causes downstream failures when the content field is expected to be a structured object.

## Solution
Align the single-item image path with the multi-item path by wrapping the image URL in `ChatCompletionImageObject(type="image_url", image_url=ChatCompletionImageUrlObject(url=...))` instead of assigning the raw string.

## Testing
Verified the fix matches the existing multi-item pattern at lines 521-529 of the same file.