### PR TITLE
fix(ui): wire team_id filter to key alias dropdown on Virtual Keys tab

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4345,6 +4345,9 @@ async def key_aliases(
     search: Optional[str] = Query(
         None, description="Search key aliases (case-insensitive partial match)"
     ),
+    team_id: Optional[str] = Query(
+        None, description="Filter aliases to keys belonging to this team"
+    ),
 ) -> Dict[str, Any]:
     """
     Lists key aliases with pagination and optional search.
@@ -4419,6 +4422,10 @@ async def key_aliases(
         if search:
             query_params.append(f"%{search}%")
             where_parts.append(f"key_alias ILIKE ${len(query_params)}")
+
+        if team_id:
+            query_params.append(team_id)
+            where_parts.append(f"team_id = ${len(query_params)}")
 
         where_sql = " AND ".join(where_parts)
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeyAliases.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeyAliases.ts
@@ -8,6 +8,7 @@ const infiniteKeyAliasKeys = createQueryKeys("infiniteKeyAliases");
 export const useInfiniteKeyAliases = (
   size: number = 50,
   search?: string,
+  team_id?: string,
 ) => {
   const { accessToken } = useAuthorized();
   return useInfiniteQuery<PaginatedKeyAliasResponse>({
@@ -15,6 +16,7 @@ export const useInfiniteKeyAliases = (
       filters: {
         size,
         ...(search && { search }),
+        ...(team_id && { team_id }),
       },
     }),
     queryFn: async ({ pageParam }) => {
@@ -23,6 +25,7 @@ export const useInfiniteKeyAliases = (
         pageParam as number,
         size,
         search,
+        team_id,
       );
     },
     initialPageParam: 1,

--- a/ui/litellm-dashboard/src/components/KeyAliasSelect/PaginatedKeyAliasSelect/PaginatedKeyAliasSelect.tsx
+++ b/ui/litellm-dashboard/src/components/KeyAliasSelect/PaginatedKeyAliasSelect/PaginatedKeyAliasSelect.tsx
@@ -12,6 +12,7 @@ export interface PaginatedKeyAliasSelectProps {
   pageSize?: number;
   allowClear?: boolean;
   disabled?: boolean;
+  allFilters?: { [key: string]: string };
 }
 
 const SCROLL_THRESHOLD = 0.8;
@@ -25,11 +26,14 @@ export const PaginatedKeyAliasSelect = ({
   pageSize = 50,
   allowClear = true,
   disabled = false,
+  allFilters,
 }: PaginatedKeyAliasSelectProps) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
     wait: DEBOUNCE_MS,
   });
+
+  const teamId = allFilters?.["Team ID"] || undefined;
 
   const {
     data,
@@ -37,7 +41,7 @@ export const PaginatedKeyAliasSelect = ({
     hasNextPage,
     isFetchingNextPage,
     isLoading,
-  } = useInfiniteKeyAliases(pageSize, debouncedSearch || undefined);
+  } = useInfiniteKeyAliases(pageSize, debouncedSearch || undefined, teamId);
 
   const options = useMemo(() => {
     if (!data?.pages) return [];

--- a/ui/litellm-dashboard/src/components/molecules/filter.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/filter.tsx
@@ -7,6 +7,7 @@ export interface FilterOptionCustomComponentProps {
   value?: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  allFilters?: { [key: string]: string };
 }
 
 export interface FilterOption {
@@ -209,6 +210,7 @@ const FilterComponent: React.FC<FilterComponentProps> = ({
                         value={tempValues[option.name] || undefined}
                         onChange={(value) => handleFilterChange(option.name, value ?? "")}
                         placeholder={`Select ${option.label || option.name}...`}
+                        allFilters={tempValues}
                       />
                     );
                   })()

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -3263,6 +3263,7 @@ export const keyAliasesCall = async (
   page: number = 1,
   size: number = 50,
   search?: string,
+  team_id?: string,
 ): Promise<PaginatedKeyAliasResponse> => {
   /**
    * Get key aliases from proxy with pagination and optional search
@@ -3273,6 +3274,7 @@ export const keyAliasesCall = async (
         page: String(page),
         size: String(size),
         ...(search ? { search } : {}),
+        ...(team_id ? { team_id } : {}),
       }),
     );
     let url = proxyBaseUrl ? `${proxyBaseUrl}/key/aliases` : `/key/aliases`;


### PR DESCRIPTION
## Summary
- The Key Alias dropdown on the Virtual Keys page was showing aliases from **all teams** regardless of which team was selected — `team_id` was never passed through the frontend to the `/key/aliases` backend endpoint
- Added `team_id` as an optional query parameter to the backend `/key/aliases` endpoint
- Wired `team_id` through the full frontend chain: `keyAliasesCall` → `useInfiniteKeyAliases` → `PaginatedKeyAliasSelect`
- Extended the `FilterComponent` framework to pass current filter state (`allFilters`) to custom filter components so they can react to sibling filter values

## Screenshots 

<img width="817" height="611" alt="Screenshot 2026-04-03 at 3 37 02 PM" src="https://github.com/user-attachments/assets/0a46bcd2-cfd2-4766-9747-0151aa444171" />
<img width="803" height="583" alt="Screenshot 2026-04-03 at 3 37 17 PM" src="https://github.com/user-attachments/assets/79206057-9653-4a2c-b1ec-ca1f61478045" />
<img width="798" height="468" alt="Screenshot 2026-04-03 at 3 37 30 PM" src="https://github.com/user-attachments/assets/5a189023-4d73-44ff-b822-b0303a456528" />


## Test plan
- [x] No team selected → Key Alias dropdown shows all aliases
- [x] Select team-alpha → Key Alias dropdown shows only alpha-* aliases
- [x] Select team-beta → Key Alias dropdown shows only beta-* aliases
- [x] Select a team + select an alias → key table shows matching result (not 0)
- [x] Clear team filter → alias dropdown returns to showing all aliases
- [x] Verify `/key/aliases?team_id=<id>` returns only that team's aliases via curl