### PR TITLE
[Fix] Fix Beta Header filtering

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -12,6 +12,7 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
 from litellm.constants import (
     BEDROCK_MIN_THINKING_BUDGET_TOKENS,
     RESPONSE_FORMAT_TOOL_NAME,
@@ -1362,11 +1363,16 @@ class AmazonConverseConfig(BaseConfig):
         # Append pre-formatted tools (systemTool etc.) after transformation
         bedrock_tools.extend(pre_formatted_tools)
 
-        # Set anthropic_beta in additional_request_params if we have any beta features
+        # Filter and set anthropic_beta in additional_request_params if we have any beta features
         # ONLY apply to Anthropic/Claude models - other models (e.g., Qwen, Llama) don't support this field
         base_model = BedrockModelInfo.get_base_model(model)
         if anthropic_beta_list and base_model.startswith("anthropic"):
-            additional_request_params["anthropic_beta"] = anthropic_beta_list
+            filtered_beta_list = filter_and_transform_beta_headers(
+                beta_headers=anthropic_beta_list,
+                provider="bedrock_converse",
+            )
+            if filtered_beta_list:
+                additional_request_params["anthropic_beta"] = filtered_beta_list
 
         return bedrock_tools, anthropic_beta_list
 

--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 import httpx
 
+from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,
@@ -144,8 +145,13 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
 
         # Filter out beta headers that Bedrock Invoke doesn't support
         # Uses centralized configuration from anthropic_beta_headers_config.json
-        beta_list = list(beta_set)
-        _anthropic_request["anthropic_beta"] = beta_list
+        filtered_beta_list = filter_and_transform_beta_headers(
+            beta_headers=list(beta_set),
+            provider="bedrock",
+        )
+
+        if filtered_beta_list:
+            _anthropic_request["anthropic_beta"] = filtered_beta_list
 
         return _anthropic_request
 

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -12,6 +12,7 @@ from typing import (
 
 import httpx
 
+from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
 from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
@@ -460,8 +461,15 @@ class AmazonAnthropicClaudeMessagesConfig(
         if "tool-search-tool-2025-10-19" in beta_set:
             beta_set.add("tool-examples-2025-10-29")
 
-        if beta_set:
-            anthropic_messages_request["anthropic_beta"] = list(beta_set)
+        # Filter out beta headers that Bedrock Invoke doesn't support
+        # Uses centralized configuration from anthropic_beta_headers_config.json
+        filtered_beta_list = filter_and_transform_beta_headers(
+            beta_headers=list(beta_set),
+            provider="bedrock",
+        )
+
+        if filtered_beta_list:
+            anthropic_messages_request["anthropic_beta"] = filtered_beta_list
 
         return anthropic_messages_request
 

--- a/tests/llm_translation/base_llm_unit_tests.py
+++ b/tests/llm_translation/base_llm_unit_tests.py
@@ -401,7 +401,7 @@ class BaseLLMChatTest(ABC):
             {
                 "type": "file",
                 "file": {
-                    "file_id": "https://upload.wikimedia.org/wikipedia/commons/2/20/Re_example.pdf"
+                    "file_id": "https://raw.githubusercontent.com/BerriAI/litellm/main/tests/llm_translation/fixtures/dummy.pdf"
                 },
             },
         ]

--- a/tests/llm_translation/test_bedrock_anthropic_regression.py
+++ b/tests/llm_translation/test_bedrock_anthropic_regression.py
@@ -403,8 +403,9 @@ class TestBedrockAnthropic1MContextRegression:
         )
 
         # Multiple beta headers including 1M context
+        # Use computer-use-2025-01-24 (supported by both bedrock and bedrock_converse)
         headers = {
-            "anthropic-beta": "context-1m-2025-08-07,computer-use-2024-10-22"
+            "anthropic-beta": "context-1m-2025-08-07,computer-use-2025-01-24"
         }
         messages = [{"role": "user", "content": "Test"}]
 
@@ -435,7 +436,7 @@ class TestBedrockAnthropic1MContextRegression:
 
         # Verify both headers are present
         assert "context-1m-2025-08-07" in beta_headers
-        assert "computer-use-2024-10-22" in beta_headers
+        assert "computer-use-2025-01-24" in beta_headers
 
 
 class TestBedrockAnthropicCombinedRegressions:

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -319,71 +319,80 @@ def test_opus_4_5_model_detection():
             f"Should not detect {model} as Opus 4.5"
 
 
-# def test_structured_outputs_beta_header_filtered_for_bedrock_invoke():
-#     """
-#     Test that unsupported beta headers are filtered out for Bedrock Invoke API.
-    
-#     Bedrock Invoke API only supports a specific whitelist of beta flags and returns
-#     "invalid beta flag" error for others (e.g., structured-outputs, mcp-servers).
-#     This test ensures unsupported headers are filtered while keeping supported ones.
-    
-#     Fixes: https://github.com/BerriAI/litellm/issues/16726
-#     """
-#     config = AmazonAnthropicClaudeConfig()
-    
-#     messages = [{"role": "user", "content": "test"}]
-    
-#     # Test 1: structured-outputs beta header (unsupported)
-#     headers = {"anthropic-beta": "structured-outputs-2025-11-13"}
-    
-#     result = config.transform_request(
-#         model="anthropic.claude-4-0-sonnet-20250514-v1:0",
-#         messages=messages,
-#         optional_params={},
-#         litellm_params={},
-#         headers=headers,
-#     )
-    
-#     # Verify structured-outputs beta is filtered out
-#     anthropic_beta = result.get("anthropic_beta", [])
-#     assert not any("structured-outputs" in beta for beta in anthropic_beta), \
-#         f"structured-outputs beta should be filtered, got: {anthropic_beta}"
-    
-#     # Test 2: mcp-servers beta header (unsupported - the main issue from #16726)
-#     headers = {"anthropic-beta": "mcp-servers-2025-12-04"}
-    
-#     result = config.transform_request(
-#         model="anthropic.claude-4-0-sonnet-20250514-v1:0",
-#         messages=messages,
-#         optional_params={},
-#         litellm_params={},
-#         headers=headers,
-#     )
-    
-#     # Verify mcp-servers beta is filtered out
-#     anthropic_beta = result.get("anthropic_beta", [])
-#     assert not any("mcp-servers" in beta for beta in anthropic_beta), \
-#         f"mcp-servers beta should be filtered, got: {anthropic_beta}"
-    
-#     # Test 3: Mix of supported and unsupported beta headers
-#     headers = {"anthropic-beta": "computer-use-2024-10-22,mcp-servers-2025-12-04,structured-outputs-2025-11-13"}
-    
-#     result = config.transform_request(
-#         model="anthropic.claude-4-0-sonnet-20250514-v1:0",
-#         messages=messages,
-#         optional_params={},
-#         litellm_params={},
-#         headers=headers,
-#     )
-    
-#     # Verify only supported betas are kept
-#     anthropic_beta = result.get("anthropic_beta", [])
-#     assert not any("structured-outputs" in beta for beta in anthropic_beta), \
-#         f"structured-outputs beta should be filtered, got: {anthropic_beta}"
-#     assert not any("mcp-servers" in beta for beta in anthropic_beta), \
-#         f"mcp-servers beta should be filtered, got: {anthropic_beta}"
-#     assert any("computer-use" in beta for beta in anthropic_beta), \
-#         f"computer-use beta should be kept, got: {anthropic_beta}"
+def test_unsupported_beta_headers_filtered_for_bedrock_invoke():
+    """
+    Test that unsupported beta headers are filtered out for Bedrock Invoke API.
+
+    Bedrock Invoke API only supports a specific set of beta flags and returns
+    "invalid beta flag" error for others (e.g., advanced-tool-use, mcp-servers).
+    This test ensures unsupported headers are filtered while keeping supported ones.
+
+    Regression test for commit 2ec0072008 which accidentally removed the
+    filter_and_transform_beta_headers call.
+
+    Fixes: https://github.com/BerriAI/litellm/issues/16726
+    """
+    config = AmazonAnthropicClaudeConfig()
+
+    messages = [{"role": "user", "content": "test"}]
+
+    # Test 1: advanced-tool-use beta header (unsupported on bedrock invoke,
+    # maps to null in anthropic_beta_headers_config.json for bedrock_converse
+    # and maps to tool-search-tool for bedrock invoke)
+    headers = {"anthropic-beta": "mcp-servers-2025-12-04"}
+
+    result = config.transform_request(
+        model="anthropic.claude-sonnet-4-20250514-v1:0",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers=headers,
+    )
+
+    anthropic_beta = result.get("anthropic_beta", [])
+    assert not any("mcp-servers" in beta for beta in anthropic_beta), (
+        f"mcp-servers beta should be filtered out for bedrock invoke, got: {anthropic_beta}"
+    )
+
+    # Test 2: Mix of supported and unsupported beta headers
+    headers = {
+        "anthropic-beta": "computer-use-2025-01-24,mcp-servers-2025-12-04,interleaved-thinking-2025-05-14"
+    }
+
+    result = config.transform_request(
+        model="anthropic.claude-sonnet-4-20250514-v1:0",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers=headers,
+    )
+
+    anthropic_beta = result.get("anthropic_beta", [])
+    assert not any("mcp-servers" in beta for beta in anthropic_beta), (
+        f"mcp-servers beta should be filtered, got: {anthropic_beta}"
+    )
+    assert any("computer-use" in beta for beta in anthropic_beta), (
+        f"computer-use beta should be kept, got: {anthropic_beta}"
+    )
+    assert any("interleaved-thinking" in beta for beta in anthropic_beta), (
+        f"interleaved-thinking beta should be kept, got: {anthropic_beta}"
+    )
+
+    # Test 3: Only unsupported headers → anthropic_beta should be absent
+    headers = {"anthropic-beta": "mcp-servers-2025-12-04"}
+
+    result = config.transform_request(
+        model="anthropic.claude-sonnet-4-20250514-v1:0",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers=headers,
+    )
+
+    anthropic_beta = result.get("anthropic_beta", [])
+    assert len(anthropic_beta) == 0 or "anthropic_beta" not in result, (
+        f"All unsupported betas should be filtered out, got: {anthropic_beta}"
+    )
 
 
 def test_output_config_removed_from_bedrock_chat_invoke_request():


### PR DESCRIPTION
## [Fix] Fix Beta Header filtering 

Commit 2ec0072008 (Feb 11) accidentally removed the filter_and_transform_beta_headers() call from Bedrock Invoke transformations during a refactor that moved filtering to the HTTP handler layer. The HTTP handler only filters the anthropic-beta HTTP header, but Bedrock sends beta flags in the request body (anthropic_beta field) — so unsupported flags like mcp-servers-2025-12-04 were passing through unfiltered, causing Bedrock to return 400 "invalid beta flag".

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
