### PR TITLE
fix: store hashed password on /user/new when password field is provided

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -890,9 +890,9 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     allowed_cache_controls: Optional[list] = []
     config: Optional[dict] = {}
     permissions: Optional[dict] = {}
-    model_max_budget: Optional[dict] = (
-        {}
-    )  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
+    model_max_budget: Optional[
+        dict
+    ] = {}  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
 
     model_config = ConfigDict(protected_namespaces=())
     model_rpm_limit: Optional[dict] = None
@@ -1034,9 +1034,9 @@ class RegenerateKeyRequest(GenerateKeyRequest):
     spend: Optional[float] = None
     metadata: Optional[dict] = None
     new_master_key: Optional[str] = None
-    grace_period: Optional[str] = (
-        None  # Duration to keep old key valid (e.g. "24h", "2d"); None = immediate revoke
-    )
+    grace_period: Optional[
+        str
+    ] = None  # Duration to keep old key valid (e.g. "24h", "2d"); None = immediate revoke
 
 
 class ResetSpendRequest(LiteLLMPydanticObjectBase):
@@ -1556,12 +1556,12 @@ class NewCustomerRequest(BudgetNewRequest):
     blocked: bool = False  # allow/disallow requests for this end-user
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
     spend: Optional[float] = None
-    allowed_model_region: Optional[AllowedModelRegion] = (
-        None  # require all user requests to use models in this specific region
-    )
-    default_model: Optional[str] = (
-        None  # if no equivalent model in allowed region - default all requests to this model
-    )
+    allowed_model_region: Optional[
+        AllowedModelRegion
+    ] = None  # require all user requests to use models in this specific region
+    default_model: Optional[
+        str
+    ] = None  # if no equivalent model in allowed region - default all requests to this model
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
     @model_validator(mode="before")
@@ -1584,12 +1584,12 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
-    allowed_model_region: Optional[AllowedModelRegion] = (
-        None  # require all user requests to use models in this specific region
-    )
-    default_model: Optional[str] = (
-        None  # if no equivalent model in allowed region - default all requests to this model
-    )
+    allowed_model_region: Optional[
+        AllowedModelRegion
+    ] = None  # require all user requests to use models in this specific region
+    default_model: Optional[
+        str
+    ] = None  # if no equivalent model in allowed region - default all requests to this model
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
 
@@ -1679,15 +1679,15 @@ class NewTeamRequest(TeamBase):
     ] = None  # raise an error if 'guaranteed_throughput' is set and we're overallocating tpm
 
     model_tpm_limit: Optional[Dict[str, int]] = None
-    team_member_budget: Optional[float] = (
-        None  # allow user to set a budget for all team members
-    )
-    team_member_rpm_limit: Optional[int] = (
-        None  # allow user to set RPM limit for all team members
-    )
-    team_member_tpm_limit: Optional[int] = (
-        None  # allow user to set TPM limit for all team members
-    )
+    team_member_budget: Optional[
+        float
+    ] = None  # allow user to set a budget for all team members
+    team_member_rpm_limit: Optional[
+        int
+    ] = None  # allow user to set RPM limit for all team members
+    team_member_tpm_limit: Optional[
+        int
+    ] = None  # allow user to set TPM limit for all team members
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     team_member_budget_duration: Optional[str] = None  # e.g. "30d", "1mo"
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
@@ -1784,9 +1784,9 @@ class BlockKeyRequest(LiteLLMPydanticObjectBase):
 
 class AddTeamCallback(LiteLLMPydanticObjectBase):
     callback_name: str
-    callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = (
-        "success_and_failure"
-    )
+    callback_type: Optional[
+        Literal["success", "failure", "success_and_failure"]
+    ] = "success_and_failure"
     callback_vars: Dict[str, str]
 
     @model_validator(mode="before")
@@ -2128,9 +2128,9 @@ class ConfigList(LiteLLMPydanticObjectBase):
     stored_in_db: Optional[bool]
     field_default_value: Any
     premium_field: bool = False
