### PR TITLE
fix(guardrails): Azure prompt_shield and text_moderation now check input for Responses API

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
@@ -134,7 +134,7 @@ class AzureContentSafetyPromptShieldGuardrail(AzureGuardrailBase, CustomGuardrai
             "Azure Prompt Shield: Running pre-call prompt scan, on call_type: %s",
             call_type,
         )
-        new_messages: Optional[List[AllMessageValues]] = data.get("messages")
+        new_messages: Optional[List[AllMessageValues]] = data.get("messages") or data.get("input")
         if new_messages is None:
             verbose_proxy_logger.warning(
                 "Azure Prompt Shield: not running guardrail. No messages in data"

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
@@ -134,7 +134,14 @@ class AzureContentSafetyPromptShieldGuardrail(AzureGuardrailBase, CustomGuardrai
             "Azure Prompt Shield: Running pre-call prompt scan, on call_type: %s",
             call_type,
         )
-        new_messages: Optional[List[AllMessageValues]] = data.get("messages") or data.get("input")
+        new_messages: Optional[List[AllMessageValues]] = data.get("messages")
+        if new_messages is None:
+            # Responses API uses "input" instead of "messages"
+            input_data = data.get("input")
+            if isinstance(input_data, str):
+                new_messages = [{"role": "user", "content": input_data}]
+            elif isinstance(input_data, list):
+                new_messages = input_data
         if new_messages is None:
             verbose_proxy_logger.warning(
                 "Azure Prompt Shield: not running guardrail. No messages in data"

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
@@ -136,12 +136,19 @@ class AzureContentSafetyPromptShieldGuardrail(AzureGuardrailBase, CustomGuardrai
         )
         new_messages: Optional[List[AllMessageValues]] = data.get("messages")
         if new_messages is None:
-            # Responses API uses "input" instead of "messages"
+            # Responses API uses "input" instead of "messages".
+            # Input can be a plain string or a list that may contain
+            # non-message items (e.g. tool-call outputs without a "role"
+            # key). Filter to only message-shaped dicts so get_user_prompt()
+            # doesn't break its reverse iteration on a non-message item.
             input_data = data.get("input")
             if isinstance(input_data, str):
                 new_messages = [{"role": "user", "content": input_data}]
             elif isinstance(input_data, list):
-                new_messages = input_data
+                new_messages = [
+                    item for item in input_data
+                    if isinstance(item, dict) and "role" in item
+                ]
         if new_messages is None:
             verbose_proxy_logger.warning(
                 "Azure Prompt Shield: not running guardrail. No messages in data"

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
@@ -227,7 +227,14 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
             "Azure Text Moderation: Running pre-call prompt scan, on call_type: %s",
             call_type,
         )
-        new_messages: Optional[List[AllMessageValues]] = data.get("messages") or data.get("input")
+        new_messages: Optional[List[AllMessageValues]] = data.get("messages")
+        if new_messages is None:
+            # Responses API uses "input" instead of "messages"
+            input_data = data.get("input")
+            if isinstance(input_data, str):
+                new_messages = [{"role": "user", "content": input_data}]
+            elif isinstance(input_data, list):
+                new_messages = input_data
         if new_messages is None:
             verbose_proxy_logger.warning(
                 "Azure Text Moderation: not running guardrail. No messages in data"

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
@@ -229,12 +229,19 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
         )
         new_messages: Optional[List[AllMessageValues]] = data.get("messages")
         if new_messages is None:
-            # Responses API uses "input" instead of "messages"
+            # Responses API uses "input" instead of "messages".
+            # Input can be a plain string or a list that may contain
+            # non-message items (e.g. tool-call outputs without a "role"
+            # key). Filter to only message-shaped dicts so get_user_prompt()
+            # doesn't break its reverse iteration on a non-message item.
             input_data = data.get("input")
             if isinstance(input_data, str):
                 new_messages = [{"role": "user", "content": input_data}]
             elif isinstance(input_data, list):
-                new_messages = input_data
+                new_messages = [
+                    item for item in input_data
+                    if isinstance(item, dict) and "role" in item
+                ]
         if new_messages is None:
             verbose_proxy_logger.warning(
                 "Azure Text Moderation: not running guardrail. No messages in data"

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
@@ -227,7 +227,7 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
             "Azure Text Moderation: Running pre-call prompt scan, on call_type: %s",
             call_type,
         )
-        new_messages: Optional[List[AllMessageValues]] = data.get("messages")
+        new_messages: Optional[List[AllMessageValues]] = data.get("messages") or data.get("input")
         if new_messages is None:
             verbose_proxy_logger.warning(
                 "Azure Text Moderation: not running guardrail. No messages in data"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_prompt_shield.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_prompt_shield.py
@@ -265,3 +265,123 @@ def test_split_preserves_whitespace():
     original = ("line one\n" + "line two\t\tcol\n" + "  indented\n") * 200
     chunks = guardrail.split_text_by_words(original, 500)
     assert "".join(chunks) == original
+
+
+# ---------- Responses API (data["input"]) tests ----------
+
+
+@pytest.mark.asyncio
+async def test_azure_prompt_shield_responses_api_string_input():
+    """Test guardrail works when Responses API sends input as a plain string."""
+    guardrail = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure_prompt_shield",
+        api_key="test_key",
+        api_base="test_base",
+    )
+    with patch.object(guardrail, "async_make_request") as mock_request:
+        mock_request.return_value = {
+            "userPromptAnalysis": {"attackDetected": False},
+            "documentsAnalysis": [],
+        }
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+            cache=None,
+            data={"input": "What is the capital of France?"},
+            call_type="completion",
+        )
+
+        mock_request.assert_called_once()
+        assert (
+            mock_request.call_args.kwargs["user_prompt"]
+            == "What is the capital of France?"
+        )
+
+
+@pytest.mark.asyncio
+async def test_azure_prompt_shield_responses_api_list_input():
+    """Test guardrail works when Responses API sends input as a message list."""
+    guardrail = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure_prompt_shield",
+        api_key="test_key",
+        api_base="test_base",
+    )
+    with patch.object(guardrail, "async_make_request") as mock_request:
+        mock_request.return_value = {
+            "userPromptAnalysis": {"attackDetected": False},
+            "documentsAnalysis": [],
+        }
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+            cache=None,
+            data={
+                "input": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi there"},
+                    {"role": "user", "content": "Tell me about Paris"},
+                ]
+            },
+            call_type="completion",
+        )
+
+        mock_request.assert_called_once()
+        assert (
+            mock_request.call_args.kwargs["user_prompt"]
+            == "Tell me about Paris"
+        )
+
+
+@pytest.mark.asyncio
+async def test_azure_prompt_shield_responses_api_multi_turn_with_tool_output():
+    """Test guardrail filters out non-message items (tool outputs) from input list.
+
+    Responses API lists can contain tool-call output items that lack a "role"
+    key. These must be filtered out so get_user_prompt() can find user messages
+    that appear before them in the list.
+    """
+    guardrail = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure_prompt_shield",
+        api_key="test_key",
+        api_base="test_base",
+    )
+    with patch.object(guardrail, "async_make_request") as mock_request:
+        mock_request.return_value = {
+            "userPromptAnalysis": {"attackDetected": False},
+            "documentsAnalysis": [],
+        }
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+            cache=None,
+            data={
+                "input": [
+                    {"role": "user", "content": "Search for weather in Tokyo"},
+                    {"role": "assistant", "content": "Let me look that up."},
+                    {"role": "user", "content": "Thanks, also check Paris"},
+                    # Tool output — no "role" key, should be filtered out
+                    {"type": "tool_result", "tool_use_id": "abc", "content": "72°F"},
+                ]
+            },
+            call_type="completion",
+        )
+
+        mock_request.assert_called_once()
+        assert "Paris" in mock_request.call_args.kwargs["user_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_azure_prompt_shield_responses_api_no_input():
+    """Test guardrail skips gracefully when neither messages nor input is present."""
+    guardrail = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure_prompt_shield",
+        api_key="test_key",
+        api_base="test_base",
+    )
+    with patch.object(guardrail, "async_make_request") as mock_request:
+        result = await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="completion",
+        )
+
+        mock_request.assert_not_called()
+        assert result == {"model": "gpt-4o"}


### PR DESCRIPTION
## Summary

Fixes Azure guardrails (prompt_shield, text_moderation) silently skipping on `/v1/responses` endpoint requests.

## Root Cause

Both guardrail handlers only check `data.get("messages")` for user content. The Responses API (`/v1/responses`) uses `data["input"]` instead of `data["messages"]`, so the handlers exit early with a warning:

```
Azure Prompt Shield: not running guardrail. No messages in data
Azure Text Moderation: not running guardrail. No messages in data
```

This means **content moderation and prompt injection detection are completely bypassed** for any traffic using the Responses API.

## Fix

Added fallback to `data.get("input")` in both handlers:

```python
# Before
new_messages = data.get("messages")

# After
new_messages = data.get("messages") or data.get("input")
```

## Files Changed

- `litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py`
- `litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py`

## Testing

The fix is a minimal fallback that doesn't change existing `/v1/chat/completions` behavior (where `data["messages"]` is always present and truthy). For `/v1/responses`, `data["input"]` provides the message list.

## Disclaimer

AI agents (Claude Code) assisted with this contribution.

Fixes #25215