### PR TITLE
docs: add asqav audit trail callback integration

### DIFF
--- a/docs/my-website/docs/observability/asqav_integration.md
+++ b/docs/my-website/docs/observability/asqav_integration.md
@@ -40,11 +40,20 @@ The integration is a single LiteLLM `CustomLogger` subclass. Drop it into your p
 
 ```python
 import os
-import time
 import uuid
 import httpx
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
+
+
+def _latency_ms(start, end):
+    """LiteLLM passes datetime objects; older paths may pass floats."""
+    if not start or not end:
+        return None
+    delta = end - start
+    if hasattr(delta, "total_seconds"):
+        return int(delta.total_seconds() * 1000)
+    return int(delta * 1000)
 
 
 class AsqavLogger(CustomLogger):
@@ -73,7 +82,7 @@ class AsqavLogger(CustomLogger):
         self._sign("llm:call", {
             "model": kwargs.get("model"),
             "message_count": len(kwargs.get("messages") or []),
-            "latency_ms": int((end_time - start_time) * 1000) if start_time and end_time else None,
+            "latency_ms": _latency_ms(start_time, end_time),
             "prompt_tokens": getattr(usage, "prompt_tokens", None),
             "completion_tokens": getattr(usage, "completion_tokens", None),
         })
@@ -110,6 +119,15 @@ import httpx
 from litellm.integrations.custom_logger import CustomLogger
 
 
+def _latency_ms(start, end):
+    if not start or not end:
+        return None
+    delta = end - start
+    if hasattr(delta, "total_seconds"):
+        return int(delta.total_seconds() * 1000)
+    return int(delta * 1000)
+
+
 class AsqavLogger(CustomLogger):
     def __init__(self) -> None:
         self.api_key = os.environ["ASQAV_API_KEY"]
@@ -133,7 +151,7 @@ class AsqavLogger(CustomLogger):
         self._sign("llm:call", {
             "model": kwargs.get("model"),
             "message_count": len(kwargs.get("messages") or []),
-            "latency_ms": int((end_time - start_time) * 1000) if start_time and end_time else None,
+            "latency_ms": _latency_ms(start_time, end_time),
             "prompt_tokens": getattr(usage, "prompt_tokens", None),
             "completion_tokens": getattr(usage, "completion_tokens", None),
         })

--- a/docs/my-website/docs/observability/asqav_integration.md
+++ b/docs/my-website/docs/observability/asqav_integration.md
@@ -77,9 +77,12 @@ litellm_settings:
 
 general_settings:
   master_key: "sk-1234"
+```
 
-environment_variables:
-  ASQAV_API_KEY: "your-asqav-api-key"
+Set your Asqav API key in the environment before starting the proxy:
+
+```bash
+export ASQAV_API_KEY="your-asqav-api-key"
 ```
 
 ### 3. Start the proxy

--- a/docs/my-website/docs/observability/asqav_integration.md
+++ b/docs/my-website/docs/observability/asqav_integration.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 - **Signed audit logs** - Every call produces a cryptographically signed record, verifiable offline
 - **Governance callbacks** - Hook into LiteLLM's callback system with zero changes to your inference code
-- **Compliance-ready exports** - Structured logs compatible with SOC 2, ISO 27001, and EU AI Act requirements
+- **Compliance-ready exports** - Structured logs providing compliance-ready audit trails
 - **Model and cost tracking** - Token usage, latency, and cost captured per request
 
 :::tip
