### PR TITLE
fix(mcp): validate MCP tool prefix against registry instead of heuristic

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -3,6 +3,7 @@ Semantic MCP Tool Filtering using semantic-router
 
 Filters MCP tools semantically for /chat/completions and /responses endpoints.
 """
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -6,6 +6,7 @@ Filters MCP tools semantically for /chat/completions and /responses endpoints.
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
+from litellm.proxy._experimental.mcp_server.utils import is_tool_name_prefixed
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
@@ -190,7 +191,12 @@ class SemanticMCPToolFilter:
             matched_tool_names = self._extract_tool_names_from_matches(matches)
 
             if not matched_tool_names:
-                return available_tools
+                # No semantic matches — drop MCP tools (prefixed) and keep only
+                # non-MCP tools to avoid exceeding provider tool limits.
+                return [
+                    t for t in available_tools
+                    if not is_tool_name_prefixed(self._extract_tool_info(t)[0])
+                ]
 
             return self._get_tools_by_names(matched_tool_names, available_tools)
 

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -6,7 +6,6 @@ Filters MCP tools semantically for /chat/completions and /responses endpoints.
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
-from litellm.proxy._experimental.mcp_server.utils import is_tool_name_prefixed
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
@@ -191,12 +190,9 @@ class SemanticMCPToolFilter:
             matched_tool_names = self._extract_tool_names_from_matches(matches)
 
             if not matched_tool_names:
-                # No semantic matches — drop MCP tools (prefixed) and keep only
-                # non-MCP tools to avoid exceeding provider tool limits.
-                return [
-                    t for t in available_tools
-                    if not is_tool_name_prefixed(self._extract_tool_info(t)[0])
-                ]
+                # No semantic matches — return empty so only non-MCP tools
+                # (added back by the hook) reach the LLM.
+                return []
 
             return self._get_tools_by_names(matched_tool_names, available_tools)
 

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -8,7 +8,11 @@ Reduces context window size and improves tool selection accuracy.
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._experimental.mcp_server.utils import is_tool_name_prefixed
+from litellm.proxy._experimental.mcp_server.utils import (
+    MCP_TOOL_PREFIX_SEPARATOR,
+    get_server_prefix,
+    normalize_server_name,
+)
 from litellm.constants import (
     DEFAULT_MCP_SEMANTIC_FILTER_EMBEDDING_MODEL,
     DEFAULT_MCP_SEMANTIC_FILTER_SIMILARITY_THRESHOLD,
@@ -44,11 +48,34 @@ class SemanticToolFilterHook(CustomLogger):
         """
         super().__init__()
         self.filter = semantic_filter
+        self._registered_server_prefixes: Optional[set] = None
 
         verbose_proxy_logger.debug(
             f"Initialized SemanticToolFilterHook with filter: "
             f"enabled={semantic_filter.enabled}, top_k={semantic_filter.top_k}"
         )
