### PR TITLE
fix: read phoenix_project_name from team/key metadata in ArizePhoenix Logger

### DIFF
--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -118,18 +118,32 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
         """
         Retrieve dynamic Phoenix project name from request metadata.
 
-        Users can set `metadata.phoenix_project_name` in their request to route
-        traces to different Phoenix projects dynamically.
+        Priority order (highest to lowest):
+        1. Per-request metadata: ``metadata.phoenix_project_name``
+        2. Team / key metadata via ``metadata.user_api_key_auth_metadata.phoenix_project_name``
+           (the proxy merges both team and key metadata into ``user_api_key_auth_metadata``
+           inside the standard logging payload — this is where ``phoenix_project_name`` lands
+           when it is set on a team or API key via the management endpoints)
+        3. ``litellm_params.metadata.phoenix_project_name`` (SDK / non-proxy usage)
         """
         standard_logging_payload = kwargs.get("standard_logging_object")
         if isinstance(standard_logging_payload, dict):
             metadata = standard_logging_payload.get("metadata")
             if isinstance(metadata, dict):
+                # 1. Per-request metadata (highest priority)
                 project_name = metadata.get("phoenix_project_name")
                 if project_name:
                     return str(project_name)
 
-        # Also check litellm_params.metadata for SDK usage
+                # 2. Team / key metadata — the proxy stores merged team+key metadata
+                #    in user_api_key_auth_metadata inside StandardLoggingMetadata.
+                auth_metadata = metadata.get("user_api_key_auth_metadata")
+                if isinstance(auth_metadata, dict):
+                    project_name = auth_metadata.get("phoenix_project_name")
+                    if project_name:
+                        return str(project_name)
+
+        # 3. litellm_params.metadata for direct SDK usage (non-proxy)
         litellm_params = kwargs.get("litellm_params")
         if isinstance(litellm_params, dict):
             metadata = litellm_params.get("metadata") or {}

--- a/tests/test_litellm/integrations/arize/test_arize_phoenix.py
+++ b/tests/test_litellm/integrations/arize/test_arize_phoenix.py
@@ -228,6 +228,139 @@ class TestGetDynamicProjectName:
         kwargs = {"standard_logging_object": "not-a-dict"}
         assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) is None
 
+    # ------------------------------------------------------------------
+    # Tests for team / key metadata path (the bug reported by Viktor O.)
+    # ------------------------------------------------------------------
+
+    def test_extracts_from_user_api_key_auth_metadata(self):
+        """
+        phoenix_project_name set on a team is merged into
+        user_api_key_auth_metadata by the proxy's pre-call utils.
+        _get_dynamic_project_name must check that nested dict.
+        """
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project"
+                    }
+                }
+            }
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) == "team-project"
+
+    def test_per_request_metadata_takes_priority_over_team_metadata(self):
+        """
+        A per-request phoenix_project_name must win over a team-level one.
+        """
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "phoenix_project_name": "request-project",
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project"
+                    },
+                }
+            }
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) == "request-project"
+
+    def test_falls_back_to_team_metadata_when_no_top_level_name(self):
+        """
+        When there is no top-level phoenix_project_name but the team metadata
+        has one, the team value must be returned.
+        """
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    # no top-level phoenix_project_name
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project"
+                    },
+                }
+            }
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) == "team-project"
+
+    def test_team_metadata_takes_priority_over_litellm_params(self):
+        """
+        Team metadata (via standard_logging_object) must win over
+        litellm_params.metadata (SDK-level).
+        """
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project"
+                    }
+                }
+            },
+            "litellm_params": {
+                "metadata": {"phoenix_project_name": "sdk-project"},
+            },
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) == "team-project"
+
+    def test_empty_user_api_key_auth_metadata_does_not_crash(self):
+        """Empty auth_metadata dict must not raise and must fall through."""
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {}
+                }
+            }
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) is None
+
+    def test_none_user_api_key_auth_metadata_does_not_crash(self):
+        """None auth_metadata must not raise and must fall through."""
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": None
+                }
+            }
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs) is None
+
+    def test_full_priority_chain_all_sources_present(self):
+        """
+        Full priority chain:
+        per-request > team (user_api_key_auth_metadata) > litellm_params
+        """
+        # Per-request wins
+        kwargs_request = {
+            "standard_logging_object": {
+                "metadata": {
+                    "phoenix_project_name": "request-project",
+                    "user_api_key_auth_metadata": {"phoenix_project_name": "team-project"},
+                }
+            },
+            "litellm_params": {"metadata": {"phoenix_project_name": "sdk-project"}},
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs_request) == "request-project"
+
+        # No per-request → team wins
+        kwargs_team = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {"phoenix_project_name": "team-project"},
+                }
+            },
+            "litellm_params": {"metadata": {"phoenix_project_name": "sdk-project"}},
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs_team) == "team-project"
+
+        # No per-request, no team → SDK wins
+        kwargs_sdk = {
+            "standard_logging_object": {"metadata": {}},
+            "litellm_params": {"metadata": {"phoenix_project_name": "sdk-project"}},
+        }
+        assert ArizePhoenixLogger._get_dynamic_project_name(kwargs_sdk) == "sdk-project"
+
+        # Nothing → None
+        assert ArizePhoenixLogger._get_dynamic_project_name({}) is None
+
 
 class TestDynamicProjectNameOnSpan:
     """set_arize_phoenix_attributes sets openinference.project.name on the span."""