@@ -25,7 +25,7 @@ https://github.com/BerriAI/litellm
 pip install "asqav[litellm]"
 ```
 
-Get your API key from [app.asqav.com](https://app.asqav.com/).
+Get your API key from [asqav.com](https://asqav.com/).
 
 ## Quick Start
 
@@ -100,7 +100,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
-Signed audit records appear immediately in your [Asqav dashboard](https://app.asqav.com/).
+Signed audit records appear immediately in your [Asqav dashboard](https://asqav.com/).
 
 </TabItem>
 </Tabs>
@@ -125,5 +125,5 @@ Records are retrievable and verifiable via the Asqav API or dashboard.
 
 ## Support
 
-- Docs: [docs.asqav.com](https://docs.asqav.com/)
-- Issues: [github.com/asqav/asqav-sdk](https://github.com/asqav/asqav-sdk/issues)
+- Docs: [asqav.com](https://asqav.com/)
+- Issues: [github.com/jagmarques/asqav-sdk](https://github.com/jagmarques/asqav-sdk/issues)

--- a/docs/my-website/docs/observability/asqav_integration.md
+++ b/docs/my-website/docs/observability/asqav_integration.md
@@ -1,0 +1,126 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Asqav - Signed Audit Trail & AI Governance
+
+[Asqav](https://asqav.com/) provides cryptographically signed audit trails and governance for AI applications. Every LLM call is logged with a tamper-evident signature, giving compliance teams verifiable records of model inputs, outputs, and metadata.
+
+**Key Features:**
+
+- **Signed audit logs** - Every call produces a cryptographically signed record, verifiable offline
+- **Governance callbacks** - Hook into LiteLLM's callback system with zero changes to your inference code
+- **Compliance-ready exports** - Structured logs compatible with SOC 2, ISO 27001, and EU AI Act requirements
+- **Model and cost tracking** - Token usage, latency, and cost captured per request
+
+:::tip
+
+This is community maintained. Please make an issue if you run into a bug:
+https://github.com/BerriAI/litellm
+
+:::
+
+## Pre-Requisites
+
+```bash
+pip install "asqav[litellm]"
+```
+
+Get your API key from [app.asqav.com](https://app.asqav.com/).
+
+## Quick Start
+
+<Tabs>
+<TabItem value="sdk" label="Python SDK">
+
+```python
+import os
+import litellm
+from asqav.extras.litellm import AsqavGuardrail
+
+os.environ["ASQAV_API_KEY"] = "your-asqav-api-key"
+os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
+
+# Register the Asqav callback
+asqav_handler = AsqavGuardrail()
+litellm.callbacks = [asqav_handler]
+
+response = litellm.completion(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Summarize the EU AI Act."}],
+)
+
+print(response)
+```
+
+Every call is logged to Asqav with a signed audit record. No other changes to your code are needed.
+
+</TabItem>
+<TabItem value="proxy" label="LiteLLM Proxy">
+
+### 1. Install the package on the proxy server
+
+```bash
+pip install "asqav[litellm]"
+```
+
+### 2. Add Asqav to your `config.yaml`
+
+```yaml
+model_list:
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  callbacks: ["asqav.extras.litellm.AsqavGuardrail"]
+
+general_settings:
+  master_key: "sk-1234"
+
+environment_variables:
+  ASQAV_API_KEY: "your-asqav-api-key"
+```
+
+### 3. Start the proxy
+
+```bash
+litellm --config config.yaml
+```
+
+### 4. Test it
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer sk-1234' \
+  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+Signed audit records appear immediately in your [Asqav dashboard](https://app.asqav.com/).
+
+</TabItem>
+</Tabs>
+
+## Environment Variables
+
+| Variable         | Description                                  |
+| ---------------- | -------------------------------------------- |
+| `ASQAV_API_KEY`  | Your Asqav API key for authentication        |
+
+## What Gets Logged?
+
+The [LiteLLM Standard Logging Payload](https://docs.litellm.ai/docs/proxy/logging_spec) is captured on each successful LLM API call, including:
+
+- Request messages and model parameters
+- Response content and finish reason
+- Token usage and cost
+- Latency metrics
+- A cryptographic signature over the full record
+
+Records are retrievable and verifiable via the Asqav API or dashboard.
+
+## Support
+
+- Docs: [docs.asqav.com](https://docs.asqav.com/)
+- Issues: [github.com/asqav/asqav-sdk](https://github.com/asqav/asqav-sdk/issues)

--- a/docs/my-website/docs/observability/asqav_integration.md
+++ b/docs/my-website/docs/observability/asqav_integration.md
@@ -3,14 +3,16 @@ import TabItem from '@theme/TabItem';
 
 # Asqav - Signed Audit Trail & AI Governance
 
-[Asqav](https://asqav.com/) provides cryptographically signed audit trails and governance for AI applications. Every LLM call is logged with a tamper-evident signature, giving compliance teams verifiable records of model inputs, outputs, and metadata.
+[Asqav](https://asqav.com/) provides cryptographically signed audit trails for AI applications. Every LLM call is signed server-side with ML-DSA, giving compliance teams verifiable, tamper-evident records of model inputs, outputs, and metadata.
+
+This integration is a self-contained custom callback that uses only `httpx` (already a LiteLLM dependency). No extra packages to install.
 
 **Key Features:**
 
-- **Signed audit logs** - Every call produces a cryptographically signed record, verifiable offline
-- **Governance callbacks** - Hook into LiteLLM's callback system with zero changes to your inference code
-- **Compliance-ready exports** - Structured logs providing compliance-ready audit trails
-- **Model and cost tracking** - Token usage, latency, and cost captured per request
+- Signed audit logs for every call, verifiable from the Asqav dashboard
+- Pure-stdlib + httpx: no extra dependencies
+- Fail-open: any Asqav outage is logged but never breaks an LLM request
+- Captures model, message count, token usage, and latency
 
 :::tip
 
@@ -21,49 +23,132 @@ https://github.com/BerriAI/litellm
 
 ## Pre-Requisites
 
+1. Create an account at [asqav.com](https://asqav.com/) and copy your API key.
+2. Create an agent in the Asqav dashboard and copy its `agent_id`.
+
 ```bash
