### PR TITLE
fix(gemini): capture thoughtSignature from sibling thought parts

### DIFF
--- a/litellm/llms/predibase/chat/transformation.py
+++ b/litellm/llms/predibase/chat/transformation.py
@@ -175,7 +175,10 @@ class PredibaseConfig(BaseConfig):
                 completion_response["generated_text"]
             )
 
-        if "details" in completion_response and "tokens" in completion_response["details"]:
+        if (
+            "details" in completion_response
+            and "tokens" in completion_response["details"]
+        ):
             model_response.choices[0].finish_reason = map_finish_reason(
                 completion_response["details"]["finish_reason"]
             )
@@ -203,7 +206,9 @@ class PredibaseConfig(BaseConfig):
                 and "best_of_sequences" in completion_response["details"]
             ):
                 choices_list = []
-                for idx, item in enumerate(completion_response["details"]["best_of_sequences"]):
+                for idx, item in enumerate(
+                    completion_response["details"]["best_of_sequences"]
+                ):
                     sum_logprob = 0
                     for token in item["tokens"]:
                         if token["logprob"] is not None:
@@ -342,7 +347,9 @@ class PredibaseConfig(BaseConfig):
             base_url = os.getenv("PREDIBASE_API_BASE", "")
 
         completion_url = f"{base_url}/{tenant_id}/deployments/v2/llms/{model}"
-        should_stream = stream if stream is not None else optional_params.get("stream", False)
+        should_stream = (
+            stream if stream is not None else optional_params.get("stream", False)
+        )
         if should_stream is True:
             completion_url += "/generate_stream"
         else:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1585,6 +1585,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ]:
         function: Optional[ChatCompletionToolCallFunctionChunk] = None
         _tools: List[ChatCompletionToolCallChunk] = []
+        # Collect all thoughtSignature values from any part (Gemini may place
+        # the signature on a separate thought part, not the functionCall part)
+        _all_signatures = [
+            p.get("thoughtSignature")
+            for p in parts
+            if p.get("thoughtSignature")
+        ]
         for part in parts:
             if "functionCall" in part:
                 _function_chunk: ChatCompletionToolCallFunctionChunk = {
@@ -1593,8 +1600,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         part["functionCall"]["args"], ensure_ascii=False
                     ),
                 }
-                # Extract thought signature if present
-                thought_signature = part.get("thoughtSignature")
+                # Extract thought signature: prefer this part's own, fallback to
+                # a signature from a sibling thought part
+                thought_signature = part.get("thoughtSignature") or (
+                    _all_signatures[0] if _all_signatures else None
+                )
 
                 if is_function_call is True:
                     function_dict: Dict[str, Any] = dict(_function_chunk)

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1585,10 +1585,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ]:
         function: Optional[ChatCompletionToolCallFunctionChunk] = None
         _tools: List[ChatCompletionToolCallChunk] = []
-        # Collect thoughtSignature values only from thought parts (thought: true).
-        # Gemini may place thoughtSignature on a separate thought part rather than
-        # the functionCall part. We exclude functionCall parts to avoid bleeding
-        # signatures across parallel function calls.
+        # Collect thoughtSignature values ONLY from thought parts (thought: true).
+        # Gemini may return: [{thought: true, thoughtSignature: "..."}, {functionCall: A}, ...]
+        # In this layout the signature belongs to ALL function calls in the turn (it
+        # encodes the model's reasoning context for multi-turn preservation), so we
+        # propagate it to every parallel call via the fallback below.
+        # We intentionally exclude functionCall parts here — a signature on a
+        # functionCall part is already consumed via `part.get("thoughtSignature")`
+        # in the loop and must NOT bleed into sibling calls.
         _thought_signatures = [
             p.get("thoughtSignature")
             for p in parts

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1585,12 +1585,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ]:
         function: Optional[ChatCompletionToolCallFunctionChunk] = None
         _tools: List[ChatCompletionToolCallChunk] = []
-        # Collect all thoughtSignature values from any part (Gemini may place
-        # the signature on a separate thought part, not the functionCall part)
-        _all_signatures = [
+        # Collect thoughtSignature values only from thought parts (thought: true).
+        # Gemini may place thoughtSignature on a separate thought part rather than
+        # the functionCall part. We exclude functionCall parts to avoid bleeding
+        # signatures across parallel function calls.
+        _thought_signatures = [
             p.get("thoughtSignature")
             for p in parts
-            if p.get("thoughtSignature")
+            if p.get("thought") and p.get("thoughtSignature")
         ]
         for part in parts:
             if "functionCall" in part:
@@ -1603,7 +1605,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 # Extract thought signature: prefer this part's own, fallback to
                 # a signature from a sibling thought part
                 thought_signature = part.get("thoughtSignature") or (
-                    _all_signatures[0] if _all_signatures else None
+                    _thought_signatures[0] if _thought_signatures else None
                 )
 
                 if is_function_call is True:

--- a/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
@@ -212,8 +212,11 @@ class XecGuardGuardrail(CustomGuardrail):
             isinstance(kwargs, dict)
             and "litellm_params" in kwargs
             and "metadata" in kwargs["litellm_params"]
-            and "standard_logging_guardrail_information"in kwargs["litellm_params"]["metadata"]
-            and kwargs["litellm_params"]["metadata"]["standard_logging_guardrail_information"]
+            and "standard_logging_guardrail_information"
+            in kwargs["litellm_params"]["metadata"]
+            and kwargs["litellm_params"]["metadata"][
+                "standard_logging_guardrail_information"
+            ]
         ):
             return kwargs, result
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
@@ -331,9 +331,9 @@ def test_sibling_thought_part_propagates_to_all_parallel_calls() -> None:
     # Both function calls must carry the thought signature from the sibling thought part.
     for i, tool in enumerate(tools):
         sig = tool.get("provider_specific_fields", {}).get("thought_signature")
