### PR TITLE
docs : Fix typo in 'Deepeek' to 'Deepseek'

### DIFF
--- a/docs/my-website/docs/completion/prompt_caching.md
+++ b/docs/my-website/docs/completion/prompt_caching.md
@@ -560,7 +560,7 @@ print(response.usage)
 </TabItem>
 </Tabs>
 
-### Deepeek Example 
+### Deepseek Example 
 
 Works the same as OpenAI. 
 


### PR DESCRIPTION
## Summary

### Problem
The codebase contained a typo where the provider "Deepseek" was misspelled as "Deepeek," which can cause confusion in logs, documentation, or integration settings.

### Fix
Update documentation to reflect the correct spelling: **Deepseek**.

## Type

- 📖 Documentation