### PR TITLE
fix(ui): don't inject vector_store_ids: [] when editing a model

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -552,6 +552,33 @@ describe("ModelInfoView", () => {
     expect(updatePayload.litellm_params.litellm_credential_name).not.toBe("from-json");
   });
 
+  it("should not include vector_store_ids in update payload when model has none", async () => {
+    // Regression: editing a model without vector stores used to inject
+    // vector_store_ids: [] into litellm_params, which then propagated to
+    // inference requests and broke Anthropic calls.
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.litellm_params).not.toHaveProperty("vector_store_ids");
+  });
+
   it("should display health check model field for wildcard models", async () => {
     const wildcardModelData = {
       ...defaultModelData,

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -267,6 +267,9 @@ export default function ModelInfoView({
       }
       if (values.vector_store_ids?.length > 0) {
         updatedLitellmParams.vector_store_ids = values.vector_store_ids;
+      } else if (values.vector_store_ids !== undefined) {
+        // User explicitly cleared previously-set vector stores — send [] to clear on backend
+        updatedLitellmParams.vector_store_ids = [];
       } else {
         delete updatedLitellmParams.vector_store_ids;
       }
@@ -631,9 +634,11 @@ export default function ModelInfoView({
                     guardrails: Array.isArray(localModelData.litellm_params?.guardrails)
                       ? localModelData.litellm_params.guardrails
                       : [],
-                    vector_store_ids: Array.isArray(localModelData.litellm_params?.vector_store_ids)
-                      ? localModelData.litellm_params.vector_store_ids
-                      : [],
+                    vector_store_ids:
+                      Array.isArray(localModelData.litellm_params?.vector_store_ids) &&
+                      localModelData.litellm_params.vector_store_ids.length > 0
+                        ? localModelData.litellm_params.vector_store_ids
+                        : undefined,
                     tags: Array.isArray(localModelData.litellm_params?.tags) ? localModelData.litellm_params.tags : [],
                     health_check_model: isWildcardModel ? localModelData.model_info?.health_check_model : null,
                     litellm_credential_name: localModelData.litellm_params?.litellm_credential_name || "",

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -265,10 +265,10 @@ export default function ModelInfoView({
       if (values.guardrails) {
         updatedLitellmParams.guardrails = values.guardrails;
       }
-      if (values.vector_store_ids !== undefined) {
-        updatedLitellmParams.vector_store_ids = Array.isArray(values.vector_store_ids)
-          ? values.vector_store_ids
-          : [];
+      if (values.vector_store_ids?.length > 0) {
+        updatedLitellmParams.vector_store_ids = values.vector_store_ids;
+      } else {
+        delete updatedLitellmParams.vector_store_ids;
       }
 
       // Handle cache control settings


### PR DESCRIPTION
## Summary

- **Bug:** Adding an Anthropic model, editing it (without touching vector stores), then using it → broken. The edit-model form was unconditionally sending `vector_store_ids: []` in the PATCH payload, which the backend merged into `litellm_params` and then propagated to every inference call, breaking Anthropic requests.
- **Root cause:** The form initialized `vector_store_ids` to `[]` and the submit handler included it in the payload whenever it was not `undefined` — so an untouched form field still sent an empty array.
- **Fix:** Mirror the `cache_control_injection_points` pattern directly below in the same handler — only include the field when `length > 0`, otherwise `delete` the key from the payload so the backend's PATCH merge leaves the stored value untouched.

## Test plan

- [x] Added regression test `should not include vector_store_ids in update payload when model has none` in `model_info_view.test.tsx` that renders the component, clicks Edit Settings → Save Changes, and asserts the payload's `litellm_params` has no `vector_store_ids` key
- [x] Verified the test fails against the pre-fix handler (receives `[]`) and passes with the fix
- [x] Full `model_info_view.test.tsx` suite passes (34/34)
- [ ] Manual QA: add an Anthropic model, edit an unrelated field, save, make a completion call — verify the model works