### PR TITLE
feat(responses): add universal server-side context compaction

### DIFF
--- a/litellm/responses/compaction.py
+++ b/litellm/responses/compaction.py
@@ -1,0 +1,124 @@
+"""
+Universal server-side context compaction for the Responses API.
+
+Summarizes conversation history when input tokens exceed a configured threshold,
+using the same model the caller is already using. Works across all providers.
+"""
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import litellm
+from litellm._logging import verbose_logger
+
+SUMMARIZATION_SYSTEM_PROMPT = (
+    "You have written a partial transcript for the initial task above. "
+    "Please write a summary of the transcript. The purpose of this summary is "
+    "to provide continuity so you can continue to make progress towards solving "
+    "the task in a future context, where the raw history above may not be "
+    "accessible and will be replaced with this summary. Write down anything "
+    "that would be helpful, including the state, next steps, learnings etc. "
+    "You must wrap your summary in a <summary></summary> block."
+)
+
+MIN_COMPACT_THRESHOLD = 1000
+
+
+def _get_compact_threshold(context_management: List[Dict[str, Any]]) -> Optional[int]:
+    """Extract the compact_threshold from a context_management list, if present."""
+    for entry in context_management:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") == "compaction":
+            threshold = entry.get("compact_threshold")
+            if threshold is not None:
+                return max(int(threshold), MIN_COMPACT_THRESHOLD)
+            return None
+    return None
+
+
+def _extract_summary(text: str) -> str:
+    """Pull content out of <summary>...</summary> tags, falling back to the full text."""
+    match = re.search(r"<summary>(.*?)</summary>", text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _serialize_messages_for_summary(messages: List[Dict[str, Any]]) -> str:
+    """Render a message list into a readable transcript for the summarizer."""
+    parts: List[str] = []
+    for msg in messages:
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            text_parts = []
+            for block in content:
+                if isinstance(block, dict):
+                    text_parts.append(block.get("text", str(block)))
+                else:
+                    text_parts.append(str(block))
+            content = "\n".join(text_parts)
+        parts.append(f"[{role}]: {content}")
+    return "\n\n".join(parts)
+
+
+async def maybe_compact_context(
+    messages: List[Dict[str, Any]],
+    model: str,
+    context_management: List[Dict[str, Any]],
+    custom_llm_provider: Optional[str] = None,
+) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """
+    Check whether compaction should trigger and, if so, summarize ALL messages.
+
+    Returns:
+        (messages, summary_text):
+        - If compaction triggered: messages is [{role: "user", content: summary}],
+          summary_text is the raw summary string.
+        - If not triggered: messages is unchanged, summary_text is None.
+    """
+    threshold = _get_compact_threshold(context_management)
+    if threshold is None:
+        return messages, None
+
+    token_count = litellm.token_counter(model=model, messages=messages)
+    verbose_logger.debug(
+        "compaction: token_count=%d, threshold=%d", token_count, threshold
+    )
+
+    if token_count <= threshold:
+        return messages, None
+
+    verbose_logger.info(
+        "compaction: triggering summarization (tokens=%d > threshold=%d)",
+        token_count,
+        threshold,
+    )
+
+    transcript = _serialize_messages_for_summary(messages)
+
+    summarization_messages: List[Dict[str, Any]] = [
+        {"role": "user", "content": transcript},
+        {"role": "user", "content": SUMMARIZATION_SYSTEM_PROMPT},
+    ]
+
+    acompletion_kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": summarization_messages,
+    }
+    if custom_llm_provider is not None:
+        acompletion_kwargs["custom_llm_provider"] = custom_llm_provider
+
+    summary_response = await litellm.acompletion(**acompletion_kwargs)
+
+    summary_text_raw = summary_response.choices[0].message.content or ""
+    summary_text = _extract_summary(summary_text_raw)
+
+    verbose_logger.debug("compaction: summary length=%d chars", len(summary_text))
+
+    compacted_messages: List[Dict[str, Any]] = [
+        {"role": "user", "content": summary_text},
+    ]
+
+    return compacted_messages, summary_text

