### PR TITLE
fix(presidio): use correct text positions in anonymize_text

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -519,28 +519,25 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     request_data["metadata"]["pii_tokens"] = {}
                 pii_tokens = request_data["metadata"]["pii_tokens"]
 
-                # Build a mapping from (start, end) in original text to the
-                # entity type from anonymizer items for replacement text lookup.
-                anon_item_by_entity = {}
-                for item in redacted_text.get("items", []):
-                    anon_item_by_entity[item["entity_type"]] = (
-                        anon_item_by_entity.get(item["entity_type"], [])
-                    )
-                    anon_item_by_entity[item["entity_type"]].append(item)
-
-                # Process analyze_results in reverse order by start position
-                # so that replacing later spans first does not shift earlier
-                # coordinates in the original text.
-                sorted_results = sorted(
-                    analyze_results, key=lambda x: x["start"], reverse=True
+                # Assign sequence numbers in forward (left-to-right) order so
+                # that <PERSON_1> is the first entity in the text, etc.
+                sorted_forward = sorted(
+                    analyze_results, key=lambda x: x["start"]
                 )
-                for ar in sorted_results:
+                seq_map = {}
+                for idx, ar in enumerate(sorted_forward, start=1):
+                    seq_map[(ar["start"], ar["end"])] = idx
+
+                # Apply replacements in reverse order by start position so
+                # that replacing later spans first does not shift earlier
+                # coordinates in the original text.
+                for ar in reversed(sorted_forward):
                     start = ar["start"]
                     end = ar["end"]
                     entity_type = ar["entity_type"]
                     replacement = f"<{entity_type}>"
 
-                    seq = len(pii_tokens) + 1
+                    seq = seq_map[(start, end)]
                     if replacement.endswith(">"):
                         replacement = f"{replacement[:-1]}_{seq}>"
                     else:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -485,61 +485,74 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
                     redacted_text = await response.json()
 
-            new_text = text
             if redacted_text is not None:
                 verbose_proxy_logger.debug("redacted_text: %s", redacted_text)
-                # Process items in reverse order by start position so that
-                # replacing later spans first does not shift earlier coordinates.
-                for item in sorted(
-                    redacted_text["items"], key=lambda x: x["start"], reverse=True
-                ):
-                    start = item["start"]
-                    end = item["end"]
-                    replacement = item["text"]  # replacement token
-                    if item["operator"] == "replace" and output_parse_pii is True:
-                        if request_data is None:
-                            verbose_proxy_logger.warning(
-                                "Presidio anonymize_text called without request_data — "
-                                "PII tokens cannot be stored per-request. "
-                                "This may indicate a missing caller update."
+
+                if not output_parse_pii:
+                    # No need to build numbered tokens — just use Presidio's
+                    # already-anonymized text directly.  The old code incorrectly
+                    # applied anonymizer item positions (which reference the
+                    # *output* text) to the *original* text, causing offset errors.
+                    for item in redacted_text.get("items", []):
+                        entity_type = item.get("entity_type", None)
+                        if entity_type is not None:
+                            masked_entity_count[entity_type] = (
+                                masked_entity_count.get(entity_type, 0) + 1
                             )
-                            request_data = {}
-                        # Store pii_tokens in metadata to avoid leaking to LLM providers.
-                        # Providers like Anthropic reject unknown top-level fields.
-                        if not request_data.get("metadata"):
-                            request_data["metadata"] = {}
-                        if "pii_tokens" not in request_data["metadata"]:
-                            request_data["metadata"]["pii_tokens"] = {}
-                        pii_tokens = request_data["metadata"]["pii_tokens"]
+                    return redacted_text["text"]
 
-                        # Append a sequential number to make each token unique
-                        # per request, so unmasking maps back to the correct
-                        # original value.  Format: <PHONE_NUMBER_1>, <PHONE_NUMBER_2>
-                        # This is LLM-friendly and degrades gracefully if the
-                        # LLM doesn't echo the token verbatim.
-                        seq = len(pii_tokens) + 1
-                        if replacement.endswith(">"):
-                            replacement = f"{replacement[:-1]}_{seq}>"
-                        else:
-                            replacement = f"{replacement}_{seq}"
+                # output_parse_pii is True — we need sequentially numbered
+                # tokens and a pii_tokens mapping for later unmasking.
+                # Use analyze_results positions (which reference the ORIGINAL
+                # text) instead of anonymizer items (which reference the output).
+                new_text = text
+                if request_data is None:
+                    verbose_proxy_logger.warning(
+                        "Presidio anonymize_text called without request_data — "
+                        "PII tokens cannot be stored per-request. "
+                        "This may indicate a missing caller update."
+                    )
+                    request_data = {}
+                if not request_data.get("metadata"):
+                    request_data["metadata"] = {}
+                if "pii_tokens" not in request_data["metadata"]:
+                    request_data["metadata"]["pii_tokens"] = {}
+                pii_tokens = request_data["metadata"]["pii_tokens"]
 
-                        # Use ORIGINAL text (not new_text) since start/end
-                        # reference the original text's coordinates.
-                        pii_tokens[replacement] = text[start:end]
+                # Build a mapping from (start, end) in original text to the
+                # entity type from anonymizer items for replacement text lookup.
+                anon_item_by_entity = {}
+                for item in redacted_text.get("items", []):
+                    anon_item_by_entity[item["entity_type"]] = (
+                        anon_item_by_entity.get(item["entity_type"], [])
+                    )
+                    anon_item_by_entity[item["entity_type"]].append(item)
 
+                # Process analyze_results in reverse order by start position
+                # so that replacing later spans first does not shift earlier
+                # coordinates in the original text.
+                sorted_results = sorted(
+                    analyze_results, key=lambda x: x["start"], reverse=True
+                )
+                for ar in sorted_results:
+                    start = ar["start"]
+                    end = ar["end"]
+                    entity_type = ar["entity_type"]
+                    replacement = f"<{entity_type}>"
+
+                    seq = len(pii_tokens) + 1
+                    if replacement.endswith(">"):
+                        replacement = f"{replacement[:-1]}_{seq}>"
+                    else:
+                        replacement = f"{replacement}_{seq}"
+
+                    pii_tokens[replacement] = text[start:end]
                     new_text = new_text[:start] + replacement + new_text[end:]
-                    entity_type = item.get("entity_type", None)
-                    if entity_type is not None:
-                        masked_entity_count[entity_type] = (
-                            masked_entity_count.get(entity_type, 0) + 1
-                        )
-                # When output_parse_pii is True, new_text contains sequentially
-                # numbered tokens (e.g. <PHONE_NUMBER_1>) that match the keys
-                # in pii_tokens.  Returning redacted_text["text"] (Presidio's
-                # original output) would send un-numbered tokens to the LLM,
-                # making unmasking impossible.
-                # When output_parse_pii is False, new_text == redacted_text["text"]
-                # because no suffix is appended.
+
+                    masked_entity_count[entity_type] = (
+                        masked_entity_count.get(entity_type, 0) + 1
+                    )
+
                 return new_text
             else:
                 raise Exception("Invalid anonymizer response: received None")

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2230,3 +2230,165 @@ async def test_apply_to_output_streaming_bytes_only_logs_warning():
         mock_logger.warning.assert_called_once()
         warning_msg = mock_logger.warning.call_args[0][0]
         assert "Output PII masking was skipped" in warning_msg
+
+
+@pytest.mark.asyncio
+async def test_anonymize_text_uses_correct_positions_no_parse_pii():
+    """
+    Regression test for anonymizer offset bug (fixes #24160).
+
+    The Presidio anonymizer returns items with start/end positions that
+    reference the *anonymized output* text, not the original input text.
+    When output_parse_pii is False, anonymize_text must return
+    redacted_text["text"] directly instead of manually splicing the
+    original text using those positions, which produces garbled output
+    with remnants of original PII data.
+    """
+    original_text = (
+        "My name is John Smith, my email is john@example.com, phone 555-867-5309"
+    )
+    # Positions as returned by the analyzer (reference original text)
+    analyze_results = [
+        {"end": 51, "entity_type": "EMAIL_ADDRESS", "score": 1.0, "start": 35},
+        {"end": 21, "entity_type": "PERSON", "score": 0.85, "start": 11},
+        {"end": 71, "entity_type": "PHONE_NUMBER", "score": 0.75, "start": 59},
+    ]
+    # Anonymizer response — positions reference the *anonymized* text
+    anonymizer_response = {
+        "text": "My name is <PERSON>, my email is <EMAIL_ADDRESS>, phone <PHONE_NUMBER>",
+        "items": [
+            {
+                "start": 56,
+                "end": 70,
+                "entity_type": "PHONE_NUMBER",
+                "text": "<PHONE_NUMBER>",
+                "operator": "replace",
+            },
+            {
+                "start": 33,
+                "end": 48,
+                "entity_type": "EMAIL_ADDRESS",
+                "text": "<EMAIL_ADDRESS>",
+                "operator": "replace",
+            },
+            {
+                "start": 11,
+                "end": 19,
+                "entity_type": "PERSON",
+                "text": "<PERSON>",
+                "operator": "replace",
+            },
+        ],
+    }
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        presidio_analyzer_api_base="http://test-analyzer/",
+        presidio_anonymizer_api_base="http://test-anonymizer/",
+        mock_testing=False,
+    )
+
+    mock_iterator = _make_mock_session_iterator(
+        json_response=anonymizer_response,
+    )
+
+    masked_entity_count = {}
+    with patch.object(guardrail, "_get_session_iterator", mock_iterator):
+        result = await guardrail.anonymize_text(
+            text=original_text,
+            analyze_results=analyze_results,
+            output_parse_pii=False,
+            masked_entity_count=masked_entity_count,
+        )
+
+    expected = "My name is <PERSON>, my email is <EMAIL_ADDRESS>, phone <PHONE_NUMBER>"
+    assert result == expected, (
+        f"anonymize_text produced garbled output with PII remnants.\n"
+        f"Expected: {expected!r}\n"
+        f"Got:      {result!r}"
+    )
+    assert masked_entity_count == {
+        "PERSON": 1,
+        "EMAIL_ADDRESS": 1,
+        "PHONE_NUMBER": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_anonymize_text_uses_correct_positions_with_parse_pii():
+    """
+    Regression test for anonymizer offset bug with output_parse_pii=True
+    (fixes #24160).
+
+    When output_parse_pii is True, anonymize_text must use positions from
+    analyze_results (which reference the original text) to build numbered
+    tokens and the pii_tokens mapping, not positions from anonymizer items
+    (which reference the anonymized output text).
+    """
+    original_text = (
+        "My name is John Smith, my email is john@example.com, phone 555-867-5309"
+    )
+    analyze_results = [
+        {"end": 51, "entity_type": "EMAIL_ADDRESS", "score": 1.0, "start": 35},
+        {"end": 21, "entity_type": "PERSON", "score": 0.85, "start": 11},
+        {"end": 71, "entity_type": "PHONE_NUMBER", "score": 0.75, "start": 59},
+    ]
+    anonymizer_response = {
+        "text": "My name is <PERSON>, my email is <EMAIL_ADDRESS>, phone <PHONE_NUMBER>",
+        "items": [
+            {
+                "start": 56,
+                "end": 70,
+                "entity_type": "PHONE_NUMBER",
+                "text": "<PHONE_NUMBER>",
+                "operator": "replace",
+            },
+            {
+                "start": 33,
+                "end": 48,
+                "entity_type": "EMAIL_ADDRESS",
+                "text": "<EMAIL_ADDRESS>",
+                "operator": "replace",
+            },
+            {
+                "start": 11,
+                "end": 19,
+                "entity_type": "PERSON",
+                "text": "<PERSON>",
+                "operator": "replace",
+            },
+        ],
+    }
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        presidio_analyzer_api_base="http://test-analyzer/",
+        presidio_anonymizer_api_base="http://test-anonymizer/",
+        mock_testing=False,
+        output_parse_pii=True,
+    )
+
+    mock_iterator = _make_mock_session_iterator(
+        json_response=anonymizer_response,
+    )
+
+    masked_entity_count = {}
+    request_data = {"metadata": {}}
+    with patch.object(guardrail, "_get_session_iterator", mock_iterator):
+        result = await guardrail.anonymize_text(
+            text=original_text,
+            analyze_results=analyze_results,
+            output_parse_pii=True,
+            masked_entity_count=masked_entity_count,
+            request_data=request_data,
+        )
+
+    # Result must not contain any remnants of original PII
+    assert "John" not in result
+    assert "john@example.com" not in result
+    assert "555-867-5309" not in result
+
+    # pii_tokens must map numbered tokens back to correct original values
+    pii_tokens = request_data["metadata"]["pii_tokens"]
+    token_values = set(pii_tokens.values())
+    assert "John Smith" in token_values
+    assert "john@example.com" in token_values
+    assert "555-867-5309" in token_values

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2392,3 +2392,9 @@ async def test_anonymize_text_uses_correct_positions_with_parse_pii():
     assert "John Smith" in token_values
     assert "john@example.com" in token_values
     assert "555-867-5309" in token_values
+
+    # Tokens must be numbered in left-to-right order of appearance:
+    # PERSON (pos 11) → _1, EMAIL_ADDRESS (pos 35) → _2, PHONE_NUMBER (pos 59) → _3
+    assert pii_tokens.get("<PERSON_1>") == "John Smith"
+    assert pii_tokens.get("<EMAIL_ADDRESS_2>") == "john@example.com"
+    assert pii_tokens.get("<PHONE_NUMBER_3>") == "555-867-5309"


### PR DESCRIPTION
## Relevant issues

Fixes #24160

## What this PR does

The Presidio `/anonymize` endpoint returns `items[]` with `start`/`end` positions that reference the **anonymized output** text, not the original input text. `anonymize_text()` was applying these positions to the **original** text, producing garbled output with remnants of un-masked PII data.

**Example (before fix):**
```
Input:    "My name is John Smith, my email is john@example.com, phone 555-867-5309"
Expected: "My name is <PERSON>, my email is <EMAIL_ADDRESS>, phone <PHONE_NUMBER>"
Actual:   "My name is <PERSON>th, my email i<EMAIL_ADDRESS>com, pho<PHONE_NUMBER>9"
                      ^^              ^                ^^^     ^^^^^^^^^^^^^^^ ^
                      PII remnants leaking through due to offset mismatch
```

**Root cause:**
The anonymizer returns item positions relative to its own output (e.g. `<PERSON>` starts at char 11 in the anonymized text), but the code used these offsets to splice the original text where `John Smith` starts at char 11 but is 10 chars long vs 8 for `<PERSON>` — a 2-char shift that cascades through all subsequent entities.

**Fix (two paths):**

1. `output_parse_pii=False` — return `redacted_text["text"]` directly from the anonymizer (it's already correctly masked)
2. `output_parse_pii=True` — use `analyze_results` positions (which reference the **original** text) to build numbered replacement tokens and the `pii_tokens` mapping

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

- **`litellm/proxy/guardrails/guardrail_hooks/presidio.py`** — `anonymize_text()` method:
  - When `output_parse_pii=False`: return `redacted_text["text"]` directly instead of manual splicing with wrong positions
  - When `output_parse_pii=True`: iterate `analyze_results` (original-text positions) instead of `redacted_text["items"]` (output-text positions) for building numbered tokens
- **`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py`** — added 2 regression tests:
  - `test_anonymize_text_uses_correct_positions_no_parse_pii` — verifies clean masking without PII remnants
  - `test_anonymize_text_uses_correct_positions_with_parse_pii` — verifies numbered tokens map to correct original PII values