### PR TITLE
fix(anthropic): support haiku 4.5 structured output and mixed JSON tool calls

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -108,12 +108,20 @@ def convert_tool_call_to_json_mode(
         convert_tool_call_to_json_mode=convert_tool_call_to_json_mode,
     ):
         # to support 'json_schema' logic on older models
-        json_mode_content_str: Optional[str] = tool_calls[0]["function"].get(
-            "arguments"
-        )
+        json_mode_content_str: Optional[str] = None
+        filtered_tool_calls = []
+        for tool in tool_calls:
+            if tool["function"]["name"] == RESPONSE_FORMAT_TOOL_NAME:
+                json_mode_content_str = tool["function"].get("arguments")
+            else:
+                filtered_tool_calls.append(tool)
+
         if json_mode_content_str is not None:
-            message = litellm.Message(content=json_mode_content_str)
-            finish_reason = "stop"
+            message = litellm.Message(
+                content=json_mode_content_str,
+                tool_calls=filtered_tool_calls if len(filtered_tool_calls) > 0 else None,
+            )
+            finish_reason = "stop" if len(filtered_tool_calls) == 0 else "tool_calls"
             return message, finish_reason
     return None, None
 
@@ -434,13 +442,10 @@ def _should_convert_tool_call_to_json_mode(
     """
     Determine if tool calls should be converted to JSON mode
     """
-    if (
-        convert_tool_call_to_json_mode
-        and tool_calls is not None
-        and len(tool_calls) == 1
-        and tool_calls[0]["function"]["name"] == RESPONSE_FORMAT_TOOL_NAME
-    ):
-        return True
+    if convert_tool_call_to_json_mode and tool_calls is not None:
+        for tool in tool_calls:
+            if tool["function"]["name"] == RESPONSE_FORMAT_TOOL_NAME:
+                return True
     return False
 
 
@@ -562,12 +567,28 @@ def convert_to_model_response_object(  # noqa: PLR0915
                     convert_tool_call_to_json_mode=convert_tool_call_to_json_mode,
                 ):
                     # to support 'json_schema' logic on older models
-                    json_mode_content_str: Optional[str] = tool_calls[0][
-                        "function"
-                    ].get("arguments")
+                    json_mode_content_str: Optional[str] = None
+                    filtered_tool_calls = []
+                    for _tc in tool_calls:
+                        if _tc["function"]["name"] == RESPONSE_FORMAT_TOOL_NAME:
+                            json_mode_content_str = _tc["function"].get("arguments")
+                        else:
+                            filtered_tool_calls.append(_tc)
+
+                    if len(filtered_tool_calls) == 0:
+                        tool_calls = None
+                    else:
+                        tool_calls = filtered_tool_calls
+
                     if json_mode_content_str is not None:
-                        message = litellm.Message(content=json_mode_content_str)
-                        finish_reason = "stop"
+                        if tool_calls is None:
+                            message = litellm.Message(content=json_mode_content_str)
+                            finish_reason = "stop"
+                        else:
+                            if choice["message"].get("content") is None:
+                                choice["message"]["content"] = json_mode_content_str
+                            elif isinstance(choice["message"].get("content"), str):
+                                choice["message"]["content"] += f"\n{json_mode_content_str}"
                 if message is None:
                     # Preserve provider_specific_fields if already present
                     # in the response (e.g. from proxy passthrough)

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -589,6 +589,7 @@ def convert_to_model_response_object(  # noqa: PLR0915
                                 choice["message"]["content"] = json_mode_content_str
                             elif isinstance(choice["message"].get("content"), str):
                                 choice["message"]["content"] += f"\n{json_mode_content_str}"
+                            finish_reason = "tool_calls"
                 if message is None:
                     # Preserve provider_specific_fields if already present
                     # in the response (e.g. from proxy passthrough)

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1473,6 +1473,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         "sonnet-4-6",
                         "sonnet_4.6",
                         "sonnet_4_6",
+                        "haiku-4.5",
+                        "haiku-4-5",
+                        "haiku_4.5",
+                        "haiku_4_5",
                     }
                 ):
                     _output_format = (

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1456,28 +1456,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "top_p":
                 optional_params["top_p"] = value
             elif param == "response_format" and isinstance(value, dict):
-                if any(
-                    substring in model
-                    for substring in {
-                        "sonnet-4.5",
-                        "sonnet-4-5",
-                        "opus-4.1",
-                        "opus-4-1",
-                        "opus-4.5",
-                        "opus-4-5",
-                        "opus-4.6",
-                        "opus-4-6",
-                        "opus-4.7",
-                        "opus-4-7",
-                        "sonnet-4.6",
-                        "sonnet-4-6",
-                        "sonnet_4.6",
-                        "sonnet_4_6",
-                        "haiku-4.5",
-                        "haiku-4-5",
-                        "haiku_4.5",
-                        "haiku_4_5",
-                    }
+                if litellm.supports_response_schema(
+                    model=model, custom_llm_provider="anthropic"
                 ):
                     _output_format = (
                         self.map_response_format_to_anthropic_output_format(value)
@@ -2443,7 +2423,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         _message.provider_specific_fields = provider_specific_fields
 
         if json_mode_message is not None:
-            completion_response["stop_reason"] = "stop"
+            completion_response["stop_reason"] = (
+                "tool_use" if json_mode_message.tool_calls else "stop"
+            )
             _message = json_mode_message
 
         model_response.choices[0].message = _message

--- a/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
+++ b/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
@@ -40,7 +40,7 @@ def test_convert_to_model_response_object_basic():
                     "content": "Hi there! How can I assist you today?",
                     "refusal": None,
                 },
-                "finish_reason": "stop",
+                "finish_reason": None,
             }
         ],
         "usage": {
@@ -344,7 +344,7 @@ def test_convert_to_model_response_object_json_mode():
                         }
                     ],
                 },
