### PR TITLE
fix: body litellm_metadata values overwritten by header on /v1/messages

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -660,20 +660,25 @@ class LiteLLMProxyRequestSetup:
         if chain_id:
             metadata_from_headers["trace_id"] = chain_id
             metadata_from_headers["session_id"] = chain_id
-            # Only prefer body trace_id on litellm_metadata routes (/v1/messages, threads, etc.)
+            # Only prefer body values on litellm_metadata routes (/v1/messages, threads, etc.)
             # On /chat/completions, metadata["trace_id"] belongs to observability tools
             # (e.g. LangFuse) and should not override the header chain ID.
             _body_trace_id: Optional[str] = None
+            _body_session_id: Optional[str] = None
             if _metadata_variable_name == "litellm_metadata":
                 _body_metadata = data.get(_metadata_variable_name)
-                _body_trace_id = (
-                    _body_metadata.get("trace_id")
-                    if isinstance(_body_metadata, dict)
-                    else None
-                )
-            effective_id = _body_trace_id or chain_id
-            data["litellm_session_id"] = effective_id
-            data["litellm_trace_id"] = effective_id
+                if isinstance(_body_metadata, dict):
+                    _body_trace_id = _body_metadata.get("trace_id")
+                    _body_session_id = _body_metadata.get("session_id")
+            effective_trace_id = _body_trace_id or chain_id
+            # session_id mirrors trace_id when not explicitly set in the body
+            effective_session_id = _body_session_id or _body_trace_id or chain_id
+            data["litellm_session_id"] = effective_session_id
+            data["litellm_trace_id"] = effective_trace_id
+            # Sync metadata_from_headers so the merge loop below injects
+            # consistent values when the body doesn't set these keys.
+            metadata_from_headers["trace_id"] = effective_trace_id
+            metadata_from_headers["session_id"] = effective_session_id
             verbose_proxy_logger.debug(
                 f"Extracted chain_id from header (trace-id/session-id): {chain_id}"
             )

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -667,7 +667,11 @@ class LiteLLMProxyRequestSetup:
             )
 
         if isinstance(data[_metadata_variable_name], dict):
-            data[_metadata_variable_name].update(metadata_from_headers)
+            # Only inject header-derived values for keys NOT already set by the user
+            # in the request body. This ensures body values take priority over headers.
+            for key, value in metadata_from_headers.items():
+                if key not in data[_metadata_variable_name]:
+                    data[_metadata_variable_name][key] = value
         return data
 
     @staticmethod

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -660,13 +660,17 @@ class LiteLLMProxyRequestSetup:
         if chain_id:
             metadata_from_headers["trace_id"] = chain_id
             metadata_from_headers["session_id"] = chain_id
-            # Prefer body trace_id over header so all three fields stay consistent.
-            _body_metadata = data.get(_metadata_variable_name)
-            _body_trace_id = (
-                _body_metadata.get("trace_id")
-                if isinstance(_body_metadata, dict)
-                else None
-            )
+            # Only prefer body trace_id on litellm_metadata routes (/v1/messages, threads, etc.)
+            # On /chat/completions, metadata["trace_id"] belongs to observability tools
+            # (e.g. LangFuse) and should not override the header chain ID.
+            _body_trace_id: Optional[str] = None
+            if _metadata_variable_name == "litellm_metadata":
+                _body_metadata = data.get(_metadata_variable_name)
+                _body_trace_id = (
+                    _body_metadata.get("trace_id")
+                    if isinstance(_body_metadata, dict)
+                    else None
+                )
             effective_id = _body_trace_id or chain_id
             data["litellm_session_id"] = effective_id
             data["litellm_trace_id"] = effective_id
@@ -675,7 +679,8 @@ class LiteLLMProxyRequestSetup:
             )
 
         if isinstance(data[_metadata_variable_name], dict):
