### PR TITLE
fix(vertex_ai): regex in supports_response_json_schema misses gemini-3-flash

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -176,7 +176,7 @@ def supports_response_json_schema(model: str) -> bool:
 
     # Gemini 2.0+ and 2.5+ models support responseJsonSchema
     # Pattern matches: gemini-2.0-*, gemini-2.5-*, gemini-3-*, etc.
-    gemini_2_plus_pattern = re.compile(r"gemini-([2-9]|[1-9]\d+)\.")
+    gemini_2_plus_pattern = re.compile(r"gemini-([2-9]|[1-9]\d+)[.-]")
 
     return bool(gemini_2_plus_pattern.search(model_lower))
 

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -16,6 +16,7 @@ from litellm.llms.vertex_ai.common_utils import (
     get_vertex_location_from_url,
     get_vertex_project_id_from_url,
     set_schema_property_ordering,
+    supports_response_json_schema,
 )
 
 
@@ -1382,3 +1383,36 @@ def test_add_object_type_does_not_add_type_when_anyof_present():
 
     # Verify type was not added (anyOf handles the type)
     assert "type" not in input_schema, "type should not be added when anyOf is present"
+
+
+class TestSupportsResponseJsonSchema:
+    """Test supports_response_json_schema correctly identifies Gemini 2.0+ models."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-2.0-flash",
+            "gemini-2.5-flash",
+            "gemini-2.5-pro",
+            "gemini-3.1-flash-lite-preview",
+            "vertex_ai/gemini-3.1-flash-lite-preview",
+            "gemini-3-flash-preview",  # no dot after major version
+            "vertex_ai/gemini-3-flash-preview",
+            "gemini-4-ultra",  # future model
+        ],
+    )
+    def test_gemini_2_plus_returns_true(self, model):
+        assert supports_response_json_schema(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-1.5-flash",
+            "gemini-1.5-pro",
+            "vertex_ai/gemini-1.5-flash-001",
+            "chat-bison",
+            "text-bison",
+        ],
+    )
+    def test_older_models_return_false(self, model):
+        assert supports_response_json_schema(model) is False


### PR DESCRIPTION
## Summary

- `supports_response_json_schema()` regex misses `gemini-3-flash-preview` because the pattern requires a dot after the version number but Google named this model with a hyphen
- One-character fix: `\.` to `[.-]`
- Adds test coverage for the detection function

## Problem

The regex `r"gemini-([2-9]|[1-9]\d+)\."` in `supports_response_json_schema()` correctly matches models with a minor version (`gemini-2.0-*`, `gemini-2.5-*`, `gemini-3.1-*`) but fails on `gemini-3-flash-preview` because it uses a hyphen (`gemini-3-`) instead of a dot (`gemini-3.`).

When the regex fails, the request falls through to `_build_vertex_schema()` which strips `additionalProperties`. This causes `dict[str, T]` fields in structured output schemas (represented via `additionalProperties: {type: "number"}`) to return empty objects `{}` from the Vertex AI API.

| Model | Before | After |
|-------|--------|-------|
| `gemini-2.5-flash` | Works | Works |
| `gemini-3.1-flash-lite` | Works | Works |
| `gemini-3-flash-preview` | Returns `{}` for dicts | Fixed |

## Fix

```python
# Before
gemini_2_plus_pattern = re.compile(r"gemini-([2-9]|[1-9]\d+)\.")

# After
gemini_2_plus_pattern = re.compile(r"gemini-([2-9]|[1-9]\d+)[.-]")
```

## Test plan

- Added `TestSupportsResponseJsonSchema` with parametrized tests covering:
  - Gemini 2.0+ models with dots (`gemini-2.5-flash`) -> `True`
  - Gemini 3+ models with hyphens (`gemini-3-flash-preview`) -> `True`
  - Gemini 1.5 models -> `False`
  - Vertex AI prefixed models -> correct behavior
- Verified fix against live Vertex AI API through LiteLLM proxy

Fixes #14251