-                "finish_reason": None,
+                "finish_reason": "stop",
             }
         ],
         "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5},
@@ -372,6 +372,61 @@ def test_convert_to_model_response_object_json_mode():
     assert result.usage.total_tokens == 10
     assert result.usage.prompt_tokens == 5
     assert result.usage.completion_tokens == 5
+
+
+def test_convert_to_model_response_object_json_mode_with_parallel_real_tool():
+    model_response_object = ModelResponse(model="gpt-3.5-turbo")
+    from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
+
+    response_object = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_real",
+                            "type": "function",
+                            "function": {
+                                "arguments": '{"movie":"Inception"}',
+                                "name": "get_showtimes",
+                            },
+                        },
+                        {
+                            "id": "call_json",
+                            "type": "function",
+                            "function": {
+                                "arguments": '{"title":"Inception"}',
+                                "name": RESPONSE_FORMAT_TOOL_NAME,
+                            },
+                        },
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5},
+        "model": "gpt-3.5-turbo",
+    }
+
+    result = convert_to_model_response_object(
+        model_response_object=model_response_object,
+        response_object=response_object,
+        stream=False,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        hidden_params=None,
+        _response_headers=None,
+        convert_tool_call_to_json_mode=True,
+    )
+
+    assert result.choices[0].message.content == '{"title":"Inception"}'
+    assert result.choices[0].finish_reason == "tool_calls"
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "get_showtimes"
 
 
 def test_convert_to_model_response_object_function_output():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -73,6 +73,34 @@ def test_anthropic_json_mode_non_streaming_mixed_internal_and_user_tools():
     assert extra == '{"answer": 42}'
 
 
+def test_haiku_45_uses_model_metadata_for_native_structured_output():
+    config = AnthropicConfig()
+    mapped_params = config.map_openai_params(
+        non_default_params={
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "MovieReview",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"title": {"type": "string"}},
+                        "required": ["title"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        },
+        optional_params={},
+        model="claude-haiku-4-5-20251001",
+        drop_params=False,
+    )
+
+    assert "output_format" in mapped_params
+    assert "tools" not in mapped_params
+    assert "tool_choice" not in mapped_params
+
+
 def test_calculate_usage():
     """
     Do not include cache_creation_input_tokens in the prompt_tokens


### PR DESCRIPTION
Fixes related Anthropic parameter mapping and simulated response-conversion paths for #25308.

## What changed

- Uses LiteLLM model capability metadata for Anthropic native structured output instead of adding another hardcoded Haiku 4.5 name allowlist.
- Keeps `claude-haiku-4-5-20251001` on Anthropic native `output_format` when `response_format` is supplied.
- Handles mixed real tool calls plus the synthetic `json_tool_call` fallback in the generic response conversion path.
- Handles the same mixed-tool case in Anthropic's direct non-streaming JSON-mode response transform.
- Migrates synthetic `json_tool_call` arguments into assistant message content while preserving real user tool calls and `finish_reason=\"tool_calls\"`.

## Validation

Environment used for validation: A100 host, Ubuntu 22.04.5, Python 3.10.12. LiteLLM source was checked out at the relevant base/head/fixed SHAs; package metadata reported `litellm 1.85.0`, `openai 2.36.0`, `pydantic 2.13.4`, `httpx 0.28.1`, and `aiohttp 3.13.5`.

Command:

```bash
PYTHONPATH=. python validate_litellm_prs.py --pr 25317
PYTHONPATH=. python -m pytest -q tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_haiku_45_uses_model_metadata_for_native_structured_output tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_json_mode_response_preserves_parallel_real_tool_call tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py::test_convert_to_model_response_object_json_mode_with_parallel_real_tool
```

Results:

- Base `62757ff48f59d74c0ca681feb85522f9d003a9e7`: failed; Haiku 4.5 mapped to synthetic `json_tool_call`, the generic conversion leaked `json_tool_call`, and the direct Anthropic transform returned no usable message.
- Previous PR head `b262bb3314e9365058eeac17d7368e2dde6db1dc`: fixed Haiku 4.5 native mapping and generic conversion, but the direct Anthropic transform still failed the mixed-tool case.
- Fixed branch: passed targeted validation; native `output_format` is used, synthetic `json_tool_call` is removed, content is migrated, and real `get_showtimes` tool calls survive in both conversion paths.
- Current PR head `f5f2a93d267e3780bb97d8064e37212dbde5e9ea`: rebased onto current `main`; mergeable.
- Focused tests on current branch: `3 passed`.

Representative redacted fixed mapping:

```json
{"json_mode":true,"output_format":{"type":"json_schema","schema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}},"tools":[{"name":"get_showtimes","type":"custom"}]}
```

## Scope

This validates LiteLLM's Anthropic parameter mapping and response-conversion paths with simulated provider payloads. It does not claim a live Anthropic API replay.