### PR TITLE
fix(guardrails): infer event_type from input_type in log_guardrail_in…

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -891,6 +891,14 @@ def log_guardrail_information(func):
         request_data: dict = kwargs.get("data") or kwargs.get("request_data") or {}
         event_type = _infer_event_type_from_function_name(func.__name__)
 
+        # For apply_guardrail, infer event type from input_type kwarg
+        if event_type is None and func.__name__ == "apply_guardrail":
+            _input_type = kwargs.get("input_type")
+            if _input_type == "request":
+                event_type = GuardrailEventHooks.pre_call
+            elif _input_type == "response":
+                event_type = GuardrailEventHooks.post_call
+
         # Store original inputs for comparison (for apply_guardrail functions)
         original_inputs = None
         if func.__name__ == "apply_guardrail" and "inputs" in kwargs:
@@ -923,6 +931,14 @@ def log_guardrail_information(func):
         self: CustomGuardrail = args[0]
         request_data: dict = kwargs.get("data") or kwargs.get("request_data") or {}
         event_type = _infer_event_type_from_function_name(func.__name__)
+
+        # For apply_guardrail, infer event type from input_type kwarg
+        if event_type is None and func.__name__ == "apply_guardrail":
+            _input_type = kwargs.get("input_type")
+            if _input_type == "request":
+                event_type = GuardrailEventHooks.pre_call
+            elif _input_type == "response":
+                event_type = GuardrailEventHooks.post_call
 
         # Store original inputs for comparison (for apply_guardrail functions)
         original_inputs = None

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -888,12 +888,18 @@ def log_guardrail_information(func):
     async def async_wrapper(*args, **kwargs):
         start_time = datetime.now()  # Move start_time inside the wrapper
         self: CustomGuardrail = args[0]
-        request_data: dict = kwargs.get("data") or kwargs.get("request_data") or {}
+        # apply_guardrail signature: (self, inputs, request_data, input_type, ...)
+        # Support both keyword and positional callers for request_data (args[2])
+        request_data: dict = (
+            kwargs.get("data")
+            or kwargs.get("request_data")
+            or (args[2] if len(args) > 2 and isinstance(args[2], dict) else {})
+        )
         event_type = _infer_event_type_from_function_name(func.__name__)
 
-        # For apply_guardrail, infer event type from input_type kwarg
+        # For apply_guardrail, infer event type from input_type (kwarg or positional arg[3])
         if event_type is None and func.__name__ == "apply_guardrail":
-            _input_type = kwargs.get("input_type")
+            _input_type = kwargs.get("input_type") or (args[3] if len(args) > 3 else None)
             if _input_type == "request":
                 event_type = GuardrailEventHooks.pre_call
             elif _input_type == "response":
@@ -929,12 +935,18 @@ def log_guardrail_information(func):
     def sync_wrapper(*args, **kwargs):
         start_time = datetime.now()  # Move start_time inside the wrapper
         self: CustomGuardrail = args[0]
-        request_data: dict = kwargs.get("data") or kwargs.get("request_data") or {}
+        # apply_guardrail signature: (self, inputs, request_data, input_type, ...)
+        # Support both keyword and positional callers for request_data (args[2])
+        request_data: dict = (
+            kwargs.get("data")
+            or kwargs.get("request_data")
+            or (args[2] if len(args) > 2 and isinstance(args[2], dict) else {})
+        )
         event_type = _infer_event_type_from_function_name(func.__name__)
 
-        # For apply_guardrail, infer event type from input_type kwarg
+        # For apply_guardrail, infer event type from input_type (kwarg or positional arg[3])
         if event_type is None and func.__name__ == "apply_guardrail":
