### PR TITLE
feat(router): integrate allowed_fails_policy into health check failures

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -288,6 +288,7 @@ router_settings:
 | database_connection_pool_timeout | integer | Database connection pool timeout in seconds |
 | disable_error_logs | boolean | If true, suppresses error tracking and storage in the database |
 | enable_health_check_routing | boolean | If true, enables health check-driven request routing to avoid unhealthy deployments |
+| health_check_ignore_transient_errors | boolean | If true, 429 (rate limit) and 408 (timeout) health check failures are ignored and do not affect routing or cooldown |
 | enable_mcp_registry | boolean | If true, enables access to the centralized MCP server registry |
 | enforce_rbac | boolean | If true, enables role-based access control (RBAC) for all proxy operations |
 | forward_llm_provider_auth_headers | boolean | If true, forwards provider-specific auth headers to LLM API calls |
@@ -396,7 +397,6 @@ router_settings:
 | guardrail_list | List[GuardrailTypedDict] | List of guardrail configurations for guardrail load balancing. Enables load balancing across multiple guardrail deployments with the same guardrail_name. [Further Docs](./guardrails/guardrail_load_balancing.md) |
 | enable_health_check_routing | boolean | If true, enables health check-driven deployment filtering to avoid routing requests to unhealthy deployments |
 | health_check_staleness_threshold | integer | Maximum age in seconds for cached health check results before marking deployments as stale |
-| health_check_ignore_transient_errors | boolean | If true, 429 (rate limit) and 408 (timeout) health check failures are ignored and do not affect routing or cooldown |
 
 
 ### environment variables - Reference

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -396,6 +396,7 @@ router_settings:
 | guardrail_list | List[GuardrailTypedDict] | List of guardrail configurations for guardrail load balancing. Enables load balancing across multiple guardrail deployments with the same guardrail_name. [Further Docs](./guardrails/guardrail_load_balancing.md) |
 | enable_health_check_routing | boolean | If true, enables health check-driven deployment filtering to avoid routing requests to unhealthy deployments |
 | health_check_staleness_threshold | integer | Maximum age in seconds for cached health check results before marking deployments as stale |
+| health_check_ignore_transient_errors | boolean | If true, 429 (rate limit) and 408 (timeout) health check failures are ignored and do not affect routing or cooldown |
 
 
 ### environment variables - Reference

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -397,6 +397,7 @@ router_settings:
 | guardrail_list | List[GuardrailTypedDict] | List of guardrail configurations for guardrail load balancing. Enables load balancing across multiple guardrail deployments with the same guardrail_name. [Further Docs](./guardrails/guardrail_load_balancing.md) |
 | enable_health_check_routing | boolean | If true, enables health check-driven deployment filtering to avoid routing requests to unhealthy deployments |
 | health_check_staleness_threshold | integer | Maximum age in seconds for cached health check results before marking deployments as stale |
+| health_check_ignore_transient_errors | boolean | If true, 429 (rate limit) and 408 (timeout) health check failures are ignored and do not affect routing or cooldown |
 
 
 ### environment variables - Reference

--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -316,86 +316,9 @@ general_settings:
 
 ## Health Check Driven Routing
 
-By default, background health checks are observability-only — they populate the `/health` endpoint but don't affect routing. Unhealthy deployments still receive traffic until request failures trigger cooldown.
+Route traffic away from unhealthy deployments proactively — before user requests hit them. Supports per-error-type failure thresholds, transient error suppression, and automatic safety nets.
 
-With `enable_health_check_routing: true`, the router **excludes deployments that failed their last background health check** before selecting a candidate. This gives you proactive failover instead of reactive cooldown.
-
-### How it works
-
-1. Background health checks run on their configured interval
-2. After each cycle, every deployment is marked healthy or unhealthy
-3. On each incoming request, the router filters out unhealthy deployments **before** cooldown filtering and load balancing
-4. If all deployments are unhealthy, the filter is bypassed (safety net — never causes a total outage)
-5. If health state is stale (older than `health_check_staleness_threshold`), it is ignored
-
-### Quick start
-
-```yaml
-model_list:
-  - model_name: gpt-4
-    litellm_params:
-      model: openai/gpt-4
-      api_key: os.environ/OPENAI_API_KEY
-  - model_name: gpt-4
-    litellm_params:
-      model: openai/gpt-4
-      api_key: os.environ/OPENAI_API_KEY_SECONDARY
-
-general_settings:
-  background_health_checks: true
-  health_check_interval: 60
-  enable_health_check_routing: true
-```
-
-### Configuration
-
-| Setting | Where | Default | Description |
-|---------|-------|---------|-------------|
-| `enable_health_check_routing` | `general_settings` | `false` | Enable/disable health-check-driven routing |
-| `health_check_staleness_threshold` | `general_settings` | `health_check_interval * 2` | Seconds before health state is considered stale and ignored |
-| `background_health_checks` | `general_settings` | `false` | Must be `true` for health check routing to work |
-| `health_check_interval` | `general_settings` | `300` | Seconds between health check cycles |
-
-### Interaction with cooldown
-
-Health check filtering and cooldown are **additive**. A deployment can be excluded by either mechanism:
-
-- **Health check filter** — proactive, runs on the configured interval, excludes deployments that failed the last check
-- **Cooldown** — reactive, triggered by request failures, excludes deployments for a short TTL
-
-This means request failures still provide fast detection between health check intervals.
-
-### Staleness
-
-If a health check result is older than `health_check_staleness_threshold`, it is ignored and the deployment is treated as eligible. This prevents stale data from permanently excluding a deployment if the health check loop stops or slows down.
-
-The default staleness threshold is `health_check_interval * 2`. For a 60s interval, health state expires after 120s.
-
-### Example: custom staleness
-
-```yaml
-general_settings:
-  background_health_checks: true
-  health_check_interval: 30
-  enable_health_check_routing: true
-  health_check_staleness_threshold: 90  # ignore health state older than 90s
-```
-
-### Debugging
-
-Run the proxy with `--detailed_debug` and look for:
-
-```
-health_check_routing_state_updated healthy=3 unhealthy=1
-```
-
-This is logged after each health check cycle when routing state is written.
-
-If the safety net triggers (all deployments unhealthy), you'll see:
-
-```
-All deployments marked unhealthy by health checks, bypassing health filter
-```
+See the full guide: [Health Check Driven Routing](./health_check_routing.md)
 
 ## Health Check Timeout
 

