### PR TITLE
fix: pass file_url through chat completions → responses API transformation

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -785,9 +785,13 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             file_data = item.get("file", {})
                             converted = {"type": "input_file"}
                             if isinstance(file_data, dict):
-                                for key in ["file_id", "file_data", "filename"]:
-                                    if key in file_data:
-                                        converted[key] = file_data[key]
+                                if "file_url" in file_data:
+                                    # file_url is mutually exclusive with file_id/file_data/filename
+                                    converted["file_url"] = file_data["file_url"]
+                                else:
+                                    for key in ["file_id", "file_data", "filename"]:
+                                        if key in file_data:
+                                            converted[key] = file_data[key]
                             result.append(converted)
                             verbose_logger.debug(
                                 f"Chat provider:   file -> {converted}"

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -937,7 +937,14 @@ def responses_api_bridge_check(
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
     tools: Optional[List[Any]] = None,
     reasoning_effort: Optional[Any] = None,
+    caller_model_info: Optional[Dict[str, Any]] = None,
 ) -> Tuple[dict, str]:
+    # If the proxy DB (or caller) has already set mode="responses" on this model,
+    # honour it immediately — the static litellm model list may say "chat".
+    if (caller_model_info or {}).get("mode") == "responses":
+        return {**(caller_model_info or {}), "mode": "responses"}, model.replace(
+            "responses/", ""
+        )
     model_info: Dict[str, Any] = {}
     try:
         model_info = cast(
@@ -1378,6 +1385,7 @@ def completion(  # type: ignore # noqa: PLR0915
             model=model,
             custom_llm_provider=custom_llm_provider,
             web_search_options=web_search_options,
+            caller_model_info=model_info,
         )
 
         if not _should_allow_input_examples(
@@ -1627,6 +1635,7 @@ def completion(  # type: ignore # noqa: PLR0915
                 web_search_options=web_search_options,
                 tools=tools,
                 reasoning_effort=reasoning_effort,
+                caller_model_info=model_info,
             )
 
         if responses_api_model_info.get("mode") == "responses":

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -676,6 +676,7 @@ class ChatCompletionDocumentObject(TypedDict):
 class ChatCompletionFileObjectFile(TypedDict, total=False):
     file_data: str
     file_id: str
+    file_url: str
     filename: str
     format: str
     detail: str  # For video/image resolution control (low, medium, high, ultra_high)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2188,6 +2188,54 @@ def test_convert_chat_completion_file_type_with_file_id():
     assert "file_data" not in content[1]
 
 
+def test_convert_chat_completion_file_type_with_file_url():
+    """
+    Test that Chat Completion content with type 'file' using file_url is correctly
+    passed through to Responses API input_file format.
+
+    file_url allows callers to reference a remote file by URL instead of uploading
+    the raw bytes (file_data) or a pre-uploaded file ID (file_id). The Responses API
+    accepts file_url so LiteLLM should forward it without stripping it.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/25304
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Analyze this document."},
+                {
+                    "type": "file",
+                    "file": {
+                        "file_url": "https://example.com/documents/report.pdf",
+                        "filename": "report.pdf",
+                    },
+                },
+            ],
+        }
+    ]
+
+    (
+        input_items,
+        instructions,
+    ) = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    content = input_items[0]["content"]
+    assert content[1]["type"] == "input_file"
+    assert content[1]["file_url"] == "https://example.com/documents/report.pdf"
+    # filename is dropped when file_url is present: the Responses API treats them as
+    # mutually exclusive and rejects the request if both are sent.
+    assert "filename" not in content[1]
+    assert "file_id" not in content[1]
+    assert "file_data" not in content[1]
+
+
 # =============================================================================
 # Tests for reasoning_items round-trip (encrypted_content preservation)
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fixes `file_url` being silently dropped when a chat completions request includes a `file` content part with a `file_url` field and the model is configured to use the Responses API bridge
- Adds `file_url` to the `ChatCompletionFileObjectFile` TypedDict so it's recognised as a valid field
- In the transformation, `file_url` is now forwarded to `input_file`; since the Responses API treats `file_url` as mutually exclusive with `file_id`/`file_data`/`filename`, those other keys are skipped when `file_url` is present
- Adds a fix to `responses_api_bridge_check` so that `mode: "responses"` set in the proxy DB model_info takes effect even when the static litellm model registry says `"chat"` for the same model name (e.g. `gpt-5.1`)
- Adds a regression test

Closes #25304

## Test plan

- `pytest tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py::test_convert_chat_completion_file_type_with_file_url`
- Tested end-to-end via local proxy against a real Responses API endpoint: calling `/v1/chat/completions` with a `file_url` content part on a model with `mode: "responses"` correctly routes to the Responses API and the model reads the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)