### PR TITLE
fix(router): pass custom_llm_provider to get_llm_provider for unprefixed model names

### DIFF
--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -1115,7 +1115,10 @@ async def delete_file(
                 file_id=original_file_id,
             )
 
-            response = await litellm.afile_delete(**data)  # type: ignore
+            response = await litellm.afile_delete(
+                custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
+                **data,
+            )  # type: ignore
 
             verbose_proxy_logger.debug(
                 f"Deleted file using model: {model_used}"

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3864,14 +3864,29 @@ class Router:
             self._add_deployment_model_to_endpoint_for_llm_passthrough_route(
                 kwargs=kwargs, model=model, model_name=model_name
             )
-            ### get custom
-            response = original_generic_function(
-                **{
-                    **data,
-                    "caching": self.cache_responses,
-                    **kwargs,
-                }
-            )
+            
+            # Get custom_llm_provider from deployment params
+            try:
+                custom_llm_provider = data.get("custom_llm_provider")
+                _, inferred_custom_llm_provider, _, _ = get_llm_provider(
+                    model=data["model"],
+                    custom_llm_provider=custom_llm_provider,
+                )
+                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+            except Exception:
+                custom_llm_provider = None
+            
+            # Build response kwargs
+            response_kwargs = {
+                **data,
+                "caching": self.cache_responses,
+                **kwargs,
+            }
+            # Only set custom_llm_provider if it's not None
+            if custom_llm_provider is not None:
+                response_kwargs["custom_llm_provider"] = custom_llm_provider
+            
+            response = original_generic_function(**response_kwargs)
 
             rpm_semaphore = self._get_client(
                 deployment=deployment,
@@ -3961,7 +3976,12 @@ class Router:
             self.routing_strategy_pre_call_checks(deployment=deployment)
 
             try:
-                _, custom_llm_provider, _, _ = get_llm_provider(model=data["model"])
+                custom_llm_provider = data.get("custom_llm_provider")
+                _, inferred_custom_llm_provider, _, _ = get_llm_provider(
+                    model=data["model"],
+                    custom_llm_provider=custom_llm_provider,
+                )
+                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
             except Exception:
                 custom_llm_provider = None
 
@@ -4219,9 +4239,14 @@ class Router:
                 self.total_calls[model_name] += 1
 
                 ## REPLACE MODEL IN FILE WITH SELECTED DEPLOYMENT ##
-                stripped_model, custom_llm_provider, _, _ = get_llm_provider(
-                    model=data["model"]
+                # For DB/config deployments, use provider from deployment params
+                custom_llm_provider = data.get("custom_llm_provider")
+                stripped_model, inferred_custom_llm_provider, _, _ = get_llm_provider(
+                    model=data["model"],
+                    custom_llm_provider=custom_llm_provider,
                 )
+                # Preserve explicitly stored provider, fallback to inferred
+                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
 
                 ## REPLACE MODEL IN FILE WITH SELECTED DEPLOYMENT ##
                 purpose = cast(Optional[OpenAIFilesPurpose], kwargs.get("purpose"))
@@ -4367,8 +4392,13 @@ class Router:
             )
             self.total_calls[model_name] += 1
 
-            # Get custom provider
-            _, custom_llm_provider, _, _ = get_llm_provider(model=data["model"])
+            # Get custom provider from deployment params
+            custom_llm_provider = data.get("custom_llm_provider")
+            _, inferred_custom_llm_provider, _, _ = get_llm_provider(
+                model=data["model"],
+                custom_llm_provider=custom_llm_provider,
+            )
+            custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
 
             response = avector_store_create_sdk(
                 **{
@@ -4486,7 +4516,12 @@ class Router:
             self.total_calls[model_name] += 1
 
             ## SET CUSTOM PROVIDER TO SELECTED DEPLOYMENT ##
-            _, custom_llm_provider, _, _ = get_llm_provider(model=data["model"])
+            custom_llm_provider = data.get("custom_llm_provider")
+            _, inferred_custom_llm_provider, _, _ = get_llm_provider(
+                model=data["model"],
+                custom_llm_provider=custom_llm_provider,
+            )
+            custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
 
             response = litellm.acreate_batch(
                 **{
@@ -4720,7 +4755,12 @@ class Router:
             self.total_calls[model_name] += 1
 
             ## SET CUSTOM PROVIDER TO SELECTED DEPLOYMENT ##
-            _, custom_llm_provider, _, _ = get_llm_provider(model=data["model"])
+            custom_llm_provider = data.get("custom_llm_provider")
+            _, inferred_custom_llm_provider, _, _ = get_llm_provider(
+                model=data["model"],
+                custom_llm_provider=custom_llm_provider,
+            )
+            custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
 
             response = litellm.acancel_batch(
                 **{

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -238,6 +238,79 @@ async def test_async_router_acreate_file_with_jsonl():
 
 
 @pytest.mark.asyncio
+async def test_async_router_acreate_file_uses_deployment_custom_llm_provider():
+    """
+    Ensure file routing preserves deployment custom_llm_provider instead of
+    inferring provider from model string alone.
+    """
+    from unittest.mock import MagicMock, patch
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "team-azure-batch",
+                "litellm_params": {
+                    "model": "gpt-4.1-mini",
+                    "custom_llm_provider": "azure",
+                    "api_base": "https://example-resource.openai.azure.com",
+                },
+            },
+        ],
+    )
+
+    with patch("litellm.acreate_file", return_value=MagicMock()) as mock_acreate_file:
+        await router.acreate_file(
+            model="team-azure-batch",
+            purpose="batch",
+            file=MagicMock(),
+        )
+
+        assert mock_acreate_file.call_count == 1
+        assert mock_acreate_file.call_args.kwargs["custom_llm_provider"] == "azure"
+
+
+@pytest.mark.asyncio
+async def test_async_router_afile_content_uses_deployment_custom_llm_provider():
+    """
+    Regression test: Ensure afile_content preserves deployment custom_llm_provider
+    when model name lacks provider prefix (e.g., "gpt-4.1-mini" instead of "azure/gpt-4.1-mini").
+    
+    This prevents "None is not a valid LlmProviders" errors when calling file content operations.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "team-azure-batch",
+                "litellm_params": {
+                    "model": "gpt-4.1-mini",  # No provider prefix
+                    "custom_llm_provider": "azure",
+                    "api_base": "https://example-resource.openai.azure.com",
+                    "api_key": "test-key",
+                },
+            },
+        ],
+    )
+
+    # Mock the Azure file handler's afile_content method
+    mock_response = MagicMock(spec=HttpxBinaryResponseContent)
+    mock_response.response = MagicMock()
+    
+    with patch("litellm.llms.azure.files.handler.AzureOpenAIFilesAPI.afile_content", 
+               return_value=mock_response) as mock_afile_content:
+        result = await router.afile_content(
+            model="team-azure-batch",
+            file_id="file-123",
+        )
+
+        # Verify the call was made (proves custom_llm_provider was correctly passed)
+        assert mock_afile_content.call_count == 1
+        assert result == mock_response
+
+
+@pytest.mark.asyncio
 async def test_arouter_async_get_healthy_deployments():
     """
     Test that afile_content returns the correct file content


### PR DESCRIPTION
## Summary
Fixes 'LLM Provider NOT provided' errors when models are configured with `custom_llm_provider` but model names lack provider prefix (e.g., `gpt-4.1-mini` instead of `azure/gpt-4.1-mini`).

## Root Cause
The router was calling `get_llm_provider(model=data['model'])` without passing `custom_llm_provider` parameter, causing provider inference to fail for unprefixed model names.

## Changes
- Router now passes deployment's `custom_llm_provider` to `get_llm_provider()` in 6 code paths:
  - File creation (`_acreate_file`)
  - File content (`_ageneric_api_call_with_fallbacks_helper`)
  - Batch creation (`acreate_batch`)
  - Batch cancellation (`acancel_batch`)
  - Vector store creation (`avector_store_create`)
  - Generic API calls (sync version)
- File delete endpoint now explicitly passes `custom_llm_provider`
- Added 2 regression tests

<img width="781" height="761" alt="image" src="https://github.com/user-attachments/assets/2536a802-adcf-4667-8223-2cdb927d2bc0" />

