### PR TITLE
fix(auth): add missing await in get_org_object() cache lookup

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2437,7 +2437,7 @@ async def get_org_object(
         cache_key = "org_id:{}:with_budget".format(org_id)
 
     # check if in cache
-    cached_org_obj = user_api_key_cache.async_get_cache(key=cache_key)
+    cached_org_obj = await user_api_key_cache.async_get_cache(key=cache_key)
     if cached_org_obj is not None:
         if isinstance(cached_org_obj, dict):
             return LiteLLM_OrganizationTable(**cached_org_obj)

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -38,6 +38,7 @@ from litellm.proxy.auth.auth_checks import (
     _virtual_key_max_budget_check,
     _virtual_key_soft_budget_check,
     get_key_object,
+    get_org_object,
     get_user_object,
     vector_store_access_check,
 )
@@ -1780,3 +1781,40 @@ async def test_team_member_budget_check_reads_from_spend_counter():
                 proxy_logging_obj=proxy_logging_obj,
             )
         assert exc_info.value.current_cost == 1.5
+
+
+@pytest.mark.asyncio
+async def test_get_org_object_returns_cached_org():
+    """
+    Verify that get_org_object() correctly returns a cached organization object
+    instead of falling through to a DB query. Regression test for a missing
+    `await` on async_get_cache that caused the cache to be bypassed on every call.
+    """
+    from litellm.proxy._types import LiteLLM_OrganizationTable
+
+    cached_org = LiteLLM_OrganizationTable(
+        organization_id="test-org-123",
+        organization_alias="Test Org",
+        budget_id="budget-1",
+        models=["gpt-4"],
+        created_by="admin",
+        updated_by="admin",
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=cached_org)
+
+    mock_prisma = MagicMock()
+    # If cache works, find_unique should never be called
+    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock()
+
+    result = await get_org_object(
+        org_id="test-org-123",
+        prisma_client=mock_prisma,
+        user_api_key_cache=mock_cache,
+    )
+
+    assert result is not None
+    assert result.organization_id == "test-org-123"
+    mock_cache.async_get_cache.assert_awaited_once()
+    mock_prisma.db.litellm_organizationtable.find_unique.assert_not_awaited()


### PR DESCRIPTION
## Summary

`get_org_object()` in `litellm/proxy/auth/auth_checks.py` (line 2440) is missing `await` when calling `user_api_key_cache.async_get_cache()`. This causes the organization cache to be completely bypassed, forcing a database query on every single org lookup.

## Bug Details

```python
# Before (bug): returns coroutine object, not cached value
cached_org_obj = user_api_key_cache.async_get_cache(key=cache_key)

# After (fix): correctly awaits the async cache lookup
cached_org_obj = await user_api_key_cache.async_get_cache(key=cache_key)
```

**Why this breaks silently:**
1. `async_get_cache()` without `await` returns a coroutine object
2. A coroutine is always truthy, so `cached_org_obj is not None` → `True` ✓
3. But `isinstance(cached_org_obj, dict)` → `False` ✗
4. And `isinstance(cached_org_obj, LiteLLM_OrganizationTable)` → `False` ✗
5. Falls through to the DB query **every time**

This is the **only** call site missing `await` — all 14 other calls to `async_get_cache` in the same file correctly use `await`. The sibling function `get_org_object_by_alias()` at line 1969 also correctly uses `await`.

## Impact

- **Every organization lookup hits the database** instead of using the cache
- Increased DB load proportional to org-scoped request volume
- Higher latency on auth checks for org-enabled deployments

## Changes

- `litellm/proxy/auth/auth_checks.py`: Added missing `await` at line 2440
- `tests/test_litellm/proxy/auth/test_auth_checks.py`: Added regression test that verifies cache hits return the org object directly without hitting the database

## Test Results

```
1 passed in 6.90s
ruff check: All checks passed!
```
