### PR TITLE
fix(chatgpt): normalize Responses input and health checks

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -107,6 +107,21 @@ class HealthCheckHelpers:
             return await litellm.acompletion(**model_params)
 
     @staticmethod
+    def _get_responses_health_check_input(
+        prompt: Optional[str] = None,
+        input: Optional[list] = None,
+    ) -> list:
+        if input is not None:
+            return input
+
+        return [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt or "test"}],
+            }
+        ]
+
+    @staticmethod
     def get_mode_handlers(
         model: str,
         custom_llm_provider: str,
@@ -207,7 +222,10 @@ class HealthCheckHelpers:
             ),
             "responses": lambda: litellm.aresponses(
                 **_filter_model_params(model_params=model_params),
-                input=prompt or "test",
+                input=HealthCheckHelpers._get_responses_health_check_input(
+                    prompt=prompt,
+                    input=input,
+                ),
             ),
             "ocr": lambda: litellm.aocr(
                 **_filter_model_params(model_params=model_params),

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -73,6 +73,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             litellm_params,
             headers,
         )
+        request["input"] = self._normalize_chatgpt_input(request.get("input"))
         base_instructions = get_chatgpt_default_instructions()
         existing_instructions = request.get("instructions")
         if existing_instructions:
@@ -104,6 +105,18 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         }
 
         return {k: v for k, v in request.items() if k in allowed_keys}
+
+    @staticmethod
+    def _normalize_chatgpt_input(input_value: Any) -> Any:
+        if isinstance(input_value, str):
+            return [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": input_value}],
+                }
+            ]
+
+        return input_value
 
     def transform_response_api_response(
         self,

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -82,6 +82,40 @@ def test_get_litellm_internal_health_check_user_api_key_auth():
     assert result.team_alias == LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 
 
+def test_get_responses_health_check_input_wraps_prompt_in_responses_message():
+    result = HealthCheckHelpers._get_responses_health_check_input(prompt="ping")
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "ping"}],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_mode_handlers_responses_uses_structured_responses_input():
+    with patch("litellm.aresponses", new_callable=AsyncMock) as mock_aresponses:
+        mock_aresponses.return_value = {"status": "ok"}
+
+        handler = HealthCheckHelpers.get_mode_handlers(
+            model="chatgpt/gpt-5.4",
+            custom_llm_provider="chatgpt",
+            model_params={"model": "chatgpt/gpt-5.4"},
+            prompt="health test",
+        )["responses"]
+
+        await handler()
+
+        mock_aresponses.assert_awaited_once()
+        assert mock_aresponses.await_args.kwargs["input"] == [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "health test"}],
+            }
+        ]
+
+
 @pytest.mark.asyncio
 async def test_ahealth_check_failure_masks_raw_request_headers():
     """

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -107,6 +107,24 @@ class TestChatGPTResponsesAPITransformation:
             "You are Codex, based on GPT-5."
         )
 
+    def test_chatgpt_normalizes_string_input_for_responses_api(self):
+        config = ChatGPTResponsesAPIConfig()
+
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.4",
+            input="hi",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["input"] == [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }
+        ]
+
     @pytest.mark.parametrize(
         "model_name",
         [


### PR DESCRIPTION
## Summary
This PR fixes two ChatGPT Responses regressions that showed up when routing ChatGPT models through LiteLLM.

The first commit makes the ChatGPT Responses provider normalize plain string `input` values into the message-list shape that ChatGPT expects. The second commit updates the health-check path to send the canonical structured Responses payload instead of relying on provider-specific recovery.

## Root Cause
The generic Responses API flow allows string inputs, but ChatGPT's `/responses` endpoint rejects them with `400` and `{"detail":"Input must be a list"}`. That surfaced in two places:

1. Provider calls that reached ChatGPT with a plain string `input`
2. UI health checks for `mode: responses`, which were sending `input=prompt or "test"`

## Changes
- normalize string ChatGPT Responses input into a single user message with `input_text`
- add a ChatGPT provider regression test for string input normalization
- add a small helper for canonical Responses health-check input
- update the Responses health handler to use structured input
- add health-check tests covering the structured Responses path

## Impact
- `chatgpt/*` models using the Responses API no longer fail when a caller passes a plain string input through LiteLLM
- ChatGPT model health checks stop returning `400` due to invalid Responses input shape
- the health-check path now uses the canonical Responses message format instead of relying on provider-specific normalization

## Validation
Ran in Docker with Python 3.11 and LiteLLM proxy extras installed:

```bash
docker run --rm -v "$PWD:/work" -w /work python:3.11-slim sh -lc \
  'pip install -q --upgrade pip setuptools wheel && \
   pip install -q -e ".[proxy]" pytest pytest-asyncio httpx && \
   pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py \
          tests/test_litellm/litellm_core_utils/test_health_check_helpers.py -q'
```

Result: `21 passed`

## Commit Structure
- `fix(chatgpt): normalize string responses input`
- `fix(health): use structured responses input`
