### PR TITLE
fix(chatgpt): preserve responses routing and recover empty output

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -579,6 +579,130 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         return choices
 
+    @staticmethod
+    def _strip_sse_data_prefix(chunk: str) -> str:
+        stripped_chunk = chunk.strip()
+        if stripped_chunk.startswith("data:"):
+            return stripped_chunk[len("data:") :].strip()
+        return stripped_chunk
+
+    @classmethod
+    def _recover_output_items_from_raw_sse(
+        cls, raw_sse: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        if not raw_sse or not isinstance(raw_sse, str):
+            return []
+
+        recovered_output_items: Dict[int, Dict[str, Any]] = {}
+        recovered_text_only_items: Dict[int, Dict[str, Any]] = {}
+
+        for chunk in raw_sse.splitlines():
+            stripped_chunk = cls._strip_sse_data_prefix(chunk)
+            if (
+                not stripped_chunk
+                or stripped_chunk == "[DONE]"
+                or stripped_chunk.startswith("event:")
+            ):
+                continue
+
+            try:
+                parsed_chunk = json.loads(stripped_chunk)
+            except json.JSONDecodeError:
+                continue
+
+            if not isinstance(parsed_chunk, dict):
+                continue
+
+            event_type = parsed_chunk.get("type")
+
+            if event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
+                response_payload = parsed_chunk.get("response")
+                if isinstance(response_payload, dict):
+                    response_output = response_payload.get("output")
+                    if isinstance(response_output, list) and len(response_output) > 0:
+                        return cast(List[Dict[str, Any]], response_output)
+                continue
+
+            if event_type == "response.output_item.done":
+                item = parsed_chunk.get("item")
+                if not isinstance(item, dict):
+                    continue
+                try:
+                    output_index = int(parsed_chunk.get("output_index"))
+                except (TypeError, ValueError):
+                    output_index = len(recovered_output_items)
+                recovered_output_items[output_index] = item
+                continue
+
+            if event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+                text = parsed_chunk.get("text")
+                if not isinstance(text, str):
+                    continue
+
+                try:
+                    output_index = int(parsed_chunk.get("output_index"))
+                except (TypeError, ValueError):
+                    output_index = len(recovered_text_only_items)
+
+                item = recovered_output_items.get(
+                    output_index
+                ) or recovered_text_only_items.get(output_index)
+                if item is None:
+                    item = {
+                        "type": "message",
+                        "id": parsed_chunk.get("item_id") or f"msg_{output_index}",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [],
+                    }
+                    recovered_text_only_items[output_index] = item
+
+                content = item.setdefault("content", [])
+                if not isinstance(content, list):
+                    continue
+
+                try:
+                    content_index = int(parsed_chunk.get("content_index"))
+                except (TypeError, ValueError):
+                    content_index = len(content)
+
+                while len(content) <= content_index:
+                    content.append(
+                        {
+                            "type": "output_text",
+                            "text": "",
+                            "annotations": [],
+                        }
+                    )
+
+                content_item = content[content_index]
+                if not isinstance(content_item, dict):
+                    content_item = {}
+                    content[content_index] = content_item
+
+                content_item["type"] = "output_text"
+                content_item["text"] = text
+                if parsed_chunk.get("annotations") is not None:
+                    content_item["annotations"] = parsed_chunk["annotations"]
+                else:
+                    content_item.setdefault("annotations", [])
+
+        if recovered_output_items:
+            return [item for _, item in sorted(recovered_output_items.items())]
+
+        if recovered_text_only_items:
+            return [item for _, item in sorted(recovered_text_only_items.items())]
+
+        return []
+
+    @classmethod
+    def _recover_output_items_from_logging(
+        cls, logging_obj: "LiteLLMLoggingObj"
+    ) -> List[Dict[str, Any]]:
+        model_call_details = getattr(logging_obj, "model_call_details", {}) or {}
+        original_response = model_call_details.get("original_response")
+        return cls._recover_output_items_from_raw_sse(original_response)
+
     def transform_response(  # noqa: PLR0915
         self,
         model: str,
@@ -603,9 +727,20 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         if raw_response.error is not None:
             raise ValueError(f"Error in response: {raw_response.error}")
 
+        output_items = raw_response.output
+        if len(output_items) == 0:
+            recovered_output_items = self._recover_output_items_from_logging(logging_obj)
+            if recovered_output_items:
+                output_items = recovered_output_items
+                raw_response.output = recovered_output_items
+                verbose_logger.warning(
+                    "Recovered empty Responses API output from raw SSE for model=%s",
+                    model,
+                )
+
         # Convert response output to choices using the static helper
         choices = self._convert_response_output_to_choices(
-            output_items=raw_response.output,
+            output_items=output_items,
             handle_raw_dict_callback=self._handle_raw_dict_response_item,
         )
 
@@ -619,7 +754,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 )
             else:
                 raise ValueError(
-                    f"Unknown items in responses API response: {raw_response.output}"
+                    f"Unknown items in responses API response: {output_items}"
                 )
 
         setattr(model_response, "choices", choices)

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 import litellm
 from litellm import ModelResponse
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
 from litellm.llms.base_llm.bridges.completion_transformation import (
     CompletionTransformationBridge,
@@ -39,7 +40,6 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamEvents,
 )
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
-from litellm.utils import CustomStreamWrapper
 
 if TYPE_CHECKING:
     from openai.types.responses import ResponseInputImageParam

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -39,6 +39,7 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamEvents,
 )
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
+from litellm.utils import CustomStreamWrapper
 
 if TYPE_CHECKING:
     from openai.types.responses import ResponseInputImageParam