-    nested_fields: Optional[List[FieldDetail]] = (
-        None  # For nested dictionary or Pydantic fields
-    )
+    nested_fields: Optional[
+        List[FieldDetail]
+    ] = None  # For nested dictionary or Pydantic fields
 
 
 class UserHeaderMapping(LiteLLMPydanticObjectBase):
@@ -2488,9 +2488,9 @@ class UserAPIKeyAuth(
     user_max_budget: Optional[float] = None
     request_route: Optional[str] = None
     user: Optional[Any] = None  # Expanded user object when expand=user is used
-    created_by_user: Optional[Any] = (
-        None  # Expanded created_by user when expand=user is used
-    )
+    created_by_user: Optional[
+        Any
+    ] = None  # Expanded created_by user when expand=user is used
     end_user_object_permission: Optional[LiteLLM_ObjectPermissionTable] = None
     # Decoded upstream IdP claims (groups, roles, etc.) propagated by JWT auth machinery
     # and forwarded into outbound tokens by guardrails such as MCPJWTSigner.
@@ -2629,9 +2629,9 @@ class LiteLLM_OrganizationMembershipTable(LiteLLMPydanticObjectBase):
     budget_id: Optional[str] = None
     created_at: datetime
     updated_at: datetime
-    user: Optional[Any] = (
-        None  # You might want to replace 'Any' with a more specific type if available
-    )
+    user: Optional[
+        Any
+    ] = None  # You might want to replace 'Any' with a more specific type if available
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
     user_email: Optional[str] = None
 
@@ -3786,9 +3786,9 @@ class TeamModelDeleteRequest(BaseModel):
 # Organization Member Requests
 class OrganizationMemberAddRequest(OrgMemberAddRequest):
     organization_id: str
-    max_budget_in_organization: Optional[float] = (
-        None  # Users max budget within the organization
-    )
+    max_budget_in_organization: Optional[
+        float
+    ] = None  # Users max budget within the organization
 
 
 class OrganizationMemberDeleteRequest(MemberDeleteRequest):
@@ -4043,9 +4043,9 @@ class ProviderBudgetResponse(LiteLLMPydanticObjectBase):
     Maps provider names to their budget configs.
     """
 
-    providers: Dict[str, ProviderBudgetResponseObject] = (
-        {}
-    )  # Dictionary mapping provider names to their budget configurations
+    providers: Dict[
+        str, ProviderBudgetResponseObject
+    ] = {}  # Dictionary mapping provider names to their budget configurations
 
 
 class ProxyStateVariables(TypedDict):
@@ -4207,9 +4207,9 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     enforce_rbac: bool = False
     roles_jwt_field: Optional[str] = None  # v2 on role mappings
     role_mappings: Optional[List[RoleMapping]] = None
-    object_id_jwt_field: Optional[str] = (
-        None  # can be either user / team, inferred from the role mapping
-    )
+    object_id_jwt_field: Optional[
+        str
+    ] = None  # can be either user / team, inferred from the role mapping
     scope_mappings: Optional[List[ScopeMapping]] = None
     enforce_scope_based_access: bool = False
     enforce_team_based_model_access: bool = False

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1427,6 +1427,13 @@ class NewUserRequest(GenerateRequestBase):
     organizations: Optional[List[str]] = None
     password: Optional[str] = None
 
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and len(v) < 8:
+            raise ValueError("password must be at least 8 characters")
+        return v
+
 
 class NewUserResponse(GenerateKeyResponse):
     max_budget: Optional[float] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1432,6 +1432,8 @@ class NewUserRequest(GenerateRequestBase):
     def validate_password(cls, v: Optional[str]) -> Optional[str]:
         if v is not None and len(v) < 8:
             raise ValueError("password must be at least 8 characters")
+        if v is not None and len(v) > 128:
+            raise ValueError("password must be at most 128 characters")
         return v
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1425,6 +1425,7 @@ class NewUserRequest(GenerateRequestBase):
     send_invite_email: Optional[bool] = None
     sso_user_id: Optional[str] = None
     organizations: Optional[List[str]] = None
+    password: Optional[str] = None
 
 
 class NewUserResponse(GenerateKeyResponse):

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -455,6 +455,10 @@ async def new_user(
         data_json = data.json()  # type: ignore
         data_json = _update_internal_new_user_params(data_json, data)
         _hash_password_in_dict(data_json)
+        # Pop password before passing to generate_key_helper_fn — the function
+        # does not accept a password parameter and user_data does not include it.
+        # We store it via a targeted update after the user row is created.
+        hashed_password = data_json.pop("password", None)
         teams = data.teams
         if teams is None:
             teams = check_if_default_team_set()
@@ -463,6 +467,15 @@ async def new_user(
         )
 
         response = await generate_key_helper_fn(request_type="user", **data_json)
+
+        # Store the hashed password on the newly created user row.
+        if hashed_password is not None:
+            created_user_id = response.get("user_id")
+            if created_user_id is not None:
+                await prisma_client.db.litellm_usertable.update(
+                    where={"user_id": created_user_id},
+                    data={"password": hashed_password},
+                )
         # Admin UI Logic
         # Add User to Team and Organization
         # if team_id passed add this user to the team

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -471,11 +471,15 @@ async def new_user(
         # Store the hashed password on the newly created user row.
         if hashed_password is not None:
             created_user_id = response.get("user_id")
-            if created_user_id is not None:
-                await prisma_client.db.litellm_usertable.update(
-                    where={"user_id": created_user_id},
-                    data={"password": hashed_password},
+            if created_user_id is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail="User was created but user_id was not returned — password could not be stored.",
                 )
+            await prisma_client.db.litellm_usertable.update(
+                where={"user_id": created_user_id},
+                data={"password": hashed_password},
+            )
         # Admin UI Logic
         # Add User to Team and Organization
         # if team_id passed add this user to the team

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -395,6 +395,7 @@ async def new_user(
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - internal user-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
     - prompts: Optional[List[str]] - List of allowed prompts for the user. If specified, the user will only be able to use these specific prompts.
     - organizations: List[str] - List of organization id's the user is a member of
+    - password: Optional[str] - Password for the user (minimum 8 characters). Stored as a scrypt hash; never returned in responses.
     Returns:
     - key: (str) The generated api key for the user
     - expires: (datetime) Datetime object for when key expires.

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -81,9 +81,9 @@ def _update_internal_new_user_params(data_json: dict, data: NewUserRequest) -> d
     auto_create_key = data_json.pop("auto_create_key", True)
 
     if auto_create_key is False:
-        data_json[
-            "table_name"
-        ] = "user"  # only create a user, don't create key if 'auto_create_key' set to False
+        data_json["table_name"] = (
+            "user"  # only create a user, don't create key if 'auto_create_key' set to False
+        )
 
     if litellm.default_internal_user_params and (
         data.user_role != LitellmUserRoles.PROXY_ADMIN.value
@@ -1121,9 +1121,9 @@ def _update_internal_user_params(
         "budget_duration" not in non_default_values
     ):  # applies internal user limits, if user role updated
         if is_internal_user and litellm.internal_user_budget_duration is not None:
-            non_default_values[
-                "budget_duration"
-            ] = litellm.internal_user_budget_duration
+            non_default_values["budget_duration"] = (
+                litellm.internal_user_budget_duration
+            )
             from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
             non_default_values["budget_reset_at"] = get_budget_reset_time(
@@ -2384,13 +2384,13 @@ async def ui_view_users(
             }
 
         # Query users with pagination and filters
-        users: Optional[
-            List[BaseModel]
-        ] = await prisma_client.db.litellm_usertable.find_many(
-            where=where_conditions,
-            skip=skip,
-            take=page_size,
-            order={"created_at": "desc"},
+        users: Optional[List[BaseModel]] = (
+            await prisma_client.db.litellm_usertable.find_many(
+                where=where_conditions,
+                skip=skip,
+                take=page_size,
+                order={"created_at": "desc"},
+            )
         )
 
         if not users:

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -421,12 +421,6 @@ async def new_user(
             raise HTTPException(
                 status_code=400, detail=CommonProxyErrors.db_not_connected_error.value
             )
-
-        if prisma_client is None:
-            raise HTTPException(
-                status_code=500,
-                detail=CommonProxyErrors.db_not_connected_error.value,
-            )
         # Check for duplicate user_id or email
         await _check_duplicate_user_id(data.user_id, prisma_client)
         await _check_duplicate_user_email(data.user_email, prisma_client)
@@ -477,10 +471,17 @@ async def new_user(
                     status_code=500,
                     detail="User was created but user_id was not returned — password could not be stored.",
                 )
-            await prisma_client.db.litellm_usertable.update(
-                where={"user_id": created_user_id},
-                data={"password": hashed_password},
-            )
+            try:
+                await prisma_client.db.litellm_usertable.update(
+                    where={"user_id": created_user_id},
+                    data={"password": hashed_password},
+                )
+            except Exception as pwd_err:
+                # Roll back the user row so the caller can safely retry.
+                await prisma_client.db.litellm_usertable.delete(
+                    where={"user_id": created_user_id}
+                )
+                raise pwd_err
         # Admin UI Logic
         # Add User to Team and Organization
         # if team_id passed add this user to the team

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -2672,3 +2672,81 @@ async def test_new_user_password_raises_if_user_id_missing(mocker):
 
     assert exc_info.value.status_code == 500
     assert "user_id" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_new_user_password_update_failure_rolls_back_user(mocker):
+    """
+    If litellm_usertable.update() raises after the user row is created,
+    the user row must be deleted so the caller can safely retry without
+    being stuck with a passwordless user that cannot be recreated.
+    """
+    from litellm.proxy._types import NewUserRequest, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_no_duplicate(*args, **kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_no_duplicate,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_no_duplicate,
+    )
+
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+
+    created_user_id = "test-user-rollback-456"
+
+    mock_generate_key = mocker.AsyncMock(
+        return_value={
+            "user_id": created_user_id,
+            "token": "sk-test-token",
+            "expires": None,
+            "max_budget": None,
+        }
+    )
+
+    # Simulate a transient DB error on the password update
+    db_error = Exception("DB connection lost")
+    mock_update = mocker.AsyncMock(side_effect=db_error)
+    mock_delete = mocker.AsyncMock()
+    mock_prisma_client.db.litellm_usertable.update = mock_update
+    mock_prisma_client.db.litellm_usertable.delete = mock_delete
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.UserManagementEventHooks.async_user_created_hook",
+        mocker.AsyncMock(),
+    )
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.generate_key_helper_fn",
+        mock_generate_key,
+    )
+
+    user_request = NewUserRequest(
+        user_id=created_user_id,
+        user_email="rollback@example.com",
+        password="secure_pass_123",
+    )
+    mock_user_key = UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
+
+    with pytest.raises(Exception) as exc_info:
+        await new_user(data=user_request, user_api_key_dict=mock_user_key)
+
+    # The original DB error must propagate
+    assert exc_info.value is db_error
+
+    # The user row must have been deleted (rollback)
+    mock_delete.assert_called_once_with(where={"user_id": created_user_id})

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -2618,9 +2618,7 @@ async def test_new_user_password_raises_if_user_id_missing(mocker):
     If generate_key_helper_fn returns a response without user_id,
     new_user must raise HTTP 500 rather than silently drop the password.
     """
-    from fastapi import HTTPException
-
-    from litellm.proxy._types import NewUserRequest, UserAPIKeyAuth
+    from litellm.proxy._types import NewUserRequest, ProxyException, UserAPIKeyAuth
     from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
 
     mock_prisma_client = mocker.MagicMock()
@@ -2667,11 +2665,11 @@ async def test_new_user_password_raises_if_user_id_missing(mocker):
     )
     mock_user_key = UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ProxyException) as exc_info:
         await new_user(data=user_request, user_api_key_dict=mock_user_key)
 
