### PR TITLE
fix(security): prevent key plaintext leak in error response for inval…

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -184,9 +184,7 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
         # Extract the API key from the Bearer token
         if not authorization.startswith("Bearer "):
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
-            raise HTTPException(
-                status_code=403, detail="Invalid Authorization header format"
-            )
+            raise HTTPException(status_code=403, detail="Invalid Authorization header format")
 
         api_key = authorization[len("Bearer ") :].strip()
 
@@ -200,9 +198,7 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
         raise HTTPException(status_code=403, detail=str(e))
 
 
-def update_valid_token_with_end_user_params(
-    valid_token: UserAPIKeyAuth, end_user_params: dict
-) -> UserAPIKeyAuth:
+def update_valid_token_with_end_user_params(valid_token: UserAPIKeyAuth, end_user_params: dict) -> UserAPIKeyAuth:
     valid_token.end_user_id = end_user_params.get("end_user_id")
     valid_token.end_user_tpm_limit = end_user_params.get("end_user_tpm_limit")
     valid_token.end_user_rpm_limit = end_user_params.get("end_user_rpm_limit")
@@ -220,14 +216,10 @@ async def get_global_proxy_spend(
     global_proxy_spend = None
     if litellm.max_budget > 0:  # user set proxy max budget
         # check cache
-        global_proxy_spend = await user_api_key_cache.async_get_cache(
-            key="{}:spend".format(litellm_proxy_admin_name)
-        )
+        global_proxy_spend = await user_api_key_cache.async_get_cache(key="{}:spend".format(litellm_proxy_admin_name))
         if global_proxy_spend is None and prisma_client is not None:
             # get from db
-            sql_query = (
-                """SELECT SUM(spend) as total_spend FROM "MonthlyGlobalSpend";"""
-            )
+            sql_query = """SELECT SUM(spend) as total_spend FROM "MonthlyGlobalSpend";"""
 
             response = await prisma_client.db.query_raw(query=sql_query)
 
@@ -343,10 +335,7 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                     return UserAPIKeyAuth()
                 ## IF AUTH ENABLED
                 ### IF CUSTOM PARSER REQUIRED
-                if (
-                    endpoint.get("custom_auth_parser") is not None
-                    and endpoint.get("custom_auth_parser") == "langfuse"
-                ):
+                if endpoint.get("custom_auth_parser") is not None and endpoint.get("custom_auth_parser") == "langfuse":
                     """
                     - langfuse returns {'Authorization': 'Basic YW55dGhpbmc6YW55dGhpbmc'}
                     - check the langfuse public key if it contains the litellm api key
@@ -362,8 +351,7 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                     if headers is not None:
                         header_key = headers.get("litellm_user_api_key", "")
                         if (
-                            isinstance(request.headers, dict)
-                            and request.headers.get(key=header_key) is not None  # type: ignore
+                            isinstance(request.headers, dict) and request.headers.get(key=header_key) is not None  # type: ignore
                         ):
                             api_key = request.headers.get(key=header_key)  # type: ignore
     return api_key
@@ -408,9 +396,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             request=request,
             route=route,
         )
-        pass_through_endpoints: Optional[List[dict]] = general_settings.get(
-            "pass_through_endpoints", None
-        )
+        pass_through_endpoints: Optional[List[dict]] = general_settings.get("pass_through_endpoints", None)
         ## CHECK IF X-LITELM-API-KEY IS PASSED IN - supercedes Authorization header
         api_key, passed_in_key = get_api_key(
             custom_litellm_key_header=custom_litellm_key_header,
@@ -432,18 +418,14 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             )
 
         if open_telemetry_logger is not None:
-            parent_otel_span = (
-                open_telemetry_logger.create_litellm_proxy_request_started_span(
-                    start_time=start_time,
-                    headers=dict(request.headers),
-                )
+            parent_otel_span = open_telemetry_logger.create_litellm_proxy_request_started_span(
+                start_time=start_time,
+                headers=dict(request.headers),
             )
 
         ### USER-DEFINED AUTH FUNCTION ###
         if enterprise_custom_auth is not None:
-            response = await enterprise_custom_auth(
-                request=request, api_key=api_key, user_custom_auth=user_custom_auth
-            )
+            response = await enterprise_custom_auth(request=request, api_key=api_key, user_custom_auth=user_custom_auth)
             if response is not None and isinstance(response, UserAPIKeyAuth):
                 return UserAPIKeyAuth.model_validate(response)
             elif response is not None and isinstance(response, str):
@@ -498,9 +480,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             from litellm.proxy.proxy_server import premium_user
 
             if premium_user is not True:
-                raise ValueError(
-                    f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}"
-                )
+                raise ValueError(f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}")
             is_jwt = jwt_handler.is_jwt(token=api_key)
             verbose_proxy_logger.debug("is_jwt: %s", is_jwt)
             if is_jwt:
@@ -526,9 +506,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 end_user_object = result["end_user_object"]
                 org_id = result["org_id"]
                 token = result["token"]
-                team_membership: Optional[LiteLLM_TeamMembership] = result.get(
-                    "team_membership", None
-                )
+                team_membership: Optional[LiteLLM_TeamMembership] = result.get("team_membership", None)
 
                 global_proxy_spend = await get_global_proxy_spend(
                     litellm_proxy_admin_name=litellm_proxy_admin_name,
@@ -547,15 +525,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 valid_token = UserAPIKeyAuth(
                     api_key=None,
                     team_id=team_id,
-                    team_alias=(
-                        team_object.team_alias if team_object is not None else None
-                    ),
-                    team_tpm_limit=(
-                        team_object.tpm_limit if team_object is not None else None
-                    ),
-                    team_rpm_limit=(
-                        team_object.rpm_limit if team_object is not None else None
-                    ),
+                    team_alias=(team_object.team_alias if team_object is not None else None),
+                    team_tpm_limit=(team_object.tpm_limit if team_object is not None else None),
+                    team_rpm_limit=(team_object.rpm_limit if team_object is not None else None),
                     team_models=team_object.models if team_object is not None else [],
                     user_role=(
                         LitellmUserRoles(user_object.user_role)
@@ -566,25 +538,15 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     org_id=org_id,
                     parent_otel_span=parent_otel_span,
                     end_user_id=end_user_id,
-                    user_tpm_limit=(
-                        user_object.tpm_limit if user_object is not None else None
-                    ),
-                    user_rpm_limit=(
-                        user_object.rpm_limit if user_object is not None else None
-                    ),
+                    user_tpm_limit=(user_object.tpm_limit if user_object is not None else None),
+                    user_rpm_limit=(user_object.rpm_limit if user_object is not None else None),
                     team_member_rpm_limit=(
-                        team_membership.safe_get_team_member_rpm_limit()
-                        if team_membership is not None
-                        else None
+                        team_membership.safe_get_team_member_rpm_limit() if team_membership is not None else None
                     ),
                     team_member_tpm_limit=(
-                        team_membership.safe_get_team_member_tpm_limit()
-                        if team_membership is not None
-                        else None
+                        team_membership.safe_get_team_member_tpm_limit() if team_membership is not None else None
                     ),
-                    team_metadata=team_object.metadata
-                    if team_object is not None
-                    else None,
+                    team_metadata=team_object.metadata if team_object is not None else None,
                 )
                 # run through common checks
                 _ = await common_checks(
@@ -633,9 +595,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             raise Exception("No api key passed in.")
         elif api_key == "":
             # missing 'Bearer ' prefix
-            raise Exception(
-                "Malformed API Key passed in. Ensure Key has `Bearer ` prefix."
-            )
+            raise Exception("Malformed API Key passed in. Ensure Key has `Bearer ` prefix.")
 
         if route == "/user/auth":
             if general_settings.get("allow_user_auth", False) is True:
@@ -650,9 +610,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         _end_user_object = None
         end_user_params = {}
 
-        end_user_id = get_end_user_id_from_request_body(
-            request_data, _safe_get_request_headers(request)
-        )
+        end_user_id = get_end_user_id_from_request_body(request_data, _safe_get_request_headers(request))
         if end_user_id:
             try:
                 end_user_params["end_user_id"] = end_user_id
@@ -667,9 +625,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     route=route,
                 )
                 if _end_user_object is not None:
-                    end_user_params[
-                        "allowed_model_region"
-                    ] = _end_user_object.allowed_model_region
+                    end_user_params["allowed_model_region"] = _end_user_object.allowed_model_region
                     if _end_user_object.litellm_budget_table is not None:
                         _apply_budget_limits_to_end_user_params(
                             end_user_params=end_user_params,
@@ -696,9 +652,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             except Exception as e:
                 if isinstance(e, litellm.BudgetExceededError):
                     raise e
-                verbose_proxy_logger.debug(
-                    "Unable to find user in db. Error - {}".format(str(e))
-                )
+                verbose_proxy_logger.debug("Unable to find user in db. Error - {}".format(str(e)))
                 pass
 
         ### CHECK IF ADMIN ###
@@ -721,9 +675,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
         ## Check UI Hash Key
         if valid_token is None and get_secret_bool("EXPERIMENTAL_UI_LOGIN"):
-            valid_token = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(
-                api_key
-            )
+            valid_token = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(api_key)
 
         if (
             valid_token is not None
@@ -736,10 +688,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     expiry_time = valid_token.expires
                 else:
                     expiry_time = datetime.fromisoformat(valid_token.expires)
-                if (
-                    expiry_time.tzinfo is None
-                    or expiry_time.tzinfo.utcoffset(expiry_time) is None
-                ):
+                if expiry_time.tzinfo is None or expiry_time.tzinfo.utcoffset(expiry_time) is None:
                     expiry_time = expiry_time.replace(tzinfo=timezone.utc)
                 if expiry_time < current_time:
                     await _delete_cache_key_object(
@@ -760,11 +709,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             return valid_token
 
-        if (
-            valid_token is not None
-            and isinstance(valid_token, UserAPIKeyAuth)
-            and valid_token.team_id is not None
-        ):
+        if valid_token is not None and isinstance(valid_token, UserAPIKeyAuth) and valid_token.team_id is not None:
             ## UPDATE TEAM VALUES BASED ON CACHED TEAM OBJECT - allows `/team/update` values to work for cached token
             try:
                 team_obj: LiteLLM_TeamTableCachedObj = await get_team_object(
@@ -788,9 +733,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         if field_name in valid_token.__fields__:
                             setattr(valid_token, field_name, v)
             except Exception as e:
-                verbose_logger.debug(
-                    e
-                )  # moving from .warning to .debug as it spams logs when team missing from cache.
+                verbose_logger.debug(e)  # moving from .warning to .debug as it spams logs when team missing from cache.
 
         try:
             is_master_key_valid = secrets.compare_digest(api_key, master_key)  # type: ignore
@@ -803,11 +746,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         except Exception:
             raise HTTPException(
                 status_code=500,
-                detail={
-                    "Master key must be a valid string. Current type={}".format(
-                        type(master_key)
-                    )
-                },
+                detail={"Master key must be a valid string. Current type={}".format(type(master_key))},
             )
 
         if is_master_key_valid:
@@ -841,9 +780,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         ## IF it's not a master key
         ## Route should not be in master_key_only_routes
         if route in LiteLLMRoutes.master_key_only_routes.value:  # type: ignore
-            raise Exception(
-                f"Tried to access route={route}, which is only for MASTER KEY"
-            )
+            raise Exception(f"Tried to access route={route}, which is only for MASTER KEY")
 
         ## Check DB
 
@@ -861,13 +798,11 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         _user_role = None
 
         if valid_token is None:
-            if isinstance(
-                api_key, str
-            ):  # if generated token, make sure it starts with sk-.
-                assert api_key.startswith(
-                    "sk-"
-                ), "LiteLLM Virtual Key expected. Received={}, expected to start with 'sk-'.".format(
-                    api_key
+            if isinstance(api_key, str):  # if generated token, make sure it starts with sk-.
+                assert api_key.startswith("sk-"), (
+                    "LiteLLM Virtual Key expected. Received={}, expected to start with 'sk-'.".format(
+                        abbreviate_api_key(api_key=api_key)
+                    )
                 )  # prevent token hashes from being used
             else:
                 verbose_logger.warning(
@@ -898,9 +833,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             valid_token.end_user_id = end_user_params.get("end_user_id")
             valid_token.end_user_tpm_limit = end_user_params.get("end_user_tpm_limit")
             valid_token.end_user_rpm_limit = end_user_params.get("end_user_rpm_limit")
-            valid_token.allowed_model_region = end_user_params.get(
-                "allowed_model_region"
-            )
+            valid_token.allowed_model_region = end_user_params.get("allowed_model_region")
             # update key budget with temp budget increase
             valid_token = _update_key_budget_with_temp_budget_increase(
                 valid_token
@@ -924,21 +857,14 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             ## base case ## key is disabled
             if valid_token.blocked is True:
-                raise Exception(
-                    "Key is blocked. Update via `/key/unblock` if you're admin."
-                )
+                raise Exception("Key is blocked. Update via `/key/unblock` if you're admin.")
             config = valid_token.config
 
             if config != {}:
                 model_list = config.get("model_list", [])
                 new_model_list = model_list
-                verbose_proxy_logger.debug(
-                    f"\n new llm router model list {new_model_list}"
-                )
-            elif (
-                isinstance(valid_token.models, list)
-                and "all-team-models" in valid_token.models
-            ):
+                verbose_proxy_logger.debug(f"\n new llm router model list {new_model_list}")
+            elif isinstance(valid_token.models, list) and "all-team-models" in valid_token.models:
                 # Do not do any validation at this step
                 # the validation will occur when checking the team has access to this model
                 pass
@@ -995,9 +921,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 if prisma_client is not None:
                     _cache_key = f"{valid_token.team_id}_{valid_token.user_id}"
 
-                    team_member_info = await user_api_key_cache.async_get_cache(
-                        key=_cache_key
-                    )
+                    team_member_info = await user_api_key_cache.async_get_cache(key=_cache_key)
                     if team_member_info is None:
                         # read from DB
                         _user_id = valid_token.user_id
@@ -1017,13 +941,8 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                                 ttl=5,
                             )
 
-                    if (
-                        team_member_info is not None
-                        and team_member_info.litellm_budget_table is not None
-                    ):
-                        team_member_budget = (
-                            team_member_info.litellm_budget_table.max_budget
-                        )
+                    if team_member_info is not None and team_member_info.litellm_budget_table is not None:
+                        team_member_budget = team_member_info.litellm_budget_table.max_budget
                         if team_member_budget is not None and team_member_budget > 0:
                             if valid_token.team_member_spend > team_member_budget:
                                 raise litellm.BudgetExceededError(
@@ -1038,10 +957,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     expiry_time = valid_token.expires
                 else:
                     expiry_time = datetime.fromisoformat(valid_token.expires)
-                if (
-                    expiry_time.tzinfo is None
-                    or expiry_time.tzinfo.utcoffset(expiry_time) is None
-                ):
+                if expiry_time.tzinfo is None or expiry_time.tzinfo.utcoffset(expiry_time) is None:
                     expiry_time = expiry_time.replace(tzinfo=timezone.utc)
                 verbose_proxy_logger.debug(
                     f"Checking if token expired, expiry time {expiry_time} and current time {current_time}"
@@ -1116,9 +1032,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             )  # save team table in cache - used for tpm/rpm limiting - tpm_rpm_limiter.py
 
             global_proxy_spend = None
-            if (
-                litellm.max_budget > 0 and prisma_client is not None
-            ):  # user set proxy max budget
+            if litellm.max_budget > 0 and prisma_client is not None:  # user set proxy max budget
                 # check cache
                 global_proxy_spend = await user_api_key_cache.async_get_cache(
                     key="{}:spend".format(litellm_proxy_admin_name)
@@ -1218,25 +1132,17 @@ async def user_api_key_auth(
     request: Request,
     api_key: str = fastapi.Security(api_key_header),
     azure_api_key_header: str = fastapi.Security(azure_api_key_header),
-    anthropic_api_key_header: Optional[str] = fastapi.Security(
-        anthropic_api_key_header
-    ),
-    google_ai_studio_api_key_header: Optional[str] = fastapi.Security(
-        google_ai_studio_api_key_header
-    ),
+    anthropic_api_key_header: Optional[str] = fastapi.Security(anthropic_api_key_header),
+    google_ai_studio_api_key_header: Optional[str] = fastapi.Security(google_ai_studio_api_key_header),
     azure_apim_header: Optional[str] = fastapi.Security(azure_apim_header),
-    custom_litellm_key_header: Optional[str] = fastapi.Security(
-        custom_litellm_key_header
-    ),
+    custom_litellm_key_header: Optional[str] = fastapi.Security(custom_litellm_key_header),
 ) -> UserAPIKeyAuth:
     """
     Parent function to authenticate user api key / jwt token.
     """
 
     request_data = await _read_request_body(request=request)
-    request_data = populate_request_with_path_params(
-        request_data=request_data, request=request
-    )
+    request_data = populate_request_with_path_params(request_data=request_data, request=request)
     route: str = get_request_route(request=request)
 
     ## CHECK IF ROUTE IS ALLOWED
@@ -1255,9 +1161,7 @@ async def user_api_key_auth(
     ## ENSURE DISABLE ROUTE WORKS ACROSS ALL USER AUTH FLOWS ##
     RouteChecks.should_call_route(route=route, valid_token=user_api_key_auth_obj)
 
-    end_user_id = get_end_user_id_from_request_body(
-        request_data, _safe_get_request_headers(request)
-    )
+    end_user_id = get_end_user_id_from_request_body(request_data, _safe_get_request_headers(request))
     if end_user_id is not None:
         user_api_key_auth_obj.end_user_id = end_user_id
 
@@ -1288,9 +1192,7 @@ async def _return_user_api_key_auth_obj(
         )
     )
 
-    retrieved_user_role = (
-        user_role or _get_user_role(user_obj=user_obj) or LitellmUserRoles.INTERNAL_USER
-    )
+    retrieved_user_role = user_role or _get_user_role(user_obj=user_obj) or LitellmUserRoles.INTERNAL_USER
 
     user_api_key_kwargs = {
         "api_key": api_key,
@@ -1313,9 +1215,7 @@ async def _return_user_api_key_auth_obj(
         return UserAPIKeyAuth(**user_api_key_kwargs)
 
 
-def get_api_key_from_custom_header(
-    request: Request, custom_litellm_key_header_name: str
-) -> str:
+def get_api_key_from_custom_header(request: Request, custom_litellm_key_header_name: str) -> str:
     """
     Get API key from custom header
 
@@ -1352,10 +1252,7 @@ def get_api_key_from_custom_header(
 
 def _get_temp_budget_increase(valid_token: UserAPIKeyAuth):
     valid_token_metadata = valid_token.metadata
-    if (
-        "temp_budget_increase" in valid_token_metadata
-        and "temp_budget_expiry" in valid_token_metadata
-    ):
+    if "temp_budget_increase" in valid_token_metadata and "temp_budget_expiry" in valid_token_metadata:
         expiry = datetime.fromisoformat(valid_token_metadata["temp_budget_expiry"])
         if expiry > datetime.now():
             return valid_token_metadata["temp_budget_increase"]

--- a/tests/test_litellm/integrations/test_prometheus_invalid_key_filtering.py
+++ b/tests/test_litellm/integrations/test_prometheus_invalid_key_filtering.py
@@ -10,6 +10,7 @@ import sys
 from unittest.mock import Mock, patch
 
 import pytest
+from litellm.proxy.auth.auth_utils import abbreviate_api_key
 from prometheus_client import REGISTRY
 
 sys.path.insert(0, os.path.abspath("../../.."))
@@ -72,7 +73,7 @@ class TestInvalidAPIKeyDetection:
         assert prometheus_logger._is_invalid_api_key_request(status_code=status_code) == expected
 
     def test_auth_error_message_detection(self, prometheus_logger):
-        exception = AssertionError("LiteLLM Virtual Key expected. Received=invalid-key-12345, expected to start with 'sk-'.")
+        exception = AssertionError(f"LiteLLM Virtual Key expected. Received={abbreviate_api_key(api_key='invalid-key-12345')}, expected to start with 'sk-'.")
         assert prometheus_logger._is_invalid_api_key_request(status_code=None, exception=exception) is True
 
     def test_non_auth_exception_not_detected(self, prometheus_logger):


### PR DESCRIPTION
Previous PR was closed https://github.com/BerriAI/litellm/pull/18902, with what I believe is a mistaken justification. Maintainer linked to a pr that did not touch this code path and claimed the issue was taken care of.

Currently [this error](https://github.com/kenairhodesScale/litellm/blob/553bf27b70857b63a62b25fbf9d8ffd270ee3943/litellm/proxy/auth/user_api_key_auth.py) may log an api key in plainttext. This will occur in scenarios like:

user only providing the part of their api key after 'sk-'
user providing an api key for a different service than litellm
Similar to other error messages in the codebase, wrap the attempted api key with abbreviate_api_key to mask it in the error message.