### PR TITLE
fix(mcp): use prefix-aware matching in semantic tool filter

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -245,6 +245,7 @@ class SemanticMCPToolFilter:
         server or client prefixes still match the semantic router's index names.
         """
         matched_tools = []
+        # Guard against multiple index names matching the same tool via suffix
         seen: set = set()
         for index_name in tool_names:
             for tool in available_tools:

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -245,11 +245,13 @@ class SemanticMCPToolFilter:
         server or client prefixes still match the semantic router's index names.
         """
         matched_tools = []
+        seen: set = set()
         for index_name in tool_names:
             for tool in available_tools:
                 tool_name, _ = self._extract_tool_info(tool)
-                if self._tool_name_matches(tool_name, index_name):
+                if tool_name not in seen and self._tool_name_matches(tool_name, index_name):
                     matched_tools.append(tool)
+                    seen.add(tool_name)
                     break
         return matched_tools
 

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -3,6 +3,7 @@ Semantic MCP Tool Filtering using semantic-router
 
 Filters MCP tools semantically for /chat/completions and /responses endpoints.
 """
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
@@ -100,6 +101,25 @@ class SemanticMCPToolFilter:
             description = str(tool.description) if tool.description else str(tool.name)
 
         return name, description
+
+    @staticmethod
+    def _normalize_tool_name(name: str) -> str:
+        """Normalize tool name for comparison: lowercase, replace hyphens with underscores."""
+        return name.replace("-", "_").lower()
+
+    def _tool_name_matches(self, client_name: str, index_name: str) -> bool:
+        """
+        Check if client_name matches index_name, accounting for prefixes.
+
+        MCP tools may be prefixed by the server name (e.g., "weather-get_forecast")
+        or further prefixed by clients. This matches by normalizing hyphens/underscores
+        and checking if client_name ends with index_name.
+        """
+        if client_name == index_name:
+            return True
+        norm_client = self._normalize_tool_name(client_name)
+        norm_index = self._normalize_tool_name(index_name)
+        return norm_client.endswith(norm_index)
 
     def _build_router(self, tools: List) -> None:
         """Build semantic router with tools (MCPTool objects or OpenAI function dicts)."""
@@ -216,17 +236,19 @@ class SemanticMCPToolFilter:
     def _get_tools_by_names(
         self, tool_names: List[str], available_tools: List[Any]
     ) -> List[Any]:
-        """Get tools from available_tools by their names, preserving order."""
-        # Match tools from available_tools (preserves format - dict or MCPTool)
-        matched_tools = []
-        for tool in available_tools:
-            tool_name, _ = self._extract_tool_info(tool)
-            if tool_name in tool_names:
-                matched_tools.append(tool)
+        """Get tools from available_tools by their names, preserving order.
 
-        # Reorder to match semantic router's ordering
-        tool_map = {self._extract_tool_info(t)[0]: t for t in matched_tools}
-        return [tool_map[name] for name in tool_names if name in tool_map]
+        Uses prefix-aware matching so that client-provided tool names with
+        server or client prefixes still match the semantic router's index names.
+        """
+        matched_tools = []
+        for index_name in tool_names:
+            for tool in available_tools:
+                tool_name, _ = self._extract_tool_info(tool)
+                if self._tool_name_matches(tool_name, index_name):
+                    matched_tools.append(tool)
+                    break
+        return matched_tools
 
     def extract_user_query(self, messages: List[Dict[str, Any]]) -> str:
         """

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -113,13 +113,16 @@ class SemanticMCPToolFilter:
 
         MCP tools may be prefixed by the server name (e.g., "weather-get_forecast")
         or further prefixed by clients. This matches by normalizing hyphens/underscores
-        and checking if client_name ends with index_name.
+        and checking if client_name ends with index_name at a word boundary.
         """
         if client_name == index_name:
             return True
         norm_client = self._normalize_tool_name(client_name)
         norm_index = self._normalize_tool_name(index_name)
-        return norm_client.endswith(norm_index)
+        if not norm_client.endswith(norm_index):
+            return False
+        # Ensure match is at a word boundary (preceded by underscore separator)
+        return len(norm_client) == len(norm_index) or norm_client[-(len(norm_index) + 1)] == "_"
 
     def _build_router(self, tools: List) -> None:
         """Build semantic router with tools (MCPTool objects or OpenAI function dicts)."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -392,3 +392,132 @@ async def test_semantic_filter_hook_skips_no_tools():
     assert result is None, "Hook should skip requests without tools"
     print("✅ Hook correctly skips requests without tools")
 