-            _input_type = kwargs.get("input_type")
+            _input_type = kwargs.get("input_type") or (args[3] if len(args) > 3 else None)
             if _input_type == "request":
                 event_type = GuardrailEventHooks.pre_call
             elif _input_type == "response":

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1021,3 +1021,38 @@ class TestLogGuardrailInformationApplyGuardrailEventType:
             f"guardrail_mode must be a string, got {type(guardrail_mode)}: {guardrail_mode}"
         )
         assert guardrail_mode == GuardrailEventHooks.post_call
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_positional_input_type_logs_correct_event_type(self):
+        """
+        When apply_guardrail is called with input_type passed positionally (args[3]),
+        the decorator must still infer the correct event_type. This guards against
+        regressions where only kwargs.get("input_type") is checked.
+        """
+        mode = Mode(tags={}, default="pre_call")
+
+        class _TestGuardrail(CustomGuardrail):
+            @log_guardrail_information
+            async def apply_guardrail(
+                self,
+                inputs: GenericGuardrailAPIInputs,
+                request_data: dict,
+                input_type,
+                logging_obj=None,
+            ) -> GenericGuardrailAPIInputs:
+                return inputs
+
+        guardrail = _TestGuardrail(guardrail_name="test", event_hook=mode)
+        request_data: dict = {"metadata": {}}
+        inputs = GenericGuardrailAPIInputs(texts=["hello"])
+
+        # Pass input_type positionally — it lands in args[3], not kwargs
+        await guardrail.apply_guardrail(inputs, request_data, "request")
+
+        slg_list = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg_list) == 1
+        guardrail_mode = slg_list[0]["guardrail_mode"]
+        assert isinstance(guardrail_mode, str), (
+            f"guardrail_mode must be a string, got {type(guardrail_mode)}: {guardrail_mode}"
+        )
+        assert guardrail_mode == GuardrailEventHooks.pre_call

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -932,3 +932,105 @@ class TestTracingFieldsPopulation:
         assert slg["classification"] == classification
         assert slg["detection_method"] == "llm-judge"
         assert slg["confidence_score"] == 0.94
+
+
+class TestLogGuardrailInformationApplyGuardrailEventType:
+    """
+    Tests that the log_guardrail_information decorator infers the correct
+    event_type from input_type when decorating apply_guardrail, so that
+    guardrail_mode is logged as a string (not a GuardrailMode dict), preventing
+    the 'guardrail_mode.replace is not a function' error in the UI.
+    """
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_request_logs_pre_call_event_type(self):
+        """
+        When apply_guardrail is called with input_type='request', the logged
+        guardrail_mode should be GuardrailEventHooks.pre_call (a string), not
+        a GuardrailMode dict.
+        """
+        from litellm.integrations.custom_guardrail import (
+            CustomGuardrail,
+            log_guardrail_information,
+        )
+        from litellm.types.guardrails import GuardrailEventHooks, Mode
+        from litellm.types.utils import GenericGuardrailAPIInputs
+
+        # Build a Mode object (tags-based routing), which is what custom-code
+        # guardrails use. Without the fix, this becomes a GuardrailMode dict
+        # in the logged data, triggering .replace is not a function in the UI.
+        mode = Mode(tags={}, default="pre_call")
+
+        class _TestGuardrail(CustomGuardrail):
+            @log_guardrail_information
+            async def apply_guardrail(
+                self,
+                inputs: GenericGuardrailAPIInputs,
+                request_data: dict,
+                input_type,
+                logging_obj=None,
+            ) -> GenericGuardrailAPIInputs:
+                return inputs
+
+        guardrail = _TestGuardrail(guardrail_name="test", event_hook=mode)
+        request_data: dict = {"metadata": {}}
+        inputs = GenericGuardrailAPIInputs(texts=["hello"])
+
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+        slg_list = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg_list) == 1
+        guardrail_mode = slg_list[0]["guardrail_mode"]
+        # Must be a string, not a dict — the UI calls .replace() on this value
+        assert isinstance(guardrail_mode, str), (
+            f"guardrail_mode must be a string, got {type(guardrail_mode)}: {guardrail_mode}"
+        )
+        assert guardrail_mode == GuardrailEventHooks.pre_call
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_response_logs_post_call_event_type(self):
+        """
+        When apply_guardrail is called with input_type='response', the logged
+        guardrail_mode should be GuardrailEventHooks.post_call (a string).
+        """
+        from litellm.integrations.custom_guardrail import (
+            CustomGuardrail,
+            log_guardrail_information,
+        )
+        from litellm.types.guardrails import GuardrailEventHooks, Mode
+        from litellm.types.utils import GenericGuardrailAPIInputs
+
+        mode = Mode(tags={}, default="post_call")
+
+        class _TestGuardrail(CustomGuardrail):
+            @log_guardrail_information
+            async def apply_guardrail(
+                self,
+                inputs: GenericGuardrailAPIInputs,
+                request_data: dict,
+                input_type,
+                logging_obj=None,
+            ) -> GenericGuardrailAPIInputs:
+                return inputs
+
+        guardrail = _TestGuardrail(guardrail_name="test", event_hook=mode)
+        request_data: dict = {"metadata": {}}
+        inputs = GenericGuardrailAPIInputs(texts=["hello"])
+
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="response",
+        )
+
+        slg_list = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(slg_list) == 1
+        guardrail_mode = slg_list[0]["guardrail_mode"]
+        assert isinstance(guardrail_mode, str), (
+            f"guardrail_mode must be a string, got {type(guardrail_mode)}: {guardrail_mode}"
+        )
+        assert guardrail_mode == GuardrailEventHooks.post_call

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2,9 +2,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_guardrail import CustomGuardrail, log_guardrail_information
 from litellm.proxy._types import CallTypes, UserAPIKeyAuth