-        assert sig == thought_signature, (
-            f"tool[{i}] expected thought_signature={thought_signature!r}, got {sig!r}"
-        )
-        assert THOUGHT_SIGNATURE_SEPARATOR in tool["id"], (
-            f"tool[{i}] thought signature should be embedded in ID"
-        )
+        assert (
+            sig == thought_signature
+        ), f"tool[{i}] expected thought_signature={thought_signature!r}, got {sig!r}"
+        assert (
+            THOUGHT_SIGNATURE_SEPARATOR in tool["id"]
+        ), f"tool[{i}] thought signature should be embedded in ID"

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
@@ -285,3 +285,55 @@ def test_parallel_tool_calls_with_signatures(enable_preview_features):
     assert THOUGHT_SIGNATURE_SEPARATOR not in tools[1]["id"]
     sig2 = _get_thought_signature_from_tool({"id": tools[1]["id"], "type": "function"})
     assert sig2 is None
+
+
+def test_sibling_thought_part_propagates_to_all_parallel_calls() -> None:
+    """
+    Regression test for the scenario this PR addresses.
+
+    Gemini may return a structure like:
+        [{thought: true, thoughtSignature: "..."}, {functionCall: A}, {functionCall: B}]
+
+    The thoughtSignature is on a *sibling* thought part, not on the functionCall parts.
+    It represents the model's reasoning for the entire turn and should be propagated to
+    ALL parallel function calls so that multi-turn context is preserved on the next turn.
+
+    This also verifies that a functionCall part's OWN thoughtSignature (a separate scenario
+    where Gemini puts the signature directly on the functionCall) does NOT bleed into
+    sibling calls — _thought_signatures only collects from parts where thought==True,
+    so functionCall-level signatures stay scoped to their own call.
+    """
+    thought_signature = "ErcN4Ad4qImqBhBo8LkVzGuqK7Y="
+
+    # Gemini response: one thought part with signature, two parallel function calls
+    parts_sibling_thought = [
+        HttpxPartType(
+            thought=True,
+            thoughtSignature=thought_signature,
+        ),
+        HttpxPartType(
+            functionCall={"name": "get_temperature", "args": {"location": "Paris"}},
+        ),
+        HttpxPartType(
+            functionCall={"name": "get_temperature", "args": {"location": "London"}},
+        ),
+    ]
+
+    function, tools, _ = VertexGeminiConfig._transform_parts(
+        parts=parts_sibling_thought,
+        cumulative_tool_call_idx=0,
+        is_function_call=False,
+    )
+
+    assert tools is not None
+    assert len(tools) == 2
+
+    # Both function calls must carry the thought signature from the sibling thought part.
+    for i, tool in enumerate(tools):
+        sig = tool.get("provider_specific_fields", {}).get("thought_signature")
+        assert sig == thought_signature, (
+            f"tool[{i}] expected thought_signature={thought_signature!r}, got {sig!r}"
+        )
+        assert THOUGHT_SIGNATURE_SEPARATOR in tool["id"], (
+            f"tool[{i}] thought signature should be embedded in ID"
+        )


### PR DESCRIPTION
## Problem

When using Gemini models for multi-turn tool-calling, `thoughtSignature` may be placed on a **separate thought part** (`thought: true`) rather than the `functionCall` part. The current `_transform_parts()` only checks the `functionCall` part for `thoughtSignature`, so it is lost when placed on a sibling thought part.

Without the signature, Gemini loses multi-turn thinking coherence and degenerates (garbage responses, repetition loops).

**Example Gemini response:**
```json
{
  "parts": [
    {"thought": true, "text": "I need to list files...", "thoughtSignature": "ErcNCrQN..."},
    {"functionCall": {"name": "Bash", "args": {"command": "ls -R"}}}
  ]
}
```

The `thoughtSignature` is on `parts[0]` but `_transform_parts` only checks `parts[1]`.

## Fix

Collect all `thoughtSignature` values from **any** part before iterating. When a `functionCall` part has no `thoughtSignature` of its own, fall back to the first available collected signature.

Addresses Failure 1 from #25322