### PR TITLE
fix(vertex_ai): normalize Gemini finish_reason enum through map_finis…

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1282,9 +1282,12 @@ class CustomStreamWrapper:
                             and chunk.candidates[0].finish_reason.name  # type: ignore
                             != "FINISH_REASON_UNSPECIFIED"
                         ):  # every non-final chunk in vertex ai has this
-                            self.received_finish_reason = chunk.candidates[  # type: ignore
-                                0
-                            ].finish_reason.name
+                            from litellm.litellm_core_utils.core_helpers import (
+                                map_finish_reason,
+                            )
+                            self.received_finish_reason = map_finish_reason(  # type: ignore
+                                chunk.candidates[0].finish_reason.name
+                            )
                     except Exception:
                         if chunk.candidates[0].finish_reason.name == "SAFETY":  # type: ignore
                             raise Exception(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1282,9 +1282,6 @@ class CustomStreamWrapper:
                             and chunk.candidates[0].finish_reason.name  # type: ignore
                             != "FINISH_REASON_UNSPECIFIED"
                         ):  # every non-final chunk in vertex ai has this
-                            from litellm.litellm_core_utils.core_helpers import (
-                                map_finish_reason,
-                            )
                             self.received_finish_reason = map_finish_reason(  # type: ignore
                                 chunk.candidates[0].finish_reason.name
                             )

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1826,3 +1826,73 @@ async def test_custom_stream_wrapper_anext_exhaustion_raises_stop_async_iteratio
         pass  # expected clean termination
     except RuntimeError as e:
         pytest.fail(f"PEP 479 regression: StopIteration leaked as RuntimeError: {e}")
+
+
+def test_gemini_legacy_vertex_stop_finish_reason_normalised():
+    """
+    The legacy vertex_ai SDK streaming path sets finish_reason from a proto enum
+    whose .name attribute is an uppercase string (e.g. "STOP", "MAX_TOKENS").
+    Before the fix, received_finish_reason was stored as "STOP" which never
+    matched "stop" in finish_reason_handler, silently breaking the tool_calls
+    override.  After the fix, map_finish_reason() is applied so the value is
+    always an OpenAI-normalised lowercase string.
+    """
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="gemini-1.5-pro",
+        logging_obj=MagicMock(),
+        custom_llm_provider="vertex_ai",
+    )
+
+    # Simulate a proto-like chunk: .candidates[0].finish_reason.name == "STOP"
+    mock_finish_reason = MagicMock()
+    mock_finish_reason.name = "STOP"
+    mock_candidate = MagicMock()
+    mock_candidate.finish_reason = mock_finish_reason
+    mock_chunk = MagicMock()
+    mock_chunk.candidates = [mock_candidate]
+    # Ensure the chunk is not treated as a ModelResponseStream
+    mock_chunk.__class__ = type("FakeProtoChunk", (), {})
+
+    with patch("litellm.litellm_core_utils.streaming_handler.proto", create=True):
+        wrapper.chunk_creator(chunk=mock_chunk)
+
+    assert wrapper.received_finish_reason == "stop", (
+        f"Expected 'stop' but got {wrapper.received_finish_reason!r}. "
+        "map_finish_reason() was not applied to the Gemini enum name."
+    )
+
+
+def test_gemini_legacy_vertex_tool_calls_finish_reason_with_stop_enum():
+    """
+    When Gemini emits finish_reason STOP alongside tool-call content, the final
+    chunk must report finish_reason='tool_calls'.  This requires that the raw
+    "STOP" enum name is first normalised to lowercase "stop" by map_finish_reason()
+    so that finish_reason_handler's equality check fires correctly.
+    """
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="gemini-1.5-pro",
+        logging_obj=MagicMock(),
+        custom_llm_provider="vertex_ai",
+    )
+
+    mock_finish_reason = MagicMock()
+    mock_finish_reason.name = "STOP"
+    mock_candidate = MagicMock()
+    mock_candidate.finish_reason = mock_finish_reason
+    mock_chunk = MagicMock()
+    mock_chunk.candidates = [mock_candidate]
+    mock_chunk.__class__ = type("FakeProtoChunk", (), {})
+
+    with patch("litellm.litellm_core_utils.streaming_handler.proto", create=True):
+        wrapper.chunk_creator(chunk=mock_chunk)
+
+    # Signal that tool_calls were present in the stream
+    wrapper.tool_call = True
+
+    final = wrapper.finish_reason_handler()
+    assert final.choices[0].finish_reason == "tool_calls", (
+        f"Expected 'tool_calls' but got {final.choices[0].finish_reason!r}. "
+        "STOP enum was not normalised through map_finish_reason()."
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a case-mismatch bug in the legacy `vertex_ai` SDK streaming path that prevented `finish_reason` from being correctly reported as `"tool_calls"` when Gemini returns tool/function calls during streaming.

### Root cause

In `streaming_handler.py`, the legacy code path for raw Vertex AI SDK chunks (i.e., when `chunk` is **not** a `ModelResponseStream`) stores the Gemini finish_reason enum name directly:

```python
# Before (buggy)
self.received_finish_reason = chunk.candidates[0].finish_reason.name
# stores "STOP", "MAX_TOKENS", etc. (uppercase Gemini enum names)
```

Later, `finish_reason_handler` corrects tool-call responses with:

```python
if model_response.choices[0].finish_reason == "stop" and self.tool_call:
    model_response.choices[0].finish_reason = "tool_calls"
```

But this comparison uses **lowercase** `"stop"`, while `received_finish_reason` holds **uppercase** `"STOP"` — so the override never fires, and callers always see `finish_reason="STOP"` instead of `"tool_calls"`.

### Fix

Apply `map_finish_reason()` (already used throughout the rest of the codebase) before storing:

```python
# After (fixed)
from litellm.litellm_core_utils.core_helpers import map_finish_reason
self.received_finish_reason = map_finish_reason(
    chunk.candidates[0].finish_reason.name
)
# stores "stop", "length", "content_filter", etc.
```

This normalises all Gemini enum names to their OpenAI-compatible lowercase equivalents, making the `== "stop"` check in `finish_reason_handler` work correctly and allowing `finish_reason` to be properly set to `"tool_calls"` when tool calls are present in the response.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible — it only solves 1 specific problem
- [ ] I have added a test in the `tests/test_litellm/` directory (unit test for `finish_reason_handler` with Gemini tool-call chunk)
- [ ] My PR passes all unit tests on `make test-unit`