### PR TITLE
fix(ui): add paginated team search to usage page filter

### DIFF
--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/EntityUsage.tsx
@@ -25,6 +25,7 @@ import {
 import { ExportOutlined, LoadingOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
 import React, { useMemo, useState } from "react";
+import TeamMultiSelect from "../../../common_components/team_multi_select";
 import { ActivityMetrics, processActivityData } from "../../../activity_metrics";
 import { UsageExportHeader } from "../../../EntityUsageExport";
 import type { EntityType } from "../../../EntityUsageExport/types";
@@ -468,11 +469,20 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
           }
         />
       )}
+      {entityType === "team" && (
+        <div className="mb-4">
+          <Text className="mb-2">Filter by team</Text>
+          <TeamMultiSelect
+            value={selectedTags}
+            onChange={setSelectedTags}
+          />
+        </div>
+      )}
       <UsageExportHeader
         dateValue={dateValue}
         entityType={entityType}
         spendData={spendData}
-        showFilters={entityList !== null && entityList.length > 0}
+        showFilters={entityType !== "team" && entityList !== null && entityList.length > 0}
         filterLabel={getFilterLabel(entityType)}
         filterPlaceholder={getFilterPlaceholder(entityType)}
         selectedFilters={selectedTags}

--- a/ui/litellm-dashboard/src/components/common_components/team_multi_select.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_multi_select.tsx
@@ -25,7 +25,7 @@ const TeamMultiSelect: React.FC<TeamMultiSelectProps> = ({
   disabled,
   organizationId,
   pageSize = 20,
-  placeholder = "Search teams by name or ID...",
+  placeholder = "Search teams by alias...",
 }) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {

--- a/ui/litellm-dashboard/src/components/common_components/team_multi_select.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_multi_select.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState, type UIEvent } from "react";
+import { Select, Typography } from "antd";
+import { LoadingOutlined } from "@ant-design/icons";
+import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
+import { useInfiniteTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+import { Team } from "../key_team_helpers/key_list";
+
+const { Text } = Typography;
+
+interface TeamMultiSelectProps {
+  value?: string[];
+  onChange?: (value: string[]) => void;
+  disabled?: boolean;
+  organizationId?: string | null;
+  pageSize?: number;
+  placeholder?: string;
+}
+
+const SCROLL_THRESHOLD = 0.8;
+const DEBOUNCE_MS = 300;
+
+const TeamMultiSelect: React.FC<TeamMultiSelectProps> = ({
+  value = [],
+  onChange,
+  disabled,
+  organizationId,
+  pageSize = 20,
+  placeholder = "Search teams by name or ID...",
+}) => {
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
+    wait: DEBOUNCE_MS,
+  });
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteTeams(
+    pageSize,
+    debouncedSearch || undefined,
+    organizationId,
+  );
+
+  const teams = useMemo(() => {
+    if (!data?.pages) return [];
+    const seen = new Set<string>();
+    const result: Team[] = [];
+    for (const page of data.pages) {
+      for (const team of page.teams) {
+        if (seen.has(team.team_id)) continue;
+        seen.add(team.team_id);
+        result.push(team);
+      }
+    }
+    return result;
+  }, [data]);
+
+  const handlePopupScroll = (e: UIEvent<HTMLDivElement>) => {
+    const target = e.currentTarget;
+    const scrollRatio =
+      (target.scrollTop + target.clientHeight) / target.scrollHeight;
+    if (scrollRatio >= SCROLL_THRESHOLD && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  const handleSearch = (val: string) => {
+    setSearchInput(val);
+    setDebouncedSearch(val);
+  };
+
+  return (
+    <Select
+      mode="multiple"
+      showSearch
+      placeholder={placeholder}
+      value={value}
+      onChange={(val: string[]) => onChange?.(val)}
+      disabled={disabled}
+      allowClear
+      filterOption={false}
+      onSearch={handleSearch}
+      searchValue={searchInput}
+      onPopupScroll={handlePopupScroll}
+      loading={isLoading}
+      notFoundContent={isLoading ? <LoadingOutlined spin /> : "No teams found"}
+      style={{ width: "100%" }}
+      popupRender={(menu) => (
+        <>
+          {menu}
+          {isFetchingNextPage && (
+            <div style={{ textAlign: "center", padding: 8 }}>
+              <LoadingOutlined spin />
+            </div>
+          )}
+        </>
+      )}
+    >
+      {teams.map((team) => (
+        <Select.Option key={team.team_id} value={team.team_id}>
+          <span className="font-medium">{team.team_alias}</span>{" "}
+          <Text type="secondary">({team.team_id})</Text>
+        </Select.Option>
+      ))}
+    </Select>
+  );
+};
+
+export default TeamMultiSelect;


### PR DESCRIPTION
## Summary
- **Bug:** Team ID wasn't showing up when typing in the usage page team filter — users were forced to scroll through all teams
- **Root cause:** The old filter used a static `<Select>` with no `showSearch`, loading all teams upfront via the unpaginated v1 `/team/list` endpoint
- **Fix:** Created a new `TeamMultiSelect` component that mirrors the existing `TeamDropdown` pattern — paginated `v2/team/list` endpoint, debounced server-side search, infinite scroll. Options display both team alias and team ID so users can search by either

## Screenshot

<img width="1390" height="436" alt="Screenshot 2026-04-03 at 2 09 23 PM" src="https://github.com/user-attachments/assets/fa03dc3d-a769-432d-8606-c06ebc090b6a" />

<img width="1389" height="574" alt="Screenshot 2026-04-03 at 2 19 37 PM" src="https://github.com/user-attachments/assets/9123c5eb-3e00-48e0-9f48-1e906d9cf1a2" />


greptile comment not real bug 

<img width="1377" height="268" alt="Screenshot 2026-04-03 at 2 36 41 PM" src="https://github.com/user-attachments/assets/240c7c2a-5cb9-4649-b1df-add5c6366ac4" />



## Test plan
- [x] Go to Usage page → Team Usage tab
- [x] Verify the team filter dropdown is full-width and shows "Search teams by name or ID..."
- [x] Type a team alias — verify results filter as you type
- [x] Select multiple teams — verify usage data filters correctly
- [x] Scroll to bottom of dropdown — verify more teams load (infinite scroll)
- [x] Verify other entity type filters (org, customer, tag) are unaffected