### PR TITLE
fix(test): patch verbose_logger in check_migration module scope

### DIFF
--- a/tests/test_litellm/proxy/db/test_check_migration.py
+++ b/tests/test_litellm/proxy/db/test_check_migration.py
@@ -28,7 +28,7 @@ def test_check_migration_out_of_sync(mocker):
     - logs an error when the Prisma schema is out of sync with the database.
     """
     # Mock the logger BEFORE importing the function
-    mock_logger = mocker.patch("litellm._logging.verbose_logger")
+    mock_logger = mocker.patch("litellm.proxy.db.check_migration.verbose_logger")
 
     # Import the function after mocking the logger
     from litellm.proxy.db.check_migration import check_prisma_schema_diff


### PR DESCRIPTION
## Summary

- `test_check_migration_out_of_sync` patches `litellm._logging.verbose_logger` but `check_migration.py` imports it at module level via `from litellm._logging import verbose_logger`, creating a local binding the patch never reaches
- Fix: patch `litellm.proxy.db.check_migration.verbose_logger` instead
- This test has been failing on every PR and on `main` continuously

## Test plan

- [ ] `Unit Tests: Proxy Infrastructure` passes