### PR TITLE
fix: correct invalid min-release-age value in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@
 # Packages needing lifecycle scripts: npm rebuild <pkg>
 ignore-scripts=true
 # Protects local npm install only — npm ci (used in CI) ignores this
-min-release-age=3d
+min-release-age=3


### PR DESCRIPTION
## Relevant issues

Fixes #25057

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** — N/A, config file fix only
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Corrects `min-release-age=3d` to `min-release-age=3` in `.npmrc`. The `min-release-age` option expects a number (days), not a string with a unit suffix. The invalid value `3d` causes npm to silently ignore the setting, defeating the supply-chain hardening intended by #24838.