### PR TITLE
fix(anthropic): don't drop text_delta when backend sends empty tool_calls

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1418,7 +1418,7 @@ class LiteLLMAnthropicMessagesAdapter:
         for choice in choices:
             if choice.delta.content is not None and len(choice.delta.content) > 0:
                 text += choice.delta.content
-            if choice.delta.tool_calls is not None:
+            if choice.delta.tool_calls is not None and len(choice.delta.tool_calls) > 0:
                 partial_json = ""
                 for tool in choice.delta.tool_calls:
                     if (


### PR DESCRIPTION
## Summary

Fixes streaming text content being silently dropped when an OpenAI-compatible backend sends `tool_calls: []` (empty list) in `chat.completion.chunk` deltas.

## Root Cause

In `_translate_streaming_openai_chunk_to_anthropic` (~line 1421):

```python
if choice.delta.tool_calls is not None:  # True for empty list []
    partial_json = ""                     # overwrites, drops text
    for tool in choice.delta.tool_calls:  # never iterates
        ...
```

Some backends (e.g. `mlx_lm.server`) always populate `tool_calls: []` in every streaming delta, even for plain-text responses. The `is not None` check treats an empty list as truthy, so the code enters the tool_calls branch, sets `partial_json = ""`, and returns `input_json_delta` instead of `text_delta`.

## Fix

Added `and len(choice.delta.tool_calls) > 0` to the condition, consistent with the existing pattern on line 1419 for `choice.delta.content`.

## Testing

This is a one-character-class fix (adding a length guard). The existing streaming test suite validates the non-empty tool_calls path remains functional.

## Disclaimer

AI agents (Claude Code) assisted with this contribution.

Fixes #25172