### PR TITLE
Fixes three things in `litellm/constants.py` found during code review.

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -307,12 +307,12 @@ AZURE_FILE_SEARCH_COST_PER_GB_PER_DAY = float(
 )
 AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS = float(
     os.getenv(
-        "AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 3.0
+        "AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 0.003
     )  # $0.003 USD per 1K Tokens
 )
 AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS = float(
     os.getenv(
-        "AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 12.0
+        "AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 0.012
     )  # $0.012 USD per 1K Tokens
 )
 AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY = float(
@@ -388,9 +388,6 @@ CACHED_STREAMING_CHUNK_DELAY = float(os.getenv("CACHED_STREAMING_CHUNK_DELAY", 0
 AUDIO_SPEECH_CHUNK_SIZE = int(
     os.getenv("AUDIO_SPEECH_CHUNK_SIZE", 8192)
 )  # chunk_size for audio speech streaming. Balance between latency and memory usage
-MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB = int(
-    os.getenv("MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB", 512)
-)
 DEFAULT_MAX_TOKENS_FOR_TRITON = int(os.getenv("DEFAULT_MAX_TOKENS_FOR_TRITON", 2000))
 #### Networking settings ####
 request_timeout: float = float(os.getenv("REQUEST_TIMEOUT", 6000))  # time in seconds
@@ -840,7 +837,7 @@ clarifai_models: set = set(
         "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Instruct-2507",
         "clarifai/qwen.qwen3.qwen3-next-80B-A3B-Thinking",
         "clarifai/openai.chat-completion.gpt-oss-120b",
-        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507",
         "clarifai/openai.chat-completion.gpt-5-nano",
         "clarifai/openai.chat-completion.gpt-4o",
         "clarifai/gcp.generate.gemini-2_5-pro",

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_azure_assistant_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_azure_assistant_cost_tracking.py
@@ -201,6 +201,6 @@ class TestAzureAssistantCostTracking:
         azure_container_info = litellm.model_cost.get("azure/container", {})
         assert azure_container_info.get("code_interpreter_cost_per_session") == 0.03
         
-        assert AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS == 3.0
-        assert AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS == 12.0
+        assert AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS == 0.003
+        assert AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS == 0.012
         assert AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY == 0.1


### PR DESCRIPTION
Fixed three things in `litellm/constants.py`:

1. **Missing comma in `clarifai_models` set** (`clarifai_models`):
   - A missing comma between two string literals caused Python to silently concatenate them into one string via implicit string concatenation.
   - `clarifai/openai.chat-completion.gpt-5-nano` was never added to the set as a separate entry.
   - Fix: Added the missing comma.

2. **Azure Computer Use cost constants were 1000× too large**:
   - `AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS` had default value `3.0` instead of `0.003`.
   - `AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS` had default value `12.0` instead of `0.012`.
   - Variable names say `PER_1K_TOKENS` and inline comments confirm `$0.003`/`$0.012` per 1K tokens, but the stored defaults were 1000× higher — causing any cost calculation to overcharge by 1000×.
   - Fix: Corrected defaults to `0.003` and `0.012`.

3. **Duplicate `MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB` definition**:
   - The constant was defined twice in the same file — first with default `1024` (with comment `# 1MB = 1024KB`), then again later with default `512`.
   - The second definition silently overwrote the first at import time, making the effective default `512 KB` instead of the intended `1024 KB`.
   - Fix: Removed the duplicate second definition, keeping the original `1024` default.

🐛 Bug Fix