--- a/litellm/responses/compaction.py
+++ b/litellm/responses/compaction.py
@@ -99,8 +99,8 @@ async def maybe_compact_context(
     transcript = _serialize_messages_for_summary(messages)
 
     summarization_messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": SUMMARIZATION_SYSTEM_PROMPT},
         {"role": "user", "content": transcript},
-        {"role": "user", "content": SUMMARIZATION_SYSTEM_PROMPT},
     ]
 
     acompletion_kwargs: Dict[str, Any] = {

--- a/litellm/responses/compaction.py
+++ b/litellm/responses/compaction.py
@@ -127,7 +127,7 @@ async def maybe_compact_context(
     if custom_llm_provider is not None:
         acompletion_kwargs["custom_llm_provider"] = custom_llm_provider
     if litellm_metadata is not None:
-        acompletion_kwargs["metadata"] = litellm_metadata
+        acompletion_kwargs["metadata"] = {**litellm_metadata}
 
     summary_response = await litellm.acompletion(**acompletion_kwargs)
 

--- a/litellm/responses/compaction.py
+++ b/litellm/responses/compaction.py
@@ -33,6 +33,10 @@ def _get_compact_threshold(context_management: List[Dict[str, Any]]) -> Optional
             threshold = entry.get("compact_threshold")
             if threshold is not None:
                 return max(int(threshold), MIN_COMPACT_THRESHOLD)
+            verbose_logger.warning(
+                "compaction: context_management has type='compaction' but no "
+                "compact_threshold — compaction will not trigger"
+            )
             return None
     return None
 

--- a/litellm/responses/compaction.py
+++ b/litellm/responses/compaction.py
@@ -5,6 +5,7 @@ Summarizes conversation history when input tokens exceed a configured threshold,
 using the same model the caller is already using. Works across all providers.
 """
 
+import copy
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -127,7 +128,7 @@ async def maybe_compact_context(
     if custom_llm_provider is not None:
         acompletion_kwargs["custom_llm_provider"] = custom_llm_provider
     if litellm_metadata is not None:
-        acompletion_kwargs["metadata"] = {**litellm_metadata}
+        acompletion_kwargs["metadata"] = copy.deepcopy(litellm_metadata)
 
     summary_response = await litellm.acompletion(**acompletion_kwargs)
 

--- a/litellm/responses/compaction.py
+++ b/litellm/responses/compaction.py
@@ -12,14 +12,22 @@ import litellm
 from litellm._logging import verbose_logger
 
 SUMMARIZATION_SYSTEM_PROMPT = (
-    "You have written a partial transcript for the initial task above. "
-    "Please write a summary of the transcript. The purpose of this summary is "
-    "to provide continuity so you can continue to make progress towards solving "
-    "the task in a future context, where the raw history above may not be "
-    "accessible and will be replaced with this summary. Write down anything "
-    "that would be helpful, including the state, next steps, learnings etc. "
-    "You must wrap your summary in a <summary></summary> block."
+    "You are a conversation summarizer. The user will provide a transcript of a "
+    "conversation between a user and an assistant. Produce a concise summary that "
+    "captures: (1) what the user asked or talked about, (2) what the assistant "
+    "replied, and (3) any decisions, conclusions, or pending questions. "
+    "Write the summary in plain prose, in the third person (e.g. 'The user asked "
+    "about X. The assistant explained Y.'). Do NOT use XML tags, markdown headers, "
+    "or any special formatting. "
+    "Act like a compression algorithm: use as few words as possible while preserving "
+    "all important information. For simple or repetitive conversations, a few "
+    "sentences may suffice. For complex conversations involving multiple disparate "
+    "tasks, detailed technical decisions, or extensive context, you may use more "
+    "detail. The absolute maximum is 5000 words, but most summaries should be "
+    "significantly shorter than that."
 )
+
+MAX_SUMMARY_TOKENS = 4096
 
 MIN_COMPACT_THRESHOLD = 1000
 
@@ -42,7 +50,7 @@ def _get_compact_threshold(context_management: List[Dict[str, Any]]) -> Optional
 
 
 def _extract_summary(text: str) -> str:
-    """Pull content out of <summary>...</summary> tags, falling back to the full text."""
+    """Extract the summary, stripping any XML-style tags the model may have added."""
     match = re.search(r"<summary>(.*?)</summary>", text, re.DOTALL)
     if match:
         return match.group(1).strip()
@@ -72,6 +80,7 @@ async def maybe_compact_context(
     model: str,
     context_management: List[Dict[str, Any]],
     custom_llm_provider: Optional[str] = None,
+    litellm_metadata: Optional[Dict[str, Any]] = None,
 ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
     """
     Check whether compaction should trigger and, if so, summarize ALL messages.
@@ -86,9 +95,12 @@ async def maybe_compact_context(
     if threshold is None:
         return messages, None
 
-    token_count = litellm.token_counter(model=model, messages=messages)
+    char_count = sum(
+        len(str(msg.get("content", ""))) for msg in messages
+    )
+    token_count = char_count // 4
     verbose_logger.debug(
-        "compaction: token_count=%d, threshold=%d", token_count, threshold
+        "compaction: estimated token_count=%d, threshold=%d", token_count, threshold
     )
 
     if token_count <= threshold:
@@ -110,9 +122,12 @@ async def maybe_compact_context(
     acompletion_kwargs: Dict[str, Any] = {
         "model": model,
         "messages": summarization_messages,
+        "max_tokens": MAX_SUMMARY_TOKENS,
     }
     if custom_llm_provider is not None:
         acompletion_kwargs["custom_llm_provider"] = custom_llm_provider
+    if litellm_metadata is not None:
+        acompletion_kwargs["metadata"] = litellm_metadata
 
     summary_response = await litellm.acompletion(**acompletion_kwargs)
 

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -2,6 +2,8 @@
 Handler for transforming responses api requests to litellm.completion requests
 """
 
+import base64
+import uuid
 from typing import Any, Coroutine, Dict, List, Optional, Union
 
 import litellm
@@ -135,7 +137,7 @@ class LiteLLMCompletionTransformationHandler:
             )
 
             if summary_text is not None:
-                responses_api_response.output = _prepend_compaction_output(
+                responses_api_response.output = _append_compaction_output(
                     summary_text, responses_api_response.output
                 )
 
@@ -157,12 +159,17 @@ class LiteLLMCompletionTransformationHandler:
         )
 
 
-def _prepend_compaction_output(
+def _append_compaction_output(
     summary_text: str, existing_output: List[Any]
 ) -> List[Any]:
-    """Prepend a compaction output item before the existing output items."""
+    """Append a compaction output item after the first output item."""
+    encoded_content = base64.b64encode(summary_text.encode("utf-8")).decode("utf-8")
     compaction_item = {
         "type": "compaction",
-        "content": summary_text,
+        "id": "cmp_" + uuid.uuid4().hex,
+        "encrypted_content": encoded_content,
+        "created_by": None,
     }
-    return [compaction_item] + list(existing_output)
+    if existing_output:
+        return [existing_output[0], compaction_item] + list(existing_output[1:])
+    return [compaction_item]

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -2,9 +2,10 @@
 Handler for transforming responses api requests to litellm.completion requests
 """
 
-from typing import Any, Coroutine, Dict, Optional, Union
+from typing import Any, Coroutine, Dict, List, Optional, Union
 
 import litellm
+from litellm.responses.compaction import maybe_compact_context
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )
@@ -109,6 +110,17 @@ class LiteLLMCompletionTransformationHandler:
         acompletion_args.update(kwargs)
         acompletion_args.update(litellm_completion_request)
 
+        context_management = acompletion_args.pop("context_management", None)
+        summary_text: Optional[str] = None
+        if context_management:
+            compacted_messages, summary_text = await maybe_compact_context(
+                messages=acompletion_args["messages"],
+                model=acompletion_args["model"],
+                context_management=context_management,
+                custom_llm_provider=acompletion_args.get("custom_llm_provider"),
+            )
+            acompletion_args["messages"] = compacted_messages
+
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
         ] = await litellm.acompletion(
@@ -121,6 +133,11 @@ class LiteLLMCompletionTransformationHandler:
                 request_input=request_input,
                 responses_api_request=responses_api_request,
             )
+
+            if summary_text is not None:
+                responses_api_response.output = _prepend_compaction_output(
+                    summary_text, responses_api_response.output
+                )
 
             return responses_api_response
 
@@ -138,3 +155,14 @@ class LiteLLMCompletionTransformationHandler:
         raise ValueError(
             f"Unexpected response type: {type(litellm_completion_response)}"
         )
+
+
+def _prepend_compaction_output(
+    summary_text: str, existing_output: List[Any]
+) -> List[Any]:
+    """Prepend a compaction output item before the existing output items."""
+    compaction_item = {
+        "type": "compaction",
+        "content": summary_text,
+    }
+    return [compaction_item] + list(existing_output)

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -169,7 +169,6 @@ def _append_compaction_output(
         "type": "compaction",
         "id": "cmp_" + uuid.uuid4().hex,
         "encrypted_content": encoded_content,
-        "created_by": None,
     }
     if existing_output:
         return [existing_output[0], compaction_item] + list(existing_output[1:])

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -108,10 +108,7 @@ class LiteLLMCompletionTransformationHandler:
                 litellm_completion_request=litellm_completion_request,
             )
 
-        acompletion_args = {}
-        acompletion_args.update(kwargs)
-        acompletion_args.update(litellm_completion_request)
-
+        acompletion_args = {**kwargs, **litellm_completion_request}
         context_management = acompletion_args.pop("context_management", None)
         summary_text: Optional[str] = None
         if context_management:

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -120,6 +120,7 @@ class LiteLLMCompletionTransformationHandler:
                 model=acompletion_args["model"],
                 context_management=context_management,
                 custom_llm_provider=acompletion_args.get("custom_llm_provider"),
+                litellm_metadata=kwargs.get("litellm_metadata"),
             )
             acompletion_args["messages"] = compacted_messages
 

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -62,12 +62,12 @@ class LiteLLMCompletionTransformationHandler:
         completion_args = {}
         completion_args.update(kwargs)
         completion_args.update(litellm_completion_request)
