### PR TITLE
Anthropic add_code_execution_tool only add one tool

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1399,7 +1399,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             or []
         )
         tools = self.add_code_execution_tool(messages=anthropic_messages, tools=_tools)
-        if len(tools) > 1:
+        if len(tools) >= 1:
             optional_params["tools"] = tools
 
         ## Load Config

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1948,14 +1948,28 @@ def test_transform_request_adds_tool_code_execution_when_container_upload_in_mes
     """
     config = AnthropicConfig()
 
-    messages = [{"role": "user", "content": "Hello"}, {type: "file", file: {file_id: 'uploadedFileId'}}]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Analyse this file"},
+                {"type": "container_upload", "file_id": "file_abc123"},
+            ],
+        }
+    ]
 
     result = config.transform_request(
         model="claude-sonnet-4-5",
-        messages=messages
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
     )
 
-    assert len(result["tools"]) >= 1
+    assert "tools" in result
+    assert any(
+        t.get("type", "").startswith("code_execution") for t in result["tools"]
+    )
 
 def test_transform_request_respects_user_max_tokens():
     """

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1952,8 +1952,8 @@ def test_transform_request_adds_tool_code_execution_when_container_upload_in_mes
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Analyse this file"},
-                {"type": "container_upload", "file_id": "file_abc123"},
+                {"type": "text", "text": "Analyse this file"},                
+                {"type": "file", "file": {"file_id": "file_abc123" }}
             ],
         }
     ]

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1939,6 +1939,23 @@ def test_transform_request_uses_dynamic_max_tokens():
 
     assert result["max_tokens"] == 64000
 
+def test_transform_request_adds_tool_code_execution_when_container_upload_in_messages():
+    """
+    Test that transform_request correctly adds the required code_execution tool to the request
+    when max_tokens is not explicitly provided.
+
+    Fixes: https://github.com/BerriAI/litellm/pull/25217
+    """
+    config = AnthropicConfig()
+
+    messages = [{"role": "user", "content": "Hello"}, {type: "file", file: {file_id: 'uploadedFileId'}}]
+
+    result = config.transform_request(
+        model="claude-sonnet-4-5",
+        messages=messages
+    )
+
+    assert len(result["tools"]) >= 1
 
 def test_transform_request_respects_user_max_tokens():
     """


### PR DESCRIPTION
When calling Anthropic with files, and this files it's of type `container_upload`, Anthropic requires the `code_execution` tool.

The tool its created correctly, but then because it only returns one tool, the `if` check won't apply that tool, resulting in a failed call to the AI

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
