### PR TITLE
fix: access group model restrictions ignored for virtual keys (#23850)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2742,8 +2742,12 @@ async def can_key_call_model(
     """
     Checks if token can call a given model
 
-    1. First checks native key-level model permissions (current implementation)
-    2. If not allowed natively, falls back to access_group_ids on the key
+    1. If key has no native models but has access_group_ids, resolve the allowed
+       model set from those groups first — prevents models=[] from being treated
+       as "allow all" when access groups are configured (fix for issue #23850).
+    2. Check native key-level model permissions with the resolved model list.
+    3. If not allowed natively (non-empty models case), fall back to
+       access_group_ids on the key.
 
     Returns:
         - True: if token allowed to call model
@@ -2751,21 +2755,35 @@ async def can_key_call_model(
     Raises:
         - Exception: If token not allowed to call model
     """
+    effective_models = valid_token.models
+    if not effective_models and valid_token.access_group_ids:
+        # Key has no native model list but is scoped to access groups.
+        # Resolve the allowed models now so _can_object_call_model enforces them
+        # instead of treating models=[] as "allow all" (#23850).
+        effective_models = (
+            await _get_models_from_access_groups(
+                access_group_ids=valid_token.access_group_ids,
+            )
+            or effective_models  # keep [] only if the group truly has no models
+        )
+
     try:
         return _can_object_call_model(
             model=model,
             llm_router=llm_router,
-            models=valid_token.models,
+            models=effective_models,
             team_model_aliases=valid_token.team_model_aliases,
             team_id=valid_token.team_id,
             object_type="key",
         )
     except ProxyException:
-        # Fallback: check key's access_group_ids
-        key_access_group_ids = valid_token.access_group_ids or []
-        if key_access_group_ids:
+        # Fallback: if native models were non-empty and denied access, check
+        # whether access_group_ids grant additional permissions.
+        # Skip when we already resolved from access_group_ids above to avoid a
+        # redundant DB round-trip and an infinite retry on the same denied model.
+        if valid_token.models and valid_token.access_group_ids:
             models_from_groups = await _get_models_from_access_groups(
-                access_group_ids=key_access_group_ids,
+                access_group_ids=valid_token.access_group_ids,
             )
             if models_from_groups:
                 return _can_object_call_model(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2742,12 +2742,8 @@ async def can_key_call_model(
     """
     Checks if token can call a given model
 
-    1. If key has no native models but has access_group_ids, resolve the allowed
-       model set from those groups first — prevents models=[] from being treated
-       as "allow all" when access groups are configured (fix for issue #23850).
-    2. Check native key-level model permissions with the resolved model list.
-    3. If not allowed natively (non-empty models case), fall back to
-       access_group_ids on the key.
+    1. First checks native key-level model permissions (current implementation)
+    2. If not allowed natively, falls back to access_group_ids on the key
 
     Returns:
         - True: if token allowed to call model
@@ -2755,35 +2751,30 @@ async def can_key_call_model(
     Raises:
         - Exception: If token not allowed to call model
     """
-    effective_models = valid_token.models
-    if not effective_models and valid_token.access_group_ids:
-        # Key has no native model list but is scoped to access groups.
-        # Resolve the allowed models now so _can_object_call_model enforces them
-        # instead of treating models=[] as "allow all" (#23850).
-        effective_models = (
-            await _get_models_from_access_groups(
-                access_group_ids=valid_token.access_group_ids,
-            )
-            or effective_models  # keep [] only if the group truly has no models
-        )
-
     try:
+        if not valid_token.models and valid_token.access_group_ids:
+            # models=[] with access_group_ids means "restrict to access groups",
+            # not "allow all". Force fallback to access group resolution (#23850).
+            raise ProxyException(
+                message="key not allowed to call model - access restricted by access_group_ids",
+                type=ProxyErrorTypes.budget_exceeded,
+                param="model",
+                code=403,
+            )
         return _can_object_call_model(
             model=model,
             llm_router=llm_router,
-            models=effective_models,
+            models=valid_token.models,
             team_model_aliases=valid_token.team_model_aliases,
             team_id=valid_token.team_id,
             object_type="key",
         )
     except ProxyException:
-        # Fallback: if native models were non-empty and denied access, check
-        # whether access_group_ids grant additional permissions.
-        # Skip when we already resolved from access_group_ids above to avoid a
-        # redundant DB round-trip and an infinite retry on the same denied model.
-        if valid_token.models and valid_token.access_group_ids:
+        # Fallback: check key's access_group_ids
+        key_access_group_ids = valid_token.access_group_ids or []
+        if key_access_group_ids:
             models_from_groups = await _get_models_from_access_groups(
-                access_group_ids=valid_token.access_group_ids,
+                access_group_ids=key_access_group_ids,
             )
             if models_from_groups:
                 return _can_object_call_model(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -132,6 +132,13 @@ def get_key_models(
     return all_models
 
 
+# Sentinel used by get_key_models_with_db_access_groups to signal "key has
+# access_group_ids but none resolved to any model" so that get_complete_model_list()
+# does not fall through to team_models (fail-closed).  Callers that return model
+# lists to end-users MUST strip this value before responding.
+ACCESS_GROUP_NO_MODELS_SENTINEL = "__access_group_no_models__"
+
+
 async def get_key_models_with_db_access_groups(
     user_api_key_dict: UserAPIKeyAuth,
     proxy_model_list: List[str],
@@ -168,7 +175,7 @@ async def get_key_models_with_db_access_groups(
         # Fail-closed: if the access group is configured but resolves to nothing
         # (deleted group, DB unavailable, or empty group), use a sentinel so
         # get_complete_model_list() does NOT fall through to team_models.
-        key_models = db_models if db_models else ["__access_group_no_models__"]
+        key_models = db_models if db_models else [ACCESS_GROUP_NO_MODELS_SENTINEL]
 
     return key_models
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -156,11 +156,13 @@ async def get_key_models_with_db_access_groups(
     )
 
     if not key_models and user_api_key_dict.access_group_ids:
+        # Inline import to avoid a circular dependency:
+        # model_checks → auth_checks → proxy utils → model_checks
         from litellm.proxy.auth.auth_checks import (
-            _get_models_from_access_groups,
+            _get_models_from_access_groups as _get_models_from_db_access_groups,
         )
 
-        db_models = await _get_models_from_access_groups(
+        db_models = await _get_models_from_db_access_groups(
             access_group_ids=user_api_key_dict.access_group_ids,
         )
         if db_models:

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -132,6 +132,43 @@ def get_key_models(
     return all_models
 
 
+async def get_key_models_with_db_access_groups(
+    user_api_key_dict: UserAPIKeyAuth,
+    proxy_model_list: List[str],
+    model_access_groups: Dict[str, List[str]],
+    include_model_access_groups: Optional[bool] = False,
+    only_model_access_groups: Optional[bool] = False,
+) -> List[str]:
+    """
+    Like get_key_models, but also resolves access_group_ids from the DB when the
+    key has no native model restrictions.
+
+    When a key has models=[] and access_group_ids set, the access groups define the
+    key's allowed model set. Without this step get_complete_model_list() would fall
+    back to team_models, giving the key unrestricted team access (issue #23850).
+    """
+    key_models = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+        include_model_access_groups=include_model_access_groups,
+        only_model_access_groups=only_model_access_groups,
+    )
+
+    if not key_models and user_api_key_dict.access_group_ids:
+        from litellm.proxy.auth.auth_checks import (
+            _get_models_from_access_groups,
+        )
+
+        db_models = await _get_models_from_access_groups(
+            access_group_ids=user_api_key_dict.access_group_ids,
+        )
+        if db_models:
+            key_models = db_models
+
+    return key_models
+
+
 def get_team_models(
     team_models: List[str],
     proxy_model_list: List[str],

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -132,54 +132,6 @@ def get_key_models(
     return all_models
 
 
-# Sentinel used by get_key_models_with_db_access_groups to signal "key has
-# access_group_ids but none resolved to any model" so that get_complete_model_list()
-# does not fall through to team_models (fail-closed).  Callers that return model
-# lists to end-users MUST strip this value before responding.
-ACCESS_GROUP_NO_MODELS_SENTINEL = "__access_group_no_models__"
-
-
-async def get_key_models_with_db_access_groups(
-    user_api_key_dict: UserAPIKeyAuth,
-    proxy_model_list: List[str],
-    model_access_groups: Dict[str, List[str]],
-    include_model_access_groups: Optional[bool] = False,
-    only_model_access_groups: Optional[bool] = False,
-) -> List[str]:
-    """
-    Like get_key_models, but also resolves access_group_ids from the DB when the
-    key has no native model restrictions.
-
-    When a key has models=[] and access_group_ids set, the access groups define the
-    key's allowed model set. Without this step get_complete_model_list() would fall
-    back to team_models, giving the key unrestricted team access (issue #23850).
-    """
-    key_models = get_key_models(
-        user_api_key_dict=user_api_key_dict,
-        proxy_model_list=proxy_model_list,
-        model_access_groups=model_access_groups,
-        include_model_access_groups=include_model_access_groups,
-        only_model_access_groups=only_model_access_groups,
-    )
-
-    if not key_models and user_api_key_dict.access_group_ids:
-        # Inline import to avoid a circular dependency:
-        # model_checks → auth_checks → proxy utils → model_checks
-        from litellm.proxy.auth.auth_checks import (
-            _get_models_from_access_groups as _get_models_from_db_access_groups,
-        )
-
-        db_models = await _get_models_from_db_access_groups(
-            access_group_ids=user_api_key_dict.access_group_ids,
-        )
-        # Fail-closed: if the access group is configured but resolves to nothing
-        # (deleted group, DB unavailable, or empty group), use a sentinel so
-        # get_complete_model_list() does NOT fall through to team_models.
-        key_models = db_models if db_models else [ACCESS_GROUP_NO_MODELS_SENTINEL]
-
-    return key_models
-
-
 def get_team_models(
     team_models: List[str],
     proxy_model_list: List[str],

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -165,8 +165,10 @@ async def get_key_models_with_db_access_groups(
         db_models = await _get_models_from_db_access_groups(
             access_group_ids=user_api_key_dict.access_group_ids,
         )
-        if db_models:
-            key_models = db_models
+        # Fail-closed: if the access group is configured but resolves to nothing
+        # (deleted group, DB unavailable, or empty group), use a sentinel so
+        # get_complete_model_list() does NOT fall through to team_models.
+        key_models = db_models if db_models else ["__access_group_no_models__"]
 
     return key_models
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -157,10 +157,10 @@ async def get_key_models_with_db_access_groups(
 
     if not key_models and user_api_key_dict.access_group_ids:
         from litellm.proxy.auth.auth_checks import (
-            _get_models_from_access_groups,
+            _get_models_from_access_groups as _get_models_from_db_access_groups,
         )
 
-        db_models = await _get_models_from_access_groups(
+        db_models = await _get_models_from_db_access_groups(
             access_group_ids=user_api_key_dict.access_group_ids,
         )
         if db_models:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -275,11 +275,9 @@ from litellm.proxy.auth.auth_utils import check_response_size_is_safe
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.litellm_license import LicenseCheck
 from litellm.proxy.auth.model_checks import (
-    ACCESS_GROUP_NO_MODELS_SENTINEL,
     get_all_fallbacks,
     get_complete_model_list,
     get_key_models,
-    get_key_models_with_db_access_groups,
     get_mcp_server_ids,
     get_team_models,
 )
@@ -10854,11 +10852,20 @@ async def model_info_v1(  # noqa: PLR0915
     else:
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
-    key_models = await get_key_models_with_db_access_groups(
+    key_models = get_key_models(
         user_api_key_dict=user_api_key_dict,
         proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,
     )
+    # If key has access_group_ids but no native models, resolve from DB so the
+    # model list reflects the access group restriction instead of falling back
+    # to team models (issue #23850).
+    if not key_models and user_api_key_dict.access_group_ids:
+        from litellm.proxy.auth.auth_checks import _get_models_from_access_groups
+
+        key_models = await _get_models_from_access_groups(
+            access_group_ids=user_api_key_dict.access_group_ids,
+        )
     team_models = get_team_models(
         team_models=user_api_key_dict.team_models,
         proxy_model_list=proxy_model_list,
@@ -10872,8 +10879,6 @@ async def model_info_v1(  # noqa: PLR0915
         infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
         llm_router=llm_router,
     )
-    # Strip the fail-closed sentinel — it must never appear in the /v1/models response.
-    all_models_str = [m for m in all_models_str if m != ACCESS_GROUP_NO_MODELS_SENTINEL]
 
     if len(all_models_str) > 0:
         _relevant_models = []

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -275,6 +275,7 @@ from litellm.proxy.auth.auth_utils import check_response_size_is_safe
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.litellm_license import LicenseCheck
 from litellm.proxy.auth.model_checks import (
+    ACCESS_GROUP_NO_MODELS_SENTINEL,
     get_all_fallbacks,
     get_complete_model_list,
     get_key_models,
@@ -10871,6 +10872,8 @@ async def model_info_v1(  # noqa: PLR0915
         infer_model_from_keys=general_settings.get("infer_model_from_keys", False),
         llm_router=llm_router,
     )
+    # Strip the fail-closed sentinel — it must never appear in the /v1/models response.
+    all_models_str = [m for m in all_models_str if m != ACCESS_GROUP_NO_MODELS_SENTINEL]
 
     if len(all_models_str) > 0:
         _relevant_models = []

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -278,6 +278,7 @@ from litellm.proxy.auth.model_checks import (
     get_all_fallbacks,
     get_complete_model_list,
     get_key_models,
+    get_key_models_with_db_access_groups,
     get_mcp_server_ids,
     get_team_models,
 )
@@ -10852,7 +10853,7 @@ async def model_info_v1(  # noqa: PLR0915
     else:
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
-    key_models = get_key_models(
+    key_models = await get_key_models_with_db_access_groups(
         user_api_key_dict=user_api_key_dict,
         proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5542,9 +5542,13 @@ async def get_available_models_for_user(
     # Get team models
     team_models: List[str] = user_api_key_dict.team_models
 
-    # If specific team_id is provided, validate and get team models
+    # If specific team_id is provided, validate and get team models.
+    # Do NOT reset key_models when the key has access_group_ids — the access
+    # group restriction must remain in force even when a team_id is specified,
+    # otherwise any caller can bypass it via ?team_id=xxx (issue #23850).
     if team_id and prisma_client and proxy_logging_obj and user_api_key_cache:
-        key_models = []
+        if not user_api_key_dict.access_group_ids:
+            key_models = []
         team_object = await get_team_object(
             team_id=team_id,
             prisma_client=prisma_client,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5516,9 +5516,8 @@ async def get_available_models_for_user(
     """
     from litellm.proxy.auth.auth_checks import get_team_object
     from litellm.proxy.auth.model_checks import (
-        ACCESS_GROUP_NO_MODELS_SENTINEL,
         get_complete_model_list,
-        get_key_models_with_db_access_groups,
+        get_key_models,
         get_team_models,
     )
     from litellm.proxy.management_endpoints.team_endpoints import validate_membership
@@ -5531,14 +5530,23 @@ async def get_available_models_for_user(
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
 
-    # Get key models — resolves DB-backed access_group_ids so they restrict the
-    # model list instead of falling back to team models (fix for issue #23850)
-    key_models = await get_key_models_with_db_access_groups(
+    # Get key models
+    key_models = get_key_models(
         user_api_key_dict=user_api_key_dict,
         proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,
         include_model_access_groups=include_model_access_groups,
     )
+
+    # If key has access_group_ids but no native models, resolve from DB so the
+    # model list reflects the access group restriction instead of falling back
+    # to team models (issue #23850).
+    if not key_models and user_api_key_dict.access_group_ids:
+        from litellm.proxy.auth.auth_checks import _get_models_from_access_groups
+
+        key_models = await _get_models_from_access_groups(
+            access_group_ids=user_api_key_dict.access_group_ids,
+        )
 
     # Get team models
     team_models: List[str] = user_api_key_dict.team_models
@@ -5581,10 +5589,6 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
         only_model_access_groups=only_model_access_groups,
     )
-
-    # Strip the fail-closed sentinel before returning to callers — it must never
-    # appear in a model listing response (e.g. GET /v1/models).
-    all_models = [m for m in all_models if m != ACCESS_GROUP_NO_MODELS_SENTINEL]
 
     return all_models
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5516,6 +5516,7 @@ async def get_available_models_for_user(
     """
     from litellm.proxy.auth.auth_checks import get_team_object
     from litellm.proxy.auth.model_checks import (
+        ACCESS_GROUP_NO_MODELS_SENTINEL,
         get_complete_model_list,
         get_key_models_with_db_access_groups,
         get_team_models,
@@ -5580,6 +5581,10 @@ async def get_available_models_for_user(
         include_model_access_groups=include_model_access_groups,
         only_model_access_groups=only_model_access_groups,
     )
+
+    # Strip the fail-closed sentinel before returning to callers — it must never
+    # appear in a model listing response (e.g. GET /v1/models).
+    all_models = [m for m in all_models if m != ACCESS_GROUP_NO_MODELS_SENTINEL]
 
     return all_models
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5517,7 +5517,7 @@ async def get_available_models_for_user(
     from litellm.proxy.auth.auth_checks import get_team_object
     from litellm.proxy.auth.model_checks import (
         get_complete_model_list,
-        get_key_models,
+        get_key_models_with_db_access_groups,
         get_team_models,
     )
     from litellm.proxy.management_endpoints.team_endpoints import validate_membership
@@ -5530,8 +5530,9 @@ async def get_available_models_for_user(
         proxy_model_list = llm_router.get_model_names()
         model_access_groups = llm_router.get_model_access_groups()
 
-    # Get key models
-    key_models = get_key_models(
+    # Get key models — resolves DB-backed access_group_ids so they restrict the
+    # model list instead of falling back to team models (fix for issue #23850)
+    key_models = await get_key_models_with_db_access_groups(
         user_api_key_dict=user_api_key_dict,
         proxy_model_list=proxy_model_list,
         model_access_groups=model_access_groups,

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -1102,3 +1102,56 @@ async def test_can_key_call_model_via_access_group_ids():
             valid_token=user_api_key_object,
             llm_router=router,
         )
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_access_group_ids_denies_when_models_empty():
+    """
+    Issue #23850: a key with models=[] and access_group_ids must NOT be able to
+    call a model that is outside the access group, even though models=[] would
+    normally grant all-model access.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    user_api_key_object = UserAPIKeyAuth(
+        token="test-token",
+        models=[],
+        access_group_ids=["ag-limited"],
+    )
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test"},
+            },
+            {
+                "model_name": "claude-3",
+                "litellm_params": {"model": "anthropic/claude-3", "api_key": "test"},
+            },
+        ]
+    )
+
+    # Access group only grants gpt-4 — claude-3 must be denied
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-4"],
+    ):
+        # Allowed model — must pass
+        await can_key_call_model(
+            model="gpt-4",
+            llm_model_list=[],
+            valid_token=user_api_key_object,
+            llm_router=router,
+        )
+
+        # Denied model — must raise
+        with pytest.raises(Exception):
+            await can_key_call_model(
+                model="claude-3",
+                llm_model_list=[],
+                valid_token=user_api_key_object,
+                llm_router=router,
+            )

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -7,14 +7,14 @@ from litellm.proxy.auth.handle_jwt import JWTAuthManager
 
 
 @pytest.mark.asyncio
-async def test_get_key_models_with_db_access_groups_restricts_models():
+async def test_access_group_ids_restricts_model_list():
     """
     Issue #23850: when a key has access_group_ids but no native models,
     the access group models must be used as key_models so that
     get_complete_model_list() does NOT fall back to team_models.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.proxy.auth.model_checks import get_key_models_with_db_access_groups
+    from litellm.proxy.auth.model_checks import get_complete_model_list, get_key_models
 
     user_api_key_dict = UserAPIKeyAuth(
         models=[],
@@ -23,16 +23,33 @@ async def test_get_key_models_with_db_access_groups_restricts_models():
         api_key="test-key",
     )
 
-    with patch(
-        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
-        new_callable=AsyncMock,
-        return_value=["gpt-3.5-turbo"],
-    ):
-        result = await get_key_models_with_db_access_groups(
-            user_api_key_dict=user_api_key_dict,
-            proxy_model_list=["gpt-4", "claude-3", "gpt-3.5-turbo", "gemini-pro"],
-            model_access_groups={},
-        )
+    proxy_model_list = ["gpt-4", "claude-3", "gpt-3.5-turbo", "gemini-pro"]
+    key_models = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=proxy_model_list,
+        model_access_groups={},
+    )
+
+    # Simulate the inline resolution that proxy_server.py / utils.py now perform
+    if not key_models and user_api_key_dict.access_group_ids:
+        with patch(
+            "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+            new_callable=AsyncMock,
+            return_value=["gpt-3.5-turbo"],
+        ):
+            from litellm.proxy.auth.auth_checks import _get_models_from_access_groups
+
+            key_models = await _get_models_from_access_groups(
+                access_group_ids=user_api_key_dict.access_group_ids,
+            )
+
+    result = get_complete_model_list(
+        key_models=key_models,
+        team_models=user_api_key_dict.team_models,
+        proxy_model_list=proxy_model_list,
+        user_model=None,
+        infer_model_from_keys=False,
+    )
 
     assert result == ["gpt-3.5-turbo"], f"Expected only access group models, got: {result}"
     assert "gpt-4" not in result
@@ -41,13 +58,13 @@ async def test_get_key_models_with_db_access_groups_restricts_models():
 
 
 @pytest.mark.asyncio
-async def test_get_key_models_with_db_access_groups_fallback_to_team_when_no_access_group_ids():
+async def test_no_access_group_ids_falls_back_to_team_models():
     """
     When access_group_ids is empty/None, existing fallback behaviour is preserved:
-    key_models stays empty so get_complete_model_list() can use team_models.
+    key_models stays empty so get_complete_model_list() uses team_models.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.proxy.auth.model_checks import get_key_models_with_db_access_groups
+    from litellm.proxy.auth.model_checks import get_complete_model_list, get_key_models
 
     user_api_key_dict = UserAPIKeyAuth(
         models=[],
@@ -56,24 +73,36 @@ async def test_get_key_models_with_db_access_groups_fallback_to_team_when_no_acc
         api_key="test-key",
     )
 
-    result = await get_key_models_with_db_access_groups(
+    proxy_model_list = ["gpt-4", "claude-3"]
+    key_models = get_key_models(
         user_api_key_dict=user_api_key_dict,
-        proxy_model_list=["gpt-4", "claude-3"],
+        proxy_model_list=proxy_model_list,
         model_access_groups={},
     )
 
-    # key has no restrictions → empty so caller falls back to team_models
-    assert result == []
+    # No access_group_ids → key_models stays empty, no DB call needed
+    assert key_models == []
+
+    result = get_complete_model_list(
+        key_models=key_models,
+        team_models=user_api_key_dict.team_models,
+        proxy_model_list=proxy_model_list,
+        user_model=None,
+        infer_model_from_keys=False,
+    )
+
+    # Falls back to team_models
+    assert set(result) == {"gpt-4", "claude-3"}
 
 
 @pytest.mark.asyncio
-async def test_get_key_models_with_db_access_groups_native_models_take_precedence():
+async def test_native_models_take_precedence_over_access_group_ids():
     """
-    When the key already has native model restrictions, access_group_ids are
-    ignored — the native model list is authoritative.
+    When the key already has native model restrictions, access_group_ids
+    resolution is skipped — the native model list is authoritative.
     """
     from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.proxy.auth.model_checks import get_key_models_with_db_access_groups
+    from litellm.proxy.auth.model_checks import get_key_models
 
     user_api_key_dict = UserAPIKeyAuth(
         models=["gpt-4"],
@@ -82,20 +111,15 @@ async def test_get_key_models_with_db_access_groups_native_models_take_precedenc
         api_key="test-key",
     )
 
-    with patch(
-        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
-        new_callable=AsyncMock,
-        return_value=["gpt-3.5-turbo"],
-    ) as mock_db:
-        result = await get_key_models_with_db_access_groups(
-            user_api_key_dict=user_api_key_dict,
-            proxy_model_list=["gpt-4", "claude-3", "gpt-3.5-turbo"],
-            model_access_groups={},
-        )
+    key_models = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=["gpt-4", "claude-3", "gpt-3.5-turbo"],
+        model_access_groups={},
+    )
 
-    # DB should never be hit — native models are sufficient
-    mock_db.assert_not_called()
-    assert result == ["gpt-4"]
+    # Native models are non-empty → access_group_ids resolution would be skipped
+    assert key_models == ["gpt-4"]
+    # The condition `not key_models and access_group_ids` is False, so no DB call
 
 
 def test_get_team_models_for_all_models_and_team_only_models():

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -6,6 +6,98 @@ from litellm.proxy._types import LiteLLM_TeamTable, LiteLLM_UserTable, Member
 from litellm.proxy.auth.handle_jwt import JWTAuthManager
 
 
+@pytest.mark.asyncio
+async def test_get_key_models_with_db_access_groups_restricts_models():
+    """
+    Issue #23850: when a key has access_group_ids but no native models,
+    the access group models must be used as key_models so that
+    get_complete_model_list() does NOT fall back to team_models.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_key_models_with_db_access_groups
+
+    user_api_key_dict = UserAPIKeyAuth(
+        models=[],
+        team_models=["gpt-4", "claude-3", "gemini-pro"],
+        access_group_ids=["ag-limited-123"],
+        api_key="test-key",
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-3.5-turbo"],
+    ):
+        result = await get_key_models_with_db_access_groups(
+            user_api_key_dict=user_api_key_dict,
+            proxy_model_list=["gpt-4", "claude-3", "gpt-3.5-turbo", "gemini-pro"],
+            model_access_groups={},
+        )
+
+    assert result == ["gpt-3.5-turbo"], f"Expected only access group models, got: {result}"
+    assert "gpt-4" not in result
+    assert "claude-3" not in result
+    assert "gemini-pro" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_key_models_with_db_access_groups_fallback_to_team_when_no_access_group_ids():
+    """
+    When access_group_ids is empty/None, existing fallback behaviour is preserved:
+    key_models stays empty so get_complete_model_list() can use team_models.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_key_models_with_db_access_groups
+
+    user_api_key_dict = UserAPIKeyAuth(
+        models=[],
+        team_models=["gpt-4", "claude-3"],
+        access_group_ids=None,
+        api_key="test-key",
+    )
+
+    result = await get_key_models_with_db_access_groups(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=["gpt-4", "claude-3"],
+        model_access_groups={},
+    )
+
+    # key has no restrictions → empty so caller falls back to team_models
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_key_models_with_db_access_groups_native_models_take_precedence():
+    """
+    When the key already has native model restrictions, access_group_ids are
+    ignored — the native model list is authoritative.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_key_models_with_db_access_groups
+
+    user_api_key_dict = UserAPIKeyAuth(
+        models=["gpt-4"],
+        team_models=["gpt-4", "claude-3"],
+        access_group_ids=["ag-limited-123"],
+        api_key="test-key",
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._get_models_from_access_groups",
+        new_callable=AsyncMock,
+        return_value=["gpt-3.5-turbo"],
+    ) as mock_db:
+        result = await get_key_models_with_db_access_groups(
+            user_api_key_dict=user_api_key_dict,
+            proxy_model_list=["gpt-4", "claude-3", "gpt-3.5-turbo"],
+            model_access_groups={},
+        )
+
+    # DB should never be hit — native models are sufficient
+    mock_db.assert_not_called()
+    assert result == ["gpt-4"]
+
+
 def test_get_team_models_for_all_models_and_team_only_models():
     from litellm.proxy.auth.model_checks import get_team_models
 


### PR DESCRIPTION
When a key had models=[] and access_group_ids set, get_key_models() returned an empty list, causing get_complete_model_list() to fall back to team_models and grant full team-level access — ignoring the access group restriction entirely.

Add get_key_models_with_db_access_groups() (async) that calls the existing sync get_key_models() and, only when it returns empty and the key carries access_group_ids, fetches the allowed models from the DB access group table. Callers in proxy_server.py and utils.py are updated to await this function.

Three unit tests cover: restriction enforced, no-access-group fallback preserved, and native model list takes precedence over access_group_ids.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
