### PR TITLE
fix: prevent is_tool_name_prefixed from misclassifying hyphenated non-MCP tools

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2389,7 +2389,17 @@ class MCPServerManager:
                     return server
 
         # If not found and tool name is prefixed, try extracting server name from prefix
-        if is_tool_name_prefixed(tool_name):
+        # Build the set of known server names/aliases so that
+        # is_tool_name_prefixed does not misclassify ordinary hyphenated
+        # tool names (e.g. "text-to-speech") as MCP-prefixed.
+        known_server_names: set = set()
+        for server in self.get_registry().values():
+            known_server_names.add(server.name)
+            if hasattr(server, "server_name") and server.server_name:
+                known_server_names.add(server.server_name)
+            if hasattr(server, "alias") and server.alias:
+                known_server_names.add(server.alias)
+        if is_tool_name_prefixed(tool_name, known_server_names=known_server_names):
             (
                 original_tool_name,
                 server_name_from_prefix,

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -1,7 +1,7 @@
 """
 MCP Server Utilities
 """
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Collection, Dict, Mapping, Optional, Tuple
 
 import os
 import importlib
@@ -100,17 +100,44 @@ def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:
     return prefixed_name, ""
 
 
-def is_tool_name_prefixed(tool_name: str) -> bool:
+def is_tool_name_prefixed(
+    tool_name: str,
+    known_server_names: Optional[Collection[str]] = None,
+) -> bool:
     """
-    Check if tool name has server prefix
+    Check if tool name has a known MCP server prefix.
+
+    When *known_server_names* is provided the function verifies that the
+    substring before the first ``MCP_TOOL_PREFIX_SEPARATOR`` matches one of
+    the registered MCP server names (after normalisation).  This prevents
+    false positives for ordinary tool names that happen to contain the
+    separator character (e.g. ``"text-to-speech"``).
+
+    When *known_server_names* is ``None`` the function falls back to the
+    legacy behaviour of simply checking whether the separator is present.
 
     Args:
-        tool_name: Tool name to check
+        tool_name: Tool name to check.
+        known_server_names: Optional collection of registered MCP server
+            names / aliases to validate the prefix against.
 
     Returns:
-        True if tool name is prefixed, False otherwise
+        True if tool name is prefixed with a known server name, False
+        otherwise.
     """
-    return MCP_TOOL_PREFIX_SEPARATOR in tool_name
+    if MCP_TOOL_PREFIX_SEPARATOR not in tool_name:
+        return False
+
+    if known_server_names is None:
+        # Legacy / fallback behaviour
+        return True
+
+    prefix = tool_name.split(MCP_TOOL_PREFIX_SEPARATOR, 1)[0]
+    normalized_prefix = normalize_server_name(prefix)
+    return any(
+        normalize_server_name(name) == normalized_prefix
+        for name in known_server_names
+    )
 
 
 def validate_mcp_server_name(

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1642,6 +1642,28 @@ def test_add_server_prefix_to_name():
     assert result == "-send_email"
 
 
+def test_is_tool_name_prefixed_with_known_servers():
+    """Ensure is_tool_name_prefixed validates against known server names."""
+    from litellm.proxy._experimental.mcp_server.utils import is_tool_name_prefixed
+
+    known = {"zapier_mcp_server", "google_drive"}
+
+    # A properly prefixed MCP tool should be detected
+    assert is_tool_name_prefixed("zapier_mcp_server-send_email", known_server_names=known) is True
+    assert is_tool_name_prefixed("google_drive-list_files", known_server_names=known) is True
+
+    # A non-MCP tool that happens to contain a hyphen must NOT be misclassified
+    assert is_tool_name_prefixed("text-to-speech", known_server_names=known) is False
+    assert is_tool_name_prefixed("my-cool-tool", known_server_names=known) is False
+
+    # Tool with no separator at all
+    assert is_tool_name_prefixed("send_email", known_server_names=known) is False
+
+    # Legacy behaviour: when no known_server_names provided, any hyphen counts
+    assert is_tool_name_prefixed("text-to-speech") is True
+    assert is_tool_name_prefixed("send_email") is False
+
+
 def test_get_server_auth_header_with_alias():
     """Test _get_server_auth_header function with server alias."""
     from litellm.proxy._experimental.mcp_server.rest_endpoints import (


### PR DESCRIPTION
## Summary
- `is_tool_name_prefixed()` previously checked only whether the tool name contained the `MCP_TOOL_PREFIX_SEPARATOR` (`"-"`). Any non-MCP tool whose name included a hyphen (e.g. `"text-to-speech"`) was wrongly classified as MCP-prefixed.
- The fix adds an optional `known_server_names` parameter. When provided, the function validates that the prefix (substring before the first separator) matches a registered MCP server name, eliminating false positives.
- The call site in `MCPServerManager._get_mcp_server_from_tool_name` now builds and passes the set of known server names/aliases from the registry.

Closes #25081

## Test plan
- [x] Added unit test `test_is_tool_name_prefixed_with_known_servers` covering:
  - Properly prefixed MCP tools are correctly identified
  - Hyphenated non-MCP tools (e.g. `"text-to-speech"`) are no longer misclassified
  - Tools with no separator return `False`
  - Legacy behaviour (no `known_server_names`) is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)