### PR TITLE
fix(router): clamp least_busy request counter to prevent negative drift

### DIFF
--- a/litellm/router_strategy/least_busy.py
+++ b/litellm/router_strategy/least_busy.py
@@ -76,7 +76,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_value: Optional[int] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(request_count_value - 1, 0)
                 self.router_cache.set_cache(
                     key=request_count_api_key, value=request_count_dict
                 )
@@ -109,7 +109,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_value: Optional[int] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(request_count_value - 1, 0)
                 self.router_cache.set_cache(
                     key=request_count_api_key, value=request_count_dict
                 )
@@ -144,7 +144,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_value: Optional[int] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(request_count_value - 1, 0)
                 await self.router_cache.async_set_cache(
                     key=request_count_api_key, value=request_count_dict
                 )
@@ -178,7 +178,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_value: Optional[int] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(request_count_value - 1, 0)
                 await self.router_cache.async_set_cache(
                     key=request_count_api_key, value=request_count_dict
                 )

--- a/tests/test_litellm/test_least_busy_counter_clamp.py
+++ b/tests/test_litellm/test_least_busy_counter_clamp.py
@@ -9,11 +9,8 @@ others starve.
 Regression test for https://github.com/BerriAI/litellm/issues/25323
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 
-from litellm.caching.caching import DualCache
 from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
 
 
@@ -37,6 +34,12 @@ class FakeCache:
         return self.store.get(key)
 
     def set_cache(self, key, value, **kwargs):
+        self.store[key] = value
+
+    async def async_get_cache(self, key, **kwargs):
+        return self.store.get(key)
+
+    async def async_set_cache(self, key, value, **kwargs):
         self.store[key] = value
 
 
@@ -79,26 +82,35 @@ def test_sync_failure_counter_never_goes_negative():
 @pytest.mark.asyncio
 async def test_async_success_counter_never_goes_negative():
     """async_log_success_event should clamp the counter at 0."""
-    cache = MagicMock()
-    cache.async_get_cache = pytest.importorskip("asyncio").coroutine(
-        lambda *a, **kw: None
-    )
+    cache = FakeCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
 
-    # Use a real FakeCache but wrap async methods
-    real_cache = FakeCache()
     model_group = "test-group"
     deploy_id = "deploy-1"
     cache_key = f"{model_group}_request_count"
-    real_cache.store[cache_key] = {deploy_id: 0}
+    cache.store[cache_key] = {deploy_id: 0}
 
-    handler = LeastBusyLoggingHandler(router_cache=real_cache)
-
-    # Patch sync cache methods to work (async methods call sync internally)
     kwargs = _make_kwargs(model_group, deploy_id)
+    await handler.async_log_success_event(kwargs, None, None, None)
 
-    # Test the sync path which is equivalent
-    handler.log_success_event(kwargs, None, None, None)
-    assert real_cache.store[cache_key][deploy_id] == 0
+    assert cache.store[cache_key][deploy_id] == 0, "Async success counter went negative"
+
+
+@pytest.mark.asyncio
+async def test_async_failure_counter_never_goes_negative():
+    """async_log_failure_event should clamp the counter at 0."""
+    cache = FakeCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+
+    model_group = "test-group"
+    deploy_id = "deploy-1"
+    cache_key = f"{model_group}_request_count"
+    cache.store[cache_key] = {deploy_id: 0}
+
+    kwargs = _make_kwargs(model_group, deploy_id)
+    await handler.async_log_failure_event(kwargs, None, None, None)
+
+    assert cache.store[cache_key][deploy_id] == 0, "Async failure counter went negative"
 
 
 def test_counter_clamp_with_multiple_decrements():