@@ -252,6 +385,52 @@ class TestDynamicProjectNameOnSpan:
         ArizePhoenixLogger.set_arize_phoenix_attributes(span, {}, response_obj=None)
 
         span.set_attribute.assert_called_once_with("openinference.project.name", "env-project")
+
+    @patch.dict("os.environ", {"PHOENIX_PROJECT_NAME": "env-fallback"}, clear=False)
+    @patch("litellm.integrations.arize._utils.set_attributes")
+    def test_team_metadata_project_name_sets_span_attribute(self, _mock_set_attrs):
+        """
+        Regression test: phoenix_project_name from team metadata (stored in
+        user_api_key_auth_metadata) must be applied to the span, not the env fallback.
+        """
+        span = MagicMock()
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project"
+                    }
+                }
+            }
+        }
+        ArizePhoenixLogger.set_arize_phoenix_attributes(span, kwargs, response_obj=None)
+
+        span.set_attribute.assert_called_once_with("openinference.project.name", "team-project")
+
+    @patch.dict(
+        "os.environ",
+        {"PHOENIX_PROJECT_NAME": "env-fallback"},
+        clear=False,
+    )
+    @patch("litellm.integrations.arize._utils.set_attributes")
+    def test_per_request_overrides_team_metadata_on_span(self, _mock_set_attrs):
+        """
+        Per-request phoenix_project_name must override team metadata on the span.
+        """
+        span = MagicMock()
+        kwargs = {
+            "standard_logging_object": {
+                "metadata": {
+                    "phoenix_project_name": "request-project",
+                    "user_api_key_auth_metadata": {
+                        "phoenix_project_name": "team-project"
+                    },
+                }
+            }
+        }
+        ArizePhoenixLogger.set_arize_phoenix_attributes(span, kwargs, response_obj=None)
+
+        span.set_attribute.assert_called_once_with("openinference.project.name", "request-project")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When phoenix_project_name is set on a team or API key via the management endpoints the proxy merges those fields into user_api_key_auth_metadata inside StandardLoggingMetadata. _get_dynamic_project_name was only checking the top-level metadata dict, so team/key values were silently dropped and traces always flowed to the default Phoenix project.

Fix: also check metadata.user_api_key_auth_metadata.phoenix_project_name
with priority: per-request > team/key (auth_metadata) > litellm_params > env var.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