+        completion_args.pop("context_management", None)
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
         ] = litellm.completion(
-            **litellm_completion_request,
-            **kwargs,
+            **completion_args,
         )
 
         if isinstance(litellm_completion_response, ModelResponse):
@@ -153,6 +153,7 @@ class LiteLLMCompletionTransformationHandler:
                     "custom_llm_provider"
                 ),
                 litellm_metadata=kwargs.get("litellm_metadata", {}),
+                compaction_summary_text=summary_text,
             )
         raise ValueError(
             f"Unexpected response type: {type(litellm_completion_response)}"

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -57,8 +57,10 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         responses_api_request: ResponsesAPIOptionalRequestParams,
         custom_llm_provider: Optional[str] = None,
         litellm_metadata: Optional[dict] = None,
+        compaction_summary_text: Optional[str] = None,
     ):
         self.model: str = model
+        self.compaction_summary_text: Optional[str] = compaction_summary_text
         self.litellm_custom_stream_wrapper: litellm.CustomStreamWrapper = (
             litellm_custom_stream_wrapper
         )
@@ -1175,6 +1177,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 chat_completion_response=litellm_model_response,
                 responses_api_request=self.responses_api_request,
             )
+
+            # Append compaction output item if compaction was triggered
+            if self.compaction_summary_text is not None:
+                from litellm.responses.litellm_completion_transformation.handler import (
+                    _append_compaction_output,
+                )
+
+                responses_api_response.output = _append_compaction_output(
+                    self.compaction_summary_text,
+                    responses_api_response.output,
+                )
 
             # Use the cached response ID to ensure consistency across all events
             if self._cached_response_id:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -376,6 +376,16 @@ class LiteLLMCompletionResponsesConfig:
         elif isinstance(input, list):
             existing_tool_call_ids: Set[str] = set()
             for _input in input:
+                if isinstance(_input, dict) and _input.get("type") == "compaction":
+                    messages.clear()
+                    compaction_content = _input.get("content", "")
+                    messages.append(
+                        ChatCompletionSystemMessage(
+                            role="system", content=compaction_content
+                        )
+                    )
+                    continue
+
                 chat_completion_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
                     input_item=_input
                 )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -390,8 +390,13 @@ class LiteLLMCompletionResponsesConfig:
                 else:
                     decoded_content = compaction_item.get("content", "")
                 messages.append(
-                    ChatCompletionUserMessage(
-                        role="user", content=decoded_content
+                    ChatCompletionSystemMessage(
+                        role="system",
+                        content=(
+                            "The following is a summary of the prior conversation history, "
+                            "which was compacted to save context space. Treat this as established "
+                            "context, not as a new user message:\n\n" + decoded_content
+                        ),
                     )
                 )
                 if last_compaction_idx > 0:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2,6 +2,7 @@
 Handles transforming from Responses API -> LiteLLM completion  (Chat Completion API)
 """
 
+import base64
 from collections.abc import Sequence
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union, cast
 
@@ -374,18 +375,35 @@ class LiteLLMCompletionResponsesConfig:
         if isinstance(input, str):
             messages.append(ChatCompletionUserMessage(role="user", content=input))
         elif isinstance(input, list):
+            last_compaction_idx: Optional[int] = None
+            for idx, _inp in enumerate(input):
+                if isinstance(_inp, dict) and _inp.get("type") == "compaction":
+                    last_compaction_idx = idx
+
+            if last_compaction_idx is not None:
+                compaction_item = input[last_compaction_idx]
+                encrypted = compaction_item.get("encrypted_content", "")
+                if encrypted:
+                    decoded_content = base64.b64decode(
+                        encrypted.encode("utf-8")
+                    ).decode("utf-8")
+                else:
+                    decoded_content = compaction_item.get("content", "")
+                messages.append(
+                    ChatCompletionUserMessage(
+                        role="user", content=decoded_content
+                    )
+                )
+                if last_compaction_idx > 0:
+                    pre_item = input[last_compaction_idx - 1]
+                    pre_msgs = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+                        input_item=pre_item
+                    )
+                    messages.extend(pre_msgs)
+                input = list(input[last_compaction_idx + 1:])
+
             existing_tool_call_ids: Set[str] = set()
             for _input in input:
-                if isinstance(_input, dict) and _input.get("type") == "compaction":
-                    messages.clear()
-                    compaction_content = _input.get("content", "")
-                    messages.append(
-                        ChatCompletionSystemMessage(
-                            role="system", content=compaction_content
-                        )
-                    )
-                    continue
-
                 chat_completion_messages = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
                     input_item=_input
                 )

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -919,7 +919,16 @@ def responses(
                 **emulated_kwargs,
             )
 
-        if responses_api_provider_config is None:
+        # If the user enables compaction context_management, always use our compaction handler, never the provider's native compaction
+        _has_compaction = False
+        _ctx_mgmt = response_api_optional_params.get("context_management")
+        if _ctx_mgmt and isinstance(_ctx_mgmt, list):
+            _has_compaction = any(
+                isinstance(e, dict) and e.get("type") == "compaction"
+                for e in _ctx_mgmt
+            )
+
+        if responses_api_provider_config is None or _has_compaction:
             return litellm_completion_transformation_handler.response_api_handler(
                 model=model,
                 input=input,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -919,16 +919,16 @@ def responses(
                 **emulated_kwargs,
             )
 
-        # If the user enables compaction context_management, always use our compaction handler, never the provider's native compaction
-        _has_compaction = False
+        _override_native_compaction = False
         _ctx_mgmt = response_api_optional_params.get("context_management")
         if _ctx_mgmt and isinstance(_ctx_mgmt, list):
-            _has_compaction = any(
-                isinstance(e, dict) and e.get("type") == "compaction"
-                for e in _ctx_mgmt
-            )
+            for e in _ctx_mgmt:
+                if isinstance(e, dict) and e.get("type") == "compaction":
+                    if e.get("override_native_compaction", False):
+                        _override_native_compaction = True
+                    break
 
-        if responses_api_provider_config is None or _has_compaction:
+        if responses_api_provider_config is None or _override_native_compaction:
             return litellm_completion_transformation_handler.response_api_handler(
                 model=model,
                 input=input,

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -249,6 +249,121 @@ async def test_gemini_3_responses_api_streaming_with_thought_signatures():
     print(f"✅ Collected {len(chunks)} streaming chunks")
 
 
+@pytest.mark.asyncio
+async def test_mock_google_ai_studio_compaction():
+    """
+    Test that universal compaction works for Google AI Studio via the Responses API.
+
+    Sends a very large input ("cats " * 100_000) with a low compact_threshold (50_000).
+    Mocks litellm.acompletion so no real API call is made:
+      - 1st call: summarization (triggered by compaction)
+      - 2nd call: the actual completion using ONLY the summary
+    Validates the response output has a compaction item followed by a text item.
+    """
+    request_model = "gemini/gemini-2.5-flash"
+    large_input = "cats " * 100_000
+
+    summary_response = litellm.ModelResponse(
+        id="summary-id",
+        created=1000000000,
+        model=request_model,
+        object="chat.completion",
+        choices=[
+            litellm.utils.Choices(
+                index=0,
+                message=litellm.utils.Message(
+                    role="assistant",
+                    content="<summary>The user repeated the word cats many times.</summary>",
+                ),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+    final_response = litellm.ModelResponse(
+        id="final-id",
+        created=1000000001,
+        model=request_model,
+        object="chat.completion",
+        choices=[
+            litellm.utils.Choices(
+                index=0,
+                message=litellm.utils.Message(
+                    role="assistant",
+                    content="Based on the summary, you were talking about cats.",
+                ),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+    call_count = 0
+
+    async def mock_acompletion(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return summary_response
+        return final_response
+
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_ac:
+        mock_ac.side_effect = mock_acompletion
+
+        response = await litellm.aresponses(
+            model=request_model,
+            input=large_input,
+            context_management=[
+                {"type": "compaction", "compact_threshold": 50000}
+            ],
+        )
+
+        assert call_count == 2, f"Expected 2 acompletion calls, got {call_count}"
+
+        # 1st call: summarization — messages should contain the large input
+        first_call_kwargs = mock_ac.call_args_list[0][1]
+        first_msgs = first_call_kwargs.get("messages", [])
+        assert any(
+            "cats" in str(m.get("content", "")) for m in first_msgs
+        ), "Summarization call should contain the original input"
+
+        # 2nd call: actual completion — messages should contain ONLY the summary
+        second_call_kwargs = mock_ac.call_args_list[1][1]
+        second_msgs = second_call_kwargs.get("messages", [])
+        assert len(second_msgs) == 1, (
+            f"After compaction, completion should receive exactly 1 message (the summary), "
+            f"got {len(second_msgs)}"
+        )
+        assert "cats many times" in str(second_msgs[0].get("content", "")), (
+            "Completion call should see the extracted summary, not the original input"
+        )
+
+        # Validate response structure
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        assert isinstance(response, ResponsesAPIResponse)
+        assert len(response.output) >= 2, (
+            f"Response output should have at least 2 items (compaction + text), "
+            f"got {len(response.output)}"
+        )
+
+        # First output item should be the compaction block
+        compaction_item = response.output[0]
+        if isinstance(compaction_item, dict):
+            assert compaction_item["type"] == "compaction"
+            assert "cats many times" in compaction_item["content"]
+        else:
+            assert getattr(compaction_item, "type", None) == "compaction"
+
+        # Second output item should be the text response
+        text_item = response.output[1]
+        if isinstance(text_item, dict):
+            assert text_item.get("type") == "message"
+        else:
+            assert getattr(text_item, "type", None) == "message"
+
+        print("compaction test passed: response output =", json.dumps(response.output, indent=2, default=str))
+
+
 class TestGoogleAIStudioResponsesAPITest(BaseResponsesAPITest):
     def get_base_completion_call_args(self):
         #litellm._turn_on_debug()

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -346,20 +346,25 @@ async def test_mock_google_ai_studio_compaction():
             f"got {len(response.output)}"
         )
 
-        # First output item should be the compaction block
-        compaction_item = response.output[0]
-        if isinstance(compaction_item, dict):
-            assert compaction_item["type"] == "compaction"
-            assert "cats many times" in compaction_item["content"]
-        else:
-            assert getattr(compaction_item, "type", None) == "compaction"
-
-        # Second output item should be the text response
-        text_item = response.output[1]
+        # First output item should be the text response (assistant message)
+        text_item = response.output[0]
         if isinstance(text_item, dict):
             assert text_item.get("type") == "message"
         else:
             assert getattr(text_item, "type", None) == "message"
+
+        # Second output item should be the compaction block
+        import base64
+        compaction_item = response.output[1]
+        if isinstance(compaction_item, dict):
+            assert compaction_item["type"] == "compaction"
+            assert "encrypted_content" in compaction_item
+            decoded = base64.b64decode(compaction_item["encrypted_content"]).decode("utf-8")
+            assert "cats many times" in decoded
+            assert compaction_item["id"].startswith("cmp_")
+            assert compaction_item["created_by"] is None
+        else:
+            assert getattr(compaction_item, "type", None) == "compaction"
 
         print("compaction test passed: response output =", json.dumps(response.output, indent=2, default=str))
 

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -362,7 +362,6 @@ async def test_mock_google_ai_studio_compaction():
             decoded = base64.b64decode(compaction_item["encrypted_content"]).decode("utf-8")
             assert "cats many times" in decoded
             assert compaction_item["id"].startswith("cmp_")
-            assert compaction_item["created_by"] is None
         else:
             assert getattr(compaction_item, "type", None) == "compaction"
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1,5 +1,8 @@
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 sys.path.insert(
     0, os.path.abspath("../../..")
@@ -2242,3 +2245,203 @@ class TestCompactionInputProcessing:
         assert messages[1]["content"] == "mid reply"
         assert messages[2]["role"] == "user"
         assert messages[2]["content"] == "latest question"
+
+
+class TestCompactionRouting:
+    """Tests for override_native_compaction routing in main.py."""
+
+    def _make_summary_and_final_responses(self, model: str):
+        """Create mock summary and final ModelResponse objects."""
+        import litellm
+
+        summary_response = litellm.ModelResponse(
+            id="summary-id",
+            created=1000000000,
+            model=model,
+            object="chat.completion",
+            choices=[
+                litellm.utils.Choices(
+                    index=0,
+                    message=litellm.utils.Message(
+                        role="assistant",
+                        content="<summary>The user talked about cats.</summary>",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+        )
+        final_response = litellm.ModelResponse(
+            id="final-id",
+            created=1000000001,
+            model=model,
+            object="chat.completion",
+            choices=[
+                litellm.utils.Choices(
+                    index=0,
+                    message=litellm.utils.Message(
+                        role="assistant",
+                        content="Based on the summary, you were talking about cats.",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+        )
+        return summary_response, final_response
+
+    @pytest.mark.asyncio
+    async def test_override_native_compaction_true_uses_litellm_path(self):
+        """When override_native_compaction=True, use litellm's compaction even for OpenAI."""
+        import base64
+        import litellm
+
+        model = "openai/gpt-4o"
+        summary_resp, final_resp = self._make_summary_and_final_responses(model)
+        call_count = 0
+
+        async def mock_acompletion(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return summary_resp if call_count == 1 else final_resp
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_ac:
+            mock_ac.side_effect = mock_acompletion
+
+            response = await litellm.aresponses(
+                model=model,
+                input="cats " * 100_000,
+                context_management=[
+                    {
+                        "type": "compaction",
+                        "compact_threshold": 50000,
+                        "override_native_compaction": True,
+                    }
+                ],
+            )
+
+        # Should have gone through litellm's compaction (2 acompletion calls)
+        assert call_count == 2
+        # Output should have our format: message first, then compaction with encrypted_content
+        assert len(response.output) >= 2
+        compaction_items = [
+            item
+            for item in response.output
+            if (item.get("type") if isinstance(item, dict) else getattr(item, "type", None)) == "compaction"
+        ]
+        assert len(compaction_items) == 1
+        compaction = compaction_items[0]
+        if isinstance(compaction, dict):
+            assert "encrypted_content" in compaction
+            decoded = base64.b64decode(compaction["encrypted_content"]).decode("utf-8")
+            assert "cats" in decoded
+            assert compaction["id"].startswith("cmp_")
+
+    @pytest.mark.asyncio
+    async def test_override_native_compaction_false_uses_native_path(self):
+        """When override_native_compaction is False/missing, native provider handles compaction."""
+        import litellm
+        from litellm.responses.litellm_completion_transformation.handler import (
+            LiteLLMCompletionTransformationHandler,
+        )
+
+        handler_called = False
+        original_handler = LiteLLMCompletionTransformationHandler.response_api_handler
+
+        def spy_handler(self_handler, *args, **kwargs):
+            nonlocal handler_called
+            handler_called = True
+            return original_handler(self_handler, *args, **kwargs)
+
+        # Mock the native provider path to avoid real API calls
+        with patch(
+            "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.response_api_handler"
+        ) as mock_native, patch.object(
+            LiteLLMCompletionTransformationHandler,
+            "response_api_handler",
+            spy_handler,
+        ):
+            mock_native.return_value = MagicMock()
+
+            try:
+                await litellm.aresponses(
+                    model="openai/gpt-4o",
+                    input="hello",
+                    context_management=[
+                        {"type": "compaction", "compact_threshold": 50000}
+                    ],
+                )
+            except Exception:
+                pass  # We only care about which path was taken
+
+        # The litellm handler should NOT have been called
+        assert not handler_called, (
+            "Without override_native_compaction=True, native provider path should be used"
+        )
+
+    @pytest.mark.asyncio
+    async def test_override_native_compaction_missing_uses_native_path(self):
+        """When override_native_compaction key is entirely absent, native provider handles it."""
+        import litellm
+        from litellm.responses.litellm_completion_transformation.handler import (
+            LiteLLMCompletionTransformationHandler,
+        )
+
+        handler_called = False
+        original_handler = LiteLLMCompletionTransformationHandler.response_api_handler
+
+        def spy_handler(self_handler, *args, **kwargs):
+            nonlocal handler_called
+            handler_called = True
+            return original_handler(self_handler, *args, **kwargs)
+
+        with patch(
+            "litellm.llms.custom_httpx.llm_http_handler.BaseLLMHTTPHandler.response_api_handler"
+        ) as mock_native, patch.object(
+            LiteLLMCompletionTransformationHandler,
+            "response_api_handler",
+            spy_handler,
+        ):
+            mock_native.return_value = MagicMock()
+
+            try:
+                await litellm.aresponses(
+                    model="openai/gpt-4o",
+                    input="hello",
+                    context_management=[
+                        {"type": "compaction", "compact_threshold": 50000}
+                    ],
+                )
+            except Exception:
+                pass
+
+        assert not handler_called, (
+            "Without override_native_compaction key, native provider path should be used"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_provider_config_always_uses_litellm_path(self):
+        """When no native provider config exists, always use litellm's compaction."""
+        import litellm
+
+        # Use a provider that litellm recognizes but has no native responses API config
+        model = "anthropic/claude-haiku-4-5-20251001"
+        summary_resp, final_resp = self._make_summary_and_final_responses(model)
+        call_count = 0
+
+        async def mock_acompletion(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return summary_resp if call_count == 1 else final_resp
+
+        with patch("litellm.acompletion", new_callable=AsyncMock) as mock_ac:
+            mock_ac.side_effect = mock_acompletion
+
+            response = await litellm.aresponses(
+                model=model,
+                input="cats " * 100_000,
+                context_management=[
+                    {"type": "compaction", "compact_threshold": 50000}
+                ],
+            )
+
+        # Should use litellm's path (2 calls: summarization + final)
+        assert call_count == 2

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2079,3 +2079,167 @@ class TestEnsureOutputItemContentPartAdded:
 
         events = iterator._pending_response_events
         assert len(events) == 2
+
+
+class TestCompactionOutputFormat:
+    """Tests for _append_compaction_output in handler.py"""
+
+    def test_append_compaction_output_format(self):
+        """Compaction item should be at index 1 with encrypted_content, id, created_by."""
+        import base64
+
+        from litellm.responses.litellm_completion_transformation.handler import (
+            _append_compaction_output,
+        )
+
+        summary = "The user repeated the word cats many times."
+        existing_output = [{"type": "message", "role": "assistant", "content": "Hello"}]
+
+        result = _append_compaction_output(summary, existing_output)
+
+        assert len(result) == 2
+        # First item is the assistant message
+        assert result[0]["type"] == "message"
+        # Second item is the compaction
+        compaction = result[1]
+        assert compaction["type"] == "compaction"
+        assert compaction["id"].startswith("cmp_")
+        assert compaction["created_by"] is None
+        assert "content" not in compaction
+        # Verify encrypted_content is base64-encoded summary
+        decoded = base64.b64decode(compaction["encrypted_content"]).decode("utf-8")
+        assert decoded == summary
+
+    def test_append_compaction_output_empty_existing(self):
+        """When existing_output is empty, compaction item is the only element."""
+        from litellm.responses.litellm_completion_transformation.handler import (
+            _append_compaction_output,
+        )
+
+        result = _append_compaction_output("summary", [])
+        assert len(result) == 1
+        assert result[0]["type"] == "compaction"
+
+    def test_append_compaction_output_preserves_extra_items(self):
+        """Items after the first in existing_output are preserved after compaction."""
+        from litellm.responses.litellm_completion_transformation.handler import (
+            _append_compaction_output,
+        )
+
+        existing = [
+            {"type": "message", "role": "assistant"},
+            {"type": "function_call", "name": "foo"},
+        ]
+        result = _append_compaction_output("summary", existing)
+        assert len(result) == 3
+        assert result[0]["type"] == "message"
+        assert result[1]["type"] == "compaction"
+        assert result[2]["type"] == "function_call"
+
+
+class TestCompactionInputProcessing:
+    """Tests for compaction input handling in transformation.py"""
+
+    def test_compaction_input_processing(self):
+        """Compaction item in input should produce decoded user msg + predecessor + remaining."""
+        import base64
+
+        summary = "Summary of conversation"
+        encrypted = base64.b64encode(summary.encode("utf-8")).decode("utf-8")
+
+        input_items = [
+            {"type": "message", "role": "user", "content": "old msg 1"},
+            {"type": "message", "role": "user", "content": "old msg 2"},
+            {"type": "message", "role": "assistant", "content": "assistant reply"},
+            {"type": "compaction", "id": "cmp_abc", "encrypted_content": encrypted, "created_by": None},
+            {"type": "message", "role": "user", "content": "new question"},
+        ]
+
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request={},
+        )
+
+        # Should be: [user(decoded_summary), assistant(reply), user(new question)]
+        assert len(messages) == 3
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == summary
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == "assistant reply"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "new question"
+
+    def test_compaction_input_at_index_0(self):
+        """Compaction at index 0 with no predecessor should still work."""
+        import base64
+
+        summary = "Summary"
+        encrypted = base64.b64encode(summary.encode("utf-8")).decode("utf-8")
+
+        input_items = [
+            {"type": "compaction", "id": "cmp_abc", "encrypted_content": encrypted, "created_by": None},
+            {"type": "message", "role": "user", "content": "follow up"},
+        ]
+
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request={},
+        )
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == summary
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "follow up"
+
+    def test_compaction_input_backward_compat(self):
+        """Old format with 'content' field (no encrypted_content) should still work."""
+        input_items = [
+            {"type": "message", "role": "assistant", "content": "prior reply"},
+            {"type": "compaction", "content": "plaintext summary"},
+            {"type": "message", "role": "user", "content": "new msg"},
+        ]
+
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request={},
+        )
+
+        assert len(messages) == 3
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "plaintext summary"
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == "prior reply"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "new msg"
+
+    def test_multiple_compaction_items_uses_last(self):
+        """When multiple compaction items exist, only the last one matters."""
+        import base64
+
+        old_summary = base64.b64encode(b"old summary").decode("utf-8")
+        new_summary = base64.b64encode(b"new summary").decode("utf-8")
+
+        input_items = [
+            {"type": "message", "role": "user", "content": "ancient msg"},
+            {"type": "message", "role": "assistant", "content": "ancient reply"},
+            {"type": "compaction", "id": "cmp_old", "encrypted_content": old_summary},
+            {"type": "message", "role": "user", "content": "mid msg"},
+            {"type": "message", "role": "assistant", "content": "mid reply"},
+            {"type": "compaction", "id": "cmp_new", "encrypted_content": new_summary},
+            {"type": "message", "role": "user", "content": "latest question"},
+        ]
+
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request={},
+        )
+
+        # Should use new_summary, keep mid reply (predecessor of last compaction), then latest question
+        assert len(messages) == 3
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "new summary"
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == "mid reply"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == "latest question"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2104,7 +2104,6 @@ class TestCompactionOutputFormat:
         compaction = result[1]
         assert compaction["type"] == "compaction"
         assert compaction["id"].startswith("cmp_")