-from litellm.types.utils import GuardrailTracingDetail
+from litellm.types.guardrails import GuardrailEventHooks, Mode
+from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailTracingDetail
 
 
 class TestCustomGuardrailDeploymentHook:
@@ -949,13 +950,6 @@ class TestLogGuardrailInformationApplyGuardrailEventType:
         guardrail_mode should be GuardrailEventHooks.pre_call (a string), not
         a GuardrailMode dict.
         """
-        from litellm.integrations.custom_guardrail import (
-            CustomGuardrail,
-            log_guardrail_information,
-        )
-        from litellm.types.guardrails import GuardrailEventHooks, Mode
-        from litellm.types.utils import GenericGuardrailAPIInputs
-
         # Build a Mode object (tags-based routing), which is what custom-code
         # guardrails use. Without the fix, this becomes a GuardrailMode dict
         # in the logged data, triggering .replace is not a function in the UI.
@@ -997,13 +991,6 @@ class TestLogGuardrailInformationApplyGuardrailEventType:
         When apply_guardrail is called with input_type='response', the logged
         guardrail_mode should be GuardrailEventHooks.post_call (a string).
         """
-        from litellm.integrations.custom_guardrail import (
-            CustomGuardrail,
-            log_guardrail_information,
-        )
-        from litellm.types.guardrails import GuardrailEventHooks, Mode
-        from litellm.types.utils import GenericGuardrailAPIInputs
-
         mode = Mode(tags={}, default="post_call")
 
         class _TestGuardrail(CustomGuardrail):


### PR DESCRIPTION
…formation for apply_guardrail

When apply_guardrail is called with a Mode-based event_hook and event_type=None, the logged guardrail_mode was set to a GuardrailMode dict instead of a string. This caused the UI error 'guardrail_mode.replace is not a function' (issue #23439).

Fix: in the log_guardrail_information decorator, after inferring event_type from the function name, also check input_type kwarg when func.__name__ == 'apply_guardrail':
  - input_type='request'  → event_type = GuardrailEventHooks.pre_call
  - input_type='response' → event_type = GuardrailEventHooks.post_call

This ensures guardrail_mode is always logged as a plain string, not a dict.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
