### PR TITLE
fix(prompt-templates): ensure_alternating_roles handles tool-call chains

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -337,24 +337,35 @@ def _insert_assistant_continue_message(
     """
     Add assistant continuation messages between consecutive user messages.
 
-    Only checks directly adjacent messages to preserve backward compatibility.
+    Skips tool messages and assistant messages with tool calls in the
+    alternation check, matching strict templates like llama.cpp.
     """
     if not ensure_alternating_roles or len(messages) <= 1:
         return messages
 
     continue_message = assistant_continue_message or DEFAULT_ASSISTANT_CONTINUE_MESSAGE
 
+    # Find indexes where assistant_continue should be inserted (before that index)
+    insert_before_indexes: set = set()
+
+    for i in range(len(messages)):
+        curr = messages[i]
+        if _counts_for_alternation(curr) and curr["role"] == "user":
+            # Look backwards for the previous counted message
+            j = i - 1
+            while j >= 0:
+                if _counts_for_alternation(messages[j]):
+                    if messages[j]["role"] == "user":
+                        insert_before_indexes.add(i)
+                    break
+                j -= 1
+
+    # Build the result with assistant_continue inserted at the right positions
     modified_messages: List[AllMessageValues] = []
     for i, message in enumerate(messages):
-        if (
-            i < len(messages) - 1
-            and message.get("role") == "user"
-            and messages[i + 1].get("role") == "user"
-        ):
-            modified_messages.append(message)
+        if i in insert_before_indexes:
             modified_messages.append(continue_message)
-        else:
-            modified_messages.append(message)
+        modified_messages.append(message)
 
     return modified_messages
 

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -859,8 +859,8 @@ def test_ensure_alternating_roles_three_consecutive_assistants():
     ]
 
 
-def test_ensure_alternating_roles_does_not_split_tool_call_chain():
-    """Tool-call chains [user, assistant(tc), tool, user] are preserved as-is."""
+def test_ensure_alternating_roles_inserts_assistant_continue_across_tool_chain():
+    """[user, assistant(tc), tool, user] gets assistant_continue before the second user."""
     messages = [
         {"role": "user", "content": "Search for X"},
         {
@@ -899,15 +899,16 @@ def test_ensure_alternating_roles_does_not_split_tool_call_chain():
             ],
         },
         {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        {"role": "assistant", "content": "Please continue."},
         {"role": "user", "content": "Thanks, now do Y"},
     ]
 
 
 def test_ensure_alternating_roles_assistant_tool_call_then_assistant():
     """
-    Preserve old behavior for malformed adjacent assistant turns:
-    [assistant(tool_calls), assistant(no-tool-calls), user] should insert
-    user_continue between assistant messages.
+    Malformed [assistant(tc), assistant(no-tc), user]:
+    user_continue inserts break between adjacents, then assistant_continue
+    fills the counted-sequence gap.
     """
     messages = [
         {
@@ -945,6 +946,7 @@ def test_ensure_alternating_roles_assistant_tool_call_then_assistant():
                 }
             ],
         },
+        {"role": "assistant", "content": "Please continue."},
         {"role": "user", "content": "Please continue."},
         {"role": "assistant", "content": "Here's what I found."},
         {"role": "user", "content": "Thanks"},
@@ -993,7 +995,181 @@ def test_ensure_alternating_roles_trailing_tool_call_assistant():
                 }
             ],
         },
+        {"role": "assistant", "content": "Please continue."},
         {"role": "user", "content": "Please continue."},
+    ]
+
+
+def test_ensure_alternating_roles_multiple_tool_results():
+    """[user, assistant(tc), tool, tool, user] — multiple tool results before next user."""
+    messages = [
+        {"role": "user", "content": "Search for X and Y"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "search_x", "arguments": "{}"},
+                },
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "search_y", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "result X"},
+        {"role": "tool", "tool_call_id": "c2", "content": "result Y"},
+        {"role": "user", "content": "Thanks"},
+    ]
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    assert transformed_messages == [
+        {"role": "user", "content": "Search for X and Y"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "search_x", "arguments": "{}"},
+                },
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "search_y", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "result X"},
+        {"role": "tool", "tool_call_id": "c2", "content": "result Y"},
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "Thanks"},
+    ]
+
+
+def test_ensure_alternating_roles_chained_tool_calls():
+    """[user, assistant(tc), tool, assistant(tc), tool, user] — chained tool calls."""
+    messages = [
+        {"role": "user", "content": "Do multi-step task"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "step1", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "step1 done"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "step2", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c2", "content": "step2 done"},
+        {"role": "user", "content": "What happened?"},
+    ]
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    assert transformed_messages == [
+        {"role": "user", "content": "Do multi-step task"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "step1", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "step1 done"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "step2", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c2", "content": "step2 done"},
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "What happened?"},
+    ]
+
+
+def test_ensure_alternating_roles_system_prefix_with_tool_chain():
+    """[system, user, assistant(tc), tool, user] — system prefix doesn't interfere."""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Search for X"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        {"role": "user", "content": "Thanks"},
+    ]
+
+    transformed_messages = get_completion_messages(
+        messages=messages,
+        assistant_continue_message=None,
+        user_continue_message=None,
+        ensure_alternating_roles=True,
+    )
+
+    assert transformed_messages == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Search for X"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        {"role": "assistant", "content": "Please continue."},
+        {"role": "user", "content": "Thanks"},
     ]
 
 


### PR DESCRIPTION
## Relevant issues

Fixes #18685

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

`_insert_assistant_continue_message()` only checked direct adjacency (`messages[i+1].get("role") == "user"`) to detect consecutive user messages. This missed cases where two user messages were separated by tool-call chains (`assistant(tool_calls)` → `tool`), which don't count for alternation on backends like llama.cpp.

For example, `[user, assistant(tc), tool, user]` has a counted sequence of `[user, user]` — a violation — but the old code saw `user` followed by `assistant` and skipped it.

### Fix

Rewrite `_insert_assistant_continue_message()` to use the existing `_counts_for_alternation()` helper with a backward-scan approach — the same approach already used by `_insert_user_continue_message()` (fixed in PR #24015).

**Before**: `[user, assistant(tc), tool, user]` → unchanged → llama.cpp raises `InternalServerError`  
**After**: `[user, assistant(tc), tool, assistant_continue, user]` → counted sequence alternates correctly

### Tests

- Updated 3 existing tests to match corrected behavior
- Added 3 new tests: multiple tool results, chained tool calls, system prefix with tool chain