### PR TITLE
[Fix] Update Deprecated Cohere Embed Model in Test

### DIFF
--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -376,7 +376,7 @@ def test_openai_azure_embedding_optional_arg():
 @pytest.mark.parametrize(
     "model, api_base",
     [
-        ("embed-english-v2.0", None),
+        ("embed-english-v3.0", None),
     ],
 )
 @pytest.mark.parametrize("sync_mode", [True, False])


### PR DESCRIPTION
## Summary

### Problem
`test_cohere_embedding` fails because Cohere removed `embed-english-v2.0` on April 4, 2026.

### Fix
Replace `embed-english-v2.0` with `embed-english-v3.0` per [Cohere's deprecation guide](https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v20-aya-expanse-8b). No other changes needed since the test already passes `input_type`, which v3.0 requires.

## Testing
- CI should pass with the updated model

## Type
🐛 Bug Fix
✅ Test