### PR TITLE
fix(mcp): return only non-MCP tools when semantic filter finds zero matches

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
 
+from litellm.proxy._experimental.mcp_server.utils import is_tool_name_prefixed
+
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
 
@@ -190,7 +192,13 @@ class SemanticMCPToolFilter:
             matched_tool_names = self._extract_tool_names_from_matches(matches)
 
             if not matched_tool_names:
-                return available_tools
+                # Return only non-MCP tools (built-in tools without a server prefix)
+                # to avoid exceeding provider tool limits when no semantic matches exist
+                return [
+                    tool
+                    for tool in available_tools
+                    if not is_tool_name_prefixed(self._extract_tool_info(tool)[0])
+                ]
 
             return self._get_tools_by_names(matched_tool_names, available_tools)
 

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -194,11 +194,17 @@ class SemanticMCPToolFilter:
             if not matched_tool_names:
                 # Return only non-MCP tools (built-in tools without a server prefix)
                 # to avoid exceeding provider tool limits when no semantic matches exist
-                return [
+                non_mcp_tools = [
                     tool
                     for tool in available_tools
                     if not is_tool_name_prefixed(self._extract_tool_info(tool)[0])
                 ]
+                if non_mcp_tools:
+                    return non_mcp_tools
+
+                # Fallback: if all tools are MCP tools (no built-in tools), return
+                # a bounded subset to avoid an empty tool list that would confuse the model
+                return available_tools[:limit]
 
             return self._get_tools_by_names(matched_tool_names, available_tools)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -192,6 +192,64 @@ async def test_semantic_filter_disabled():
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_zero_matches_returns_only_non_mcp_tools():
+    """
+    Test that when zero semantic matches are found, only non-MCP tools are returned.
+
+    Given: A mix of MCP tools (prefixed) and built-in tools (not prefixed)
+    When: Semantic filter finds zero matches (e.g., irrelevant query like "hello")
+    Then: Only built-in (non-prefixed) tools should be returned, not all tools
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/24984
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    # Create mock tools: 3 MCP tools (prefixed with server name) and 2 built-in tools
+    mcp_tools = [
+        MCPTool(name="server1-tool_a", description="MCP tool A", inputSchema={"type": "object"}),
+        MCPTool(name="server1-tool_b", description="MCP tool B", inputSchema={"type": "object"}),
+        MCPTool(name="server2-tool_c", description="MCP tool C", inputSchema={"type": "object"}),
+    ]
+    builtin_tools = [
+        MCPTool(name="web_search", description="Search the web", inputSchema={"type": "object"}),
+        MCPTool(name="code_interpreter", description="Run code", inputSchema={"type": "object"}),
+    ]
+    all_tools = mcp_tools + builtin_tools
+
+    # Mock router that returns zero matches for any query
+    mock_router = Mock()
+    mock_router.return_value = []  # No semantic matches
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=5,
+        similarity_threshold=0.1,
+        enabled=True,
+    )
+
+    # Inject a mock router that returns empty matches
+    filter_instance.tool_router = mock_router
+
+    # Filter with a query that matches nothing
+    filtered = await filter_instance.filter_tools(
+        query="hello",
+        available_tools=all_tools,
+    )
+
+    # Should return only non-MCP tools, not all tools
+    assert len(filtered) == 2, f"Expected 2 non-MCP tools, got {len(filtered)}"
+    filtered_names = [t.name for t in filtered]
+    assert "web_search" in filtered_names
+    assert "code_interpreter" in filtered_names
+    # No MCP tools should be returned
+    for name in filtered_names:
+        assert "-" not in name, f"MCP tool {name} should not be returned on zero matches"
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_empty_tools():
     """
     Test that filter handles empty tool list gracefully.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -205,6 +205,7 @@ async def test_semantic_filter_zero_matches_returns_only_non_mcp_tools():
     from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
         SemanticMCPToolFilter,
     )
+    from litellm.proxy._experimental.mcp_server.utils import MCP_TOOL_PREFIX_SEPARATOR
 
     # Create mock tools: 3 MCP tools (prefixed with server name) and 2 built-in tools
     mcp_tools = [
@@ -246,7 +247,50 @@ async def test_semantic_filter_zero_matches_returns_only_non_mcp_tools():
     assert "code_interpreter" in filtered_names
     # No MCP tools should be returned
     for name in filtered_names:
-        assert "-" not in name, f"MCP tool {name} should not be returned on zero matches"
+        assert MCP_TOOL_PREFIX_SEPARATOR not in name, f"MCP tool {name} should not be returned on zero matches"
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_zero_matches_all_mcp_tools():
+    """
+    Test that when all tools are MCP tools and zero matches, bounded subset is returned.
+
+    Given: Only MCP tools (no built-in tools)
+    When: Semantic filter finds zero matches
+    Then: Returns top-K MCP tools (bounded) rather than empty list
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/24984
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    # Create only MCP tools
+    mcp_tools = [
+        MCPTool(name=f"server1-tool_{i}", description=f"MCP tool {i}", inputSchema={"type": "object"})
+        for i in range(20)
+    ]
+
+    mock_router = Mock()
+    mock_router.return_value = []
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=5,
+        similarity_threshold=0.1,
+        enabled=True,
+    )
+    filter_instance.tool_router = mock_router
+
+    filtered = await filter_instance.filter_tools(
+        query="hello",
+        available_tools=mcp_tools,
+    )
+
+    # Should return bounded subset (top_k), not empty and not all 20
+    assert len(filtered) == 5, f"Expected bounded subset of 5, got {len(filtered)}"
+    assert len(filtered) < len(mcp_tools), "Should not return all tools"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
When the semantic tool filter finds zero matches for a query, it now returns only non-MCP (built-in) tools instead of returning all available tools.

## Why
When zero semantic matches exist (e.g., an irrelevant query like "hello"), `filter_tools()` fell back to returning ALL tools. With 100+ MCP tools configured, this exceeds OpenAI"s 128 tool limit and causes requests to fail. See: #24984

## How
In `semantic_tool_filter.py`, the fallback when `matched_tool_names` is empty now filters to only non-MCP tools using `is_tool_name_prefixed()` from `utils.py`. MCP tools are identifiable by their server-name prefix (contains `MCP_TOOL_PREFIX_SEPARATOR`). Built-in tools like `web_search` or `code_interpreter` pass through unaffected.

## Testing
- Added `test_semantic_filter_zero_matches_returns_only_non_mcp_tools` — verifies that on zero matches, only non-prefixed tools are returned
- Existing tests continue to pass
- `ruff check` passes

## Checklist
- [x] Tests added
- [x] Linter passes
- [x] No breaking change for non-MCP tools

Closes #24984