-    assert exc_info.value.status_code == 500
-    assert "user_id" in exc_info.value.detail
+    assert exc_info.value.code == 500
+    assert "user_id" in exc_info.value.message
 
 
 @pytest.mark.asyncio
@@ -2742,11 +2740,13 @@ async def test_new_user_password_update_failure_rolls_back_user(mocker):
     )
     mock_user_key = UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
 
-    with pytest.raises(Exception) as exc_info:
+    from litellm.proxy._types import ProxyException
+
+    with pytest.raises(ProxyException) as exc_info:
         await new_user(data=user_request, user_api_key_dict=mock_user_key)
 
-    # The original DB error must propagate
-    assert exc_info.value is db_error
+    # The original DB error message must be surfaced
+    assert "DB connection lost" in exc_info.value.message
 
     # The user row must have been deleted (rollback)
     mock_delete.assert_called_once_with(where={"user_id": created_user_id})

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -2591,9 +2591,9 @@ async def test_new_user_password_is_hashed_and_stored(mocker):
 
     # Password must NOT be passed to generate_key_helper_fn
     call_kwargs = mock_generate_key.call_args.kwargs
-    assert "password" not in call_kwargs, (
-        "password should be popped before calling generate_key_helper_fn"
-    )
+    assert (
+        "password" not in call_kwargs
+    ), "password should be popped before calling generate_key_helper_fn"
 
     # Password must be stored via a separate update call with the correct args
     mock_update.assert_called_once()
