### PR TITLE
docs: document default_team_params in config reference

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -201,7 +201,7 @@ router_settings:
 | enable_json_schema_validation | boolean | If true, enables json schema validation for all requests. |
 | enable_key_alias_format_validation | boolean | If true, validates `key_alias` format on `/key/generate` and `/key/update`. Must be 2-255 chars, start/end with alphanumeric, only allow `a-zA-Z0-9_-/.@`. Default `false`. |
 | disable_copilot_system_to_assistant | boolean | **DEPRECATED** - GitHub Copilot API supports system prompts. |
-| default_team_params | object | Default parameters applied to every new team created via `/team/new` (including SSO auto-created teams). Only fills in fields not explicitly set in the request. Sub-fields: `max_budget` (float), `budget_duration` (string, e.g. `"30d"`), `models` (array of strings), `tpm_limit` (integer), `rpm_limit` (integer), `team_member_permissions` (array of strings, e.g. `["/team/daily/activity", "/key/generate"]`). |
+| default_team_params | object | Default parameters applied to every new team created via `/team/new` (including SSO auto-created teams). Only fills in fields not explicitly set in the request. Sub-fields: `max_budget` (float), `budget_duration` (string, e.g. `"30d"`), `tpm_limit` (integer), `rpm_limit` (integer), `team_member_permissions` (array of strings, e.g. `["/team/daily/activity", "/key/generate"]`), `models` (array of strings — only applied to SSO auto-created teams). |
 
 ### general_settings - Reference
 

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -201,6 +201,7 @@ router_settings:
 | enable_json_schema_validation | boolean | If true, enables json schema validation for all requests. |
 | enable_key_alias_format_validation | boolean | If true, validates `key_alias` format on `/key/generate` and `/key/update`. Must be 2-255 chars, start/end with alphanumeric, only allow `a-zA-Z0-9_-/.@`. Default `false`. |
 | disable_copilot_system_to_assistant | boolean | **DEPRECATED** - GitHub Copilot API supports system prompts. |
+| default_team_params | object | Default parameters applied to every new team created via `/team/new` (including SSO auto-created teams). Only fills in fields not explicitly set in the request. Sub-fields: `max_budget` (float), `budget_duration` (string, e.g. `"30d"`), `models` (array of strings), `tpm_limit` (integer), `rpm_limit` (integer), `team_member_permissions` (array of strings, e.g. `["/team/daily/activity", "/key/generate"]`). |
 
 ### general_settings - Reference
 

--- a/docs/my-website/docs/proxy/self_serve.md
+++ b/docs/my-website/docs/proxy/self_serve.md
@@ -358,10 +358,15 @@ When you connect litellm to your SSO provider, litellm can auto-create teams. Us
 
 ```yaml showLineNumbers title="Default Params for new teams"
 litellm_settings:
-  default_team_params:             # Default Params to apply when litellm auto creates a team from SSO IDP provider
-    max_budget: 100                # Optional[float], optional): $100 budget for the team
-    budget_duration: 30d           # Optional[str], optional): 30 days budget_duration for the team
-    models: ["gpt-3.5-turbo"]      # Optional[List[str]], optional): models to be used by the team
+  default_team_params:             # Applied to all /team/new calls (including SSO auto-created teams) when the field is not explicitly set
+    max_budget: 100                # Optional[float]: $100 budget for the team
+    budget_duration: 30d           # Optional[str]: 30 days budget_duration for the team
+    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models to be used by the team
+    tpm_limit: 100000              # Optional[int]: tokens per minute limit
+    rpm_limit: 1000                # Optional[int]: requests per minute limit
+    team_member_permissions:       # Optional[List[str]]: permissions granted to non-admin team members
+      - "/team/daily/activity"     # Allow members to view team usage
+      - "/key/generate"            # Allow members to generate API keys
 ```
 
 
@@ -390,10 +395,14 @@ litellm_settings:
         max_budget_in_team: 100 # Optional[float], optional): $100 budget for the team. Defaults to None.
         user_role: "user" # Optional[str], optional): "user" or "admin". Defaults to "user"
   