+
+    def _get_registered_server_prefixes(self) -> set:
+        """Get the set of known MCP server prefixes from the registry."""
+        if self._registered_server_prefixes is None:
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                global_mcp_server_manager,
+            )
+
+            registry = global_mcp_server_manager.get_registry()
+            self._registered_server_prefixes = {
+                normalize_server_name(get_server_prefix(server))
+                for server in registry.values()
+                if get_server_prefix(server)
+            }
+        return self._registered_server_prefixes
+
+    def _is_mcp_tool(self, tool_name: str) -> bool:
+        """Check if a tool is an MCP tool by validating its prefix against the registry."""
+        if MCP_TOOL_PREFIX_SEPARATOR not in tool_name:
+            return False
+        prefix = tool_name.split(MCP_TOOL_PREFIX_SEPARATOR, 1)[0]
+        return normalize_server_name(prefix) in self._get_registered_server_prefixes()
 
     def _should_expand_mcp_tools(self, tools: List[Any]) -> bool:
         """
@@ -231,10 +258,8 @@ class SemanticToolFilterHook(CustomLogger):
                     t.get("name", "") if isinstance(t, dict) else getattr(t, "name", "")
                 )
 
-            mcp_tools = [t for t in tools if is_tool_name_prefixed(_tool_name(t))]
-            non_mcp_tools = [
-                t for t in tools if not is_tool_name_prefixed(_tool_name(t))
-            ]
+            mcp_tools = [t for t in tools if self._is_mcp_tool(_tool_name(t))]
+            non_mcp_tools = [t for t in tools if not self._is_mcp_tool(_tool_name(t))]
 
             if not mcp_tools:
                 return None

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -4,6 +4,7 @@ Semantic Tool Filter Hook
 Pre-call hook that filters MCP tools semantically before LLM inference.
 Reduces context window size and improves tool selection accuracy.
 """
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
@@ -226,10 +227,14 @@ class SemanticToolFilterHook(CustomLogger):
             # Separate MCP tools (prefixed) from non-MCP tools — only filter
             # MCP tools, always pass non-MCP tools through untouched.
             def _tool_name(t):
-                return t.get("name", "") if isinstance(t, dict) else getattr(t, "name", "")
+                return (
+                    t.get("name", "") if isinstance(t, dict) else getattr(t, "name", "")
+                )
 
             mcp_tools = [t for t in tools if is_tool_name_prefixed(_tool_name(t))]
-            non_mcp_tools = [t for t in tools if not is_tool_name_prefixed(_tool_name(t))]
+            non_mcp_tools = [
+                t for t in tools if not is_tool_name_prefixed(_tool_name(t))
+            ]
 
             if not mcp_tools:
                 return None

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -7,6 +7,7 @@ Reduces context window size and improves tool selection accuracy.
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy._experimental.mcp_server.utils import is_tool_name_prefixed
 from litellm.constants import (
     DEFAULT_MCP_SEMANTIC_FILTER_EMBEDDING_MODEL,
     DEFAULT_MCP_SEMANTIC_FILTER_SIMILARITY_THRESHOLD,
@@ -222,11 +223,24 @@ class SemanticToolFilterHook(CustomLogger):
                 f"with query: '{user_query[:50]}...'"
             )
 
