### PR TITLE
[Feature] UI - Teams: Allow Editing Router Settings After Team Creation

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
@@ -241,9 +241,13 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
               key !== "fallbacks"
             ) {
               const inputEl = document.querySelector(`input[name="${key}"]`) as HTMLInputElement | null;
-              if (inputEl && inputEl.value !== undefined && inputEl.value !== "") {
-                const parsed = parseInputValue(key, inputEl.value, value);
-                return [key, parsed];
+              if (inputEl) {
+                if (inputEl.value !== undefined && inputEl.value !== "") {
+                  const parsed = parseInputValue(key, inputEl.value, value);
+                  return [key, parsed];
+                }
+                // Input exists but is empty — user cleared it, set to null
+                return [key, null];
               }
               return [key, value];
             } else if (key === "routing_strategy") {

--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
@@ -47,6 +47,7 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
     const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
     const [availableRoutingStrategies, setAvailableRoutingStrategies] = useState<string[]>([]);
     const [routerFieldsMetadata, setRouterFieldsMetadata] = useState<{ [key: string]: any }>({});
+    const [selectedTabIndex, setSelectedTabIndex] = useState(0);
     const [routingStrategyDescriptions, setRoutingStrategyDescriptions] = useState<{ [key: string]: string }>({});
     const isInternalUpdateRef = useRef(false);
     const lastInitializedValueRef = useRef<string | null>(null);
@@ -342,10 +343,10 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
 
     return (
       <div className="w-full">
-        <TabGroup className="w-full">
-          <TabList variant="line" defaultValue="1" className="px-8 pt-4">
-            <Tab value="1">Loadbalancing</Tab>
-            <Tab value="2">Fallbacks</Tab>
+        <TabGroup className="w-full" index={selectedTabIndex} onIndexChange={setSelectedTabIndex}>
+          <TabList variant="line" className="px-8 pt-4">
+            <Tab>Loadbalancing</Tab>
+            <Tab>Fallbacks</Tab>
           </TabList>
           <TabPanels className="px-8 py-6">
             <TabPanel>

--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
@@ -47,7 +47,6 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
     const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
     const [availableRoutingStrategies, setAvailableRoutingStrategies] = useState<string[]>([]);
     const [routerFieldsMetadata, setRouterFieldsMetadata] = useState<{ [key: string]: any }>({});
-    const [selectedTabIndex, setSelectedTabIndex] = useState(0);
     const [routingStrategyDescriptions, setRoutingStrategyDescriptions] = useState<{ [key: string]: string }>({});
     const isInternalUpdateRef = useRef(false);
     const lastInitializedValueRef = useRef<string | null>(null);
@@ -343,10 +342,10 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
 
     return (
       <div className="w-full">
-        <TabGroup className="w-full" index={selectedTabIndex} onIndexChange={setSelectedTabIndex}>
-          <TabList variant="line" className="px-8 pt-4">
-            <Tab>Loadbalancing</Tab>
-            <Tab>Fallbacks</Tab>
+        <TabGroup className="w-full">
+          <TabList variant="line" defaultValue="1" className="px-8 pt-4">
+            <Tab value="1">Loadbalancing</Tab>
+            <Tab value="2">Fallbacks</Tab>
           </TabList>
           <TabPanels className="px-8 py-6">
             <TabPanel>

--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
@@ -92,11 +92,15 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
         })
         : null;
 
-      // Skip if this is an internal update (from our own onChange)
-      if (isInternalUpdateRef.current) {
+      // Skip if this is an internal update (from our own onChange) and the value hasn't actually changed
+      if (isInternalUpdateRef.current && valueKey === lastInitializedValueRef.current) {
         isInternalUpdateRef.current = false;
-        lastInitializedValueRef.current = valueKey;
         return;
+      }
+
+      // Reset the flag if value actually changed externally
+      if (isInternalUpdateRef.current && valueKey !== lastInitializedValueRef.current) {
+        isInternalUpdateRef.current = false;
       }
 
       // Only update if the value actually changed from an external source

--- a/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/RouterSettingsAccordion.tsx
@@ -92,15 +92,11 @@ const RouterSettingsAccordion = forwardRef<RouterSettingsAccordionRef, RouterSet
         })
         : null;
 
-      // Skip if this is an internal update (from our own onChange) and the value hasn't actually changed
-      if (isInternalUpdateRef.current && valueKey === lastInitializedValueRef.current) {
+      // Skip if this is an internal update (from our own onChange)
+      if (isInternalUpdateRef.current) {
         isInternalUpdateRef.current = false;
+        lastInitializedValueRef.current = valueKey;
         return;
-      }
-
-      // Reset the flag if value actually changed externally
-      if (isInternalUpdateRef.current && valueKey !== lastInitializedValueRef.current) {
-        isInternalUpdateRef.current = false;
       }
 
       // Only update if the value actually changed from an external source

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/components/networking", () => ({
   fetchMCPAccessGroups: vi.fn(),
   getTeamPermissionsCall: vi.fn(),
   organizationInfoCall: vi.fn(),
+  getRouterSettingsCall: vi.fn().mockResolvedValue({ fields: [] }),
 }));
 
 vi.mock("@/components/utils/dataUtils", () => ({

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -1308,7 +1308,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                     <div className="sticky z-10 bg-white p-4 pr-0 border-t border-gray-200 bottom-[-1.5rem] inset-x-[-1.5rem]">
                       <div className="flex justify-end items-center gap-2">
-                        <Button onClick={() => setIsEditing(false)} disabled={isTeamSaving}>
+                        <Button onClick={() => { setIsEditing(false); setRouterSettings(null); }} disabled={isTeamSaving}>
                           Cancel
                         </Button>
                         <Button icon={<SaveOutlined className="h-4 w-4" />} type="primary" htmlType="submit" loading={isTeamSaving}>

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -592,19 +592,21 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       }
 
       // Handle router_settings - read fresh values from DOM at save time.
-      // Only include if the user actually configured something meaningful
-      // (exclude defaults like enable_tag_filtering: false and empty arrays).
       const currentRouterSettings = routerSettingsRef.current?.getValue();
       if (currentRouterSettings?.router_settings) {
-        const hasValues = Object.values(currentRouterSettings.router_settings).some(
-          (value) =>
-            value !== null &&
-            value !== undefined &&
-            value !== "" &&
-            value !== false &&
-            !(Array.isArray(value) && value.length === 0),
-        );
-        if (hasValues) {
+        const isMeaningfulValue = (value: unknown) =>
+          value !== null &&
+          value !== undefined &&
+          value !== "" &&
+          value !== false &&
+          !(Array.isArray(value) && value.length === 0);
+
+        const hasNewValues = Object.values(currentRouterSettings.router_settings).some(isMeaningfulValue);
+        const hadExistingSettings = info.router_settings &&
+          Object.values(info.router_settings).some(isMeaningfulValue);
+
+        // Send if there are new values OR if the user is clearing existing ones
+        if (hasNewValues || hadExistingSettings) {
           updateData.router_settings = currentRouterSettings.router_settings;
         }
       }
@@ -1112,7 +1114,6 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                         ref={routerSettingsRef}
                         accessToken={accessToken || ""}
                         value={info.router_settings ? { router_settings: info.router_settings } : undefined}
-                        modelData={userModels.length > 0 ? { data: userModels.map((model) => ({ model_name: model })) } : undefined}
                       />
                     </Form.Item>
 

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -41,7 +41,7 @@ import ObjectPermissionsView from "../object_permissions_view";
 import NumericalInput from "../shared/numerical_input";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import EditLoggingSettings from "./EditLoggingSettings";
-import RouterSettingsAccordion, { RouterSettingsAccordionRef, RouterSettingsAccordionValue } from "../common_components/RouterSettingsAccordion";
+import RouterSettingsAccordion, { RouterSettingsAccordionRef } from "../common_components/RouterSettingsAccordion";
 import MemberModal from "./EditMembership";
 import MemberPermissions from "./member_permissions";
 import {
@@ -189,7 +189,6 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isTeamSaving, setIsTeamSaving] = useState(false);
-  const [routerSettings, setRouterSettings] = useState<RouterSettingsAccordionValue | null>(null);
   const routerSettingsRef = React.useRef<RouterSettingsAccordionRef>(null);
   const [organization, setOrganization] = useState<Organization | null>(null);
   const { userRole, userId } = useAuthorized();
@@ -592,8 +591,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         updateData.access_group_ids = values.access_group_ids;
       }
 
-      // Handle router_settings - use ref to get fresh values from DOM at save time
-      const currentRouterSettings = routerSettingsRef.current?.getValue() ?? routerSettings;
+      // Handle router_settings - read fresh values from DOM at save time
+      const currentRouterSettings = routerSettingsRef.current?.getValue();
       if (currentRouterSettings?.router_settings) {
         const hasValues = Object.values(currentRouterSettings.router_settings).some(
           (value) => value !== null && value !== undefined && value !== "",
@@ -607,7 +606,6 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
       NotificationsManager.success("Team settings updated successfully");
       setIsEditing(false);
-      setRouterSettings(null);
       fetchTeamInfo();
     } catch (error) {
       console.error("Error updating team:", error);
@@ -1106,8 +1104,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       <RouterSettingsAccordion
                         ref={routerSettingsRef}
                         accessToken={accessToken || ""}
-                        value={routerSettings || (info.router_settings ? { router_settings: info.router_settings } : undefined)}
-                        onChange={setRouterSettings}
+                        value={info.router_settings ? { router_settings: info.router_settings } : undefined}
                         modelData={userModels.length > 0 ? { data: userModels.map((model) => ({ model_name: model })) } : undefined}
                       />
                     </Form.Item>
@@ -1311,7 +1308,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                     <div className="sticky z-10 bg-white p-4 pr-0 border-t border-gray-200 bottom-[-1.5rem] inset-x-[-1.5rem]">
                       <div className="flex justify-end items-center gap-2">
-                        <Button onClick={() => { setIsEditing(false); setRouterSettings(null); }} disabled={isTeamSaving}>
+                        <Button onClick={() => setIsEditing(false)} disabled={isTeamSaving}>
                           Cancel
                         </Button>
                         <Button icon={<SaveOutlined className="h-4 w-4" />} type="primary" htmlType="submit" loading={isTeamSaving}>

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -591,11 +591,18 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         updateData.access_group_ids = values.access_group_ids;
       }
 
-      // Handle router_settings - read fresh values from DOM at save time
+      // Handle router_settings - read fresh values from DOM at save time.
+      // Only include if the user actually configured something meaningful
+      // (exclude defaults like enable_tag_filtering: false and empty arrays).
       const currentRouterSettings = routerSettingsRef.current?.getValue();
       if (currentRouterSettings?.router_settings) {
         const hasValues = Object.values(currentRouterSettings.router_settings).some(
-          (value) => value !== null && value !== undefined && value !== "",
+          (value) =>
+            value !== null &&
+            value !== undefined &&
+            value !== "" &&
+            value !== false &&
+            !(Array.isArray(value) && value.length === 0),
         );
         if (hasValues) {
           updateData.router_settings = currentRouterSettings.router_settings;

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -41,7 +41,7 @@ import ObjectPermissionsView from "../object_permissions_view";
 import NumericalInput from "../shared/numerical_input";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import EditLoggingSettings from "./EditLoggingSettings";
-import RouterSettingsAccordion, { RouterSettingsAccordionValue } from "../common_components/RouterSettingsAccordion";
+import RouterSettingsAccordion, { RouterSettingsAccordionRef, RouterSettingsAccordionValue } from "../common_components/RouterSettingsAccordion";
 import MemberModal from "./EditMembership";
 import MemberPermissions from "./member_permissions";
 import {
@@ -190,6 +190,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isTeamSaving, setIsTeamSaving] = useState(false);
   const [routerSettings, setRouterSettings] = useState<RouterSettingsAccordionValue | null>(null);
+  const routerSettingsRef = React.useRef<RouterSettingsAccordionRef>(null);
   const [organization, setOrganization] = useState<Organization | null>(null);
   const { userRole, userId } = useAuthorized();
   const { data: userOrganizations = [] } = useOrganizations();
@@ -591,13 +592,14 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         updateData.access_group_ids = values.access_group_ids;
       }
 
-      // Handle router_settings
-      if (routerSettings?.router_settings) {
-        const hasValues = Object.values(routerSettings.router_settings).some(
+      // Handle router_settings - use ref to get fresh values from DOM at save time
+      const currentRouterSettings = routerSettingsRef.current?.getValue() ?? routerSettings;
+      if (currentRouterSettings?.router_settings) {
+        const hasValues = Object.values(currentRouterSettings.router_settings).some(
           (value) => value !== null && value !== undefined && value !== "",
         );
         if (hasValues) {
-          updateData.router_settings = routerSettings.router_settings;
+          updateData.router_settings = currentRouterSettings.router_settings;
         }
       }
 
@@ -1102,6 +1104,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
                     <Form.Item label="Router Settings">
                       <RouterSettingsAccordion
+                        ref={routerSettingsRef}
                         accessToken={accessToken || ""}
                         value={routerSettings || (info.router_settings ? { router_settings: info.router_settings } : undefined)}
                         onChange={setRouterSettings}

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -41,6 +41,7 @@ import ObjectPermissionsView from "../object_permissions_view";
 import NumericalInput from "../shared/numerical_input";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import EditLoggingSettings from "./EditLoggingSettings";
+import RouterSettingsAccordion, { RouterSettingsAccordionValue } from "../common_components/RouterSettingsAccordion";
 import MemberModal from "./EditMembership";
 import MemberPermissions from "./member_permissions";
 import {
@@ -98,6 +99,7 @@ export interface TeamData {
     access_group_models?: string[];
     access_group_mcp_server_ids?: string[];
     access_group_agent_ids?: string[];
+    router_settings?: Record<string, any>;
     guardrails?: string[];
     policies?: string[];
     object_permission?: {
@@ -187,6 +189,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isTeamSaving, setIsTeamSaving] = useState(false);
+  const [routerSettings, setRouterSettings] = useState<RouterSettingsAccordionValue | null>(null);
   const [organization, setOrganization] = useState<Organization | null>(null);
   const { userRole, userId } = useAuthorized();
   const { data: userOrganizations = [] } = useOrganizations();
@@ -588,10 +591,21 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         updateData.access_group_ids = values.access_group_ids;
       }
 
+      // Handle router_settings
+      if (routerSettings?.router_settings) {
+        const hasValues = Object.values(routerSettings.router_settings).some(
+          (value) => value !== null && value !== undefined && value !== "",
+        );
+        if (hasValues) {
+          updateData.router_settings = routerSettings.router_settings;
+        }
+      }
+
       const response = await teamUpdateCall(accessToken, updateData);
 
       NotificationsManager.success("Team settings updated successfully");
       setIsEditing(false);
+      setRouterSettings(null);
       fetchTeamInfo();
     } catch (error) {
       console.error("Error updating team:", error);
@@ -1086,6 +1100,15 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       </Form.List>
                     </Form.Item>
 
+                    <Form.Item label="Router Settings">
+                      <RouterSettingsAccordion
+                        accessToken={accessToken || ""}
+                        value={routerSettings || (info.router_settings ? { router_settings: info.router_settings } : undefined)}
+                        onChange={setRouterSettings}
+                        modelData={userModels.length > 0 ? { data: userModels.map((model) => ({ model_name: model })) } : undefined}
+                      />
+                    </Form.Item>
+
                     <Form.Item
                       label={
                         <span>
@@ -1372,6 +1395,44 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       <div>Key Duration: {info.metadata?.team_member_key_duration || "No Limit"}</div>
                       <div>TPM Limit: {info.team_member_budget_table?.tpm_limit || "No Limit"}</div>
                       <div>RPM Limit: {info.team_member_budget_table?.rpm_limit || "No Limit"}</div>
+                    </div>
+                    <div>
+                      <Text className="font-medium">Router Settings</Text>
+                      {info.router_settings && Object.values(info.router_settings).some(
+                        (v) => v !== null && v !== undefined && v !== "" && !(Array.isArray(v) && v.length === 0)
+                      ) ? (
+                        <div className="mt-1 space-y-1">
+                          {info.router_settings.routing_strategy && (
+                            <div>
+                              Routing Strategy:{" "}
+                              <Badge color="blue">{info.router_settings.routing_strategy}</Badge>
+                            </div>
+                          )}
+                          {info.router_settings.num_retries != null && (
+                            <div>Number of Retries: {info.router_settings.num_retries}</div>
+                          )}
+                          {info.router_settings.allowed_fails != null && (
+                            <div>Allowed Failures: {info.router_settings.allowed_fails}</div>
+                          )}
+                          {info.router_settings.cooldown_time != null && (
+                            <div>Cooldown Time: {info.router_settings.cooldown_time}s</div>
+                          )}
+                          {info.router_settings.timeout != null && (
+                            <div>Timeout: {info.router_settings.timeout}s</div>
+                          )}
+                          {info.router_settings.retry_after != null && (
+                            <div>Retry After: {info.router_settings.retry_after}s</div>
+                          )}
+                          {info.router_settings.fallbacks && Array.isArray(info.router_settings.fallbacks) && info.router_settings.fallbacks.length > 0 && (
+                            <div>Fallbacks: {info.router_settings.fallbacks.length} configured</div>
+                          )}
+                          {info.router_settings.enable_tag_filtering && (
+                            <div>Tag Filtering: Enabled</div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="text-gray-400">No router settings configured</div>
+                      )}
                     </div>
                     <div>
                       <Text className="font-medium">Organization ID</Text>


### PR DESCRIPTION
## Relevant issues

## Summary

### Problem
Users can set router settings when creating a team, but cannot edit them afterward in the UI. The backend endpoints fully support `router_settings`, so the gap was purely in the frontend.

### Fix
Reuse the existing `RouterSettingsAccordion` component (already used in the create flow) in the team Settings tab. The component is rendered inline with its Loadbalancing/Fallbacks tabs visible directly — no extra accordion wrapper.

Also fixes two pre-existing bugs in `RouterSettingsAccordion`:
- Numeric fields (retries, timeout, etc.) were not captured on save because the component uses uncontrolled DOM inputs and the `onChange` only fired on strategy/fallback changes. Fixed by reading values via `ref.getValue()` at save time.
- Clearing a numeric field preserved the old value instead of setting it to `null`. Fixed by treating empty DOM inputs as `null`.

## Changes
- Added `router_settings` to `TeamData` interface and wired `RouterSettingsAccordion` into the team edit form with a ref-based approach (pass initial value once, read at save time)
- Added a read-only summary showing routing strategy, numeric settings, and fallback count
- Fixed `RouterSettingsAccordion` to return `null` for empty inputs instead of stale state values
- Added `getRouterSettingsCall` mock to TeamInfo tests

## Testing
- Verified read-only view displays router settings (strategy badge, retries, cooldown, etc.)
- Verified edit form pre-populates the RouterSettingsAccordion with existing values
- Verified saving strategy changes persists to backend
- Verified cancel resets to original values
- Verified empty state shows "No router settings configured"
- All 29 TeamInfo tests pass
- All 87 router settings tests pass
- UI build succeeds

## Type

🆕 New Feature
🐛 Bug Fix
✅ Test