### PR TITLE
fix(auth): make oauth2 auth on info routes opt-in

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -224,7 +224,7 @@ router_settings:
 | database_url | string | The URL for the database connection [Set up Virtual Keys](virtual_keys) |
 | database_connection_pool_limit | integer | The limit for database connection pool [Setting DB Connection Pool limit](#configure-db-pool-limits--connection-timeouts) |
 | database_connection_timeout | integer | The timeout for database connections in seconds [Setting DB Connection Pool limit, timeout](#configure-db-pool-limits--connection-timeouts) |
-| allow_requests_on_db_unavailable | boolean | If true, allows requests to succeed even if DB is unreachable. **Only use this if running LiteLLM in your VPC** This will allow requests to work even when LiteLLM cannot connect to the DB to verify a Virtual Key [Doc on graceful db unavailability](prod#5-if-running-litellm-on-vpc-gracefully-handle-db-unavailability) |
+| allow_requests_on_db_unavailable | boolean | If true, allows requests to succeed even if DB is unreachable. **Only use this if running LiteLLM in your VPC** This will allow requests to work even when LiteLLM cannot connect to the DB to verify a Virtual Key [Doc on graceful db unavailability](prod#6-if-running-litellm-on-vpc-gracefully-handle-db-unavailability) |
 | custom_auth | string | Write your own custom authentication logic [Doc Custom Auth](virtual_keys#custom-auth) |
 | max_parallel_requests | integer | The max parallel requests allowed per deployment |
 | global_max_parallel_requests | integer | The max parallel requests allowed on the proxy overall |
@@ -239,6 +239,7 @@ router_settings:
 | alert_types | List[str] | Control list of alert types to send to slack (Doc on alert types)[./alerting.md] |
 | enforced_params | List[str] | (Enterprise Feature) List of params that must be included in all requests to the proxy |
 | enable_oauth2_auth | boolean | (Enterprise Feature) If true, enables oauth2.0 authentication |
+| oauth2_auth_on_info_routes | boolean | (Enterprise Feature) If true, also applies OAuth2 auth to info routes (e.g. `/team/list`, `/key/list`). Default is false. |
 | use_x_forwarded_for | str | If true, uses the X-Forwarded-For header to get the client IP address |
 | service_account_settings | List[Dict[str, Any]] | Set `service_account_settings` if you want to create settings that only apply to service account keys (Doc on service accounts)[./service_accounts.md] | 
 | image_generation_model | str | The default model to use for image generation - ignores model set in request |

--- a/docs/my-website/docs/proxy/oauth2.md
+++ b/docs/my-website/docs/proxy/oauth2.md
@@ -39,6 +39,10 @@ model_list:
 general_settings: 
   master_key: sk-1234
   enable_oauth2_auth: true
+  # Optional: also apply OAuth2 introspection to info routes
+  # like /team/list, /key/list, /models
+  # Default is false
+  oauth2_auth_on_info_routes: false
 ```
 
 3. Use token in requests to LiteLLM 
@@ -66,6 +70,16 @@ Start the LiteLLM Proxy with [`--detailed_debug` mode and you should see more ve
 If both `enable_oauth2_auth` and `enable_jwt_auth` are enabled, LiteLLM can split auth paths:
 - JWT validation for user tokens
 - OAuth2 introspection for machine tokens
+
+By default, OAuth2 is enforced on LLM API routes only.  
+To also enforce OAuth2 on info routes (for example `/team/list`, `/key/list`, `/models`), set:
+
+```yaml title="config.yaml"
+general_settings:
+  enable_oauth2_auth: true
+  enable_jwt_auth: true
+  oauth2_auth_on_info_routes: true
+```
 
 For JWT-shaped machine tokens, configure `litellm_jwtauth.routing_overrides`:
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -732,6 +732,40 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
                     return await Oauth2Handler.check_oauth2_token(token=api_key)
 
+        # Allow explicit JWT routing overrides to still use OAuth2 even when
+        # `enable_oauth2_auth` is false. This keeps opaque-token OAuth2 disabled
+        # while supporting targeted machine JWT -> OAuth2 introspection flows.
+        if (
+            general_settings.get("enable_oauth2_auth", False) is not True
+            and general_settings.get("enable_jwt_auth", False) is True
+        ):
+            is_jwt = jwt_handler.is_jwt(token=api_key)
+            if is_jwt:
+                should_apply_oauth2_on_info_routes = bool(
+                    general_settings.get("oauth2_auth_on_info_routes", False)
+                )
+                should_consider_oauth2_override = RouteChecks.is_llm_api_route(
+                    route=route
+                ) or (
+                    should_apply_oauth2_on_info_routes
+                    and RouteChecks.is_info_route(route=route)
+                )
+                route_jwt_to_oauth2 = should_consider_oauth2_override and (
+                    _should_route_jwt_to_oauth2_override(
+                        token=api_key, jwt_handler=jwt_handler
+                    )
+                )
+                if route_jwt_to_oauth2:
+                    from litellm.proxy.proxy_server import premium_user
+
+                    if premium_user is not True:
+                        raise ValueError(
+                            "Oauth2 token validation is only available for premium users"
+                            + CommonProxyErrors.not_premium_user.value
+                        )
+
+                    return await Oauth2Handler.check_oauth2_token(token=api_key)
+
         if general_settings.get("enable_oauth2_proxy_auth", False) is True:
             return await handle_oauth2_proxy_request(request=request)
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -691,12 +691,17 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
         ########## End of Route Checks Before Reading DB / Cache for "token" ########
 
         if general_settings.get("enable_oauth2_auth", False) is True:
-            # Only apply OAuth2 M2M authentication to LLM API routes and info routes, not UI/management routes
-            # This allows UI SSO to work separately from API M2M authentication
-            # Note: Info routes are already scoped to the user
-            if RouteChecks.is_llm_api_route(route=route) or RouteChecks.is_info_route(
-                route=route
-            ):
+            # By default, OAuth2 M2M auth is enforced only on LLM API routes.
+            # Info-route OAuth2 auth can be explicitly enabled via:
+            # general_settings.oauth2_auth_on_info_routes: true
+            should_apply_oauth2_on_info_routes = bool(
+                general_settings.get("oauth2_auth_on_info_routes", False)
+            )
+            should_apply_oauth2_auth = RouteChecks.is_llm_api_route(route=route) or (
+                should_apply_oauth2_on_info_routes
+                and RouteChecks.is_info_route(route=route)
+            )
+            if should_apply_oauth2_auth:
                 # When both OAuth2 and JWT auth are enabled, use token format to decide:
                 # - JWT tokens (3 dot-separated parts) -> skip OAuth2, fall through to JWT handler
                 # - Opaque tokens -> use OAuth2 handler

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -975,6 +975,106 @@ class TestJWTOAuth2Coexistence:
             assert result.user_id == "machine-client-aud-list"
 
     @pytest.mark.asyncio
+    async def test_routing_override_routes_jwt_to_oauth2_when_oauth2_globally_disabled(
+        self,
+    ):
+        """
+        If enable_oauth2_auth is false, JWT tokens matching routing_overrides
+        should still route to OAuth2 introspection.
+        """
+        jwt_token = (
+            "eyJhbGciOiJSUzI1NiJ9."
+            "eyJpc3MiOiJtYWNoaW5lLWlzc3Vlci5leGFtcGxlLmNvbSIsImNsaWVudF9pZCI6Ik1JRF9MSVRFTExNIn0."
+            "c2ln"
+        )
+        general_settings = {
+            "enable_oauth2_auth": False,
+            "enable_jwt_auth": True,
+        }
+        mock_oauth2_response = UserAPIKeyAuth(
+            api_key=jwt_token,
+            user_id="machine-client-override-oauth2-off",
+        )
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/chat/completions"
+        mock_request.headers = {"authorization": f"Bearer {jwt_token}"}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.premium_user", True), patch(
+            "litellm.proxy.proxy_server.master_key", "sk-master"
+        ), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.Oauth2Handler.check_oauth2_token",
+            new_callable=AsyncMock,
+            return_value=mock_oauth2_response,
+        ) as mock_oauth2, patch(
+            "litellm.proxy.auth.user_api_key_auth.JWTAuthManager.auth_builder",
+            new_callable=AsyncMock,
+        ) as mock_jwt_auth:
+            litellm.proxy.proxy_server.jwt_handler.update_environment(
+                prisma_client=None,
+                user_api_key_cache=DualCache(),
+                litellm_jwtauth=LiteLLM_JWTAuth(
+                    routing_overrides=[
+                        JWTRoutingOverride(
+                            iss="machine-issuer.example.com",
+                            client_id="MID_LITELLM",
+                            path="oauth2",
+                        )
+                    ]
+                ),
+            )
+
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key=f"Bearer {jwt_token}",
+            )
+
+            mock_oauth2.assert_called_once_with(token=jwt_token)
+            mock_jwt_auth.assert_not_called()
+            assert result.user_id == "machine-client-override-oauth2-off"
+
+    @pytest.mark.asyncio
+    async def test_opaque_token_does_not_use_oauth2_when_oauth2_globally_disabled(
+        self,
+    ):
+        """
+        With enable_oauth2_auth=false, opaque tokens must not be sent to OAuth2.
+        """
+        opaque_token = "sk-ui-session-token"
+        general_settings = {
+            "enable_oauth2_auth": False,
+            "enable_jwt_auth": True,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/chat/completions"
+        mock_request.headers = {"authorization": f"Bearer {opaque_token}"}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.premium_user", True), patch(
+            "litellm.proxy.proxy_server.master_key", "sk-master"
+        ), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.Oauth2Handler.check_oauth2_token",
+            new_callable=AsyncMock,
+        ) as mock_oauth2:
+            with pytest.raises(Exception):
+                await user_api_key_auth(
+                    request=mock_request,
+                    api_key=f"Bearer {opaque_token}",
+                )
+
+            mock_oauth2.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_info_route_does_not_use_oauth2_by_default(self):
         """
         With both auth modes enabled, info routes should not force OAuth2 unless

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -975,6 +975,85 @@ class TestJWTOAuth2Coexistence:
             assert result.user_id == "machine-client-aud-list"
 
     @pytest.mark.asyncio
+    async def test_info_route_does_not_use_oauth2_by_default(self):
+        """
+        With both auth modes enabled, info routes should not force OAuth2 unless
+        explicitly configured.
+        """
+        ui_session_key = "sk-ui-session-token"
+
+        general_settings = {
+            "enable_oauth2_auth": True,
+            "enable_jwt_auth": True,
+        }
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/team/list"
+        mock_request.headers = {"authorization": f"Bearer {ui_session_key}"}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.premium_user", True), patch(
+            "litellm.proxy.proxy_server.master_key", "sk-master"
+        ), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.Oauth2Handler.check_oauth2_token",
+            new_callable=AsyncMock,
+        ) as mock_oauth2:
+            with pytest.raises(Exception):
+                await user_api_key_auth(
+                    request=mock_request,
+                    api_key=f"Bearer {ui_session_key}",
+                )
+
+            mock_oauth2.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_info_route_can_use_oauth2_when_explicitly_enabled(self):
+        """
+        Setting oauth2_auth_on_info_routes enables OAuth2 auth on info routes.
+        """
+        opaque_token = "opaque-info-route-token"
+
+        general_settings = {
+            "enable_oauth2_auth": True,
+            "enable_jwt_auth": True,
+            "oauth2_auth_on_info_routes": True,
+        }
+
+        mock_oauth2_response = UserAPIKeyAuth(
+            api_key=opaque_token,
+            user_id="machine-client-info-route",
+            team_id="m2m-team",
+        )
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/team/list"
+        mock_request.headers = {"authorization": f"Bearer {opaque_token}"}
+        mock_request.query_params = {}
+
+        with patch(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        ), patch("litellm.proxy.proxy_server.premium_user", True), patch(
+            "litellm.proxy.proxy_server.master_key", "sk-master"
+        ), patch(
+            "litellm.proxy.proxy_server.prisma_client", None
+        ), patch(
+            "litellm.proxy.auth.user_api_key_auth.Oauth2Handler.check_oauth2_token",
+            new_callable=AsyncMock,
+            return_value=mock_oauth2_response,
+        ) as mock_oauth2:
+            result = await user_api_key_auth(
+                request=mock_request,
+                api_key=f"Bearer {opaque_token}",
+            )
+
+            mock_oauth2.assert_called_once_with(token=opaque_token)
+            assert result.user_id == "machine-client-info-route"
+
+    @pytest.mark.asyncio
     async def test_only_oauth2_enabled_handles_all_tokens(self):
         """
         When only enable_oauth2_auth is True (no JWT), all LLM API tokens


### PR DESCRIPTION
## Relevant issues

Regression follow-up for https://github.com/BerriAI/litellm/pull/22713

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix  
📖 Documentation  
✅ Test

## Changes

- Makes OAuth2 auth on info routes opt-in via `general_settings.oauth2_auth_on_info_routes` (default `false`).
- Preserves OAuth2 auth on LLM API routes and existing JWT/OAuth2 coexistence behavior.
- Adds tests covering:
  - info routes do **not** use OAuth2 by default
  - info routes **do** use OAuth2 when explicitly enabled
- Updates proxy config docs to document `oauth2_auth_on_info_routes`.
- Scope is limited to:
  - `litellm/proxy/auth/user_api_key_auth.py`
  - `tests/test_litellm/proxy/auth/test_user_api_key_auth.py`
  - `docs/my-website/docs/proxy/config_settings.md`

### Verification run

- `python -m pytest tests/test_litellm/proxy/auth/test_user_api_key_auth.py -k "info_route_does_not_use_oauth2_by_default or info_route_can_use_oauth2_when_explicitly_enabled" -q`
- Result: `2 passed`