### PR TITLE
bump litellm-enterprise to 0.1.37

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3585,15 +3585,15 @@ files = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.36"
+version = "0.1.37"
 description = "Package for LiteLLM Enterprise features"
 optional = true
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-    {file = "litellm_enterprise-0.1.36-py3-none-any.whl", hash = "sha256:beb2a45d33e0e103e20cad305b548d911118e48370c795bf4206f79f1fbb10e5"},
-    {file = "litellm_enterprise-0.1.36.tar.gz", hash = "sha256:d171bd761447540f1fd3123b028bda44a8bc8f6466e9fe1124aba9b91b293738"},
+    {file = "litellm_enterprise-0.1.37-py3-none-any.whl", hash = "sha256:c1c231d21df6ab0fe77e2c1e10c14764a726a8eea9c328803ca872e5256afc10"},
+    {file = "litellm_enterprise-0.1.37.tar.gz", hash = "sha256:f1616f36fe66c3ddb0cd9d4a70aba2c777feb6d822475ddab1022a9ae8284122"},
 ]
 
 [[package]]
@@ -8309,4 +8309,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "aa154d5d88c1578218aae8884e65653d1879d03005ed77d7fe085ca4bc01aa62"
+content-hash = "52550fa85d5f42463574ad126eab67bacac96b881af6b0de980cb4cd5ba20e28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ mcp = {version = "1.26.0", optional = true, python = ">=3.10"}
 a2a-sdk = {version = "0.3.25", optional = true, python = ">=3.10"}
 litellm-proxy-extras = {version = "0.4.65", optional = true}
 rich = {version = "13.9.4", optional = true}
-litellm-enterprise = {version = "0.1.36", optional = true}
+litellm-enterprise = {version = "0.1.37", optional = true}
 diskcache = {version = "5.6.3", optional = true}
 polars = {version = "1.39.3", optional = true, python = ">=3.10"}
 semantic-router = {version = "0.1.12", optional = true, python = ">=3.9,<3.14"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,4 +85,4 @@ requests-toolbelt==1.0.0 # transitive dep (langfuse)
 ########################
 # LITELLM ENTERPRISE DEPENDENCIES
 ########################
-litellm-enterprise==0.1.36
+litellm-enterprise==0.1.37


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure

## Changes

Bumps `litellm-enterprise` from `0.1.36` to `0.1.37` in `requirements.txt` and `pyproject.toml`.