### PR TITLE
fix: use numeric npm min-release-age config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -41,7 +41,7 @@ COPY . .
 ENV LITELLM_NON_ROOT=true
 
 # Build Admin UI using the upstream command order while keeping a single RUN layer
-# NOTE: .npmrc (which has ignore-scripts=true and min-release-age=3d) is temporarily
+# NOTE: .npmrc (which has ignore-scripts=true and min-release-age=3) is temporarily
 # renamed during npm install/ci. This is safe because npm ci installs from
 # package-lock.json with pinned versions + integrity hashes.
 RUN mkdir -p /var/lib/litellm/ui && \

--- a/litellm-js/proxy/.npmrc
+++ b/litellm-js/proxy/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/litellm-js/spend-logs/.npmrc
+++ b/litellm-js/spend-logs/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/tests/proxy_admin_ui_tests/.npmrc
+++ b/tests/proxy_admin_ui_tests/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc
+++ b/tests/proxy_admin_ui_tests/ui_unit_tests/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3

--- a/ui/litellm-dashboard/.npmrc
+++ b/ui/litellm-dashboard/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3


### PR DESCRIPTION
## Relevant issues

Fixes #25057

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [N/A] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [N/A] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

- replace invalid `min-release-age=3d` with `min-release-age=3` in all six `.npmrc` files added by #24838
- preserve the intended 3-day npm supply-chain hardening behavior using the config format npm actually accepts
- fix `npm install` failures in project directories such as `ui/litellm-dashboard`

## Validation

- reproduced the failure locally with `npm install` in `ui/litellm-dashboard`
- verified `npm install` succeeds after the `.npmrc` fix