### PR TITLE
fix(constants): fix missing comma, wrong Azure costs, and duplicate constant

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -307,12 +307,12 @@ AZURE_FILE_SEARCH_COST_PER_GB_PER_DAY = float(
 )
 AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS = float(
     os.getenv(
-        "AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 3.0
+        "AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 0.003
     )  # $0.003 USD per 1K Tokens
 )
 AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS = float(
     os.getenv(
-        "AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 12.0
+        "AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 0.012
     )  # $0.012 USD per 1K Tokens
 )
 AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY = float(
@@ -388,9 +388,6 @@ CACHED_STREAMING_CHUNK_DELAY = float(os.getenv("CACHED_STREAMING_CHUNK_DELAY", 0
 AUDIO_SPEECH_CHUNK_SIZE = int(
     os.getenv("AUDIO_SPEECH_CHUNK_SIZE", 8192)
 )  # chunk_size for audio speech streaming. Balance between latency and memory usage
-MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB = int(
-    os.getenv("MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB", 512)
-)
 DEFAULT_MAX_TOKENS_FOR_TRITON = int(os.getenv("DEFAULT_MAX_TOKENS_FOR_TRITON", 2000))
 #### Networking settings ####
 request_timeout: float = float(os.getenv("REQUEST_TIMEOUT", 6000))  # time in seconds
@@ -840,7 +837,7 @@ clarifai_models: set = set(
         "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Instruct-2507",
         "clarifai/qwen.qwen3.qwen3-next-80B-A3B-Thinking",
         "clarifai/openai.chat-completion.gpt-oss-120b",
-        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507",
         "clarifai/openai.chat-completion.gpt-5-nano",
         "clarifai/openai.chat-completion.gpt-4o",
         "clarifai/gcp.generate.gemini-2_5-pro",


### PR DESCRIPTION
## Summary

Fixes three data bugs in `litellm/constants.py` reported in #25140.

## Changes

### 1. Missing comma in `clarifai_models` (line 843)

Adjacent string literals without a comma caused Python to silently concatenate them:
```python
# Before — implicit concatenation, "gpt-5-nano" lost
"clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
"clarifai/openai.chat-completion.gpt-5-nano",

# After — both models present as separate set entries
"clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507",
"clarifai/openai.chat-completion.gpt-5-nano",
```

### 2. Azure Computer Use costs 1000x too large (lines 310, 315)

Default values were `3.0` and `12.0` but inline comments say `$0.003` and `$0.012` per 1K tokens. The variable names explicitly say `PER_1K_TOKENS`, so the correct defaults are `0.003` and `0.012`. This overcharged cost tracking by 1000x.

### 3. Duplicate `MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB` (lines 85 vs 391)

Defined twice with conflicting defaults (`1024` then `512`). The second definition silently overwrote the first. Removed the duplicate; retained the documented `1024` KB (1 MB) default.

## Testing

These are data/constant fixes with no behavioral logic change beyond correcting values. Existing tests are unaffected.

## Disclaimer

AI agents (Claude Code) assisted with this contribution.

Fixes #25140