### PR TITLE
fix(embedding): omit null encoding_format for openai requests

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4913,9 +4913,6 @@ def embedding(  # noqa: PLR0915
 
             if encoding_format is not None:
                 optional_params["encoding_format"] = encoding_format
-            else:
-                # Omiting causes openai sdk to add default value of "float"
-                optional_params["encoding_format"] = None
 
             api_version = None
 

--- a/tests/test_litellm/llms/openai/embeddings/test_openai_embeddings_encoding_format.py
+++ b/tests/test_litellm/llms/openai/embeddings/test_openai_embeddings_encoding_format.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+import litellm
+
+
+@patch("litellm.main.openai_chat_completions.embedding", return_value={"ok": True})
+def test_openai_embedding_does_not_send_encoding_format_when_unset(mock_embedding):
+    """Regression test: do not send encoding_format=null to OpenAI-compatible APIs."""
+    litellm.embedding(
+        model="text-embedding-3-small",
+        input=["hello"],
+        api_base="https://example.com/v1",
+        api_key="test-key",
+        custom_llm_provider="openai",
+    )
+
+    optional_params = mock_embedding.call_args.kwargs["optional_params"]
+    assert "encoding_format" not in optional_params
+
+
+@patch("litellm.main.openai_chat_completions.embedding", return_value={"ok": True})
+def test_openai_embedding_preserves_explicit_encoding_format(mock_embedding):
+    """Explicit encoding_format should still be forwarded."""
+    litellm.embedding(
+        model="text-embedding-3-small",
+        input=["hello"],
+        api_base="https://example.com/v1",
+        api_key="test-key",
+        custom_llm_provider="openai",
+        encoding_format="float",
+    )
+
+    optional_params = mock_embedding.call_args.kwargs["optional_params"]
+    assert optional_params["encoding_format"] == "float"


### PR DESCRIPTION
## Relevant issues

Fixes #25388

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
- Stop sending `encoding_format: null` in embedding requests when it is not set.
- Preserve explicit `encoding_format` values (for example, `"float"`).
- Add regression tests for both behaviors (unset omitted, explicit preserved).