### PR TITLE
fix: persist budget_id to DB for auto-created end users using max_end_user_budget_id

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2897,6 +2897,7 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
     spend: float = 0.0
     allowed_model_region: Optional[AllowedModelRegion] = None
     default_model: Optional[str] = None
+    budget_id: Optional[str] = None
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
     object_permission_id: Optional[str] = None
     object_permission: Optional[LiteLLM_ObjectPermissionTable] = None

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -918,9 +918,26 @@ async def _apply_default_budget_to_end_user(
     if default_budget is not None:
         # Apply default budget to end user object
         end_user_obj.litellm_budget_table = default_budget
-        verbose_proxy_logger.debug(
-            f"Applied default budget {litellm.max_end_user_budget_id} to end user {end_user_obj.user_id}"
-        )
+
+        # Backfill budget_id to DB for existing users that were created without it
+        if end_user_obj.budget_id is None:
+            try:
+                await prisma_client.db.litellm_endusertable.update(
+                    where={"user_id": end_user_obj.user_id},
+                    data={"budget_id": litellm.max_end_user_budget_id},
+                )
+                end_user_obj.budget_id = litellm.max_end_user_budget_id
+                verbose_proxy_logger.debug(
+                    f"Persisted default budget_id {litellm.max_end_user_budget_id} to end user {end_user_obj.user_id}"
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    f"Failed to persist default budget_id for end user {end_user_obj.user_id}"
+                )
+        else:
+            verbose_proxy_logger.debug(
+                f"Applied default budget {litellm.max_end_user_budget_id} to end user {end_user_obj.user_id}"
+            )
 
     return end_user_obj
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4679,14 +4679,17 @@ class ProxyUpdateSpend:
                         ) in end_user_list_transactions.items():
                             if litellm.max_end_user_budget is not None:
                                 pass
+                            _create_data: dict = {
+                                "user_id": end_user_id,
+                                "spend": response_cost,
+                                "blocked": False,
+                            }
+                            if litellm.max_end_user_budget_id is not None:
+                                _create_data["budget_id"] = litellm.max_end_user_budget_id
                             batcher.litellm_endusertable.upsert(
                                 where={"user_id": end_user_id},
                                 data={
-                                    "create": {
-                                        "user_id": end_user_id,
-                                        "spend": response_cost,
-                                        "blocked": False,
-                                    },
+                                    "create": _create_data,
                                     "update": {"spend": {"increment": response_cost}},
                                 },
                             )


### PR DESCRIPTION
## Summary

Fixes #25386

When `max_end_user_budget_id` is configured, end users created via the `x-litellm-end-user-id` header have their default budget applied only in-memory at auth time. The `budget_id` is never written to the `LiteLLM_EndUserTable` row in the database, so:

- `/customer/info` shows `litellm_budget_table: null`
- The budget reset job (`WHERE budget_id IN (...)`) never finds these users
- Spend accumulates forever and never resets, eventually permanently blocking users

## Changes

1. **`litellm/proxy/utils.py`** — Include `budget_id` in the upsert `create` clause in `update_end_user_spend()` when `max_end_user_budget_id` is configured. Only affects new user creation — existing explicit budget assignments are never overwritten.

2. **`litellm/proxy/auth/auth_checks.py`** — Lazy backfill in `_apply_default_budget_to_end_user()`: when applying the in-memory default budget, if the user's DB record has `budget_id = NULL`, persist it. This self-heals existing users on their next request without requiring a migration.

3. **`litellm/proxy/_types.py`** — Add `budget_id: Optional[str] = None` to `LiteLLM_EndUserTable` Pydantic model to match the Prisma schema.

## Test plan

- [ ] New end user created via `x-litellm-end-user-id` with `max_end_user_budget_id` configured → verify `budget_id` is set in DB
- [ ] Existing end user with `budget_id = NULL` makes a request → verify `budget_id` gets backfilled
- [ ] End user with explicitly assigned budget → verify it is NOT overwritten by the default
- [ ] Budget reset job runs → verify it now finds and resets spend for auto-created users
- [ ] `/customer/info` reflects the assigned budget after fix