### PR TITLE
docs: Add Customers tab to Reset Budgets section

### DIFF
--- a/docs/my-website/docs/proxy/users.md
+++ b/docs/my-website/docs/proxy/users.md
@@ -622,6 +622,48 @@ curl 'http://0.0.0.0:4000/team/new' \
 }'
 ```
 </TabItem>
+<TabItem value="customers" label="Customers">
+
+Use `/customer/new` to create a customer with a `budget_duration`. The budget will automatically reset at the end of the specified duration.
+
+```bash
+curl 'http://0.0.0.0:4000/customer/new' \
+--header 'Authorization: Bearer <your-master-key>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "user_id": "my-customer-id",
+  "max_budget": 10,
+  "budget_duration": "30d", # 👈 KEY CHANGE
+}'
+```
+
+To update an existing customer's budget duration:
+
+```bash
+curl 'http://0.0.0.0:4000/customer/update' \
+--header 'Authorization: Bearer <your-master-key>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "user_id": "my-customer-id",
+  "max_budget": 10,
+  "budget_duration": "30d", # 👈 KEY CHANGE
+}'
+```
+
+Then pass the customer's `user_id` as the `user` parameter in `/chat/completions` requests:
+
+```bash
+curl 'http://0.0.0.0:4000/chat/completions' \
+--header 'Authorization: Bearer <your-api-key>' \
+--header 'Content-Type: application/json' \
+--data '{
+  "model": "gpt-4o",
+  "user": "my-customer-id",
+  "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+
+</TabItem>
 </Tabs>
 
 **Note:** By default, the server checks for resets every 10 minutes, to minimize DB calls.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Docs feedback: update https://docs.litellm.ai/docs/proxy/users#reset-budgets to show how to reset budgets for customers (`/customer/new`)

## Pre-Submission checklist

- [x] This is a documentation-only change, no code tests needed
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Added a **Customers** tab to the [Reset Budgets](https://docs.litellm.ai/docs/proxy/users#reset-budgets) section showing how to:

- Create a customer with `budget_duration` via `/customer/new` so the budget automatically resets
- Update an existing customer's budget duration via `/customer/update`
- Pass the customer's `user_id` as the `user` parameter in `/chat/completions` requests

The existing section only had tabs for Internal Users, Keys, and Teams despite mentioning "customers" in the heading text.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C09DYGJAVEU/p1775602105084419?thread_ts=1775602105.084419&cid=C09DYGJAVEU)

<div><a href="https://cursor.com/agents/bc-f38900b0-9d12-5223-ab5d-a746aff5b2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f38900b0-9d12-5223-ab5d-a746aff5b2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