-  default_team_params:             # Default Params to apply when litellm auto creates a team from SSO IDP provider
-    max_budget: 100                # Optional[float], optional): $100 budget for the team
-    budget_duration: 30d           # Optional[str], optional): 30 days budget_duration for the team
-    models: ["gpt-3.5-turbo"]      # Optional[List[str]], optional): models to be used by the team
+  default_team_params:             # Applied to all /team/new calls (including SSO auto-created teams) when the field is not explicitly set
+    max_budget: 100                # Optional[float]: $100 budget for the team
+    budget_duration: 30d           # Optional[str]: 30 days budget_duration for the team
+    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models to be used by the team
+    tpm_limit: 100000              # Optional[int]: tokens per minute limit
+    rpm_limit: 1000                # Optional[int]: requests per minute limit
+    team_member_permissions:       # Optional[List[str]]: permissions granted to non-admin team members
+      - "/team/daily/activity"
 
 
   upperbound_key_generate_params:    # Upperbound for /key/generate requests when self-serve flow is on

--- a/docs/my-website/docs/proxy/self_serve.md
+++ b/docs/my-website/docs/proxy/self_serve.md
@@ -361,7 +361,7 @@ litellm_settings:
   default_team_params:             # Applied to all /team/new calls (including SSO auto-created teams) when the field is not explicitly set
     max_budget: 100                # Optional[float]: $100 budget for the team
     budget_duration: 30d           # Optional[str]: 30 days budget_duration for the team
-    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models to be used by the team
+    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models for the team (only applied to SSO auto-created teams)
     tpm_limit: 100000              # Optional[int]: tokens per minute limit
     rpm_limit: 1000                # Optional[int]: requests per minute limit
     team_member_permissions:       # Optional[List[str]]: permissions granted to non-admin team members
@@ -398,7 +398,7 @@ litellm_settings:
   default_team_params:             # Applied to all /team/new calls (including SSO auto-created teams) when the field is not explicitly set
     max_budget: 100                # Optional[float]: $100 budget for the team
     budget_duration: 30d           # Optional[str]: 30 days budget_duration for the team
-    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models to be used by the team
+    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models for the team (only applied to SSO auto-created teams)
     tpm_limit: 100000              # Optional[int]: tokens per minute limit
     rpm_limit: 1000                # Optional[int]: requests per minute limit
     team_member_permissions:       # Optional[List[str]]: permissions granted to non-admin team members

--- a/docs/my-website/docs/tutorials/msft_sso.md
+++ b/docs/my-website/docs/tutorials/msft_sso.md
@@ -123,10 +123,12 @@ Navigate to your litellm config file and set the following params
 
 ```yaml showLineNumbers title="litellm config with default_team_params"
 litellm_settings:
-  default_team_params:             # Default Params to apply when litellm auto creates a team from SSO IDP provider
-    max_budget: 100                # Optional[float], optional): $100 budget for the team
-    budget_duration: 30d           # Optional[str], optional): 30 days budget_duration for the team
-    models: ["gpt-3.5-turbo"]      # Optional[List[str]], optional): models to be used by the team
+  default_team_params:             # Applied to all /team/new calls (including SSO auto-created teams) when the field is not explicitly set
+    max_budget: 100                # Optional[float]: $100 budget for the team
+    budget_duration: 30d           # Optional[str]: 30 days budget_duration for the team
+    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models to be used by the team
+    team_member_permissions:       # Optional[List[str]]: permissions granted to non-admin team members
+      - "/team/daily/activity"     # Allow members to view team usage
 ```
 
 ### 3.2 Auto-create a new team on LiteLLM

--- a/docs/my-website/docs/tutorials/msft_sso.md
+++ b/docs/my-website/docs/tutorials/msft_sso.md
@@ -126,7 +126,7 @@ litellm_settings:
   default_team_params:             # Applied to all /team/new calls (including SSO auto-created teams) when the field is not explicitly set
     max_budget: 100                # Optional[float]: $100 budget for the team
     budget_duration: 30d           # Optional[str]: 30 days budget_duration for the team
-    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models to be used by the team
+    models: ["gpt-3.5-turbo"]      # Optional[List[str]]: models for the team (only applied to SSO auto-created teams)
     team_member_permissions:       # Optional[List[str]]: permissions granted to non-admin team members
       - "/team/daily/activity"     # Allow members to view team usage
 ```


### PR DESCRIPTION
## Summary
- Add `default_team_params` to the `litellm_settings` reference table in `config_settings.md` with all sub-fields documented
- Update `self_serve.md` and `msft_sso.md` config examples to include `team_member_permissions`, `tpm_limit`, and `rpm_limit`
- Fix misleading comment that implied `default_team_params` only applies to SSO auto-created teams — it applies to all `/team/new` calls

## Test plan
- [x] Verify docs render correctly on local Docusaurus dev server