### PR TITLE
fix(lemonade): respect api_key and LEMONADE_API_KEY in _get_openai_compatible_provider_info

### DIFF
--- a/litellm/llms/lemonade/chat/transformation.py
+++ b/litellm/llms/lemonade/chat/transformation.py
@@ -110,8 +110,7 @@ class LemonadeChatConfig(OpenAILikeChatConfig):
             or get_secret_str("LEMONADE_API_BASE")
             or "http://localhost:8000/api/v1"
         )  # type: ignore
-        # Lemonade doesn't check the key
-        key = "lemonade"
+        key = api_key or get_secret_str("LEMONADE_API_KEY") or "lemonade"
         return api_base, key
 
     def transform_response(

--- a/tests/test_litellm/llms/lemonade/test_lemonade.py
+++ b/tests/test_litellm/llms/lemonade/test_lemonade.py
@@ -37,7 +37,7 @@ def test_get_openai_compatible_provider_info():
     )
 
     assert api_base == "http://localhost:8000/api/v1"
-    assert key == "lemonade"
+    assert key == "lemonade"  # falls back to sentinel when no key provided
 
 
 def test_get_openai_compatible_provider_info_with_custom_base():
@@ -50,7 +50,32 @@ def test_get_openai_compatible_provider_info_with_custom_base():
     )
 
     assert api_base == custom_api_base
-    assert key == "lemonade"
+    assert key == "lemonade"  # falls back to sentinel when no key provided
+
+
+def test_get_openai_compatible_provider_info_with_api_key():
+    """Test that a passed api_key is respected"""
+    config = LemonadeChatConfig()
+
+    api_base, key = config._get_openai_compatible_provider_info(
+        api_base=None,
+        api_key="my-secret-key",
+    )
+
+    assert key == "my-secret-key"
+
+
+def test_get_openai_compatible_provider_info_with_env_key(monkeypatch):
+    """Test that LEMONADE_API_KEY env var is used when no api_key is passed"""
+    monkeypatch.setenv("LEMONADE_API_KEY", "env-secret-key")
+    config = LemonadeChatConfig()
+
+    api_base, key = config._get_openai_compatible_provider_info(
+        api_base=None,
+        api_key=None,
+    )
+
+    assert key == "env-secret-key"
 
 
 def test_transform_response():


### PR DESCRIPTION
## Changes

### Fix — `_get_openai_compatible_provider_info` ignores `api_key` (closes #25363)

`_get_openai_compatible_provider_info` in `litellm/llms/lemonade/chat/transformation.py` hardcoded `key = "lemonade"` regardless of any `api_key` passed by the caller or set via environment variable. Lemonade server now supports API key authentication, so the hardcoded value meant user-configured keys were silently dropped.

**Fix:** use the standard priority chain used by other providers (e.g. Groq):

```python
# before
# Lemonade doesn't check the key
key = "lemonade"

# after
key = api_key or get_secret_str("LEMONADE_API_KEY") or "lemonade"
```

The `"lemonade"` sentinel is kept as a fallback for backward compatibility with keyless deployments.

## Test plan

- [ ] `test_get_openai_compatible_provider_info` — existing test still passes (no key → falls back to `"lemonade"`)
- [ ] `test_get_openai_compatible_provider_info_with_api_key` — passed `api_key` is returned
- [ ] `test_get_openai_compatible_provider_info_with_env_key` — `LEMONADE_API_KEY` env var is used when no key passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)