### PR TITLE
fix: rewrite absolute /ui/assets/ paths when SERVER_ROOT_PATH is set

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1373,6 +1373,15 @@ try:
                             f"{server_root_path}",
                         )
 
+                        # Replace absolute /ui/assets/ paths with server_root_path-prefixed
+                        # equivalents so logo/asset requests include the root path prefix.
+                        # Some JS bundles emit absolute paths like "/ui/assets/logos/" which
+                        # resolve incorrectly when the app is served under a sub-path.
+                        modified_content = modified_content.replace(
+                            '"/ui/assets/',
+                            f'"{server_root_path}/ui/assets/',
+                        )
+
                         # Replace the /.well-known/litellm-ui-config with the server root path
                         modified_content = modified_content.replace(
                             "/litellm/.well-known/litellm-ui-config",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1377,9 +1377,14 @@ try:
                         # equivalents so logo/asset requests include the root path prefix.
                         # Some JS bundles emit absolute paths like "/ui/assets/logos/" which
                         # resolve incorrectly when the app is served under a sub-path.
+                        # Both double-quoted and single-quoted variants are handled.
                         modified_content = modified_content.replace(
                             '"/ui/assets/',
                             f'"{server_root_path}/ui/assets/',
+                        )
+                        modified_content = modified_content.replace(
+                            "'/ui/assets/",
+                            f"'{server_root_path}/ui/assets/",
                         )
 
                         # Replace the /.well-known/litellm-ui-config with the server root path

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -54,7 +54,7 @@ from litellm.constants import (
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
     LITELLM_UI_ALLOW_HEADERS,
     LITELLM_UI_SESSION_DURATION,
-    DAILY_TAG_SPEND_BATCH_MULTIPLIER
+    DAILY_TAG_SPEND_BATCH_MULTIPLIER,
 )
 from litellm.litellm_core_utils.litellm_logging import (
     _init_custom_logger_compatible_class,
@@ -2330,9 +2330,13 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
-            if llm_router.health_check_ignore_transient_errors and exception_status in (
-                429,
-                408,
+            if (
+                llm_router.health_check_ignore_transient_errors
+                and exception_status
+                in (
+                    429,
+                    408,
+                )
             ):
                 continue
 
@@ -6301,7 +6305,9 @@ class ProxyStartupEvent:
 
         ### UPDATE DAILY TAG SPEND (separate scheduler job with longer interval) ###
         ## Reduces QPS as there are more tags for a single request
-        tag_spend_update_interval = int(batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER)
+        tag_spend_update_interval = int(
+            batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER
+        )
         from litellm.proxy.utils import update_daily_tag_spend
 
         scheduler.add_job(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import inspect
 import json
 import os
+import re
 import smtplib
 import sys
 import threading
@@ -5396,14 +5397,27 @@ def get_proxy_base_url() -> Optional[str]:
     return os.getenv("PROXY_BASE_URL")
 
 
+_SERVER_ROOT_PATH_PATTERN = re.compile(r"^(/[a-zA-Z0-9_-]+)*$")
+
+
 def get_server_root_path() -> str:
     """
     Get the server root path from the environment variables.
 
     - If SERVER_ROOT_PATH is set, return it.
     - Otherwise, default to "/".
+
+    Raises ValueError on startup if the value contains characters that could
+    be injected into served static files (e.g. script tags).
     """
-    return os.getenv("SERVER_ROOT_PATH", "")
+    value = os.getenv("SERVER_ROOT_PATH", "")
+    if value and not _SERVER_ROOT_PATH_PATTERN.match(value):
+        raise ValueError(
+            f"Invalid SERVER_ROOT_PATH {value!r}: must be empty or match "
+            r"^(/[a-zA-Z0-9_-]+)*$ (e.g. '/myapp' or '/myapp/v1'). "
+            "Characters outside this set could be injected into served UI assets."
+        )
+    return value
 
 
 def normalize_route_for_root_path(route: str) -> Optional[str]:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1899,9 +1899,9 @@ class ProxyLogging:
                     normalized_call_type = CallTypes.aembedding.value
             if normalized_call_type is not None:
                 litellm_logging_obj.call_type = normalized_call_type
-                litellm_logging_obj.model_call_details[
-                    "call_type"
-                ] = normalized_call_type
+                litellm_logging_obj.model_call_details["call_type"] = (
+                    normalized_call_type
+                )
             # Pass-through endpoints are logged via the callback loop's
             # async_post_call_failure_hook — skip pre_call and failure handlers.
             if litellm_logging_obj.call_type == CallTypes.pass_through.value:
@@ -2525,8 +2525,7 @@ class PrismaClient:
             required_view = "LiteLLM_VerificationTokenView"
             expected_views_str = ", ".join(f"'{view}'" for view in expected_views)
             pg_schema = os.getenv("DATABASE_SCHEMA", "public")
-            ret = await self.db.query_raw(
-                f"""
+            ret = await self.db.query_raw(f"""
                 WITH existing_views AS (
                     SELECT viewname
                     FROM pg_views
@@ -2538,8 +2537,7 @@ class PrismaClient:
                     (SELECT COUNT(*) FROM existing_views) AS view_count,
                     ARRAY_AGG(viewname) AS view_names
                 FROM existing_views
-                """
-            )
+                """)
             expected_total_views = len(expected_views)
             if ret[0]["view_count"] == expected_total_views:
                 verbose_proxy_logger.info("All necessary views exist!")
@@ -2548,8 +2546,7 @@ class PrismaClient:
                 ## check if required view exists ##
                 if ret[0]["view_names"] and required_view not in ret[0]["view_names"]:
                     await self.health_check()  # make sure we can connect to db
-                    await self.db.execute_raw(
-                        """
+                    await self.db.execute_raw("""
                             CREATE VIEW "LiteLLM_VerificationTokenView" AS
                             SELECT
                             v.*,
@@ -2559,8 +2556,7 @@ class PrismaClient:
                             t.rpm_limit AS team_rpm_limit
                             FROM "LiteLLM_VerificationToken" v
                             LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id;
-                        """
-                    )
+                        """)
 
                     verbose_proxy_logger.info(
                         "LiteLLM_VerificationTokenView Created in DB!"
@@ -4869,25 +4865,27 @@ async def update_daily_tag_spend(
 ):
     """
     Separate scheduler job to commit daily tag spend updates.
-    
+
     Runs at a longer interval (2.3x default) than the main update_spend job
     to reduce query contention for DailyTagSpend table.
-    
+
     This is called by a dedicated scheduler job and does NOT process:
     - Regular spend updates (user, key, team, org)
     - End-user spend
     - Agent spend
     - Spend logs
-    
+
     Only processes tag spend transactions from the daily_tag_spend_update_queue.
-    
+
     Args:
         prisma_client: PrismaClient instance
         proxy_logging_obj: ProxyLogging instance for error handling
     """
     n_retry_times = 3
     try:
-        if proxy_logging_obj.db_spend_update_writer.redis_update_buffer._should_commit_spend_updates_to_redis():
+        if (
+            proxy_logging_obj.db_spend_update_writer.redis_update_buffer._should_commit_spend_updates_to_redis()
+        ):
             await proxy_logging_obj.db_spend_update_writer._commit_daily_tag_spend_to_db_with_redis(
                 prisma_client=prisma_client,
                 n_retry_times=n_retry_times,

--- a/tests/test_litellm/proxy/test_server_root_path_ui_assets.py
+++ b/tests/test_litellm/proxy/test_server_root_path_ui_assets.py
@@ -29,6 +29,7 @@ def _apply_server_root_path_replacements(
                     content = f.read()
                 modified = content.replace(litellm_asset_prefix, server_root_path)
                 modified = modified.replace('"/ui/assets/', f'"{server_root_path}/ui/assets/')
+                modified = modified.replace("'/ui/assets/", f"'{server_root_path}/ui/assets/")
                 modified = modified.replace(
                     "/litellm/.well-known/litellm-ui-config",
                     f"{server_root_path}/.well-known/litellm-ui-config",
@@ -117,3 +118,67 @@ def test_binary_files_are_skipped(tmp_path):
     _apply_server_root_path_replacements(str(ui_path), "/root")
 
     assert png_file.read_bytes() == b"\x89PNG\r\n\x1a\n"
+
+
+def test_single_quoted_ui_asset_paths_rewritten(tmp_path):
+    """
+    Single-quoted '/ui/assets/' paths must also be rewritten.
+    Some HTML/CSS files use single quotes for attribute values.
+    """
+    ui_path = tmp_path / "ui"
+    ui_path.mkdir()
+
+    js_file = ui_path / "bundle.js"
+    js_file.write_text("let eq='/ui/assets/logos/',r={}")
+
+    server_root_path = "/myapp"
+    _apply_server_root_path_replacements(str(ui_path), server_root_path)
+
+    result = js_file.read_text()
+    assert f"'{server_root_path}/ui/assets/logos/'" in result
+    assert "'/ui/assets/logos/'" not in result
+
+
+def test_invalid_server_root_path_raises_value_error():
+    """
+    get_server_root_path() must raise ValueError for values that could
+    be injected into served JS/HTML files (XSS prevention).
+    """
+    import os
+    from unittest.mock import patch
+
+    from litellm.proxy.utils import get_server_root_path
+
+    malicious_paths = [
+        '"><script>alert(1)</script>',
+        "/myapp/../../etc/passwd",
+        "/myapp with spaces",
+        "/myapp?query=1",
+    ]
+    for path in malicious_paths:
+        with patch.dict(os.environ, {"SERVER_ROOT_PATH": path}):
+            try:
+                result = get_server_root_path()
+                assert False, f"Expected ValueError for path {path!r}, got {result!r}"
+            except ValueError:
+                pass  # expected
+
+
+def test_valid_server_root_path_accepted():
+    """Valid SERVER_ROOT_PATH values must be accepted without error."""
+    import os
+    from unittest.mock import patch
+
+    from litellm.proxy.utils import get_server_root_path
+
+    valid_paths = [
+        "",
+        "/myapp",
+        "/myapp/v1",
+        "/web-llmgateway/v1",
+        "/a-b_c",
+    ]
+    for path in valid_paths:
+        with patch.dict(os.environ, {"SERVER_ROOT_PATH": path}):
+            result = get_server_root_path()
+            assert result == path

--- a/tests/test_litellm/proxy/test_server_root_path_ui_assets.py
+++ b/tests/test_litellm/proxy/test_server_root_path_ui_assets.py
@@ -18,7 +18,17 @@ def _apply_server_root_path_replacements(
     litellm_asset_prefix: str = "/litellm-asset-prefix",
 ) -> None:
     """Replicate the replacement logic from proxy_server.py for testing."""
-    skip_extensions = (".png", ".jpg", ".jpeg", ".gif", ".ico", ".woff", ".woff2", ".ttf", ".eot")
+    skip_extensions = (
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".ico",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".eot",
+    )
     for root, _, files in os.walk(ui_path):
         for filename in files:
             if filename.endswith(skip_extensions):
@@ -28,8 +38,12 @@ def _apply_server_root_path_replacements(
                 with open(file_path, "r", encoding="utf-8") as f:
                     content = f.read()
                 modified = content.replace(litellm_asset_prefix, server_root_path)
-                modified = modified.replace('"/ui/assets/', f'"{server_root_path}/ui/assets/')
-                modified = modified.replace("'/ui/assets/", f"'{server_root_path}/ui/assets/")
+                modified = modified.replace(
+                    '"/ui/assets/', f'"{server_root_path}/ui/assets/'
+                )
+                modified = modified.replace(
+                    "'/ui/assets/", f"'{server_root_path}/ui/assets/"
+                )
                 modified = modified.replace(
                     "/litellm/.well-known/litellm-ui-config",
                     f"{server_root_path}/.well-known/litellm-ui-config",
@@ -62,12 +76,12 @@ def test_absolute_ui_asset_paths_rewritten_with_server_root_path(tmp_path):
     _apply_server_root_path_replacements(str(ui_path), server_root_path)
 
     result = js_file.read_text()
-    assert f'"{server_root_path}/ui/assets/logos/"' in result, (
-        f"Absolute /ui/assets/ path not rewritten to include SERVER_ROOT_PATH. Got: {result}"
-    )
-    assert '"/ui/assets/logos/"' not in result, (
-        "Old absolute /ui/assets/ path should have been replaced"
-    )
+    assert (
+        f'"{server_root_path}/ui/assets/logos/"' in result
+    ), f"Absolute /ui/assets/ path not rewritten to include SERVER_ROOT_PATH. Got: {result}"
+    assert (
+        '"/ui/assets/logos/"' not in result
+    ), "Old absolute /ui/assets/ path should have been replaced"
 
 
 def test_litellm_asset_prefix_still_rewritten(tmp_path):
@@ -76,9 +90,7 @@ def test_litellm_asset_prefix_still_rewritten(tmp_path):
     ui_path.mkdir()
 
     js_file = ui_path / "bundle.js"
-    js_file.write_text(
-        'let t="/litellm-asset-prefix/_next/",eq="/ui/assets/logos/"'
-    )
+    js_file.write_text('let t="/litellm-asset-prefix/_next/",eq="/ui/assets/logos/"')
 
     server_root_path = "/myapp"
     _apply_server_root_path_replacements(str(ui_path), server_root_path)

--- a/tests/test_litellm/proxy/test_server_root_path_ui_assets.py
+++ b/tests/test_litellm/proxy/test_server_root_path_ui_assets.py
@@ -1,0 +1,119 @@
+"""
+Tests for SERVER_ROOT_PATH rewriting of absolute /ui/assets/ paths in JS bundles.
+
+Regression test for https://github.com/BerriAI/litellm/issues/25283
+
+When LiteLLM is served under a sub-path (SERVER_ROOT_PATH=/web-llmgateway/v1),
+some JS chunks emit absolute paths like "/ui/assets/logos/" that the browser
+resolves without the sub-path prefix, causing 404s for logo assets.
+The startup path-rewriting logic must patch these absolute paths.
+"""
+
+import os
+
+
+def _apply_server_root_path_replacements(
+    ui_path: str,
+    server_root_path: str,
+    litellm_asset_prefix: str = "/litellm-asset-prefix",
+) -> None:
+    """Replicate the replacement logic from proxy_server.py for testing."""
+    skip_extensions = (".png", ".jpg", ".jpeg", ".gif", ".ico", ".woff", ".woff2", ".ttf", ".eot")
+    for root, _, files in os.walk(ui_path):
+        for filename in files:
+            if filename.endswith(skip_extensions):
+                continue
+            file_path = os.path.join(root, filename)
+            try:
+                with open(file_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                modified = content.replace(litellm_asset_prefix, server_root_path)
+                modified = modified.replace('"/ui/assets/', f'"{server_root_path}/ui/assets/')
+                modified = modified.replace(
+                    "/litellm/.well-known/litellm-ui-config",
+                    f"{server_root_path}/.well-known/litellm-ui-config",
+                )
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(modified)
+            except (UnicodeDecodeError, PermissionError, OSError):
+                continue
+
+
+def test_absolute_ui_asset_paths_rewritten_with_server_root_path(tmp_path):
+    """
+    JS bundles that use absolute "/ui/assets/logos/" paths should have those
+    paths rewritten to include SERVER_ROOT_PATH when it is set.
+
+    Reproduces: browser requests /{SERVER_ROOT_PATH}/assets/logos/... (404)
+    instead of /{SERVER_ROOT_PATH}/ui/assets/logos/... (200).
+    """
+    ui_path = tmp_path / "ui"
+    ui_path.mkdir()
+
+    # Simulate a JS chunk that uses an absolute /ui/assets/ path.
+    # This mirrors the pattern seen in the packaged UI output:
+    #   _next/static/chunks/0d219667baa010f5.js
+    js_file = ui_path / "_next" / "static" / "chunks" / "logos.js"
+    js_file.parent.mkdir(parents=True)
+    js_file.write_text('let eq="/ui/assets/logos/",r={github:`${eq}github.svg`}')
+
+    server_root_path = "/web-llmgateway/v1"
+    _apply_server_root_path_replacements(str(ui_path), server_root_path)
+
+    result = js_file.read_text()
+    assert f'"{server_root_path}/ui/assets/logos/"' in result, (
+        f"Absolute /ui/assets/ path not rewritten to include SERVER_ROOT_PATH. Got: {result}"
+    )
+    assert '"/ui/assets/logos/"' not in result, (
+        "Old absolute /ui/assets/ path should have been replaced"
+    )
+
+
+def test_litellm_asset_prefix_still_rewritten(tmp_path):
+    """Existing litellm-asset-prefix replacement must still work alongside the new fix."""
+    ui_path = tmp_path / "ui"
+    ui_path.mkdir()
+
+    js_file = ui_path / "bundle.js"
+    js_file.write_text(
+        'let t="/litellm-asset-prefix/_next/",eq="/ui/assets/logos/"'
+    )
+
+    server_root_path = "/myapp"
+    _apply_server_root_path_replacements(str(ui_path), server_root_path)
+
+    result = js_file.read_text()
+    assert f'"{server_root_path}/_next/"' in result
+    assert f'"{server_root_path}/ui/assets/logos/"' in result
+    assert '"/litellm-asset-prefix/_next/"' not in result
+    assert '"/ui/assets/logos/"' not in result
+
+
+def test_no_replacement_when_no_server_root_path(tmp_path):
+    """When server_root_path is empty, paths should remain unchanged."""
+    ui_path = tmp_path / "ui"
+    ui_path.mkdir()
+
+    original = 'let eq="/ui/assets/logos/",r={}'
+    js_file = ui_path / "bundle.js"
+    js_file.write_text(original)
+
+    # Simulate the guard: only replace when server_root_path is non-empty
+    server_root_path = ""
+    if server_root_path and server_root_path != "/":
+        _apply_server_root_path_replacements(str(ui_path), server_root_path)
+
+    assert js_file.read_text() == original
+
+
+def test_binary_files_are_skipped(tmp_path):
+    """Image and font files must not be touched by the replacement logic."""
+    ui_path = tmp_path / "ui"
+    ui_path.mkdir()
+
+    png_file = ui_path / "logo.png"
+    png_file.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    _apply_server_root_path_replacements(str(ui_path), "/root")
+
+    assert png_file.read_bytes() == b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
## What's the problem?

Fixes #25283.

When `SERVER_ROOT_PATH` is set (e.g. `/web-llmgateway/v1`), some compiled Next.js chunks emit absolute paths like `"/ui/assets/logos/"` that browsers resolve without the sub-path prefix, causing 404s for logo assets.

Two additional gaps found during review:

1. **Security**: `SERVER_ROOT_PATH` was injected verbatim into served JS/HTML files at startup with no sanitization. A malicious env var value (e.g. with script tags) would be embedded permanently into static assets — stored XSS.
2. **Correctness**: Only double-quoted paths (`"/ui/assets/`) were handled; single-quoted variants (`'/ui/assets/`) used in HTML/CSS were skipped silently.

## What's the fix?

- **`proxy_server.py`**: Add replacement for absolute `"/ui/assets/` paths (double-quoted), and also for `'/ui/assets/` (single-quoted)
- **`utils.py`**: Add regex validation in `get_server_root_path()` — raises `ValueError` at startup if `SERVER_ROOT_PATH` contains characters outside `^(/[a-zA-Z0-9_-]+)*$`, preventing injection into static assets

## Tests

7 tests total in `test_server_root_path_ui_assets.py`:
- `test_absolute_ui_asset_paths_rewritten_with_server_root_path`
- `test_litellm_asset_prefix_still_rewritten`
- `test_no_replacement_when_no_server_root_path`
- `test_binary_files_are_skipped`
- `test_single_quoted_ui_asset_paths_rewritten` (new)
- `test_invalid_server_root_path_raises_value_error` (new — 4 malicious path variants)
- `test_valid_server_root_path_accepted` (new — 5 valid path variants)

## Checklist

- [x] Added tests in `tests/test_litellm/`
- [x] `make test-unit` passes locally