### PR TITLE
fix(constants): fix missing comma, wrong cost multiplier, and duplicate constant

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -307,12 +307,12 @@ AZURE_FILE_SEARCH_COST_PER_GB_PER_DAY = float(
 )
 AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS = float(
     os.getenv(
-        "AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 3.0
+        "AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 0.003
     )  # $0.003 USD per 1K Tokens
 )
 AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS = float(
     os.getenv(
-        "AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 12.0
+        "AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 0.012
     )  # $0.012 USD per 1K Tokens
 )
 AZURE_VECTOR_STORE_COST_PER_GB_PER_DAY = float(
@@ -388,9 +388,6 @@ CACHED_STREAMING_CHUNK_DELAY = float(os.getenv("CACHED_STREAMING_CHUNK_DELAY", 0
 AUDIO_SPEECH_CHUNK_SIZE = int(
     os.getenv("AUDIO_SPEECH_CHUNK_SIZE", 8192)
 )  # chunk_size for audio speech streaming. Balance between latency and memory usage
-MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB = int(
-    os.getenv("MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB", 512)
-)
 DEFAULT_MAX_TOKENS_FOR_TRITON = int(os.getenv("DEFAULT_MAX_TOKENS_FOR_TRITON", 2000))
 #### Networking settings ####
 request_timeout: float = float(os.getenv("REQUEST_TIMEOUT", 6000))  # time in seconds
@@ -840,7 +837,7 @@ clarifai_models: set = set(
         "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Instruct-2507",
         "clarifai/qwen.qwen3.qwen3-next-80B-A3B-Thinking",
         "clarifai/openai.chat-completion.gpt-oss-120b",
-        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507"
+        "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507",
         "clarifai/openai.chat-completion.gpt-5-nano",
         "clarifai/openai.chat-completion.gpt-4o",
         "clarifai/gcp.generate.gemini-2_5-pro",

--- a/tests/test_litellm/test_constants_fixes.py
+++ b/tests/test_litellm/test_constants_fixes.py
@@ -1,0 +1,40 @@
+"""Tests for constants.py fixes (issue #25140)."""
+
+import ast
+import re
+
+
+def test_clarifai_models_no_implicit_concatenation():
+    """Ensure clarifai_models entries are properly comma-separated (no implicit string concatenation)."""
+    with open("litellm/constants.py") as f:
+        content = f.read()
+
+    # The two strings that were previously concatenated due to missing comma
+    assert "clarifai/qwen.qwenLM.Qwen3-30B-A3B-Thinking-2507" in content
+    assert "clarifai/openai.chat-completion.gpt-5-nano" in content
+
+    # Verify comma exists between them
+    pattern = r'"clarifai/qwen\.qwenLM\.Qwen3-30B-A3B-Thinking-2507"\s*,\s*\n\s*"clarifai/openai\.chat-completion\.gpt-5-nano"'
+    assert re.search(pattern, content), "Missing comma between clarifai model entries"
+
+
+def test_azure_computer_use_cost_defaults():
+    """Ensure Azure Computer Use cost defaults match documented values ($0.003/$0.012 per 1K tokens)."""
+    with open("litellm/constants.py") as f:
+        content = f.read()
+
+    assert '"AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 0.003' in content
+    assert '"AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 0.012' in content
+
+
+def test_no_duplicate_max_size_per_item_in_memory_cache():
+    """Ensure MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB is defined only once."""
+    with open("litellm/constants.py") as f:
+        content = f.read()
+
+    definitions = re.findall(
+        r"^MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB\s*=", content, re.MULTILINE
+    )
+    assert len(definitions) == 1, (
+        f"Expected 1 definition, found {len(definitions)}"
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #25140

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Three bugs fixed in `litellm/constants.py`:

1. **Missing comma** in `clarifai_models` set between `Qwen3-30B-A3B-Thinking-2507` and `gpt-5-nano` — Python silently concatenated both strings into one, losing `gpt-5-nano` from the set
2. **Azure Computer Use costs 1000× too large** — `AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS` was `3.0` instead of `0.003`, output was `12.0` instead of `0.012`
3. **Duplicate constant** — `MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB` defined twice (1024 then 512), second silently overwrote first. Removed the duplicate.