### PR TITLE
fix(chatgpt): strip system messages before forwarding to backend

### DIFF
--- a/litellm/llms/chatgpt/chat/transformation.py
+++ b/litellm/llms/chatgpt/chat/transformation.py
@@ -62,6 +62,24 @@ class ChatGPTConfig(OpenAIConfig):
         )
         return {**default_headers, **validated_headers}
 
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        # The ChatGPT subscription backend rejects system-role messages
+        # unconditionally — it ships its own built-in instructions
+        # (CHATGPT_DEFAULT_INSTRUCTIONS). Strip them so callers using frameworks
+        # that always inject a system prompt (e.g. Claude Code, LangChain) work
+        # without provider-specific configuration.
+        messages = [m for m in (messages or []) if m.get("role") != "system"]
+        return super().transform_request(
+            model, messages, optional_params, litellm_params, headers
+        )
+
     def post_stream_processing(self, stream: Any) -> Any:
         return ChatGPTToolCallNormalizer(stream)
 


### PR DESCRIPTION
## Description

The ChatGPT subscription backend (`chatgpt.com/backend-api/codex`) rejects any request containing a `system`-role message with:

```json
{"detail": "System messages are not allowed"}
```

This causes `litellm.BadRequestError` for any caller that injects a system prompt — including Claude Code, LangChain, and most agent frameworks.

The provider already ships its own hardcoded system instructions (`CHATGPT_DEFAULT_INSTRUCTIONS` in `common_utils.py`), so dropping caller system messages is correct and results in no loss of functionality.

## Fix

Override `transform_request()` in `ChatGPTConfig` to strip system-role messages before the request body is assembled. This is the correct intercept point — `validate_environment()` only builds HTTP headers and has no effect on the message list sent upstream.

```python
def transform_request(self, model, messages, optional_params, litellm_params, headers) -> dict:
    # The ChatGPT subscription backend rejects system-role messages
    # unconditionally — it ships its own built-in instructions.
    messages = [m for m in (messages or []) if m.get("role") != "system"]
    return super().transform_request(model, messages, optional_params, litellm_params, headers)
```

## Related

- Fixes #21420

## Testing

Verified against `chatgpt/gpt-5.4` via a self-hosted LiteLLM proxy with a request containing a system message — returns a valid response instead of a 400 error.