### PR TITLE
fix(cost-map): add us-south1 to vertex qwen3-235b-a22b-instruct-2507-maas

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -31944,7 +31944,8 @@
         "output_cost_per_token": 1e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_regions": [
-            "global"
+            "global",
+            "us-south1"
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -31929,7 +31929,8 @@
         "output_cost_per_token": 1e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_regions": [
-            "global"
+            "global",
+            "us-south1"
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true


### PR DESCRIPTION
Refs #25380

  ## Summary

  Add `us-south1` to `supported_regions` for the Vertex Qwen model:

  `vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas`

  This updates both:
  - `model_prices_and_context_window.json`
  - `litellm/model_prices_and_context_window_backup.json`

  ## Why

  LiteLLM's packaged metadata currently lists only:

  ```json
  ["global"]
  ```
  for this model.

  When LiteLLM is configured to use this Vertex Qwen model in us-south1, it warns that the region is unsupported and routes to global instead.

  Observed warning:

  ```Vertex AI model 'qwen/qwen3-235b-a22b-instruct-2507-maas' does not support region 'us-south1' (supported: ['global']). Routing to 'global'.```

  I also verified the packaged metadata inside the latest Docker image:

  ghcr.io/berriai/litellm:main-stable

  and it currently reports:

  ["global"]

  for this model's supported_regions.

  ## What changed

  Added us-south1 to:
```
  "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
    "supported_regions": [
      "global",
      "us-south1"
    ]
  }
```
  ## Validation

  This matches working behavior against Vertex AI for the same model in us-south1.

  As a local workaround before this patch, overriding LiteLLM's cost map to add us-south1 removed the warning and allowed the expected us-south1 configuration to work correctly.