### PR TITLE
bump litellm-proxy-extras to 0.4.64

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm-proxy-extras"
-version = "0.4.63"
+version = "0.4.64"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 authors = ["BerriAI"]
 readme = "README.md"
@@ -22,7 +22,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "0.4.63"
+version = "0.4.64"
 version_files = [
     "pyproject.toml:version",
     "../requirements.txt:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ boto3 = { version = "1.42.80", optional = true }
 redisvl = {version = "0.4.1", optional = true, markers = "python_version >= '3.9' and python_version < '3.14'"}
 mcp = {version = "1.26.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "0.3.25", optional = true, python = ">=3.10"}
-litellm-proxy-extras = {version = "0.4.63", optional = true}
+litellm-proxy-extras = {version = "0.4.64", optional = true}
 rich = {version = "13.9.4", optional = true}
 litellm-enterprise = {version = "0.1.35", optional = true}
 diskcache = {version = "5.6.3", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ grpcio==1.80.0
 sentry_sdk==2.21.0 # for sentry error handling
 detect-secrets==1.5.0 # Enterprise - secret detection / masking in LLM requests
 tzdata==2025.1 # IANA time zone database
-litellm-proxy-extras==0.4.63 # for proxy extras - e.g. prisma migrations
+litellm-proxy-extras==0.4.64 # for proxy extras - e.g. prisma migrations
 llm-sandbox==0.3.31 # for skill execution in sandbox
 ### LITELLM PACKAGE DEPENDENCIES
 python-dotenv==1.0.1 # for env


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

- [ ] Tests added
- [x] Version bump only — no logic changes

## Type

- [x] New pip package version bump

## Changes

Bumps `litellm-proxy-extras` from `0.4.63` → `0.4.64` in:
- `litellm-proxy-extras/pyproject.toml`
- `requirements.txt`
- `pyproject.toml`