### PR TITLE
fix(usage): propagate prompt_tokens_details.cached_tokens to _cache_read_input_tokens

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1675,6 +1675,16 @@ class Usage(SafeAttributeModel, CompletionUsage):
         ):
             self._cache_read_input_tokens = params["prompt_cache_hit_tokens"]
 
+        ## OPENAI-STYLE MAPPING ##
+        # Providers using OpenAI format (Moonshot/Kimi, OpenAI with prompt caching,
+        # and other OpenAI-compatible providers) return cached tokens in
+        # prompt_tokens_details.cached_tokens but not as a top-level field.
+        # Propagate to _cache_read_input_tokens for spend logging consistency.
+        if self._cache_read_input_tokens == 0 and _prompt_tokens_details is not None:
+            _ptd_cached = getattr(_prompt_tokens_details, "cached_tokens", 0) or 0
+            if _ptd_cached > 0:
+                self._cache_read_input_tokens = _ptd_cached
+
         for k, v in params.items():
             setattr(self, k, v)
 

--- a/tests/local_testing/test_openai_style_cached_tokens.py
+++ b/tests/local_testing/test_openai_style_cached_tokens.py
@@ -1,0 +1,105 @@
+"""
+Test: OpenAI-style prompt_tokens_details.cached_tokens propagation to _cache_read_input_tokens.
+
+Providers like Moonshot/Kimi and OpenAI (with prompt caching) return cached tokens in
+prompt_tokens_details.cached_tokens. This should be propagated to _cache_read_input_tokens
+for spend logging, streaming, and callback consistency.
+"""
+import pytest
+from litellm.types.utils import Usage
+
+
+def test_openai_style_cached_tokens_propagation():
+    """cached_tokens in prompt_tokens_details should set _cache_read_input_tokens."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_tokens_details={"cached_tokens": 800},
+    )
+    assert usage.prompt_tokens_details.cached_tokens == 800
+    assert usage._cache_read_input_tokens == 800
+
+
+def test_anthropic_style_still_works():
+    """Anthropic's top-level cache_read_input_tokens should still work."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cache_read_input_tokens=800,
+    )
+    assert usage._cache_read_input_tokens == 800
+
+
+def test_deepseek_style_still_works():
+    """DeepSeek's prompt_cache_hit_tokens should still work."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_cache_hit_tokens=800,
+    )
+    assert usage._cache_read_input_tokens == 800
+
+
+def test_no_double_counting():
+    """When both Anthropic field and ptd.cached_tokens exist, no double-counting."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cache_read_input_tokens=800,
+        prompt_tokens_details={"cached_tokens": 800},
+    )
+    assert usage._cache_read_input_tokens == 800  # Not 1600
+
+
+def test_anthropic_takes_precedence():
+    """When Anthropic field is set, ptd.cached_tokens doesn't override."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cache_read_input_tokens=600,
+        prompt_tokens_details={"cached_tokens": 800},
+    )
+    assert usage._cache_read_input_tokens == 600  # Anthropic value wins
+
+
+def test_no_cached_tokens():
+    """When no cached tokens at all, _cache_read_input_tokens stays 0."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+    )
+    assert usage._cache_read_input_tokens == 0
+
+
+def test_cached_tokens_none():
+    """When cached_tokens is None, don't propagate."""
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_tokens_details={"cached_tokens": None},
+    )
+    assert usage._cache_read_input_tokens == 0
+
+
+def test_moonshot_real_response():
+    """Simulate actual Moonshot API response format."""
+    usage = Usage(
+        prompt_tokens=48502,
+        completion_tokens=181,
+        total_tokens=48683,
+        prompt_tokens_details={"cached_tokens": 47872},
+        completion_tokens_details={
+            "reasoning_tokens": 100,
+            "text_tokens": None,
+            "audio_tokens": None,
+        },
+    )
+    assert usage._cache_read_input_tokens == 47872
+    assert usage.prompt_tokens_details.cached_tokens == 47872


### PR DESCRIPTION
## Summary
- `Usage.__init__` now propagates `prompt_tokens_details.cached_tokens` to `_cache_read_input_tokens` when it wasn't already set by Anthropic or DeepSeek mappings
- Adds 8 unit tests covering OpenAI-style, Anthropic, DeepSeek, no-double-counting, and real Moonshot response scenarios

## Problem

`Usage.__init__` has explicit mappings for:
- **Anthropic**: `cache_read_input_tokens` → `_cache_read_input_tokens` 
- **DeepSeek**: `prompt_cache_hit_tokens` → `_cache_read_input_tokens`

But NOT for the OpenAI-standard `prompt_tokens_details.cached_tokens`, used by:
- **Moonshot/Kimi** (kimi-k2.5)
- **OpenAI** (with prompt caching enabled)
- Any OpenAI-compatible provider

This leaves `_cache_read_input_tokens = 0` even when `prompt_tokens_details.cached_tokens` is correctly populated.

### Impact
- **Spend logging**: `cache_read_input_tokens` in SpendLogs is 0
- **Streaming chunk builder**: wrong cache counts
- **Langfuse integration**: `_extract_cache_read_input_tokens()` returns 0
- **Custom logger callbacks**: any callback reading `cache_read_input_tokens` gets 0

Note: The cost calculator itself reads `prompt_tokens_details.cached_tokens` directly via `_parse_prompt_tokens_details()`, so **calculated cost is correct**. But all other consumers of `_cache_read_input_tokens` get incorrect data.

## Fix

5-line addition after the existing DeepSeek mapping block in `litellm/types/utils.py`:

```python
## OPENAI-STYLE MAPPING ##
if self._cache_read_input_tokens == 0 and _prompt_tokens_details is not None:
    _ptd_cached = getattr(_prompt_tokens_details, "cached_tokens", 0) or 0
    if _ptd_cached > 0:
        self._cache_read_input_tokens = _ptd_cached
```

Only acts when `_cache_read_input_tokens` is still 0 (not set by Anthropic/DeepSeek), so existing provider behavior is unchanged.

## Test plan
- [x] `test_openai_style_cached_tokens_propagation` — cached_tokens propagates
- [x] `test_anthropic_style_still_works` — no regression
- [x] `test_deepseek_style_still_works` — no regression
- [x] `test_no_double_counting` — when both fields exist, no double-counting
- [x] `test_anthropic_takes_precedence` — Anthropic value not overwritten
- [x] `test_no_cached_tokens` — stays 0 when no cache data
- [x] `test_cached_tokens_none` — None handled correctly
- [x] `test_moonshot_real_response` — real Moonshot API response format

All 8 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)