-pip install "asqav[litellm]"
+export ASQAV_API_KEY="sk_live_..."
+export ASQAV_AGENT_ID="agent_..."
 ```
 
-Get your API key from [asqav.com](https://asqav.com/).
-
 ## Quick Start
+
+The integration is a single LiteLLM `CustomLogger` subclass. Drop it into your project and register it as a callback.
 
 <Tabs>
 <TabItem value="sdk" label="Python SDK">
 
 ```python
 import os
+import time
+import uuid
+import httpx
 import litellm
-from asqav.extras.litellm import AsqavGuardrail
+from litellm.integrations.custom_logger import CustomLogger
 
-os.environ["ASQAV_API_KEY"] = "your-asqav-api-key"
-os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
 
-# Register the Asqav callback
-asqav_handler = AsqavGuardrail()
-litellm.callbacks = [asqav_handler]
+class AsqavLogger(CustomLogger):
+    """Posts a signed audit record to Asqav after every LLM call."""
+
+    def __init__(self) -> None:
+        self.api_key = os.environ["ASQAV_API_KEY"]
+        self.agent_id = os.environ["ASQAV_AGENT_ID"]
+        self.base_url = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
+        self.session_id = str(uuid.uuid4())
+        self._client = httpx.Client(timeout=5.0)
+
+    def _sign(self, action_type: str, context: dict) -> None:
+        try:
+            self._client.post(
+                f"{self.base_url}/agents/{self.agent_id}/sign",
+                headers={"X-API-Key": self.api_key, "Content-Type": "application/json"},
+                json={"action_type": action_type, "context": context, "session_id": self.session_id},
+            )
+        except Exception as e:
+            # Fail-open: never break the LLM request on a signing error.
+            print(f"asqav signing failed: {e}")
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        usage = getattr(response_obj, "usage", None)
+        self._sign("llm:call", {
+            "model": kwargs.get("model"),
+            "message_count": len(kwargs.get("messages") or []),
+            "latency_ms": int((end_time - start_time) * 1000) if start_time and end_time else None,
+            "prompt_tokens": getattr(usage, "prompt_tokens", None),
+            "completion_tokens": getattr(usage, "completion_tokens", None),
+        })
+
+    def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self._sign("llm:error", {
+            "model": kwargs.get("model"),
+            "error": str(kwargs.get("exception") or response_obj),
+        })
+
+
+litellm.callbacks = [AsqavLogger()]
 
 response = litellm.completion(
     model="gpt-4o-mini",
     messages=[{"role": "user", "content": "Summarize the EU AI Act."}],
 )
-
 print(response)
 ```
 
-Every call is logged to Asqav with a signed audit record. No other changes to your code are needed.
+Every successful and failed call is now signed in the Asqav dashboard.
 
 </TabItem>
 <TabItem value="proxy" label="LiteLLM Proxy">
 
-### 1. Install the package on the proxy server
+### 1. Save the callback as a Python file
 
-```bash
-pip install "asqav[litellm]"
+Create `asqav_callback.py` next to your `config.yaml`:
+
+```python
+import os
+import uuid
+import httpx
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class AsqavLogger(CustomLogger):
+    def __init__(self) -> None:
+        self.api_key = os.environ["ASQAV_API_KEY"]
+        self.agent_id = os.environ["ASQAV_AGENT_ID"]
+        self.base_url = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
+        self.session_id = str(uuid.uuid4())
+        self._client = httpx.Client(timeout=5.0)
+
+    def _sign(self, action_type, context):
+        try:
+            self._client.post(
+                f"{self.base_url}/agents/{self.agent_id}/sign",
+                headers={"X-API-Key": self.api_key, "Content-Type": "application/json"},
+                json={"action_type": action_type, "context": context, "session_id": self.session_id},
+            )
+        except Exception as e:
+            print(f"asqav signing failed: {e}")
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        usage = getattr(response_obj, "usage", None)
+        self._sign("llm:call", {
+            "model": kwargs.get("model"),
+            "message_count": len(kwargs.get("messages") or []),
+            "latency_ms": int((end_time - start_time) * 1000) if start_time and end_time else None,
+            "prompt_tokens": getattr(usage, "prompt_tokens", None),
+            "completion_tokens": getattr(usage, "completion_tokens", None),
+        })
+
+    def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self._sign("llm:error", {
+            "model": kwargs.get("model"),
+            "error": str(kwargs.get("exception") or response_obj),
+        })
+
+
+asqav_logger = AsqavLogger()
 ```
 
