### PR TITLE
feat: load model cost map from LITELLM_MODEL_COST_MAP_PATH

### DIFF
--- a/litellm/litellm_core_utils/get_model_cost_map.py
+++ b/litellm/litellm_core_utils/get_model_cost_map.py
@@ -1,11 +1,10 @@
 """
 Pulls the cost + context window + provider route for known models from https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
 
-This can be disabled by setting the LITELLM_LOCAL_MODEL_COST_MAP environment variable to True.
+Remote fetch can be disabled with LITELLM_LOCAL_MODEL_COST_MAP=True (uses the local backup).
 
-```
-export LITELLM_LOCAL_MODEL_COST_MAP=True
-```
+To load the backup map from a file instead of the package copy (e.g. PyInstaller, air-gapped
+deployments), set LITELLM_MODEL_COST_MAP_PATH to a UTF-8 JSON file path.
 """
 
 import json
@@ -35,13 +34,27 @@ class GetModelCostMap:
 
     @staticmethod
     def load_local_model_cost_map() -> dict:
-        """Load the local backup model cost map bundled with the package."""
-        content = json.loads(
+        """Load the local backup model cost map (file or bundled package JSON)."""
+        path = os.getenv("LITELLM_MODEL_COST_MAP_PATH", "").strip()
+        if path:
+            with open(path, encoding="utf-8") as f:
+                content = json.load(f)
+            if not isinstance(content, dict):
+                raise TypeError(
+                    "LITELLM_MODEL_COST_MAP_PATH must point to a JSON object "
+                    f"(got {type(content).__name__})"
+                )
+            if not content:
+                raise ValueError(
+                    "LITELLM_MODEL_COST_MAP_PATH: JSON object must be non-empty"
+                )
+            return content
+
+        return json.loads(
             files("litellm")
             .joinpath("model_prices_and_context_window_backup.json")
             .read_text(encoding="utf-8")
         )
-        return content
 
     @classmethod
     def _get_backup_model_count(cls) -> int:
@@ -248,6 +261,9 @@ def get_model_cost_map(url: str) -> dict:
     1. If ``LITELLM_LOCAL_MODEL_COST_MAP`` is set, uses the local backup only.
     2. Otherwise fetches from ``url``, validates integrity, and falls back
        to the local backup on any failure.
+
+    When ``LITELLM_MODEL_COST_MAP_PATH`` is set, the local backup is read from that
+    file instead of the bundled JSON (applies to both steps above).
 
     Only the backup model count is cached (a single int) for validation.
     The full backup dict is only parsed when it must be *returned* as a

--- a/tests/llm_translation/test_model_cost_map_resilience.py
+++ b/tests/llm_translation/test_model_cost_map_resilience.py
@@ -210,6 +210,60 @@ class TestGetModelCostMapFallback:
         assert len(result) > 0
 
 
+class TestExternalModelCostMapPath:
+    """LITELLM_MODEL_COST_MAP_PATH loads JSON from disk for local backup."""
+
+    def test_should_load_from_file_when_path_set(self, tmp_path):
+        payload = {"external-only-model": {"litellm_provider": "openai"}}
+        path = tmp_path / "model_cost_map.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        GetModelCostMap._backup_model_count = -1
+        with patch.dict(os.environ, {"LITELLM_MODEL_COST_MAP_PATH": str(path)}):
+            loaded = GetModelCostMap.load_local_model_cost_map()
+        assert loaded == payload
+
+    def test_should_raise_when_file_missing(self):
+        GetModelCostMap._backup_model_count = -1
+        with patch.dict(
+            os.environ, {"LITELLM_MODEL_COST_MAP_PATH": "/nonexistent/cost_map.json"}
+        ):
+            with pytest.raises(FileNotFoundError):
+                GetModelCostMap.load_local_model_cost_map()
+
+    def test_should_raise_when_json_not_object(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("[1, 2]", encoding="utf-8")
+        GetModelCostMap._backup_model_count = -1
+        with patch.dict(os.environ, {"LITELLM_MODEL_COST_MAP_PATH": str(path)}):
+            with pytest.raises(TypeError, match="LITELLM_MODEL_COST_MAP_PATH"):
+                GetModelCostMap.load_local_model_cost_map()
+
+    def test_should_raise_when_json_object_empty(self, tmp_path):
+        path = tmp_path / "empty.json"
+        path.write_text("{}", encoding="utf-8")
+        GetModelCostMap._backup_model_count = -1
+        with patch.dict(os.environ, {"LITELLM_MODEL_COST_MAP_PATH": str(path)}):
+            with pytest.raises(ValueError, match="non-empty"):
+                GetModelCostMap.load_local_model_cost_map()
+
+    def test_should_use_file_with_local_only_mode(self, tmp_path):
+        payload = {"external-only-model": {"litellm_provider": "openai"}}
+        path = tmp_path / "model_cost_map.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        GetModelCostMap._backup_model_count = -1
+        with patch.dict(
+            os.environ,
+            {
+                "LITELLM_LOCAL_MODEL_COST_MAP": "True",
+                "LITELLM_MODEL_COST_MAP_PATH": str(path),
+            },
+        ):
+            with patch("httpx.get") as mock_get:
+                result = get_model_cost_map("https://example.com/map.json")
+                mock_get.assert_not_called()
+        assert result == payload
+
+
 class TestBackupModelCostMapExists:
     """Validates the local backup file is always present and valid."""
 


### PR DESCRIPTION
### relevant issues

- Fixes #25062

### Type
🆕 New Feature

### Changes
- LITELLM_MODEL_COST_MAP_PATH loads the local model cost map from a file; otherwise unchanged bundled backup.
- Tests added.