### PR TITLE
fix: callback mode display and failure callback support

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -54,7 +54,7 @@ from litellm.constants import (
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
     LITELLM_UI_ALLOW_HEADERS,
     LITELLM_UI_SESSION_DURATION,
-    DAILY_TAG_SPEND_BATCH_MULTIPLIER
+    DAILY_TAG_SPEND_BATCH_MULTIPLIER,
 )
 from litellm.litellm_core_utils.litellm_logging import (
     _init_custom_logger_compatible_class,
@@ -637,9 +637,9 @@ except ImportError:
 server_root_path = get_server_root_path()
 _license_check = LicenseCheck()
 premium_user: bool = _license_check.is_premium()
-premium_user_data: Optional["EnterpriseLicenseData"] = (
-    _license_check.airgapped_license_data
-)
+premium_user_data: Optional[
+    "EnterpriseLicenseData"
+] = _license_check.airgapped_license_data
 global_max_parallel_request_retries_env: Optional[str] = os.getenv(
     "LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRIES"
 )
@@ -1534,9 +1534,9 @@ master_key: Optional[str] = None
 config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
-shared_aiohttp_session: Optional["ClientSession"] = (
-    None  # Global shared session for connection reuse
-)
+shared_aiohttp_session: Optional[
+    "ClientSession"
+] = None  # Global shared session for connection reuse
 user_api_key_cache = DualCache(
     default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value
 )
@@ -1547,13 +1547,13 @@ model_max_budget_limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(
     dual_cache=user_api_key_cache
 )
 litellm.logging_callback_manager.add_litellm_callback(model_max_budget_limiter)
-redis_usage_cache: Optional[RedisCache] = (
-    None  # redis cache used for tracking spend, tpm/rpm limits
-)
+redis_usage_cache: Optional[
+    RedisCache
+] = None  # redis cache used for tracking spend, tpm/rpm limits
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
-native_background_mode: List[str] = (
-    []
-)  # Models that should use native provider background mode instead of polling
+native_background_mode: List[
+    str
+] = []  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -2038,9 +2038,9 @@ async def update_cache(  # noqa: PLR0915
         _id = "team_id:{}".format(team_id)
         try:
             # Fetch the existing cost for the given user
-            existing_spend_obj: Optional[LiteLLM_TeamTable] = (
-                await user_api_key_cache.async_get_cache(key=_id)
-            )
+            existing_spend_obj: Optional[
+                LiteLLM_TeamTable
+            ] = await user_api_key_cache.async_get_cache(key=_id)
             if existing_spend_obj is None:
                 # do nothing if team not in api key cache
                 return
@@ -2161,9 +2161,11 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(f"""
+        verbose_proxy_logger.debug(
+            f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """)
+        """
+        )
 
 
 def _get_process_rss_mb() -> Optional[float]:
@@ -2316,9 +2318,13 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
-            if llm_router.health_check_ignore_transient_errors and exception_status in (
-                429,
-                408,
+            if (
+                llm_router.health_check_ignore_transient_errors
+                and exception_status
+                in (
+                    429,
+                    408,
+                )
             ):
                 continue
 
@@ -5290,10 +5296,10 @@ class ProxyConfig:
         )
 
         try:
-            guardrails_in_db: List[Guardrail] = (
-                await GuardrailRegistry.get_all_guardrails_from_db(
-                    prisma_client=prisma_client
-                )
+            guardrails_in_db: List[
+                Guardrail
+            ] = await GuardrailRegistry.get_all_guardrails_from_db(
+                prisma_client=prisma_client
             )
             verbose_proxy_logger.debug(
                 "guardrails from the DB %s", str(guardrails_in_db)
@@ -5675,9 +5681,9 @@ async def initialize(  # noqa: PLR0915
         user_api_base = api_base
         dynamic_config[user_model]["api_base"] = api_base
     if api_version:
-        os.environ["AZURE_API_VERSION"] = (
-            api_version  # set this for azure - litellm can read this from the env
-        )
+        os.environ[
+            "AZURE_API_VERSION"
+        ] = api_version  # set this for azure - litellm can read this from the env
     if max_tokens:  # model-specific param
         dynamic_config[user_model]["max_tokens"] = max_tokens
     if temperature:  # model-specific param
@@ -6019,9 +6025,9 @@ class ProxyStartupEvent:
         """
         from litellm.secret_managers.main import str_to_bool
 
-        _use_redis_transaction_buffer: Optional[Union[bool, str]] = (
-            general_settings.get("use_redis_transaction_buffer", False)
-        )
+        _use_redis_transaction_buffer: Optional[
+            Union[bool, str]
+        ] = general_settings.get("use_redis_transaction_buffer", False)
         if isinstance(_use_redis_transaction_buffer, str):
             _use_redis_transaction_buffer = str_to_bool(_use_redis_transaction_buffer)
 
@@ -6287,7 +6293,9 @@ class ProxyStartupEvent:
 
         ### UPDATE DAILY TAG SPEND (separate scheduler job with longer interval) ###
         ## Reduces QPS as there are more tags for a single request
-        tag_spend_update_interval = int(batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER)
+        tag_spend_update_interval = int(
+            batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER
+        )
         from litellm.proxy.utils import update_daily_tag_spend
 
         scheduler.add_job(
@@ -12422,26 +12430,22 @@ async def update_config(  # noqa: PLR0915
                 **config["litellm_settings"],
             }
 
-            # if litellm.success_callback in updated_litellm_settings and config["litellm_settings"]
-            if (
-                "success_callback" in updated_litellm_settings
-                and "success_callback" in config["litellm_settings"]
-            ):
-                # check both success callback are lists
-                if isinstance(
-                    config["litellm_settings"]["success_callback"], list
-                ) and isinstance(updated_litellm_settings["success_callback"], list):
-                    updated_success_callbacks_normalized = normalize_callback_names(
-                        updated_litellm_settings["success_callback"]
-                    )
-                    combined_success_callback = (
-                        config["litellm_settings"]["success_callback"]
-                        + updated_success_callbacks_normalized
-                    )
-                    combined_success_callback = list(set(combined_success_callback))
-                    config["litellm_settings"][
-                        "success_callback"
-                    ] = combined_success_callback
+            # Merge callback lists (success_callback and failure_callback)
+            for cb_key in ("success_callback", "failure_callback"):
+                if (
+                    cb_key in updated_litellm_settings
+                    and cb_key in config["litellm_settings"]
+                ):
+                    if isinstance(
+                        config["litellm_settings"][cb_key], list
+                    ) and isinstance(updated_litellm_settings[cb_key], list):
+                        updated_normalized = normalize_callback_names(
+                            updated_litellm_settings[cb_key]
+                        )
+                        combined = (
+                            config["litellm_settings"][cb_key] + updated_normalized
+                        )
+                        config["litellm_settings"][cb_key] = list(set(combined))
 
         # Save the updated config
         await proxy_config.save_config(new_config=config)
@@ -12724,9 +12728,9 @@ async def get_config_list(
                             hasattr(sub_field_info, "description")
                             and sub_field_info.description is not None
                         ):
-                            nested_fields[idx].field_description = (
-                                sub_field_info.description
-                            )
+                            nested_fields[
+                                idx
+                            ].field_description = sub_field_info.description
                         idx += 1
 
                     _stored_in_db = None
@@ -12890,11 +12894,24 @@ async def delete_callback(
         config = await proxy_config.get_config()
         callback_name = data.callback_name.lower()
 
-        # Check if callback exists in current configuration
+        # Check if callback exists in any callback list
         litellm_settings = config.get("litellm_settings", {})
         success_callbacks = litellm_settings.get("success_callback", [])
+        failure_callbacks = litellm_settings.get("failure_callback", [])
+        both_callbacks = litellm_settings.get("callbacks", [])
 
-        if callback_name not in success_callbacks:
+        found = False
+        if callback_name in success_callbacks:
+            success_callbacks.remove(callback_name)
+            found = True
+        if callback_name in failure_callbacks:
+            failure_callbacks.remove(callback_name)
+            found = True
+        if callback_name in both_callbacks:
+            both_callbacks.remove(callback_name)
+            found = True
+
+        if not found:
             raise HTTPException(
                 status_code=404,
                 detail={
@@ -12902,11 +12919,11 @@ async def delete_callback(
                 },
             )
 
-        # Remove callback from success_callback list
-        success_callbacks.remove(callback_name)
         config.setdefault("litellm_settings", {})[
             "success_callback"
         ] = success_callbacks
+        config["litellm_settings"]["failure_callback"] = failure_callbacks
+        config["litellm_settings"]["callbacks"] = both_callbacks
 
         # Save the updated configuration
         await proxy_config.save_config(new_config=config)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12919,11 +12919,16 @@ async def delete_callback(
                 },
             )
 
-        config.setdefault("litellm_settings", {})[
-            "success_callback"
-        ] = success_callbacks
-        config["litellm_settings"]["failure_callback"] = failure_callbacks
-        config["litellm_settings"]["callbacks"] = both_callbacks
+        # Only write back keys that were originally present to avoid
+        # creating empty lists that would reset callbacks on restart
+        if "success_callback" in litellm_settings:
+            config.setdefault("litellm_settings", {})[
+                "success_callback"
+            ] = success_callbacks
+        if "failure_callback" in litellm_settings:
+            config["litellm_settings"]["failure_callback"] = failure_callbacks
+        if "callbacks" in litellm_settings:
+            config["litellm_settings"]["callbacks"] = both_callbacks
 
         # Save the updated configuration
         await proxy_config.save_config(new_config=config)

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/callbacks/useCallbacks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/callbacks/useCallbacks.ts
@@ -1,0 +1,47 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+import { getCallbacksCall, getCallbackConfigsCall } from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import {
+  AlertingObject,
+  AlertData,
+  AvailableCallback,
+  CallbackConfig,
+} from "@/components/Settings/LoggingAndAlerts/LoggingCallbacks/types";
+
+export const callbackKeys = createQueryKeys("callbacks");
+const callbackConfigKeys = createQueryKeys("callbackConfigs");
+
+export interface CallbacksData {
+  callbacks: AlertingObject[];
+  alerts: AlertData[];
+  availableCallbacks: Record<string, AvailableCallback>;
+}
+
+export const useCallbacks = (): UseQueryResult<CallbacksData> => {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return useQuery<CallbacksData>({
+    queryKey: callbackKeys.list({}),
+    queryFn: async () => {
+      const data = await getCallbacksCall(accessToken!, userId!, userRole!);
+      return {
+        callbacks: data.callbacks || [],
+        alerts: data.alerts || [],
+        availableCallbacks: data.available_callbacks || {},
+      };
+    },
+    enabled: Boolean(accessToken && userId && userRole),
+  });
+};
+
+export const useCallbackConfigs = (): UseQueryResult<CallbackConfig[]> => {
+  const { accessToken } = useAuthorized();
+  return useQuery<CallbackConfig[]>({
+    queryKey: callbackConfigKeys.list({}),
+    queryFn: async () => {
+      const data = await getCallbackConfigsCall(accessToken!);
+      return data || [];
+    },
+    enabled: Boolean(accessToken),
+  });
+};

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/callbacks/useDeleteCallback.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/callbacks/useDeleteCallback.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteCallback } from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { callbackKeys } from "./useCallbacks";
+
+interface DeleteCallbackResponse {
+  message: string;
+  removed_callback: string;
+  remaining_callbacks: string[];
+  deleted_at: string;
+}
+
+export const useDeleteCallback = () => {
+  const { accessToken } = useAuthorized();
+  const queryClient = useQueryClient();
+
+  return useMutation<DeleteCallbackResponse, Error, string>({
+    mutationFn: async (callbackName: string) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return deleteCallback(accessToken, callbackName);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: callbackKeys.all });
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/callbacks/useUpdateCallback.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/callbacks/useUpdateCallback.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { setCallbacksCall } from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { callbackKeys } from "./useCallbacks";
+
+interface CallbackPayload {
+  environment_variables: Record<string, string>;
+  litellm_settings: Record<string, string[]>;
+}
+
+interface UpdateCallbackParams {
+  payload: CallbackPayload;
+}
+
+interface UpdateCallbackResponse {
+  message: string;
+}
+
+export const useUpdateCallback = () => {
+  const { accessToken } = useAuthorized();
+  const queryClient = useQueryClient();
+
+  return useMutation<UpdateCallbackResponse, Error, UpdateCallbackParams>({
+    mutationFn: async ({ payload }) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return setCallbacksCall(accessToken, payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: callbackKeys.all });
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
@@ -43,7 +43,6 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
       key: "name",
       render: (_: string, record: AlertingObject) => {
         const id = record.name;
-        console.log("availableCallbacks", availableCallbacks);
         const displayName = availableCallbacks[id]?.ui_callback_name || id;
         return <div className="font-medium text-gray-800">{displayName}</div>;
       },

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.tsx
@@ -4,7 +4,7 @@ import { Table } from "antd";
 import Title from "antd/es/typography/Title";
 import React from "react";
 import TableIconActionButton from "../../../common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
-import { AlertingObject } from "./types";
+import { AlertingObject, CallbackMode } from "./types";
 
 type LoggingCallbacksProps = {
   callbacks: AlertingObject[];
@@ -22,12 +22,7 @@ type LoggingCallbacksProps = {
   onAdd?: () => void;
 };
 
-type CallbackRow = AlertingObject & {
-  id?: string;
-  mode?: "success" | "failure" | "info" | string;
-};
-
-const CALLBACK_MODES: { value: string; label: string }[] = [
+export const CALLBACK_MODES: { value: CallbackMode; label: string }[] = [
   { value: "success", label: "Success" },
   { value: "failure", label: "Failure" },
   { value: "success_and_failure", label: "Success & Failure" },
@@ -41,12 +36,12 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
   onDelete = () => {},
   onAdd = () => {},
 }) => {
-  const columns: TableProps<CallbackRow>["columns"] = [
+  const columns: TableProps<AlertingObject>["columns"] = [
     {
       title: <span className="font-medium text-gray-700">Callback Name</span>,
       dataIndex: "name",
       key: "name",
-      render: (_: string, record: CallbackRow) => {
+      render: (_: string, record: AlertingObject) => {
         const id = record.name;
         console.log("availableCallbacks", availableCallbacks);
         const displayName = availableCallbacks[id]?.ui_callback_name || id;
@@ -55,9 +50,9 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
     },
     {
       title: <span className="font-medium text-gray-700">Mode</span>,
-      key: "mode",
-      render: (_: unknown, record: CallbackRow) => {
-        const mode = record.mode || "success";
+      key: "type",
+      render: (_: unknown, record: AlertingObject) => {
+        const mode = record.type || "success";
         const label = CALLBACK_MODES.find((m) => m.value === mode)?.label || mode;
         const badgeClass =
           mode === "success"
@@ -77,7 +72,7 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
       title: <span className="font-medium text-gray-700 text-right w-full block">Actions</span>,
       key: "actions",
       align: "right",
-      render: (_: unknown, record: CallbackRow) => (
+      render: (_: unknown, record: AlertingObject) => (
         <div className="flex justify-end gap-2">
           <TableIconActionButton variant="Test" tooltipText="Test Callback" onClick={() => onTest(record)} />
           <TableIconActionButton variant="Edit" tooltipText="Edit Callback" onClick={() => onEdit(record)} />
@@ -108,8 +103,8 @@ export const LoggingCallbacksTable: React.FC<LoggingCallbacksProps> = ({
           <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
             <Table
               columns={columns}
-              dataSource={callbacks as CallbackRow[]}
-              rowKey={(record) => record.name}
+              dataSource={callbacks}
+              rowKey={(record) => `${record.name}-${record.type || "success"}`}
               pagination={false}
               rowClassName={() => "hover:bg-gray-50"}
             />

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
@@ -2,7 +2,7 @@ export type CallbackMode = "success" | "failure" | "success_and_failure";
 
 export interface AlertingObject {
   name: string;
-  variables: AlertingVariables;
+  variables: Record<string, string | null>;
   type?: CallbackMode;
 }
 
@@ -12,4 +12,30 @@ export interface AlertingVariables {
   LANGFUSE_SECRET_KEY: string | null;
   LANGFUSE_HOST: string | null;
   OPENMETER_API_KEY: string | null;
+}
+
+export interface AvailableCallback {
+  litellm_callback_name: string;
+  litellm_callback_params: string[];
+  ui_callback_name: string;
+}
+
+export interface CallbackConfigParam {
+  type?: string;
+  ui_name?: string;
+  required?: boolean;
+}
+
+export interface CallbackConfig {
+  id: string;
+  displayName: string;
+  logo?: string;
+  dynamic_params?: Record<string, CallbackConfigParam>;
+}
+
+export interface AlertData {
+  name: string;
+  variables: { SLACK_WEBHOOK_URL: string };
+  active_alerts: string[];
+  alerts_to_webhook: Record<string, string>;
 }

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
@@ -1,6 +1,9 @@
+export type CallbackMode = "success" | "failure" | "success_and_failure";
+
 export interface AlertingObject {
   name: string;
   variables: AlertingVariables;
+  type?: CallbackMode;
 }
 
 export interface AlertingVariables {

--- a/ui/litellm-dashboard/src/components/settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/settings.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { alertingSettingsCall, getCallbackConfigsCall, getCallbacksCall } from "./networking";
+import { alertingSettingsCall } from "./networking";
 import Settings from "./settings";
 
 vi.mock("./networking", () => ({
@@ -10,6 +11,45 @@ vi.mock("./networking", () => ({
   serviceHealthCheck: vi.fn(),
   deleteCallback: vi.fn(),
   alertingSettingsCall: vi.fn().mockResolvedValue([]),
+}));
+
+const mockCallbacksData = {
+  callbacks: [] as any[],
+  alerts: [] as any[],
+  availableCallbacks: {} as Record<string, any>,
+};
+
+const mockCallbackConfigs: any[] = [];
+
+vi.mock("@/app/(dashboard)/hooks/callbacks/useCallbacks", () => ({
+  useCallbacks: () => ({
+    data: mockCallbacksData,
+    isLoading: false,
+    isError: false,
+  }),
+  useCallbackConfigs: () => ({
+    data: mockCallbackConfigs,
+    isLoading: false,
+    isError: false,
+  }),
+  callbackKeys: { all: ["callbacks"], lists: () => ["callbacks", "list"], list: () => ["callbacks", "list", {}] },
+}));
+
+const mockUpdateMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+
+vi.mock("@/app/(dashboard)/hooks/callbacks/useUpdateCallback", () => ({
+  useUpdateCallback: () => ({
+    mutate: mockUpdateMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/callbacks/useDeleteCallback", () => ({
+  useDeleteCallback: () => ({
+    mutate: mockDeleteMutate,
+    isPending: false,
+  }),
 }));
 
 vi.mock("./molecules/notifications_manager", () => ({
@@ -63,6 +103,15 @@ beforeAll(() => {
   });
 });
 
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
 describe("Settings", () => {
   const defaultProps = {
     accessToken: "token",
@@ -70,23 +119,17 @@ describe("Settings", () => {
     userID: "user-123",
     premiumUser: false,
   };
-  const mockGetCallbacksCall = vi.mocked(getCallbacksCall);
-  const mockGetCallbackConfigsCall = vi.mocked(getCallbackConfigsCall);
-  const mockAlertingSettingsCall = vi.mocked(alertingSettingsCall);
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetCallbacksCall.mockResolvedValue({
-      callbacks: [],
-      available_callbacks: [],
-      alerts: [],
-    });
-    mockGetCallbackConfigsCall.mockResolvedValue([]);
-    mockAlertingSettingsCall.mockResolvedValue([]);
+    mockCallbacksData.callbacks = [];
+    mockCallbacksData.alerts = [];
+    mockCallbacksData.availableCallbacks = {};
+    mockCallbackConfigs.length = 0;
   });
 
   it("should render the logging callbacks tab when access token is provided", async () => {
-    const { getByText } = render(<Settings {...defaultProps} />);
+    const { getByText } = render(<Settings {...defaultProps} />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(getByText("Active Logging Callbacks")).toBeInTheDocument();
@@ -94,21 +137,13 @@ describe("Settings", () => {
   });
 
   it("should display additional settings tabs", async () => {
-    const { getByText } = render(<Settings {...defaultProps} />);
+    const { getByText } = render(<Settings {...defaultProps} />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(getByText("CloudZero Cost Tracking")).toBeInTheDocument();
       expect(getByText("Alerting Types")).toBeInTheDocument();
       expect(getByText("Alerting Settings")).toBeInTheDocument();
       expect(getByText("Email Alerts")).toBeInTheDocument();
-    });
-  });
-
-  it("should load callback configs from the backend when access token is provided", async () => {
-    render(<Settings {...defaultProps} />);
-
-    await waitFor(() => {
-      expect(mockGetCallbackConfigsCall).toHaveBeenCalledWith(defaultProps.accessToken);
     });
   });
 
@@ -146,21 +181,17 @@ describe("Settings", () => {
       },
     };
 
-    mockGetCallbacksCall.mockResolvedValue({
-      callbacks: [mockCallback],
-      available_callbacks: {
-        langfuse: {
-          litellm_callback_name: "langfuse",
-          litellm_callback_params: ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"],
-          ui_callback_name: "Langfuse",
-        },
+    mockCallbacksData.callbacks = [mockCallback];
+    mockCallbacksData.availableCallbacks = {
+      langfuse: {
+        litellm_callback_name: "langfuse",
+        litellm_callback_params: ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"],
+        ui_callback_name: "Langfuse",
       },
-      alerts: [],
-    });
+    };
+    mockCallbackConfigs.push(mockCallbackConfig);
 
-    mockGetCallbackConfigsCall.mockResolvedValue([mockCallbackConfig]);
-
-    const { getByText, container } = render(<Settings {...defaultProps} />);
+    const { getByText, container } = render(<Settings {...defaultProps} />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(getByText("Active Logging Callbacks")).toBeInTheDocument();
@@ -195,7 +226,7 @@ describe("Settings", () => {
   });
 
   it("should display CloudZero Cost Tracking tab", async () => {
-    const { getByText } = render(<Settings {...defaultProps} />);
+    const { getByText } = render(<Settings {...defaultProps} />, { wrapper: createWrapper() });
 
     await waitFor(() => {
       expect(getByText("Active Logging Callbacks")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -319,8 +319,20 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
     if (!selectedEditCallback) {
       return;
     }
-    const mode = formValues.callback_mode || selectedEditCallback.type || "success";
-    await handleCallbackSubmit(formValues, selectedEditCallback.name, true, mode);
+    const newMode = formValues.callback_mode || selectedEditCallback.type || "success";
+    const oldMode = selectedEditCallback.type || "success";
+
+    // If mode changed, delete from old list(s) first, then add to new list
+    if (newMode !== oldMode) {
+      try {
+        await deleteCallbackMutation.mutateAsync(selectedEditCallback.name);
+      } catch {
+        NotificationsManager.fromBackend("Failed to remove callback from previous mode");
+        return;
+      }
+    }
+
+    await handleCallbackSubmit(formValues, selectedEditCallback.name, true, newMode);
   };
 
   const addNewCallbackCall = async (formValues: Record<string, any>) => {

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -24,21 +24,21 @@ import { Button as Button2, Form, Input, Modal, Select, Typography } from "antd"
 import EmailSettings from "./email_settings";
 import NotificationsManager from "./molecules/notifications_manager";
 
-const { Title, Paragraph } = Typography;
+const { Title } = Typography;
 
 import FormItem from "antd/es/form/FormItem";
 import AlertingSettings from "./alerting/alerting_settings";
 import CloudZeroCostTracking from "./CloudZeroCostTracking/CloudZeroCostTracking";
 import DeleteResourceModal from "./common_components/DeleteResourceModal";
 import {
-  deleteCallback,
-  getCallbackConfigsCall,
-  getCallbacksCall,
   serviceHealthCheck,
   setCallbacksCall,
 } from "./networking";
+import { useCallbacks, useCallbackConfigs } from "@/app/(dashboard)/hooks/callbacks/useCallbacks";
+import { useUpdateCallback } from "@/app/(dashboard)/hooks/callbacks/useUpdateCallback";
+import { useDeleteCallback } from "@/app/(dashboard)/hooks/callbacks/useDeleteCallback";
 import { CALLBACK_MODES, LoggingCallbacksTable } from "./Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable";
-import { AlertingObject } from "./Settings/LoggingAndAlerts/LoggingCallbacks/types";
+import { AlertingObject, CallbackConfig } from "./Settings/LoggingAndAlerts/LoggingCallbacks/types";
 import { parseErrorMessage } from "./shared/errorUtils";
 interface SettingsPageProps {
   accessToken: string | null;
@@ -47,17 +47,11 @@ interface SettingsPageProps {
   premiumUser: boolean;
 }
 
-interface genericCallbackParams {
-  litellm_callback_name: string; // what to send in request
-  ui_callback_name: string; // what to show on UI
-  litellm_callback_params: string[] | null; // known required params for this callback
-}
-
 const assetsLogoFolder = "../ui/assets/logos/";
 
 interface DynamicParamsFieldsProps {
   params: string[];
-  callbackConfigs: any[];
+  callbackConfigs: CallbackConfig[];
   selectedCallback: string | null;
 }
 
@@ -124,7 +118,7 @@ const DynamicParamsFields: React.FC<DynamicParamsFieldsProps> = ({ params, callb
 
 // Shared component for rendering callback selector
 interface CallbackSelectorProps {
-  callbackConfigs: any[];
+  callbackConfigs: CallbackConfig[];
   selectedCallback: string | null;
   onCallbackChange: (value: string) => void;
   disabled?: boolean;
@@ -188,8 +182,8 @@ const CallbackSelector: React.FC<CallbackSelectorProps> = ({
 // Shared helper function to get dynamic params for a callback
 const getDynamicParamsForCallback = (
   callbackName: string | null,
-  callbackConfigs: any[],
-  fallbackVariables?: Record<string, any>,
+  callbackConfigs: CallbackConfig[],
+  fallbackVariables?: Record<string, string | null>,
 ): string[] => {
   if (!callbackName) {
     return fallbackVariables ? Object.keys(fallbackVariables) : [];
@@ -224,9 +218,6 @@ const buildCallbackPayload = (formValues: Record<string, any>, callbackName: str
 };
 
 const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, premiumUser }) => {
-  const [callbacks, setCallbacks] = useState<AlertingObject[]>([]);
-  const [alerts, setAlerts] = useState<any[]>([]);
-  const [isModalVisible, setIsModalVisible] = useState(false);
   const [addForm] = Form.useForm();
   const [editForm] = Form.useForm();
   const [selectedCallback, setSelectedCallback] = useState<string | null>(null);
@@ -235,40 +226,31 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
   const [activeAlerts, setActiveAlerts] = useState<string[]>([]);
 
   const [showAddCallbacksModal, setShowAddCallbacksModal] = useState(false);
-  const [callbackConfigs, setCallbackConfigs] = useState<any[]>([]);
-  const [allCallbacks, setAllCallbacks] = useState<
-    Record<
-      string,
-      {
-        litellm_callback_name: string;
-        litellm_callback_params: string[];
-        ui_callback_name: string;
-      }
-    >
-  >({});
-
   const [selectedCallbackParams, setSelectedCallbackParams] = useState<string[]>([]);
-
   const [showEditCallback, setShowEditCallback] = useState(false);
-  const [selectedEditCallback, setSelectedEditCallback] = useState<any | null>(null);
+  const [selectedEditCallback, setSelectedEditCallback] = useState<AlertingObject | null>(null);
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
-  const [callbackToDelete, setCallbackToDelete] = useState<any | null>(null);
-  const [isUpdatingCallback, setIsUpdatingCallback] = useState(false);
-  const [isAddingCallback, setIsAddingCallback] = useState(false);
-  const [isDeletingCallback, setIsDeletingCallback] = useState(false);
+  const [callbackToDelete, setCallbackToDelete] = useState<AlertingObject | null>(null);
 
+  // React Query hooks for callbacks
+  const { data: callbacksData } = useCallbacks();
+  const { data: callbackConfigs = [] } = useCallbackConfigs();
+  const updateCallbackMutation = useUpdateCallback();
+  const deleteCallbackMutation = useDeleteCallback();
+
+  const callbacks = callbacksData?.callbacks ?? [];
+  const allCallbacks = callbacksData?.availableCallbacks ?? {};
+  const alerts = callbacksData?.alerts ?? [];
+
+  // Derive alerting state from query data
   useEffect(() => {
-    if (!accessToken) {
-      return;
+    if (alerts.length > 0) {
+      const alertInfo = alerts[0];
+      setCatchAllWebhookURL(alertInfo.variables.SLACK_WEBHOOK_URL);
+      setActiveAlerts(alertInfo.active_alerts);
+      setAlertToWebhooks(alertInfo.alerts_to_webhook);
     }
-    getCallbackConfigsCall(accessToken)
-      .then((data) => {
-        setCallbackConfigs(data || []);
-      })
-      .catch((error) => {
-        NotificationsManager.fromBackend("Failed to load callback configs: " + parseErrorMessage(error));
-      });
-  }, [accessToken]);
+  }, [alerts]);
 
   useEffect(() => {
     if (showEditCallback && selectedEditCallback) {
@@ -301,81 +283,36 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
     region_outage_alerts: "Region Outage Alerts",
   };
 
-  useEffect(() => {
-    if (!accessToken || !userRole || !userID) {
-      return;
-    }
-    getCallbacksCall(accessToken, userID, userRole).then((data) => {
-      setCallbacks(data.callbacks);
-      setAllCallbacks(data.available_callbacks);
-      // setCallbacks(callbacks_data);
-
-      let alerts_data = data.alerts;
-      if (alerts_data) {
-        if (alerts_data.length > 0) {
-          let _alert_info = alerts_data[0];
-          let catch_all_webhook = _alert_info.variables.SLACK_WEBHOOK_URL;
-
-          let active_alerts = _alert_info.active_alerts;
-          setActiveAlerts(active_alerts);
-          setCatchAllWebhookURL(catch_all_webhook);
-          setAlertToWebhooks(_alert_info.alerts_to_webhook);
-        }
-      }
-
-      setAlerts(alerts_data);
-    });
-  }, [accessToken, userRole, userID]);
-
   const isAlertOn = (alertName: string) => {
     return activeAlerts && activeAlerts.includes(alertName);
   };
 
-  // Shared handler for callback form submission
   const handleCallbackSubmit = async (formValues: Record<string, any>, callbackName: string, isEdit: boolean, mode: string = "success") => {
-    if (!accessToken) {
-      return;
-    }
-
-    if (isEdit) {
-      setIsUpdatingCallback(true);
-    } else {
-      setIsAddingCallback(true);
-    }
-
     const payload = buildCallbackPayload(formValues, callbackName, mode);
 
-    try {
-      await setCallbacksCall(accessToken, payload);
-      NotificationsManager.success(
-        isEdit ? "Callback updated successfully" : `Callback ${callbackName} added successfully`,
-      );
-
-      if (isEdit) {
-        setShowEditCallback(false);
-        editForm.resetFields();
-        setSelectedEditCallback(null);
-      } else {
-        setShowAddCallbacksModal(false);
-        addForm.resetFields();
-        setSelectedCallback(null);
-        setSelectedCallbackParams([]);
-      }
-
-      // Refresh the callbacks list
-      if (userID && userRole) {
-        const updatedData = await getCallbacksCall(accessToken, userID, userRole);
-        setCallbacks(updatedData.callbacks);
-      }
-    } catch (error) {
-      NotificationsManager.fromBackend(error);
-    } finally {
-      if (isEdit) {
-        setIsUpdatingCallback(false);
-      } else {
-        setIsAddingCallback(false);
-      }
-    }
+    updateCallbackMutation.mutate(
+      { payload },
+      {
+        onSuccess: () => {
+          NotificationsManager.success(
+            isEdit ? "Callback updated successfully" : `Callback ${callbackName} added successfully`,
+          );
+          if (isEdit) {
+            setShowEditCallback(false);
+            editForm.resetFields();
+            setSelectedEditCallback(null);
+          } else {
+            setShowAddCallbacksModal(false);
+            addForm.resetFields();
+            setSelectedCallback(null);
+            setSelectedCallbackParams([]);
+          }
+        },
+        onError: (error) => {
+          NotificationsManager.fromBackend(error);
+        },
+      },
+    );
   };
 
   const updateCallbackCall = async (formValues: Record<string, any>) => {
@@ -427,149 +364,27 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
     }
     NotificationsManager.success("Alerts updated successfully");
   };
-  const handleSaveChanges = (callback: any) => {
-    if (!accessToken) {
-      return;
-    }
-
-    const updatedVariables = Object.fromEntries(
-      Object.entries(callback.variables).map(([key, value]) => [
-        key,
-        (document.querySelector(`input[name="${key}"]`) as HTMLInputElement)?.value || value,
-      ]),
-    );
-
-    const payload = {
-      environment_variables: updatedVariables,
-      litellm_settings: {
-        success_callback: [callback.name],
-      },
-    };
-
-    try {
-      setCallbacksCall(accessToken, payload);
-    } catch (error) {
-      NotificationsManager.fromBackend(error);
-    }
-    NotificationsManager.success("Callback updated successfully");
-  };
-
-  const handleOk = () => {
-    if (!accessToken) {
-      return;
-    }
-    // Handle form submission
-    addForm.validateFields().then((values) => {
-      // Call API to add the callback
-      let payload;
-      if (values.callback === "langfuse" || values.callback === "langfuse_otel") {
-        payload = {
-          environment_variables: {
-            LANGFUSE_PUBLIC_KEY: values.langfusePublicKey,
-            LANGFUSE_SECRET_KEY: values.langfusePrivateKey,
-          },
-          litellm_settings: {
-            success_callback: [values.callback],
-          },
-        };
-        setCallbacksCall(accessToken, payload);
-        let newCallback: AlertingObject = {
-          name: values.callback,
-          variables: {
-            SLACK_WEBHOOK_URL: null,
-            LANGFUSE_HOST: null,
-            LANGFUSE_PUBLIC_KEY: values.langfusePublicKey,
-            LANGFUSE_SECRET_KEY: values.langfusePrivateKey,
-            OPENMETER_API_KEY: null,
-          },
-        };
-        // add langfuse to callbacks
-        setCallbacks(callbacks ? [...callbacks, newCallback] : [newCallback]);
-      } else if (values.callback === "slack") {
-        payload = {
-          general_settings: {
-            alerting: ["slack"],
-            alerting_threshold: 300,
-          },
-          environment_variables: {
-            SLACK_WEBHOOK_URL: values.slackWebhookUrl,
-          },
-        };
-        setCallbacksCall(accessToken, payload);
-
-        let newCallback: AlertingObject = {
-          name: values.callback,
-          variables: {
-            SLACK_WEBHOOK_URL: values.slackWebhookUrl,
-            LANGFUSE_HOST: null,
-            LANGFUSE_PUBLIC_KEY: null,
-            LANGFUSE_SECRET_KEY: null,
-            OPENMETER_API_KEY: null,
-          },
-        };
-        setCallbacks(callbacks ? [...callbacks, newCallback] : [newCallback]);
-      } else if (values.callback == "openmeter") {
-        payload = {
-          environment_variables: {
-            OPENMETER_API_KEY: values.openMeterApiKey,
-          },
-          litellm_settings: {
-            success_callback: [values.callback],
-          },
-        };
-        setCallbacksCall(accessToken, payload);
-        let newCallback: AlertingObject = {
-          name: values.callback,
-          variables: {
-            SLACK_WEBHOOK_URL: null,
-            LANGFUSE_HOST: null,
-            LANGFUSE_PUBLIC_KEY: null,
-            LANGFUSE_SECRET_KEY: null,
-            OPENMETER_API_KEY: values.openMeterAPIKey,
-          },
-        };
-        // add langfuse to callbacks
-        setCallbacks(callbacks ? [...callbacks, newCallback] : [newCallback]);
-      } else {
-        payload = {
-          error: "Invalid callback value",
-        };
-      }
-      setIsModalVisible(false);
-      addForm.resetFields();
-      setSelectedCallback(null);
-    });
-  };
 
   const handleDeleteCallback = (callback: any) => {
     setCallbackToDelete(callback);
     setShowDeleteConfirmModal(true);
   };
 
-  const confirmDeleteCallback = async () => {
-    if (!callbackToDelete || !accessToken) {
+  const confirmDeleteCallback = () => {
+    if (!callbackToDelete) {
       return;
     }
 
-    try {
-      setIsDeletingCallback(true);
-      await deleteCallback(accessToken, callbackToDelete.name);
-      NotificationsManager.success(`Callback ${callbackToDelete.name} deleted successfully`);
-
-      // Refresh the callbacks list
-      if (userID && userRole) {
-        const data = await getCallbacksCall(accessToken, userID, userRole);
-        setCallbacks(data.callbacks);
-      }
-
-      setShowDeleteConfirmModal(false);
-      setCallbackToDelete(null);
-    } catch (error) {
-      console.error("Failed to delete callback:", error);
-      NotificationsManager.fromBackend(error);
-    } finally {
-      setIsDeletingCallback(false);
-    }
+    deleteCallbackMutation.mutate(callbackToDelete.name, {
+      onSuccess: () => {
+        NotificationsManager.success(`Callback ${callbackToDelete.name} deleted successfully`);
+        setShowDeleteConfirmModal(false);
+        setCallbackToDelete(null);
+      },
+      onError: (error) => {
+        NotificationsManager.fromBackend(error);
+      },
+    });
   };
 
   if (!accessToken) {
@@ -769,12 +584,12 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
                 setSelectedCallbackParams([]);
                 addForm.resetFields();
               }}
-              disabled={isAddingCallback}
+              disabled={updateCallbackMutation.isPending}
             >
               Cancel
             </Button2>
-            <Button2 htmlType="submit" loading={isAddingCallback} disabled={isAddingCallback}>
-              {isAddingCallback ? "Adding..." : "Add Callback"}
+            <Button2 htmlType="submit" loading={updateCallbackMutation.isPending} disabled={updateCallbackMutation.isPending}>
+              {updateCallbackMutation.isPending ? "Adding..." : "Add Callback"}
             </Button2>
           </div>
         </Form>
@@ -840,7 +655,7 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
                 setSelectedEditCallback(null);
                 editForm.resetFields();
               }}
-              disabled={isUpdatingCallback}
+              disabled={updateCallbackMutation.isPending}
             >
               Cancel
             </Button2>
@@ -848,10 +663,10 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
               onClick={() => {
                 editForm.submit();
               }}
-              loading={isUpdatingCallback}
-              disabled={isUpdatingCallback}
+              loading={updateCallbackMutation.isPending}
+              disabled={updateCallbackMutation.isPending}
             >
-              {isUpdatingCallback ? "Saving..." : "Save Changes"}
+              {updateCallbackMutation.isPending ? "Saving..." : "Save Changes"}
             </Button2>
           </div>
         </Form>
@@ -864,14 +679,14 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
         resourceInformationTitle="Callback Information"
         resourceInformation={[
           { label: "Callback Name", value: callbackToDelete?.name },
-          { label: "Mode", value: callbackToDelete?.mode || "success" },
+          { label: "Mode", value: callbackToDelete?.type || "success" },
         ]}
         onCancel={() => {
           setShowDeleteConfirmModal(false);
           setCallbackToDelete(null);
         }}
         onOk={confirmDeleteCallback}
-        confirmLoading={isDeletingCallback}
+        confirmLoading={deleteCallbackMutation.isPending}
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -37,7 +37,7 @@ import {
   serviceHealthCheck,
   setCallbacksCall,
 } from "./networking";
-import { LoggingCallbacksTable } from "./Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable";
+import { CALLBACK_MODES, LoggingCallbacksTable } from "./Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable";
 import { AlertingObject } from "./Settings/LoggingAndAlerts/LoggingCallbacks/types";
 import { parseErrorMessage } from "./shared/errorUtils";
 interface SettingsPageProps {
@@ -204,12 +204,22 @@ const getDynamicParamsForCallback = (
 };
 
 // Shared helper function to build callback payload
-const buildCallbackPayload = (formValues: Record<string, any>, callbackName: string) => {
+const buildCallbackPayload = (formValues: Record<string, any>, callbackName: string, mode: string = "success") => {
+  const { callback_mode, callback, ...envVars } = formValues;
+  const litellm_settings: Record<string, string[]> = {};
+
+  if (mode === "success") {
+    litellm_settings.success_callback = [callbackName];
+  } else if (mode === "failure") {
+    litellm_settings.failure_callback = [callbackName];
+  } else if (mode === "success_and_failure") {
+    litellm_settings.success_callback = [callbackName];
+    litellm_settings.failure_callback = [callbackName];
+  }
+
   return {
-    environment_variables: formValues,
-    litellm_settings: {
-      success_callback: [callbackName],
-    },
+    environment_variables: envVars,
+    litellm_settings,
   };
 };
 
@@ -268,6 +278,7 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
       editForm.setFieldsValue({
         ...normalized,
         callback: selectedEditCallback.name,
+        callback_mode: selectedEditCallback.type || "success",
       });
     }
   }, [showEditCallback, selectedEditCallback, editForm]);
@@ -321,7 +332,7 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
   };
 
   // Shared handler for callback form submission
-  const handleCallbackSubmit = async (formValues: Record<string, any>, callbackName: string, isEdit: boolean) => {
+  const handleCallbackSubmit = async (formValues: Record<string, any>, callbackName: string, isEdit: boolean, mode: string = "success") => {
     if (!accessToken) {
       return;
     }
@@ -332,7 +343,7 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
       setIsAddingCallback(true);
     }
 
-    const payload = buildCallbackPayload(formValues, callbackName);
+    const payload = buildCallbackPayload(formValues, callbackName, mode);
 
     try {
       await setCallbacksCall(accessToken, payload);
@@ -371,7 +382,8 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
     if (!selectedEditCallback) {
       return;
     }
-    await handleCallbackSubmit(formValues, selectedEditCallback.name, true);
+    const mode = formValues.callback_mode || selectedEditCallback.type || "success";
+    await handleCallbackSubmit(formValues, selectedEditCallback.name, true, mode);
   };
 
   const addNewCallbackCall = async (formValues: Record<string, any>) => {
@@ -379,7 +391,8 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
     if (!new_callback) {
       return;
     }
-    await handleCallbackSubmit(formValues, new_callback, false);
+    const mode = formValues.callback_mode || "success";
+    await handleCallbackSubmit(formValues, new_callback, false, mode);
   };
 
   const handleSelectedCallbackChange = (callbackName: string) => {
@@ -728,6 +741,20 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
             onCallbackChange={handleSelectedCallbackChange}
           />
 
+          <FormItem
+            label="Callback Mode"
+            name="callback_mode"
+            initialValue="success"
+          >
+            <Select size="large" className="w-full">
+              {CALLBACK_MODES.map((m) => (
+                <SelectItem key={m.value} value={m.value}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </Select>
+          </FormItem>
+
           <DynamicParamsFields
             params={selectedCallbackParams}
             callbackConfigs={callbackConfigs}
@@ -779,6 +806,20 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
                 onCallbackChange={() => {}}
                 disabled={true}
               />
+
+              <FormItem
+                label="Callback Mode"
+                name="callback_mode"
+                initialValue={selectedEditCallback.type || "success"}
+              >
+                <Select size="large" className="w-full">
+                  {CALLBACK_MODES.map((m) => (
+                    <SelectItem key={m.value} value={m.value}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </FormItem>
 
               <DynamicParamsFields
                 params={getDynamicParamsForCallback(


### PR DESCRIPTION
## Summary
- **Mode column always showed "Success"**: Backend returns `type` field on each callback, but the UI table was reading `record.mode` (which didn't exist), defaulting everything to "Success". Now reads `type` directly.
- **Adding callbacks via UI only created success_callback**: `buildCallbackPayload()` hardcoded `success_callback`. Added a "Callback Mode" dropdown (Success / Failure / Success & Failure) to both Add and Edit modals.
- **Delete endpoint only checked success_callback**: Deleting a failure callback would 404. Now searches all three lists (`success_callback`, `failure_callback`, `callbacks`).
- **failure_callback merge missing in config update**: Only `success_callback` had list-merge logic. Adding a second failure callback would silently overwrite the first. Merge logic now applies to both.
- **Duplicate table rows**: Table `rowKey` was just `record.name`, causing rendering issues when the same callback appeared in multiple lists. Now uses composite key `name-type`.

## Screenshots

<img width="801" height="572" alt="Screenshot 2026-04-07 at 10 40 48 AM" src="https://github.com/user-attachments/assets/077ae9d0-a34f-4d47-81d3-155f8db62bcd" />


## Test plan
- [x] Add a callback via config.yaml with both `success_callback` and `failure_callback` — verify mode badges display correctly (green Success, red Failure)
- [x] Add a callback via UI with each mode (Success, Failure, Success & Failure) — verify correct config keys are set
- [x] Edit a callback and change its mode — verify badge updates
- [ ] Delete a failure-only callback — verify no 404 error
- [ ] Verify no duplicate rows when same callback is in multiple lists