### PR TITLE
fix(proxy): make responses polling retrieval non-billable (#25015)

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -24,6 +24,13 @@ from litellm.types.utils import StandardLoggingPayload
 from litellm.utils import get_end_user_id_for_cost_tracking
 
 
+_NON_BILLABLE_PROXY_CALL_TYPES = frozenset({"get_responses", "aget_responses"})
+
+
+def _is_non_billable_proxy_call_type(call_type: Optional[str]) -> bool:
+    return call_type in _NON_BILLABLE_PROXY_CALL_TYPES
+
+
 class _ProxyDBLogger(CustomLogger):
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         await self._PROXY_track_cost_callback(
@@ -163,9 +170,21 @@ class _ProxyDBLogger(CustomLogger):
                 if sl_object is not None
                 else kwargs.get("response_cost", None)
             )
+            call_type = cast(
+                Optional[str],
+                (
+                    sl_object.get("call_type", None)
+                    if sl_object is not None
+                    else kwargs.get("call_type", None)
+                ),
+            )
             tags: Optional[List[str]] = (
                 sl_object.get("request_tags", None) if sl_object is not None else None
             )
+
+            # Retrieval endpoints like GET /v1/responses/{id} are non-billable.
+            if _is_non_billable_proxy_call_type(call_type):
+                response_cost = 0.0
 
             if response_cost is not None:
                 user_api_key = metadata.get("user_api_key", None)

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -23,7 +23,6 @@ from litellm.proxy.utils import ProxyUpdateSpend
 from litellm.types.utils import StandardLoggingPayload
 from litellm.utils import get_end_user_id_for_cost_tracking
 
-
 _NON_BILLABLE_PROXY_CALL_TYPES = frozenset({"get_responses", "aget_responses"})
 
 
@@ -62,11 +61,11 @@ class _ProxyDBLogger(CustomLogger):
         )
         _metadata["user_api_key"] = user_api_key_dict.api_key
         _metadata["status"] = "failure"
-        _metadata[
-            "error_information"
-        ] = StandardLoggingPayloadSetup.get_error_information(
-            original_exception=original_exception,
-            traceback_str=traceback_str,
+        _metadata["error_information"] = (
+            StandardLoggingPayloadSetup.get_error_information(
+                original_exception=original_exception,
+                traceback_str=traceback_str,
+            )
         )
 
         _metadata = await _ProxyDBLogger._enrich_failure_metadata_with_key_info(
@@ -183,7 +182,11 @@ class _ProxyDBLogger(CustomLogger):
             )
 
             # Retrieval endpoints like GET /v1/responses/{id} are non-billable.
-            if _is_non_billable_proxy_call_type(call_type):
+            # Keep existing skip behavior when no response_cost is provided.
+            if (
+                _is_non_billable_proxy_call_type(call_type)
+                and response_cost is not None
+            ):
                 response_cost = 0.0
 
             if response_cost is not None:

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1,9 +1,7 @@
-import json
 import os
 import sys
 
 import pytest
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../../..")
@@ -14,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.hooks.proxy_track_cost_callback import _ProxyDBLogger
-from litellm.types.utils import StandardLoggingPayload
 
 
 @pytest.mark.asyncio
@@ -62,7 +59,6 @@ async def test_async_post_call_failure_hook():
 
         # Check the arguments passed to update_database
         call_args = mock_update_database.call_args[1]
-        print("call_args", json.dumps(call_args, indent=4, default=str))
         assert call_args["token"] == "test_api_key"
         assert call_args["response_cost"] == 0.0
         assert call_args["user_id"] == "test_user_id"
@@ -167,6 +163,59 @@ async def test_track_cost_callback_skips_when_no_standard_logging_object():
 
         # failed_tracking_alert should NOT be called — this is not an error
         mock_proxy_logging.failed_tracking_alert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_track_cost_callback_sets_zero_cost_for_aget_responses():
+    logger = _ProxyDBLogger()
+
+    kwargs = {
+        "call_type": "aget_responses",
+        "model": "openai/gpt-4.1",
+        "stream": False,
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "sk-test-key",
+                "user_api_key_user_id": "test-user",
+                "user_api_key_team_id": "test-team",
+            }
+        },
+        "standard_logging_object": {
+            "response_cost": 0.42,
+            "request_tags": [],
+            "call_type": "aget_responses",
+        },
+    }
+
+    with patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj",
+    ) as mock_proxy_logging, patch(
+        "litellm.proxy.proxy_server.increment_spend_counters",
+        new_callable=AsyncMock,
+    ) as mock_increment_spend_counters, patch(
+        "litellm.proxy.proxy_server.update_cache",
+        new_callable=AsyncMock,
+    ):
+        mock_proxy_logging.failed_tracking_alert = AsyncMock()
+        mock_proxy_logging.db_spend_update_writer = MagicMock()
+        mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
+        mock_proxy_logging.slack_alerting_instance = MagicMock()
+        mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()
+
+        await logger._PROXY_track_cost_callback(
+            kwargs=kwargs,
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+        call_kwargs = mock_proxy_logging.db_spend_update_writer.update_database.call_args[
+            1
+        ]
+        assert call_kwargs["response_cost"] == 0.0
+
+        assert mock_increment_spend_counters.await_count == 1
+        assert mock_increment_spend_counters.await_args.kwargs["response_cost"] == 0.0
 
 
 @pytest.mark.asyncio
@@ -338,7 +387,7 @@ async def test_enrich_failure_metadata_skips_when_no_api_key():
             "user_api_key_team_id": None,
             "user_api_key_team_alias": None,
         }