-            # Filter tools semantically
-            filtered_tools = await self.filter.filter_tools(
+            # Separate MCP tools (prefixed) from non-MCP tools — only filter
+            # MCP tools, always pass non-MCP tools through untouched.
+            def _tool_name(t):
+                return t.get("name", "") if isinstance(t, dict) else getattr(t, "name", "")
+
+            mcp_tools = [t for t in tools if is_tool_name_prefixed(_tool_name(t))]
+            non_mcp_tools = [t for t in tools if not is_tool_name_prefixed(_tool_name(t))]
+
+            if not mcp_tools:
+                return None
+
+            # Filter only MCP tools semantically
+            filtered_mcp_tools = await self.filter.filter_tools(
                 query=user_query,
-                available_tools=tools,  # type: ignore
+                available_tools=mcp_tools,  # type: ignore
             )
+
+            filtered_tools = filtered_mcp_tools + non_mcp_tools
 
             # Always update tools and emit header (even if count unchanged)
             data["tools"] = filtered_tools

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -48,7 +48,6 @@ class SemanticToolFilterHook(CustomLogger):
         """
         super().__init__()
         self.filter = semantic_filter
-        self._registered_server_prefixes: Optional[set] = None
 
         verbose_proxy_logger.debug(
             f"Initialized SemanticToolFilterHook with filter: "
@@ -56,19 +55,20 @@ class SemanticToolFilterHook(CustomLogger):
         )
 
     def _get_registered_server_prefixes(self) -> set:
-        """Get the set of known MCP server prefixes from the registry."""
-        if self._registered_server_prefixes is None:
-            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-                global_mcp_server_manager,
-            )
+        """Get the set of known MCP server prefixes from the registry.
 
-            registry = global_mcp_server_manager.get_registry()
-            self._registered_server_prefixes = {
-                normalize_server_name(get_server_prefix(server))
-                for server in registry.values()
-                if get_server_prefix(server)
-            }
-        return self._registered_server_prefixes
+        Queries the registry each time so newly added servers are recognized.
+        """
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        registry = global_mcp_server_manager.get_registry()
+        return {
+            normalize_server_name(get_server_prefix(server))
+            for server in registry.values()
+            if get_server_prefix(server)
+        }
 
     def _is_mcp_tool(self, tool_name: str) -> bool:
         """Check if a tool is an MCP tool by validating its prefix against the registry."""
@@ -258,8 +258,11 @@ class SemanticToolFilterHook(CustomLogger):
                     t.get("name", "") if isinstance(t, dict) else getattr(t, "name", "")
                 )
 
-            mcp_tools = [t for t in tools if self._is_mcp_tool(_tool_name(t))]
-            non_mcp_tools = [t for t in tools if not self._is_mcp_tool(_tool_name(t))]
+            mcp_tools, non_mcp_tools = [], []
+            for t in tools:
+                (
+                    mcp_tools if self._is_mcp_tool(_tool_name(t)) else non_mcp_tools
+                ).append(t)
 
             if not mcp_tools:
                 return None

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -245,6 +245,16 @@ class SemanticToolFilterHook(CustomLogger):
                 available_tools=mcp_tools,  # type: ignore
             )
 
+            # If no MCP tools matched and no non-MCP tools exist, fall back
+            # to the first top_k MCP tools to avoid an empty tool list.
+            if not filtered_mcp_tools and not non_mcp_tools:
+                limit = self.filter.top_k
+                filtered_mcp_tools = mcp_tools[:limit]
+                verbose_proxy_logger.warning(
+                    f"No semantic matches and no non-MCP tools — "
+                    f"falling back to first {limit} MCP tools"
+                )
+
             filtered_tools = filtered_mcp_tools + non_mcp_tools
 
             # Always update tools and emit header (even if count unchanged)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -324,24 +324,34 @@ async def test_semantic_filter_hook_triggers_on_completion():
         "metadata": {},  # Hook needs metadata field to store filter stats
     }
 
-    # Mock user API key dict and cache
-    mock_user_api_key_dict = Mock()
-    mock_cache = Mock()
+    # Mock registry so "server" prefix is recognized as MCP
+    mock_server = Mock()
+    mock_server.alias = "server"
+    mock_server.server_name = "server"
+    mock_server.server_id = "server-id"
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+    ) as mock_manager:
+        mock_manager.get_registry.return_value = {"server-id": mock_server}
 
-    # Call hook
-    result = await hook.async_pre_call_hook(
-        user_api_key_dict=mock_user_api_key_dict,
-        cache=mock_cache,
-        data=data,
-        call_type="completion",
-    )
+        # Mock user API key dict and cache
+        mock_user_api_key_dict = Mock()
+        mock_cache = Mock()
 
-    # Assertions
-    assert result is not None, "Hook should return modified data"
-    assert "tools" in result, "Result should contain tools"
-    assert len(result["tools"]) < len(tools), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
+        # Call hook
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=mock_user_api_key_dict,
+            cache=mock_cache,
+            data=data,
+            call_type="completion",
+        )
 
-    print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
+        # Assertions
+        assert result is not None, "Hook should return modified data"
+        assert "tools" in result, "Result should contain tools"
+        assert len(result["tools"]) < len(tools), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
+
+        print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
 
 
 
@@ -472,16 +482,25 @@ async def test_hook_falls_back_to_top_k_when_only_mcp_and_zero_matches():
         "metadata": {},
     }
 
-    result = await hook.async_pre_call_hook(
-        user_api_key_dict=Mock(),
-        cache=Mock(),
-        data=data,
-        call_type="completion",
-    )
+    mock_server = Mock()
+    mock_server.alias = "server"
+    mock_server.server_name = "server"
+    mock_server.server_id = "server-id"
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+    ) as mock_manager:
+        mock_manager.get_registry.return_value = {"server-id": mock_server}
 
-    assert result is not None
-    # Should fall back to first top_k (3) MCP tools, not empty
-    assert len(result["tools"]) == 3, f"Expected 3 tools (top_k), got {len(result['tools'])}"
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=Mock(),
+            cache=Mock(),
+            data=data,
+            call_type="completion",
+        )
+
+        assert result is not None
+        # Should fall back to first top_k (3) MCP tools, not empty
+        assert len(result["tools"]) == 3, f"Expected 3 tools (top_k), got {len(result['tools'])}"
 
 
 @pytest.mark.asyncio
@@ -581,22 +600,136 @@ async def test_hook_preserves_non_mcp_tools():
         "metadata": {},
     }
 
-    mock_user_api_key_dict = Mock()
-    mock_cache = Mock()
+    mock_server = Mock()
+    mock_server.alias = "server"
+    mock_server.server_name = "server"
+    mock_server.server_id = "server-id"
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+    ) as mock_manager:
+        mock_manager.get_registry.return_value = {"server-id": mock_server}
 
-    result = await hook.async_pre_call_hook(
-        user_api_key_dict=mock_user_api_key_dict,
-        cache=mock_cache,
-        data=data,
-        call_type="completion",
+        mock_user_api_key_dict = Mock()
+        mock_cache = Mock()
+
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=mock_user_api_key_dict,
+            cache=mock_cache,
+            data=data,
+            call_type="completion",
+        )
+
+        assert result is not None
+        filtered_names = [t.name if hasattr(t, 'name') else t.get('name', '') for t in result["tools"]]
+        # Non-MCP tools should always be present
+        assert "web_search" in filtered_names, f"web_search missing from {filtered_names}"
+        assert "code_interpreter" in filtered_names, f"code_interpreter missing from {filtered_names}"
+        # MCP tools should be filtered (fewer than 10)
+        mcp_count = sum(1 for n in filtered_names if "-" in n)
+        assert mcp_count <= 3, f"Expected at most 3 MCP tools (top_k=3), got {mcp_count}"
+
+
+@pytest.mark.asyncio
+async def test_hook_does_not_filter_hyphenated_non_mcp_tools():
+    """
+    Test that non-MCP tools with hyphens (e.g., text-to-speech) are NOT
+    misclassified as MCP tools when their prefix doesn't match a registered server.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
     )
 