-            # Body values take priority — only inject from headers if the key isn't already set.
+            # Only inject header-derived values for keys NOT already set by the user
+            # in the request body. This ensures body values take priority over headers.
             for key, value in metadata_from_headers.items():
                 if key not in data[_metadata_variable_name]:
                     data[_metadata_variable_name][key] = value

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -660,15 +660,22 @@ class LiteLLMProxyRequestSetup:
         if chain_id:
             metadata_from_headers["trace_id"] = chain_id
             metadata_from_headers["session_id"] = chain_id
-            data["litellm_session_id"] = chain_id
-            data["litellm_trace_id"] = chain_id
+            # Prefer body trace_id over header so all three fields stay consistent.
+            _body_metadata = data.get(_metadata_variable_name)
+            _body_trace_id = (
+                _body_metadata.get("trace_id")
+                if isinstance(_body_metadata, dict)
+                else None
+            )
+            effective_id = _body_trace_id or chain_id
+            data["litellm_session_id"] = effective_id
+            data["litellm_trace_id"] = effective_id
             verbose_proxy_logger.debug(
                 f"Extracted chain_id from header (trace-id/session-id): {chain_id}"
             )
 
         if isinstance(data[_metadata_variable_name], dict):
-            # Only inject header-derived values for keys NOT already set by the user
-            # in the request body. This ensures body values take priority over headers.
+            # Body values take priority — only inject from headers if the key isn't already set.
             for key, value in metadata_from_headers.items():
                 if key not in data[_metadata_variable_name]:
                     data[_metadata_variable_name][key] = value

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1975,6 +1975,28 @@ class TestAddLitellmMetadataFromRequestHeaders:
         assert result["litellm_session_id"] == "from-body"
         assert result["litellm_trace_id"] == "from-body"
 
+    def test_should_not_bleed_metadata_trace_id_into_chain_ids_on_chat_completions_route(self):
+        """On /chat/completions, metadata["trace_id"] (e.g. LangFuse) must not override the header chain ID."""
+        data = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {"trace_id": "langfuse-id"},
+        }
+        headers = {"x-litellm-trace-id": "chain-id", "content-type": "application/json"}
+
+        result = LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+            headers=headers,
+            data=data,
+            _metadata_variable_name="metadata",
+        )
+
+        # Header chain ID must win for top-level fields on this route.
+        assert result["litellm_session_id"] == "chain-id"
+        assert result["litellm_trace_id"] == "chain-id"
+        # The observability trace_id in the metadata dict must be untouched.
+        assert result["metadata"]["trace_id"] == "langfuse-id"
+
+
     @pytest.mark.asyncio
     async def test_should_preserve_body_trace_id_in_full_pipeline_on_messages_route(self):
         """Body trace_id must survive the full add_litellm_data_to_request pipeline."""

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1912,3 +1912,82 @@ async def test_bearer_token_not_in_debug_logs():
         f"Bearer token leaked in debug logs. "
         f"Found token in log output:\n{log_output[:500]}"
     )