-        result = await _ProxyDBLogger._enrich_failure_metadata_with_key_info(metadata)
+        await _ProxyDBLogger._enrich_failure_metadata_with_key_info(metadata)
         mock_get_key.assert_not_called()
 
 

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -166,11 +166,14 @@ async def test_track_cost_callback_skips_when_no_standard_logging_object():
 
 
 @pytest.mark.asyncio
-async def test_track_cost_callback_sets_zero_cost_for_aget_responses():
+@pytest.mark.parametrize("call_type", ["aget_responses", "get_responses"])
+async def test_track_cost_callback_sets_zero_cost_for_non_billable_call_types(
+    call_type,
+):
     logger = _ProxyDBLogger()
 
     kwargs = {
-        "call_type": "aget_responses",
+        "call_type": call_type,
         "model": "openai/gpt-4.1",
         "stream": False,
         "litellm_params": {
@@ -183,7 +186,7 @@ async def test_track_cost_callback_sets_zero_cost_for_aget_responses():
         "standard_logging_object": {
             "response_cost": 0.42,
             "request_tags": [],
-            "call_type": "aget_responses",
+            "call_type": call_type,
         },
     }
 
@@ -209,9 +212,9 @@ async def test_track_cost_callback_sets_zero_cost_for_aget_responses():
             end_time=datetime.now(),
         )
 
-        call_kwargs = mock_proxy_logging.db_spend_update_writer.update_database.call_args[
-            1
-        ]
+        call_kwargs = (
+            mock_proxy_logging.db_spend_update_writer.update_database.call_args[1]
+        )
         assert call_kwargs["response_cost"] == 0.0
 
         assert mock_increment_spend_counters.await_count == 1


### PR DESCRIPTION
## Relevant issues

Fixes #25015

## Pre-Submission checklist

Please complete all items before asking a LiteLLM maintainer to review your PR.

- [x] I have added testing in the [tests/test_litellm/](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, adding at least 1 test is a hard requirement - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting @greptileai and received a confidence score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you are seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:


## Type

Bug Fix  
Test

## Changes

- Fixes duplicate spend tracking for OpenAI Responses polling retrieval calls.
- Treats retrieval call types get_responses and aget_responses as non-billable in proxy cost tracking.
- Forces response_cost to 0.0 for these retrieval calls before spend counters and database updates are applied.
- Adds regression coverage in proxy hook tests to verify retrieval polling does not increase spend.
- Keeps the PR scope focused on Issue #25015 only.
- Local validation: ruff check passed for changed files and the targeted proxy hook test file passed.