@@ -2602,12 +2602,14 @@ async def test_new_user_password_is_hashed_and_stored(mocker):
     stored_password = call_kwargs.kwargs["data"]["password"]
 
     # Must NOT be stored as plaintext
-    assert stored_password != plaintext_password, "Password must not be stored as plaintext"
+    assert (
+        stored_password != plaintext_password
+    ), "Password must not be stored as plaintext"
 
     # Must be verifiable
-    assert verify_password(plaintext_password, stored_password), (
-        "Stored password hash must verify against the original plaintext"
-    )
+    assert verify_password(
+        plaintext_password, stored_password
+    ), "Stored password hash must verify against the original plaintext"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -2516,3 +2516,100 @@ class TestGetUserIdFromRequestValidation:
         request = self._make_request(f"user_id={exact_id}")
         result = get_user_id_from_request(request)
         assert result == exact_id
+
+
+@pytest.mark.asyncio
+async def test_new_user_password_is_hashed_and_stored(mocker):
+    """
+    /user/new with a password field must:
+    1. Hash the password (not store plaintext).
+    2. Actually persist the hashed password on the user row.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/25328
+    """
+    from litellm.proxy._types import NewUserRequest, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+    from litellm.proxy.utils import verify_password
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_no_duplicate(*args, **kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_no_duplicate,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_no_duplicate,
+    )
+
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+
+    created_user_id = "test-user-password-123"
+
+    mock_generate_key = mocker.AsyncMock(
+        return_value={
+            "user_id": created_user_id,
+            "token": "sk-test-token",
+            "expires": None,
+            "max_budget": None,
+        }
+    )
+
+    # Capture the data passed to litellm_usertable.update
+    update_calls: list = []
+
+    async def mock_update(where, data):
+        update_calls.append({"where": where, "data": data})
+
+    mock_prisma_client.db.litellm_usertable.update = mock_update
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.UserManagementEventHooks.async_user_created_hook",
+        mocker.AsyncMock(),
+    )
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.generate_key_helper_fn",
+        mock_generate_key,
+    )
+
+    plaintext_password = "super_secret_pass"
+    user_request = NewUserRequest(
+        user_id=created_user_id,
+        user_email="newuser@example.com",
+        password=plaintext_password,
+    )
+    mock_user_key = UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
+
+    await new_user(data=user_request, user_api_key_dict=mock_user_key)
+
+    # Password must NOT be passed to generate_key_helper_fn
+    call_kwargs = mock_generate_key.call_args.kwargs
+    assert "password" not in call_kwargs, (
+        "password should be popped before calling generate_key_helper_fn"
+    )
+
+    # Password must be stored via a separate update call
+    assert len(update_calls) == 1, (
+        f"Expected exactly 1 usertable.update call for password, got {len(update_calls)}"
+    )
+    stored_password = update_calls[0]["data"]["password"]
+
+    # Must NOT be stored as plaintext
+    assert stored_password != plaintext_password, "Password must not be stored as plaintext"
+
+    # Must be verifiable
+    assert verify_password(plaintext_password, stored_password), (
+        "Stored password hash must verify against the original plaintext"
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -2564,12 +2564,7 @@ async def test_new_user_password_is_hashed_and_stored(mocker):
         }
     )
 