@@ -97,7 +98,7 @@ def _build_reasoning_item(
 
 
 def _reasoning_item_to_response_input(
-    r_item: Union[ChatCompletionReasoningItem, Dict[str, Any]]
+    r_item: Union[ChatCompletionReasoningItem, Dict[str, Any]],
 ) -> Dict[str, Any]:
     """Convert a stored ChatCompletionReasoningItem back to a Responses API input item."""
     r_input: Dict[str, Any] = {
@@ -300,10 +301,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             if key in ("max_tokens", "max_completion_tokens"):
                 responses_api_request["max_output_tokens"] = value
             elif key == "tools" and value is not None:
-                responses_api_request[
-                    "tools"
-                ] = self._convert_tools_to_responses_format(
-                    cast(List[Dict[str, Any]], value)
+                responses_api_request["tools"] = (
+                    self._convert_tools_to_responses_format(
+                        cast(List[Dict[str, Any]], value)
+                    )
                 )
             elif key == "response_format":
                 text_format = self._transform_response_format_to_text_format(value)
@@ -506,9 +507,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         annotations=annotations,
                         reasoning_items=cast(
                             Optional[List[ChatCompletionReasoningItem]],
-                            [pending_reasoning_item]
-                            if pending_reasoning_item is not None
-                            else None,
+                            (
+                                [pending_reasoning_item]
+                                if pending_reasoning_item is not None
+                                else None
+                            ),
                         ),
                     )
 
@@ -566,9 +569,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 reasoning_content=reasoning_content,
                 reasoning_items=cast(
                     Optional[List[ChatCompletionReasoningItem]],
-                    [pending_reasoning_item]
-                    if pending_reasoning_item is not None
-                    else None,
+                    (
+                        [pending_reasoning_item]
+                        if pending_reasoning_item is not None
+                        else None
+                    ),
                 ),
             )
             choices.append(
@@ -578,13 +583,6 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             pending_reasoning_item = None
 
         return choices
-
-    @staticmethod
-    def _strip_sse_data_prefix(chunk: str) -> str:
-        stripped_chunk = chunk.strip()
-        if stripped_chunk.startswith("data:"):
-            return stripped_chunk[len("data:") :].strip()
-        return stripped_chunk
 
     @classmethod
     def _recover_output_items_from_raw_sse(
@@ -597,7 +595,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         recovered_text_only_items: Dict[int, Dict[str, Any]] = {}
 
         for chunk in raw_sse.splitlines():
-            stripped_chunk = cls._strip_sse_data_prefix(chunk)
+            stripped_chunk = (
+                CustomStreamWrapper._strip_sse_data_from_chunk(chunk.strip()) or ""
+            ).strip()
             if (
                 not stripped_chunk
                 or stripped_chunk == "[DONE]"
@@ -623,7 +623,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         return cast(List[Dict[str, Any]], response_output)
                 continue
 
-            if event_type == "response.output_item.done":
+            if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
                 item = parsed_chunk.get("item")
                 if not isinstance(item, dict):
                     continue
@@ -729,7 +729,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         output_items = raw_response.output
         if len(output_items) == 0:
-            recovered_output_items = self._recover_output_items_from_logging(logging_obj)
+            recovered_output_items = self._recover_output_items_from_logging(
+                logging_obj
+            )
             if recovered_output_items:
                 output_items = recovered_output_items
                 raw_response.output = recovered_output_items
@@ -1289,9 +1291,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 )
 
                 if provider_specific_fields:
-                    function_chunk[
-                        "provider_specific_fields"
-                    ] = provider_specific_fields
+                    function_chunk["provider_specific_fields"] = (
+                        provider_specific_fields
+                    )
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(
@@ -1342,7 +1344,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 raise ValueError(
                     f"Chat provider: Invalid function argument delta {parsed_chunk}"
                 )
-        elif event_type == "response.output_item.done":
+        elif event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
             # New output item added
             output_item = parsed_chunk.get("item", {})
             if output_item.get("type") == "function_call":
@@ -1364,9 +1366,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
                 # Add provider_specific_fields to function if present
                 if provider_specific_fields:
-                    function_chunk[
-                        "provider_specific_fields"
-                    ] = provider_specific_fields
+                    function_chunk["provider_specific_fields"] = (
+                        provider_specific_fields
+                    )
 
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 tool_call_chunk = ChatCompletionToolCallChunk(

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from litellm.constants import STREAM_SSE_DONE_STRING
 from litellm.exceptions import AuthenticationError
@@ -134,6 +134,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
         completed_response = None
         error_message = None
+        streamed_output_items: Dict[int, dict] = {}
         for chunk in body_text.splitlines():
             stripped_chunk = CustomStreamWrapper._strip_sse_data_from_chunk(chunk)
             if not stripped_chunk:
@@ -150,10 +151,24 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             if not isinstance(parsed_chunk, dict):
                 continue
             event_type = parsed_chunk.get("type")
+            if event_type == "response.output_item.done":
+                item = parsed_chunk.get("item")
+                output_index = parsed_chunk.get("output_index")
+                if isinstance(item, dict):
+                    try:
+                        index = int(output_index)
+                    except (TypeError, ValueError):
+                        index = len(streamed_output_items)
+                    streamed_output_items[index] = item
+                continue
             if event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
                 response_payload = parsed_chunk.get("response")
                 if isinstance(response_payload, dict):
                     response_payload = dict(response_payload)
+                    if not response_payload.get("output") and streamed_output_items:
+                        response_payload["output"] = [
+                            item for _, item in sorted(streamed_output_items.items())
+                        ]
                     if "created_at" in response_payload:
                         response_payload["created_at"] = _safe_convert_created_field(
                             response_payload["created_at"]

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -77,9 +77,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         existing_instructions = request.get("instructions")
         if existing_instructions:
             if base_instructions not in existing_instructions:
-                request[
-                    "instructions"
-                ] = f"{base_instructions}\n\n{existing_instructions}"
+                request["instructions"] = (
+                    f"{base_instructions}\n\n{existing_instructions}"
+                )
         else:
             request["instructions"] = base_instructions
         request["store"] = False
@@ -151,7 +151,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             if not isinstance(parsed_chunk, dict):
                 continue
             event_type = parsed_chunk.get("type")
-            if event_type == "response.output_item.done":
+            if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
                 item = parsed_chunk.get("item")
                 output_index = parsed_chunk.get("output_index")
                 if isinstance(item, dict):

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6754,6 +6754,18 @@ class Router:
             _shared_model_info = {
                 k: v for k, v in _model_info.items() if k not in _custom_pricing_fields
             }
+            _existing_shared_mode = (
+                cast(Optional[dict], litellm.model_cost.get(_model_name, {})) or {}
+            ).get("mode")
+            if (
+                _existing_shared_mode is not None
+                and _shared_model_info.get("mode") != _existing_shared_mode
+            ):
+                # Keep the built-in bridge mode stable for shared backend keys.
+                # Multiple aliases can point at the same provider/model backend,
+                # but their deployment-level overrides should not downgrade the
+                # backend from responses -> chat via last-write-wins registration.
+                _shared_model_info.pop("mode", None)
             litellm.register_model(
                 model_cost={
                     _model_name: _shared_model_info,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -640,6 +640,71 @@ def test_transform_response_recovers_output_item_done_from_raw_sse():
     assert result.choices[0].message.content == "Recovered from output item"
 
 
+def test_transform_response_recovers_output_item_done_from_whitespace_padded_raw_sse():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    output_item_event = {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "message",
+            "id": "msg_from_item",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Recovered from padded output item",
+                    "annotations": [],
+                }
+            ],
+        },
+    }
+    completed_event = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_from_stream",
+            "object": "response",
+            "created_at": 1760144904,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "output": [],
+        },
+    }
+    raw_sse = "\n".join(
+        [
+            f"   data:  {json.dumps(output_item_event)}   ",
+            f"\tdata: {json.dumps(completed_event)}",
+            "data: [DONE]",
+            "",
+        ]
+    )
+
+    raw_response = _make_empty_responses_api_response()
+    model_response = _make_empty_model_response()
+    logging_obj = Mock()
+    logging_obj.model_call_details = {"original_response": raw_sse}
+
+    result = handler.transform_response(
+        model="gpt-5.4",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=logging_obj,
+        request_data={"model": "gpt-5.4"},
+        messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+
+    assert len(result.choices) == 1
+    assert result.choices[0].message.content == "Recovered from padded output item"
+
+
 def test_transform_response_prefers_completed_output_from_raw_sse():
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -508,32 +508,17 @@ and I learn to carry this small calm home."""
     print("✓ transform_response correctly handled reasoning items and output messages")
 
 
-def test_transform_response_recovers_empty_output_from_raw_sse():
-    from litellm.completion_extras.litellm_responses_transformation.transformation import (
-        LiteLLMResponsesTransformationHandler,
-    )
+def _make_empty_responses_api_response(model: str = "gpt-5.4"):
     from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
-    from litellm.types.utils import ModelResponse, Usage
 
-    handler = LiteLLMResponsesTransformationHandler()
-
-    raw_sse = "\n".join(
-        [
-            'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"item_id":"msg_from_stream","text":"Recovered from SSE"}',
-            'data: {"type":"response.completed","response":{"id":"resp_from_stream","object":"response","created_at":1760144904,"status":"completed","model":"gpt-5.4","output":[]}}',
-            "data: [DONE]",
-            "",
-        ]
-    )
-
-    raw_response = ResponsesAPIResponse(
+    return ResponsesAPIResponse(
         id="resp_from_stream",
         created_at=1760144904,
         error=None,
         incomplete_details=None,
         instructions=None,
         metadata={},
-        model="gpt-5.4",
+        model=model,
         object="response",
         output=[],
         parallel_tool_calls=True,
@@ -565,7 +550,12 @@ def test_transform_response_recovers_empty_output_from_raw_sse():
         service_tier="default",
         top_logprobs=0,
     )
-    model_response = ModelResponse(
+
+
+def _make_empty_model_response():
+    from litellm.types.utils import ModelResponse, Usage
+
+    return ModelResponse(
         id="chatcmpl-test-recovered",
         created=1760144904,
         model=None,
@@ -574,6 +564,26 @@ def test_transform_response_recovers_empty_output_from_raw_sse():
         choices=[],
         usage=Usage(completion_tokens=0, prompt_tokens=0, total_tokens=0),
     )
+
+
+def test_transform_response_recovers_empty_output_from_raw_sse():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    raw_sse = "\n".join(
+        [
+            'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"item_id":"msg_from_stream","text":"Recovered from SSE"}',
+            'data: {"type":"response.completed","response":{"id":"resp_from_stream","object":"response","created_at":1760144904,"status":"completed","model":"gpt-5.4","output":[]}}',
+            "data: [DONE]",
+            "",
+        ]
+    )
+
+    raw_response = _make_empty_responses_api_response()
+    model_response = _make_empty_model_response()
     logging_obj = Mock()
     logging_obj.model_call_details = {"original_response": raw_sse}
 
@@ -591,6 +601,80 @@ def test_transform_response_recovers_empty_output_from_raw_sse():
 
     assert len(result.choices) == 1
     assert result.choices[0].message.content == "Recovered from SSE"
+
+
+def test_transform_response_recovers_output_item_done_from_raw_sse():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    raw_sse = "\n".join(
+        [
+            'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_from_item","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Recovered from output item","annotations":[]}]}}',
+            'data: {"type":"response.completed","response":{"id":"resp_from_stream","object":"response","created_at":1760144904,"status":"completed","model":"gpt-5.4","output":[]}}',
+            "data: [DONE]",
+            "",
+        ]
+    )
+
+    raw_response = _make_empty_responses_api_response()
+    model_response = _make_empty_model_response()
+    logging_obj = Mock()
+    logging_obj.model_call_details = {"original_response": raw_sse}
+
+    result = handler.transform_response(
+        model="gpt-5.4",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=logging_obj,
+        request_data={"model": "gpt-5.4"},
+        messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+
+    assert len(result.choices) == 1
+    assert result.choices[0].message.content == "Recovered from output item"
+
+
+def test_transform_response_prefers_completed_output_from_raw_sse():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    raw_sse = "\n".join(
+        [
+            'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_from_item","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Earlier stream text","annotations":[]}]}}',
+            'data: {"type":"response.completed","response":{"id":"resp_from_stream","object":"response","created_at":1760144904,"status":"completed","model":"gpt-5.4","output":[{"type":"message","id":"msg_from_completed","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Authoritative completed text","annotations":[]}]}]}}',
+            "data: [DONE]",
+            "",
+        ]
+    )
+
+    raw_response = _make_empty_responses_api_response()
+    model_response = _make_empty_model_response()
+    logging_obj = Mock()
+    logging_obj.model_call_details = {"original_response": raw_sse}
+
+    result = handler.transform_response(
+        model="gpt-5.4",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=logging_obj,
+        request_data={"model": "gpt-5.4"},
+        messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+
+    assert len(result.choices) == 1
+    assert result.choices[0].message.content == "Authoritative completed text"
 
 
 def test_convert_tools_to_responses_format():

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -508,6 +508,91 @@ and I learn to carry this small calm home."""
     print("✓ transform_response correctly handled reasoning items and output messages")
 
 
+def test_transform_response_recovers_empty_output_from_raw_sse():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+    from litellm.types.utils import ModelResponse, Usage
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    raw_sse = "\n".join(
+        [
+            'data: {"type":"response.output_text.done","output_index":0,"content_index":0,"item_id":"msg_from_stream","text":"Recovered from SSE"}',
+            'data: {"type":"response.completed","response":{"id":"resp_from_stream","object":"response","created_at":1760144904,"status":"completed","model":"gpt-5.4","output":[]}}',
+            "data: [DONE]",
+            "",
+        ]
+    )
+
+    raw_response = ResponsesAPIResponse(
+        id="resp_from_stream",
+        created_at=1760144904,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        model="gpt-5.4",
+        object="response",
+        output=[],
+        parallel_tool_calls=True,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning={"effort": "low", "summary": "detailed"},
+        status="completed",
+        text={"format": {"type": "text"}, "verbosity": "medium"},
+        truncation="disabled",
+        usage=ResponseAPIUsage(
+            input_tokens=1,
+            input_tokens_details=None,
+            output_tokens=1,
+            output_tokens_details=None,
+            total_tokens=2,
+            cost=None,
+        ),
+        user=None,
+        store=True,
+        background=False,
+        billing={"payer": "developer"},
+        max_tool_calls=None,
+        prompt_cache_key=None,
+        safety_identifier=None,
+        service_tier="default",
+        top_logprobs=0,
+    )
+    model_response = ModelResponse(
+        id="chatcmpl-test-recovered",
+        created=1760144904,
+        model=None,
+        object="chat.completion",
+        system_fingerprint=None,
+        choices=[],
+        usage=Usage(completion_tokens=0, prompt_tokens=0, total_tokens=0),
+    )
+    logging_obj = Mock()
+    logging_obj.model_call_details = {"original_response": raw_sse}
+
+    result = handler.transform_response(
+        model="gpt-5.4",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=logging_obj,
+        request_data={"model": "gpt-5.4"},
+        messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+
+    assert len(result.choices) == 1
+    assert result.choices[0].message.content == "Recovered from SSE"
+
+
 def test_convert_tools_to_responses_format():
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -13,6 +13,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
+from litellm.llms.openai.common_utils import OpenAIError
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
@@ -242,3 +243,40 @@ class TestChatGPTResponsesAPITransformation:
         )
 
         assert parsed.output_text == "Hello from stream!"
+
+    @pytest.mark.parametrize(
+        "error_chunk",
+        [
+            {
+                "type": "response.failed",
+                "response": {"error": {"message": "ChatGPT upstream failed"}},
+            },
+            {
+                "type": "error",
+                "error": {"message": "ChatGPT upstream failed"},
+            },
+        ],
+    )
+    def test_chatgpt_non_stream_sse_response_raises_openai_error(self, error_chunk):
+        config = ChatGPTResponsesAPIConfig()
+        sse_body = "\n".join(
+            [
+                f"data: {json.dumps(error_chunk)}",
+                "data: [DONE]",
+                "",
+            ]
+        )
+        raw_response = httpx.Response(
+            502, headers={"content-type": "text/event-stream"}, text=sse_body
+        )
+        logging_obj = MagicMock()
+
+        with pytest.raises(OpenAIError) as exc_info:
+            config.transform_response_api_response(
+                model="chatgpt/gpt-5.4",
+                raw_response=raw_response,
+                logging_obj=logging_obj,
+            )
+
+        assert "ChatGPT upstream failed" in str(exc_info.value)
+        assert exc_info.value.status_code == 502

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -197,3 +197,48 @@ class TestChatGPTResponsesAPITransformation:
         )
 
         assert parsed.output_text == "Hello!"
+
+    @pytest.mark.parametrize(
+        ("model_name", "response_model"),
+        [
+            ("chatgpt/gpt-5.2-codex", "gpt-5.2-codex"),
+            ("chatgpt/gpt-5.3-codex", "gpt-5.3-codex"),
+        ],
+    )
+    def test_chatgpt_non_stream_sse_response_recovers_output_items(
+        self, model_name: str, response_model: str
+    ):
+        config = ChatGPTResponsesAPIConfig()
+        response_payload = {
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 1700000000,
+            "status": "completed",
+            "model": response_model,
+            "output": [],
+        }
+        streamed_output_item = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hello from stream!"}],
+        }
+        sse_body = "\n".join(
+            [
+                f"data: {json.dumps({'type': 'response.output_item.done', 'output_index': 0, 'item': streamed_output_item})}",
+                f"data: {json.dumps({'type': 'response.completed', 'response': response_payload})}",
+                "data: [DONE]",
+                "",
+            ]
+        )
+        raw_response = httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, text=sse_body
+        )
+        logging_obj = MagicMock()
+
+        parsed = config.transform_response_api_response(
+            model=model_name,
+            raw_response=raw_response,
+            logging_obj=logging_obj,
+        )
+
+        assert parsed.output_text == "Hello from stream!"

--- a/tests/test_litellm/proxy/prompts/test_prompt_endpoints.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_endpoints.py
@@ -248,7 +248,9 @@ class TestPromptVersionsEndpoint:
         }
 
         # Mock the IN_MEMORY_PROMPT_REGISTRY at the import location
