### PR TITLE
fix(streaming): preserve usage from trailing empty-choices chunks (vLLM)

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1561,6 +1561,12 @@ class CustomStreamWrapper:
                         and self.stream_options["include_usage"] is True
                     ):
                         return model_response
+                    # Still return model_response when it carries usage data
+                    # so trailing usage chunks (e.g. from vLLM) get accumulated
+                    # in self.chunks for calculate_total_usage(). The __next__
+                    # loop will strip the usage field and skip empty responses.
+                    if getattr(model_response, "usage", None) is not None:
+                        return model_response
                     return
             ## CHECK FOR TOOL USE
 

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1543,6 +1543,92 @@ def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
         f"Expected completion_tokens=135 from provider, got {hidden_usage.completion_tokens}"
     )
 
+def test_usage_chunk_empty_choices_vllm_pattern(logging_obj):
+    """
+    Test that usage data from a trailing chunk with an empty choices array
+    (as sent by vLLM) is preserved in _hidden_params.
+
+    Reproduces issue #25389: vLLM sends usage in a separate SSE chunk after
+    finish_reason with choices=[]. Without the fix, chunk_creator() returns
+    None for this chunk and the usage is lost.
+    """
+    # Simulate vLLM's streaming pattern:
+    # 1) content chunk
+    # 2) finish_reason chunk
+    # 3) usage-only chunk with empty choices array
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-abc",
+            object="chat.completion.chunk",
+            created=1000000,
+            model="vllm/qwen",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(role="assistant", content="Hello"),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-abc",
+            object="chat.completion.chunk",
+            created=1000000,
+            model="vllm/qwen",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content=""),
+                    finish_reason="stop",
+                )
+            ],
+        ),
+        # vLLM sends usage in a chunk with an EMPTY choices array
+        ModelResponseStream(
+            id="chatcmpl-abc",
+            object="chat.completion.chunk",
+            created=1000000,
+            model="vllm/qwen",
+            choices=[],
+            usage=Usage(
+                prompt_tokens=26,
+                completion_tokens=242,
+                total_tokens=268,
+            ),
+        ),
+    ]
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=ModelResponseListIterator(model_responses=chunks),
+        model="vllm/qwen",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        stream_options=None,
+    )
+
+    collected = []
+    for chunk in wrapper:
+        collected.append(chunk)
+
+    assert len(collected) > 0, "Expected at least one chunk"
+
+    # The empty-choices usage chunk must NOT leak as a visible chunk
+    for c in collected:
+        assert len(c.choices) > 0, (
+            "Empty-choices usage chunk should not be yielded to the caller"
+        )
+
+    last_chunk = collected[-1]
+    hidden_usage = last_chunk._hidden_params.get("usage")
+    assert hidden_usage is not None, "Expected usage in _hidden_params"
+    assert hidden_usage.prompt_tokens == 26, (
+        f"Expected prompt_tokens=26, got {hidden_usage.prompt_tokens}"
+    )
+    assert hidden_usage.completion_tokens == 242, (
+        f"Expected completion_tokens=242, got {hidden_usage.completion_tokens}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_custom_stream_wrapper_aclose():
     """Test that aclose() delegates to the underlying completion_stream's aclose()"""


### PR DESCRIPTION
## Relevant issues

Fixes #25389

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

vLLM (and some other OpenAI-compatible backends) sends usage data in a trailing SSE chunk with an empty `choices` array, after the `finish_reason: "stop"` chunk:

```
data: {"choices":[{"finish_reason":"stop","delta":{"content":""}}]}   ← chunk N-1
data: {"choices":[], "usage":{"prompt_tokens":26,...}}                 ← chunk N
data: [DONE]
```

In `chunk_creator()`, the `else` branch for empty choices returned `None` when `stream_options` wasn't set. This meant the usage chunk was never accumulated in `self.chunks`, so `calculate_total_usage()` had nothing to work with and usage was lost from `_hidden_params`.

The fix: when the empty-choices chunk carries usage data, return it so `__next__()` accumulates it in `self.chunks`. The existing downstream logic (lines 1884-1904) already handles this correctly — it strips `usage` from the response, recreates it, checks emptiness, and `continue`s without yielding the chunk to the caller.

**Before:** `_hidden_params["usage"]` shows zeros or is missing for vLLM streaming responses.
**After:** `_hidden_params["usage"]` correctly reflects the provider-reported token counts.

## Test

Added `test_usage_chunk_empty_choices_vllm_pattern` which simulates the exact vLLM 3-chunk streaming pattern. It verifies both that:
1. Usage data is preserved in `_hidden_params` with correct token counts
2. No empty-choices chunk leaks to the caller

All 51 streaming handler tests pass.