### PR TITLE
litellm24945_Bug_litellm_metadata_from_request_body_is_overridden_on_/v1/messages_endpoint

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -667,7 +667,9 @@ class LiteLLMProxyRequestSetup:
             )
 
         if isinstance(data[_metadata_variable_name], dict):
-            data[_metadata_variable_name].update(metadata_from_headers)
+            for key, value in metadata_from_headers.items():
+                if key not in data[_metadata_variable_name]:
+                    data[_metadata_variable_name][key] = value
         return data
 
     @staticmethod
@@ -1063,8 +1065,11 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
                 )
             else:
                 data["litellm_metadata"] = parsed_litellm_metadata
-        # Merge litellm_metadata into the metadata variable (preserving existing values)
-        if isinstance(data["litellm_metadata"], dict):
+        # Merge litellm_metadata into the metadata variable (preserving existing values).
+        # Skip when both sides are the same dict (LITELLM_METADATA_ROUTES like /v1/messages
+        # where _metadata_variable_name == "litellm_metadata") — merging a dict with itself
+        # is a no-op and would mask the self-reference bug.
+        if isinstance(data["litellm_metadata"], dict) and data["litellm_metadata"] is not data[_metadata_variable_name]:
             for key, value in data["litellm_metadata"].items():
                 if key not in data[_metadata_variable_name]:
                     data[_metadata_variable_name][key] = value

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -10,6 +10,8 @@ from fastapi import Request
 
 import litellm
 from litellm.proxy._types import TeamCallbackMetadata, UserAPIKeyAuth
+from unittest.mock import MagicMock
+from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.litellm_pre_call_utils import (
     KeyAndTeamLoggingSettings,
     LiteLLMProxyRequestSetup,
@@ -1911,4 +1913,62 @@ async def test_bearer_token_not_in_debug_logs():
     assert secret_token not in log_output, (
         f"Bearer token leaked in debug logs. "
         f"Found token in log output:\n{log_output[:500]}"
+    )
+
+
+def test_litellm_metadata_not_overridden_by_headers_on_messages_endpoint():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/24945
+
+    User-supplied values in litellm_metadata (e.g. trace_id, tags) should NOT be
+    overwritten by proxy-injected header values on /v1/messages (and other
+    LITELLM_METADATA_ROUTES). Body values take priority over header values.
+    """
+    # Simulate /v1/messages — _metadata_variable_name == "litellm_metadata"
+    _metadata_variable_name = "litellm_metadata"
+    # User supplied trace_id and tags in the request body
+    data: dict = {
+        _metadata_variable_name: {
+            "trace_id": "from-body",
+            "tags": ["user-tag"],
+        }
+    }
+    # Proxy receives x-litellm-trace-id and x-litellm-tags via headers
+    headers = {
+        "x-litellm-trace-id": "from-header",
+        "x-litellm-tags": '["proxy-tag"]',
+    }
+    LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+        headers=headers,
+        data=data,
+        _metadata_variable_name=_metadata_variable_name,
+    )
+    # Body values must NOT be overwritten by header values
+    assert data[_metadata_variable_name]["trace_id"] == "from-body", (
+        "trace_id from request body was overridden by x-litellm-trace-id header"
+    )
+    assert data[_metadata_variable_name]["tags"] == ["user-tag"], (
+        "tags from request body were overridden by x-litellm-tags header"
+    )
+
+
+def test_header_metadata_added_when_not_in_body_on_messages_endpoint():
+    """
+    Companion to the regression test above: header-supplied metadata fields that
+    the user did NOT provide in the body should still be injected by the proxy.
+    """
+    _metadata_variable_name = "litellm_metadata"
+    # User sends no trace_id in the body
+    data: dict = {_metadata_variable_name: {}}
+    headers = {
+        "x-litellm-trace-id": "from-header",
+    }
+    LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+        headers=headers,
+        data=data,
+        _metadata_variable_name=_metadata_variable_name,
+    )
+    # Header value should be set since user did not supply it
+    assert data[_metadata_variable_name]["trace_id"] == "from-header", (
+        "trace_id from header was not injected when body did not supply it"
     )

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -21,14 +21,6 @@ from litellm.proxy.litellm_pre_call_utils import (
     add_litellm_data_to_request,
     check_if_token_is_service_account,
 )
-    _get_dynamic_logging_metadata,
-    _get_enforced_params,
-    _get_metadata_variable_name,
-    _update_model_if_key_alias_exists,
-    add_guardrails_from_policy_engine,
-    add_litellm_data_to_request,
-    check_if_token_is_service_account,
-)
 
 sys.path.insert(
     0, os.path.abspath("../../..")

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -10,11 +10,17 @@ from fastapi import Request
 
 import litellm
 from litellm.proxy._types import TeamCallbackMetadata, UserAPIKeyAuth
-from unittest.mock import MagicMock
-from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.litellm_pre_call_utils import (
     KeyAndTeamLoggingSettings,
     LiteLLMProxyRequestSetup,
+    _get_dynamic_logging_metadata,
+    _get_enforced_params,
+    _get_metadata_variable_name,
+    _update_model_if_key_alias_exists,
+    add_guardrails_from_policy_engine,
+    add_litellm_data_to_request,
+    check_if_token_is_service_account,
+)
     _get_dynamic_logging_metadata,
     _get_enforced_params,
     _get_metadata_variable_name,


### PR DESCRIPTION
## Relevant issues

Fixes - #24945 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test

## Changes

`litellm/proxy/litellm_pre_call_utils.py`
                                                                                                                                                                                                                                                                             
  - `add_litellm_metadata_from_request_headers` (line 669-672): Changed blind .update() to a non-overwriting loop — header values now only fill keys the user did not supply in the request body. Headers act as defaults, not overrides.                                      
  - Merge guard (line 1067-1072): Added an is not identity check so the litellm_metadata → _metadata_variable_name merge loop is skipped when both sides are the same dict object (the /v1/messages case). Makes the self-reference explicit instead of a silent no-op.      
                                                                                                                                                                                                                                                                             `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`
                                                                                                                                                                                                                                                                             
  - `test_litellm_metadata_not_overridden_by_headers_on_messages_endpoint` — verifies body values (trace_id, tags) survive header injection.                                                                                                                                   
  - `test_header_metadata_added_when_not_in_body_on_messages_endpoint` — verifies header values are still injected when the body does not supply them.