### PR TITLE
fix: get_model_info now returns supports_xhigh/none/minimal_reasoning_effort fields

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -140,6 +140,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_url_context: Optional[bool]
     supports_none_reasoning_effort: Optional[bool]
     supports_xhigh_reasoning_effort: Optional[bool]
+    supports_minimal_reasoning_effort: Optional[bool]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5861,6 +5861,18 @@ def _get_model_info_helper(  # noqa: PLR0915
                 supports_url_context=_model_info.get("supports_url_context", None),
                 supports_reasoning=_model_info.get("supports_reasoning", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),
+                supports_parallel_function_calling=_model_info.get(
+                    "supports_parallel_function_calling", None
+                ),
+                supports_none_reasoning_effort=_model_info.get(
+                    "supports_none_reasoning_effort", None
+                ),
+                supports_xhigh_reasoning_effort=_model_info.get(
+                    "supports_xhigh_reasoning_effort", None
+                ),
+                supports_minimal_reasoning_effort=_model_info.get(
+                    "supports_minimal_reasoning_effort", None
+                ),
                 search_context_cost_per_query=_model_info.get(
                     "search_context_cost_per_query", None
                 ),

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1174,31 +1174,47 @@ def test_get_model_info_shows_supports_xhigh_reasoning_effort():
     where get_model_info omitted reasoning-effort capability fields even
     though they exist in model_cost.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    original_env_var = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = getattr(litellm, "model_cost", None)
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
 
-    model = "gpt-5.4"
-    info = litellm.get_model_info(model)
-    model_cost = litellm.model_cost[model]
+        model = "gpt-5.4"
+        info = litellm.get_model_info(model)
+        model_cost = litellm.model_cost[model]
 
-    assert info.get("supports_xhigh_reasoning_effort") == model_cost.get(
-        "supports_xhigh_reasoning_effort"
-    ), (
-        f"get_model_info should return supports_xhigh_reasoning_effort={model_cost.get('supports_xhigh_reasoning_effort')!r} "
-        f"for {model!r}, got {info.get('supports_xhigh_reasoning_effort')!r}"
-    )
-    assert info.get("supports_none_reasoning_effort") == model_cost.get(
-        "supports_none_reasoning_effort"
-    ), (
-        f"get_model_info should return supports_none_reasoning_effort={model_cost.get('supports_none_reasoning_effort')!r} "
-        f"for {model!r}, got {info.get('supports_none_reasoning_effort')!r}"
-    )
-    assert info.get("supports_minimal_reasoning_effort") == model_cost.get(
-        "supports_minimal_reasoning_effort"
-    ), (
-        f"get_model_info should return supports_minimal_reasoning_effort={model_cost.get('supports_minimal_reasoning_effort')!r} "
-        f"for {model!r}, got {info.get('supports_minimal_reasoning_effort')!r}"
-    )
+        assert info.get("supports_xhigh_reasoning_effort") == model_cost.get(
+            "supports_xhigh_reasoning_effort"
+        ), (
+            f"get_model_info should return supports_xhigh_reasoning_effort={model_cost.get('supports_xhigh_reasoning_effort')!r} "
+            f"for {model!r}, got {info.get('supports_xhigh_reasoning_effort')!r}"
+        )
+        assert info.get("supports_none_reasoning_effort") == model_cost.get(
+            "supports_none_reasoning_effort"
+        ), (
+            f"get_model_info should return supports_none_reasoning_effort={model_cost.get('supports_none_reasoning_effort')!r} "
+            f"for {model!r}, got {info.get('supports_none_reasoning_effort')!r}"
+        )
+        assert info.get("supports_minimal_reasoning_effort") == model_cost.get(
+            "supports_minimal_reasoning_effort"
+        ), (
+            f"get_model_info should return supports_minimal_reasoning_effort={model_cost.get('supports_minimal_reasoning_effort')!r} "
+            f"for {model!r}, got {info.get('supports_minimal_reasoning_effort')!r}"
+        )
+        assert info.get("supports_parallel_function_calling") == model_cost.get(
+            "supports_parallel_function_calling"
+        ), (
+            f"get_model_info should return supports_parallel_function_calling={model_cost.get('supports_parallel_function_calling')!r} "
+            f"for {model!r}, got {info.get('supports_parallel_function_calling')!r}"
+        )
+    finally:
+        if original_env_var is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_env_var
+        if original_model_cost is not None:
+            litellm.model_cost = original_model_cost
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1166,6 +1166,41 @@ def test_get_model_info_shows_supports_computer_use():
     )  # Expecting None due to the default in ModelInfoBase
 
 
