### PR TITLE
fix(bedrock): support Anthropic-format requests from clients like Cursor IDE

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5037,9 +5037,9 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
             return char
         return "_"
 
-    # If the string is empty, return a default valid identifier
-    if input_tool_name is None or len(input_tool_name) == 0:
-        return input_tool_name
+    # If the string is empty or None, return as-is — callers must handle this
+    if not input_tool_name:
+        return ""
     bedrock_tool_name = copy.copy(input_tool_name)
     # If it doesn't start with a letter, prepend 'a'
     if not bedrock_tool_name[0].isalpha():
@@ -5161,6 +5161,18 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
         # related issue: https://github.com/BerriAI/litellm/issues/5007
         # Bedrock tool names must satisfy regular expression pattern: [a-zA-Z][a-zA-Z0-9_]* ensure this is true
         name = make_valid_bedrock_tool_name(input_tool_name=name)
+
+        # Bedrock rejects tools whose name is empty or blank — skip them with a warning
+        # This can happen when MCP tools sent by clients (e.g. Cursor) have missing metadata
+        if not name or not name.strip():
+            verbose_logger.warning(
+                "Skipping tool with empty name when converting to Bedrock format. "
+                "Bedrock requires tool names to be non-empty and match [a-zA-Z0-9_-]+. "
+                "Tool: %s",
+                tool,
+            )
+            continue
+
         _tool_description = tool.get("function", {}).get("description", None)
         if _tool_description:  # bedrock doesn't accept empty "" or None descriptions
             description = _tool_description

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4439,6 +4439,27 @@ class BedrockConverseMessagesProcessor:
                                     message=cast(ChatCompletionFileObject, element)
                                 )
                                 _parts.append(_part)