-    assert result is not None
-    filtered_names = [t.name if hasattr(t, 'name') else t.get('name', '') for t in result["tools"]]
-    # Non-MCP tools should always be present
-    assert "web_search" in filtered_names, f"web_search missing from {filtered_names}"
-    assert "code_interpreter" in filtered_names, f"code_interpreter missing from {filtered_names}"
-    # MCP tools should be filtered (fewer than 10)
-    mcp_count = sum(1 for n in filtered_names if "-" in n)
-    assert mcp_count <= 3, f"Expected at most 3 MCP tools (top_k=3), got {mcp_count}"
+    # Mock the semantic router to return no matches
+    filter_instance.tool_router = Mock(return_value=[])
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    # Mock registry with only "weather" as a registered server
+    mock_server = Mock()
+    mock_server.alias = "weather"
+    mock_server.server_name = "weather"
+    mock_server.server_id = "weather-id"
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+    ) as mock_manager:
+        mock_manager.get_registry.return_value = {"weather-id": mock_server}
+
+        tools = [
+            MCPTool(name="weather-get_forecast", description="Get forecast", inputSchema={"type": "object"}),
+            MCPTool(name="text-to-speech", description="Convert text to speech", inputSchema={"type": "object"}),
+            MCPTool(name="code-review", description="Review code", inputSchema={"type": "object"}),
+            MCPTool(name="web_search", description="Search the web", inputSchema={"type": "object"}),
+        ]
+
+        data = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": tools,
+            "metadata": {},
+        }
+
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=Mock(),
+            cache=Mock(),
+            data=data,
+            call_type="completion",
+        )
+
+        assert result is not None
+        filtered_names = [
+            t.name if hasattr(t, "name") else t.get("name", "")
+            for t in result["tools"]
+        ]
+        # Hyphenated non-MCP tools should pass through (not filtered)
+        assert "text-to-speech" in filtered_names, f"text-to-speech should not be filtered: {filtered_names}"
+        assert "code-review" in filtered_names, f"code-review should not be filtered: {filtered_names}"
+        # Non-hyphenated non-MCP tool also passes through
+        assert "web_search" in filtered_names, f"web_search should not be filtered: {filtered_names}"
+
+
+def test_is_mcp_tool_with_registered_prefix():
+    """Test _is_mcp_tool correctly identifies MCP tools by checking against registry."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    # Mock registry
+    mock_server = Mock()
+    mock_server.alias = "weather"
+    mock_server.server_name = "weather"
+    mock_server.server_id = "weather-id"
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+    ) as mock_manager:
+        mock_manager.get_registry.return_value = {"weather-id": mock_server}
+
+        # MCP tool with registered prefix
+        assert hook._is_mcp_tool("weather-get_forecast") is True
+        # Non-MCP tool with hyphen but unregistered prefix
+        assert hook._is_mcp_tool("text-to-speech") is False
+        assert hook._is_mcp_tool("code-review") is False
+        # Non-MCP tool without hyphen
+        assert hook._is_mcp_tool("web_search") is False
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -394,6 +394,47 @@ async def test_semantic_filter_hook_skips_no_tools():
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_hook_skips_non_mcp_only_tools():
+    """
+    Test that the hook returns None when all tools are non-MCP (no prefix).
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "tools": [
+            MCPTool(name="web_search", description="Search the web", inputSchema={"type": "object"}),
+            MCPTool(name="code_interpreter", description="Run code", inputSchema={"type": "object"}),
+        ],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is None, "Hook should skip when no MCP tools are present"
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_zero_matches_returns_empty():
     """
     Test that filter_tools returns an empty list when zero semantic matches are found.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -305,16 +305,16 @@ async def test_semantic_filter_hook_triggers_on_completion():
     
     # Prepare data - completion request with tools
     tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
+        MCPTool(name=f"server-tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
         for i in range(10)
     ]
-    
+
     # Build router with the tools before filtering
     filter_instance._build_router(tools)
-    
+
     # Create hook
     hook = SemanticToolFilterHook(filter_instance)
-    
+
     data = {
         "model": "gpt-4",
         "messages": [
@@ -323,11 +323,11 @@ async def test_semantic_filter_hook_triggers_on_completion():
         "tools": tools,
         "metadata": {},  # Hook needs metadata field to store filter stats
     }
-    
+
     # Mock user API key dict and cache
     mock_user_api_key_dict = Mock()
     mock_cache = Mock()
-    
+
     # Call hook
     result = await hook.async_pre_call_hook(
         user_api_key_dict=mock_user_api_key_dict,
@@ -335,12 +335,12 @@ async def test_semantic_filter_hook_triggers_on_completion():
         data=data,
         call_type="completion",
     )
-    
+
     # Assertions
     assert result is not None, "Hook should return modified data"
     assert "tools" in result, "Result should contain tools"
     assert len(result["tools"]) < len(tools), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
-    
+
     print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
 
 
@@ -394,13 +394,12 @@ async def test_semantic_filter_hook_skips_no_tools():
 
 
 @pytest.mark.asyncio
-async def test_semantic_filter_zero_matches_returns_only_non_mcp_tools():
+async def test_semantic_filter_zero_matches_returns_empty():
     """