+
+
+class TestAddLitellmMetadataFromRequestHeaders:
+    """Tests for fix: https://github.com/BerriAI/litellm/issues/24945
+
+    On /v1/messages, user-supplied litellm_metadata values (e.g. trace_id) were
+    silently overwritten by proxy-injected header values. Body values should win.
+    """
+
+    def test_should_preserve_body_trace_id_over_header_on_messages_route(self):
+        """Body trace_id must not be overwritten by x-litellm-trace-id header."""
+        data = {
+            "model": "anthropic/claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "litellm_metadata": {"trace_id": "from-body"},
+        }
+        headers = {"x-litellm-trace-id": "from-header", "content-type": "application/json"}
+
+        result = LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+            headers=headers,
+            data=data,
+            _metadata_variable_name="litellm_metadata",
+        )
+
+        assert result["litellm_metadata"]["trace_id"] == "from-body"
+
+    def test_should_use_header_trace_id_as_fallback_when_body_has_no_trace_id(self):
+        """When body doesn't set trace_id, the header value should still be injected."""
+        data = {
+            "model": "anthropic/claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "litellm_metadata": {},
+        }
+        headers = {"x-litellm-trace-id": "from-header", "content-type": "application/json"}
+
+        result = LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+            headers=headers,
+            data=data,
+            _metadata_variable_name="litellm_metadata",
+        )
+
+        assert result["litellm_metadata"]["trace_id"] == "from-header"
+        assert result["litellm_metadata"]["session_id"] == "from-header"
+
+    @pytest.mark.asyncio
+    async def test_should_preserve_body_trace_id_in_full_pipeline_on_messages_route(self):
+        """Body trace_id must survive the full add_litellm_data_to_request pipeline."""
+        from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.url.path = "/v1/messages"
+        mock_request.url.__str__ = lambda self: "http://localhost:4000/v1/messages"
+        mock_request.method = "POST"
+        mock_request.query_params = {}
+        mock_request.headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer sk-1234",
+            "x-litellm-trace-id": "from-header",
+        }
+        mock_request.client = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+
+        data = {
+            "model": "anthropic/claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "litellm_metadata": {"trace_id": "from-body"},
+        }
+
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=mock_request,
+            user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key", metadata={}, team_metadata={}),
+            proxy_config=MagicMock(),
+            general_settings={},
+            version="test-version",
+        )
+
+        assert result.get("litellm_metadata", {}).get("trace_id") == "from-body"
+

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1956,6 +1956,25 @@ class TestAddLitellmMetadataFromRequestHeaders:
         assert result["litellm_metadata"]["trace_id"] == "from-header"
         assert result["litellm_metadata"]["session_id"] == "from-header"
 
+    def test_should_keep_top_level_ids_consistent_with_body_trace_id(self):
+        """litellm_session_id and litellm_trace_id should also reflect the body trace_id."""
+        data = {
+            "model": "anthropic/claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "litellm_metadata": {"trace_id": "from-body"},
+        }
+        headers = {"x-litellm-trace-id": "from-header", "content-type": "application/json"}
+
+        result = LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+            headers=headers,
+            data=data,
+            _metadata_variable_name="litellm_metadata",
+        )
+
+        assert result["litellm_metadata"]["trace_id"] == "from-body"
+        assert result["litellm_session_id"] == "from-body"
+        assert result["litellm_trace_id"] == "from-body"
+
     @pytest.mark.asyncio
     async def test_should_preserve_body_trace_id_in_full_pipeline_on_messages_route(self):
         """Body trace_id must survive the full add_litellm_data_to_request pipeline."""

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -1972,6 +1972,7 @@ class TestAddLitellmMetadataFromRequestHeaders:
         )
 
         assert result["litellm_metadata"]["trace_id"] == "from-body"
+        assert result["litellm_metadata"]["session_id"] == "from-body"  # must mirror trace_id
         assert result["litellm_session_id"] == "from-body"
         assert result["litellm_trace_id"] == "from-body"
 


### PR DESCRIPTION
## Relevant issues

Fixes #24945

## Pre-Submission checklist

- [x] I have Added testing in 
[`tests/test_litellm/proxy/test_litellm_pre_call_utils.py`](https://github.com/SahilKhan101/litellm/blob/fix/litellm-metadata-overwrite-on-messages-route/tests/test_litellm/proxy/test_litellm_pre_call_utils.py) under `TestAddLitellmMetadataFromRequestHeaders`
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

On the `/v1/messages` (Anthropic-compatible) endpoint, user-supplied values inside `litellm_metadata` were being silently overwritten by proxy-injected metadata derived from request headers.

**Root cause:** `/v1/messages` uses `litellm_metadata` as both the user-facing and proxy-internal metadata container (unlike `/chat/completions` which separates them into `metadata` vs `litellm_metadata`). The proxy was calling `.update()` to inject header-derived values (e.g. `trace_id` from `x-litellm-trace-id`), overwriting any values the user had already set in the request body.

**Fix:** Changed `.update()` to a conditional merge that only injects a header-derived value if the key isn't already set by the user. Body values now take priority; headers act as a fallback.
