### PR TITLE
tag query fix

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -15,6 +15,7 @@ USER root
 # Install build dependencies in one layer
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
+    g++ \
     python3-dev \
     libssl-dev \
     pkg-config \

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1393,6 +1393,10 @@ APSCHEDULER_REPLACE_EXISTING = os.getenv(
     "1",
 ]  # always replace existing jobs
 
+# The number of tag entries are higher than number of user, team entries. This leads to a higher QPS. 
+# This will run tag spcific tasks at a later time to smooth QPS
+DAILY_TAG_SPEND_BATCH_MULTIPLIER = 2.3
+
 DEFAULT_HEALTH_CHECK_INTERVAL = int(
     os.getenv("DEFAULT_HEALTH_CHECK_INTERVAL", 300)
 )  # 5 minutes

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1020,6 +1020,9 @@ class DBSpendUpdateWriter:
             proxy_logging_obj=proxy_logging_obj,
             daily_spend_transactions=daily_agent_spend_update_transactions,
         )
+        
+        ################## Tool Registry Upserts ##################
+        await self._flush_tool_discovery_queue(prisma_client=prisma_client)
 
     async def _commit_daily_tag_spend_to_db(
         self,
@@ -1043,9 +1046,6 @@ class DBSpendUpdateWriter:
                 proxy_logging_obj=proxy_logging_obj,
                 daily_spend_transactions=daily_tag_spend_update_transactions,
             )
-
-        ################## Tool Registry Upserts ##################
-        await self._flush_tool_discovery_queue(prisma_client=prisma_client)
 
     async def _flush_tool_discovery_queue(
         self,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -991,19 +991,7 @@ class DBSpendUpdateWriter:
             daily_spend_transactions=daily_org_spend_update_transactions,
         )
 
-        ################## Daily Tag Spend Update Transactions ##################
-        # Aggregate all in memory daily tag spend transactions and commit to db
-        daily_tag_spend_update_transactions = cast(
-            Dict[str, DailyTagSpendTransaction],
-            await self.daily_tag_spend_update_queue.flush_and_get_aggregated_daily_spend_update_transactions(),
-        )
-
-        await DBSpendUpdateWriter.update_daily_tag_spend(
-            n_retry_times=n_retry_times,
-            prisma_client=prisma_client,
-            proxy_logging_obj=proxy_logging_obj,
-            daily_spend_transactions=daily_tag_spend_update_transactions,
-        )
+        # NOTE: Daily tag spend is committed by a separate scheduler job.
 
         ################## Daily End-User Spend Update Transactions ##################
         # Aggregate all in memory daily end-user spend transactions and commit to db
@@ -1032,6 +1020,29 @@ class DBSpendUpdateWriter:
             proxy_logging_obj=proxy_logging_obj,
             daily_spend_transactions=daily_agent_spend_update_transactions,
         )
