### PR TITLE
feat: add brave/search to model_prices_and_context_window.json

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10342,6 +10342,11 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
     },
+    "brave/search": {
+        "input_cost_per_query": 0.005,
+        "litellm_provider": "brave",
+        "mode": "search"
+    },
     "dataforseo/search": {
         "input_cost_per_query": 0.003,
         "litellm_provider": "dataforseo",


### PR DESCRIPTION
Brave Search is supported by litellm as a search provider (documented at docs.litellm.ai/docs/search/brave and listed in provider_endpoints_support.json) but was missing from model_prices_and_context_window.json, making it invisible to any code that discovers search providers from litellm.model_cost.

#19433 added Brave Search runtime support but did not add a pricing entry to model_prices_and_context_window.json.

Cost: $0.005/query ($5 per 1,000 requests) per https://brave.com/search/api/

## Relevant issues

Fixes gap from #19433

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Type

🐛 Bug Fix

## Changes

- Added `brave/search` entry to `model_prices_and_context_window.json` with `input_cost_per_query: 0.005` and `mode: search`