+                            elif element["type"] in ("tool_result", "tool_use"):
+                                if element["type"] == "tool_result":
+                                    tool_use_id = element.get("tool_use_id", str(uuid.uuid4()))
+                                    inner_content = element.get("content", "")
+                                    tool_result_blocks: List[BedrockToolResultContentBlock] = []
+                                    if isinstance(inner_content, str):
+                                        tool_result_blocks.append(
+                                            BedrockToolResultContentBlock(text=inner_content)
+                                        )
+                                    elif isinstance(inner_content, list):
+                                        for inner in inner_content:
+                                            if isinstance(inner, dict) and inner.get("type") == "text":
+                                                tool_result_blocks.append(
+                                                    BedrockToolResultContentBlock(text=inner.get("text", ""))
+                                                )
+                                    bedrock_tool_result = BedrockToolResultBlock(
+                                        content=tool_result_blocks,
+                                        toolUseId=tool_use_id,
+                                    )
+                                    _parts.append(BedrockContentBlock(toolResult=bedrock_tool_result))
+                                continue
                             _cache_point_block = (
                                 litellm.AmazonConverseConfig()._get_cache_point_block(
                                     message_block=cast(
@@ -4601,17 +4622,21 @@ class BedrockConverseMessagesProcessor:
                                     image_url=image_url
                                 )
                                 assistants_parts.append(assistants_part)
-                                # Add cache point block for assistant content elements
-                        _cache_point_block = (
-                            litellm.AmazonConverseConfig()._get_cache_point_block(
-                                message_block=cast(
-                                    OpenAIMessageContentListBlock, element
-                                ),
-                                block_type="content_block",
-                            )
-                        )
-                        if _cache_point_block is not None:
-                            assistants_parts.append(_cache_point_block)
+                            elif element["type"] == "tool_use":
+                                tool_input = element.get("input", {})
+                                if isinstance(tool_input, str):
+                                    try:
+                                        tool_input = json.loads(tool_input)
+                                    except Exception:
+                                        tool_input = {}
+                                bedrock_tool_use = BedrockToolUseBlock(
+                                    toolUseId=element.get("id", str(uuid.uuid4())),
+                                    name=element.get("name", ""),
+                                    input=tool_input,
+                                )
+                                assistants_parts.append(
+                                    BedrockContentBlock(toolUse=bedrock_tool_use)
+                                )
                     assistant_content.extend(assistants_parts)
                 elif _assistant_content is not None and isinstance(
                     _assistant_content, str
@@ -4621,15 +4646,6 @@ class BedrockConverseMessagesProcessor:
                         assistant_content.append(
                             BedrockContentBlock(text=_assistant_content)
                         )
-                    # If content is empty/whitespace, skip it (don't add a placeholder)
-                    # Add cache point block for assistant string content
-                    _cache_point_block = (
-                        litellm.AmazonConverseConfig()._get_cache_point_block(
-                            assistant_message_block, block_type="content_block"
-                        )
-                    )
-                    if _cache_point_block is not None:
-                        assistant_content.append(_cache_point_block)
 
                 _tool_calls = assistant_message_block.get("tool_calls", [])
                 if _tool_calls:
@@ -4815,6 +4831,34 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                                 )
                             )
                             _parts.append(_part)
+                        elif element["type"] in ("tool_result", "tool_use"):
+                            # Anthropic-format tool results/uses embedded in user messages
+                            # (e.g. sent by Cursor IDE after a tool call).  Convert the
+                            # tool_result to a Bedrock toolResult block.  Skip the
+                            # cachePoint — Bedrock rejects cachePoint blocks placed
+                            # immediately after toolResult content with no preceding text.
+                            if element["type"] == "tool_result":
+                                tool_use_id = element.get("tool_use_id", str(uuid.uuid4()))
+                                inner_content = element.get("content", "")
+                                tool_result_blocks: List[BedrockToolResultContentBlock] = []
+                                if isinstance(inner_content, str):
+                                    tool_result_blocks.append(
+                                        BedrockToolResultContentBlock(text=inner_content)
+                                    )
+                                elif isinstance(inner_content, list):
+                                    for inner in inner_content:
+                                        if isinstance(inner, dict) and inner.get("type") == "text":
+                                            tool_result_blocks.append(
+                                                BedrockToolResultContentBlock(text=inner.get("text", ""))
+                                            )
+                                bedrock_tool_result = BedrockToolResultBlock(
+                                    content=tool_result_blocks,
+                                    toolUseId=tool_use_id,
+                                )
+                                _parts.append(BedrockContentBlock(toolResult=bedrock_tool_result))
+                            # Skip cachePoint for tool_result/tool_use — add it at
+                            # message level (after all content) if needed, handled below.
+                            continue
                         _cache_point_block = (
                             litellm.AmazonConverseConfig()._get_cache_point_block(
                                 message_block=cast(
@@ -4970,17 +5014,30 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                                 image_url=image_url
                             )
                             assistants_parts.append(assistants_part)
-                        # Add cache point block for assistant content elements
-                        _cache_point_block = (
-                            litellm.AmazonConverseConfig()._get_cache_point_block(
-                                message_block=cast(
-                                    OpenAIMessageContentListBlock, element
-                                ),
-                                block_type="content_block",
+                        elif element["type"] == "tool_use":
+                            # Anthropic-format tool invocation embedded in assistant
+                            # content list (e.g. from Cursor IDE). Convert to Bedrock
+                            # toolUse ContentBlock directly. Skip cachePoint — Bedrock
+                            # rejects cachePoint immediately after toolUse blocks.
+                            tool_input = element.get("input", {})
+                            if isinstance(tool_input, str):
+                                try:
+                                    tool_input = json.loads(tool_input)
+                                except Exception:
+                                    tool_input = {}
+                            bedrock_tool_use = BedrockToolUseBlock(
+                                toolUseId=element.get("id", str(uuid.uuid4())),
+                                name=element.get("name", ""),
+                                input=tool_input,
                             )
-                        )
-                        if _cache_point_block is not None:
-                            assistants_parts.append(_cache_point_block)
+                            assistants_parts.append(
+                                BedrockContentBlock(toolUse=bedrock_tool_use)
+                            )
+                            continue  # skip _get_cache_point_block for tool_use
+                        # Anthropic prompt caching only supports cachePoint blocks in
+                        # system, tools, and USER messages — NOT in assistant messages.
+                        # Bedrock rejects cachePoint in assistant content with
+                        # "There is nothing available to cache."  Skip it here.
                 assistant_content.extend(assistants_parts)
             elif _assistant_content is not None and isinstance(_assistant_content, str):
                 # Skip completely empty strings to avoid blank content blocks
@@ -4988,14 +5045,6 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
                     assistant_content.append(
                         BedrockContentBlock(text=_assistant_content)
                     )
-                # Add cache point block for assistant string content
-                _cache_point_block = (
-                    litellm.AmazonConverseConfig()._get_cache_point_block(
-                        assistant_message_block, block_type="content_block"
-                    )
-                )
-                if _cache_point_block is not None:
-                    assistant_content.append(_cache_point_block)
             _tool_calls = assistant_message_block.get("tool_calls", [])
             if _tool_calls:
                 assistant_content.extend(
@@ -5152,11 +5201,20 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
             tool_block_list.append(tool)  # type: ignore
             continue
 
-        # Handle regular OpenAI-style function tools
-        parameters = tool.get("function", {}).get(
-            "parameters", {"type": "object", "properties": {}}
-        )
-        name = tool.get("function", {}).get("name", "")
+        # Detect Anthropic-format tools (name + input_schema at top level, no "function" wrapper).
+        # Clients like Cursor IDE send tools in this format when talking to an OpenAI-compatible
+        # proxy that sits in front of a non-Anthropic backend such as Bedrock.
+        if "function" not in tool and "name" in tool and "input_schema" in tool:
+            parameters = tool.get("input_schema", {"type": "object", "properties": {}})
+            name = tool.get("name", "")
+            _raw_description = tool.get("description", None)
+        else:
+            # Handle regular OpenAI-style function tools
+            parameters = tool.get("function", {}).get(
+                "parameters", {"type": "object", "properties": {}}
+            )
+            name = tool.get("function", {}).get("name", "")
+            _raw_description = tool.get("function", {}).get("description", None)
 
         # related issue: https://github.com/BerriAI/litellm/issues/5007
         # Bedrock tool names must satisfy regular expression pattern: [a-zA-Z][a-zA-Z0-9_]* ensure this is true
@@ -5173,7 +5231,7 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
             )
             continue
 
-        _tool_description = tool.get("function", {}).get("description", None)
+        _tool_description = _raw_description
         if _tool_description:  # bedrock doesn't accept empty "" or None descriptions
             description = _tool_description
         else:

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -574,11 +574,15 @@ class AmazonConverseConfig(BaseConfig):
         elif isinstance(tool_choice, dict):
             # only supported for anthropic + mistral models - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
 
-            # An empty dict {} has no "type" field — it is not a specific-function
-            # tool_choice, it is the client's way of saying "use default tool mode".
-            # Map it to "any" (required) so Bedrock forces the model to call at
-            # least one tool.  This matches the intent: agents like Cursor always
-            # send tools alongside {} and expect a tool call back, not plain text.
+            # An empty dict {} is sent by agentic clients (e.g. Cursor IDE) that
+            # always provide tools and expect the model to invoke one.  We map it
+            # to "any" (must call ≥1 tool) rather than "auto" (may skip tools)
+            # because:
+            #   1. These clients never send {} without tools — they want a tool call.
+            #   2. With "auto", the model often returns plain text instead, which
+            #      breaks the agent loop (tool edits show as chat text).
+            # If a caller truly wants optional tool use, they should send
+            # tool_choice="auto" explicitly.
             if not tool_choice:
                 return ToolChoiceValuesBlock(any={})
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -573,10 +573,19 @@ class AmazonConverseConfig(BaseConfig):
             return ToolChoiceValuesBlock(auto={})
         elif isinstance(tool_choice, dict):
             # only supported for anthropic + mistral models - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
+
+            # An empty dict {} has no "type" field — it is not a specific-function
+            # tool_choice, it is the client's way of saying "use default tool mode".
+            # Map it to "any" (required) so Bedrock forces the model to call at
+            # least one tool.  This matches the intent: agents like Cursor always
+            # send tools alongside {} and expect a tool call back, not plain text.
+            if not tool_choice:
+                return ToolChoiceValuesBlock(any={})
+
             tool_name = tool_choice.get("function", {}).get("name", "")
             if not tool_name or not tool_name.strip():
                 # Bedrock rejects toolChoice.tool.name="" — fall back to auto.
-                # This happens when clients (e.g. Cursor) send tool_choice with a blank tool name.
+                # This happens when clients send tool_choice with a blank tool name.
                 verbose_logger.warning(
                     "tool_choice specifies an empty tool name; falling back to tool_choice='auto' "
                     "because Bedrock requires toolChoice.tool.name to match [a-zA-Z0-9_-]+."
@@ -1120,10 +1129,30 @@ class AmazonConverseConfig(BaseConfig):
             return ContentBlock(cachePoint=cache_point)
 
     def _transform_system_message(
-        self, messages: List[AllMessageValues], model: Optional[str] = None
+        self,
+        messages: List[AllMessageValues],
+        model: Optional[str] = None,
+        system_kwarg: Optional[List[dict]] = None,
     ) -> Tuple[List[AllMessageValues], List[SystemContentBlock]]:
         system_prompt_indices = []
         system_content_blocks: List[SystemContentBlock] = []
+
+        # Process blocks from the top-level `system` kwarg (Anthropic block format:
+        # [{"type": "text", "text": "...", "cache_control": {...}}]).  These are
+        # prepended so the kwarg system prompt appears before any role:system messages
+        # extracted from the messages array.
+        if system_kwarg:
+            for block in system_kwarg:
+                if block.get("type") == "text" and block.get("text"):
+                    system_content_blocks.append(
+                        SystemContentBlock(text=block["text"])
+                    )
+                    cache_block = self._get_cache_point_block(
+                        block, block_type="system", model=model
+                    )
+                    if cache_block:
+                        system_content_blocks.append(cache_block)
+
         for idx, message in enumerate(messages):
             if message["role"] == "system":
                 system_prompt_indices.append(idx)
@@ -1495,8 +1524,16 @@ class AmazonConverseConfig(BaseConfig):
         litellm_params: dict,
         headers: Optional[dict] = None,
     ) -> RequestObject:
+        # Pop the `system` kwarg before _prepare_request_params sees it.
+        # If left in optional_params it is not in AmazonConverseConfig.__annotations__
+        # and falls through to additionalModelRequestFields instead of the proper
+        # top-level system field.
+        _raw_system = optional_params.pop("system", None)
+        system_kwarg: Optional[List[dict]] = (
+            _raw_system if isinstance(_raw_system, list) else None
+        )
         messages, system_content_blocks = self._transform_system_message(
-            messages, model=model
+            messages, model=model, system_kwarg=system_kwarg
         )
 
         # Convert last user message to guarded_text if guardrailConfig is present
@@ -1553,8 +1590,16 @@ class AmazonConverseConfig(BaseConfig):
         litellm_params: dict,
         headers: Optional[dict] = None,
     ) -> RequestObject:
+        # Pop the `system` kwarg before _prepare_request_params sees it.
+        # If left in optional_params it is not in AmazonConverseConfig.__annotations__
+        # and falls through to additionalModelRequestFields instead of the proper
+        # top-level system field.
+        _raw_system = optional_params.pop("system", None)
+        system_kwarg: Optional[List[dict]] = (
+            _raw_system if isinstance(_raw_system, list) else None
+        )
         messages, system_content_blocks = self._transform_system_message(
-            messages, model=model
+            messages, model=model, system_kwarg=system_kwarg
         )
 
         # Convert last user message to guarded_text if guardrailConfig is present

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -573,9 +573,16 @@ class AmazonConverseConfig(BaseConfig):
             return ToolChoiceValuesBlock(auto={})
         elif isinstance(tool_choice, dict):
             # only supported for anthropic + mistral models - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
-            specific_tool = SpecificToolChoiceBlock(
-                name=tool_choice.get("function", {}).get("name", "")
-            )
+            tool_name = tool_choice.get("function", {}).get("name", "")
+            if not tool_name or not tool_name.strip():
+                # Bedrock rejects toolChoice.tool.name="" — fall back to auto.
+                # This happens when clients (e.g. Cursor) send tool_choice with a blank tool name.
+                verbose_logger.warning(
+                    "tool_choice specifies an empty tool name; falling back to tool_choice='auto' "
+                    "because Bedrock requires toolChoice.tool.name to match [a-zA-Z0-9_-]+."
+                )
+                return ToolChoiceValuesBlock(auto={})
+            specific_tool = SpecificToolChoiceBlock(name=tool_name)
             return ToolChoiceValuesBlock(tool=specific_tool)
         else:
             raise litellm.utils.UnsupportedParamsError(

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -797,6 +797,11 @@ ValidUserMessageContentTypes = [
     "guarded_text",
     "video_url",
     "file",
+    # Anthropic/Bedrock multi-turn tool use: clients like Cursor send tool results
+    # back in user messages as {"type": "tool_result", ...}. Allow them through so
+    # downstream provider transformations can handle them correctly.
+    "tool_result",
+    "tool_use",
 ]  # used for validating user messages. Prevent users from accidentally sending anthropic messages.
 
 ValidUserMessageContentTypesLiteral = Literal[
@@ -819,6 +824,11 @@ ValidUserMessageContentTypes = [
     "guarded_text",
     "video_url",
     "file",
+    # Anthropic/Bedrock multi-turn tool use: clients like Cursor send tool results
+    # back in user messages as {"type": "tool_result", ...}. Allow them through so
+    # downstream provider transformations can handle them correctly.
+    "tool_result",
+    "tool_use",
 ]  # used for validating user messages. Prevent users from accidentally sending anthropic messages.
 
 # Assistant message content types (text, thinking, redacted_thinking, image_url)

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -788,22 +788,6 @@ class GenericChatCompletionMessage(TypedDict, total=False):
     content: Required[Union[str, List]]
 
 
-ValidUserMessageContentTypes = [
-    "text",
-    "image_url",
-    "input_audio",
-    "audio_url",
-    "document",
-    "guarded_text",
-    "video_url",
-    "file",
-    # Anthropic/Bedrock multi-turn tool use: clients like Cursor send tool results
-    # back in user messages as {"type": "tool_result", ...}. Allow them through so
-    # downstream provider transformations can handle them correctly.
-    "tool_result",
-    "tool_use",
-]  # used for validating user messages. Prevent users from accidentally sending anthropic messages.
-
 ValidUserMessageContentTypesLiteral = Literal[
     "text",
     "image_url",
@@ -813,6 +797,8 @@ ValidUserMessageContentTypesLiteral = Literal[
     "guarded_text",
     "video_url",
     "file",
+    "tool_result",
+    "tool_use",
 ]
 
 ValidUserMessageContentTypes = [

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7943,6 +7943,13 @@ def validate_chat_completion_tool_choice(
     elif isinstance(tool_choice, str):
         return tool_choice
     elif isinstance(tool_choice, dict):
+        # An empty dict {} has no "type" field.  Some clients (e.g. Cursor IDE)
+        # send {} to mean "use default tool mode".  Pass it through so that
+        # provider-specific code (e.g. Bedrock's map_tool_choice_values) can
+        # convert it to the correct wire format.
+        if not tool_choice:
+            return tool_choice
+
         # Handle Cursor IDE format: {"type": "auto"} -> return as-is
         if (
             tool_choice.get("type") in ["auto", "none", "required"]

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -1282,17 +1282,21 @@ async def test_assistant_message_cache_control():
     assert result[0]["role"] == "user"
     assert result[1]["role"] == "assistant"
 
-    # Assistant message should have text content and cachePoint
+    # Bedrock rejects cachePoint in assistant messages ("There is nothing
+    # available to cache"), so assistant content must NOT contain cachePoint.
     assistant_content = result[1]["content"]
-    assert len(assistant_content) == 2
+    assert len(assistant_content) == 1
     assert assistant_content[0]["text"] == "Hi there!"
-    assert "cachePoint" in assistant_content[1]
-    assert assistant_content[1]["cachePoint"]["type"] == "default"
 
 
 @pytest.mark.asyncio
 async def test_assistant_message_list_content_cache_control():
-    """Test assistant messages with list content and cache_control."""
+    """Test that cache_control on assistant list content does NOT produce cachePoint blocks.
+
+    Bedrock rejects cachePoint in assistant messages with 'There is nothing
+    available to cache'.  Prompt caching only supports cache points in system,
+    tools, and user messages.
+    """
     from litellm.litellm_core_utils.prompt_templates.factory import (
         BedrockConverseMessagesProcessor,
         _bedrock_converse_messages_pt,
@@ -1316,12 +1320,10 @@ async def test_assistant_message_list_content_cache_control():
 
     assert result == async_result
 
-    # Assistant message should have text content and cachePoint
+    # No cachePoint in assistant content
     assistant_content = result[1]["content"]
-    assert len(assistant_content) == 2
+    assert len(assistant_content) == 1
     assert assistant_content[0]["text"] == "This should be cached"
-    assert "cachePoint" in assistant_content[1]
-    assert assistant_content[1]["cachePoint"]["type"] == "default"
 
 
 @pytest.mark.asyncio
@@ -3601,3 +3603,254 @@ def test_cache_control_injection_tool_config_not_added_without_injection_point()
     tools = result["toolConfig"]["tools"]
     # No cachePoint should be appended
     assert all("cachePoint" not in tool for tool in tools)
+
+
+# ---------------------------------------------------------------------------
+# Tests for Anthropic-format client compatibility (Cursor IDE / Bedrock)
+# ---------------------------------------------------------------------------
+
+
+def test_map_tool_choice_empty_dict_returns_any():
+    """Empty tool_choice {} should map to 'any' (force tool use), not 'auto'."""
+    config = AmazonConverseConfig()
+    result = config.map_tool_choice_values(
+        model="anthropic.claude-sonnet-4-6", tool_choice={}, drop_params=False
+    )
+    assert result == {"any": {}}
+
+
+def test_map_tool_choice_auto_string_returns_auto():
+    """Verify 'auto' string still maps to auto (regression guard)."""
+    config = AmazonConverseConfig()
+    result = config.map_tool_choice_values(
+        model="anthropic.claude-sonnet-4-6", tool_choice="auto", drop_params=False
+    )
+    assert result == {"auto": {}}
+
+
+def test_map_tool_choice_specific_function():
+    """Verify a specific function tool_choice still works."""
+    config = AmazonConverseConfig()
+    result = config.map_tool_choice_values(
+        model="anthropic.claude-sonnet-4-6",
+        tool_choice={"type": "function", "function": {"name": "my_tool"}},
+        drop_params=False,
+    )
+    assert result == {"tool": {"name": "my_tool"}}
+
+
+def test_bedrock_tools_pt_anthropic_format():
+    """Anthropic-format tools (name + input_schema at top level) should be parsed correctly."""
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    anthropic_tools = [
+        {
+            "name": "edit_file",
+            "description": "Edit a file on disk",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+        {
+            "name": "read_file",
+            "description": "Read a file from disk",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+                "required": ["path"],
+            },
+        },
+    ]
+
+    result = _bedrock_tools_pt(anthropic_tools)
+    assert len(result) == 2
+
+    spec0 = result[0]["toolSpec"]
+    assert spec0["name"] == "edit_file"
+    assert spec0["description"] == "Edit a file on disk"
+    assert spec0["inputSchema"]["json"]["type"] == "object"
+    assert "path" in spec0["inputSchema"]["json"]["properties"]
+
+    spec1 = result[1]["toolSpec"]
+    assert spec1["name"] == "read_file"
+
+
+def test_bedrock_tools_pt_openai_format_still_works():
+    """OpenAI-format tools should continue to work (regression guard)."""
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    openai_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    result = _bedrock_tools_pt(openai_tools)
+    assert len(result) == 1
+    assert result[0]["toolSpec"]["name"] == "get_weather"
+    assert result[0]["toolSpec"]["description"] == "Get the weather"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_messages_tool_result_in_user_content():
+    """Anthropic-format tool_result in user message content should be converted to Bedrock toolResult."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        BedrockConverseMessagesProcessor,
+        _bedrock_converse_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "content": "I'll help.",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "/tmp/test.txt"}'},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_123",
+                    "content": "file contents here",
+                }
+            ],
+        },
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages=messages,
+        model="bedrock/anthropic.claude-sonnet-4-6",
+        llm_provider="bedrock_converse",
+    )
+
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/anthropic.claude-sonnet-4-6",
+        llm_provider="bedrock_converse",
+    )
+
+    assert result == async_result
+
+    # The tool_result user message should contain a toolResult block
+    user_msg = result[-1]
+    assert user_msg["role"] == "user"
+    tool_result_blocks = [b for b in user_msg["content"] if "toolResult" in b]
+    assert len(tool_result_blocks) >= 1
+    assert tool_result_blocks[0]["toolResult"]["toolUseId"] == "call_123"
+    assert tool_result_blocks[0]["toolResult"]["content"][0]["text"] == "file contents here"
+
+    # No cachePoint should appear after tool_result
+    cache_blocks = [b for b in user_msg["content"] if "cachePoint" in b]
+    assert len(cache_blocks) == 0
+
+
+@pytest.mark.asyncio
+async def test_bedrock_messages_tool_use_in_assistant_content():
+    """Anthropic-format tool_use in assistant content list should be converted to Bedrock toolUse."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        BedrockConverseMessagesProcessor,
+        _bedrock_converse_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "Edit the file"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I'll edit that file."},
+                {
+                    "type": "tool_use",
+                    "id": "call_456",
+                    "name": "edit_file",
+                    "input": {"path": "/tmp/test.txt", "content": "new content"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_456",
+                    "content": "File written successfully",
+                }
+            ],
+        },
+    ]
+
+    result = _bedrock_converse_messages_pt(
+        messages=messages,
+        model="bedrock/anthropic.claude-sonnet-4-6",
+        llm_provider="bedrock_converse",
+    )
+
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/anthropic.claude-sonnet-4-6",
+        llm_provider="bedrock_converse",
+    )
+
+    assert result == async_result
+
+    # The assistant message should have text + toolUse
+    assistant_msg = result[1]
+    assert assistant_msg["role"] == "assistant"
+    text_blocks = [b for b in assistant_msg["content"] if "text" in b]
+    tool_use_blocks = [b for b in assistant_msg["content"] if "toolUse" in b]
+    assert len(text_blocks) >= 1
+    assert text_blocks[0]["text"] == "I'll edit that file."
+    assert len(tool_use_blocks) >= 1
+    assert tool_use_blocks[0]["toolUse"]["name"] == "edit_file"
+    assert tool_use_blocks[0]["toolUse"]["toolUseId"] == "call_456"
+
+    # No cachePoint in assistant content
+    cache_blocks = [b for b in assistant_msg["content"] if "cachePoint" in b]
+    assert len(cache_blocks) == 0
+
+
+def test_system_kwarg_routed_to_system_field():
+    """Top-level system kwarg should go to the Bedrock system field, not additionalModelRequestFields."""
+    config = AmazonConverseConfig()
+    messages = [{"role": "user", "content": "Hello"}]
+    optional_params = {
+        "system": [
+            {"type": "text", "text": "You are a helpful assistant.", "cache_control": {"type": "ephemeral"}},
+        ],
+    }
+    result = config._transform_request(
+        model="anthropic.claude-sonnet-4-6",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+    )
+
+    # system kwarg content should be in the top-level system field
+    assert len(result["system"]) >= 1
+    system_texts = [b for b in result["system"] if "text" in b]
+    assert any(b["text"] == "You are a helpful assistant." for b in system_texts)
+
+    # system should NOT be in additionalModelRequestFields
+    additional = result.get("additionalModelRequestFields", {})
+    assert "system" not in additional


### PR DESCRIPTION
## Summary

Clients like Cursor IDE send requests in a hybrid Anthropic/OpenAI wire format that LiteLLM does not fully translate for the Bedrock Converse API. This causes tool calls to silently fail (model returns text instead of tool invocations) and 400 errors from Bedrock.

**Six issues fixed:**

1. **System kwarg routing** — `system: [{type: "text", ...}]` sent as a top-level kwarg leaked into `additionalModelRequestFields` instead of the proper Bedrock `system` field.

2. **Empty `tool_choice` handling** — `tool_choice: {}` (sent by Cursor) was rejected by validation, causing silent retry without `tool_choice`. Now mapped to `toolChoice: {any: {}}` to force tool use.

3. **Anthropic-format tools** — Tools with `name` + `input_schema` at top level (no `function` wrapper) were silently dropped by `_bedrock_tools_pt`. Now detected and parsed correctly.

4. **User message validation** — `tool_result` and `tool_use` content types in user messages were rejected by `ValidUserMessageContentTypes`. Now allowed through.

5. **Tool block conversion** — `tool_result` in user messages and `tool_use` in assistant messages were not converted to Bedrock's `toolResult`/`toolUse` format. Fixed in both sync and async message processing paths.

6. **cachePoint in assistant messages** — Bedrock rejects `cachePoint` blocks in assistant content ("There is nothing available to cache"). Removed from assistant message processing in both sync and async paths.

### Files changed

| File | Fixes |
|---|---|
| `litellm/llms/bedrock/chat/converse_transformation.py` | #1, #2 |
| `litellm/utils.py` | #2 |
| `litellm/types/llms/openai.py` | #4 |
| `litellm/litellm_core_utils/prompt_templates/factory.py` | #3, #5, #6 |

## Test plan

- [x] Verified end-to-end with Cursor IDE connected to local LiteLLM proxy → Bedrock Claude Sonnet 4.6
- [x] Confirmed tool calls are returned (`finish_reason: tool_calls`) instead of text
- [x] Confirmed no "nothing available to cache" errors
- [x] Confirmed multi-turn tool conversations complete successfully
- [ ] Add unit tests for `_bedrock_tools_pt` with Anthropic-format tools
- [ ] Add unit tests for `_bedrock_converse_messages_pt` with tool_result/tool_use in content
- [ ] Add unit tests for `map_tool_choice_values` with empty dict


Made with [Cursor](https://cursor.com)