### PR TITLE
fix(tool_choice): respect GPT-5 and Azure AI models without explicit capability flag

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -58,11 +58,6 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         """
         params = OpenAIGPT5Config.get_supported_openai_params(self, model=model)
 
-        # Azure supports tool_choice for GPT-5 deployments, but the base GPT-5 config
-        # can drop it when the deployment name isn't in the OpenAI model registry.
-        if "tool_choice" not in params:
-            params.append("tool_choice")
-
         # Only gpt-5.2+ has been verified to support logprobs on Azure.
         # The base OpenAI class includes logprobs for gpt-5.1+, but Azure
         # hasn't verified support for gpt-5.1, so remove them unless gpt-5.2/5.4+.

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -20,7 +20,7 @@ from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import ModelResponse, ProviderField
-from litellm.utils import _add_path_to_api_base, supports_tool_choice
+from litellm.utils import _add_path_to_api_base, _is_explicitly_disabled_factory
 
 
 class AzureFoundryErrorStrings(str, enum.Enum):
@@ -29,9 +29,15 @@ class AzureFoundryErrorStrings(str, enum.Enum):
 
 class AzureAIStudioConfig(OpenAIConfig):
     def get_supported_openai_params(self, model: str) -> List:
-        model_supports_tool_choice = True  # azure ai supports this by default
-        if not supports_tool_choice(model=f"azure_ai/{model}"):
-            model_supports_tool_choice = False
+        # azure ai supports tool_choice by default; only drop it when the
+        # model cost map explicitly sets supports_tool_choice=false. A missing
+        # capability flag must be treated as supported so new or custom
+        # deployments don't lose tool_choice unexpectedly.
+        model_supports_tool_choice = not _is_explicitly_disabled_factory(
+            model=f"azure_ai/{model}",
+            custom_llm_provider=None,
+            key="supports_tool_choice",
+        )
         supported_params = super().get_supported_openai_params(model)
         if not model_supports_tool_choice:
             filtered_supported_params = []

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -3,7 +3,10 @@
 from typing import Optional, Union
 
 import litellm
-from litellm.utils import _is_explicitly_disabled_factory, _supports_factory
+from litellm.utils import (
+    _is_explicitly_disabled_factory,
+    _supports_factory,
+)
 
 from .gpt_transformation import OpenAIGPTConfig
 
@@ -150,12 +153,12 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                 "extra_headers",
             ]
 
-        from litellm.utils import supports_tool_choice
-
         base_gpt_series_params = super().get_supported_openai_params(model=model)
         gpt_5_only_params = ["reasoning_effort", "verbosity"]
         base_gpt_series_params.extend(gpt_5_only_params)
-        if not supports_tool_choice(model=model):
+        if _is_explicitly_disabled_factory(
+            model=model, custom_llm_provider=None, key="supports_tool_choice"
+        ):
             base_gpt_series_params.remove("tool_choice")
 
         non_supported_params = [

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -27,6 +27,25 @@ def test_azure_gpt5_allows_tool_choice_for_deployment_names():
     assert "temperature" in supported_params
 
 
+def test_azure_gpt5_unknown_deployment_supports_tool_choice(
+    config: AzureOpenAIGPT5Config,
+):
+    """Test that unknown Azure GPT-5 deployment names still support tool_choice.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/25332.
+    Custom Azure deployment names are not in the OpenAI model registry, so the
+    base GPT-5 config used to drop tool_choice. A local workaround in this file
+    re-added it. Now that the base config defaults to supporting tool_choice
+    for unknown models (via `_is_explicitly_disabled_factory`), the workaround
+    is no longer needed and this test verifies the direct path still works.
+    """
+    # Custom deployment name not in the model cost map
+    supported_params = config.get_supported_openai_params(
+        model="my-custom-gpt5-deployment"
+    )
+    assert "tool_choice" in supported_params
+
+
 def test_azure_gpt5_maps_max_tokens(config: AzureOpenAIGPT5Config):
     params = config.map_openai_params(
         non_default_params={"max_tokens": 5},

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -100,6 +100,28 @@ def test_azure_ai_validate_environment_with_azure_ad_token():
     assert headers["Content-Type"] == "application/json"
 
 
+def test_azure_ai_unknown_model_supports_tool_choice():
+    """
+    Test that unknown Azure AI models (not in model cost map) still support tool_choice.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/25332.
+    Previously, AzureAIStudioConfig called `supports_tool_choice()` which returns
+    False when the model entry is missing the `supports_tool_choice` key. This
+    caused custom Azure AI deployments and newly-added models to lose tool_choice,
+    contradicting the comment "azure ai supports this by default". The fix uses
+    `_is_explicitly_disabled_factory` so only models with supports_tool_choice=false
+    explicitly set get tool_choice removed.
+    """
+    config = AzureAIStudioConfig()
+
+    # A custom Azure AI deployment name that is NOT in the model cost map.
+    # Before the fix, tool_choice would be incorrectly stripped.
+    supported = config.get_supported_openai_params("my-custom-deployment")
+    assert "tool_choice" in supported, (
+        "Unknown Azure AI deployments must default to supporting tool_choice"
+    )
+
+
 def test_azure_ai_grok_stop_parameter_handling():
     """
     Test that Grok models properly handle stop parameter filtering in Azure AI Studio.

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -191,6 +191,15 @@ def test_gpt5_unknown_model_supports_tool_choice(gpt5_config: OpenAIGPT5Config):
     assert "tool_choice" in supported_params
 
 