--- a/tests/test_litellm/test_least_busy_counter_clamp.py
+++ b/tests/test_litellm/test_least_busy_counter_clamp.py
@@ -1,0 +1,128 @@
+"""
+Test that LeastBusyLoggingHandler clamps request counters to zero.
+
+When success/failure callbacks fire before the pre-call callback
+(race condition) or fire multiple times, the counter can go negative.
+A negative count causes that deployment to attract ALL traffic while
+others starve.
+
+Regression test for https://github.com/BerriAI/litellm/issues/25323
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
+
+
+def _make_kwargs(model_group: str, deployment_id: str):
+    """Build kwargs dict matching the structure log_success_event expects."""
+    return {
+        "litellm_params": {
+            "metadata": {"model_group": model_group},
+            "model_info": {"id": deployment_id},
+        },
+    }
+
+
+class FakeCache:
+    """Minimal DualCache stand-in that stores values in a plain dict."""
+
+    def __init__(self):
+        self.store: dict = {}
+
+    def get_cache(self, key, **kwargs):
+        return self.store.get(key)
+
+    def set_cache(self, key, value, **kwargs):
+        self.store[key] = value
+
+
+def test_sync_success_counter_never_goes_negative():
+    """log_success_event should clamp the counter at 0, not go negative."""
+    cache = FakeCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+
+    model_group = "test-group"
+    deploy_id = "deploy-1"
+    cache_key = f"{model_group}_request_count"
+
+    # Simulate counter already at 0 (no in-flight requests)
+    cache.store[cache_key] = {deploy_id: 0}
+
+    # Fire success callback — would decrement to -1 without the clamp
+    kwargs = _make_kwargs(model_group, deploy_id)
+    handler.log_success_event(kwargs, None, None, None)
+
+    assert cache.store[cache_key][deploy_id] == 0, "Counter went negative"
+
+
+def test_sync_failure_counter_never_goes_negative():
+    """log_failure_event should clamp the counter at 0."""
+    cache = FakeCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+
+    model_group = "test-group"
+    deploy_id = "deploy-1"
+    cache_key = f"{model_group}_request_count"
+
+    cache.store[cache_key] = {deploy_id: 0}
+
+    kwargs = _make_kwargs(model_group, deploy_id)
+    handler.log_failure_event(kwargs, None, None, None)
+
+    assert cache.store[cache_key][deploy_id] == 0, "Counter went negative"
+
+
+@pytest.mark.asyncio
+async def test_async_success_counter_never_goes_negative():
+    """async_log_success_event should clamp the counter at 0."""
+    cache = MagicMock()
+    cache.async_get_cache = pytest.importorskip("asyncio").coroutine(
+        lambda *a, **kw: None
+    )
+
+    # Use a real FakeCache but wrap async methods
+    real_cache = FakeCache()
+    model_group = "test-group"
+    deploy_id = "deploy-1"
+    cache_key = f"{model_group}_request_count"
+    real_cache.store[cache_key] = {deploy_id: 0}
+
+    handler = LeastBusyLoggingHandler(router_cache=real_cache)
+
+    # Patch sync cache methods to work (async methods call sync internally)
+    kwargs = _make_kwargs(model_group, deploy_id)
+
+    # Test the sync path which is equivalent
+    handler.log_success_event(kwargs, None, None, None)
+    assert real_cache.store[cache_key][deploy_id] == 0
+
+
+def test_counter_clamp_with_multiple_decrements():
+    """Multiple success callbacks should never push counter below 0."""
+    cache = FakeCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+
+    model_group = "test-group"
+    deploy_id = "deploy-1"
+    cache_key = f"{model_group}_request_count"
+
+    # Start with 1 in-flight request
+    cache.store[cache_key] = {deploy_id: 1}
+
+    kwargs = _make_kwargs(model_group, deploy_id)
+
+    # First decrement: 1 -> 0
+    handler.log_success_event(kwargs, None, None, None)
+    assert cache.store[cache_key][deploy_id] == 0
+
+    # Second decrement (duplicate callback): should stay at 0, not go to -1
+    handler.log_success_event(kwargs, None, None, None)
+    assert cache.store[cache_key][deploy_id] == 0
+
+    # Third decrement: still 0
+    handler.log_failure_event(kwargs, None, None, None)
+    assert cache.store[cache_key][deploy_id] == 0


### PR DESCRIPTION
## Summary

Fixes the least_busy routing strategy silently suppressing traffic to certain deployments by clamping the per-deployment request counter to prevent negative values.

## Root Cause

The request counter is incremented in `log_pre_api_call` and decremented in success/failure callbacks. Under race conditions (callback fires before pre-call, or fires twice), the counter goes negative.

A negative count is **always less than** the `0` assigned to fresh/unused deployments in `_get_available_deployments`, so the negative-count deployment wins every comparison and attracts ALL traffic, while others gradually starve to zero.

## Fix

Added `max(value - 1, 0)` on all 4 decrement paths:
- `log_success_event` (sync)
- `log_failure_event` (sync)
- `async_log_success_event`
- `async_log_failure_event`

This ensures the counter never goes below 0, preventing any single deployment from monopolizing traffic.

## Testing

The fix is a defensive floor guard on an integer counter. Existing routing tests validate the least_busy selection logic.

## Disclaimer

AI agents (Claude Code) assisted with this contribution.

Fixes #25323