### PR TITLE
Fix node-gyp symlink path after npm upgrade in Dockerfile

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -49,7 +49,7 @@ RUN mkdir -p /var/lib/litellm/ui && \
     ([ -f /app/.npmrc ] && mv /app/.npmrc /app/.npmrc.bak || true) && \
     npm install -g npm@11.12.1 && \
     npm install -g node-gyp@12.2.0 && \
-    ln -sf /usr/local/lib/node_modules/node-gyp /usr/lib/node_modules/npm/node_modules/node-gyp && \
+    ln -sf "$(npm root -g)/node-gyp" "$(npm root -g)/npm/node_modules/node-gyp" && \
     npm cache clean --force && \
     cd /app/ui/litellm-dashboard && \
     if [ -f "/app/enterprise/enterprise_ui/enterprise_colors.json" ]; then \


### PR DESCRIPTION
## Summary

`test-server-root-path` fails on every PR with `npm error Cannot find module 'node-gyp/bin/node-gyp.js'` during the Docker build.

After `npm install -g npm@11.12.1`, the active npm binary is at `/usr/local/lib/node_modules/npm/`. The previous symlink hardcoded `/usr/lib/node_modules/npm/node_modules/node-gyp` (the pre-upgrade location), so the upgraded npm couldn't find node-gyp.

Fix: use `npm root -g` to resolve the correct global modules path dynamically, ensuring the symlink targets the right npm regardless of where it's installed.