### PR TITLE
feat(bedrock): pass strict and additionalProperties to Converse API toolSpec

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5174,15 +5174,25 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
         # with circular references (see issue #19098). unpack_defs handles nested
         # refs recursively and correctly detects/skips circular references.
         unpack_defs(parameters, defs_copy)
+        _additional_properties = parameters.get("additionalProperties", None)
         tool_input_schema = BedrockToolInputSchemaBlock(
             json=BedrockToolJsonSchemaBlock(
                 type=parameters.get("type", ""),
                 properties=parameters.get("properties", {}),
                 required=parameters.get("required", []),
+                **(
+                    {"additionalProperties": _additional_properties}
+                    if _additional_properties is not None
+                    else {}
+                ),
             )
         )
+        _strict = tool.get("function", {}).get("strict", None)
         tool_spec = BedrockToolSpecBlock(
-            inputSchema=tool_input_schema, name=name, description=description
+            inputSchema=tool_input_schema,
+            name=name,
+            description=description,
+            **({"strict": _strict} if _strict is not None else {}),
         )
         tool_block = BedrockToolBlock(toolSpec=tool_spec)
         tool_block_list.append(tool_block)

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -203,13 +203,16 @@ class ConverseResponseBlock(TypedDict, total=False):
         str
     ]  # end_turn | tool_use | max_tokens | stop_sequence | content_filtered
     usage: Required[ConverseTokenUsageBlock]
-    serviceTier: ServiceTierBlock  # Optional - only present when serviceTier was sent in request
+    serviceTier: (
+        ServiceTierBlock  # Optional - only present when serviceTier was sent in request
+    )
 
 
 class ToolJsonSchemaBlock(TypedDict, total=False):
     type: Literal["object"]
     properties: dict
     required: List[str]
+    additionalProperties: bool
 
 
 class ToolInputSchemaBlock(TypedDict):
@@ -220,6 +223,7 @@ class ToolSpecBlock(TypedDict, total=False):
     inputSchema: Required[ToolInputSchemaBlock]
     name: Required[str]
     description: str
+    strict: Optional[bool]
 
 
 class SystemToolBlock(TypedDict, total=False):

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -1116,6 +1116,52 @@ def test_bedrock_tools_transformation_valid_params():
     assert "test" in result[0]["toolSpec"]["inputSchema"]["json"]["required"]
 
 
+def test_bedrock_tools_pt_strict_parameter():
+    """Test that strict and additionalProperties are passed through to Bedrock toolSpec."""
+    tools_with_strict = [
+        {
+            "type": "function",
+            "function": {
+                "name": "generate_sql",
+                "strict": True,
+                "description": "Generate a SQL query",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                    },
+                    "required": ["query"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+    result = _bedrock_tools_pt(tools_with_strict)
+    assert result[0]["toolSpec"]["strict"] is True
+    assert result[0]["toolSpec"]["inputSchema"]["json"]["additionalProperties"] is False
+
+    # Test without strict - should not have strict key or additionalProperties
+    tools_without_strict = [
+        {
+            "type": "function",
+            "function": {
+                "name": "generate_sql",
+                "description": "Generate a SQL query",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                    },
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+    result = _bedrock_tools_pt(tools_without_strict)
+    assert "strict" not in result[0]["toolSpec"]
+    assert "additionalProperties" not in result[0]["toolSpec"]["inputSchema"]["json"]
+
+
 def test_not_found_error():
     with pytest.raises(litellm.NotFoundError):
         completion(


### PR DESCRIPTION
## Relevant issues

Closes the gap where Anthropic direct API path already supports `strict` (PR #16725) but Bedrock Converse path does not.

Related: #10062, #16725, #6136

## Summary

Bedrock Converse API supports `strict: true` in `toolSpec` since 2026-02-04 (GA) — [AWS API Reference: ToolSpecification](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html).

Previously, both `strict` and `additionalProperties` were implicitly dropped during OpenAI-to-Bedrock tool conversion because `ToolSpecBlock` and `ToolJsonSchemaBlock` only whitelisted a subset of fields (introduced in #10062, which was correct at the time since Bedrock didn't support `strict`).

Without `additionalProperties: false` in the schema, Bedrock rejects `strict: true` requests with:
> `"For 'object' type, 'additionalProperties' must be explicitly set to false"`

This PR:
- Adds `strict: Optional[bool]` to `ToolSpecBlock` TypedDict
- Adds `additionalProperties: bool` to `ToolJsonSchemaBlock` TypedDict
- Passes through both parameters in `_bedrock_tools_pt()` when present
- Adds unit test verifying both fields are passed through (and absent when not specified)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

- `litellm/types/llms/bedrock.py`: Added `strict: Optional[bool]` to `ToolSpecBlock`, `additionalProperties: bool` to `ToolJsonSchemaBlock`
- `litellm/litellm_core_utils/prompt_templates/factory.py`: Pass through `strict` and `additionalProperties` from OpenAI tool format to Bedrock `toolSpec`
- `tests/llm_translation/test_bedrock_completion.py`: Updated `test_bedrock_tools_pt_strict_parameter` test to cover both fields