-        assert compaction["created_by"] is None
         assert "content" not in compaction
         # Verify encrypted_content is base64-encoded summary
         decoded = base64.b64decode(compaction["encrypted_content"]).decode("utf-8")
@@ -2151,7 +2150,7 @@ class TestCompactionInputProcessing:
             {"type": "message", "role": "user", "content": "old msg 1"},
             {"type": "message", "role": "user", "content": "old msg 2"},
             {"type": "message", "role": "assistant", "content": "assistant reply"},
-            {"type": "compaction", "id": "cmp_abc", "encrypted_content": encrypted, "created_by": None},
+            {"type": "compaction", "id": "cmp_abc", "encrypted_content": encrypted, },
             {"type": "message", "role": "user", "content": "new question"},
         ]
 
@@ -2160,10 +2159,10 @@ class TestCompactionInputProcessing:
             responses_api_request={},
         )
 
-        # Should be: [user(decoded_summary), assistant(reply), user(new question)]
+        # Should be: [system(decoded_summary), assistant(reply), user(new question)]
         assert len(messages) == 3
-        assert messages[0]["role"] == "user"
-        assert messages[0]["content"] == summary
+        assert messages[0]["role"] == "system"
+        assert summary in messages[0]["content"]
         assert messages[1]["role"] == "assistant"
         assert messages[1]["content"] == "assistant reply"
         assert messages[2]["role"] == "user"