-    Test that when zero semantic matches are found, only non-MCP tools are returned.
+    Test that filter_tools returns an empty list when zero semantic matches are found.
 
-    MCP tools have server-name prefixes (e.g., "weather-get_forecast").
-    Non-MCP tools don't (e.g., "web_search"). On zero matches, the filter
-    should drop all MCP tools to avoid exceeding the 128 tool limit.
+    The hook is responsible for adding non-MCP tools back — filter_tools only
+    operates on MCP tools passed to it.
     """
     from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
         SemanticMCPToolFilter,
@@ -418,27 +417,95 @@ async def test_semantic_filter_zero_matches_returns_only_non_mcp_tools():
     # Mock the semantic router to return no matches
     filter_instance.tool_router = Mock(return_value=[])
 
-    # Mix of MCP tools (prefixed) and non-MCP tools (no prefix)
-    available_tools = [
+    mcp_tools = [
         MCPTool(name="weather-get_forecast", description="Get forecast", inputSchema={"type": "object"}),
         MCPTool(name="email-send_email", description="Send email", inputSchema={"type": "object"}),
-        MCPTool(name="docs-read_document", description="Read doc", inputSchema={"type": "object"}),
-        MCPTool(name="web_search", description="Search the web", inputSchema={"type": "object"}),
-        MCPTool(name="code_interpreter", description="Run code", inputSchema={"type": "object"}),
     ]
 
     filtered = await filter_instance.filter_tools(
         query="hello",
-        available_tools=available_tools,
+        available_tools=mcp_tools,
     )
 
-    # Should return only non-MCP tools
-    filtered_names = [t.name for t in filtered]
-    assert "web_search" in filtered_names
-    assert "code_interpreter" in filtered_names
-    assert len(filtered) == 2, f"Expected 2 non-MCP tools, got {len(filtered)}: {filtered_names}"
-    # MCP tools should be excluded
-    assert "weather-get_forecast" not in filtered_names
-    assert "email-send_email" not in filtered_names
-    assert "docs-read_document" not in filtered_names
+    assert len(filtered) == 0, f"Expected empty list on zero matches, got {len(filtered)}"
+
+
+@pytest.mark.asyncio
+async def test_hook_preserves_non_mcp_tools():
+    """
+    Test that the hook passes non-MCP tools through untouched and only
+    filters MCP tools semantically.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    mock_router = Mock()
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10}
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # MCP tools (prefixed) — these get filtered
+    mcp_tools = [
+        MCPTool(name=f"server-tool_{i}", description=f"MCP tool {i}", inputSchema={"type": "object"})
+        for i in range(10)
+    ]
+
+    # Build router with MCP tools
+    filter_instance._build_router(mcp_tools)
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    # Request has both MCP and non-MCP tools
+    all_tools = mcp_tools + [
+        MCPTool(name="web_search", description="Search the web", inputSchema={"type": "object"}),
+        MCPTool(name="code_interpreter", description="Run code", inputSchema={"type": "object"}),
+    ]
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Use MCP tool 1"}],
+        "tools": all_tools,
+        "metadata": {},
+    }
+
+    mock_user_api_key_dict = Mock()
+    mock_cache = Mock()
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key_dict,
+        cache=mock_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is not None
+    filtered_names = [t.name if hasattr(t, 'name') else t.get('name', '') for t in result["tools"]]
+    # Non-MCP tools should always be present
+    assert "web_search" in filtered_names, f"web_search missing from {filtered_names}"
+    assert "code_interpreter" in filtered_names, f"code_interpreter missing from {filtered_names}"
+    # MCP tools should be filtered (fewer than 10)
+    mcp_count = sum(1 for n in filtered_names if "-" in n)
+    assert mcp_count <= 3, f"Expected at most 3 MCP tools (top_k=3), got {mcp_count}"
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -392,3 +392,53 @@ async def test_semantic_filter_hook_skips_no_tools():
     assert result is None, "Hook should skip requests without tools"
     print("✅ Hook correctly skips requests without tools")
 