-        with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+        with patch(
+            "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+        ) as mock_registry, patch("litellm.proxy.proxy_server.prisma_client", None):
             mock_registry.IN_MEMORY_PROMPTS = mock_prompts
 
             # Test with base prompt ID
@@ -293,7 +295,9 @@ class TestPromptVersionsEndpoint:
             user_role=LitellmUserRoles.PROXY_ADMIN
         )
 
-        with patch("litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY") as mock_registry:
+        with patch(
+            "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+        ) as mock_registry, patch("litellm.proxy.proxy_server.prisma_client", None):
             mock_registry.IN_MEMORY_PROMPTS = {}
 
             with pytest.raises(HTTPException) as exc_info:
@@ -304,4 +308,3 @@ class TestPromptVersionsEndpoint:
 
             assert exc_info.value.status_code == 404
             assert "No versions found" in exc_info.value.detail
-

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -7,8 +7,10 @@ and one has explicit zero-cost pricing in model_info, the other deployment
 should still use the built-in pricing.
 """
 
+import copy
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -18,6 +20,16 @@ sys.path.insert(
 
 import litellm
 from litellm import Router
+from litellm.utils import _invalidate_model_cost_lowercase_map
+
+
+def _restore_model_cost_entries(original_entries):
+    for key, value in original_entries.items():
+        if value is None:
+            litellm.model_cost.pop(key, None)
+        else:
+            litellm.model_cost[key] = value
+    _invalidate_model_cost_lowercase_map()
 
 
 def test_should_not_pollute_shared_key_with_zero_cost_pricing():
@@ -262,3 +274,67 @@ def test_should_preserve_builtin_pricing_regardless_of_deployment_order():
         f"Order should not matter. Expected {builtin_output_cost}, "
         f"got {info_std_2['output_cost_per_token']}"
     )
+
+
+def test_should_not_downgrade_chatgpt_shared_key_mode_with_alias_override():
+    """
+    ChatGPT aliases that share the same backend model should not be able to
+    downgrade the shared backend key from responses -> chat during router setup.
+    """
+    from litellm.main import responses_api_bridge_check
+
+    backend_model = "chatgpt/gpt-5.4"
+    model_keys = {
+        backend_model: copy.deepcopy(litellm.model_cost.get(backend_model)),
+        "chatgpt-shared-mode-base": copy.deepcopy(
+            litellm.model_cost.get("chatgpt-shared-mode-base")
+        ),
+        "chatgpt-shared-mode-alias": copy.deepcopy(
+            litellm.model_cost.get("chatgpt-shared-mode-alias")
+        ),
+    }
+
+    try:
+        backend_entry = copy.deepcopy(model_keys[backend_model]) or {}
+        backend_entry["litellm_provider"] = "chatgpt"
+        backend_entry["mode"] = "responses"
+        litellm.model_cost[backend_model] = backend_entry
+        _invalidate_model_cost_lowercase_map()
+
+        router = Router(model_list=[])
+        with patch.object(Router, "_add_deployment", lambda self, deployment: deployment):
+            router._create_deployment(
+                deployment_info={},
+                _model_name="chatgpt/gpt-5.4",
+                _litellm_params={
+                    "model": "gpt-5.4",
+                    "custom_llm_provider": "chatgpt",
+                },
+                _model_info={
+                    "id": "chatgpt-shared-mode-base",
+                    "mode": "responses",
+                },
+            )
+            router._create_deployment(
+                deployment_info={},
+                _model_name="chatgpt/gpt-5.4-medium",
+                _litellm_params={
+                    "model": "gpt-5.4",
+                    "custom_llm_provider": "chatgpt",
+                },
+                _model_info={
+                    "id": "chatgpt-shared-mode-alias",
+                    "mode": "chat",
+                },
+            )
+
+        assert litellm.model_cost[backend_model]["mode"] == "responses"
+
+        bridge_model_info, bridge_model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="chatgpt",
+        )
+        assert bridge_model == "gpt-5.4"
+        assert bridge_model_info["mode"] == "responses"
+    finally:
+        _restore_model_cost_entries(model_keys)


### PR DESCRIPTION
## Summary

Fix ChatGPT `/v1/chat/completions` proxy failures when multiple aliases share the same `gpt-5.4` backend model.

## Root cause

There were two separate breakpoints in the ChatGPT proxy path:

1. Router startup re-registered shared backend keys like `chatgpt/gpt-5.4` using deployment-level `model_info`. If one alias set `mode: chat`, that last write downgraded the shared backend key from `responses` to `chat`, which sent `/v1/chat/completions` to the legacy ChatGPT chat-completions endpoint and surfaced as `403 Forbidden`.
2. Even after routing was corrected, ChatGPT non-stream Responses payloads could still end with `response.completed.output=[]` while the real assistant message had already been emitted in earlier SSE events. The bridge then raised `Unknown items in responses API response: []`.

## What changed

- preserve the existing shared backend `mode` when router deployment registration reuses a provider/model key that already exists in `litellm.model_cost`
- teach the ChatGPT Responses parser to recover `response.output_item.done` entries when `response.completed.output` is empty
- add a defensive `/responses -> /chat/completions` bridge fallback that reconstructs output items from raw SSE when `raw_response.output` is empty
- add regression coverage for:
  - shared ChatGPT aliases reusing the same backend model without downgrading `responses` routing
  - ChatGPT SSE parsing when `response.completed.output == []`
  - bridge recovery from raw SSE `response.output_text.done` events

## Validation

Ran targeted regression tests in the LiteLLM container runtime:

- `tests/test_litellm/test_router_model_cost_isolation.py -k downgrade`
- `tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -k recovers_output_items`
- `tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py -k recovers_empty_output_from_raw_sse`