@@ -2177,7 +2176,7 @@ class TestCompactionInputProcessing:
         encrypted = base64.b64encode(summary.encode("utf-8")).decode("utf-8")
 
         input_items = [
-            {"type": "compaction", "id": "cmp_abc", "encrypted_content": encrypted, "created_by": None},
+            {"type": "compaction", "id": "cmp_abc", "encrypted_content": encrypted},
             {"type": "message", "role": "user", "content": "follow up"},
         ]
 
@@ -2187,8 +2186,8 @@ class TestCompactionInputProcessing:
         )
 
         assert len(messages) == 2
-        assert messages[0]["role"] == "user"
-        assert messages[0]["content"] == summary
+        assert messages[0]["role"] == "system"
+        assert summary in messages[0]["content"]
         assert messages[1]["role"] == "user"
         assert messages[1]["content"] == "follow up"
 
@@ -2206,8 +2205,8 @@ class TestCompactionInputProcessing:
         )
 
         assert len(messages) == 3
-        assert messages[0]["role"] == "user"
-        assert messages[0]["content"] == "plaintext summary"
+        assert messages[0]["role"] == "system"
+        assert "plaintext summary" in messages[0]["content"]
         assert messages[1]["role"] == "assistant"
         assert messages[1]["content"] == "prior reply"
         assert messages[2]["role"] == "user"