-    # Capture the data passed to litellm_usertable.update
-    update_calls: list = []
-
-    async def mock_update(where, data):
-        update_calls.append({"where": where, "data": data})
-
+    mock_update = mocker.AsyncMock()
     mock_prisma_client.db.litellm_usertable.update = mock_update
 
     mocker.patch(
@@ -2600,11 +2595,11 @@ async def test_new_user_password_is_hashed_and_stored(mocker):
         "password should be popped before calling generate_key_helper_fn"
     )
 
-    # Password must be stored via a separate update call
-    assert len(update_calls) == 1, (
-        f"Expected exactly 1 usertable.update call for password, got {len(update_calls)}"
-    )
-    stored_password = update_calls[0]["data"]["password"]
+    # Password must be stored via a separate update call with the correct args
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args
+    assert call_kwargs.kwargs["where"] == {"user_id": created_user_id}
+    stored_password = call_kwargs.kwargs["data"]["password"]
 
     # Must NOT be stored as plaintext
     assert stored_password != plaintext_password, "Password must not be stored as plaintext"
@@ -2613,3 +2608,65 @@ async def test_new_user_password_is_hashed_and_stored(mocker):
     assert verify_password(plaintext_password, stored_password), (
         "Stored password hash must verify against the original plaintext"
     )
