### PR TITLE
chore/bump litellm 1.83.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,6 @@ litellm/proxy/db/migrations/*
 litellm/proxy/migrations/*config.yaml
 litellm/proxy/migrations/*
 litellm/proxy/to_delete_loadtest_work/*
-config.yaml
 tests/litellm/litellm_core_utils/llm_cost_calc/log.txt
 tests/test_custom_dir/*
 test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,5 +138,7 @@ COPY docker/supervisord.conf /etc/supervisord.conf
 
 ENTRYPOINT ["docker/prod_entrypoint.sh"]
 
+COPY config.yaml /app/config.yaml
+
 # Append "--detailed_debug" to the end of CMD to view detailed debug logs
-CMD ["--port", "4000"]
+CMD ["--port", "4000", "--config", "/app/config.yaml"]

--- a/config.yaml
+++ b/config.yaml
@@ -3,5 +3,13 @@ model_list:
     litellm_params:
       model: gemini/gemini-2.5-flash
       api_key: os.environ/GEMINI_API_KEY
+  - model_name: gemini-3-flash-preview
+    litellm_params:
+      model: gemini/gemini-3-flash-preview
+      api_key: os.environ/GEMINI_API_KEY
+
+litellm_settings:
+  drop_params: true
+
 general_settings:
-    master_key: os.environ/LITELLM_MASTER_KEY
+  master_key: os.environ/LITELLM_MASTER_KEY

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,10 @@ model_list:
     litellm_params:
       model: gemini/gemini-3-flash-preview
       api_key: os.environ/GEMINI_API_KEY
+  - model_name: gemini-3.1-pro-preview
+    litellm_params:
+      model: gemini/gemini-3.1-pro-preview
+      api_key: os.environ/GEMINI_API_KEY
 
 litellm_settings:
   drop_params: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+model_list:
+  - model_name: gemini-2.5-flash
+    litellm_params:
+      model: gemini/gemini-2.5-flash
+      api_key: os.environ/GEMINI_API_KEY
+general_settings:
+    master_key: os.environ/LITELLM_MASTER_KEY

--- a/docker/build_from_pip/requirements.txt
+++ b/docker/build_from_pip/requirements.txt
@@ -1,4 +1,4 @@
-litellm[proxy]==1.83.0
+litellm[proxy]==1.83.3
 prometheus_client==0.20.0
 langfuse==2.59.7
 prisma==0.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "1.83.0"
+version = "1.83.3"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
@@ -18,7 +18,7 @@ Repository = "https://github.com/BerriAI/litellm"
 documentation = "https://docs.litellm.ai"
 Documentation = "https://docs.litellm.ai"
 
-# Dependencies pinned from `pip install litellm[proxy]==1.83.0` PyPI resolution.
+# Dependencies pinned from `pip install litellm[proxy]==1.83.3` PyPI resolution.
 # Docker builds use requirements.txt (different pins). These two paths are independent.
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
@@ -181,7 +181,7 @@ requires = ["poetry-core", "wheel"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.83.0"
+version = "1.83.3"
 version_files = [
     "pyproject.toml:^version"
 ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME="pam-litellm"
+
+if [[ "$(docker images -q $IMAGE_NAME 2>/dev/null)" == "" ]]; then
+  echo "Image not found, building..."
+  docker build --platform linux/amd64 -t $IMAGE_NAME .
+fi
+
+echo "Starting LiteLLM on http://localhost:4000"
+docker run --rm \
+  -p 4000:4000 \
+  -e GEMINI_API_KEY="${GEMINI_API_KEY:?GEMINI_API_KEY is not set}" \
+  -e LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY is not set}" \
+  "$IMAGE_NAME"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+BASE_URL="${LITELLM_BASE_URL:-http://localhost:4000}"
+MASTER_KEY="${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY is not set}"
+
+echo "Testing LiteLLM at $BASE_URL"
+
+# Health check
+echo -n "Health check... "
+curl -sf "$BASE_URL/health/liveliness" > /dev/null
+echo "OK"
+
+# Chat completion
+echo -n "Chat completion... "
+RESPONSE=$(curl -sf "$BASE_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-2.5-flash",
+    "messages": [{"role": "user", "content": "Say hello in one word."}],
+    "max_tokens": 10
+  }')
+echo "$RESPONSE" | python3 -c "import sys,json; print('OK -', json.load(sys.stdin)['choices'][0]['message']['content'])"


### PR DESCRIPTION
## Summary                                                                    
Bump LiteLLM from 1.83.0 to 1.83.3, which includes Skills Marketplace, MCP
Toolsets, Guardrail Fallbacks, Team Guardrails, new Bedrock models, and
various bug fixes.

## Changes
- Updated version in `pyproject.toml` (poetry + commitizen)
- Updated pip pin in `docker/build_from_pip/requirements.txt`

## How to test
- Verify `poetry install` resolves correctly
- Confirm proxy starts with `litellm --config <config>`