+
+    async def _commit_daily_tag_spend_to_db(
+        self,
+        prisma_client: PrismaClient,
+        n_retry_times: int,
+        proxy_logging_obj: ProxyLogging,
+    ):
+        """
+        Commit only tag spend updates to database.
+        This is called by a separate scheduler job at a longer interval.
+        """
+        daily_tag_spend_update_transactions = cast(
+            Dict[str, DailyTagSpendTransaction],
+            await self.daily_tag_spend_update_queue.flush_and_get_aggregated_daily_spend_update_transactions(),
+        )
+
+        if daily_tag_spend_update_transactions:
+            await DBSpendUpdateWriter.update_daily_tag_spend(
+                n_retry_times=n_retry_times,
+                prisma_client=prisma_client,
+                proxy_logging_obj=proxy_logging_obj,
+                daily_spend_transactions=daily_tag_spend_update_transactions,
+            )
 
         ################## Tool Registry Upserts ##################
         await self._flush_tool_discovery_queue(prisma_client=prisma_client)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -54,6 +54,7 @@ from litellm.constants import (
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
     LITELLM_UI_ALLOW_HEADERS,
     LITELLM_UI_SESSION_DURATION,
+    DAILY_TAG_SPEND_BATCH_MULTIPLIER
 )
 from litellm.litellm_core_utils.litellm_logging import (
     _init_custom_logger_compatible_class,
@@ -508,6 +509,7 @@ from litellm.proxy.utils import (
     migrate_passwords_to_scrypt_async,
     model_dump_with_preserved_fields,
     update_spend,
+    update_daily_tag_spend,
 )
 from litellm.proxy.vector_store_endpoints.endpoints import router as vector_store_router
 from litellm.proxy.vector_store_endpoints.management_endpoints import (
@@ -6208,6 +6210,23 @@ class ProxyStartupEvent:
             id="update_spend_job",
             replace_existing=True,
             misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
+        )
+
+        ### UPDATE DAILY TAG SPEND (separate scheduler job with longer interval) ###
+        ## Reduces QPS as there are more tags for a single request
+        tag_spend_update_interval = int(batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER)
+        scheduler.add_job(
+            update_daily_tag_spend,
+            "interval",
+            seconds=tag_spend_update_interval,
+            args=[prisma_client, proxy_logging_obj],
+            id="update_daily_tag_spend_job",
+            replace_existing=True,
+            misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
+        )
+        verbose_proxy_logger.info(
+            f"Tag spend update job scheduled at {tag_spend_update_interval}s interval "
+            f"({tag_spend_update_interval / batch_writing_interval:.1f}x main job interval)"
         )
 
         ### MONITOR SPEND LOGS QUEUE (queue-size-based job) ###

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4827,6 +4827,9 @@ async def update_spend(  # noqa: PLR0915
 
     Triggered every minute.
 
+    NOTE: This job now skips tag spend updates, which are handled by a separate
+    scheduler job (update_daily_tag_spend) at a longer interval to reduce contention.
+
     Requires:
     user_id_list: dict,
     keys_list: list,
@@ -4857,6 +4860,39 @@ async def update_spend(  # noqa: PLR0915
             db_writer_client=db_writer_client,
             proxy_logging_obj=proxy_logging_obj,
         )
+
+
+async def update_daily_tag_spend(
+    prisma_client: PrismaClient,
+    proxy_logging_obj: ProxyLogging,
+):
+    """
+    Separate scheduler job to commit daily tag spend updates.
+    
+    Runs at a longer interval (2x default) than the main update_spend job
+    to reduce query contention for DailyTagSpend table.
+    
+    This is called by a dedicated scheduler job and does NOT process:
+    - Regular spend updates (user, key, team, org)
+    - End-user spend
+    - Agent spend
+    - Spend logs
+    
+    Only processes tag spend transactions from the daily_tag_spend_update_queue.
+    
+    Args:
+        prisma_client: PrismaClient instance
+        proxy_logging_obj: ProxyLogging instance for error handling
+    """
+    n_retry_times = 3
+    try:
+        await proxy_logging_obj.db_spend_update_writer._commit_daily_tag_spend_to_db(
+            prisma_client=prisma_client,
+            n_retry_times=n_retry_times,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+    except Exception as e:
+        verbose_proxy_logger.error(f"Error updating daily tag spend: {e}")
 
 
 async def update_spend_logs_job(

--- a/tests/proxy_unit_tests/test_update_daily_tag_spend.py
+++ b/tests/proxy_unit_tests/test_update_daily_tag_spend.py
@@ -1,0 +1,95 @@
+from typing import Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.proxy.utils import update_daily_tag_spend
+from litellm.proxy._types import DailyTagSpendTransaction
+import httpx
+from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
+
+@pytest.mark.asyncio
+async def test_update_daily_tag_spend_delegates_to_tag_commit_writer():
+    prisma_client = MagicMock()
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.db_spend_update_writer = MagicMock()
+    proxy_logging_obj.db_spend_update_writer._commit_daily_tag_spend_to_db = AsyncMock()
+
+    await update_daily_tag_spend(prisma_client, proxy_logging_obj)
+
+    proxy_logging_obj.db_spend_update_writer._commit_daily_tag_spend_to_db.assert_awaited_once_with(
+        prisma_client=prisma_client,
+        n_retry_times=3,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+@pytest.mark.asyncio
+async def test_update_daily_tag_spend_logs_error_and_does_not_raise():
+    prisma_client = MagicMock()
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.db_spend_update_writer = MagicMock()
+    proxy_logging_obj.db_spend_update_writer._commit_daily_tag_spend_to_db = AsyncMock(
+        side_effect=ValueError("boom")
+    )
+
+    with patch("litellm.proxy.utils.verbose_proxy_logger.error") as error_logger:
+        await update_daily_tag_spend(prisma_client, proxy_logging_obj)
+
+    proxy_logging_obj.db_spend_update_writer._commit_daily_tag_spend_to_db.assert_awaited_once()
+    error_logger.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_daily_tag_spend_retries_then_succeeds():
+    prisma_client = MagicMock()
+    proxy_logging_obj = MagicMock()
+
+    mock_batcher = MagicMock()
+    mock_table = MagicMock()
+    mock_batcher.litellm_dailytagspend = mock_table
+
+    # Fail entering batch context 3 times with retryable DB errors, then succeed.
+    prisma_client.db.batch_.return_value.__aenter__ = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("x"),
+            httpx.ConnectError("x"),
+            httpx.ConnectError("x"),
+            mock_batcher,
+        ]
+    )
+
+    daily_spend_transactions: Dict[str, DailyTagSpendTransaction] = {
+        "k": {
+            "tag": "prod-tag",
+            "date": "2026-04-03",
+            "api_key": "key-1",
+            "model": "gpt-4o",
+            "model_group": None,
+            "custom_llm_provider": "openai",
+            "mcp_namespaced_tool_name": "",
+            "endpoint": "",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "spend": 0.01,
+            "api_requests": 1,
+            "successful_requests": 1,
+            "failed_requests": 0,
+            "request_id": None,
+        }
+    }
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock, patch(
+        "random.uniform", return_value=0
+    ):
+        await DBSpendUpdateWriter.update_daily_tag_spend(
+            n_retry_times=3,
+            prisma_client=prisma_client,
+            proxy_logging_obj=proxy_logging_obj,
+            daily_spend_transactions=daily_spend_transactions,
+        )
+
+    assert prisma_client.db.batch_.return_value.__aenter__.await_count == 4
+    assert sleep_mock.await_count == 3
+    mock_table.upsert.assert_called_once()


### PR DESCRIPTION
## Relevant issues

Improves DailyTagSpend write fanout/QPS imbalance by decoupling tag spend flushes from the main spend scheduler and running tag commits at a longer interval.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [tests/test_litellm/](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting @greptileai and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link: _TBD_

- [ ] **CI run for the last commit**  
       Link: _TBD_

- [ ] **Merge / cherry-pick CI run**  
       Links: _TBD_

## Type

🐛 Bug Fix  
🧹 Refactoring  
🚄 Infrastructure  
✅ Test

## Changes

- Split DailyTagSpend flushes into a separate scheduler job instead of running through the main update_spend flow.
- Configured tag spend job interval to run at a longer cadence using DAILY_TAG_SPEND_BATCH_MULTIPLIER, reducing tag-write burst pressure.
- Kept request-path enqueue behavior unchanged, so tag spend data still accumulates per request and is eventually flushed.
- Added and updated tests for:
  - update_daily_tag_spend delegation behavior
  - non-raising/logging behavior on tag flush errors
  - retry-path behavior for tag spend DB writes in the DB writer layer
- Observed improvement target: DailyTagSpend call rate now tracks closer to DailyTeamSpend, improving QPS parity and reducing tag table overrepresentation.
- Docker dev Build for the latest version was failing due to a broken dependency to g++. 

The fix reduces the QPS. The below numbers show the most run queries tracked by postgres in a duration of 4-5 minutes under a simulated load test. The validation here is the ratio of database calls between the `DailyTagSpend` and `DailyTeamSpend` must nearly 1, which means the same number of QPS is achieved by queries to these tables.

**Before Fix**

```
litellm=# select
  calls,
  left(query, 50) as query_prefix
from pg_stat_statements
where query ilike 'insert%'
order by calls desc
limit 5;
 calls |                    query_prefix                    
-------+----------------------------------------------------
    52 | INSERT INTO "public"."LiteLLM_DailyTagSpend" ("id"
    25 | INSERT INTO "public"."LiteLLM_DailyTeamSpend" ("id
    25 | INSERT INTO "public"."LiteLLM_DailyUserSpend" ("id
     1 | INSERT INTO "public"."LiteLLM_SpendLogs" ("model_i
     1 | INSERT INTO "public"."LiteLLM_SpendLogs" ("call_ty
(5 rows)
```

**With Adjusted Batch Interval Fix**
```
litellm=# select
  calls,
  left(query, 50) as query_prefix
from pg_stat_statements
where query ilike 'insert%'
order by calls desc
limit 5;
 calls |                    query_prefix                    
-------+----------------------------------------------------
    53 | INSERT INTO "public"."LiteLLM_DailyUserSpend" ("id
    53 | INSERT INTO "public"."LiteLLM_DailyTeamSpend" ("id
    52 | INSERT INTO "public"."LiteLLM_DailyTagSpend" ("id"
     1 | INSERT INTO "public"."LiteLLM_SpendLogs" ("respons
     1 | INSERT INTO "public"."LiteLLM_SpendLogs" ("mcp_nam
(5 rows)
```