### PR TITLE
fix(router): isolate and bound retry previous_models metadata

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -72,6 +72,7 @@ from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+from litellm.litellm_core_utils.secret_redaction import redact_string
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
@@ -562,8 +563,6 @@ class Router:
         self.total_calls: defaultdict = defaultdict(int)  # dict to store total calls made to each model
         self.fail_calls: defaultdict = defaultdict(int)  # dict to store fail_calls made to each model
         self.success_calls: defaultdict = defaultdict(int)  # dict to store success_calls  made to each model
-        self.previous_models: List = []  # list to store failed calls (passed in as metadata to next call)
-
         # make Router.chat.completions.create compatible for openai.chat.completions.create
         default_litellm_params = default_litellm_params or {}
         self.chat = litellm.Chat(params=default_litellm_params, router_obj=self)
@@ -6940,34 +6939,32 @@ class Router:
         """
         When a retry or fallback happens, log the details of the just failed model call - similar to Sentry breadcrumbing
         """
-        try:
-            _metadata_var = "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
-            # Log failed model as the previous model
-            previous_model = {
-                "exception_type": type(e).__name__,
-                "exception_string": str(e),
-            }
-            for (
-                k,
-                v,
-            ) in kwargs.items():  # log everything in kwargs except the old previous_models value - prevent nesting
-                if k not in [_metadata_var, "messages", "original_function"]:
-                    previous_model[k] = v
-                elif k == _metadata_var and isinstance(v, dict):
-                    previous_model[_metadata_var] = {}  # type: ignore
-                    for metadata_k, metadata_v in kwargs[_metadata_var].items():
-                        if metadata_k != "previous_models":
-                            previous_model[k][metadata_k] = metadata_v  # type: ignore
+        _metadata_var = "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
+        metadata = kwargs.get(_metadata_var)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            kwargs[_metadata_var] = metadata
 
-            # check current size of self.previous_models, if it's larger than 3, remove the first element
-            if len(self.previous_models) > 3:
-                self.previous_models.pop(0)
+        # Keep retry breadcrumbs useful without copying arbitrary request kwargs
+        # (credentials, headers, messages, and tool schemas) into metadata.
+        previous_model = {
+            "litellm_call_id": kwargs.get("litellm_call_id"),
+            "litellm_trace_id": kwargs.get("litellm_trace_id"),
+            "model": kwargs.get("model"),
+            "exception_type": type(e).__name__,
+            "exception_string": redact_string(str(e))[:200],
+        }
 