+
+def test_normalize_tool_name():
+    """Test that tool name normalization handles hyphens and case."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    assert SemanticMCPToolFilter._normalize_tool_name("get-weather-forecast") == "get_weather_forecast"
+    assert SemanticMCPToolFilter._normalize_tool_name("Send_Notification") == "send_notification"
+    assert SemanticMCPToolFilter._normalize_tool_name("weather-get_forecast") == "weather_get_forecast"
+    assert SemanticMCPToolFilter._normalize_tool_name("read_document") == "read_document"
+
+
+def test_tool_name_matches():
+    """Test prefix-aware tool name matching."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    mock_router = Mock()
+    f = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # Exact match
+    assert f._tool_name_matches("get_forecast", "get_forecast") is True
+    # Server prefix (hyphen separator)
+    assert f._tool_name_matches("weather-get_forecast", "get_forecast") is True
+    # Client prefix (underscores throughout)
+    assert f._tool_name_matches("mcp_litellm_weather_get_forecast", "get_forecast") is True
+    # No match - tool name doesn't end with index name
+    assert f._tool_name_matches("get_forecast_v2", "get_forecast") is False
+    # No match - completely different
+    assert f._tool_name_matches("send_notification", "get_forecast") is False
+
+
+def test_get_tools_by_names_exact_match():
+    """Test that _get_tools_by_names works with exact name matches."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    available_tools = [
+        MCPTool(name="get_forecast", description="Get weather forecast", inputSchema={"type": "object"}),
+        MCPTool(name="send_notification", description="Send a notification", inputSchema={"type": "object"}),
+        MCPTool(name="read_document", description="Read a document", inputSchema={"type": "object"}),
+    ]
+
+    result = filter_instance._get_tools_by_names(
+        ["send_notification", "get_forecast"], available_tools
+    )
+
+    assert len(result) == 2
+    assert result[0].name == "send_notification"
+    assert result[1].name == "get_forecast"
+
+
+def test_get_tools_by_names_server_prefix():
+    """Test matching when available tools have server prefix (e.g., weather-get_forecast)."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    available_tools = [
+        MCPTool(name="weather-get_forecast", description="Get weather forecast", inputSchema={"type": "object"}),
+        MCPTool(name="alerts-send_notification", description="Send a notification", inputSchema={"type": "object"}),
+        MCPTool(name="docs-read_document", description="Read a document", inputSchema={"type": "object"}),
+    ]
+
+    result = filter_instance._get_tools_by_names(
+        ["get_forecast", "send_notification"], available_tools
+    )
+
+    assert len(result) == 2
+    assert result[0].name == "weather-get_forecast"
+    assert result[1].name == "alerts-send_notification"
+
+
+def test_get_tools_by_names_client_prefix():
+    """Test matching when available tools have client-added prefix with underscore normalization."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    available_tools = [
+        MCPTool(name="mcp_litellm_weather_get_forecast", description="Get weather forecast", inputSchema={"type": "object"}),
+        MCPTool(name="mcp_litellm_alerts_send_notification", description="Send a notification", inputSchema={"type": "object"}),
+    ]
+
+    # Semantic router returns server-prefixed names (with hyphens)
+    result = filter_instance._get_tools_by_names(
+        ["weather-get_forecast", "alerts-send_notification"], available_tools
+    )
+
+    assert len(result) == 2
+    assert result[0].name == "mcp_litellm_weather_get_forecast"
+    assert result[1].name == "mcp_litellm_alerts_send_notification"
+

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -430,6 +430,9 @@ def test_tool_name_matches():
     assert f._tool_name_matches("get_forecast_v2", "get_forecast") is False
     # No match - completely different
     assert f._tool_name_matches("send_notification", "get_forecast") is False
+    # No match - suffix without word boundary (e.g., "preview" should not match "view")
+    assert f._tool_name_matches("preview", "view") is False
+    assert f._tool_name_matches("broadcast", "cast") is False
 
 
 def test_get_tools_by_names_exact_match():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -524,3 +524,31 @@ def test_get_tools_by_names_client_prefix():
     assert result[0].name == "mcp_litellm_weather_get_forecast"
     assert result[1].name == "mcp_litellm_alerts_send_notification"
 
+
+def test_get_tools_by_names_no_duplicates():
+    """Test that the same tool is not returned twice when multiple index names match it."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    available_tools = [
+        MCPTool(name="weather_get_forecast", description="Get weather forecast", inputSchema={"type": "object"}),
+    ]
+
+    # Both index names match the same tool via suffix
+    result = filter_instance._get_tools_by_names(
+        ["get_forecast", "weather_get_forecast"], available_tools
+    )
+
+    assert len(result) == 1
+    assert result[0].name == "weather_get_forecast"
+


### PR DESCRIPTION
## Relevant issues

Fixes #22445

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

`_get_tools_by_names()` used exact string matching to map semantic router results back to client-provided tools. This fails when tool names are prefixed by server names (e.g., `weather-get_forecast` vs `get_forecast`) or when clients normalize separators (e.g., hyphens to underscores). The filter matches zero tools and falls back to returning all tools unfiltered.

- Add `_normalize_tool_name()` and `_tool_name_matches()` for prefix-aware matching via normalized suffix comparison
- Simplify `_get_tools_by_names()` to a single pass that preserves semantic relevance ordering
- 5 new tests covering normalization, exact match, server prefix, and client prefix scenarios