+
+@pytest.mark.asyncio
+async def test_semantic_filter_zero_matches_returns_only_non_mcp_tools():
+    """
+    Test that when zero semantic matches are found, only non-MCP tools are returned.
+
+    MCP tools have server-name prefixes (e.g., "weather-get_forecast").
+    Non-MCP tools don't (e.g., "web_search"). On zero matches, the filter
+    should drop all MCP tools to avoid exceeding the 128 tool limit.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=5,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # Mock the semantic router to return no matches
+    filter_instance.tool_router = Mock(return_value=[])
+
+    # Mix of MCP tools (prefixed) and non-MCP tools (no prefix)
+    available_tools = [
+        MCPTool(name="weather-get_forecast", description="Get forecast", inputSchema={"type": "object"}),
+        MCPTool(name="email-send_email", description="Send email", inputSchema={"type": "object"}),
+        MCPTool(name="docs-read_document", description="Read doc", inputSchema={"type": "object"}),
+        MCPTool(name="web_search", description="Search the web", inputSchema={"type": "object"}),
+        MCPTool(name="code_interpreter", description="Run code", inputSchema={"type": "object"}),
+    ]
+
+    filtered = await filter_instance.filter_tools(
+        query="hello",
+        available_tools=available_tools,
+    )
+
+    # Should return only non-MCP tools
+    filtered_names = [t.name for t in filtered]
+    assert "web_search" in filtered_names
+    assert "code_interpreter" in filtered_names
+    assert len(filtered) == 2, f"Expected 2 non-MCP tools, got {len(filtered)}: {filtered_names}"
+    # MCP tools should be excluded
+    assert "weather-get_forecast" not in filtered_names
+    assert "email-send_email" not in filtered_names
+    assert "docs-read_document" not in filtered_names
+

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -435,6 +435,56 @@ async def test_semantic_filter_hook_skips_non_mcp_only_tools():
 
 
 @pytest.mark.asyncio
+async def test_hook_falls_back_to_top_k_when_only_mcp_and_zero_matches():
+    """
+    Test that when all tools are MCP and zero semantic matches are found,
+    the hook falls back to the first top_k MCP tools instead of returning empty.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # Mock the semantic router to return no matches
+    filter_instance.tool_router = Mock(return_value=[])
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    # Only MCP tools (all prefixed), no non-MCP tools
+    mcp_only_tools = [
+        MCPTool(name=f"server-tool_{i}", description=f"MCP tool {i}", inputSchema={"type": "object"})
+        for i in range(10)
+    ]
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": mcp_only_tools,
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is not None
+    # Should fall back to first top_k (3) MCP tools, not empty
+    assert len(result["tools"]) == 3, f"Expected 3 tools (top_k), got {len(result['tools'])}"
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_zero_matches_returns_empty():
     """
     Test that filter_tools returns an empty list when zero semantic matches are found.


### PR DESCRIPTION
## Relevant issues

Fixes #25081

> **Note:** This PR is stacked on #24986 (MCP/non-MCP separation). The diff includes those commits until #24986 is merged.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix

## Changes

`is_tool_name_prefixed()` checks `"-" in tool_name`, which misclassifies non-MCP tools with hyphens (e.g., `text-to-speech`, `code-review`) as MCP tools. These tools get sent through the semantic filter and silently dropped.

- Replace `is_tool_name_prefixed()` in the hook with `_is_mcp_tool()` that splits on the first `-` and validates the prefix against known MCP server names from the registry
- Lazy-cache the registered server prefixes (queried once from `global_mcp_server_manager.get_registry()`)
- 2 new tests: hyphenated non-MCP tools pass through, `_is_mcp_tool` unit test
- 3 existing hook tests updated with registry mock
