### PR TITLE
fix(ui): allow changing team organization from team settings

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -491,7 +491,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           ...(secretManagerSettings !== undefined ? { secret_manager_settings: secretManagerSettings } : {}),
         },
         ...(values.policies?.length > 0 ? { policies: values.policies } : {}),
-        organization_id: values.organization_id,
+        organization_id: values.organization_id ?? "",
       };
 
       updateData.max_budget = mapEmptyStringToNull(updateData.max_budget);
@@ -1077,8 +1077,17 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       />
                     </Form.Item>
 
-                    <Form.Item label="Organization ID" name="organization_id">
-                      <Input type="" disabled />
+                    <Form.Item label="Organization" name="organization_id">
+                      <Select
+                        allowClear
+                        placeholder="Select an organization"
+                        showSearch
+                        optionFilterProp="label"
+                        options={userOrganizations.map((org) => ({
+                          value: org.organization_id,
+                          label: org.organization_alias || org.organization_id,
+                        }))}
+                      />
                     </Form.Item>
 
                     <Form.Item label="Logging Settings" name="logging_settings">

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -491,7 +491,9 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           ...(secretManagerSettings !== undefined ? { secret_manager_settings: secretManagerSettings } : {}),
         },
         ...(values.policies?.length > 0 ? { policies: values.policies } : {}),
-        organization_id: values.organization_id ?? "",
+        ...(values.organization_id !== info.organization_id
+          ? { organization_id: values.organization_id ?? "" }
+          : {}),
       };
 
       updateData.max_budget = mapEmptyStringToNull(updateData.max_budget);


### PR DESCRIPTION
## Summary
- Replace the disabled read-only Organization ID input on the Team Settings page with a searchable Select dropdown populated from the organizations list
- Admins (proxy, team, org) can now assign, reassign, or unassign a team's organization directly from the UI
- Clearing the dropdown sends an empty string to the backend, which correctly unsets the organization_id

## Screenshots
<img width="1314" height="830" alt="Screenshot 2026-04-03 at 11 59 51 AM" src="https://github.com/user-attachments/assets/381745ee-2cc8-4755-a21d-345b346fd411" />

## Test plan
- [x] As a proxy admin, open a team's Settings tab and verify the Organization dropdown appears
- [x] Select an organization and save — verify the team is now associated with that org
- [x] Clear the organization and save — verify the team is unassigned from the org
- [x] Re-save without changes — verify no errors (idempotent)
- [x] As a team admin, verify the dropdown is editable in the settings tab