### PR TITLE
bump litellm-enterprise to 0.1.36

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm-enterprise"
-version = "0.1.35"
+version = "0.1.36"
 description = "Package for LiteLLM Enterprise features"
 authors = ["BerriAI"]
 readme = "README.md"
@@ -22,7 +22,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "0.1.35"
+version = "0.1.36"
 version_files = [
     "pyproject.toml:version",
     "../requirements.txt:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ mcp = {version = "1.26.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "0.3.25", optional = true, python = ">=3.10"}
 litellm-proxy-extras = {version = "0.4.64", optional = true}
 rich = {version = "13.9.4", optional = true}
-litellm-enterprise = {version = "0.1.35", optional = true}
+litellm-enterprise = {version = "0.1.36", optional = true}
 diskcache = {version = "5.6.3", optional = true}
 polars = {version = "1.39.3", optional = true, python = ">=3.10"}
 semantic-router = {version = "0.1.12", optional = true, python = ">=3.9,<3.14"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,4 +85,4 @@ requests-toolbelt==1.0.0 # transitive dep (langfuse)
 ########################
 # LITELLM ENTERPRISE DEPENDENCIES
 ########################
-litellm-enterprise==0.1.35
+litellm-enterprise==0.1.36


### PR DESCRIPTION
## Relevant issues / links

Bumps litellm-enterprise package version to keep in sync with published releases.

## Pre-Submission checklist

- [x] Version bumped across all three files

## Type

- [x] Bug fix

## Changes

Bumps `litellm-enterprise` from `0.1.35` → `0.1.36` across:
- `enterprise/pyproject.toml`
- `pyproject.toml`
- `requirements.txt`