### PR TITLE
fix: drop invalid top-level params (strict) from OpenAI extra_body

### DIFF
--- a/litellm/litellm_core_utils/llm_request_utils.py
+++ b/litellm/litellm_core_utils/llm_request_utils.py
@@ -1,6 +1,12 @@
 from typing import Dict, Optional
 
 import litellm
+from litellm._logging import verbose_logger
+
+# Params that callers (e.g. LangChain) sometimes pass at the top level but
+# that are NOT valid top-level OpenAI API fields.  Forwarding them in
+# extra_body causes OpenAI to return "400 Unrecognized request argument".
+_OPENAI_INVALID_TOP_LEVEL_PARAMS = frozenset({"strict"})
 
 
 def _ensure_extra_body_is_safe(extra_body: Optional[Dict]) -> Optional[Dict]:
@@ -26,6 +32,18 @@ def _ensure_extra_body_is_safe(extra_body: Optional[Dict]) -> Optional[Dict]:
             # Langfuse TextPromptClients have .__dict__ attribute
             if _prompt is not None and hasattr(_prompt, "__dict__"):
                 extra_body["metadata"]["prompt"] = _prompt.__dict__
+    
+    # Drop params that are invalid at the OpenAI top-level request body.
+    # Some callers (e.g. LangChain) pass these at the completion() top level;
+    # they end up in extra_body and cause "400 Unrecognized request argument".
+    dropped = [k for k in _OPENAI_INVALID_TOP_LEVEL_PARAMS if k in extra_body]
+    for k in dropped:
+        extra_body.pop(k)
+    if dropped:
+        verbose_logger.debug(
+            "LiteLLM: dropped invalid top-level OpenAI params from extra_body: %s",
+            dropped,
+        )
 
     return extra_body
 

--- a/tests/test_litellm/litellm_core_utils/test_llm_request_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_llm_request_utils.py
@@ -1,0 +1,100 @@
+"""
+Tests for litellm_core_utils.llm_request_utils module.
+
+Covers _ensure_extra_body_is_safe, including the fix for top-level kwargs
+(e.g. `strict=True`) that callers like LangChain pass to litellm.completion()
+but that are not valid at the OpenAI top-level request body.
+"""
+
+from litellm.litellm_core_utils.llm_request_utils import _ensure_extra_body_is_safe
+from litellm.utils import get_optional_params
+
+
+# ---------------------------------------------------------------------------
+# _ensure_extra_body_is_safe
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_extra_body_is_safe_strips_strict():
+    """strict is not a valid top-level OpenAI param and must be removed."""
+    result = _ensure_extra_body_is_safe({"strict": True, "some_custom_key": "value"})
+    assert isinstance(result, dict)
+    body: dict = result
+    assert "strict" not in body
+    assert body.get("some_custom_key") == "value"
+
+
+def test_ensure_extra_body_is_safe_none_passthrough():
+    assert _ensure_extra_body_is_safe(None) is None
+
+
+def test_ensure_extra_body_is_safe_non_dict_passthrough():
+    sentinel = object()
+    assert _ensure_extra_body_is_safe(sentinel) is sentinel  # type: ignore[arg-type]
+
+
+def test_ensure_extra_body_is_safe_empty_dict():
+    assert _ensure_extra_body_is_safe({}) == {}
+
+
+def test_ensure_extra_body_is_safe_preserves_valid_keys():
+    body = {"some_provider_param": 42, "another": "hello"}
+    result = _ensure_extra_body_is_safe(body)
+    assert result == {"some_provider_param": 42, "another": "hello"}
+
+
+def test_ensure_extra_body_is_safe_strict_false_also_stripped():
+    """strict=False is equally invalid at the top level."""
+    result = _ensure_extra_body_is_safe({"strict": False})
+    assert isinstance(result, dict)
+    body: dict = result
+    assert "strict" not in body
+
+
+# ---------------------------------------------------------------------------
+# get_optional_params — end-to-end: strict must not reach extra_body for OpenAI
+# ---------------------------------------------------------------------------
+
+
+def test_get_optional_params_openai_strict_not_in_extra_body():
+    """
+    Regression test for: litellm.BadRequestError: OpenAIException - Unrecognized
+    request argument supplied: strict
+
+    When strict=True is passed as a top-level kwarg (LangChain-style),
+    it must NOT appear in extra_body for OpenAI models.
+    """
+    params = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        strict=True,
+        temperature=0.7,
+    )
+    extra_body: dict = params.get("extra_body", {})
+    assert "strict" not in extra_body, (
+        "'strict' must not be forwarded in extra_body for OpenAI — "
+        "it causes a 400 'Unrecognized request argument' error."
+    )
+
+
+def test_get_optional_params_openai_strict_false_not_in_extra_body():
+    params = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        strict=False,
+    )
+    extra_body: dict = params.get("extra_body", {})
+    assert "strict" not in extra_body
+
+
+def test_get_optional_params_openai_strict_does_not_block_other_extra_body_keys():
+    """Unrecognized provider-extension keys other than strict still flow through."""
+    params = get_optional_params(
+        model="gpt-4o",
+        custom_llm_provider="openai",
+        strict=True,
+        my_custom_provider_extension="foo",
+    )
+    extra_body: dict = params.get("extra_body", {})
+    assert "strict" not in extra_body
+    assert extra_body.get("my_custom_provider_extension") == "foo"


### PR DESCRIPTION
## Relevant issues

Fixes #25198
Related to #22804

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes
### Problem
When `strict=True` is passed as a top-level kwarg to `litellm.completion()` 
for an OpenAI/GPT model (e.g. via LangChain agents), LiteLLM sweeps it into 
`extra_body`, causing OpenAI to reject the request with:
`400 - Unrecognized request argument supplied: strict`

See issue #25198 for full root cause analysis.

### Fix
Added `_OPENAI_INVALID_TOP_LEVEL_PARAMS = frozenset({"strict"})` in `litellm/litellm_core_utils/llm_request_utils.py` and strip matching keys inside `_ensure_extra_body_is_safe`.

This function is only called for `openai`, `azure`, and `openai_compatible_providers` - Anthropic and all other providers are unaffected.

### Files Changed
- `litellm/litellm_core_utils/llm_request_utils.py` - filter known-invalid top-level params from `extra_body`
- `tests/test_litellm/litellm_core_utils/test_llm_request_utils.py` - 9 unit tests (all passing)
