### PR TITLE
[Infra] Bump version 1.83.4 → 1.83.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "1.83.4"
+version = "1.83.5"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
@@ -181,7 +181,7 @@ requires = ["poetry-core", "wheel"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.83.4"
+version = "1.83.5"
 version_files = [
     "pyproject.toml:^version"
 ]


### PR DESCRIPTION
## Summary

Patch version bump from 1.83.4 to 1.83.5 using `cz bump --increment patch`.

## Changes

- Updated `version` in `pyproject.toml` from 1.83.4 to 1.83.5
- Updated `tool.commitizen.version` in `pyproject.toml` from 1.83.4 to 1.83.5

## Type

🚄 Infrastructure