### PR TITLE
feat: Add Gateway API support to Helm chart (HTTPRoute)

### DIFF
--- a/deploy/charts/litellm-helm/templates/httproute.yaml
+++ b/deploy/charts/litellm-helm/templates/httproute.yaml
@@ -11,8 +11,10 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    - name: {{ .Values.httpRoute.gatewayName }}
-      namespace: {{ default .Release.Namespace .Values.httpRoute.gatewayNamespace }}
+    - name: {{ required "httpRoute.gatewayName is required when httpRoute.enabled is true" .Values.httpRoute.gatewayName }}
+      {{- with (default "" .Values.httpRoute.gatewayNamespace) }}
+      namespace: {{ . }}
+      {{- end }}
       {{- with .Values.httpRoute.gatewayGroup }}
       group: {{ . }}
       {{- end }}

--- a/deploy/charts/litellm-helm/templates/httproute.yaml
+++ b/deploy/charts/litellm-helm/templates/httproute.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "litellm.fullname" . }}
+  labels:
+    {{- include "litellm.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.gatewayName }}
+      namespace: {{ default .Release.Namespace .Values.httpRoute.gatewayNamespace }}
+      {{- with .Values.httpRoute.gatewayGroup }}
+      group: {{ . }}
+      {{- end }}
+      {{- with .Values.httpRoute.gatewayKind }}
+      kind: {{ . }}
+      {{- end }}
+      {{- with .Values.httpRoute.gatewaySectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml .Values.httpRoute.hostnames | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- range .Values.httpRoute.rules }}
+    - matches:
+        {{- if .matches }}
+        {{- toYaml .matches | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ include "litellm.fullname" $ }}
+          port: {{ $.Values.service.port }}
+        {{- end }}
+    {{- end }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "litellm.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/litellm-helm/templates/httproute.yaml
+++ b/deploy/charts/litellm-helm/templates/httproute.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   parentRefs:
     - name: {{ required "httpRoute.gatewayName is required when httpRoute.enabled is true" .Values.httpRoute.gatewayName }}
-      {{- with (default "" .Values.httpRoute.gatewayNamespace) }}
+      {{- with .Values.httpRoute.gatewayNamespace }}
       namespace: {{ . }}
       {{- end }}
       {{- with .Values.httpRoute.gatewayGroup }}

--- a/deploy/charts/litellm-helm/tests/http_route_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/http_route_tests.yaml
@@ -1,0 +1,136 @@
+suite: HTTPRoute Configuration Tests
+templates:
+  - httproute.yaml
+tests:
+  - it: should not create HTTPRoute by default
+    template: httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HTTPRoute when enabled
+    template: httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gatewayName: "my-gateway"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: "my-gateway"
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should map HTTPRoute values correctly
+    template: httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gatewayName: "my-gateway"
+      httpRoute.gatewayNamespace: "gateway-ns"
+      httpRoute.hostnames:
+        - litellm.example.com
+      service.port: 4000
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: litellm.example.com
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: "gateway-ns"
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 4000
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-litellm
+
+  - it: should map full parentRefs in HTTPRoute
+    template: httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gatewayName: "my-envoy-gateway"
+      httpRoute.gatewayNamespace: "envoy-gateway-system"
+      httpRoute.gatewayGroup: "gateway.networking.k8s.io"
+      httpRoute.gatewayKind: "Gateway"
+      httpRoute.gatewaySectionName: "default"
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: "my-envoy-gateway"
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: "envoy-gateway-system"
+      - equal:
+          path: spec.parentRefs[0].group
+          value: "gateway.networking.k8s.io"
+      - equal:
+          path: spec.parentRefs[0].kind
+          value: "Gateway"
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: "default"
+
+  - it: should add annotations to HTTPRoute
+    template: httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gatewayName: "my-gateway"
+      httpRoute.annotations:
+        external-dns.alpha.kubernetes.io/hostname: litellm.example.com
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+    asserts:
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+          value: litellm.example.com
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+
+  - it: should allow custom matches in HTTPRoute and still render default backendRefs
+    template: httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gatewayName: "my-gateway"
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /v1
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /v1
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-litellm
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 4000
+
+  - it: should allow custom backendRefs in HTTPRoute
+    template: httproute.yaml
+    set:
+      httpRoute.enabled: true
+      httpRoute.gatewayName: "my-gateway"
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /v1
+          backendRefs:
+            - name: custom-service
+              port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /v1
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: custom-service
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -147,6 +147,10 @@ httpRoute:
   annotations: {}
   hostnames: []
   rules: []
+  # - matches:
+  #     - path:
+  #         type: PathPrefix
+  #         value: /
   #   backendRefs:
   #   - name: litellm
   #     port: 4000

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -139,7 +139,7 @@ ingress:
 
 httpRoute:
   enabled: false
-  gatewayName: "my-envoy-gateway" # required
+  gatewayName: "" # required when httpRoute.enabled is true
   gatewayNamespace: ""
   gatewayGroup: ""
   gatewayKind: ""

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -150,10 +150,6 @@ httpRoute:
   # - matches:
   #     - path:
   #         type: PathPrefix
-  rules: []
-  # - matches:
-  #     - path:
-  #         type: PathPrefix
   #         value: /
   #   backendRefs:
   #   - name: litellm

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -139,7 +139,7 @@ ingress:
 
 httpRoute:
   enabled: false
-  gatewayName: ""
+  gatewayName: "my-envoy-gateway" # required
   gatewayNamespace: ""
   gatewayGroup: ""
   gatewayKind: ""

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -137,6 +137,20 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  enabled: false
+  gatewayName: ""
+  gatewayNamespace: ""
+  gatewayGroup: ""
+  gatewayKind: ""
+  gatewaySectionName: ""
+  annotations: {}
+  hostnames: []
+  rules: []
+  #   backendRefs:
+  #   - name: litellm
+  #     port: 4000
+
 # masterkey: changeit
 
 # if set, use this secret for the master key; otherwise, autogenerate a new one

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -150,6 +150,10 @@ httpRoute:
   # - matches:
   #     - path:
   #         type: PathPrefix
+  rules: []
+  # - matches:
+  #     - path:
+  #         type: PathPrefix
   #         value: /
   #   backendRefs:
   #   - name: litellm


### PR DESCRIPTION
## Relevant issues

Fixes #24973

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`deploy/charts/litellm-helm/tests/http_route_tests.yaml`](https://github.com/BerriAI/litellm/tree/main/deploy/charts/litellm-helm/tests/http_route_tests.yaml) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`helm unittest -f 'tests/*.yaml' deploy/charts/litellm-helm`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🚄 Infrastructure

## Changes

Added optional support for Kubernetes Gateway API in the Helm chart
Introduced templates for:
- `HTTPRoute`

Added new `httpRoute` configuration block in values.yaml:
httpRoute.enabled flag to toggle the feature
Configurable fields for  HTTPRoute resources
Ensured Gateway API resources are only created when explicitly enabled
Maintained backward compatibility by keeping Ingress as the default behavior