### PR TITLE
fix(test): Fix flaky test_check_migration_out_of_sync

### DIFF
--- a/tests/test_litellm/proxy/db/test_check_migration.py
+++ b/tests/test_litellm/proxy/db/test_check_migration.py
@@ -3,9 +3,7 @@ import sys
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 
 
 def test_check_migration_out_of_sync(mocker):

--- a/tests/test_litellm/proxy/db/test_check_migration.py
+++ b/tests/test_litellm/proxy/db/test_check_migration.py
@@ -1,24 +1,11 @@
-import json
 import os
 import sys
 
 import pytest
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
-
-
-import json
-import os
-import sys
-import time
-
-import pytest
-from fastapi.testclient import TestClient
-
-import litellm
 
 
 def test_check_migration_out_of_sync(mocker):
@@ -27,14 +14,14 @@ def test_check_migration_out_of_sync(mocker):
     - 🚨 [IMPORTANT] Does NOT Raise an Exception when the Prisma schema is out of sync with the database.
     - logs an error when the Prisma schema is out of sync with the database.
     """
-    # Mock the logger BEFORE importing the function
-    mock_logger = mocker.patch("litellm._logging.verbose_logger")
-
-    # Import the function after mocking the logger
+    # Import the function
     from litellm.proxy.db.check_migration import check_prisma_schema_diff
 
+    # Mock the logger in the module where it's used
+    mock_logger = mocker.patch("litellm.proxy.db.check_migration.verbose_logger")
+
     # Mock the helper function to simulate out-of-sync state
-    mock_diff_helper = mocker.patch(
+    mocker.patch(
         "litellm.proxy.db.check_migration.check_prisma_schema_diff_helper",
         return_value=(True, ["ALTER TABLE users ADD COLUMN new_field TEXT;"]),
     )


### PR DESCRIPTION
## Relevant issues

This PR fixes a flaky CI test failure in `test_check_migration_out_of_sync`. This makes the constantly failing test "Unit Tests: Proxy Infrastructure / proxy-infra test" passing.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

✅ Test

## Changes

- Fixed `test_check_migration_out_of_sync` by patching `verbose_logger` in the module where it is used. This prevents the test from failing when the module has been previously imported elsewhere.
- Cleaned up redundant imports and unused variables in `tests/test_litellm/proxy/db/test_check_migration.py`.