### PR TITLE
feat(dashscope): preserve cache_control for explicit prompt caching

### DIFF
--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -4,6 +4,8 @@ Translates from OpenAI's `/v1/chat/completions` to DashScope's `/v1/chat/complet
 
 from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overload
 
+from litellm.types.llms.openai import ChatCompletionToolParam
+
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 
@@ -11,6 +13,18 @@ from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
 class DashScopeChatConfig(OpenAIGPTConfig):
+    def remove_cache_control_flag_from_messages_and_tools(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        tools: Optional[List[ChatCompletionToolParam]] = None,
+    ) -> Tuple[List[AllMessageValues], Optional[List[ChatCompletionToolParam]]]:
+        """
+        Override to preserve cache_control for DashScope.
+        DashScope supports cache_control - don't strip it.
+        """
+        return messages, tools
+
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]

--- a/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py
@@ -144,3 +144,47 @@ class TestDashScopeConfig:
         assert transformed_messages[0]["content"][0]["text"] == "Hello"
         assert transformed_messages[0]["content"][1]["type"] == "text"
         assert transformed_messages[0]["content"][1]["text"] == "World"
+
+    def test_dashscope_preserves_cache_control_in_messages(self):
+        """DashScope should NOT strip cache_control from messages."""
+        config = DashScopeChatConfig()
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant.",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {
+                "role": "user",
+                "content": "Hello, world!",
+            },
+        ]
+
+        transformed_messages, _ = config.remove_cache_control_flag_from_messages_and_tools(
+            model="dashscope/qwen-turbo", messages=messages
+        )
+
+        assert transformed_messages[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_dashscope_preserves_cache_control_in_tools(self):
+        """DashScope should NOT strip cache_control from tools."""
+        config = DashScopeChatConfig()
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather information",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+        _, transformed_tools = config.remove_cache_control_flag_from_messages_and_tools(
+            model="dashscope/qwen-turbo", messages=[], tools=tools
+        )
+
+        assert transformed_tools[0].get("cache_control") == {"type": "ephemeral"}


### PR DESCRIPTION
## Relevant issues

Fixes #25330

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The DashScope provider inherits `OpenAIGPTConfig`, which strips all `cache_control` fields from messages and tools by default via `remove_cache_control_flag_from_messages_and_tools()`. This prevents users from using explicit prompt caching with DashScope-hosted models that support it.

This PR overrides `remove_cache_control_flag_from_messages_and_tools()` in `DashScopeChatConfig` to preserve `cache_control` fields, following the exact same pattern already used by:
- ZAI (`litellm/llms/zai/chat/transformation.py`)
- MiniMax (`litellm/llms/minimax/chat/transformation.py`)
- Databricks (`litellm/llms/databricks/chat/transformation.py`)

This change is safe for models that don't use `cache_control` — if no `cache_control` field is present, the behavior is identical to before.

### Files changed

- `litellm/llms/dashscope/chat/transformation.py` — Added override method
- `tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py` — Added 2 tests for cache_control preservation in messages and tools

## Verification

Beyond the unit tests, this change was validated with live 10-round multi-turn conversation tests against the DashScope API:

**Explicit caching works correctly:**
- With `cache_control` markers on user messages, `cached_tokens` grows each round as conversation history accumulates, and `cache_creation_input_tokens` is reported on initial cache build.
- Cache hits begin from the first round after prompt tokens exceed the 1024-token threshold.

**Implicit caching is not affected:**
- Models relying on implicit prefix-matching caching produce identical `cached_tokens` values with and without this change, confirmed by running the same conversation against both the reverted codebase and the patched codebase.
- Results were further cross-validated by comparing litellm output against direct API calls (bypassing litellm entirely via raw HTTP requests to the same `/compatible-mode/v1/chat/completions` endpoint). The `cached_tokens` matched on every round.

**No regressions on non-caching models:**
- Models that do not support explicit caching were tested with `cache_control` present in the request. The DashScope API silently ignores the unrecognized field — no errors or behavioral changes observed.