### PR TITLE
fix(auto_router): handle OpenAI content-block format in semantic routing

### DIFF
--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -120,7 +120,15 @@ class AutoRouter(CustomLogger):
             )
 
         user_message: Dict[str, str] = messages[-1]
-        message_content: str = user_message.get("content", "")
+        message_content: Union[str, list] = user_message.get("content", "")
+        # Handle content as a list of content blocks (OpenAI multi-modal format).
+        # Embedding models expect a plain string; extract text parts when needed.
+        if isinstance(message_content, list):
+            message_content = " ".join(
+                block.get("text", "")
+                for block in message_content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
         route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(
             text=message_content
         )


### PR DESCRIPTION
## Summary

The `auto_router` strategy extracts the last user message's `content` field and passes it as a plain string to the semantic router for embedding. However, when a client uses the OpenAI multi-modal content format — `content: [{"type": "text", "text": "..."}]` — `message_content` becomes a `list` instead of a `str`.

This list gets forwarded to the embedding model as the `input` value, which causes HTTP 400 errors from embedding backends that only accept strings or arrays of strings (LM Studio, OpenRouter, and others).

## Root Cause

```python
# auto_router.py (before fix)
user_message = messages[-1]
message_content: str = user_message.get("content", "")  # may be a list!
route_choice = self.routelayer(text=message_content)  # list passed to embedder → 400
```

## Fix

Extract text from content blocks when `content` is a list:

```python
message_content = user_message.get("content", "")
if isinstance(message_content, list):
    message_content = " ".join(
        block.get("text", "")
        for block in message_content
        if isinstance(block, dict) and block.get("type") == "text"
    )
```

## Reproduction

Send a request to `smart-router` with content-block format:

```bash
curl http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-..." \
  -d '{"model":"smart-router","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}],"max_tokens":5}'
```

Before fix: `400 - input field must be a string or an array of strings`  
After fix: routes and responds correctly.

## Related

Closes #19016