### PR TITLE
fix: update model name from db 

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7318,6 +7318,7 @@ class Router:
                 if (
                     deployment.litellm_params == _deployment_on_router.litellm_params
                     and deployment.model_info == _deployment_on_router.model_info
+                    and deployment.model_name == _deployment_on_router.model_name
                 ):
                     # No need to update
                     return None

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -828,6 +828,21 @@ def test_upsert_deployment(model_list):
     assert len(router.model_list) == len(model_list)
 
 
+def test_upsert_deployment_updates_model_name(model_list):
+    """Test that changing only model_name still updates an existing deployment."""
+    router = Router(model_list=model_list)
+    deployment = router.get_deployment_by_model_group_name(
+        model_group_name="gpt-3.5-turbo"
+    )
+    deployment_id = deployment.model_info.id
+    deployment.model_name = "gpt-3.5-turbo-renamed"
+
+    updated_deployment = router.upsert_deployment(deployment=deployment)
+
+    assert updated_deployment is not None
+    assert router.get_deployment(model_id=deployment_id).model_name == deployment.model_name
+
+
 def test_delete_deployment(model_list):
     """Test if the 'delete_deployment' function is working correctly"""
     router = Router(model_list=model_list)


### PR DESCRIPTION
## What changed
- preserve deployment updates when only `model_name` changes for an existing `model_id`
- keep the current `model_info` equality guard from `main` while also checking `model_name`
- add a router unit test covering the `model_name`-only update path

## Why
`Router.upsert_deployment()` treated an update as a no-op when `litellm_params` and `model_info` matched the existing deployment. `model_name` lives outside `litellm_params`, so renaming a deployment with the same `model_id` could be silently skipped.

## Impact
- model updates from DB stay in sync when the deployment name changes without other config changes
- adds regression coverage for the update path

## Validation
- `python -m py_compile litellm/router.py tests/router_unit_tests/test_router_helper_utils.py`
- `poetry run pytest tests/router_unit_tests/test_router_helper_utils.py -k 'upsert_deployment' -q` could not run in this environment because `pytest_postgresql` fails to import `psycopg` / `libpq`
