### PR TITLE
feat(prometheus): add 7m and 10m latency histogram buckets

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -156,6 +156,8 @@ LATENCY_BUCKETS = (
     180.0,
     240.0,
     300.0,
+    420.0,  # 7 minutes
+    600.0,  # 10 minutes (typical default LLM request timeout)
     float("inf"),
 )
 

--- a/tests/test_litellm/types/test_prometheus_latency_buckets.py
+++ b/tests/test_litellm/types/test_prometheus_latency_buckets.py
@@ -1,0 +1,17 @@
+"""LATENCY_BUCKETS covers long-running LLM calls (histograms are in seconds)."""
+
+import math
+
+from litellm.types.integrations.prometheus import LATENCY_BUCKETS
+
+
+def test_latency_buckets_include_seven_and_ten_minutes():
+    """Buckets beyond 5 min so histograms resolve requests up to default LLM timeouts."""
+    assert 300.0 in LATENCY_BUCKETS
+    assert 420.0 in LATENCY_BUCKETS  # 7 min
+    assert 600.0 in LATENCY_BUCKETS  # 10 min
+    assert math.isinf(LATENCY_BUCKETS[-1])
+    idx_300 = LATENCY_BUCKETS.index(300.0)
+    idx_420 = LATENCY_BUCKETS.index(420.0)
+    idx_600 = LATENCY_BUCKETS.index(600.0)
+    assert idx_300 < idx_420 < idx_600


### PR DESCRIPTION
## Summary

Prometheus latency histograms (`LATENCY_BUCKETS`) previously topped out at **5 minutes** (300s) before `+Inf`. LLM requests can run up to the default request timeout (**10 minutes**), so durations between 5–10 minutes were only visible as `+Inf`.

## Changes

- Add **420s (7 min)** and **600s (10 min)** buckets to `LATENCY_BUCKETS` in `litellm/types/integrations/prometheus.py`.
- Unit test asserting ordering and presence of the new buckets.

## Testing

- `poetry run pytest tests/test_litellm/types/test_prometheus_latency_buckets.py -v`

Made with [Cursor](https://cursor.com)