### PR TITLE
fix: Default topologySpreadConstraint has no effect due to wrong label

### DIFF
--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -54,7 +54,7 @@ topologySpreadConstraints:
   #   whenUnsatisfiable: DoNotSchedule
   #   labelSelector:
   #     matchLabels:
-  # Adjust to match the name passed to `helm install`:
+  # Adjust to match `.Values.nameOverride` if you override it (default: "litellm"):
   #       app.kubernetes.io/name: litellm
 
 # At the time of writing, the litellm docker image requires write access to the

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -54,8 +54,8 @@ topologySpreadConstraints:
   #   whenUnsatisfiable: DoNotSchedule
   #   labelSelector:
   #     matchLabels:
-  # Adjust to match `.Values.nameOverride` if you override it (default: "litellm"):
-  #       app.kubernetes.io/name: litellm
+  # Adjust to match name passed to `helm install`:
+  #       app.kubernetes.io/instance: litellm
 
 # At the time of writing, the litellm docker image requires write access to the
 #  filesystem on startup so that prisma can install some dependencies.

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -46,6 +46,7 @@ podLabels: {}
 strategy: {}
 
 terminationGracePeriodSeconds: 90
+
 topologySpreadConstraints:
   []
   # - maxSkew: 1
@@ -53,6 +54,7 @@ topologySpreadConstraints:
   #   whenUnsatisfiable: DoNotSchedule
   #   labelSelector:
   #     matchLabels:
+  # Adjust to match the name passed to `helm install`:
   #       app.kubernetes.io/name: litellm
 
 # At the time of writing, the litellm docker image requires write access to the

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -53,7 +53,7 @@ topologySpreadConstraints:
   #   whenUnsatisfiable: DoNotSchedule
   #   labelSelector:
   #     matchLabels:
-  #       app: litellm
+  #       app.kubernetes.io/name: litellm
 
 # At the time of writing, the litellm docker image requires write access to the
 #  filesystem on startup so that prisma can install some dependencies.


### PR DESCRIPTION
The topologySpreadConstraint used a label (`app`) that does not exist by default, so it had no effect.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- Documentation change, n/a: [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- Documentation change, n/a: [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

📖 Documentation

## Changes
Changed label to default app.kubernetes.io/instance, added documentation.