### PR TITLE
fix(mcp): block arbitrary command execution via stdio transport

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -13,19 +13,19 @@ To build and run the application, you will use the `docker-compose.yml` file loc
 
 ### 1. Set the Master Key
 
-The application requires a `MASTER_KEY` for signing and validating tokens. You must set this key as an environment variable before running the application.
+The application requires a `LITELLM_MASTER_KEY` for signing and validating tokens. You must set this key as an environment variable before running the application.
 
 Create a `.env` file in the root of the project and add the following line:
 
 ```
-MASTER_KEY=your-secret-key
+LITELLM_MASTER_KEY=your-secret-key
 ```
 
 Replace `your-secret-key` with a strong, randomly generated secret.
 
 ### 2. Build and Run the Containers
 
-Once you have set the `MASTER_KEY`, you can build and run the containers using the following command:
+Once you have set the `LITELLM_MASTER_KEY`, you can build and run the containers using the following command:
 
 ```bash
 docker compose up -d --build
@@ -89,4 +89,4 @@ This command should succeed (showing engine versions) even with `--network none`
 ## Troubleshooting
 
 -   **`build_admin_ui.sh: not found`**: This error can occur if the Docker build context is not set correctly. Ensure that you are running the `docker-compose` command from the root of the project.
--   **`Master key is not initialized`**: This error means the `MASTER_key` environment variable is not set. Make sure you have created a `.env` file in the project root with the `MASTER_KEY` defined.
+-   **`Master key is not initialized`**: This error means the `LITELLM_MASTER_KEY` environment variable is not set. Make sure you have created a `.env` file in the project root with the `LITELLM_MASTER_KEY` defined.

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -141,6 +141,15 @@ MCP_TOOL_LISTING_TIMEOUT = float(os.getenv("LITELLM_MCP_TOOL_LISTING_TIMEOUT", "
 MCP_METADATA_TIMEOUT = float(os.getenv("LITELLM_MCP_METADATA_TIMEOUT", "10.0"))
 MCP_HEALTH_CHECK_TIMEOUT = float(os.getenv("LITELLM_MCP_HEALTH_CHECK_TIMEOUT", "10.0"))
 
+# Allowlist of commands permitted for MCP stdio transport.
+# Prevents arbitrary command execution via /mcp-rest/test/* endpoints or server creation.
+# Extend via LITELLM_MCP_STDIO_EXTRA_COMMANDS env var (comma-separated).
+_MCP_STDIO_EXTRA_COMMANDS = os.getenv("LITELLM_MCP_STDIO_EXTRA_COMMANDS", "")
+MCP_STDIO_ALLOWED_COMMANDS: frozenset = frozenset(
+    {"npx", "uvx", "python", "python3", "node", "docker", "deno"}
+    | (set(_MCP_STDIO_EXTRA_COMMANDS.split(",")) - {""})
+)
+
 LITELLM_UI_ALLOW_HEADERS = [
     "x-litellm-semantic-filter",
     "x-litellm-semantic-filter-tools",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -143,6 +143,8 @@ MCP_HEALTH_CHECK_TIMEOUT = float(os.getenv("LITELLM_MCP_HEALTH_CHECK_TIMEOUT", "
 
 # Allowlist of commands permitted for MCP stdio transport.
 # Prevents arbitrary command execution via /mcp-rest/test/* endpoints or server creation.
+# Note: allowlisted runtimes can still execute code via args (e.g. python -c "...").
+# This is an accepted residual risk since these endpoints require PROXY_ADMIN.
 # Extend via LITELLM_MCP_STDIO_EXTRA_COMMANDS env var (comma-separated).
 _MCP_STDIO_EXTRA_COMMANDS = os.getenv("LITELLM_MCP_STDIO_EXTRA_COMMANDS", "")
 MCP_STDIO_ALLOWED_COMMANDS: frozenset = frozenset(

--- a/litellm/integrations/custom_batch_logger.py
+++ b/litellm/integrations/custom_batch_logger.py
@@ -30,6 +30,8 @@ class CustomBatchLogger(CustomLogger):
         self.batch_size: int = batch_size or litellm.DEFAULT_BATCH_SIZE
         self.last_flush_time = time.time()
         self.flush_lock = flush_lock
+        # Track health transition so we emit one metric when callback goes unhealthy.
+        self._is_in_failure_state: bool = False
 
         super().__init__(**kwargs)
 
@@ -50,9 +52,33 @@ class CustomBatchLogger(CustomLogger):
                 verbose_logger.debug(
                     "CustomLogger: Flushing batch of %s events", len(self.log_queue)
                 )
-                await self.async_send_batch()
+                try:
+                    await self.async_send_batch()
+                except Exception as e:
+                    callback_name = self._get_callback_failure_name()
+                    verbose_logger.debug(
+                        "CustomBatchLogger: batch flush failed for %s: %s",
+                        callback_name,
+                        str(e),
+                    )
+                    if not self._is_in_failure_state:
+                        self._report_callback_failure(callback_name=callback_name)
+                        self._is_in_failure_state = True
+                    else:
+                        verbose_logger.debug(
+                            "CustomBatchLogger: callback %s already in failure state, skipping duplicate metric",
+                            callback_name,
+                        )
+                    return
                 self.log_queue.clear()
                 self.last_flush_time = time.time()
+                self._is_in_failure_state = False
+
+    def _get_callback_failure_name(self) -> str:
+        """
+        Default callback name for batch failures.
+        """
+        return self.__class__.__name__
 
     async def async_send_batch(self, *args, **kwargs):
         pass

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -795,9 +795,9 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
 
         This is useful for logging payloads that contain sensitive information.
         """
-        import litellm
         from copy import copy
 
+        import litellm
         from litellm import Choices, Message, ModelResponse
 
         turn_off_message_logging: bool = getattr(
@@ -888,11 +888,12 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         """
         pass
 
-    def handle_callback_failure(self, callback_name: str):
+    def _report_callback_failure(self, callback_name: str) -> None:
         """
-        Handle callback logging failures by incrementing Prometheus metrics.
+        Report callback failures to Prometheus callback failure metric.
 
-        Call this method in exception handlers within your callback when logging fails.
+        Keep this as a single helper so callback integrations have one
+        standard failure-reporting path.
         """
         try:
             import litellm
@@ -917,8 +918,16 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             from litellm._logging import verbose_logger
 
             verbose_logger.debug(
-                f"Error in handle_callback_failure for {callback_name}: {str(e)}"
+                f"Error in _report_callback_failure for {callback_name}: {str(e)}"
             )
+
+    def handle_callback_failure(self, callback_name: str):
+        """
+        Handle callback logging failures by incrementing Prometheus metrics.
+
+        Call this method in exception handlers within your callback when logging fails.
+        """
+        self._report_callback_failure(callback_name=callback_name)
 
     async def _strip_base64_from_messages(
         self,

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -27,16 +27,16 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
-from litellm.integrations.datadog.datadog_mock_client import (
-    should_use_datadog_mock,
-    create_mock_datadog_client,
-)
 from litellm.integrations.datadog.datadog_handler import (
+    get_datadog_base_url_from_env,
     get_datadog_hostname,
     get_datadog_service,
     get_datadog_source,
     get_datadog_tags,
-    get_datadog_base_url_from_env,
+)
+from litellm.integrations.datadog.datadog_mock_client import (
+    create_mock_datadog_client,
+    should_use_datadog_mock,
 )
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.llms.custom_httpx.http_handler import (
@@ -48,10 +48,10 @@ from litellm.types.integrations.base_health_check import IntegrationHealthCheckS
 from litellm.types.integrations.datadog import (
     DD_ERRORS,
     DD_MAX_BATCH_SIZE,
-    DataDogStatus,
     DatadogInitParams,
     DatadogPayload,
     DatadogProxyFailureHookJsonMessage,
+    DataDogStatus,
 )
 from litellm.types.services import ServiceLoggerPayload, ServiceTypes
 from litellm.types.utils import StandardLoggingPayload
@@ -191,32 +191,18 @@ class DataDogLogger(
 
 
         Raises:
-            Raises a NON Blocking verbose_logger.exception if an error occurs
+            Raises exceptions to framework wrapper which handles metric tracking
         """
-        try:
-            verbose_logger.debug(
-                "Datadog: Logging - Enters logging function for model %s", kwargs
-            )
-            await self._log_async_event(kwargs, response_obj, start_time, end_time)
-
-        except Exception as e:
-            verbose_logger.exception(
-                f"Datadog Layer Error - {str(e)}\n{traceback.format_exc()}"
-            )
-            pass
+        verbose_logger.debug(
+            "Datadog: Logging - Enters logging function for model %s", kwargs
+        )
+        await self._log_async_event(kwargs, response_obj, start_time, end_time)
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
-        try:
-            verbose_logger.debug(
-                "Datadog: Logging - Enters logging function for model %s", kwargs
-            )
-            await self._log_async_event(kwargs, response_obj, start_time, end_time)
-
-        except Exception as e:
-            verbose_logger.exception(
-                f"Datadog Layer Error - {str(e)}\n{traceback.format_exc()}"
-            )
-            pass
+        verbose_logger.debug(
+            "Datadog: Logging - Enters logging function for model %s", kwargs
+        )
+        await self._log_async_event(kwargs, response_obj, start_time, end_time)
 
     async def async_post_call_failure_hook(
         self,
@@ -301,11 +287,12 @@ class DataDogLogger(
             self.log_queue.append(dd_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
         except Exception as e:
             verbose_logger.exception(
                 f"Datadog: async_post_call_failure_hook - {str(e)}\n{traceback.format_exc()}"
             )
+            raise
         return None
 
     async def async_send_batch(self):
@@ -360,6 +347,7 @@ class DataDogLogger(
             verbose_logger.exception(
                 f"Datadog Error sending batch API - {str(e)}\n{traceback.format_exc()}"
             )
+            raise
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -368,52 +356,44 @@ class DataDogLogger(
         - Creates a Datadog payload
         - instantly logs it on DD API
         """
-        try:
-            if litellm.datadog_use_v1 is True:
-                dd_payload = self._create_v0_logging_payload(
-                    kwargs=kwargs,
-                    response_obj=response_obj,
-                    start_time=start_time,
-                    end_time=end_time,
-                )
-            else:
-                dd_payload = self.create_datadog_logging_payload(
-                    kwargs=kwargs,
-                    response_obj=response_obj,
-                    start_time=start_time,
-                    end_time=end_time,
-                )
-
-            # Build headers
-            headers = {}
-            # Add API key if available (required for direct API, optional for agent)
-            if self.DD_API_KEY:
-                headers["DD-API-KEY"] = self.DD_API_KEY
-
-            response = self.sync_client.post(
-                url=self.intake_url,
-                json=dd_payload,  # type: ignore
-                headers=headers,
+        if litellm.datadog_use_v1 is True:
+            dd_payload = self._create_v0_logging_payload(
+                kwargs=kwargs,
+                response_obj=response_obj,
+                start_time=start_time,
+                end_time=end_time,
+            )
+        else:
+            dd_payload = self.create_datadog_logging_payload(
+                kwargs=kwargs,
+                response_obj=response_obj,
+                start_time=start_time,
+                end_time=end_time,
             )
 
-            response.raise_for_status()
-            if response.status_code != 202:
-                raise Exception(
-                    f"Response from datadog API status_code: {response.status_code}, text: {response.text}"
-                )
+        # Build headers
+        headers = {}
+        # Add API key if available (required for direct API, optional for agent)
+        if self.DD_API_KEY:
+            headers["DD-API-KEY"] = self.DD_API_KEY
 
-            verbose_logger.debug(
-                "Datadog: Response from datadog API status_code: %s, text: %s",
-                response.status_code,
-                response.text,
+        response = self.sync_client.post(
+            url=self.intake_url,
+            json=dd_payload,  # type: ignore
+            headers=headers,
+        )
+
+        response.raise_for_status()
+        if response.status_code != 202:
+            raise Exception(
+                f"Response from datadog API status_code: {response.status_code}, text: {response.text}"
             )
 
-        except Exception as e:
-            verbose_logger.exception(
-                f"Datadog Layer Error - {str(e)}\n{traceback.format_exc()}"
-            )
-            pass
-        pass
+        verbose_logger.debug(
+            "Datadog: Response from datadog API status_code: %s, text: %s",
+            response.status_code,
+            response.text,
+        )
 
     async def _log_async_event(self, kwargs, response_obj, start_time, end_time):
         dd_payload = self.create_datadog_logging_payload(
@@ -429,7 +409,7 @@ class DataDogLogger(
         )
 
         if len(self.log_queue) >= self.batch_size:
-            await self.async_send_batch()
+            await self.flush_queue()
 
     def _create_datadog_logging_payload_helper(
         self,

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -9,7 +9,6 @@ API Reference: https://docs.datadoghq.com/llm_observability/setup/api/?tab=examp
 import asyncio
 import json
 import os
-from litellm._uuid import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -17,15 +16,16 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm._uuid import uuid
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
-from litellm.integrations.datadog.datadog_mock_client import (
-    should_use_datadog_mock,
-    create_mock_datadog_client,
-)
 from litellm.integrations.datadog.datadog_handler import (
+    get_datadog_base_url_from_env,
     get_datadog_service,
     get_datadog_tags,
-    get_datadog_base_url_from_env,
+)
+from litellm.integrations.datadog.datadog_mock_client import (
+    create_mock_datadog_client,
+    should_use_datadog_mock,
 )
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -152,36 +152,26 @@ class DataDogLLMObsLogger(CustomBatchLogger):
         return dict_datadog_llm_obs_params
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
-        try:
-            verbose_logger.debug(
-                f"DataDogLLMObs: Logging success event for model {kwargs.get('model', 'unknown')}"
-            )
-            payload = self.create_llm_obs_payload(kwargs, start_time, end_time)
-            verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
-            self.log_queue.append(payload)
+        verbose_logger.debug(
+            f"DataDogLLMObs: Logging success event for model {kwargs.get('model', 'unknown')}"
+        )
+        payload = self.create_llm_obs_payload(kwargs, start_time, end_time)
+        verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
+        self.log_queue.append(payload)
 
-            if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
-        except Exception as e:
-            verbose_logger.exception(
-                f"DataDogLLMObs: Error logging success event - {str(e)}"
-            )
+        if len(self.log_queue) >= self.batch_size:
+            await self.flush_queue()
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
-        try:
-            verbose_logger.debug(
-                f"DataDogLLMObs: Logging failure event for model {kwargs.get('model', 'unknown')}"
-            )
-            payload = self.create_llm_obs_payload(kwargs, start_time, end_time)
-            verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
-            self.log_queue.append(payload)
+        verbose_logger.debug(
+            f"DataDogLLMObs: Logging failure event for model {kwargs.get('model', 'unknown')}"
+        )
+        payload = self.create_llm_obs_payload(kwargs, start_time, end_time)
+        verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
+        self.log_queue.append(payload)
 
-            if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
-        except Exception as e:
-            verbose_logger.exception(
-                f"DataDogLLMObs: Error logging failure event - {str(e)}"
-            )
+        if len(self.log_queue) >= self.batch_size:
+            await self.flush_queue()
 
     async def async_send_batch(self):
         try:
@@ -249,8 +239,10 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             verbose_logger.exception(
                 f"DataDogLLMObs: Error sending batch - {e.response.text}"
             )
+            raise
         except Exception as e:
             verbose_logger.exception(f"DataDogLLMObs: Error sending batch - {str(e)}")
+            raise
 
     def create_llm_obs_payload(
         self, kwargs: Dict, start_time: datetime, end_time: datetime

--- a/litellm/integrations/datadog/datadog_metrics.py
+++ b/litellm/integrations/datadog/datadog_metrics.py
@@ -155,55 +155,41 @@ class DatadogMetricsLogger(CustomBatchLogger):
         self.log_queue.append(series_count)
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
-        try:
-            standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
-                "standard_logging_object", None
-            )
+        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
+            "standard_logging_object", None
+        )
 
-            if standard_logging_object is None:
-                return
+        if standard_logging_object is None:
+            return
 
-            self._add_metrics_from_log(
-                log=standard_logging_object, kwargs=kwargs, status_code="200"
-            )
+        self._add_metrics_from_log(
+            log=standard_logging_object, kwargs=kwargs, status_code="200"
+        )
 
-            if len(self.log_queue) >= self.batch_size:
-                await self.flush_queue()
-
-        except Exception as e:
-            verbose_logger.exception(
-                f"Datadog Metrics: Error in async_log_success_event: {str(e)}"
-            )
+        if len(self.log_queue) >= self.batch_size:
+            await self.flush_queue()
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
-        try:
-            standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
-                "standard_logging_object", None
-            )
+        standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
+            "standard_logging_object", None
+        )
 
-            if standard_logging_object is None:
-                return
+        if standard_logging_object is None:
+            return
 
-            # Extract status code from error information
-            status_code = "500"  # default
-            error_information = (
-                standard_logging_object.get("error_information", {}) or {}
-            )
-            error_code = error_information.get("error_code")  # type: ignore
-            if error_code is not None:
-                status_code = str(error_code)
+        # Extract status code from error information
+        status_code = "500"  # default
+        error_information = standard_logging_object.get("error_information", {}) or {}
+        error_code = error_information.get("error_code")  # type: ignore
+        if error_code is not None:
+            status_code = str(error_code)
 
-            self._add_metrics_from_log(
-                log=standard_logging_object, kwargs=kwargs, status_code=status_code
-            )
+        self._add_metrics_from_log(
+            log=standard_logging_object, kwargs=kwargs, status_code=status_code
+        )
 
-            if len(self.log_queue) >= self.batch_size:
-                await self.flush_queue()
-
-        except Exception as e:
-            verbose_logger.exception(
-                f"Datadog Metrics: Error in async_log_failure_event: {str(e)}"
-            )
+        if len(self.log_queue) >= self.batch_size:
+            await self.flush_queue()
 
     async def async_send_batch(self):
         if not self.log_queue:

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -160,6 +160,7 @@ class OpenTelemetry(CustomLogger):
         self.OTEL_EXPORTER = self.config.exporter
         self.OTEL_ENDPOINT = self.config.endpoint
         self.OTEL_HEADERS = self.config.headers
+        self._span_export_in_failure_state = False
         self._tracer_provider_cache: Dict[str, Any] = {}
         self._init_tracing(tracer_provider)
 
@@ -294,7 +295,7 @@ class OpenTelemetry(CustomLogger):
         return provider
 
     def _init_tracing(self, tracer_provider):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.trace import SpanKind
 
@@ -333,7 +334,7 @@ class OpenTelemetry(CustomLogger):
             self._response_duration_histogram = None
             return
 
-        from opentelemetry import metrics
+        import opentelemetry.metrics as metrics
         from opentelemetry.sdk.metrics import MeterProvider
 
         def create_meter_provider():
@@ -433,7 +434,7 @@ class OpenTelemetry(CustomLogger):
         end_time: Optional[Union[datetime, float]] = None,
         event_metadata: Optional[dict] = None,
     ):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.trace import Status, StatusCode
 
         _start_time_ns = 0
@@ -493,7 +494,7 @@ class OpenTelemetry(CustomLogger):
         end_time: Optional[Union[float, datetime]] = None,
         event_metadata: Optional[dict] = None,
     ):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.trace import Status, StatusCode
 
         _start_time_ns = 0
@@ -555,7 +556,7 @@ class OpenTelemetry(CustomLogger):
         user_api_key_dict: UserAPIKeyAuth,
         traceback_str: Optional[str] = None,
     ):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.trace import Status, StatusCode
 
         parent_otel_span = user_api_key_dict.parent_otel_span
@@ -746,7 +747,7 @@ class OpenTelemetry(CustomLogger):
             span = None
             # Only set attributes if the span is still recording (not closed)
             # Note: parent_span is guaranteed to be not None here
-            if hasattr(parent_span, "set_status"):
+            if parent_span is not None and hasattr(parent_span, "set_status"):
                 parent_span.set_status(Status(StatusCode.OK))
                 self.set_attributes(parent_span, kwargs, response_obj)
             # Raw-request as direct child of parent_span
@@ -808,7 +809,7 @@ class OpenTelemetry(CustomLogger):
     def _maybe_log_raw_request(
         self, kwargs, response_obj, start_time, end_time, parent_span
     ):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.trace import Status, StatusCode
 
         # only log raw LLM request/response if message_logging is on and not globally turned off
@@ -1076,8 +1077,8 @@ class OpenTelemetry(CustomLogger):
         from opentelemetry._logs import SeverityNumber, get_logger
 
         try:
-            from opentelemetry.sdk._logs import (  # type: ignore[attr-defined]  # OTEL < 1.39.0
-                LogRecord as SdkLogRecord,
+            from opentelemetry.sdk._logs import (
+                LogRecord as SdkLogRecord,  # type: ignore[attr-defined]  # OTEL < 1.39.0
             )
         except ImportError:
             from opentelemetry.sdk._logs._internal import (
@@ -1159,7 +1160,7 @@ class OpenTelemetry(CustomLogger):
           2. The parent proxy-request span
           3. The original fallback context (may be None — last resort)
         """
-        from opentelemetry import trace as _trace
+        import opentelemetry.trace as _trace
 
         if span is not None:
             return _trace.set_span_in_context(span)
@@ -1288,7 +1289,7 @@ class OpenTelemetry(CustomLogger):
             # record error on parent span (keeps hierarchy shallow)
             # Only set attributes if the span is still recording (not closed)
             # Note: parent_otel_span is guaranteed to be not None here
-            if parent_otel_span.is_recording():
+            if parent_otel_span is not None and parent_otel_span.is_recording():
                 parent_otel_span.set_status(Status(StatusCode.ERROR))
                 self.set_attributes(parent_otel_span, kwargs, response_obj)
                 self._record_exception_on_span(span=parent_otel_span, kwargs=kwargs)
@@ -1923,7 +1924,8 @@ class OpenTelemetry(CustomLogger):
         return _parent_context
 
     def _get_span_context(self, kwargs, default_span: Optional[Span] = None):
-        from opentelemetry import context, trace
+        import opentelemetry.context as context
+        import opentelemetry.trace as trace
         from opentelemetry.trace.propagation.tracecontext import (
             TraceContextTextMapPropagator,
         )
@@ -2016,7 +2018,10 @@ class OpenTelemetry(CustomLogger):
                 "OpenTelemetry: intiializing SpanExporter. Value of OTEL_EXPORTER: %s",
                 self.OTEL_EXPORTER,
             )
-            return SimpleSpanProcessor(cast(SpanExporter, self.OTEL_EXPORTER))
+            wrapped_exporter = self._wrap_exporter_with_failure_tracking(
+                cast(SpanExporter, self.OTEL_EXPORTER)
+            )
+            return SimpleSpanProcessor(cast(SpanExporter, wrapped_exporter))
 
         if self.OTEL_EXPORTER == "console":
             verbose_logger.debug(
@@ -2046,11 +2051,12 @@ class OpenTelemetry(CustomLogger):
             normalized_endpoint = self._normalize_otel_endpoint(
                 self.OTEL_ENDPOINT, "traces"
             )
-            return BatchSpanProcessor(
+            wrapped_exporter = self._wrap_exporter_with_failure_tracking(
                 OTLPSpanExporterHTTP(
                     endpoint=normalized_endpoint, headers=_split_otel_headers
-                ),
+                )
             )
+            return BatchSpanProcessor(cast(SpanExporter, wrapped_exporter))
         elif self.OTEL_EXPORTER == "otlp_grpc" or self.OTEL_EXPORTER == "grpc":
             try:
                 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
@@ -2069,17 +2075,78 @@ class OpenTelemetry(CustomLogger):
             normalized_endpoint = self._normalize_otel_endpoint(
                 self.OTEL_ENDPOINT, "traces"
             )
-            return BatchSpanProcessor(
+            wrapped_exporter = self._wrap_exporter_with_failure_tracking(
                 OTLPSpanExporterGRPC(
                     endpoint=normalized_endpoint, headers=_split_otel_headers
-                ),
+                )
             )
+            return BatchSpanProcessor(cast(SpanExporter, wrapped_exporter))
         else:
             verbose_logger.debug(
                 "OpenTelemetry: intiializing console exporter. Value of OTEL_EXPORTER: %s",
                 self.OTEL_EXPORTER,
             )
             return BatchSpanProcessor(ConsoleSpanExporter())
+
+    def _wrap_exporter_with_failure_tracking(self, exporter: SpanExporter) -> Any:
+        parent = self
+
+        class _FailureTrackingExporter:
+            def __init__(self, wrapped_exporter: SpanExporter):
+                self._wrapped_exporter = wrapped_exporter
+
+            def export(self, spans):
+                try:
+                    result = self._wrapped_exporter.export(spans)
+                except Exception:
+                    parent._report_span_export_failure()
+                    raise
+
+                if parent._is_failed_span_export_result(result):
+                    parent._report_span_export_failure()
+                else:
+                    parent._mark_span_export_success()
+                return result
+
+            def shutdown(self):
+                if hasattr(self._wrapped_exporter, "shutdown"):
+                    return self._wrapped_exporter.shutdown()
+                return None
+
+            def force_flush(self, timeout_millis: int = 30000):
+                if hasattr(self._wrapped_exporter, "force_flush"):
+                    return self._wrapped_exporter.force_flush(timeout_millis)
+                return True
+
+        return _FailureTrackingExporter(exporter)
+
+    @staticmethod
+    def _is_failed_span_export_result(result: Any) -> bool:
+        try:
+            from opentelemetry.sdk.trace.export import SpanExportResult
+
+            return result == SpanExportResult.FAILURE
+        except Exception:
+            normalized_result = str(result).strip().lower()
+            return normalized_result == "failure" or normalized_result.endswith(
+                ".failure"
+            )
+
+    def _get_callback_failure_metric_name(self) -> str:
+        if self.callback_name:
+            return self.callback_name
+        return self.__class__.__name__
+
+    def _report_span_export_failure(self) -> None:
+        if self._span_export_in_failure_state:
+            return
+        self._report_callback_failure(
+            callback_name=self._get_callback_failure_metric_name()
+        )
+        self._span_export_in_failure_state = True
+
+    def _mark_span_export_success(self) -> None:
+        self._span_export_in_failure_state = False
 
     def _get_log_exporter(self):
         """
@@ -2327,7 +2394,7 @@ class OpenTelemetry(CustomLogger):
         logging_payload: ManagementEndpointLoggingPayload,
         parent_otel_span: Optional[Span] = None,
     ):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.trace import Status, StatusCode
 
         _start_time_ns = 0
@@ -2380,7 +2447,7 @@ class OpenTelemetry(CustomLogger):
         logging_payload: ManagementEndpointLoggingPayload,
         parent_otel_span: Optional[Span] = None,
     ):
-        from opentelemetry import trace
+        import opentelemetry.trace as trace
         from opentelemetry.trace import Status, StatusCode
 
         _start_time_ns = 0

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1,4 +1,5 @@
 import os
+import types
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
@@ -2089,36 +2090,32 @@ class OpenTelemetry(CustomLogger):
             return BatchSpanProcessor(ConsoleSpanExporter())
 
     def _wrap_exporter_with_failure_tracking(self, exporter: SpanExporter) -> Any:
+        if getattr(exporter, "_litellm_failure_tracking_wrapped", False):
+            return exporter
+
+        original_export = exporter.export
         parent = self
 
-        class _FailureTrackingExporter:
-            def __init__(self, wrapped_exporter: SpanExporter):
-                self._wrapped_exporter = wrapped_exporter
+        def _export_with_failure_tracking(self, spans):
+            try:
+                result = original_export(spans)
+            except Exception:
+                parent._report_span_export_failure()
+                raise
 
-            def export(self, spans):
-                try:
-                    result = self._wrapped_exporter.export(spans)
-                except Exception:
-                    parent._report_span_export_failure()
-                    raise
+            if parent._is_failed_span_export_result(result):
+                parent._report_span_export_failure()
+            else:
+                parent._mark_span_export_success()
+            return result
 
-                if parent._is_failed_span_export_result(result):
-                    parent._report_span_export_failure()
-                else:
-                    parent._mark_span_export_success()
-                return result
-
-            def shutdown(self):
-                if hasattr(self._wrapped_exporter, "shutdown"):
-                    return self._wrapped_exporter.shutdown()
-                return None
-
-            def force_flush(self, timeout_millis: int = 30000):
-                if hasattr(self._wrapped_exporter, "force_flush"):
-                    return self._wrapped_exporter.force_flush(timeout_millis)
-                return True
-
-        return _FailureTrackingExporter(exporter)
+        setattr(
+            exporter,
+            "export",
+            types.MethodType(_export_with_failure_tracking, exporter),
+        )
+        setattr(exporter, "_litellm_failure_tracking_wrapped", True)
+        return exporter
 
     @staticmethod
     def _is_failed_span_export_result(result: Any) -> bool:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3094,6 +3094,11 @@ class Logging(LiteLLMLoggingBaseClass):
                     )
                     if capture_exception:  # log this error to sentry for debugging
                         capture_exception(e)
+                    # Track callback logging failures in Prometheus
+                    try:
+                        self._handle_callback_failure(callback=callback)
+                    except Exception:
+                        pass
         except Exception as e:
             verbose_logger.exception(
                 "LiteLLM.LoggingError: [Non-Blocking] Exception occurred while failure logging {}".format(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1122,6 +1122,20 @@ class MCPServerManager:
                 from litellm.constants import MCP_NPM_CACHE_DIR
 
                 resolved_env["NPM_CONFIG_CACHE"] = MCP_NPM_CACHE_DIR
+            # Defense-in-depth: validate command even if Pydantic validation was bypassed
+            # (e.g. MCPServer built from config/DB records predating the allowlist)
+            if server.command:
+                import os as _os
+
+                from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
+
+                base_command = _os.path.basename(server.command)
+                if base_command not in MCP_STDIO_ALLOWED_COMMANDS:
+                    raise ValueError(
+                        f"Command '{server.command}' is not in the allowed commands list "
+                        f"for stdio transport. Allowed commands: {sorted(MCP_STDIO_ALLOWED_COMMANDS)}"
+                    )
+
             stdio_config: Optional[MCPStdioConfig] = None
             if server.command and server.args is not None:
                 stdio_config = MCPStdioConfig(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1122,8 +1122,9 @@ class MCPServerManager:
                 from litellm.constants import MCP_NPM_CACHE_DIR
 
                 resolved_env["NPM_CONFIG_CACHE"] = MCP_NPM_CACHE_DIR
-            # Defense-in-depth: validate command even if Pydantic validation was bypassed
-            # (e.g. MCPServer built from config/DB records predating the allowlist)
+            # Defense-in-depth: warn for commands not in the allowlist.
+            # The Pydantic validator blocks new servers; this catches legacy
+            # config/DB records predating the allowlist.
             if server.command:
                 import os as _os
 
@@ -1131,9 +1132,12 @@ class MCPServerManager:
 
                 base_command = _os.path.basename(server.command)
                 if base_command not in MCP_STDIO_ALLOWED_COMMANDS:
-                    raise ValueError(
-                        f"Command '{server.command}' is not in the allowed commands list "
-                        f"for stdio transport. Allowed commands: {sorted(MCP_STDIO_ALLOWED_COMMANDS)}"
+                    verbose_logger.warning(
+                        "MCP stdio command '%s' is not in the allowlist (%s). "
+                        "Add it to LITELLM_MCP_STDIO_EXTRA_COMMANDS to suppress this warning. "
+                        "A future release may block non-allowlisted commands.",
+                        server.command,
+                        sorted(MCP_STDIO_ALLOWED_COMMANDS),
                     )
 
             stdio_config: Optional[MCPStdioConfig] = None

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -2,14 +2,14 @@ import importlib
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Set, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.ui_session_utils import (
     build_effective_auth_contexts,
 )
 from litellm.proxy._experimental.mcp_server.utils import merge_mcp_headers
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.http_parsing_utils import _safe_get_request_headers
@@ -1027,6 +1027,13 @@ if MCP_AVAILABLE:
         """
         Test if we can connect to the provided MCP server before adding it
         """
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "User does not have permission to test MCP server connections. Only PROXY_ADMIN users can perform this action."
+                },
+            )
 
         async def _test_connection_operation(client):
             async def _noop(session):
@@ -1041,7 +1048,7 @@ if MCP_AVAILABLE:
             raw_headers=_safe_get_request_headers(request),
         )
 
-    @router.post("/test/tools/list")
+    @router.post("/test/tools/list", dependencies=[Depends(user_api_key_auth)])
     async def test_tools_list(
         request: Request,
         new_mcp_server_request: NewMCPServerRequest,
@@ -1050,6 +1057,14 @@ if MCP_AVAILABLE:
         """
         Preview tools available from MCP server before adding it
         """
+        if LitellmUserRoles.PROXY_ADMIN != user_api_key_dict.user_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "User does not have permission to test MCP server tools. Only PROXY_ADMIN users can perform this action."
+                },
+            )
+
         # For OpenAPI spec servers, generate tools from the spec directly
         if new_mcp_server_request.spec_path:
             return await _preview_openapi_tools(new_mcp_server_request.spec_path)

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1,5 +1,6 @@
 import enum
 import json
+import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
@@ -1163,11 +1164,9 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
                 if not values.get("args"):
                     raise ValueError("args is required for stdio transport")
                 # Validate command against allowlist to prevent arbitrary execution
-                import os as _os
-
                 from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
 
-                base_command = _os.path.basename(values["command"])
+                base_command = os.path.basename(values["command"])
                 if base_command not in MCP_STDIO_ALLOWED_COMMANDS:
                     raise ValueError(
                         f"Command '{values['command']}' is not in the allowed commands list "
@@ -1234,11 +1233,9 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
                 if not values.get("args"):
                     raise ValueError("args is required for stdio transport")
                 # Validate command against allowlist to prevent arbitrary execution
-                import os as _os
-
                 from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
 
-                base_command = _os.path.basename(values["command"])
+                base_command = os.path.basename(values["command"])
                 if base_command not in MCP_STDIO_ALLOWED_COMMANDS:
                     raise ValueError(
                         f"Command '{values['command']}' is not in the allowed commands list "

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1162,6 +1162,17 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
                     raise ValueError("command is required for stdio transport")
                 if not values.get("args"):
                     raise ValueError("args is required for stdio transport")
+                # Validate command against allowlist to prevent arbitrary execution
+                import os as _os
+
+                from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
+
+                base_command = _os.path.basename(values["command"])
+                if base_command not in MCP_STDIO_ALLOWED_COMMANDS:
+                    raise ValueError(
+                        f"Command '{values['command']}' is not in the allowed commands list "
+                        f"for stdio transport. Allowed commands: {sorted(MCP_STDIO_ALLOWED_COMMANDS)}"
+                    )
             elif transport in [MCPTransport.http, MCPTransport.sse]:
                 if not values.get("url") and not values.get("spec_path"):
                     raise ValueError(
@@ -1222,6 +1233,17 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
                     raise ValueError("command is required for stdio transport")
                 if not values.get("args"):
                     raise ValueError("args is required for stdio transport")
+                # Validate command against allowlist to prevent arbitrary execution
+                import os as _os
+
+                from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
+
+                base_command = _os.path.basename(values["command"])
+                if base_command not in MCP_STDIO_ALLOWED_COMMANDS:
+                    raise ValueError(
+                        f"Command '{values['command']}' is not in the allowed commands list "
+                        f"for stdio transport. Allowed commands: {sorted(MCP_STDIO_ALLOWED_COMMANDS)}"
+                    )
             elif transport in [MCPTransport.http, MCPTransport.sse]:
                 if not values.get("url") and not values.get("spec_path"):
                     raise ValueError(

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
@@ -2,6 +2,7 @@
 Mock prometheus unit tests, these don't rely on LLM API calls
 """
 
+import asyncio
 import json
 import os
 import sys
@@ -13,7 +14,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest_asyncio
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -1056,6 +1057,94 @@ async def test_langfuse_otel_callback_failure_metric(prometheus_logger):
             mock_increment.assert_called_with(callback_name="langfuse_otel")
     
     print("✓ Langfuse OTEL callback failure metric test passed")
+
+
+@pytest.mark.asyncio
+async def test_custom_batch_logger_auto_failure_reporting():
+    """
+    Ensure batch logger failures are reported automatically via shared flush path.
+    """
+    from litellm.integrations.custom_batch_logger import CustomBatchLogger
+
+    class _TestBatchLogger(CustomBatchLogger):
+        def _get_callback_failure_name(self) -> str:
+            return "AutoTestLogger"
+
+        async def async_send_batch(self, *args, **kwargs):
+            raise RuntimeError("batch send failed")
+
+    logger = _TestBatchLogger(flush_lock=asyncio.Lock(), batch_size=1)
+    logger.log_queue.append({"dummy": "event"})
+
+    with patch.object(logger, "_report_callback_failure") as mock_report:
+        await logger.flush_queue()
+        mock_report.assert_called_once_with(callback_name="AutoTestLogger")
+
+
+@pytest.mark.asyncio
+async def test_custom_batch_logger_dedupes_repeated_failed_batch_metric():
+    """
+    Ensure periodic retries for the same failed batch do not over-increment metrics.
+    """
+    from litellm.integrations.custom_batch_logger import CustomBatchLogger
+
+    class _TestBatchLogger(CustomBatchLogger):
+        def _get_callback_failure_name(self) -> str:
+            return "AutoTestLogger"
+
+        async def async_send_batch(self, *args, **kwargs):
+            raise RuntimeError("batch send failed")
+
+    logger = _TestBatchLogger(flush_lock=asyncio.Lock(), batch_size=1)
+    logger.log_queue.append({"dummy": "event"})
+
+    with patch.object(logger, "_report_callback_failure") as mock_report:
+        await logger.flush_queue()
+        logger.log_queue.append({"dummy": "event-2"})
+        await logger.flush_queue()
+        await logger.flush_queue()
+        mock_report.assert_called_once_with(callback_name="AutoTestLogger")
+
+
+def test_otel_exporter_failure_reports_callback_metric_once_per_outage():
+    """
+    Ensure OTEL exporter failures increment callback failure metric and dedupe
+    repeated failures until export recovers.
+    """
+    from opentelemetry.sdk.trace.export import SpanExportResult
+
+    from litellm.integrations.opentelemetry import OpenTelemetry
+
+    class _DummyExporter:
+        def __init__(self):
+            self._results = [
+                SpanExportResult.FAILURE,
+                SpanExportResult.FAILURE,
+                SpanExportResult.SUCCESS,
+                SpanExportResult.FAILURE,
+            ]
+            self._idx = 0
+
+        def export(self, spans):
+            result = self._results[self._idx]
+            self._idx += 1
+            return result
+
+    otel_logger = OpenTelemetry.__new__(OpenTelemetry)
+    otel_logger.callback_name = "ArizeLogger"
+    otel_logger._span_export_in_failure_state = False
+
+    with patch.object(otel_logger, "_report_callback_failure") as mock_report:
+        wrapped_exporter = otel_logger._wrap_exporter_with_failure_tracking(
+            _DummyExporter()
+        )
+        wrapped_exporter.export([])
+        wrapped_exporter.export([])
+        wrapped_exporter.export([])
+        wrapped_exporter.export([])
+
+        assert mock_report.call_count == 2
+        mock_report.assert_any_call(callback_name="ArizeLogger")
 
 
 # ==============================================================================

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -156,7 +156,6 @@ class TestExecuteWithMcpClient:
             "Authorization": "STATIC token",
         }
 
-
     @pytest.mark.asyncio
     async def test_m2m_credentials_forwarded_to_server_model(self, monkeypatch):
         """M2M OAuth credentials (client_id, client_secret) from the nested
@@ -199,9 +198,7 @@ class TestExecuteWithMcpClient:
             },
         )
 
-        result = await rest_endpoints._execute_with_mcp_client(
-            payload, ok_operation
-        )
+        result = await rest_endpoints._execute_with_mcp_client(payload, ok_operation)
 
         assert result["status"] == "ok"
         server = captured["server"]
@@ -262,7 +259,10 @@ class TestExecuteWithMcpClient:
         assert result["status"] == "ok"
         # The incoming Authorization must be dropped — extra_headers should
         # contain no oauth2 headers (only static_headers, which are None here).
-        assert captured["extra_headers"] is None or "Authorization" not in captured["extra_headers"]
+        assert (
+            captured["extra_headers"] is None
+            or "Authorization" not in captured["extra_headers"]
+        )
 
     @pytest.mark.asyncio
     async def test_catches_exception_group(self, monkeypatch):
@@ -300,9 +300,7 @@ class TestExecuteWithMcpClient:
             auth_type=MCPAuth.none,
         )
 
-        result = await rest_endpoints._execute_with_mcp_client(
-            payload, ok_operation
-        )
+        result = await rest_endpoints._execute_with_mcp_client(payload, ok_operation)
 
         assert result["status"] == "error"
         assert result["error"] is True
@@ -365,8 +363,12 @@ class TestTestToolsList:
             credentials={"auth_value": "secret-key"},
         )
 
+        from litellm.proxy._types import LitellmUserRoles
+
         result = await rest_endpoints.test_tools_list(
-            request, payload, user_api_key_dict=UserAPIKeyAuth()
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
         )
 
         assert result["message"] == "Successfully retrieved tools"
@@ -419,8 +421,12 @@ class TestTestToolsList:
             auth_type=MCPAuth.oauth2,
         )
 
+        from litellm.proxy._types import LitellmUserRoles
+
         result = await rest_endpoints.test_tools_list(
-            request, payload, user_api_key_dict=UserAPIKeyAuth()
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
         )
 
         assert result["message"] == "Successfully retrieved tools"
@@ -484,7 +490,11 @@ class TestListToolsRestAPI:
         captured = {"called": False}
 
         async def fake_get_tools(
-            server, server_auth_header, raw_headers=None, user_api_key_auth=None, extra_headers=None
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
         ):
             captured["called"] = True
             captured["server"] = server
@@ -555,27 +565,47 @@ class TestListToolsRestAPI:
 
         captured = {"called": False, "server_arg": None}
 
-        async def fake_get_tools(server, server_auth_header, raw_headers=None, user_api_key_auth=None, extra_headers=None):
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+        ):
             captured["called"] = True
             captured["server_arg"] = server
             return ["tool-x"]
 
-        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts, raising=False)
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_allowed_mcp_servers",
-            fake_get_allowed_mcp_servers, raising=False,
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
         )
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_name",
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_name",
             lambda name: stub_server if name == "my-server" else None,
             raising=False,
         )
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_id",
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
             lambda sid: stub_server if sid == "uuid-abc-123" else None,
             raising=False,
         )
-        monkeypatch.setattr(rest_endpoints, "_get_tools_for_single_server", fake_get_tools, raising=False)
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
 
         request = _build_request(path="/mcp-rest/tools/list", method="GET")
         result = await rest_endpoints.list_tool_rest_api(
@@ -609,18 +639,27 @@ class TestListToolsRestAPI:
         async def fake_get_allowed_mcp_servers(*args, **kwargs):
             return []
 
-        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts, raising=False)
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_allowed_mcp_servers",
-            fake_get_allowed_mcp_servers, raising=False,
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
         )
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_name",
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_name",
             lambda name: stub_server if name == "restricted-server" else None,
             raising=False,
         )
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_id",
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
             lambda sid: stub_server if sid == "uuid-xyz-999" else None,
             raising=False,
         )
@@ -662,31 +701,54 @@ class TestListToolsRestAPI:
 
         oauth_headers = {"Authorization": "Bearer user-oauth-token"}
 
-        async def fake_get_user_oauth_extra_headers(server, user_api_key_dict, prefetched_creds=None):
+        async def fake_get_user_oauth_extra_headers(
+            server, user_api_key_dict, prefetched_creds=None
+        ):
             return oauth_headers
 
         captured = {}
 
-        async def fake_get_tools(server, server_auth_header, raw_headers=None, user_api_key_auth=None, extra_headers=None):
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+        ):
             captured["server"] = server
             captured["auth_header"] = server_auth_header
             return ["oauth-tool"]
 
-        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts, raising=False)
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_allowed_mcp_servers",
-            fake_get_allowed_mcp_servers, raising=False,
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
         )
         monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager, "get_mcp_server_by_id",
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
             lambda sid: stub_server if sid == "oauth-server-id" else None,
             raising=False,
         )
         monkeypatch.setattr(
-            rest_endpoints, "_get_user_oauth_extra_headers",
-            fake_get_user_oauth_extra_headers, raising=False,
+            rest_endpoints,
+            "_get_user_oauth_extra_headers",
+            fake_get_user_oauth_extra_headers,
+            raising=False,
         )
-        monkeypatch.setattr(rest_endpoints, "_get_tools_for_single_server", fake_get_tools, raising=False)
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
 
         request = _build_request(path="/mcp-rest/tools/list", method="GET")
         result = await rest_endpoints.list_tool_rest_api(
@@ -1124,3 +1186,179 @@ class TestGetToolsForSingleServer:
         assert "tool3" in tool_names
         assert "tool1" not in tool_names
         assert "tool4" not in tool_names
+
+
+class TestStdioCommandAllowlist:
+    """Tests for MCP stdio command allowlist validation."""
+
+    def test_allowed_command_passes_validation(self):
+        """npx, uvx, python, etc. should be accepted."""
+        req = NewMCPServerRequest(
+            server_name="test",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem"],
+        )
+        assert req.command == "npx"
+
+    def test_disallowed_command_raises(self):
+        """Arbitrary commands like bash should be rejected."""
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            NewMCPServerRequest(
+                server_name="test",
+                transport="stdio",
+                command="bash",
+                args=["-c", "echo pwned"],
+            )
+
+    def test_sh_command_raises(self):
+        """sh should be rejected."""
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            NewMCPServerRequest(
+                server_name="test",
+                transport="stdio",
+                command="sh",
+                args=["-c", "id > /tmp/output.txt"],
+            )
+
+    def test_absolute_path_bypass_blocked(self):
+        """/bin/bash should be blocked (basename is 'bash')."""
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            NewMCPServerRequest(
+                server_name="test",
+                transport="stdio",
+                command="/bin/bash",
+                args=["-c", "echo pwned"],
+            )
+
+    def test_absolute_path_to_allowed_command_works(self):
+        """/usr/bin/python3 should pass (basename is 'python3')."""
+        req = NewMCPServerRequest(
+            server_name="test",
+            transport="stdio",
+            command="/usr/bin/python3",
+            args=["-m", "some_module"],
+        )
+        assert req.command == "/usr/bin/python3"
+
+    def test_http_transport_ignores_allowlist(self):
+        """HTTP/SSE transport should not trigger command validation."""
+        req = NewMCPServerRequest(
+            server_name="test",
+            transport="sse",
+            url="https://example.com/mcp",
+        )
+        assert req.transport == "sse"
+
+    def test_uvx_command_passes(self):
+        req = NewMCPServerRequest(
+            server_name="test",
+            transport="stdio",
+            command="uvx",
+            args=["mcp-server-sqlite"],
+        )
+        assert req.command == "uvx"
+
+    def test_node_command_passes(self):
+        req = NewMCPServerRequest(
+            server_name="test",
+            transport="stdio",
+            command="node",
+            args=["server.js"],
+        )
+        assert req.command == "node"
+
+
+class TestEndpointRoleChecks:
+    """Tests for PROXY_ADMIN role checks on MCP test endpoints."""
+
+    def test_test_connection_has_auth_dependency(self):
+        route = _get_route("/mcp-rest/test/connection", "POST")
+        assert _route_has_dependency(route, user_api_key_auth)
+
+    def test_test_tools_list_has_auth_dependency(self):
+        route = _get_route("/mcp-rest/test/tools/list", "POST")
+        assert _route_has_dependency(route, user_api_key_auth)
+
+    @pytest.mark.asyncio
+    async def test_test_connection_rejects_non_admin(self):
+        """Non-admin users should get 403 from test_connection."""
+        from litellm.proxy._types import LitellmUserRoles
+
+        payload = NewMCPServerRequest(
+            server_name="test",
+            url="https://example.com/mcp",
+            auth_type=MCPAuth.none,
+        )
+        user_key = UserAPIKeyAuth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            user_id="non_admin",
+            api_key="sk-test",
+        )
+        request = _build_request()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rest_endpoints.test_connection(
+                request=request,
+                new_mcp_server_request=payload,
+                user_api_key_dict=user_key,
+            )
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_test_tools_list_rejects_non_admin(self):
+        """Non-admin users should get 403 from test_tools_list."""
+        from litellm.proxy._types import LitellmUserRoles
+
+        payload = NewMCPServerRequest(
+            server_name="test",
+            url="https://example.com/mcp",
+            auth_type=MCPAuth.none,
+        )
+        user_key = UserAPIKeyAuth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            user_id="non_admin",
+            api_key="sk-test",
+        )
+        request = _build_request()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rest_endpoints.test_tools_list(
+                request=request,
+                new_mcp_server_request=payload,
+                user_api_key_dict=user_key,
+            )
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_test_connection_allows_admin(self, monkeypatch):
+        """PROXY_ADMIN should pass the role check."""
+        from litellm.proxy._types import LitellmUserRoles
+
+        async def fake_execute(*args, **kwargs):
+            return {"status": "ok"}
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_execute_with_mcp_client",
+            fake_execute,
+        )
+
+        payload = NewMCPServerRequest(
+            server_name="test",
+            url="https://example.com/mcp",
+            auth_type=MCPAuth.none,
+        )
+        user_key = UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            user_id="admin",
+            api_key="sk-admin",
+        )
+        request = _build_request()
+
+        result = await rest_endpoints.test_connection(
+            request=request,
+            new_mcp_server_request=payload,
+            user_api_key_dict=user_key,
+        )
+        assert result["status"] == "ok"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -9,7 +9,7 @@ from litellm.proxy._experimental.mcp_server import rest_endpoints
 from litellm.proxy._experimental.mcp_server.auth import (
     user_api_key_auth_mcp as auth_mcp,
 )
-from litellm.proxy._types import NewMCPServerRequest, UserAPIKeyAuth
+from litellm.proxy._types import NewMCPServerRequest, UpdateMCPServerRequest, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.types.mcp import MCPAuth
 
@@ -1267,6 +1267,16 @@ class TestStdioCommandAllowlist:
             args=["server.js"],
         )
         assert req.command == "node"
+
+    def test_update_request_disallowed_command_raises(self):
+        """UpdateMCPServerRequest should also block non-allowlisted commands."""
+        with pytest.raises(ValueError, match="not in the allowed commands list"):
+            UpdateMCPServerRequest(
+                server_id="some-id",
+                transport="stdio",
+                command="bash",
+                args=["-c", "echo pwned"],
+            )
 
 
 class TestEndpointRoleChecks:


### PR DESCRIPTION
## Relevant issues

Fixes critical RCE vulnerability in MCP stdio test endpoints.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

- **Command allowlist**: Added `MCP_STDIO_ALLOWED_COMMANDS` constant (`npx`, `uvx`, `python`, `python3`, `node`, `docker`, `deno`) in `litellm/constants.py`. Extensible via `LITELLM_MCP_STDIO_EXTRA_COMMANDS` env var.
- **Pydantic validation**: `NewMCPServerRequest` and `UpdateMCPServerRequest` now validate stdio commands against the allowlist, blocking `bash`, `sh`, `/bin/bash`, etc.
- **Defense-in-depth**: `_create_mcp_client` in `mcp_server_manager.py` also validates commands for MCPServer objects loaded from config/DB.
- **PROXY_ADMIN role check**: `/mcp-rest/test/connection` and `/mcp-rest/test/tools/list` now require PROXY_ADMIN role (403 for non-admins). Also added missing `dependencies=[Depends(user_api_key_auth)]` to `test_tools_list`.
- **Docs fix**: `docker/README.md` corrected `MASTER_KEY` → `LITELLM_MASTER_KEY` (4 occurrences).
- **Tests**: 11 new tests for command allowlist validation and role checks.