-### 2. Add Asqav to your `config.yaml`
+### 2. Reference it from `config.yaml`
 
 ```yaml
 model_list:
@@ -73,21 +158,17 @@ model_list:
       api_key: os.environ/OPENAI_API_KEY
 
 litellm_settings:
-  callbacks: ["asqav.extras.litellm.AsqavGuardrail"]
+  callbacks: asqav_callback.asqav_logger
 
 general_settings:
   master_key: "sk-1234"
 ```
 
-Set your Asqav API key in the environment before starting the proxy:
+### 3. Set environment variables and start the proxy
 
 ```bash
-export ASQAV_API_KEY="your-asqav-api-key"
-```
-
-### 3. Start the proxy
-
-```bash
+export ASQAV_API_KEY="sk_live_..."
+export ASQAV_AGENT_ID="agent_..."
 litellm --config config.yaml
 ```
 
@@ -107,21 +188,24 @@ Signed audit records appear immediately in your [Asqav dashboard](https://asqav.
 
 ## Environment Variables
 
-| Variable         | Description                                  |
-| ---------------- | -------------------------------------------- |
-| `ASQAV_API_KEY`  | Your Asqav API key for authentication        |
+| Variable          | Required | Description                                                       |
+| ----------------- | -------- | ----------------------------------------------------------------- |
+| `ASQAV_API_KEY`   | yes      | Your Asqav API key                                                |
+| `ASQAV_AGENT_ID`  | yes      | The agent identifier created in your Asqav dashboard              |
+| `ASQAV_API_URL`   | no       | Override the API base (defaults to `https://api.asqav.com/api/v1`) |
 
 ## What Gets Logged?
 
-The [LiteLLM Standard Logging Payload](https://docs.litellm.ai/docs/proxy/logging_spec) is captured on each successful LLM API call, including:
+Each successful call sends:
 
-- Request messages and model parameters
-- Response content and finish reason
-- Token usage and cost
-- Latency metrics
-- A cryptographic signature over the full record
+- `model`: the LiteLLM model string
+- `message_count`: number of messages in the request
+- `latency_ms`: round-trip latency
+- `prompt_tokens` / `completion_tokens`: usage if reported by the provider
 
-Records are retrievable and verifiable via the Asqav API or dashboard.
+Each failed call sends the model and the error string under `llm:error`.
+
+The Asqav backend signs the record server-side with ML-DSA and returns a verification URL.
 
 ## Support
 


### PR DESCRIPTION
## Summary

Adds [Asqav](https://asqav.com/) as a callback integration in the observability docs. Asqav provides cryptographically signed audit trails and governance for LLM calls, useful for teams with SOC 2, ISO 27001, or EU AI Act compliance requirements.

- New file: `docs/my-website/docs/observability/asqav_integration.md`
- Covers SDK usage and LiteLLM Proxy `config.yaml` setup
- Matches existing integration doc format (Qualifire, Helicone, etc.)
- Install: `pip install "asqav[litellm]"`, callback class: `asqav.extras.litellm.AsqavGuardrail`

PraisonAI merged equivalent docs (MervinPraison/PraisonAIDocs#55).

## Test plan

- [ ] Verify the doc renders correctly in Docusaurus (no broken imports or MDX errors)
- [ ] Confirm `asqav[litellm]` installs cleanly and `AsqavGuardrail` is importable
- [ ] Check that the new file appears in the sidebar under Observability (autogenerated from `dirName: "observability"`)