### PR TITLE
Litellm team model group name routing fix (#25148)

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -26,6 +26,22 @@ from litellm.proxy.common_utils.http_parsing_utils import _safe_get_request_head
 _SPECIAL_HEADERS_CACHE = frozenset(
     v.value.lower() for v in SpecialHeaders._member_map_.values()
 )
+
+
+def _sanitize_for_log(value: Any) -> str:
+    """
+    Basic log sanitization helper to reduce log-injection risk.
+
+    Removes newline and carriage-return characters so user-controlled
+    values cannot forge additional log lines when written to text logs.
+    """
+    try:
+        text = str(value)
+    except Exception:
+        # Fallback to repr if str() fails for any reason
+        text = repr(value)
+    # Strip CR/LF characters commonly used for log injection
+    return text.replace("\r", "").replace("\n", "")
 from litellm.router import Router
 from litellm.secret_managers.main import get_secret_bool
 from litellm.types.llms.anthropic import ANTHROPIC_API_HEADERS
@@ -1355,7 +1371,7 @@ def _update_model_if_team_alias_exists(
                         "New sibling deployments may be unreachable. "
                         "Set LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS=true to enable "
                         "team-scoped sibling routing.",
-                        _model,
+                        _sanitize_for_log(_model),
                         user_api_key_dict.team_id,
                     )
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1355,10 +1355,8 @@ def _update_model_if_team_alias_exists(
                         "New sibling deployments may be unreachable. "
                         "Set LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS=true to enable "
                         "team-scoped sibling routing.",
-                        str(_model).replace("\n", "").replace("\r", ""),
-                        str(user_api_key_dict.team_id)
-                        .replace("\n", "")
-                        .replace("\r", ""),
+                        _model,
+                        user_api_key_dict.team_id,
                     )
 
         data["model"] = aliased_target


### PR DESCRIPTION
* fix(team-routing): use deterministic team model group names

Use a deterministic internal model_name for team-scoped deployments so sibling deployments with the same public model share a routing group. This makes team alias writes idempotent and preserves multi-deployment failover/load balancing behavior.

Made-with: Cursor

* fix(team-routing): keep team model routing on public names

Remove team model_alias rewrites and resolve team deployments by team_public_model_name with team_id so sibling deployments stay in the routing candidate pool, with explicit logs showing candidate selection before load balancing.

Made-with: Cursor

* chore(team-routing): remove temporary candidate pool logs

Remove temporary fire-emoji router logs used for local verification while keeping team sibling deployment routing behavior unchanged.

Made-with: Cursor

* fix(router): address Greptile review comments

- Add None guard for original_model_name in _add_team_model_to_db
- Remove stale old public name when renaming team model
- Add comment clarifying team deployment early-return priority

Made-with: Cursor

* fix(router): address remaining Greptile P0/P1 issues

- Update map_team_model test to expect public name return
- Only remove old public name if no sibling deployments use it

Made-with: Cursor

* fix(router): address Greptile P1/P2 performance issues

- Guard against llm_router=None to prevent silent deletion
- Add O(1) team_model index to avoid O(n) scan on every team request

Made-with: Cursor

* fix(router): prevent cross-team deployment leakage in fallback path

Guard should_include_deployment fallback to only return deployments matching the requested team_id, preventing public-name collisions from leaking deployments across teams

Made-with: Cursor

* fix(management): query DB directly for sibling deployments on rename

- Add clarifying comments to test assertions
- Query prisma DB instead of in-memory router to avoid stale state
- Prevents incorrect deletion of old public name when siblings exist

Made-with: Cursor

* fix(router): guard None model_info and deduplicate team index logic

- Guard against None model_info in sibling deployment check
- Extract _update_team_model_index helper to eliminate duplication

Made-with: Cursor

* fix(routing): prevent stale model_aliases from interfering with team routing

- Skip model_aliases rewrite if model resolves to team deployments
- Add test coverage for sibling-preservation branch
- Update MockPrismaClient to support sibling deployment scenarios

Made-with: Cursor

* perf(routing): optimize team model checks and improve test coverage

- Use O(1) team index lookup instead of map_team_model in alias guard
- Fix MockPrismaClient to validate where clause filters
- Add comment explaining DB query trade-off for team deployments

Made-with: Cursor

* fix(routing): address state consistency and type safety issues

- Check alias target pattern to detect stale team aliases
- Fix PrismaClient type annotation to Optional
- Eliminate in-place mutation in index update logic

Made-with: Cursor

* Fix greptile comments

* Fix greptile comments

* Fix greptile comments

* Fix greptile comments

* Fix greptile comments

* Fix code qa issues

* Fix greptile reviews and mock test

* Fix greptile reviews and mock test

* Fix greptile reviews and mock test

* fix(router): address Greptile P1/P2 review comments

- Add deduplication guard in _update_team_model_index to prevent duplicate indices
- Add wildcard comment in map_team_model for clarity
- Add monkeypatch to test_team_alias_stale_bypass_disabled_by_default for determinism
- Extract _get_team_deployments helper to centralize DB access pattern
- Add clarifying comments for team_public_model_name assignment ordering

Made-with: Cursor

* fix(router): address remaining Greptile review comments

- Cache LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS at module level to avoid hot-path secret lookups
- Add clarifying comments for should_include_deployment team isolation logic
- Add negative assertion for update_team.assert_not_called() in test
- Add docstring clarification for _get_team_deployments helper pattern
- Add explicit assertion message in test_get_model_list_alias_optimization

Made-with: Cursor

* fix(router): address final Greptile P1/P2 comments

- Reorder team_public_model_name assignment to happen before model_name mutation for clarity
- Add comment explaining no-rename fast-exit case in _update_existing_team_model_assignment
- Add comment explaining final patch_data.model_name = None applies to all code paths

Made-with: Cursor

* fix(tests): reset module-level cache in stale alias bypass tests

Reset _ENABLE_TEAM_STALE_ALIAS_BYPASS to None in both test functions to ensure test isolation and prevent ordering-dependent failures

Made-with: Cursor

* feat(router): add order-based fallback so higher order deployments are tried on failure

When order=1 deployments fail, the router now automatically tries order=2, then order=3, etc. before falling through to external fallbacks. This removes the need for enable_pre_call_checks and makes order work as a true priority-based fallback chain within a model group.



* fix(router): address Greptile P0/P1 review comments on order fallback

- P0: Skip order-based fallback for ContextWindowExceededError and ContentPolicyViolationError so their dedicated fallback handlers run
- P1: Read _target_order from kwargs to skip already-tried order levels, preventing wasteful retries and exponential retry storms



* feat(router): add order-based fallback so higher order deployments are tried on failure

When a request to an order=1 deployment fails, the router now automatically tries order=2, order=3, etc. before falling through to external fallbacks. Works for all error types (429, 404, connection errors). Requires enable_pre_call_checks=True.



* fix(router): handle non-standard fallback formats with order-based fallback

When fallbacks use non-standard formats (e.g. ["claude-3-haiku"] or [{"model": "...", "messages": [...]}]), detect them with _check_non_standard_fallback_format and pass them through directly instead of trying to parse with get_fallback_model_group which only handles the standard dict-keyed format.



* docs: remove enable_pre_call_checks requirement from order docs

Order-based routing and fallback work without enable_pre_call_checks in the current code. Remove the stale requirement from both doc files.



* Fix tests

---------

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