@@ -2237,8 +2236,8 @@ class TestCompactionInputProcessing:
 
         # Should use new_summary, keep mid reply (predecessor of last compaction), then latest question
         assert len(messages) == 3
-        assert messages[0]["role"] == "user"
-        assert messages[0]["content"] == "new summary"
+        assert messages[0]["role"] == "system"
+        assert "new summary" in messages[0]["content"]
         assert messages[1]["role"] == "assistant"
         assert messages[1]["content"] == "mid reply"
         assert messages[2]["role"] == "user"


### PR DESCRIPTION
## Relevant issues

<!-- Implements server-side context compaction for the Responses API -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

### Summary

Adds universal server-side context compaction to the Responses API, matching the OpenAI v1/responses compaction format. When input tokens exceed a configurable `compact_threshold`, the handler automatically summarizes the conversation history via the same model, then sends only the summary to the final completion call. This works across all providers (Anthropic, Gemini, OpenAI, etc.).

### What's included

- **`litellm/responses/compaction.py`** — New module with the compaction logic:
  - Token counting against a configurable threshold
  - Transcript serialization and summarization via `litellm.acompletion`
  - `<summary>` tag extraction with fallback to raw text
  - Proper forwarding of `custom_llm_provider` to fix provider resolution for prefixed model names (e.g. `anthropic/claude-...`)

