### PR TITLE
fix(bedrock): skip tools with empty names, fall back to auto on empty tool_choice

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5037,9 +5037,9 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
             return char
         return "_"
 
-    # If the string is empty, return a default valid identifier
-    if input_tool_name is None or len(input_tool_name) == 0:
-        return input_tool_name
+    # If the string is empty or None, return as-is — callers must handle this
+    if not input_tool_name:
+        return ""
     bedrock_tool_name = copy.copy(input_tool_name)
     # If it doesn't start with a letter, prepend 'a'
     if not bedrock_tool_name[0].isalpha():
@@ -5161,6 +5161,18 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
         # related issue: https://github.com/BerriAI/litellm/issues/5007
         # Bedrock tool names must satisfy regular expression pattern: [a-zA-Z][a-zA-Z0-9_]* ensure this is true
         name = make_valid_bedrock_tool_name(input_tool_name=name)
+
+        # Bedrock rejects tools whose name is empty or blank — skip them with a warning
+        # This can happen when MCP tools sent by clients (e.g. Cursor) have missing metadata
+        if not name or not name.strip():
+            verbose_logger.warning(
+                "Skipping tool with empty name when converting to Bedrock format. "
+                "Bedrock requires tool names to be non-empty and match [a-zA-Z0-9_-]+. "
+                "Tool: %s",
+                tool,
+            )
+            continue
+
         _tool_description = tool.get("function", {}).get("description", None)
         if _tool_description:  # bedrock doesn't accept empty "" or None descriptions
             description = _tool_description

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -573,9 +573,16 @@ class AmazonConverseConfig(BaseConfig):
             return ToolChoiceValuesBlock(auto={})
         elif isinstance(tool_choice, dict):
             # only supported for anthropic + mistral models - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
-            specific_tool = SpecificToolChoiceBlock(
-                name=tool_choice.get("function", {}).get("name", "")
-            )
+            tool_name = tool_choice.get("function", {}).get("name", "")
+            if not tool_name or not tool_name.strip():
+                # Bedrock rejects toolChoice.tool.name="" — fall back to auto.
+                # This happens when clients (e.g. Cursor) send tool_choice with a blank tool name.
+                verbose_logger.warning(
+                    "tool_choice specifies an empty tool name; falling back to tool_choice='auto' "
+                    "because Bedrock requires toolChoice.tool.name to match [a-zA-Z0-9_-]+."
+                )
+                return ToolChoiceValuesBlock(auto={})
+            specific_tool = SpecificToolChoiceBlock(name=tool_name)
             return ToolChoiceValuesBlock(tool=specific_tool)
         else:
             raise litellm.utils.UnsupportedParamsError(


### PR DESCRIPTION
## Problem

When clients such as Cursor send MCP tools with missing metadata, tool names and descriptions arrive as empty strings (`name=""`, `description=""`). LiteLLM passed them through unchanged to Bedrock's Converse API, which rejects them with up to 10 validation errors:

```
BedrockException: 10 validation errors detected:
  Value at 'toolConfig.toolChoice.tool.name' failed to satisfy constraint:
    Member must have length >= 1; must match [a-zA-Z0-9_-]+
  Value '' at 'toolConfig.tools.1.member.toolSpec.name' ...
  Value '' at 'toolConfig.tools.1.member.toolSpec.description' ...
  ...
```

## Root cause

Two separate pass-throughs of invalid data:

1. **`_bedrock_tools_pt`** (`litellm_core_utils/prompt_templates/factory.py`): after calling `make_valid_bedrock_tool_name`, an empty name was forwarded as-is into `BedrockToolSpecBlock(name="")`.
2. **`map_tool_choice_values`** (`llms/bedrock/chat/converse_transformation.py`): `SpecificToolChoiceBlock(name="")` was built directly from `tool_choice.function.name` without checking for blank values.

## Fix

- **`_bedrock_tools_pt`**: after `make_valid_bedrock_tool_name`, if the resulting name is still empty, skip the tool and emit a `verbose_logger.warning`. The valid tools in the list are forwarded normally.
- **`map_tool_choice_values`**: if `tool_choice.function.name` is empty or blank, fall back to `ToolChoiceValuesBlock(auto={})` with a warning instead of sending an invalid `SpecificToolChoiceBlock`.

## Verification

Reproduced with a standalone script that sends 1 valid tool + 3 empty-named tools + `tool_choice={"type":"function","function":{"name":""}}` against a local LiteLLM proxy backed by Bedrock Claude Sonnet 4.6. Before the fix: HTTP 400 with 10 Bedrock validation errors. After the fix: HTTP 200, empty tools silently dropped, valid tool passed through.

## Checklist
- [ ] Add at least 1 test in `tests/litellm/`

Made with [Cursor](https://cursor.com)