### PR TITLE
[Fix] Add namespace check to async_delete_cache in Redis cache

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1260,6 +1260,7 @@ class RedisCache(BaseCache):
         # typed as Any, redis python lib has incomplete type stubs for RedisCluster and does not include `delete`
         _redis_client: Any = self.init_async_client()
         # keys is str
+        key = self.check_and_fix_namespace(key=key)
         return await _redis_client.delete(key)
 
     def delete_cache(self, key):


### PR DESCRIPTION
🐛 Bug Fix

## Changes
Add namespace check to async_delete_cache in Redis cache

Ensure key namespace is properly handled before deletion in async flow to maintain consistency with sync delete_cache method.