### PR TITLE
added applyguardrail to inline iam

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -700,7 +700,7 @@ class BaseAWSLLM:
             "RoleSessionName": aws_session_name,
             "WebIdentityToken": oidc_token,
             "DurationSeconds": 3600,
-            "Policy": '{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"true"},"StringLike":{"aws:UserAgent":"litellm/*"}}}]}',
+            "Policy": '{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream","bedrock:ApplyGuardrail","bedrock:GetGuardrail","bedrock:ListGuardrails"],"Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"true"}}}]}',
         }
 
         # Add ExternalId parameter if provided


### PR DESCRIPTION
## Relevant issues
When assuming an AWS role via web identity (OIDC), LiteLLM attaches an inline session Policy on AssumeRoleWithWebIdentity. This change extends that policy so Bedrock guardrail APIs are allowed (bedrock:ApplyGuardrail, bedrock:GetGuardrail, bedrock:ListGuardrails) alongside bedrock:InvokeModel and bedrock:InvokeModelWithResponseStream. It also drops the Condition that required aws:UserAgent to match litellm/*, keeping only aws:SecureTransport = true.

Missing permissions: The previous inline policy only allowed model invoke actions. Any flow that calls ApplyGuardrail (or related guardrail list/get) with credentials minted through this path would get AccessDenied because those actions were not in the session policy.
User-agent condition: The old policy also required StringLike on aws:UserAgent = litellm/*. Calls that do not send that user agent (e.g. different SDK defaults or code paths) could fail even when TLS was used; removing that condition avoids those denials for guardrail (and other) Bedrock calls under this session policy.
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Add bedrock:ApplyGuardrail, bedrock:GetGuardrail, and bedrock:ListGuardrails to the JSON policy’s Action array in assume_role_params in litellm/llms/bedrock/base_aws_llm.py.
Restrict conditions to Bool / aws:SecureTransport = true (remove the aws:UserAgent StringLike condition from the same policy string).