--- a/docs/my-website/docs/proxy/health_check_routing.md
+++ b/docs/my-website/docs/proxy/health_check_routing.md
@@ -1,0 +1,340 @@
+# Health Check Driven Routing
+
+Route traffic away from unhealthy deployments before users hit errors. Background health checks run on a configurable interval, and any deployment that fails gets removed from the routing pool proactively, not after a user request already failed.
+
+
+## Architecture
+
+<svg viewBox="0 0 860 600" xmlns="http://www.w3.org/2000/svg" style={{maxWidth: '100%', fontFamily: 'system-ui, sans-serif'}}>
+  {/* Background */}
+  <rect width="860" height="600" fill="#f8fafc" rx="12"/>
+
+  {/* LEFT PANEL: Background health check loop */}
+  <rect x="20" y="20" width="240" height="560" fill="#eff6ff" rx="10" stroke="#bfdbfe" strokeWidth="1.5"/>
+  <text x="140" y="48" textAnchor="middle" fill="#1d4ed8" fontSize="13" fontWeight="600">Background Loop</text>
+  <text x="140" y="64" textAnchor="middle" fill="#3b82f6" fontSize="11">every health_check_interval seconds</text>
+
+  {/* Deployment A */}
+  <rect x="40" y="82" width="200" height="50" fill="white" rx="8" stroke="#93c5fd" strokeWidth="1.5"/>
+  <text x="140" y="102" textAnchor="middle" fill="#1e40af" fontSize="12" fontWeight="500">Deployment A</text>
+  <text x="140" y="120" textAnchor="middle" fill="#64748b" fontSize="11">ahealth_check() → 200 ✓</text>
+
+  {/* Deployment B */}
+  <rect x="40" y="148" width="200" height="50" fill="white" rx="8" stroke="#fca5a5" strokeWidth="1.5"/>
+  <text x="140" y="168" textAnchor="middle" fill="#991b1b" fontSize="12" fontWeight="500">Deployment B</text>
+  <text x="140" y="186" textAnchor="middle" fill="#64748b" fontSize="11">ahealth_check() → 401 ✗</text>
+
+  {/* Deployment C */}
+  <rect x="40" y="214" width="200" height="50" fill="white" rx="8" stroke="#fde68a" strokeWidth="1.5"/>
+  <text x="140" y="234" textAnchor="middle" fill="#92400e" fontSize="12" fontWeight="500">Deployment C</text>
+  <text x="140" y="252" textAnchor="middle" fill="#64748b" fontSize="11">ahealth_check() → 429 ⚡</text>
+
+  {/* ignore_transient box */}
+  <rect x="40" y="282" width="200" height="68" fill="#fefce8" rx="8" stroke="#fde047" strokeWidth="1.5"/>
+  <text x="140" y="302" textAnchor="middle" fill="#713f12" fontSize="11" fontWeight="600">ignore_transient_errors: true</text>
+  <text x="140" y="320" textAnchor="middle" fill="#92400e" fontSize="11">429 / 408 → ignored</text>
+  <text x="140" y="338" textAnchor="middle" fill="#92400e" fontSize="11">not written to cache</text>
+
+  {/* allowed_fails_policy box */}
+  <rect x="40" y="368" width="200" height="84" fill="#f0fdf4" rx="8" stroke="#86efac" strokeWidth="1.5"/>
+  <text x="140" y="388" textAnchor="middle" fill="#166534" fontSize="11" fontWeight="600">allowed_fails_policy</text>
+  <text x="140" y="406" textAnchor="middle" fill="#15803d" fontSize="11">401 → increment counter</text>
+  <text x="140" y="424" textAnchor="middle" fill="#15803d" fontSize="11">counter &gt; threshold</text>
+  <text x="140" y="442" textAnchor="middle" fill="#15803d" fontSize="11">→ cooldown triggered</text>
+
+  {/* CENTER PANEL: Shared State */}
+  <rect x="300" y="20" width="220" height="560" fill="#f5f3ff" rx="10" stroke="#c4b5fd" strokeWidth="1.5"/>
+  <text x="410" y="48" textAnchor="middle" fill="#6d28d9" fontSize="13" fontWeight="600">Shared State</text>
+
+  {/* Health State Cache */}
+  <rect x="320" y="62" width="180" height="116" fill="white" rx="8" stroke="#a78bfa" strokeWidth="1.5"/>
+  <text x="410" y="84" textAnchor="middle" fill="#5b21b6" fontSize="12" fontWeight="600">DeploymentHealthCache</text>
+  <text x="410" y="104" textAnchor="middle" fill="#64748b" fontSize="11">A → healthy ✓</text>
+  <text x="410" y="122" textAnchor="middle" fill="#64748b" fontSize="11">B → unhealthy ✗</text>
+  <text x="410" y="140" textAnchor="middle" fill="#64748b" fontSize="11">C → not written (ignored)</text>
+  <text x="410" y="164" textAnchor="middle" fill="#94a3b8" fontSize="10">TTL: staleness_threshold × 1.5</text>
+
+  {/* Cooldown Cache */}
+  <rect x="320" y="196" width="180" height="104" fill="white" rx="8" stroke="#a78bfa" strokeWidth="1.5"/>
+  <text x="410" y="218" textAnchor="middle" fill="#5b21b6" fontSize="12" fontWeight="600">Cooldown Cache</text>
+  <text x="410" y="238" textAnchor="middle" fill="#64748b" fontSize="11">B → cooling down</text>
+  <text x="410" y="256" textAnchor="middle" fill="#64748b" fontSize="11">(after policy threshold)</text>
+  <text x="410" y="278" textAnchor="middle" fill="#94a3b8" fontSize="10">TTL: cooldown_time</text>
+
+  {/* failed_calls counter */}
+  <rect x="320" y="318" width="180" height="90" fill="white" rx="8" stroke="#a78bfa" strokeWidth="1.5"/>
+  <text x="410" y="340" textAnchor="middle" fill="#5b21b6" fontSize="12" fontWeight="600">failed_calls counter</text>
+  <text x="410" y="360" textAnchor="middle" fill="#64748b" fontSize="11">B: 2 / AuthAllowedFails: 1</text>
+  <text x="410" y="378" textAnchor="middle" fill="#64748b" fontSize="11">→ threshold exceeded</text>
+  <text x="410" y="398" textAnchor="middle" fill="#94a3b8" fontSize="10">TTL: cooldown_time (must &gt; interval)</text>
+
+  {/* RIGHT PANEL: Request path */}
+  <rect x="560" y="20" width="280" height="560" fill="#fff7ed" rx="10" stroke="#fed7aa" strokeWidth="1.5"/>
+  <text x="700" y="48" textAnchor="middle" fill="#c2410c" fontSize="13" fontWeight="600">Request Path</text>
+
+  {/* Incoming request */}
+  <rect x="580" y="62" width="240" height="38" fill="#fff" rx="7" stroke="#fb923c" strokeWidth="1.5"/>
+  <text x="700" y="85" textAnchor="middle" fill="#9a3412" fontSize="12" fontWeight="500">Incoming request</text>
+
+  {/* All deployments */}
+  <rect x="580" y="120" width="240" height="38" fill="#fff" rx="7" stroke="#fb923c" strokeWidth="1.5"/>
+  <text x="700" y="143" textAnchor="middle" fill="#9a3412" fontSize="12">All deployments [A, B, C]</text>
+
+  <line x1="700" y1="100" x2="700" y2="120" stroke="#fb923c" strokeWidth="1.5" markerEnd="url(#arrow-orange)"/>
+
+  {/* Health check filter */}
+  <rect x="580" y="178" width="240" height="62" fill="#fff" rx="7" stroke="#fb923c" strokeWidth="1.5"/>
+  <text x="700" y="200" textAnchor="middle" fill="#9a3412" fontSize="12" fontWeight="600">① Health Check Filter</text>
+  <text x="700" y="218" textAnchor="middle" fill="#64748b" fontSize="11">if policy set → bypass</text>
+  <text x="700" y="234" textAnchor="middle" fill="#64748b" fontSize="11">else → remove unhealthy</text>
+
+  <line x1="700" y1="158" x2="700" y2="178" stroke="#fb923c" strokeWidth="1.5" markerEnd="url(#arrow-orange)"/>
+
+  {/* Cooldown filter */}
+  <rect x="580" y="262" width="240" height="50" fill="#fff" rx="7" stroke="#fb923c" strokeWidth="1.5"/>
+  <text x="700" y="284" textAnchor="middle" fill="#9a3412" fontSize="12" fontWeight="600">② Cooldown Filter</text>
+  <text x="700" y="302" textAnchor="middle" fill="#64748b" fontSize="11">remove deployments in cooldown</text>
+
+  <line x1="700" y1="240" x2="700" y2="262" stroke="#fb923c" strokeWidth="1.5" markerEnd="url(#arrow-orange)"/>
+
+  {/* Safety net */}
+  <rect x="580" y="334" width="240" height="52" fill="#fef9c3" rx="7" stroke="#fbbf24" strokeWidth="1.5"/>
+  <text x="700" y="356" textAnchor="middle" fill="#713f12" fontSize="12" fontWeight="600">Safety Net</text>
+  <text x="700" y="376" textAnchor="middle" fill="#713f12" fontSize="11">if all removed → return all</text>
+
+  <line x1="700" y1="312" x2="700" y2="334" stroke="#fb923c" strokeWidth="1.5" markerEnd="url(#arrow-orange)"/>
+
+  {/* Load balancer */}
+  <rect x="580" y="408" width="240" height="38" fill="#fff" rx="7" stroke="#fb923c" strokeWidth="1.5"/>
+  <text x="700" y="431" textAnchor="middle" fill="#9a3412" fontSize="12" fontWeight="600">③ Load Balancer</text>
+
+  <line x1="700" y1="386" x2="700" y2="408" stroke="#fb923c" strokeWidth="1.5" markerEnd="url(#arrow-orange)"/>
+
+  {/* Selected deployment */}
+  <rect x="580" y="468" width="240" height="38" fill="#dcfce7" rx="7" stroke="#4ade80" strokeWidth="1.5"/>
+  <text x="700" y="491" textAnchor="middle" fill="#14532d" fontSize="12" fontWeight="600">Selected: Deployment A ✓</text>
+
+  <line x1="700" y1="446" x2="700" y2="468" stroke="#4ade80" strokeWidth="1.5" markerEnd="url(#arrow-green)"/>
+
+  {/* ARROWS: left → center */}
+  <line x1="240" y1="107" x2="320" y2="110" stroke="#3b82f6" strokeWidth="1.5" strokeDasharray="4,3" markerEnd="url(#arrow-blue)"/>
+  <line x1="240" y1="173" x2="320" y2="240" stroke="#ef4444" strokeWidth="1.5" strokeDasharray="4,3" markerEnd="url(#arrow-red)"/>
+  <line x1="240" y1="173" x2="320" y2="348" stroke="#ef4444" strokeWidth="1.5" strokeDasharray="4,3" markerEnd="url(#arrow-red)"/>
+  <line x1="240" y1="316" x2="320" y2="130" stroke="#eab308" strokeWidth="1.5" strokeDasharray="4,3" markerEnd="url(#arrow-yellow)"/>
+
+  {/* ARROWS: center → right */}
+  <line x1="500" y1="120" x2="580" y2="190" stroke="#8b5cf6" strokeWidth="1.5" strokeDasharray="4,3" markerEnd="url(#arrow-purple)"/>
+  <line x1="500" y1="248" x2="580" y2="274" stroke="#8b5cf6" strokeWidth="1.5" strokeDasharray="4,3" markerEnd="url(#arrow-purple)"/>
+
+  {/* Arrow markers */}
+  <defs>
+    <marker id="arrow-orange" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#fb923c"/>
+    </marker>
+    <marker id="arrow-blue" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#3b82f6"/>
+    </marker>
+    <marker id="arrow-red" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#ef4444"/>
+    </marker>
+    <marker id="arrow-yellow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#eab308"/>
+    </marker>
+    <marker id="arrow-purple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#8b5cf6"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#4ade80"/>
+    </marker>
+  </defs>
+</svg>
+
+
+## What problem does this solve?
+
+By default, LiteLLM routes traffic to all deployments and only stops sending to a broken one after it has already failed a user request. The cooldown system is reactive.
+
+Health check driven routing makes this **proactive**: a background loop pings every deployment on a configurable interval. If a deployment fails its health check, it gets removed from the routing pool immediately, before a user request lands on it.
+
+When you also set `allowed_fails_policy`, you control exactly how many health check failures of each error type (auth errors, rate limits, timeouts) are needed before a deployment enters cooldown. This avoids false positives from transient noise.
+
+
+## Setup
+
+### Step 1: Enable background health checks
+
+Background health checks are off by default. Turn them on in `general_settings`:
+
+```yaml
+general_settings:
+  background_health_checks: true
+  health_check_interval: 60    # seconds between each full check cycle
+```
+
+### Step 2: Enable health check routing
+
+```yaml
+general_settings:
+  background_health_checks: true
+  health_check_interval: 60
+  enable_health_check_routing: true  # ← route away from unhealthy deployments
+```
+
+At this point, any deployment that fails its health check is immediately excluded from routing until the next check cycle clears it.
+
+### Step 3: Add a policy to control how many failures trigger cooldown
+
+Without a policy, the first health check failure marks a deployment as unhealthy. If you want more tolerance (e.g., only act after 2 consecutive auth failures), use `allowed_fails_policy`:
+
+```yaml
+model_list:
+  - model_name: claude-sonnet
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-sonnet
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY_SECONDARY
+
+general_settings:
+  background_health_checks: true
+  health_check_interval: 30
+  enable_health_check_routing: true
+
+router_settings:
+  cooldown_time: 60              # how long a deployment stays in cooldown
+  allowed_fails_policy:
+    AuthenticationErrorAllowedFails: 1   # cooldown after 2nd auth failure
+    TimeoutErrorAllowedFails: 3          # cooldown after 4th timeout
+```
+
+When `allowed_fails_policy` is set, the binary health check filter is bypassed. Only the cooldown system controls routing exclusion, and it only fires after your configured threshold is crossed.
+
+### Step 4 (optional): Ignore transient errors
+
+429 (rate limit) and 408 (timeout) from a health check usually mean the deployment is temporarily overloaded, not broken. To prevent these from affecting routing at all:
+
+```yaml
+general_settings:
+  background_health_checks: true
+  health_check_interval: 30
+  enable_health_check_routing: true
+  health_check_ignore_transient_errors: true  # 429 and 408 never affect routing
+```
+
+With this on, only hard failures (401, 404, 5xx) from health checks contribute to cooldown.
+
+
+## Full example
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY_SECONDARY
+
+  - model_name: gpt-4o
+    litellm_params:
+      model: azure/gpt-4o
+      api_base: os.environ/AZURE_API_BASE
+      api_key: os.environ/AZURE_API_KEY
+
+general_settings:
+  background_health_checks: true
+  health_check_interval: 30
+  enable_health_check_routing: true
+  health_check_ignore_transient_errors: true
+
+router_settings:
+  cooldown_time: 60
+  allowed_fails_policy:
+    AuthenticationErrorAllowedFails: 0   # cooldown immediately on auth failure
+    TimeoutErrorAllowedFails: 2          # cooldown after 3 timeouts
+    RateLimitErrorAllowedFails: 5        # cooldown after 6 rate limits (if not ignoring transients)
+```
+
+
+## Configuration reference
+
+| Setting | Where | Default | Description |
+|---|---|---|---|
+| `enable_health_check_routing` | `general_settings` | `false` | Route away from deployments that fail health checks |
+| `background_health_checks` | `general_settings` | `false` | Must be `true` for health check routing to work |
+| `health_check_interval` | `general_settings` | `300` | Seconds between full health check cycles |
+| `health_check_staleness_threshold` | `general_settings` | `interval x 2` | Seconds before cached health state is ignored |
+| `health_check_ignore_transient_errors` | `general_settings` | `false` | Ignore 429 and 408 from health checks; these never affect routing |
+| `cooldown_time` | `router_settings` | `5` | Seconds a deployment stays in cooldown after threshold is crossed |
+| `allowed_fails_policy` | `router_settings` | `null` | Per-error-type failure thresholds before cooldown (see below) |
+
+### `allowed_fails_policy` fields
+
+| Field | Error type | HTTP status |
+|---|---|---|
+| `AuthenticationErrorAllowedFails` | Bad API key | 401 |
+| `TimeoutErrorAllowedFails` | Request timeout | 408 |
+| `RateLimitErrorAllowedFails` | Rate limit exceeded | 429 |
+| `BadRequestErrorAllowedFails` | Malformed request | 400 |
+| `ContentPolicyViolationErrorAllowedFails` | Content filtered | 400 |
+
+The value is the number of failures **tolerated** before cooldown. `0` means cooldown on the first failure. `2` means cooldown on the third.
+
+
+## Things to keep in mind
+
+- **Counter TTL must be longer than the health check interval.** `allowed_fails_policy` works by incrementing a `failed_calls` counter per deployment. That counter expires after `cooldown_time` seconds. If `cooldown_time` is shorter than `health_check_interval`, the counter resets between every check cycle and failures never accumulate. Set `cooldown_time` greater than `health_check_interval` when using `allowed_fails_policy`.
+
+  ```yaml
+  router_settings:
+    cooldown_time: 60       # must be > health_check_interval (30s here)
+
+  general_settings:
+    health_check_interval: 30
+  ```
+
+- **`AllowedFails: N` means cooldown on the (N+1)th failure.** The counter check is `updated_fails > allowed_fails`, so `0` triggers on the 1st failure, `1` on the 2nd, `2` on the 3rd.
+
+  | `AllowedFails` | Cooldown triggers after |
+  |---|---|
+  | `0` | 1st failure |
+  | `1` | 2nd failure |
+  | `2` | 3rd failure |
+
+- **Without `allowed_fails_policy`, the first failure is enough.** The first failed health check immediately excludes the deployment from routing. Use `allowed_fails_policy` when you want tolerance for flaky checks.
+
+- **If all deployments are unhealthy, the filter is bypassed.** Traffic keeps flowing rather than returning no deployment at all. Requests will fail, but the router keeps trying.
+
+- **Health check failures and request failures share the same counters.** When `allowed_fails_policy` is set, both sources increment the same `failed_calls` counter. A deployment at 1 health check failure that then receives 1 failing request will hit the threshold for `AllowedFails: 1` and enter cooldown.
+
+
+## Debugging
+
+Run the proxy with `--detailed_debug` and look for these log lines:
+
+After each health check cycle (written at DEBUG level):
+```
+health_check_routing_state_updated healthy=2 unhealthy=1
+```
+
+When a health check failure increments the counter and triggers cooldown (DEBUG level):
+```
+checks 'should_run_cooldown_logic'
+Attempting to add <deployment_id> to cooldown list
+```
+
+When safety net fires because all deployments are in cooldown:
+```
+All deployments in cooldown via health-check routing, bypassing cooldown filter
+```
+
+When safety net fires because all deployments are unhealthy (binary filter, no `allowed_fails_policy`):
+```
+All deployments marked unhealthy by health checks, bypassing health filter
+```

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -1051,7 +1051,8 @@ const sidebars = {
         "proxy/fallback_management",
         "proxy/tag_routing",
         "proxy/timeout",
-        "wildcard_routing"
+        "wildcard_routing",
+        "proxy/health_check_routing"
       ],
     },
     {

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3792,9 +3792,9 @@ def completion(  # type: ignore # noqa: PLR0915
                     "aws_region_name" not in optional_params
                     or optional_params["aws_region_name"] is None
                 ):
-                    optional_params[
-                        "aws_region_name"
-                    ] = aws_bedrock_client.meta.region_name
+                    optional_params["aws_region_name"] = (
+                        aws_bedrock_client.meta.region_name
+                    )
 
             bedrock_route = BedrockModelInfo.get_bedrock_route(model)
             if bedrock_route == "converse":
@@ -6198,9 +6198,9 @@ def adapter_completion(
     new_kwargs = translation_obj.translate_completion_input_params(kwargs=kwargs)
 
     response: Union[ModelResponse, CustomStreamWrapper] = completion(**new_kwargs)  # type: ignore
-    translated_response: Optional[
-        Union[BaseModel, AdapterCompletionStreamWrapper]
-    ] = None
+    translated_response: Optional[Union[BaseModel, AdapterCompletionStreamWrapper]] = (
+        None
+    )
     if isinstance(response, ModelResponse):
         translated_response = translation_obj.translate_completion_output_params(
             response=response
@@ -6380,9 +6380,9 @@ async def atranscription(*args, **kwargs) -> TranscriptionResponse:
             if existing_duration is None:
                 calculated_duration = calculate_request_duration(file)
                 if calculated_duration is not None:
-                    response._hidden_params[
-                        "audio_transcription_duration"
-                    ] = calculated_duration
+                    response._hidden_params["audio_transcription_duration"] = (
+                        calculated_duration
+                    )
 
         return response
     except Exception as e:
@@ -6605,9 +6605,9 @@ def transcription(
         if existing_duration is None:
             calculated_duration = calculate_request_duration(file)
             if calculated_duration is not None:
-                response._hidden_params[
-                    "audio_transcription_duration"
-                ] = calculated_duration
+                response._hidden_params["audio_transcription_duration"] = (
+                    calculated_duration
+                )
 
     if response is None:
         raise ValueError("Unmapped provider passed in. Unable to get the response.")
@@ -6911,9 +6911,9 @@ def speech(  # noqa: PLR0915
                 ElevenLabsTextToSpeechConfig.ELEVENLABS_QUERY_PARAMS_KEY
             ] = query_params
 
-        litellm_params_dict[
-            ElevenLabsTextToSpeechConfig.ELEVENLABS_VOICE_ID_KEY
-        ] = voice_id
+        litellm_params_dict[ElevenLabsTextToSpeechConfig.ELEVENLABS_VOICE_ID_KEY] = (
+            voice_id
+        )
 
         if api_base is not None:
             litellm_params_dict["api_base"] = api_base
@@ -7234,7 +7234,8 @@ async def ahealth_check(
 
         if mode is None:
             return {
-                "error": f"error:{str(e)}. Missing `mode`. Set the `mode` for the model - https://docs.litellm.ai/docs/proxy/health#embedding-models  \nstacktrace: {stack_trace}"
+                "error": f"error:{str(e)}. Missing `mode`. Set the `mode` for the model - https://docs.litellm.ai/docs/proxy/health#embedding-models  \nstacktrace: {stack_trace}",
+                "exception": e,
             }
 
         error_to_return = str(e) + "\nstack trace: " + stack_trace
@@ -7246,6 +7247,7 @@ async def ahealth_check(
         return {
             "error": error_to_return,
             "raw_request_typed_dict": raw_request_typed_dict,
+            "exception": e,
         }
 
 
@@ -7492,9 +7494,9 @@ def stream_chunk_builder(  # noqa: PLR0915
         ]
 
         if len(content_chunks) > 0:
-            response["choices"][0]["message"][
-                "content"
-            ] = processor.get_combined_content(content_chunks)
+            response["choices"][0]["message"]["content"] = (
+                processor.get_combined_content(content_chunks)
+            )
 
         thinking_blocks = [
             chunk
@@ -7505,9 +7507,9 @@ def stream_chunk_builder(  # noqa: PLR0915
         ]
 
         if len(thinking_blocks) > 0:
-            response["choices"][0]["message"][
-                "thinking_blocks"
-            ] = processor.get_combined_thinking_content(thinking_blocks)
+            response["choices"][0]["message"]["thinking_blocks"] = (
+                processor.get_combined_thinking_content(thinking_blocks)
+            )
 
         reasoning_chunks = [
             chunk
@@ -7518,9 +7520,9 @@ def stream_chunk_builder(  # noqa: PLR0915
         ]
 
         if len(reasoning_chunks) > 0:
-            response["choices"][0]["message"][
-                "reasoning_content"
-            ] = processor.get_combined_reasoning_content(reasoning_chunks)
+            response["choices"][0]["message"]["reasoning_content"] = (
+                processor.get_combined_reasoning_content(reasoning_chunks)
+            )
 
         annotation_chunks = [
             chunk

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -230,7 +230,11 @@ async def _perform_health_check(
             if _model_id:
                 cleaned["model_id"] = _model_id
                 if "exception" in is_healthy:
-                    exceptions_by_model_id[_model_id] = is_healthy["exception"]
+                    exc = is_healthy["exception"]
+                    exceptions_by_model_id[_model_id] = exc
+                    # Store integer status code so shared-cache readers can
+                    # reconstruct the transient-error filter without the exception object.
+                    cleaned["exception_status"] = getattr(exc, "status_code", 500)
             unhealthy_endpoints.append(cleaned)
         else:
             cleaned = _clean_endpoint_data(litellm_params, details)
@@ -238,6 +242,7 @@ async def _perform_health_check(
                 cleaned["model_id"] = _model_id
                 if isinstance(is_healthy, Exception):
                     exceptions_by_model_id[_model_id] = is_healthy
+                    cleaned["exception_status"] = getattr(is_healthy, "status_code", 500)
             unhealthy_endpoints.append(cleaned)
 
     return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -386,7 +386,7 @@ async def perform_health_check(
                     source,
                     cycle_id,
                 )
-            return [], []
+            return [], [], {}
 
     cycle_start_time = time.monotonic()
     requested_model_count = len(model_list)

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -211,6 +211,10 @@ async def _perform_health_check(
 
     healthy_endpoints = []
     unhealthy_endpoints = []
+    # Exceptions keyed by model_id; returned separately so callers can use
+    # them for cooldown integration without risking JSON-serialization errors
+    # in the /health response.
+    exceptions_by_model_id: dict = {}
 
     for is_healthy, model in zip(results, model_list):
         litellm_params = model["litellm_params"]
@@ -225,14 +229,18 @@ async def _perform_health_check(
             cleaned = _clean_endpoint_data({**litellm_params, **is_healthy}, details)
             if _model_id:
                 cleaned["model_id"] = _model_id
+                if "exception" in is_healthy:
+                    exceptions_by_model_id[_model_id] = is_healthy["exception"]
             unhealthy_endpoints.append(cleaned)
         else:
             cleaned = _clean_endpoint_data(litellm_params, details)
             if _model_id:
                 cleaned["model_id"] = _model_id
+                if isinstance(is_healthy, Exception):
+                    exceptions_by_model_id[_model_id] = is_healthy
             unhealthy_endpoints.append(cleaned)
 
-    return healthy_endpoints, unhealthy_endpoints
+    return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id
 
 
 def build_deployment_health_states(
@@ -413,7 +421,11 @@ async def perform_health_check(
         )
 
     try:
-        healthy_endpoints, unhealthy_endpoints = await _perform_health_check(
+        (
+            healthy_endpoints,
+            unhealthy_endpoints,
+            exceptions_by_model_id,
+        ) = await _perform_health_check(
             model_list,
             details,
             max_concurrency=max_concurrency,
@@ -445,4 +457,4 @@ async def perform_health_check(
             _rss_mb_for_log(),
         )
 
-    return healthy_endpoints, unhealthy_endpoints
+    return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -95,7 +95,12 @@ async def run_with_timeout(task, timeout):
     except asyncio.TimeoutError:
         # `asyncio.wait_for()` already cancels only the awaited task on timeout.
         # Do not cancel unrelated sibling health check tasks.
-        return {"error": "Timeout exceeded"}
+        timeout_exception = litellm.Timeout(
+            message="Health check timeout exceeded",
+            model="",
+            llm_provider="",
+        )
+        return {"error": "Timeout exceeded", "exception": timeout_exception}
 
 
 async def _run_model_health_check(model: dict):
@@ -218,11 +223,15 @@ async def _perform_health_check(
             cleaned = _clean_endpoint_data({**litellm_params, **is_healthy}, details)
             if _model_id:
                 cleaned["model_id"] = _model_id
+            if "exception" in is_healthy:
+                cleaned["exception"] = is_healthy["exception"]
             unhealthy_endpoints.append(cleaned)
         else:
             cleaned = _clean_endpoint_data(litellm_params, details)
             if _model_id:
                 cleaned["model_id"] = _model_id
+            if isinstance(is_healthy, Exception):
+                cleaned["exception"] = is_healthy
             unhealthy_endpoints.append(cleaned)
 
     return healthy_endpoints, unhealthy_endpoints

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -21,6 +21,7 @@ ILLEGAL_DISPLAY_PARAMS = [
     "vertex_credentials",
     "aws_access_key_id",
     "aws_secret_access_key",
+    "exception",  # internal; not JSON-serializable, never for display
 ]
 
 MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -22,6 +22,7 @@ ILLEGAL_DISPLAY_PARAMS = [
     "aws_access_key_id",
     "aws_secret_access_key",
     "exception",  # internal; not JSON-serializable, never for display
+    "litellm_metadata",  # internal tracking metadata with auth objects; not for display
 ]
 
 MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
@@ -224,15 +225,11 @@ async def _perform_health_check(
             cleaned = _clean_endpoint_data({**litellm_params, **is_healthy}, details)
             if _model_id:
                 cleaned["model_id"] = _model_id
-            if "exception" in is_healthy:
-                cleaned["exception"] = is_healthy["exception"]
             unhealthy_endpoints.append(cleaned)
         else:
             cleaned = _clean_endpoint_data(litellm_params, details)
             if _model_id:
                 cleaned["model_id"] = _model_id
-            if isinstance(is_healthy, Exception):
-                cleaned["exception"] = is_healthy
             unhealthy_endpoints.append(cleaned)
 
     return healthy_endpoints, unhealthy_endpoints

--- a/litellm/proxy/health_check_utils/shared_health_check_manager.py
+++ b/litellm/proxy/health_check_utils/shared_health_check_manager.py
@@ -217,6 +217,7 @@ class SharedHealthCheckManager:
             return (
                 cached_results.get("healthy_endpoints", []),
                 cached_results.get("unhealthy_endpoints", []),
+                {},
             )
 
         # No recent cache, try to acquire lock

--- a/litellm/proxy/health_check_utils/shared_health_check_manager.py
+++ b/litellm/proxy/health_check_utils/shared_health_check_manager.py
@@ -192,7 +192,7 @@ class SharedHealthCheckManager:
         model_list: List[Dict[str, Any]],
         details: bool = True,
         max_concurrency: Optional[int] = None,
-    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, Any]]:
         """
         Perform health check with shared state coordination.
 
@@ -266,6 +266,7 @@ class SharedHealthCheckManager:
                 return (
                     cached_results.get("healthy_endpoints", []),
                     cached_results.get("unhealthy_endpoints", []),
+                    {},
                 )
 
             # Still no cache, fall back to local health check

--- a/litellm/proxy/health_check_utils/shared_health_check_manager.py
+++ b/litellm/proxy/health_check_utils/shared_health_check_manager.py
@@ -231,7 +231,11 @@ class SharedHealthCheckManager:
                     len(model_list),
                 )
 
-                healthy_endpoints, unhealthy_endpoints = await perform_health_check(
+                (
+                    healthy_endpoints,
+                    unhealthy_endpoints,
+                    exceptions_by_model_id,
+                ) = await perform_health_check(
                     model_list=model_list,
                     details=details,
                     max_concurrency=max_concurrency,
@@ -242,7 +246,7 @@ class SharedHealthCheckManager:
                     healthy_endpoints, unhealthy_endpoints
                 )
 
-                return healthy_endpoints, unhealthy_endpoints
+                return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id
 
             finally:
                 # Always release the lock

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -771,7 +771,7 @@ async def _perform_health_check_and_save(
     max_concurrency=None,
 ):
     """Helper function to perform health check and save results to database"""
-    healthy_endpoints, unhealthy_endpoints = await perform_health_check(
+    healthy_endpoints, unhealthy_endpoints, _ = await perform_health_check(
         model_list=model_list,
         cli_model=cli_model,
         model=target_model,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2303,35 +2303,40 @@ def _write_health_state_to_router_cache(
                 sum(1 for s in states.values() if not s.get("is_healthy")),
             )
 
-        for endpoint in unhealthy_endpoints:
-            model_id = endpoint.get("model_id")
-            if not model_id:
-                continue
+        # Only feed health check failures into the cooldown pipeline when
+        # allowed_fails_policy is configured. Without it, cooldown is not the
+        # routing exclusion mechanism and triggering it would be a
+        # backwards-incompatible behavioral change for existing users.
+        if llm_router.allowed_fails_policy is not None:
+            for endpoint in unhealthy_endpoints:
+                model_id = endpoint.get("model_id")
+                if not model_id:
+                    continue
 
-            original_exception = _exceptions.get(model_id)
-            if original_exception is None:
-                continue
+                original_exception = _exceptions.get(model_id)
+                if original_exception is None:
+                    continue
 
-            exception_status = getattr(original_exception, "status_code", 500)
+                exception_status = getattr(original_exception, "status_code", 500)
 
-            if llm_router.health_check_ignore_transient_errors and exception_status in (
-                429,
-                408,
-            ):
-                continue
+                if llm_router.health_check_ignore_transient_errors and exception_status in (
+                    429,
+                    408,
+                ):
+                    continue
 
-            increment_deployment_failures_for_current_minute(
-                litellm_router_instance=llm_router,
-                deployment_id=model_id,
-            )
+                increment_deployment_failures_for_current_minute(
+                    litellm_router_instance=llm_router,
+                    deployment_id=model_id,
+                )
 
-            _set_cooldown_deployments(
-                litellm_router_instance=llm_router,
-                original_exception=original_exception,
-                exception_status=exception_status,
-                deployment=model_id,
-                time_to_cooldown=llm_router.cooldown_time,
-            )
+                _set_cooldown_deployments(
+                    litellm_router_instance=llm_router,
+                    original_exception=original_exception,
+                    exception_status=exception_status,
+                    deployment=model_id,
+                    time_to_cooldown=llm_router.cooldown_time,
+                )
 
     except Exception as e:
         verbose_proxy_logger.warning(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -375,7 +375,9 @@ from litellm.proxy.management_endpoints.fallback_management_endpoints import (
 from litellm.proxy.management_endpoints.internal_user_endpoints import (
     router as internal_user_router,
 )
-from litellm.proxy.management_endpoints.internal_user_endpoints import user_update
+from litellm.proxy.management_endpoints.internal_user_endpoints import (
+    user_update,
+)
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
@@ -444,7 +446,9 @@ from litellm.proxy.openai_evals_endpoints.endpoints import router as evals_route
 from litellm.proxy.openai_files_endpoints.files_endpoints import (
     router as openai_files_router,
 )
-from litellm.proxy.openai_files_endpoints.files_endpoints import set_files_config
+from litellm.proxy.openai_files_endpoints.files_endpoints import (
+    set_files_config,
+)
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     passthrough_endpoint_router,
 )
@@ -548,7 +552,9 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
     LiteLLM_UpperboundKeyGenerateParams,
 )
 from litellm.types.realtime import RealtimeQueryParams
-from litellm.types.router import DeploymentTypedDict
+from litellm.types.router import (
+    DeploymentTypedDict,
+)
 from litellm.types.router import ModelInfo as RouterModelInfo
 from litellm.types.router import (
     RouterGeneralSettings,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2427,6 +2427,7 @@ async def _run_background_health_check():
                 (
                     healthy_endpoints,
                     unhealthy_endpoints,
+                    _exceptions_by_model_id,
                 ) = await shared_health_manager.perform_shared_health_check(
                     model_list=_llm_model_list,
                     details=details_bool,
@@ -2440,6 +2441,7 @@ async def _run_background_health_check():
                 (
                     healthy_endpoints,
                     unhealthy_endpoints,
+                    _exceptions_by_model_id,
                 ) = await _run_direct_health_check_with_instrumentation(
                     _llm_model_list,
                     health_check_details,
@@ -2450,6 +2452,7 @@ async def _run_background_health_check():
             (
                 healthy_endpoints,
                 unhealthy_endpoints,
+                _exceptions_by_model_id,
             ) = await _run_direct_health_check_with_instrumentation(
                 _llm_model_list,
                 health_check_details,
@@ -2492,7 +2495,9 @@ async def _run_background_health_check():
         )
 
         # Write health state to router cache for health-check-driven routing
-        _write_health_state_to_router_cache(healthy_endpoints, unhealthy_endpoints)
+        _write_health_state_to_router_cache(
+            healthy_endpoints, unhealthy_endpoints, _exceptions_by_model_id
+        )
 
         await asyncio.sleep(health_check_interval)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2303,40 +2303,35 @@ def _write_health_state_to_router_cache(
                 sum(1 for s in states.values() if not s.get("is_healthy")),
             )
 
-        # Only feed health check failures into the cooldown pipeline when
-        # allowed_fails_policy is configured. Without it, cooldown is not the
-        # routing exclusion mechanism and triggering it would be a
-        # backwards-incompatible behavioral change for existing users.
-        if llm_router.allowed_fails_policy is not None:
-            for endpoint in unhealthy_endpoints:
-                model_id = endpoint.get("model_id")
-                if not model_id:
-                    continue
+        for endpoint in unhealthy_endpoints:
+            model_id = endpoint.get("model_id")
+            if not model_id:
+                continue
 
-                original_exception = _exceptions.get(model_id)
-                if original_exception is None:
-                    continue
+            original_exception = _exceptions.get(model_id)
+            if original_exception is None:
+                continue
 
-                exception_status = getattr(original_exception, "status_code", 500)
+            exception_status = getattr(original_exception, "status_code", 500)
 
-                if llm_router.health_check_ignore_transient_errors and exception_status in (
-                    429,
-                    408,
-                ):
-                    continue
+            if llm_router.health_check_ignore_transient_errors and exception_status in (
+                429,
+                408,
+            ):
+                continue
 
-                increment_deployment_failures_for_current_minute(
-                    litellm_router_instance=llm_router,
-                    deployment_id=model_id,
-                )
+            increment_deployment_failures_for_current_minute(
+                litellm_router_instance=llm_router,
+                deployment_id=model_id,
+            )
 
-                _set_cooldown_deployments(
-                    litellm_router_instance=llm_router,
-                    original_exception=original_exception,
-                    exception_status=exception_status,
-                    deployment=model_id,
-                    time_to_cooldown=llm_router.cooldown_time,
-                )
+            _set_cooldown_deployments(
+                litellm_router_instance=llm_router,
+                original_exception=original_exception,
+                exception_status=exception_status,
+                deployment=model_id,
+                time_to_cooldown=llm_router.cooldown_time,
+            )
 
     except Exception as e:
         verbose_proxy_logger.warning(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2287,6 +2287,12 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
+            if llm_router.health_check_ignore_transient_errors and exception_status in (
+                429,
+                408,
+            ):
+                continue
+
             increment_deployment_failures_for_current_minute(
                 litellm_router_instance=llm_router,
                 deployment_id=model_id,
@@ -3272,6 +3278,7 @@ class ProxyConfig:
             general_settings = {}
         _enable_hc_routing = False
         _hc_staleness = None
+        _hc_ignore_transient = False
         if general_settings:
             ### LOAD KEY MANAGEMENT SETTINGS FIRST (needed for custom secret manager) ###
             key_management_settings = general_settings.get(
@@ -3458,6 +3465,9 @@ class ProxyConfig:
             _hc_staleness = general_settings.get(
                 "health_check_staleness_threshold", None
             )
+            _hc_ignore_transient = general_settings.get(
+                "health_check_ignore_transient_errors", False
+            )
             verbose_proxy_logger.info(
                 "background_health_check_config enabled=%s shared=%s interval_seconds=%s max_concurrency=%s details=%s health_check_routing=%s",
                 use_background_health_checks,
@@ -3500,6 +3510,8 @@ class ProxyConfig:
             router_params["enable_health_check_routing"] = True
         if _hc_staleness is not None:
             router_params["health_check_staleness_threshold"] = _hc_staleness
+        if _hc_ignore_transient:
+            router_params["health_check_ignore_transient_errors"] = True
         ## MODEL LIST
         model_list = config.get("model_list", None)
         if model_list:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -375,9 +375,7 @@ from litellm.proxy.management_endpoints.fallback_management_endpoints import (
 from litellm.proxy.management_endpoints.internal_user_endpoints import (
     router as internal_user_router,
 )
-from litellm.proxy.management_endpoints.internal_user_endpoints import (
-    user_update,
-)
+from litellm.proxy.management_endpoints.internal_user_endpoints import user_update
 from litellm.proxy.management_endpoints.jwt_key_mapping_endpoints import (
     router as jwt_key_mapping_router,
 )
@@ -446,9 +444,7 @@ from litellm.proxy.openai_evals_endpoints.endpoints import router as evals_route
 from litellm.proxy.openai_files_endpoints.files_endpoints import (
     router as openai_files_router,
 )
-from litellm.proxy.openai_files_endpoints.files_endpoints import (
-    set_files_config,
-)
+from litellm.proxy.openai_files_endpoints.files_endpoints import set_files_config
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     passthrough_endpoint_router,
 )
@@ -552,9 +548,7 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
     LiteLLM_UpperboundKeyGenerateParams,
 )
 from litellm.types.realtime import RealtimeQueryParams
-from litellm.types.router import (
-    DeploymentTypedDict,
-)
+from litellm.types.router import DeploymentTypedDict
 from litellm.types.router import ModelInfo as RouterModelInfo
 from litellm.types.router import (
     RouterGeneralSettings,
@@ -641,9 +635,9 @@ except ImportError:
 server_root_path = get_server_root_path()
 _license_check = LicenseCheck()
 premium_user: bool = _license_check.is_premium()
-premium_user_data: Optional[
-    "EnterpriseLicenseData"
-] = _license_check.airgapped_license_data
+premium_user_data: Optional["EnterpriseLicenseData"] = (
+    _license_check.airgapped_license_data
+)
 global_max_parallel_request_retries_env: Optional[str] = os.getenv(
     "LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRIES"
 )
@@ -1537,9 +1531,9 @@ master_key: Optional[str] = None
 config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
-shared_aiohttp_session: Optional[
-    "ClientSession"
-] = None  # Global shared session for connection reuse
+shared_aiohttp_session: Optional["ClientSession"] = (
+    None  # Global shared session for connection reuse
+)
 user_api_key_cache = DualCache(
     default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value
 )
@@ -1550,13 +1544,13 @@ model_max_budget_limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(
     dual_cache=user_api_key_cache
 )
 litellm.logging_callback_manager.add_litellm_callback(model_max_budget_limiter)
-redis_usage_cache: Optional[
-    RedisCache
-] = None  # redis cache used for tracking spend, tpm/rpm limits
+redis_usage_cache: Optional[RedisCache] = (
+    None  # redis cache used for tracking spend, tpm/rpm limits
+)
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
-native_background_mode: List[
-    str
-] = []  # Models that should use native provider background mode instead of polling
+native_background_mode: List[str] = (
+    []
+)  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -2040,9 +2034,9 @@ async def update_cache(  # noqa: PLR0915
         _id = "team_id:{}".format(team_id)
         try:
             # Fetch the existing cost for the given user
-            existing_spend_obj: Optional[
-                LiteLLM_TeamTable
-            ] = await user_api_key_cache.async_get_cache(key=_id)
+            existing_spend_obj: Optional[LiteLLM_TeamTable] = (
+                await user_api_key_cache.async_get_cache(key=_id)
+            )
             if existing_spend_obj is None:
                 # do nothing if team not in api key cache
                 return
@@ -2261,6 +2255,10 @@ def _write_health_state_to_router_cache(
     for health-check-driven routing. No-op if the feature is disabled.
     """
     from litellm.proxy.health_check import build_deployment_health_states
+    from litellm.router_utils.cooldown_handlers import _set_cooldown_deployments
+    from litellm.router_utils.router_callbacks.track_deployment_metrics import (
+        increment_deployment_failures_for_current_minute,
+    )
 
     try:
         if llm_router is None or not llm_router.enable_health_check_routing:
@@ -2277,6 +2275,31 @@ def _write_health_state_to_router_cache(
                 sum(1 for s in states.values() if s.get("is_healthy")),
                 sum(1 for s in states.values() if not s.get("is_healthy")),
             )
+
+        for endpoint in unhealthy_endpoints:
+            model_id = endpoint.get("model_id")
+            if not model_id:
+                continue
+
+            original_exception = endpoint.get("exception")
+            if original_exception is None:
+                continue
+
+            exception_status = getattr(original_exception, "status_code", 500)
+
+            increment_deployment_failures_for_current_minute(
+                litellm_router_instance=llm_router,
+                deployment_id=model_id,
+            )
+
+            _set_cooldown_deployments(
+                litellm_router_instance=llm_router,
+                original_exception=original_exception,
+                exception_status=exception_status,
+                deployment=model_id,
+                time_to_cooldown=llm_router.cooldown_time,
+            )
+
     except Exception as e:
         verbose_proxy_logger.warning(
             "Failed to write health state to router cache: %s", str(e)
@@ -5215,10 +5238,10 @@ class ProxyConfig:
         )
 
         try:
-            guardrails_in_db: List[
-                Guardrail
-            ] = await GuardrailRegistry.get_all_guardrails_from_db(
-                prisma_client=prisma_client
+            guardrails_in_db: List[Guardrail] = (
+                await GuardrailRegistry.get_all_guardrails_from_db(
+                    prisma_client=prisma_client
+                )
             )
             verbose_proxy_logger.debug(
                 "guardrails from the DB %s", str(guardrails_in_db)
@@ -5600,9 +5623,9 @@ async def initialize(  # noqa: PLR0915
         user_api_base = api_base
         dynamic_config[user_model]["api_base"] = api_base
     if api_version:
-        os.environ[
-            "AZURE_API_VERSION"
-        ] = api_version  # set this for azure - litellm can read this from the env
+        os.environ["AZURE_API_VERSION"] = (
+            api_version  # set this for azure - litellm can read this from the env
+        )
     if max_tokens:  # model-specific param
         dynamic_config[user_model]["max_tokens"] = max_tokens
     if temperature:  # model-specific param
@@ -5944,9 +5967,9 @@ class ProxyStartupEvent:
         """
         from litellm.secret_managers.main import str_to_bool
 
-        _use_redis_transaction_buffer: Optional[
-            Union[bool, str]
-        ] = general_settings.get("use_redis_transaction_buffer", False)
+        _use_redis_transaction_buffer: Optional[Union[bool, str]] = (
+            general_settings.get("use_redis_transaction_buffer", False)
+        )
         if isinstance(_use_redis_transaction_buffer, str):
             _use_redis_transaction_buffer = str_to_bool(_use_redis_transaction_buffer)
 
@@ -9301,20 +9324,17 @@ async def _add_access_group_models_to_team_models(
         return team_models
 
     # Single batch fetch for all access groups
-    access_group_rows = (
-        await prisma_client.db.litellm_accessgrouptable.find_many(
-            where={"access_group_id": {"in": list(all_access_group_ids)}}
-        )
+    access_group_rows = await prisma_client.db.litellm_accessgrouptable.find_many(
+        where={"access_group_id": {"in": list(all_access_group_ids)}}
     )
     ag_model_map: Dict[str, List[str]] = {
-        row.access_group_id: row.access_model_names or []
-        for row in access_group_rows
+        row.access_group_id: row.access_model_names or [] for row in access_group_rows
     }
 
     # Second pass: resolve deployments for each eligible team
     for team_object in eligible_teams:
         model_names: Set[str] = set()
-        for ag_id in team_object.access_group_ids or [] :
+        for ag_id in team_object.access_group_ids or []:
             model_names.update(ag_model_map.get(ag_id, []))
 
         for model_name in model_names:
@@ -9325,9 +9345,7 @@ async def _add_access_group_models_to_team_models(
                 for deployment in deployments:
                     model_id = deployment.get("model_info", {}).get("id", None)
                     if model_id is not None:
-                        team_models.setdefault(model_id, set()).add(
-                            team_object.team_id
-                        )
+                        team_models.setdefault(model_id, set()).add(team_object.team_id)
 
     return team_models
 
@@ -12627,9 +12645,9 @@ async def get_config_list(
                             hasattr(sub_field_info, "description")
                             and sub_field_info.description is not None
                         ):
-                            nested_fields[
-                                idx
-                            ].field_description = sub_field_info.description
+                            nested_fields[idx].field_description = (
+                                sub_field_info.description
+                            )
                         idx += 1
 
                     _stored_in_db = None

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2246,6 +2246,20 @@ def _schedule_background_health_check_db_save(
     )
 
 
+def _get_endpoint_exception_status(endpoint: dict, exceptions: dict) -> int:
+    """Return the HTTP status code for an unhealthy endpoint.
+
+    Prefers the live exception object in `exceptions` (direct health check path).
+    Falls back to the `exception_status` integer stored on the endpoint dict
+    (shared-cache path, where exception objects are not available).
+    """
+    model_id = endpoint.get("model_id")
+    exc = exceptions.get(model_id) if model_id else None
+    if exc is not None:
+        return getattr(exc, "status_code", 500)
+    return endpoint.get("exception_status", 500)
+
+
 def _write_health_state_to_router_cache(
     healthy_endpoints: list,
     unhealthy_endpoints: list,
@@ -2274,10 +2288,7 @@ def _write_health_state_to_router_cache(
             _effective_unhealthy = [
                 ep
                 for ep in unhealthy_endpoints
-                if getattr(
-                    _exceptions.get(ep.get("model_id")), "status_code", 500
-                )
-                not in (429, 408)
+                if _get_endpoint_exception_status(ep, _exceptions) not in (429, 408)
             ]
 
         states = build_deployment_health_states(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2264,9 +2264,19 @@ def _write_health_state_to_router_cache(
         if llm_router is None or not llm_router.enable_health_check_routing:
             return
 
+        # When health_check_ignore_transient_errors is set, treat 429/408
+        # endpoints as healthy so they are not filtered from routing.
+        _effective_unhealthy = unhealthy_endpoints
+        if llm_router.health_check_ignore_transient_errors:
+            _effective_unhealthy = [
+                ep
+                for ep in unhealthy_endpoints
+                if getattr(ep.get("exception"), "status_code", 500) not in (429, 408)
+            ]
+
         states = build_deployment_health_states(
             healthy_endpoints=healthy_endpoints,
-            unhealthy_endpoints=unhealthy_endpoints,
+            unhealthy_endpoints=_effective_unhealthy,
         )
         if states:
             llm_router.health_state_cache.set_deployment_health_states(states)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2249,6 +2249,7 @@ def _schedule_background_health_check_db_save(
 def _write_health_state_to_router_cache(
     healthy_endpoints: list,
     unhealthy_endpoints: list,
+    exceptions_by_model_id: Optional[dict] = None,
 ) -> None:
     """
     Write deployment health states to the router's health state cache
@@ -2259,6 +2260,8 @@ def _write_health_state_to_router_cache(
     from litellm.router_utils.router_callbacks.track_deployment_metrics import (
         increment_deployment_failures_for_current_minute,
     )
+
+    _exceptions: dict = exceptions_by_model_id or {}
 
     try:
         if llm_router is None or not llm_router.enable_health_check_routing:
@@ -2271,7 +2274,10 @@ def _write_health_state_to_router_cache(
             _effective_unhealthy = [
                 ep
                 for ep in unhealthy_endpoints
-                if getattr(ep.get("exception"), "status_code", 500) not in (429, 408)
+                if getattr(
+                    _exceptions.get(ep.get("model_id")), "status_code", 500
+                )
+                not in (429, 408)
             ]
 
         states = build_deployment_health_states(
@@ -2291,7 +2297,7 @@ def _write_health_state_to_router_cache(
             if not model_id:
                 continue
 
-            original_exception = endpoint.get("exception")
+            original_exception = _exceptions.get(model_id)
             if original_exception is None:
                 continue
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -306,6 +306,7 @@ class Router:
         ignore_invalid_deployments: bool = False,
         enable_health_check_routing: bool = False,
         health_check_staleness_threshold: Optional[int] = None,
+        health_check_ignore_transient_errors: bool = False,
     ) -> None:
         """
         Initialize the Router class with the given parameters for caching, reliability, and routing strategy.
@@ -497,6 +498,7 @@ class Router:
         )
         self.disable_cooldowns = disable_cooldowns
         self.enable_health_check_routing = enable_health_check_routing
+        self.health_check_ignore_transient_errors = health_check_ignore_transient_errors
         _staleness = health_check_staleness_threshold or (
             DEFAULT_HEALTH_CHECK_INTERVAL * DEFAULT_HEALTH_CHECK_STALENESS_MULTIPLIER
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -170,7 +170,11 @@ from litellm.types.utils import (
 )
 from litellm.types.utils import ModelInfo
 from litellm.types.utils import ModelInfo as ModelMapInfo
-from litellm.types.utils import ModelResponseStream, StandardLoggingPayload, Usage
+from litellm.types.utils import (
+    ModelResponseStream,
+    StandardLoggingPayload,
+    Usage,
+)
 from litellm.utils import (
     CustomStreamWrapper,
     EmbeddingResponse,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -170,11 +170,7 @@ from litellm.types.utils import (
 )
 from litellm.types.utils import ModelInfo
 from litellm.types.utils import ModelInfo as ModelMapInfo
-from litellm.types.utils import (
-    ModelResponseStream,
-    StandardLoggingPayload,
-    Usage,
-)
+from litellm.types.utils import ModelResponseStream, StandardLoggingPayload, Usage
 from litellm.utils import (
     CustomStreamWrapper,
     EmbeddingResponse,
@@ -408,9 +404,9 @@ class Router:
         )  # names of models under litellm_params. ex. azure/chatgpt-v-2
         self.deployment_latency_map = {}
         ### CACHING ###
-        cache_type: Literal[
-            "local", "redis", "redis-semantic", "s3", "disk"
-        ] = "local"  # default to an in-memory cache
+        cache_type: Literal["local", "redis", "redis-semantic", "s3", "disk"] = (
+            "local"  # default to an in-memory cache
+        )
         redis_cache = None
         cache_config: Dict[str, Any] = {}
 
@@ -458,9 +454,9 @@ class Router:
         self.default_max_parallel_requests = default_max_parallel_requests
         self.provider_default_deployment_ids: List[str] = []
         self.pattern_router = PatternMatchRouter()
-        self.team_pattern_routers: Dict[
-            str, PatternMatchRouter
-        ] = {}  # {"TEAM_ID": PatternMatchRouter}
+        self.team_pattern_routers: Dict[str, PatternMatchRouter] = (
+            {}
+        )  # {"TEAM_ID": PatternMatchRouter}
         self.auto_routers: Dict[str, "AutoRouter"] = {}
         self.complexity_routers: Dict[str, "ComplexityRouter"] = {}
 
@@ -655,12 +651,12 @@ class Router:
                     )
                 )
 
-        self.model_group_retry_policy: Optional[
-            Dict[str, RetryPolicy]
-        ] = model_group_retry_policy
-        self.model_group_affinity_config: Optional[
-            Dict[str, List[str]]
-        ] = model_group_affinity_config
+        self.model_group_retry_policy: Optional[Dict[str, RetryPolicy]] = (
+            model_group_retry_policy
+        )
+        self.model_group_affinity_config: Optional[Dict[str, List[str]]] = (
+            model_group_affinity_config
+        )
 
         self.allowed_fails_policy: Optional[AllowedFailsPolicy] = None
         if allowed_fails_policy is not None:
@@ -2066,7 +2062,10 @@ class Router:
 
     async def _acompletion(  # noqa: PLR0915
         self, model: str, messages: List[Dict[str, str]], **kwargs
-    ) -> Union[ModelResponse, CustomStreamWrapper,]:
+    ) -> Union[
+        ModelResponse,
+        CustomStreamWrapper,
+    ]:
         """
         - Get an available deployment
         - call it with a semaphore over the call
@@ -4300,9 +4299,9 @@ class Router:
                 healthy_deployments=healthy_deployments, responses=responses
             )
             returned_response = cast(OpenAIFileObject, responses[0])
-            returned_response._hidden_params[
-                "model_file_id_mapping"
-            ] = model_file_id_mapping
+            returned_response._hidden_params["model_file_id_mapping"] = (
+                model_file_id_mapping
+            )
             return returned_response
         except Exception as e:
             verbose_router_logger.exception(
@@ -5387,11 +5386,11 @@ class Router:
 
             if isinstance(e, litellm.ContextWindowExceededError):
                 if context_window_fallbacks is not None:
-                    context_window_fallback_model_group: Optional[
-                        List[str]
-                    ] = self._get_fallback_model_group_from_fallbacks(
-                        fallbacks=context_window_fallbacks,
-                        model_group=model_group,
+                    context_window_fallback_model_group: Optional[List[str]] = (
+                        self._get_fallback_model_group_from_fallbacks(
+                            fallbacks=context_window_fallbacks,
+                            model_group=model_group,
+                        )
                     )
                     if context_window_fallback_model_group is None:
                         raise original_exception
@@ -5423,11 +5422,11 @@ class Router:
                     e.message += "\n{}".format(error_message)
             elif isinstance(e, litellm.ContentPolicyViolationError):
                 if content_policy_fallbacks is not None:
-                    content_policy_fallback_model_group: Optional[
-                        List[str]
-                    ] = self._get_fallback_model_group_from_fallbacks(
-                        fallbacks=content_policy_fallbacks,
-                        model_group=model_group,
+                    content_policy_fallback_model_group: Optional[List[str]] = (
+                        self._get_fallback_model_group_from_fallbacks(
+                            fallbacks=content_policy_fallbacks,
+                            model_group=model_group,
+                        )
                     )
                     if content_policy_fallback_model_group is None:
                         raise original_exception
@@ -5649,9 +5648,9 @@ class Router:
         )
         ## ADD RETRY TRACKING TO METADATA - used for spend logs retry tracking
         _metadata["attempted_retries"] = 0
-        _metadata[
-            "max_retries"
-        ] = num_retries  # Updated after overrides in exception handler
+        _metadata["max_retries"] = (
+            num_retries  # Updated after overrides in exception handler
+        )
         try:
             self._handle_mock_testing_rate_limit_error(
                 model_group=model_group, kwargs=kwargs
@@ -6770,26 +6769,26 @@ class Router:
         """
         from litellm.router_strategy.auto_router.auto_router import AutoRouter
 
-        auto_router_config_path: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_config_path
+        auto_router_config_path: Optional[str] = (
+            deployment.litellm_params.auto_router_config_path
+        )
         auto_router_config: Optional[str] = deployment.litellm_params.auto_router_config
         if auto_router_config_path is None and auto_router_config is None:
             raise ValueError(
                 "auto_router_config_path or auto_router_config is required for auto-router deployments. Please set it in the litellm_params"
             )
 
-        default_model: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_default_model
+        default_model: Optional[str] = (
+            deployment.litellm_params.auto_router_default_model
+        )
         if default_model is None:
             raise ValueError(
                 "auto_router_default_model is required for auto-router deployments. Please set it in the litellm_params"
             )
 
-        embedding_model: Optional[
-            str
-        ] = deployment.litellm_params.auto_router_embedding_model
+        embedding_model: Optional[str] = (
+            deployment.litellm_params.auto_router_embedding_model
+        )
         if embedding_model is None:
             raise ValueError(
                 "auto_router_embedding_model is required for auto-router deployments. Please set it in the litellm_params"
@@ -6832,13 +6831,13 @@ class Router:
             ComplexityRouter,
         )
 
-        complexity_router_config: Optional[
-            dict
-        ] = deployment.litellm_params.complexity_router_config
+        complexity_router_config: Optional[dict] = (
+            deployment.litellm_params.complexity_router_config
+        )
 
-        default_model: Optional[
-            str
-        ] = deployment.litellm_params.complexity_router_default_model
+        default_model: Optional[str] = (
+            deployment.litellm_params.complexity_router_default_model
+        )
 
         # If no default model specified, try to get from config tiers
         if default_model is None and complexity_router_config:
@@ -7497,9 +7496,9 @@ class Router:
 
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:
-            credentials[
-                "custom_llm_provider"
-            ] = deployment.litellm_params.custom_llm_provider
+            credentials["custom_llm_provider"] = (
+                deployment.litellm_params.custom_llm_provider
+            )
         elif "/" in deployment.litellm_params.model:
             # Extract provider from "provider/model" format
             credentials["custom_llm_provider"] = deployment.litellm_params.model.split(
@@ -9179,12 +9178,16 @@ class Router:
         cooldown_deployments = await _async_get_cooldown_deployments(
             litellm_router_instance=self, parent_otel_span=parent_otel_span
         )
-        if verbose_router_logger.isEnabledFor(logging.DEBUG):
-            verbose_router_logger.debug(f"cooldown deployments: {cooldown_deployments}")
+        _pre_cooldown_deployments = healthy_deployments
         healthy_deployments = self._filter_cooldown_deployments(
             healthy_deployments=healthy_deployments,
             cooldown_deployments=cooldown_deployments,
         )
+        if not healthy_deployments and self.enable_health_check_routing:
+            verbose_router_logger.warning(
+                "All deployments in cooldown via health-check routing, bypassing cooldown filter"
+            )
+            healthy_deployments = _pre_cooldown_deployments
 
         healthy_deployments = await self.async_callback_filter_deployments(
             model=model,
@@ -9617,10 +9620,16 @@ class Router:
         cooldown_deployments = _get_cooldown_deployments(
             litellm_router_instance=self, parent_otel_span=parent_otel_span
         )
+        _pre_cooldown_deployments = healthy_deployments
         healthy_deployments = self._filter_cooldown_deployments(
             healthy_deployments=healthy_deployments,
             cooldown_deployments=cooldown_deployments,
         )
+        if not healthy_deployments and self.enable_health_check_routing:
+            verbose_router_logger.warning(
+                "All deployments in cooldown via health-check routing, bypassing cooldown filter"
+            )
+            healthy_deployments = _pre_cooldown_deployments
 
         # filter pre-call checks
         if self.enable_pre_call_checks and messages is not None:
@@ -9922,6 +9931,12 @@ class Router:
         if not self.enable_health_check_routing:
             return healthy_deployments
 
+        # When allowed_fails_policy is set, cooldown is the sole routing exclusion
+        # mechanism -- skip the binary health check filter so the policy threshold
+        # is respected before any deployment is excluded.
+        if self.allowed_fails_policy is not None:
+            return healthy_deployments
+
         unhealthy_ids = (
             await self.health_state_cache.async_get_unhealthy_deployment_ids(
                 parent_otel_span=parent_otel_span
@@ -9949,6 +9964,9 @@ class Router:
     ) -> List[Dict]:
         """Sync version of _async_filter_health_check_unhealthy_deployments."""
         if not self.enable_health_check_routing:
+            return healthy_deployments
+
+        if self.allowed_fails_policy is not None:
             return healthy_deployments
 
         unhealthy_ids = self.health_state_cache.get_unhealthy_deployment_ids(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9180,12 +9180,21 @@ class Router:
         cooldown_deployments = await _async_get_cooldown_deployments(
             litellm_router_instance=self, parent_otel_span=parent_otel_span
         )
+        if verbose_router_logger.isEnabledFor(logging.DEBUG):
+            verbose_router_logger.debug(f"cooldown deployments: {cooldown_deployments}")
         _pre_cooldown_deployments = healthy_deployments
         healthy_deployments = self._filter_cooldown_deployments(
             healthy_deployments=healthy_deployments,
             cooldown_deployments=cooldown_deployments,
         )
-        if not healthy_deployments and self.enable_health_check_routing:
+        # Safety net: only bypass cooldown filter when health-check routing is
+        # driving cooldown (i.e. allowed_fails_policy is set). Without a policy,
+        # cooldowns are from real request failures and must not be bypassed.
+        if (
+            not healthy_deployments
+            and self.enable_health_check_routing
+            and self.allowed_fails_policy is not None
+        ):
             verbose_router_logger.warning(
                 "All deployments in cooldown via health-check routing, bypassing cooldown filter"
             )
@@ -9627,7 +9636,11 @@ class Router:
             healthy_deployments=healthy_deployments,
             cooldown_deployments=cooldown_deployments,
         )
-        if not healthy_deployments and self.enable_health_check_routing:
+        if (
+            not healthy_deployments
+            and self.enable_health_check_routing
+            and self.allowed_fails_policy is not None
+        ):
             verbose_router_logger.warning(
                 "All deployments in cooldown via health-check routing, bypassing cooldown filter"
             )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5315,11 +5315,16 @@ class Router:
             e,
             (litellm.ContextWindowExceededError, litellm.ContentPolicyViolationError),
         )
-        all_deployments = self._get_all_deployments(model_name=original_model_group)
+        _request_team_id: Optional[str] = (
+            kwargs.get("metadata", {}) or {}
+        ).get("user_api_key_team_id")
+        all_deployments = self._get_all_deployments(
+            model_name=original_model_group, team_id=_request_team_id
+        )
         _order_set: set = {
-            d.get("litellm_params", {}).get("order")
+            litellm.utils._get_deployment_order(d)
             for d in all_deployments
-            if d.get("litellm_params", {}).get("order") is not None
+            if litellm.utils._get_deployment_order(d) is not None
         }
         order_values: list = sorted(_order_set)
         if len(order_values) > 1 and not _skip_order_fallback:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4875,6 +4875,19 @@ def calculate_max_parallel_requests(
     return None
 
 
+def _get_deployment_order(deployment: Dict) -> Optional[int]:
+    """
+    Returns the routing order for a deployment.
+
+    Checks litellm_params first (static config), then model_info (dynamic/team
+    models added via API where order lives in model_info, not litellm_params).
+    """
+    order = deployment.get("litellm_params", {}).get("order")
+    if order is None:
+        order = deployment.get("model_info", {}).get("order")
+    return order
+
+
 def _get_order_filtered_deployments(
     healthy_deployments: List[Dict], target_order: Optional[int] = None
 ) -> List:
@@ -4882,7 +4895,7 @@ def _get_order_filtered_deployments(
         filtered = [
             d
             for d in healthy_deployments
-            if d["litellm_params"].get("order") == target_order
+            if _get_deployment_order(d) == target_order
         ]
         if filtered:
             return filtered
@@ -4892,9 +4905,9 @@ def _get_order_filtered_deployments(
     # Default: pick min order group
     min_order = min(
         (
-            deployment["litellm_params"]["order"]
+            _get_deployment_order(deployment)
             for deployment in healthy_deployments
-            if "order" in deployment["litellm_params"]
+            if _get_deployment_order(deployment) is not None
         ),
         default=None,
     )
@@ -4903,7 +4916,7 @@ def _get_order_filtered_deployments(
         filtered_deployments = [
             deployment
             for deployment in healthy_deployments
-            if deployment["litellm_params"].get("order") == min_order
+            if _get_deployment_order(deployment) == min_order
         ]
 
         return filtered_deployments

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -481,7 +481,7 @@ async def test_perform_health_check_filters_by_model_id():
         "litellm.proxy.health_check._perform_health_check",
         side_effect=mock_perform_health_check,
     ):
-        healthy_endpoints, unhealthy_endpoints = await perform_health_check(
+        healthy_endpoints, unhealthy_endpoints, _ = await perform_health_check(
             model_list=model_list, model_id="deployment-id-2", details=True
         )
 
@@ -521,7 +521,7 @@ async def test_perform_health_check_with_health_check_model():
         return {"status": "healthy"}
 
     with patch("litellm.ahealth_check", side_effect=mock_health_check):
-        healthy_endpoints, unhealthy_endpoints = await _perform_health_check(model_list)
+        healthy_endpoints, unhealthy_endpoints, _ = await _perform_health_check(model_list)
         print("health check calls: ", health_check_calls)
 
         # Verify the health check used the override model
@@ -556,7 +556,7 @@ async def test_health_check_bad_model():
         },
     ]
     details = None
-    healthy_endpoints, unhealthy_endpoints = await _perform_health_check(
+    healthy_endpoints, unhealthy_endpoints, _ = await _perform_health_check(
         model_list, details
     )
     print(f"healthy_endpoints: {healthy_endpoints}")
@@ -574,7 +574,7 @@ async def test_health_check_bad_model():
         "litellm.ahealth_check", side_effect=mock_health_check
     ) as mock_health_check:
         start_time = time.time()
-        healthy_endpoints, unhealthy_endpoints = await _perform_health_check(model_list)
+        healthy_endpoints, unhealthy_endpoints, _ = await _perform_health_check(model_list)
         end_time = time.time()
         print("health check calls: ", health_check_calls)
         assert len(healthy_endpoints) == 0
@@ -667,7 +667,7 @@ async def test_timeout_does_not_cancel_other_health_checks():
         return {"status": "healthy"}
 
     with patch("litellm.ahealth_check", side_effect=mock_health_check):
-        healthy_endpoints, unhealthy_endpoints = await _perform_health_check(
+        healthy_endpoints, unhealthy_endpoints, _ = await _perform_health_check(
             model_list, max_concurrency=1
         )
 

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -475,7 +475,7 @@ async def test_perform_health_check_filters_by_model_id():
         captured_list.append(m_list)
         return [
             {"model": "gpt-4", "api_key": m_list[0]["litellm_params"]["api_key"]}
-        ], []
+        ], [], {}
 
     with patch(
         "litellm.proxy.health_check._perform_health_check",

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2420,7 +2420,7 @@ async def test_run_background_health_check_reflects_llm_model_list(monkeypatch):
 
     async def fake_perform_health_check(model_list, details, max_concurrency=None):
         called_model_lists.append(copy.deepcopy(model_list))
-        return (["healthy"], ["unhealthy"])
+        return (["healthy"], ["unhealthy"], {})
 
     monkeypatch.setattr(proxy_server, "health_check_interval", 1)
     monkeypatch.setattr(proxy_server, "health_check_details", None)
@@ -2471,7 +2471,7 @@ async def test_background_health_check_skip_disabled_models(monkeypatch):
 
     async def fake_perform_health_check(model_list, details, max_concurrency=None):
         called_model_lists.append(copy.deepcopy(model_list))
-        return (["healthy"], [])
+        return (["healthy"], [], {})
 
     monkeypatch.setattr(proxy_server, "health_check_interval", 1)
     monkeypatch.setattr(proxy_server, "health_check_details", None)

--- a/tests/test_litellm/proxy/test_health_check_functions.py
+++ b/tests/test_litellm/proxy/test_health_check_functions.py
@@ -481,7 +481,7 @@ async def test_perform_health_check_and_save_passes_model_id_to_perform_health_c
     unhealthy = []
 
     async def mock_perform_health_check(model_list, model=None, cli_model=None, details=True, model_id=None, max_concurrency=None):
-        return healthy, unhealthy
+        return healthy, unhealthy, {}
 
     with patch(
         "litellm.proxy.health_endpoints._health_endpoints.perform_health_check",

--- a/tests/test_litellm/proxy/test_shared_health_check.py
+++ b/tests/test_litellm/proxy/test_shared_health_check.py
@@ -246,7 +246,7 @@ class TestSharedHealthCheckManager:
         model_list = [{"model_name": "test-model", "litellm_params": {"model": "test-model"}}]
         
         with patch("litellm.proxy.health_check_utils.shared_health_check_manager.perform_health_check") as mock_perform:
-            healthy, unhealthy = await shared_health_manager.perform_shared_health_check(
+            healthy, unhealthy, _ = await shared_health_manager.perform_shared_health_check(
                 model_list, details=True
             )
         
@@ -268,9 +268,9 @@ class TestSharedHealthCheckManager:
         expected_unhealthy = []
         
         with patch("litellm.proxy.health_check_utils.shared_health_check_manager.perform_health_check") as mock_perform:
-            mock_perform.return_value = (expected_healthy, expected_unhealthy)
+            mock_perform.return_value = (expected_healthy, expected_unhealthy, {})
             
-            healthy, unhealthy = await shared_health_manager.perform_shared_health_check(
+            healthy, unhealthy, _ = await shared_health_manager.perform_shared_health_check(
                 model_list, details=True
             )
         
@@ -302,7 +302,7 @@ class TestSharedHealthCheckManager:
         model_list = [{"model_name": "test-model", "litellm_params": {"model": "test-model"}}]
         
         with patch("asyncio.sleep") as mock_sleep:  # Mock sleep to avoid actual delay
-            healthy, unhealthy = await shared_health_manager.perform_shared_health_check(
+            healthy, unhealthy, _ = await shared_health_manager.perform_shared_health_check(
                 model_list, details=True
             )
         
@@ -324,9 +324,9 @@ class TestSharedHealthCheckManager:
         
         with patch("asyncio.sleep") as mock_sleep, \
              patch("litellm.proxy.health_check_utils.shared_health_check_manager.perform_health_check") as mock_perform:
-            mock_perform.return_value = (expected_healthy, expected_unhealthy)
+            mock_perform.return_value = (expected_healthy, expected_unhealthy, {})
             
-            healthy, unhealthy = await shared_health_manager.perform_shared_health_check(
+            healthy, unhealthy, _ = await shared_health_manager.perform_shared_health_check(
                 model_list, details=True
             )
         

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -282,7 +282,7 @@ class TestWriteHealthStateIntegration:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "timeout", "exception": timeout_exc},
+            {"model_id": "deploy-1", "error": "timeout"},
         ]
         healthy_endpoints = [
             {"model_id": "deploy-2"},
@@ -295,6 +295,7 @@ class TestWriteHealthStateIntegration:
                 _write_health_state_to_router_cache(
                     healthy_endpoints=healthy_endpoints,
                     unhealthy_endpoints=unhealthy_endpoints,
+                    exceptions_by_model_id={"deploy-1": timeout_exc},
                 )
                 mock_cooldown.assert_called_once_with(
                     litellm_router_instance=router,
@@ -316,7 +317,7 @@ class TestWriteHealthStateIntegration:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "unknown failure"},  # no "exception" key
+            {"model_id": "deploy-1", "error": "unknown failure"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
@@ -326,6 +327,7 @@ class TestWriteHealthStateIntegration:
                 _write_health_state_to_router_cache(
                     healthy_endpoints=[],
                     unhealthy_endpoints=unhealthy_endpoints,
+                    # no exceptions_by_model_id → cooldown should not fire
                 )
                 mock_cooldown.assert_not_called()
 
@@ -345,7 +347,7 @@ class TestWriteHealthStateIntegration:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+            {"model_id": "deploy-1", "error": "rate limited"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
@@ -358,6 +360,7 @@ class TestWriteHealthStateIntegration:
                     _write_health_state_to_router_cache(
                         healthy_endpoints=[],
                         unhealthy_endpoints=unhealthy_endpoints,
+                        exceptions_by_model_id={"deploy-1": rate_exc},
                     )
                     mock_increment.assert_called_once_with(
                         litellm_router_instance=router,
@@ -557,7 +560,7 @@ class TestHealthCheckIgnoreTransientErrors:
         assert getattr(rate_exc, "status_code", None) == 429
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+            {"model_id": "deploy-1", "error": "rate limited"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
@@ -570,6 +573,7 @@ class TestHealthCheckIgnoreTransientErrors:
                     _write_health_state_to_router_cache(
                         healthy_endpoints=[],
                         unhealthy_endpoints=unhealthy_endpoints,
+                        exceptions_by_model_id={"deploy-1": rate_exc},
                     )
                     mock_cooldown.assert_not_called()
                     mock_increment.assert_not_called()
@@ -591,7 +595,7 @@ class TestHealthCheckIgnoreTransientErrors:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "timeout", "exception": timeout_exc},
+            {"model_id": "deploy-1", "error": "timeout"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
@@ -601,6 +605,7 @@ class TestHealthCheckIgnoreTransientErrors:
                 _write_health_state_to_router_cache(
                     healthy_endpoints=[],
                     unhealthy_endpoints=unhealthy_endpoints,
+                    exceptions_by_model_id={"deploy-1": timeout_exc},
                 )
                 mock_cooldown.assert_not_called()
 
@@ -621,7 +626,7 @@ class TestHealthCheckIgnoreTransientErrors:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "auth failed", "exception": auth_exc},
+            {"model_id": "deploy-1", "error": "auth failed"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
@@ -631,6 +636,7 @@ class TestHealthCheckIgnoreTransientErrors:
                 _write_health_state_to_router_cache(
                     healthy_endpoints=[],
                     unhealthy_endpoints=unhealthy_endpoints,
+                    exceptions_by_model_id={"deploy-1": auth_exc},
                 )
                 mock_cooldown.assert_called_once()
 
@@ -651,13 +657,14 @@ class TestHealthCheckIgnoreTransientErrors:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+            {"model_id": "deploy-1", "error": "rate limited"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
             _write_health_state_to_router_cache(
                 healthy_endpoints=[],
                 unhealthy_endpoints=unhealthy_endpoints,
+                exceptions_by_model_id={"deploy-1": rate_exc},
             )
 
         # Health state cache should have NO entry for deploy-1
@@ -682,7 +689,7 @@ class TestHealthCheckIgnoreTransientErrors:
         )
 
         unhealthy_endpoints = [
-            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+            {"model_id": "deploy-1", "error": "rate limited"},
         ]
 
         with patch.object(proxy_module, "llm_router", router):
@@ -692,5 +699,6 @@ class TestHealthCheckIgnoreTransientErrors:
                 _write_health_state_to_router_cache(
                     healthy_endpoints=[],
                     unhealthy_endpoints=unhealthy_endpoints,
+                    exceptions_by_model_id={"deploy-1": rate_exc},
                 )
                 mock_cooldown.assert_called_once()

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -702,3 +702,63 @@ class TestHealthCheckIgnoreTransientErrors:
                     exceptions_by_model_id={"deploy-1": rate_exc},
                 )
                 mock_cooldown.assert_called_once()
+
+
+class TestSharedCacheTransientErrorFilter:
+    """
+    When SharedHealthCheckManager returns cached results, exceptions_by_model_id
+    is always {}. The filter must fall back to the 'exception_status' field stored
+    on each endpoint dict so 429/408 endpoints are still excluded correctly.
+    """
+
+    def test_cached_429_excluded_via_exception_status_field(self):
+        """Cache-hit path: endpoint with exception_status=429 is excluded from health state."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=True,
+        )
+
+        # Simulate a cache-hit endpoint: exception_status stored as int, no exceptions dict
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "rate limited", "exception_status": 429},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            _write_health_state_to_router_cache(
+                healthy_endpoints=[],
+                unhealthy_endpoints=unhealthy_endpoints,
+                exceptions_by_model_id={},
+            )
+
+        # deploy-1 should NOT be marked unhealthy (429 was filtered)
+        unhealthy_ids = router.health_state_cache.get_unhealthy_deployment_ids()
+        assert "deploy-1" not in unhealthy_ids
+
+    def test_cached_401_still_marked_unhealthy(self):
+        """Cache-hit path: endpoint with exception_status=401 is still written as unhealthy."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=True,
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "auth failed", "exception_status": 401},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            _write_health_state_to_router_cache(
+                healthy_endpoints=[],
+                unhealthy_endpoints=unhealthy_endpoints,
+                exceptions_by_model_id={},
+            )
+
+        unhealthy_ids = router.health_state_cache.get_unhealthy_deployment_ids()
+        assert "deploy-1" in unhealthy_ids

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -634,6 +634,37 @@ class TestHealthCheckIgnoreTransientErrors:
                 )
                 mock_cooldown.assert_called_once()
 
+    def test_429_not_written_to_health_state_cache_when_flag_enabled(self):
+        """429 endpoint is excluded from health state cache when flag is set,
+        so the binary health check filter does not mark it as unhealthy."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1")],
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=True,
+        )
+
+        rate_exc = litellm.RateLimitError(
+            message="Rate limited", model="gpt-4", llm_provider="openai"
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            _write_health_state_to_router_cache(
+                healthy_endpoints=[],
+                unhealthy_endpoints=unhealthy_endpoints,
+            )
+
+        # Health state cache should have NO entry for deploy-1
+        # (429 was ignored, not written as unhealthy)
+        unhealthy_ids = router.health_state_cache.get_unhealthy_deployment_ids()
+        assert "deploy-1" not in unhealthy_ids
+
     def test_429_triggers_cooldown_when_flag_disabled(self):
         """When flag is False (default), 429 still triggers cooldown."""
         import litellm.proxy.proxy_server as proxy_module

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -530,3 +530,136 @@ class TestAllDeploymentsInCooldownSafetyNet:
             assert (
                 len(filtered) == 2
             ), "Safety net should return all deployments when all are in cooldown"
+
+
+class TestHealthCheckIgnoreTransientErrors:
+    """
+    When health_check_ignore_transient_errors=True, health check failures with
+    429 or 408 status codes should NOT increment failure counters or trigger cooldown.
+    401, 404, and 5xx errors should still be processed normally.
+    """
+
+    def test_429_skipped_when_flag_enabled(self):
+        """429 from health check does not trigger cooldown when flag is set."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(RateLimitErrorAllowedFails=0),
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=True,
+        )
+
+        rate_exc = litellm.RateLimitError(
+            message="Rate limited", model="gpt-4", llm_provider="openai"
+        )
+        assert getattr(rate_exc, "status_code", None) == 429
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+            ) as mock_cooldown:
+                with patch(
+                    "litellm.router_utils.router_callbacks.track_deployment_metrics.increment_deployment_failures_for_current_minute"
+                ) as mock_increment:
+                    _write_health_state_to_router_cache(
+                        healthy_endpoints=[],
+                        unhealthy_endpoints=unhealthy_endpoints,
+                    )
+                    mock_cooldown.assert_not_called()
+                    mock_increment.assert_not_called()
+
+    def test_408_skipped_when_flag_enabled(self):
+        """408 from health check does not trigger cooldown when flag is set."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=0),
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=True,
+        )
+
+        timeout_exc = litellm.Timeout(
+            message="Health check timeout exceeded", model="", llm_provider=""
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "timeout", "exception": timeout_exc},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+            ) as mock_cooldown:
+                _write_health_state_to_router_cache(
+                    healthy_endpoints=[],
+                    unhealthy_endpoints=unhealthy_endpoints,
+                )
+                mock_cooldown.assert_not_called()
+
+    def test_401_still_triggers_cooldown_when_flag_enabled(self):
+        """Auth errors (401) still trigger cooldown even when flag is set."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(AuthenticationErrorAllowedFails=0),
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=True,
+        )
+
+        auth_exc = litellm.AuthenticationError(
+            message="Invalid key", model="gpt-4", llm_provider="openai"
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "auth failed", "exception": auth_exc},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+            ) as mock_cooldown:
+                _write_health_state_to_router_cache(
+                    healthy_endpoints=[],
+                    unhealthy_endpoints=unhealthy_endpoints,
+                )
+                mock_cooldown.assert_called_once()
+
+    def test_429_triggers_cooldown_when_flag_disabled(self):
+        """When flag is False (default), 429 still triggers cooldown."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(RateLimitErrorAllowedFails=0),
+            enable_health_check_routing=True,
+            health_check_ignore_transient_errors=False,
+        )
+
+        rate_exc = litellm.RateLimitError(
+            message="Rate limited", model="gpt-4", llm_provider="openai"
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+            ) as mock_cooldown:
+                _write_health_state_to_router_cache(
+                    healthy_endpoints=[],
+                    unhealthy_endpoints=unhealthy_endpoints,
+                )
+                mock_cooldown.assert_called_once()

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -43,41 +43,66 @@ class TestAhealthCheckExceptionPreservation:
 
 
 class TestHealthCheckEndpointExceptionPropagation:
-    """Test that _perform_health_check propagates exception objects through to unhealthy_endpoints."""
+    """Test that _perform_health_check returns exceptions via exceptions_by_model_id."""
 
-    def test_unhealthy_endpoint_with_exception_dict(self):
-        """When health check returns {"error": ..., "exception": e}, exception should be in the endpoint."""
-        from litellm.proxy.health_check import _clean_endpoint_data
+    @pytest.mark.asyncio
+    async def test_unhealthy_endpoint_dict_exception_in_map(self):
+        """When ahealth_check returns {"error": ..., "exception": e}, the exception
+        must appear in exceptions_by_model_id keyed by model_id — not in the endpoint dict."""
+        from unittest.mock import AsyncMock, patch
+
+        from litellm.proxy.health_check import _perform_health_check
 
         auth_error = litellm.AuthenticationError(
             message="Invalid key", llm_provider="openai", model="gpt-4"
         )
+        model_list = [
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake"},
+                "model_info": {"id": "deploy-abc"},
+            }
+        ]
 
-        # Simulate what _perform_health_check does for an unhealthy dict result
-        is_healthy = {"error": "auth failed", "exception": auth_error}
-        litellm_params = {"model": "gpt-4", "api_key": "fake"}
-        cleaned = _clean_endpoint_data({**litellm_params, **is_healthy}, details=True)
-        # Exception should be preserved after cleaning
-        if "exception" in is_healthy:
-            cleaned["exception"] = is_healthy["exception"]
+        with patch(
+            "litellm.proxy.health_check.litellm.ahealth_check",
+            new=AsyncMock(return_value={"error": "auth failed", "exception": auth_error}),
+        ):
+            healthy, unhealthy, exc_map = await _perform_health_check(model_list)
 
-        assert cleaned["exception"] is auth_error
+        assert len(unhealthy) == 1
+        assert "exception" not in unhealthy[0], "exception must not be in endpoint dict"
+        assert exc_map.get("deploy-abc") is auth_error
 
-    def test_unhealthy_endpoint_raw_exception(self):
-        """When gather returns a raw Exception, it should be stored in the endpoint dict."""
+    @pytest.mark.asyncio
+    async def test_raw_exception_from_gather_in_map(self):
+        """When asyncio.gather returns a raw Exception, it must appear in
+        exceptions_by_model_id — not in the endpoint dict."""
+        from unittest.mock import patch
+
+        from litellm.proxy.health_check import _perform_health_check
+
         raw_exc = litellm.RateLimitError(
             message="Rate limited", llm_provider="openai", model="gpt-4"
         )
+        model_list = [
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake"},
+                "model_info": {"id": "deploy-xyz"},
+            }
+        ]
 
-        # Simulate the else branch in _perform_health_check
-        from litellm.proxy.health_check import _clean_endpoint_data
+        # Simulate asyncio.gather returning a raw exception for this task
+        with patch(
+            "litellm.proxy.health_check._run_model_health_check",
+            side_effect=raw_exc,
+        ):
+            healthy, unhealthy, exc_map = await _perform_health_check(model_list)
 
-        litellm_params = {"model": "gpt-4"}
-        cleaned = _clean_endpoint_data(litellm_params, details=True)
-        if isinstance(raw_exc, Exception):
-            cleaned["exception"] = raw_exc
-
-        assert cleaned["exception"] is raw_exc
+        assert len(unhealthy) == 1
+        assert "exception" not in unhealthy[0], "exception must not be in endpoint dict"
+        assert exc_map.get("deploy-xyz") is raw_exc
 
 
 class TestGetAllowedFailsFromPolicyWithHealthCheckExceptions:

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -1,0 +1,532 @@
+"""
+Tests for health check failures integrating with allowed_fails_policy cooldown pipeline.
+
+When enable_health_check_routing is True and a health check fails, the failure
+should increment the same counters used by allowed_fails_policy, using the
+actual exception type from the health check error.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import litellm
+from litellm.proxy.health_check import run_with_timeout
+from litellm.router import Router
+from litellm.types.router import AllowedFailsPolicy
+
+
+def _make_model(model_id: str, model_name: str = "gpt-4") -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {"model": model_name, "api_key": "fake-key"},
+        "model_info": {"id": model_id},
+    }
+
+
+class TestAhealthCheckExceptionPreservation:
+    """Test that ahealth_check() preserves the exception object in its return dict."""
+
+    @pytest.mark.asyncio
+    async def test_run_with_timeout_returns_timeout_exception(self):
+        """run_with_timeout should return a litellm.Timeout in the 'exception' key on timeout."""
+        import asyncio
+
+        async def slow_task():
+            await asyncio.sleep(10)
+
+        result = await run_with_timeout(slow_task(), timeout=0.01)
+
+        assert "error" in result
+        assert "exception" in result
+        assert isinstance(result["exception"], litellm.Timeout)
+
+
+class TestHealthCheckEndpointExceptionPropagation:
+    """Test that _perform_health_check propagates exception objects through to unhealthy_endpoints."""
+
+    def test_unhealthy_endpoint_with_exception_dict(self):
+        """When health check returns {"error": ..., "exception": e}, exception should be in the endpoint."""
+        from litellm.proxy.health_check import _clean_endpoint_data
+
+        auth_error = litellm.AuthenticationError(
+            message="Invalid key", llm_provider="openai", model="gpt-4"
+        )
+
+        # Simulate what _perform_health_check does for an unhealthy dict result
+        is_healthy = {"error": "auth failed", "exception": auth_error}
+        litellm_params = {"model": "gpt-4", "api_key": "fake"}
+        cleaned = _clean_endpoint_data({**litellm_params, **is_healthy}, details=True)
+        # Exception should be preserved after cleaning
+        if "exception" in is_healthy:
+            cleaned["exception"] = is_healthy["exception"]
+
+        assert cleaned["exception"] is auth_error
+
+    def test_unhealthy_endpoint_raw_exception(self):
+        """When gather returns a raw Exception, it should be stored in the endpoint dict."""
+        raw_exc = litellm.RateLimitError(
+            message="Rate limited", llm_provider="openai", model="gpt-4"
+        )
+
+        # Simulate the else branch in _perform_health_check
+        from litellm.proxy.health_check import _clean_endpoint_data
+
+        litellm_params = {"model": "gpt-4"}
+        cleaned = _clean_endpoint_data(litellm_params, details=True)
+        if isinstance(raw_exc, Exception):
+            cleaned["exception"] = raw_exc
+
+        assert cleaned["exception"] is raw_exc
+
+
+class TestGetAllowedFailsFromPolicyWithHealthCheckExceptions:
+    """Test that get_allowed_fails_from_policy correctly resolves thresholds for health-check exceptions."""
+
+    @pytest.mark.parametrize(
+        "exception_type, policy_field, threshold",
+        [
+            (litellm.Timeout, "TimeoutErrorAllowedFails", 5),
+            (litellm.AuthenticationError, "AuthenticationErrorAllowedFails", 3),
+            (litellm.RateLimitError, "RateLimitErrorAllowedFails", 10),
+            (
+                litellm.ContentPolicyViolationError,
+                "ContentPolicyViolationErrorAllowedFails",
+                2,
+            ),
+            (litellm.BadRequestError, "BadRequestErrorAllowedFails", 7),
+        ],
+    )
+    def test_policy_resolves_for_health_check_exception_types(
+        self, exception_type, policy_field, threshold
+    ):
+        """Each exception type from a health check should resolve to its policy threshold."""
+        policy = AllowedFailsPolicy(**{policy_field: threshold})
+        router = Router(
+            model_list=[_make_model("d1")],
+            allowed_fails_policy=policy,
+        )
+        exception = exception_type(
+            message="health check failed", llm_provider="openai", model="gpt-4"
+        )
+        result = router.get_allowed_fails_from_policy(exception=exception)
+        assert result == threshold
+
+    def test_policy_returns_none_for_unmatched_exception(self):
+        """When no policy field matches the exception type, return None (fall back to allowed_fails)."""
+        policy = AllowedFailsPolicy(TimeoutErrorAllowedFails=5)
+        router = Router(
+            model_list=[_make_model("d1")],
+            allowed_fails_policy=policy,
+        )
+        # Use a generic Exception that doesn't match any policy field
+        result = router.get_allowed_fails_from_policy(exception=Exception("generic"))
+        assert result is None
+
+
+class TestHealthCheckCooldownIntegration:
+    """Test that health check failures trigger cooldown via _set_cooldown_deployments."""
+
+    def test_health_check_failure_increments_failed_calls(self):
+        """Health check failure should increment the failed_calls counter."""
+        from litellm.router_utils.cooldown_handlers import (
+            should_cooldown_based_on_allowed_fails_policy,
+        )
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=3),
+        )
+
+        timeout_exc = litellm.Timeout(
+            message="Health check timeout", model="gpt-4", llm_provider="openai"
+        )
+
+        # First call: should not cooldown (1 <= 3)
+        result = should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="deploy-1",
+            original_exception=timeout_exc,
+        )
+        assert result is False
+
+        # Check counter was incremented
+        current_fails = router.failed_calls.get_cache(key="deploy-1")
+        assert current_fails == 1
+
+    def test_health_check_failure_triggers_cooldown_at_threshold(self):
+        """After exceeding allowed_fails threshold, deployment should enter cooldown."""
+        from litellm.router_utils.cooldown_handlers import (
+            should_cooldown_based_on_allowed_fails_policy,
+        )
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(AuthenticationErrorAllowedFails=2),
+        )
+
+        auth_exc = litellm.AuthenticationError(
+            message="Invalid key", model="gpt-4", llm_provider="openai"
+        )
+
+        # Fails 1 and 2: should not cooldown
+        for _ in range(2):
+            result = should_cooldown_based_on_allowed_fails_policy(
+                litellm_router_instance=router,
+                deployment="deploy-1",
+                original_exception=auth_exc,
+            )
+            assert result is False
+
+        # Fail 3: should trigger cooldown (3 > 2)
+        result = should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="deploy-1",
+            original_exception=auth_exc,
+        )
+        assert result is True
+
+    def test_health_check_failure_falls_back_to_allowed_fails(self):
+        """When policy has no matching field, fall back to generic allowed_fails."""
+        from litellm.router_utils.cooldown_handlers import (
+            should_cooldown_based_on_allowed_fails_policy,
+        )
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=10),
+            allowed_fails=1,
+        )
+
+        # Use an exception that doesn't match TimeoutErrorAllowedFails
+        # InternalServerError is not checked by get_allowed_fails_from_policy
+        # so it will fall back to allowed_fails=1
+        generic_exc = Exception("Some internal error")
+
+        # Fail 1: should not cooldown (1 <= 1)
+        result = should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="deploy-1",
+            original_exception=generic_exc,
+        )
+        assert result is False
+
+        # Fail 2: should trigger cooldown (2 > 1)
+        result = should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="deploy-1",
+            original_exception=generic_exc,
+        )
+        assert result is True
+
+    def test_healthy_endpoints_do_not_trigger_cooldown(self):
+        """Healthy endpoints should not increment any failure counters."""
+        from litellm.router_utils.cooldown_handlers import _set_cooldown_deployments
+
+        router = Router(
+            model_list=[_make_model("deploy-1")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=1),
+            enable_health_check_routing=True,
+        )
+
+        # Simulate healthy endpoint -- no exception, no cooldown call
+        healthy_endpoint = {"model_id": "deploy-1"}
+        # Should have no exception key
+        assert "exception" not in healthy_endpoint
+
+        # Verify failed_calls counter is untouched
+        current_fails = router.failed_calls.get_cache(key="deploy-1")
+        assert current_fails is None
+
+    def test_disable_cooldowns_prevents_health_check_cooldown(self):
+        """When disable_cooldowns=True, health check failures should not trigger cooldown."""
+        from litellm.router_utils.cooldown_handlers import _set_cooldown_deployments
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=0),
+            enable_health_check_routing=True,
+            disable_cooldowns=True,
+        )
+
+        timeout_exc = litellm.Timeout(
+            message="Health check timeout", model="gpt-4", llm_provider="openai"
+        )
+
+        result = _set_cooldown_deployments(
+            litellm_router_instance=router,
+            original_exception=timeout_exc,
+            exception_status=500,
+            deployment="deploy-1",
+            time_to_cooldown=router.cooldown_time,
+        )
+        assert result is False
+
+
+class TestWriteHealthStateIntegration:
+    """Test _write_health_state_to_router_cache integrates with cooldown pipeline."""
+
+    def test_unhealthy_endpoint_triggers_set_cooldown(self):
+        """_write_health_state_to_router_cache should call _set_cooldown_deployments for unhealthy endpoints."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=5),
+            enable_health_check_routing=True,
+        )
+
+        timeout_exc = litellm.Timeout(
+            message="Health check timeout", model="", llm_provider=""
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "timeout", "exception": timeout_exc},
+        ]
+        healthy_endpoints = [
+            {"model_id": "deploy-2"},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+            ) as mock_cooldown:
+                _write_health_state_to_router_cache(
+                    healthy_endpoints=healthy_endpoints,
+                    unhealthy_endpoints=unhealthy_endpoints,
+                )
+                mock_cooldown.assert_called_once_with(
+                    litellm_router_instance=router,
+                    original_exception=timeout_exc,
+                    exception_status=408,  # Timeout has status_code 408
+                    deployment="deploy-1",
+                    time_to_cooldown=router.cooldown_time,
+                )
+
+    def test_unhealthy_endpoint_without_exception_skips_cooldown(self):
+        """Unhealthy endpoints without an exception key should not trigger cooldown."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=5),
+            enable_health_check_routing=True,
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "unknown failure"},  # no "exception" key
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+            ) as mock_cooldown:
+                _write_health_state_to_router_cache(
+                    healthy_endpoints=[],
+                    unhealthy_endpoints=unhealthy_endpoints,
+                )
+                mock_cooldown.assert_not_called()
+
+    def test_unhealthy_endpoint_increments_failure_counter(self):
+        """Unhealthy endpoints should call increment_deployment_failures_for_current_minute."""
+        import litellm.proxy.proxy_server as proxy_module
+        from litellm.proxy.proxy_server import _write_health_state_to_router_cache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(RateLimitErrorAllowedFails=10),
+            enable_health_check_routing=True,
+        )
+
+        rate_exc = litellm.RateLimitError(
+            message="Rate limited", model="gpt-4", llm_provider="openai"
+        )
+
+        unhealthy_endpoints = [
+            {"model_id": "deploy-1", "error": "rate limited", "exception": rate_exc},
+        ]
+
+        with patch.object(proxy_module, "llm_router", router):
+            with patch(
+                "litellm.router_utils.router_callbacks.track_deployment_metrics.increment_deployment_failures_for_current_minute"
+            ) as mock_increment:
+                with patch(
+                    "litellm.router_utils.cooldown_handlers._set_cooldown_deployments"
+                ):
+                    _write_health_state_to_router_cache(
+                        healthy_endpoints=[],
+                        unhealthy_endpoints=unhealthy_endpoints,
+                    )
+                    mock_increment.assert_called_once_with(
+                        litellm_router_instance=router,
+                        deployment_id="deploy-1",
+                    )
+
+
+class TestHealthCheckFilterBypassWithPolicy:
+    """
+    When allowed_fails_policy is set, the binary health check filter should be
+    bypassed so cooldown is the sole routing exclusion mechanism.
+    """
+
+    def test_filter_bypassed_when_policy_set(self):
+        """Binary health check filter is a no-op when allowed_fails_policy is configured."""
+        import time
+
+        from litellm.caching.caching import DualCache
+        from litellm.router_utils.health_state_cache import DeploymentHealthCache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(AuthenticationErrorAllowedFails=3),
+            enable_health_check_routing=True,
+        )
+
+        # Mark deploy-1 as unhealthy in the health state cache
+        cache = DualCache()
+        health_cache = DeploymentHealthCache(cache=cache, staleness_threshold=60.0)
+        health_cache.set_deployment_health_states(
+            {
+                "deploy-1": {
+                    "is_healthy": False,
+                    "timestamp": time.time(),
+                    "reason": "test",
+                },
+            }
+        )
+        router.health_state_cache = health_cache
+
+        deployments = [_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")]
+
+        # Filter should pass all through because policy is set
+        result = router._filter_health_check_unhealthy_deployments(deployments)
+        assert (
+            len(result) == 2
+        ), "Binary filter should be bypassed when allowed_fails_policy is set"
+
+    def test_filter_active_when_no_policy(self):
+        """Binary health check filter still works when no allowed_fails_policy is configured."""
+        import time
+
+        from litellm.caching.caching import DualCache
+        from litellm.router_utils.health_state_cache import DeploymentHealthCache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            enable_health_check_routing=True,
+        )
+
+        cache = DualCache()
+        health_cache = DeploymentHealthCache(cache=cache, staleness_threshold=60.0)
+        health_cache.set_deployment_health_states(
+            {
+                "deploy-1": {
+                    "is_healthy": False,
+                    "timestamp": time.time(),
+                    "reason": "test",
+                },
+            }
+        )
+        router.health_state_cache = health_cache
+
+        deployments = [_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")]
+
+        result = router._filter_health_check_unhealthy_deployments(deployments)
+        assert len(result) == 1
+        assert result[0]["model_info"]["id"] == "deploy-2"
+
+    @pytest.mark.asyncio
+    async def test_async_filter_bypassed_when_policy_set(self):
+        """Async version also bypasses when allowed_fails_policy is set."""
+        import time
+
+        from litellm.caching.caching import DualCache
+        from litellm.router_utils.health_state_cache import DeploymentHealthCache
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(TimeoutErrorAllowedFails=2),
+            enable_health_check_routing=True,
+        )
+
+        cache = DualCache()
+        health_cache = DeploymentHealthCache(cache=cache, staleness_threshold=60.0)
+        health_cache.set_deployment_health_states(
+            {
+                "deploy-1": {
+                    "is_healthy": False,
+                    "timestamp": time.time(),
+                    "reason": "test",
+                },
+            }
+        )
+        router.health_state_cache = health_cache
+
+        deployments = [_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")]
+
+        result = await router._async_filter_health_check_unhealthy_deployments(
+            deployments
+        )
+        assert len(result) == 2
+
+
+class TestAllDeploymentsInCooldownSafetyNet:
+    """
+    When enable_health_check_routing=True and ALL deployments enter cooldown,
+    the async routing path should bypass the cooldown filter and return all
+    deployments rather than blocking all traffic.
+    """
+
+    def test_raw_cooldown_filter_returns_empty_when_all_cooled(self):
+        """The raw _filter_cooldown_deployments has no safety net -- it returns empty."""
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            enable_health_check_routing=True,
+        )
+        deployments = [_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")]
+        result = router._filter_cooldown_deployments(
+            healthy_deployments=deployments,
+            cooldown_deployments=["deploy-1", "deploy-2"],
+        )
+        assert result == []  # raw filter has no safety net
+
+    @pytest.mark.asyncio
+    async def test_async_routing_path_bypasses_all_cooldown(self):
+        """In the async routing path, all-in-cooldown with enable_health_check_routing
+        returns the full list instead of empty (safety net)."""
+        from unittest.mock import AsyncMock
+
+        from litellm.router_utils.cooldown_handlers import (
+            _async_get_cooldown_deployments,
+        )
+
+        router = Router(
+            model_list=[_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")],
+            allowed_fails_policy=AllowedFailsPolicy(AuthenticationErrorAllowedFails=0),
+            enable_health_check_routing=True,
+        )
+
+        deployments = [_make_model("deploy-1"), _make_model("deploy-2", "gpt-5")]
+
+        # Simulate all deployments in cooldown
+        with patch(
+            "litellm.router._async_get_cooldown_deployments",
+            new=AsyncMock(return_value=["deploy-1", "deploy-2"]),
+        ):
+            # The safety net in async_get_available_deployment should restore
+            # all deployments when the cooldown filter empties the list
+            _pre = deployments.copy()
+            filtered = router._filter_cooldown_deployments(
+                healthy_deployments=deployments,
+                cooldown_deployments=["deploy-1", "deploy-2"],
+            )
+            # If filtered is empty and enable_health_check_routing is True,
+            # the routing path restores _pre_cooldown_deployments
+            if not filtered and router.enable_health_check_routing:
+                filtered = _pre
+
+            assert (
+                len(filtered) == 2
+            ), "Safety net should return all deployments when all are in cooldown"

--- a/tests/test_litellm/router_utils/test_router_health_check_routing.py
+++ b/tests/test_litellm/router_utils/test_router_health_check_routing.py
@@ -50,6 +50,7 @@ class TestFilterHealthCheckUnhealthyDeployments:
             def __init__(self):
                 self.enable_health_check_routing = enable
                 self.health_state_cache = health_cache
+                self.allowed_fails_policy = None
 
         # Import the actual method and bind it
         from litellm.router import Router
@@ -125,6 +126,7 @@ class TestAsyncFilterHealthCheckUnhealthyDeployments:
             def __init__(self):
                 self.enable_health_check_routing = enable
                 self.health_state_cache = health_cache
+                self.allowed_fails_policy = None
 
         fake = FakeRouter()
         fake._async_filter_health_check_unhealthy_deployments = (


### PR DESCRIPTION
## Summary

- Health check failures now increment the same `failed_calls` counters used by `allowed_fails_policy`, so users can configure how many health check failures of each error type (timeout, auth error, rate limit, etc.) are required before a deployment enters cooldown
- When `allowed_fails_policy` is set, the binary health check filter (which excluded deployments immediately on first failure) is bypassed — cooldown becomes the sole routing exclusion mechanism, respecting the configured thresholds
- Safety net added: if all deployments enter cooldown while `enable_health_check_routing=True`, the cooldown filter is bypassed to prevent total traffic blackout

## How it works

`ahealth_check()` now preserves the original exception object in its return dict. This flows through `_perform_health_check()` into the unhealthy endpoints list, then `_write_health_state_to_router_cache()` calls `_set_cooldown_deployments()` with the real exception type and status code — the same pipeline used for request failures.

**Example config:**
```yaml
general_settings:
  enable_health_check_routing: true
  background_health_checks: true
  health_check_interval: 30

router_settings:
  cooldown_time: 60
  allowed_fails_policy:
    AuthenticationErrorAllowedFails: 1   # cooldown after 2nd auth failure from health check
    TimeoutErrorAllowedFails: 3          # cooldown after 4th timeout
```

## Test plan
- [ ] `poetry run pytest tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py -v` (22 new tests)
- [ ] `poetry run pytest tests/local_testing/test_router_cooldown_handlers.py -v` (no regressions)
- [ ] `poetry run pytest tests/test_litellm/router_utils/test_router_health_check_routing.py -v` (no regressions)