+
+
+@pytest.mark.asyncio
+async def test_new_user_password_raises_if_user_id_missing(mocker):
+    """
+    If generate_key_helper_fn returns a response without user_id,
+    new_user must raise HTTP 500 rather than silently drop the password.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import NewUserRequest, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_no_duplicate(*args, **kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_no_duplicate,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_no_duplicate,
+    )
+
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+
+    # generate_key_helper_fn returns a response with no user_id
+    mock_generate_key = mocker.AsyncMock(
+        return_value={"token": "sk-test-token", "expires": None}
+    )
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.generate_key_helper_fn",
+        mock_generate_key,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.UserManagementEventHooks.async_user_created_hook",
+        mocker.AsyncMock(),
+    )
+
+    user_request = NewUserRequest(
+        user_email="newuser@example.com",
+        password="super_secret_pass",
+    )
+    mock_user_key = UserAPIKeyAuth(user_id="admin", user_role="proxy_admin")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await new_user(data=user_request, user_api_key_dict=mock_user_key)
+
+    assert exc_info.value.status_code == 500
+    assert "user_id" in exc_info.value.detail


### PR DESCRIPTION
## What's the problem?

Fixes #25328.

Two bugs prevented the `password` field from being stored when creating a new user via `POST /user/new`:

1. `NewUserRequest` had no `password` field, so Pydantic discarded it before the handler ran.
2. `generate_key_helper_fn` does not accept `password` and its internal `user_data` dict does not include it, so even if the field existed it would never reach the database.

## What's the fix?

- Added `password: Optional[str] = None` to `NewUserRequest` with an 8-character minimum validation rule (Pydantic `field_validator`)
- In `new_user()`: hash the password via the existing `_hash_password_in_dict()`, pop it from `data_json` before forwarding to `generate_key_helper_fn`, then persist it via a targeted `litellm_usertable.update()` after the user row is created
- Raise HTTP 500 (instead of silently dropping the password) if `user_id` is not returned after creation

## Tests

- `test_new_user_password_is_hashed_and_stored` — verifies password not passed to `generate_key_helper_fn`, stored hashed, verifiable
- `test_new_user_password_raises_if_user_id_missing` — verifies HTTP 500 when `user_id` is absent from creation response

## Checklist

- [x] Added tests in `tests/test_litellm/`
- [x] `make test-unit` passes locally