### PR TITLE
feat(xai): add parallel_tool_calls to supported params

### DIFF
--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -43,6 +43,7 @@ class XAIChatConfig(OpenAIGPTConfig):
             "logprobs",
             "max_tokens",
             "n",
+            "parallel_tool_calls",
             "presence_penalty",
             "response_format",
             "seed",

--- a/tests/test_litellm/llms/xai/test_xai_chat_transformation.py
+++ b/tests/test_litellm/llms/xai/test_xai_chat_transformation.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.xai.chat.transformation import XAIChatConfig
+
+
+class TestXAIParallelToolCalls:
+    """Test suite for XAI parallel tool calls functionality."""
+
+    def test_get_supported_openai_params_includes_parallel_tool_calls(self):
+        """Test that parallel_tool_calls is in supported parameters."""
+        config = XAIChatConfig()
+        supported_params = config.get_supported_openai_params(
+            "xai/grok-4.20"
+        )
+        assert "parallel_tool_calls" in supported_params
+
+    def test_transform_request_preserves_parallel_tool_calls(self):
+        """Test that transform_request preserves parallel_tool_calls parameter."""
+        config = XAIChatConfig()
+
+        messages = [{"role": "user", "content": "What's the weather like?"}]
+        optional_params = {"parallel_tool_calls": True}
+
+        result = config.transform_request(
+            model="xai/grok-4.20",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        assert result.get("parallel_tool_calls") is True
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["role"] == "user"


### PR DESCRIPTION
## Relevant issues

None that I am aware of.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

Adds `parallel_tool_calls` to xAI's `get_supported_openai_params`. Without this, the parameter is silently dropped when calling xAI models through litellm. xAI models [support](https://docs.x.ai/developers/tools/function-calling#parallel-function-calling) this parameter.

(Disclosure: I work at xAI.)