### PR TITLE
feat(ui): add guardrails support to project create/edit forms

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useCreateProject.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useCreateProject.ts
@@ -17,6 +17,7 @@ export interface ProjectCreateParams {
   models?: string[];
   max_budget?: number;
   blocked?: boolean;
+  guardrails?: string[];
   metadata?: Record<string, unknown>;
   model_rpm_limit?: Record<string, number>;
   model_tpm_limit?: Record<string, number>;

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useUpdateProject.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/projects/useUpdateProject.ts
@@ -17,6 +17,7 @@ export interface ProjectUpdateParams {
   models?: string[];
   max_budget?: number;
   blocked?: boolean;
+  guardrails?: string[];
   metadata?: Record<string, unknown>;
   model_rpm_limit?: Record<string, number>;
   model_tpm_limit?: Record<string, number>;

--- a/ui/litellm-dashboard/src/components/Projects/ProjectModals/EditProjectModal.tsx
+++ b/ui/litellm-dashboard/src/components/Projects/ProjectModals/EditProjectModal.tsx
@@ -33,6 +33,9 @@ export function EditProjectModal({
       const metadataObj = (project.metadata ?? {}) as Record<string, unknown>;
       const rpmLimits = (metadataObj.model_rpm_limit ?? {}) as Record<string, number>;
       const tpmLimits = (metadataObj.model_tpm_limit ?? {}) as Record<string, number>;
+      const guardrails = (Array.isArray(metadataObj.guardrails)
+        ? metadataObj.guardrails
+        : []) as string[];
 
       const modelLimits: ProjectFormValues["modelLimits"] = [];
       const allLimitModels = new Set([
@@ -48,7 +51,7 @@ export function EditProjectModal({
       }
 
       // Filter out internal keys from user-facing metadata
-      const internalKeys = new Set(["model_rpm_limit", "model_tpm_limit"]);
+      const internalKeys = new Set(["model_rpm_limit", "model_tpm_limit", "guardrails"]);
       const metadata: ProjectFormValues["metadata"] = [];
       for (const [key, value] of Object.entries(metadataObj)) {
         if (!internalKeys.has(key)) {
@@ -63,6 +66,7 @@ export function EditProjectModal({
         models: project.models ?? [],
         max_budget: project.litellm_budget_table?.max_budget ?? undefined,
         isBlocked: project.blocked,
+        guardrails: guardrails.length > 0 ? guardrails : undefined,
         modelLimits: modelLimits.length > 0 ? modelLimits : undefined,
         metadata: metadata.length > 0 ? metadata : undefined,
       });

--- a/ui/litellm-dashboard/src/components/Projects/ProjectModals/ProjectBaseForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/Projects/ProjectModals/ProjectBaseForm.test.tsx
@@ -14,6 +14,10 @@ vi.mock("@/components/organisms/create_key_button", () => ({
   fetchTeamModels: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("@/components/networking", () => ({
+  getGuardrailsList: vi.fn().mockResolvedValue({ guardrails: [] }),
+}));
+
 vi.mock("@/components/key_team_helpers/fetch_available_models_team_key", () => ({
   getModelDisplayName: (model: string) => model,
 }));
@@ -85,5 +89,14 @@ describe("ProjectBaseForm", () => {
   it("should show the Advanced Settings collapse panel", () => {
     renderWithProviders(<FormWrapper />);
     expect(screen.getByText("Advanced Settings")).toBeInTheDocument();
+  });
+
+  it("should show a Guardrails field in the Advanced Settings section", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<FormWrapper />);
+    await user.click(screen.getByText("Advanced Settings"));
+    await waitFor(() => {
+      expect(screen.getByText("Guardrails")).toBeInTheDocument();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/Projects/ProjectModals/ProjectBaseForm.tsx
+++ b/ui/litellm-dashboard/src/components/Projects/ProjectModals/ProjectBaseForm.tsx
@@ -22,6 +22,7 @@ import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { Team } from "../../key_team_helpers/key_list";
 import { fetchTeamModels } from "../../organisms/create_key_button";
 import { getModelDisplayName } from "../../key_team_helpers/fetch_available_models_team_key";
+import { getGuardrailsList } from "@/components/networking";
 
 export interface ProjectFormValues {
   project_alias: string;
@@ -30,6 +31,7 @@ export interface ProjectFormValues {
   models: string[];
   max_budget?: number;
   isBlocked: boolean;
+  guardrails?: string[];
   modelLimits?: { model: string; tpm?: number; rpm?: number }[];
   metadata?: { key: string; value: string }[];
 }
@@ -46,6 +48,23 @@ export function ProjectBaseForm({
 
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const [modelsToPick, setModelsToPick] = useState<string[]>([]);
+  const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchGuardrails = async () => {
+      if (!accessToken) return;
+      try {
+        const response = await getGuardrailsList(accessToken);
+        const names = response.guardrails.map(
+          (g: { guardrail_name: string }) => g.guardrail_name
+        );
+        setGuardrailsList(names);
+      } catch (error) {
+        console.error("Failed to fetch guardrails:", error);
+      }
+    };
+    fetchGuardrails();
+  }, [accessToken]);
 
   // Sync selectedTeam from form value (needed for edit mode pre-fill)
   const teamIdValue = Form.useWatch("team_id", form);
@@ -255,6 +274,24 @@ export function ProjectBaseForm({
                           />
                         ) : null
                       }
+                    </Form.Item>
+
+                    <Divider />
+
+                    <Form.Item
+                      label="Guardrails"
+                      name="guardrails"
+                      help="Select existing guardrails or enter new ones"
+                    >
+                      <Select
+                        mode="tags"
+                        style={{ width: "100%" }}
+                        placeholder="Select or enter guardrails"
+                        options={guardrailsList.map((name) => ({
+                          value: name,
+                          label: name,
+                        }))}
+                      />
                     </Form.Item>
 
                     <Divider />

--- a/ui/litellm-dashboard/src/components/Projects/ProjectModals/projectFormUtils.test.ts
+++ b/ui/litellm-dashboard/src/components/Projects/ProjectModals/projectFormUtils.test.ts
@@ -98,4 +98,20 @@ describe("buildProjectApiParams", () => {
     });
     expect(result).not.toHaveProperty("metadata");
   });
+
+  it("should include guardrails as a top-level field when provided", () => {
+    const result = buildProjectApiParams({
+      ...baseValues,
+      guardrails: ["pii-check", "content-filter"],
+    });
+    expect(result.guardrails).toEqual(["pii-check", "content-filter"]);
+  });
+
+  it("should omit guardrails when the array is empty", () => {
+    const result = buildProjectApiParams({
+      ...baseValues,
+      guardrails: [],
+    });
+    expect(result).not.toHaveProperty("guardrails");
+  });
 });

--- a/ui/litellm-dashboard/src/components/Projects/ProjectModals/projectFormUtils.ts
+++ b/ui/litellm-dashboard/src/components/Projects/ProjectModals/projectFormUtils.ts
@@ -25,6 +25,9 @@ export function buildProjectApiParams(values: ProjectFormValues) {
     models: values.models ?? [],
     max_budget: values.max_budget,
     blocked: values.isBlocked ?? false,
+    ...(values.guardrails && values.guardrails.length > 0 && {
+      guardrails: values.guardrails,
+    }),
     ...(Object.keys(modelRpmLimit).length > 0 && {
       model_rpm_limit: modelRpmLimit,
     }),


### PR DESCRIPTION
The backend already supports guardrails on projects (PR #25087), but the dashboard UI had no way to set them. This adds a guardrails multi-select field to the project form's Advanced Settings, following the same pattern used for team guardrails.

## Relevant issues

Follows up on #25087 (backend support for project-level guardrails)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

- **`ProjectBaseForm.tsx`** — Added `guardrails?: string[]` to `ProjectFormValues` interface, added `getGuardrailsList` fetch on mount, added `Select mode="tags"` field in Advanced Settings (between Block Project and Model-Specific Limits)
- **`projectFormUtils.ts`** — Pass `guardrails` as a top-level field in API params (not nested in metadata), omit when empty
- **`useCreateProject.ts` / `useUpdateProject.ts`** — Added `guardrails?: string[]` to param type interfaces
- **`EditProjectModal.tsx`** — Extract guardrails from `metadata.guardrails` when editing, filter from user-facing KV metadata display, pre-populate form field
- **`projectFormUtils.test.ts`** — 2 new tests: guardrails included when provided, omitted when empty
- **`ProjectBaseForm.test.tsx`** — 1 new test: guardrails field renders in Advanced Settings + mock for `getGuardrailsList`