+def test_get_model_info_shows_supports_xhigh_reasoning_effort():
+    """
+    Tests that get_model_info correctly returns supports_xhigh_reasoning_effort.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/25096
+    where get_model_info omitted reasoning-effort capability fields even
+    though they exist in model_cost.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "gpt-5.4"
+    info = litellm.get_model_info(model)
+    model_cost = litellm.model_cost[model]
+
+    assert info.get("supports_xhigh_reasoning_effort") == model_cost.get(
+        "supports_xhigh_reasoning_effort"
+    ), (
+        f"get_model_info should return supports_xhigh_reasoning_effort={model_cost.get('supports_xhigh_reasoning_effort')!r} "
+        f"for {model!r}, got {info.get('supports_xhigh_reasoning_effort')!r}"
+    )
+    assert info.get("supports_none_reasoning_effort") == model_cost.get(
+        "supports_none_reasoning_effort"
+    ), (
+        f"get_model_info should return supports_none_reasoning_effort={model_cost.get('supports_none_reasoning_effort')!r} "
+        f"for {model!r}, got {info.get('supports_none_reasoning_effort')!r}"
+    )
+    assert info.get("supports_minimal_reasoning_effort") == model_cost.get(
+        "supports_minimal_reasoning_effort"
+    ), (
+        f"get_model_info should return supports_minimal_reasoning_effort={model_cost.get('supports_minimal_reasoning_effort')!r} "
+        f"for {model!r}, got {info.get('supports_minimal_reasoning_effort')!r}"
+    )
+
+
 @pytest.mark.parametrize(
     "model, custom_llm_provider",
     [


### PR DESCRIPTION
## Relevant issues

Fixes #25096

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Root Cause

`litellm.get_model_info` was not returning `supports_xhigh_reasoning_effort` (and related reasoning-effort capability flags) even though the values exist in `model_prices_and_context_window.json`.

The `_get_model_info_helper` function in `litellm/utils.py` builds a `ModelInfoBase` TypedDict object by explicitly passing each field in the constructor. Four capability fields were missing from that constructor call:

- `supports_xhigh_reasoning_effort`
- `supports_none_reasoning_effort`
- `supports_minimal_reasoning_effort`
- `supports_parallel_function_calling`

This meant that calling `litellm.get_model_info("gpt-5.4").get("supports_xhigh_reasoning_effort")` returned `None` even though `litellm.model_cost["gpt-5.4"]["supports_xhigh_reasoning_effort"]` was `True`.

### Fix

**`litellm/utils.py`** — Add the four missing fields to the `ModelInfoBase(...)` constructor call in `_get_model_info_helper`:

```python
supports_parallel_function_calling=_model_info.get("supports_parallel_function_calling", None),
supports_none_reasoning_effort=_model_info.get("supports_none_reasoning_effort", None),
supports_xhigh_reasoning_effort=_model_info.get("supports_xhigh_reasoning_effort", None),
supports_minimal_reasoning_effort=_model_info.get("supports_minimal_reasoning_effort", None),
```

**`litellm/types/utils.py`** — Add `supports_minimal_reasoning_effort` to the `ProviderSpecificModelInfo` TypedDict. The field was already present in `model_prices_and_context_window.json` and used in `gpt_5_transformation.py` but not declared in the type definition.

**`tests/test_litellm/test_utils.py`** — Add `test_get_model_info_shows_supports_xhigh_reasoning_effort` regression test that verifies `get_model_info` returns the same values for `supports_xhigh_reasoning_effort`, `supports_none_reasoning_effort`, and `supports_minimal_reasoning_effort` as `litellm.model_cost` for `gpt-5.4`.