-            self.previous_models.append(previous_model)
-            kwargs[_metadata_var]["previous_models"] = self.previous_models
-            return kwargs
-        except Exception as e:
-            raise e
+        previous_models = metadata.get("previous_models")
+        if isinstance(previous_models, list):
+            # Copy request-provided state so callers never share a mutable list.
+            request_history = list(previous_models[-3:])
+        else:
+            request_history = []
+
+        request_history.append(previous_model)
+        metadata["previous_models"] = request_history
+        return kwargs
 
     def _update_usage(self, deployment_id: str, parent_otel_span: Optional[Span]) -> int:
         """

--- a/tests/litellm/test_router_log_retry.py
+++ b/tests/litellm/test_router_log_retry.py
@@ -1,0 +1,102 @@
+from litellm import Router
+
+
+def _router() -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": "test",
+                "litellm_params": {"model": "gpt-3.5-turbo"},
+            }
+        ]
+    )
+
+
+def test_log_retry_keeps_history_request_local_and_omits_request_secrets():
+    router = _router()
+    first = router.log_retry(
+        {
+            "litellm_call_id": "call-1",
+            "litellm_trace_id": "trace-1",
+            "model": "test",
+            "api_key": "FIRST_REQUEST_SECRET",
+            "litellm_metadata": {"headers": {"authorization": "Bearer first-request-secret"}},
+        },
+        RuntimeError("first failure"),
+    )
+    second = router.log_retry(
+        {
+            "litellm_call_id": "call-2",
+            "litellm_trace_id": "trace-2",
+            "model": "test",
+            "api_key": "SECOND_REQUEST_SECRET",
+            "litellm_metadata": {"headers": {"authorization": "Bearer second-request-secret"}},
+        },
+        RuntimeError("second failure"),
+    )
+
+    first_history = first["litellm_metadata"]["previous_models"]
+    second_history = second["litellm_metadata"]["previous_models"]
+
+    assert [item["litellm_call_id"] for item in first_history] == ["call-1"]
+    assert [item["litellm_call_id"] for item in second_history] == ["call-2"]
+    assert first_history is not second_history
+    serialized_history = repr(first_history + second_history)
+    assert "FIRST_REQUEST_SECRET" not in serialized_history
+    assert "SECOND_REQUEST_SECRET" not in serialized_history
+    assert "first-request-secret" not in serialized_history
+    assert "second-request-secret" not in serialized_history
+
+
+def test_log_retry_caps_history_without_mutating_input_list():
+    router = _router()
+    original_history = [{"litellm_call_id": f"old-{index}"} for index in range(6)]
+    kwargs = {
+        "litellm_call_id": "current",
+        "model": "test",
+        "litellm_metadata": {"previous_models": original_history},
+    }
+
+    result = router.log_retry(kwargs, RuntimeError("current failure"))
+    history = result["litellm_metadata"]["previous_models"]
+
+    assert [item["litellm_call_id"] for item in history] == [
+        "old-3",
+        "old-4",
+        "old-5",
+        "current",
+    ]
+    assert len(original_history) == 6
+    assert history is not original_history
+
+
+def test_log_retry_redacts_and_bounds_exception_text():
+    router = _router()
+    secret = "sk-" + ("a" * 32)
+    result = router.log_retry(
+        {
+            "litellm_call_id": "call-secret",
+            "model": "test",
+            "litellm_metadata": {},
+        },
+        RuntimeError(f"provider rejected api_key={secret} " + "x" * 300),
+    )
+
+    exception_string = result["litellm_metadata"]["previous_models"][0]["exception_string"]
+    assert secret not in exception_string
+    assert "REDACTED" in exception_string
+    assert len(exception_string) <= 200
+
+
+def test_log_retry_initializes_invalid_metadata_and_history_values():
+    router = _router()
+    result = router.log_retry(
+        {
+            "litellm_call_id": "call-invalid",
+            "model": "test",
+            "litellm_metadata": None,
+        },
+        RuntimeError("failure"),
+    )
+
+    assert [item["litellm_call_id"] for item in result["litellm_metadata"]["previous_models"]] == ["call-invalid"]


### PR DESCRIPTION
Fixes #24965

## What changed

- Removes Router-global `previous_models` state and keeps retry history in each request's metadata.
- Copies and caps preexisting history at four entries after appending the current failure.
- Whitelists useful breadcrumb fields instead of copying arbitrary request kwargs, headers, credentials, messages, or tool schemas.
- Redacts known credential patterns from exception text and bounds it to 200 characters.
- Adds regression coverage for request isolation, secret omission, bounded history, exception redaction, and invalid metadata values.

## Scope

This branch was rebuilt on current `litellm_oss_staging` and changes only `litellm/router.py` plus `tests/litellm/test_router_log_retry.py`.

## Validation

Run against `litellm_oss_staging` at `9e7ba65759b648d6514c6f1440ecc284821e3e6f`:

```bash
PYTHONPATH=. pytest -q tests/litellm/test_router_log_retry.py
ruff format --check litellm/router.py tests/litellm/test_router_log_retry.py
ruff check litellm/router.py
python -m py_compile litellm/router.py tests/litellm/test_router_log_retry.py
git diff --check
```

The focused regression file passed: `4 passed`. Static checks passed. The broader legacy Router helper test requires the repository's full test dependency set, so it was inspected for compatibility but is left to CI rather than claimed as a local pass.