+def test_gpt5_chat_does_not_support_tool_choice(gpt5_config: OpenAIGPT5Config):
+    """gpt-5-chat explicitly sets supports_tool_choice: false in the cost map,
+    so tool_choice must be absent from supported params."""
+    supported_params = gpt5_config.get_supported_openai_params(
+        model="gpt-5-chat-latest"
+    )
+    assert "tool_choice" not in supported_params
+
+
 def test_gpt5_codex_supports_function_calling(config: OpenAIConfig):
     """Test that GPT-5-Codex supports function calling parameters."""
     supported_params = config.get_supported_openai_params(model="gpt-5-codex")

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -173,6 +173,24 @@ def test_gpt5_codex_supports_tool_choice(gpt5_config: OpenAIGPT5Config):
     assert "tool_choice" in supported_params
 
 
+def test_gpt5_unknown_model_supports_tool_choice(gpt5_config: OpenAIGPT5Config):
+    """Test that unknown GPT-5 models (not in model cost map) still support tool_choice.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/25332.
+    Previously, the code used `supports_tool_choice()` which returns False for
+    models missing the `supports_tool_choice` key in the model cost map. This
+    caused new or provider-prefixed GPT-5 models to incorrectly reject
+    tool_choice. The fix uses `_is_explicitly_disabled_factory` so only models
+    with `supports_tool_choice: false` explicitly set (e.g., gpt-5-chat) get
+    tool_choice removed.
+    """
+    # A hypothetical future GPT-5 model that isn't yet in the model cost map.
+    supported_params = gpt5_config.get_supported_openai_params(
+        model="gpt-5-future-model-not-in-map"
+    )
+    assert "tool_choice" in supported_params
+
+
 def test_gpt5_codex_supports_function_calling(config: OpenAIConfig):
     """Test that GPT-5-Codex supports function calling parameters."""
     supported_params = config.get_supported_openai_params(model="gpt-5-codex")


### PR DESCRIPTION
## Relevant issues

Fixes #25332.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`OpenAIGPT5Config.get_supported_openai_params` and `AzureAIStudioConfig.get_supported_openai_params` both called `supports_tool_choice()` to decide whether to strip `tool_choice` from the supported params list. That helper returns False when the model cost map entry is missing the `supports_tool_choice` key, which is opt-in semantics — a missing flag means "not supported".

For GPT-5, this breaks any model that isn't in the OpenAI model registry yet:
- `github_copilot/gpt-5`, `chatgpt/gpt-5.*`, `perplexity/openai/gpt-5.*` — the provider-prefixed entries in `model_prices_and_context_window.json` are missing `supports_tool_choice: true`
- Any new GPT-5 model added before its cost map entry is updated
- Custom Azure deployment names that will never be in the cost map

The OpenAI API supports `tool_choice` for all non-chat GPT-5 models. Only `gpt-5-chat*` variants disable it, and those already have `supports_tool_choice: false` set explicitly.

The same file (`gpt_5_transformation.py:129`) already uses `_is_explicitly_disabled_factory` for reasoning effort — opt-out semantics, where a missing key means "allowed". This PR uses the same helper for `tool_choice` in the two transformation layers with the bug.

`AzureOpenAIGPT5Config.get_supported_openai_params` had a local workaround (`if "tool_choice" not in params: params.append("tool_choice")`) with a comment explaining the base config was dropping it for unknown Azure deployment names. With the base fix in place, the workaround is dead code and is removed in this PR.

### Files

- `litellm/llms/openai/chat/gpt_5_transformation.py` — swap `supports_tool_choice()` for `_is_explicitly_disabled_factory()`
- `litellm/llms/azure_ai/chat/transformation.py` — same swap, add a clarifying comment
- `litellm/llms/azure/chat/gpt_5_transformation.py` — remove the now-redundant tool_choice workaround
- `tests/test_litellm/llms/openai/test_gpt5_transformation.py` — regression test for unknown GPT-5 model
- `tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py` — regression test for unknown Azure AI deployment
- `tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py` — regression test for unknown Azure GPT-5 deployment via the direct class path (replaces what the removed workaround was protecting)

### Untouched

- `gpt-5-chat*` still has `tool_choice` removed (it has `supports_tool_choice: false` set explicitly, so `_is_explicitly_disabled_factory` correctly returns True)
- Fireworks AI and Bedrock use add-only opt-in patterns on purpose and are left alone
- `supports_tool_choice()` / `_supports_factory` utility functions are unchanged
