### PR TITLE
fix(agentcore): parse A2A JSON-RPC responses in AgentCore provider

### DIFF
--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -19,6 +19,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.a2a.common_utils import extract_text_from_a2a_response
 from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.types.llms.bedrock_agentcore import (
     AgentCoreMessage,
@@ -343,6 +344,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         Parse direct JSON response (non-streaming).
 
         Supports multiple agent response schemas:
+        0. {"jsonrpc": "2.0", "result": {"message": {"parts": [...]}}} - A2A JSON-RPC
         1. {"result": {"role": "assistant", "content": [{"text": "..."}]}} - standard AgentCore
         2. {"response": [{"text": "..."}]} - Strands agent format
         3. {"result": "plain text"} or {"response": "plain text"} - simple string
@@ -360,6 +362,18 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 usage=None,
                 final_message=None,
             )
+
+        # Strategy 0: A2A JSON-RPC format
+        # {"jsonrpc": "2.0", "result": {"message": {"parts": [{"kind": "text", "text": "..."}]}}}
+        if "jsonrpc" in response_json:
+            content = extract_text_from_a2a_response(response_json)
+            if content:
+                return AgentCoreParsedResponse(
+                    content=content,
+                    usage=None,
+                    final_message=None,
+                )
+            # Fall through to other strategies if A2A extraction returned empty
 
         # Strategy 1: {"result": {"content": [{"text": "..."}]}} - standard AgentCore format
         if "result" in response_json and isinstance(response_json["result"], dict):

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -160,6 +160,67 @@ class TestAgentCoreJsonResponseParsing:
         assert parsed["content"] == ""
         assert parsed["final_message"] == response_json["result"]
 
+    def test_parse_json_a2a_jsonrpc_nested_message(self, config):
+        """Strategy 0: A2A JSON-RPC with result.message.parts[] format."""
+        response_json = {
+            "jsonrpc": "2.0",
+            "id": "test_id",
+            "result": {
+                "message": {
+                    "role": "agent",
+                    "parts": [{"kind": "text", "text": "1 + 1 = 2"}],
+                    "messageId": "123",
+                }
+            },
+        }
+        parsed = config._parse_json_response(response_json)
+        assert parsed["content"] == "1 + 1 = 2"
+        assert parsed["usage"] is None
+
+    def test_parse_json_a2a_jsonrpc_direct_parts(self, config):
+        """Strategy 0: A2A JSON-RPC with result.parts[] format (direct message)."""
+        response_json = {
+            "jsonrpc": "2.0",
+            "id": "test_id",
+            "result": {
+                "kind": "message",
+                "parts": [{"kind": "text", "text": "Direct response"}],
+            },
+        }
+        parsed = config._parse_json_response(response_json)
+        assert parsed["content"] == "Direct response"
+        assert parsed["usage"] is None
+
+    def test_parse_json_a2a_jsonrpc_multi_parts(self, config):
+        """Strategy 0: A2A JSON-RPC with multiple text parts concatenated."""
+        response_json = {
+            "jsonrpc": "2.0",
+            "id": "test_id",
+            "result": {
+                "message": {
+                    "role": "agent",
+                    "parts": [
+                        {"kind": "text", "text": "First part"},
+                        {"kind": "text", "text": "Second part"},
+                    ],
+                }
+            },
+        }
+        parsed = config._parse_json_response(response_json)
+        assert parsed["content"] == "First part Second part"
+        assert parsed["usage"] is None
+
+    def test_parse_json_a2a_jsonrpc_empty_falls_through(self, config):
+        """Strategy 0: A2A JSON-RPC with empty result falls through to Strategy 3."""
+        response_json = {
+            "jsonrpc": "2.0",
+            "id": "test_id",
+            "result": "plain text fallback",
+        }
+        parsed = config._parse_json_response(response_json)
+        assert parsed["content"] == "plain text fallback"
+        assert parsed["usage"] is None
+
 
 class TestAgentCoreNonStreamingJsonFormats:
     """Tests for _get_parsed_response with different JSON formats (non-streaming path)."""


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

**Problem**: `_parse_json_response()` in the AgentCore provider returns empty content for A2A agents. Strategy 1 matches A2A responses (because `result` is a dict), but `_extract_content_from_message()` looks for `result["content"]` which doesn't exist in A2A format — A2A agents return `result["message"]["parts"]` instead. This means `message.get("content", [])` returns `[]`, producing an empty string.

**Fix**: Added Strategy 0 before the existing strategies that detects A2A JSON-RPC responses by checking for the `"jsonrpc"` key, then delegates to the existing `extract_text_from_a2a_response()` utility from `litellm/llms/a2a/common_utils.py`. This utility already handles 5 A2A response shapes (direct message, nested message, task with artifacts, task status, streaming artifact-update). If A2A extraction returns empty, it falls through to the existing strategies — zero regression risk.

**Files modified**:
- `litellm/llms/bedrock/chat/agentcore/transformation.py` — added import + Strategy 0 in `_parse_json_response()`
- `tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py` — 4 new tests

**Tests added** (all in `TestAgentCoreJsonResponseParsing`):
- `test_parse_json_a2a_jsonrpc_nested_message` — `result.message.parts[]` format (customer's exact case)
- `test_parse_json_a2a_jsonrpc_direct_parts` — `result.parts[]` format
- `test_parse_json_a2a_jsonrpc_multi_parts` — multiple text parts concatenated
- `test_parse_json_a2a_jsonrpc_empty_falls_through` — empty A2A result falls through to Strategy 3