### PR TITLE
Fix mock target in test_check_migration_out_of_sync

### DIFF
--- a/tests/test_litellm/proxy/db/test_check_migration.py
+++ b/tests/test_litellm/proxy/db/test_check_migration.py
@@ -27,11 +27,11 @@ def test_check_migration_out_of_sync(mocker):
     - 🚨 [IMPORTANT] Does NOT Raise an Exception when the Prisma schema is out of sync with the database.
     - logs an error when the Prisma schema is out of sync with the database.
     """
-    # Mock the logger BEFORE importing the function
-    mock_logger = mocker.patch("litellm._logging.verbose_logger")
-
-    # Import the function after mocking the logger
+    # Import the function first so the module is loaded
     from litellm.proxy.db.check_migration import check_prisma_schema_diff
+
+    # Patch the local reference in the module (not the source in litellm._logging)
+    mock_logger = mocker.patch("litellm.proxy.db.check_migration.verbose_logger")
 
     # Mock the helper function to simulate out-of-sync state
     mock_diff_helper = mocker.patch(


### PR DESCRIPTION
## Summary

`test_check_migration_out_of_sync` was patching `litellm._logging.verbose_logger` but `check_migration.py` binds `verbose_logger` via `from litellm._logging import verbose_logger`, creating a local reference. The mock never intercepted the call, causing `assert_called_once()` to fail on every PR.

Fix: patch `litellm.proxy.db.check_migration.verbose_logger` — the local reference in the module under test.