- **`litellm/responses/litellm_completion_transformation/handler.py`** — Integrates compaction into the async response handler:
  - Pops `context_management` from completion args
  - Calls `maybe_compact_context` before the final `acompletion`
  - Appends a compaction output item (with `encrypted_content`, `id`, `created_by`) after the assistant message when summarization occurs

- **`litellm/responses/litellm_completion_transformation/transformation.py`** — Handles compaction input items:
  - When compaction items appear in the input list, finds the last one, keeps only its predecessor (the assistant response) and items after it
  - Base64-decodes `encrypted_content` into a user message prepended to the messages list
  - Passes `context_management` through the request transformation

- **Tests** — Unit tests covering output format, input processing, edge cases (compaction at index 0, multiple compaction items, backward compatibility)

### Compaction output format

```json
{
  "type": "compaction",
  "id": "cmp_<hex>",
  "encrypted_content": "<base64-encoded summary>",
  "created_by": null
}
```

### Usage

```python
response = await litellm.aresponses(
    model="anthropic/claude-haiku-4-5-20251001",
    input="very long conversation...",
    context_management=[
        {"type": "compaction", "compact_threshold": 50000}
    ],
)
# response.output[0] → {"type": "message", ...}
# response.output[1] → {"type": "compaction", "id": "cmp_...", "encrypted_content": "...", "created_by": null}
```