### PR TITLE
Fix: map Anthropic `compaction` finish_reason to `stop` instead of `length`

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -65,7 +65,7 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "max_tokens": "length",
     "tool_use": "tool_calls",
     "refusal": "content_filter",
-    "compaction": "length",
+    "compaction": "stop",
     # Cohere
     "COMPLETE": "stop",
     "ERROR_TOXIC": "content_filter",

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -66,7 +66,7 @@ class TestMapFinishReasonAnthropic:
             ("end_turn", "stop"),
             ("max_tokens", "length"),
             ("tool_use", "tool_calls"),
-            ("compaction", "length"),
+            ("compaction", "stop"),
             ("content_filtered", "content_filter"),
         ],
     )


### PR DESCRIPTION
## Summary

- Change `compaction` finish_reason mapping from `length` to `stop` in `_FINISH_REASON_MAP`
- Update corresponding test expectation in `test_core_helpers.py`

## Problem

When Anthropic's context compaction feature triggers with `pause_after_compaction=True`, the API returns `finish_reason: "compaction"`. LiteLLM currently maps this to `length`, which is semantically incorrect:

- **`length`** signals that `max_tokens` was hit and output was truncated. Downstream consumers interpret this as a signal to retry or continue generation.
- **`compaction`** means the context was summarized and the model paused naturally — no output was truncated. The correct OpenAI-equivalent is `stop`.

Mapping compaction to `length` causes downstream retry/continuation logic to fire unnecessarily, leading to confusing behavior for users of the compaction feature.

Fixes #25165

## Changes

- `litellm/litellm_core_utils/core_helpers.py`: `"compaction": "length"` → `"compaction": "stop"`
- `tests/test_litellm/litellm_core_utils/test_core_helpers.py`: Updated test parametrization to expect `"stop"`

## Test plan

- [x] Existing `test_anthropic_finish_reasons` parametrized test updated and passes
- [x] `TestFinishReasonMapOutputsAreValid` continues to pass (all mapped values are valid OpenAI finish reasons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)