### PR TITLE
fix(adapter): preserve tool_use arguments in /v1/messages streaming block transitions

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1561,6 +1561,12 @@ class CustomStreamWrapper:
                         and self.stream_options["include_usage"] is True
                     ):
                         return model_response
+                    # Still return model_response when it carries usage data
+                    # so trailing usage chunks (e.g. from vLLM) get accumulated
+                    # in self.chunks for calculate_total_usage(). The __next__
+                    # loop will strip the usage field and skip empty responses.
+                    if getattr(model_response, "usage", None) is not None:
+                        return model_response
                     return
             ## CHECK FOR TOOL USE
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -129,8 +129,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 if should_start_new_block and not self.sent_content_block_finish:
                     # Queue the sequence: content_block_stop -> content_block_start
-                    # The trigger chunk itself is not emitted as a delta since the
-                    # content_block_start already carries the relevant information.
                     self.chunk_queue.append(
                         {
                             "type": "content_block_stop",
@@ -144,6 +142,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                             "content_block": self.current_content_block_start,
                         }
                     )
+                    # Also queue the delta if it carries content — some providers
+                    # (e.g. Gemini) send tool arguments in the same chunk as the
+                    # function name, so dropping the delta loses those arguments.
+                    if processed_chunk.get("type") == "content_block_delta":
+                        delta = processed_chunk.get("delta", {})
+                        if delta.get("partial_json") or delta.get("text") or delta.get("thinking"):
+                            self.chunk_queue.append(processed_chunk)
                     self.sent_content_block_finish = False
                     return self.chunk_queue.popleft()
 
@@ -305,8 +310,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if not self.queued_usage_chunk:
                     if should_start_new_block and not self.sent_content_block_finish:
                         # Queue the sequence: content_block_stop -> content_block_start
-                        # The trigger chunk itself is not emitted as a delta since the
-                        # content_block_start already carries the relevant information.
 
                         # 1. Stop current content block
                         self.chunk_queue.append(
@@ -324,6 +327,15 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                                 "content_block": self.current_content_block_start,
                             }
                         )
+
+                        # 3. Queue the delta if it carries content — some providers
+                        # (e.g. Gemini) send tool arguments in the same chunk as
+                        # the function name, so dropping the delta loses those
+                        # arguments.
+                        if processed_chunk.get("type") == "content_block_delta":
+                            delta = processed_chunk.get("delta", {})
+                            if delta.get("partial_json") or delta.get("text") or delta.get("thinking"):
+                                self.chunk_queue.append(processed_chunk)
 
                         # Reset state for new block
                         self.sent_content_block_finish = False

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1543,6 +1543,92 @@ def test_usage_chunk_after_finish_reason_updates_hidden_params(logging_obj):
         f"Expected completion_tokens=135 from provider, got {hidden_usage.completion_tokens}"
     )
 
+def test_usage_chunk_empty_choices_vllm_pattern(logging_obj):
+    """
+    Test that usage data from a trailing chunk with an empty choices array
+    (as sent by vLLM) is preserved in _hidden_params.
+
+    Reproduces issue #25389: vLLM sends usage in a separate SSE chunk after
+    finish_reason with choices=[]. Without the fix, chunk_creator() returns
+    None for this chunk and the usage is lost.
+    """
+    # Simulate vLLM's streaming pattern:
+    # 1) content chunk
+    # 2) finish_reason chunk
+    # 3) usage-only chunk with empty choices array
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-abc",
+            object="chat.completion.chunk",
+            created=1000000,
+            model="vllm/qwen",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(role="assistant", content="Hello"),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-abc",
+            object="chat.completion.chunk",
+            created=1000000,
+            model="vllm/qwen",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content=""),
+                    finish_reason="stop",
+                )
+            ],
+        ),
+        # vLLM sends usage in a chunk with an EMPTY choices array
+        ModelResponseStream(
+            id="chatcmpl-abc",
+            object="chat.completion.chunk",
+            created=1000000,
+            model="vllm/qwen",
+            choices=[],
+            usage=Usage(
+                prompt_tokens=26,
+                completion_tokens=242,
+                total_tokens=268,
+            ),
+        ),
+    ]
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=ModelResponseListIterator(model_responses=chunks),
+        model="vllm/qwen",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        stream_options=None,
+    )
+
+    collected = []
+    for chunk in wrapper:
+        collected.append(chunk)
+
+    assert len(collected) > 0, "Expected at least one chunk"
+
+    # The empty-choices usage chunk must NOT leak as a visible chunk
+    for c in collected:
+        assert len(c.choices) > 0, (
+            "Empty-choices usage chunk should not be yielded to the caller"
+        )
+
+    last_chunk = collected[-1]
+    hidden_usage = last_chunk._hidden_params.get("usage")
+    assert hidden_usage is not None, "Expected usage in _hidden_params"
+    assert hidden_usage.prompt_tokens == 26, (
+        f"Expected prompt_tokens=26, got {hidden_usage.prompt_tokens}"
+    )
+    assert hidden_usage.completion_tokens == 242, (
+        f"Expected completion_tokens=242, got {hidden_usage.completion_tokens}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_custom_stream_wrapper_aclose():
     """Test that aclose() delegates to the underlying completion_stream's aclose()"""

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
@@ -2,6 +2,7 @@ import os
 import sys
 from typing import List
 
+import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
@@ -278,7 +279,8 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}
         "content_block_stop",  # End of first tool_use content block
-        "content_block_start",  # "The weather is nice today"
+        "content_block_start",  # Text block start
+        "content_block_delta",  # "The weather is nice today."
         "content_block_stop",
         "content_block_start",  # Start of second tool_use content block
         "content_block_delta",  # {"city":
@@ -288,7 +290,8 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
         "content_block_delta",  # {"city":
         "content_block_delta",  # " CHI"}
         "content_block_stop",  # End of third tool_use content block
-        "content_block_start",  # "The weather is not so nice today"
+        "content_block_start",  # Text block start
+        "content_block_delta",  # "The weather is not so nice today."
         "content_block_stop",
         "message_delta",  # Stop reason with merged usage
         "message_stop",  # Final message stop
@@ -307,3 +310,149 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
                 get_weather_calls += 1
 
     assert get_weather_calls == 3
+
+
+def test_anthropic_stream_wrapper_tool_args_in_first_chunk():
+    """
+    Regression test for #25321: non-OpenAI models (e.g. Gemini via litellm)
+    may send the tool arguments in the same streaming chunk as the function
+    name. The adapter must not discard those arguments when transitioning
+    to a new content block.
+    """
+    responses = [
+        # Single chunk containing both function name AND arguments
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    delta=Delta(
+                        tool_calls=[
+                            ChatCompletionDeltaToolCall(
+                                id="call_abc123",
+                                function=Function(
+                                    arguments='{"command": "ls -la"}',
+                                    name="Bash",
+                                ),
+                                index=0,
+                                type="function",
+                            )
+                        ]
+                    ),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    delta=Delta(content="", stop_reason="tool_calls"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=50, completion_tokens=20, total_tokens=70),
+        ),
+    ]
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockCompletionStream(responses),
+        model="gemini-2.5-flash",
+    )
+
+    chunks = []
+    chunk_types = []
+
+    for chunk in wrapper:
+        chunks.append(chunk)
+        chunk_types.append(chunk.get("type"))
+
+    expected_types = [
+        "message_start",
+        "content_block_start",  # Initial empty text block
+        "content_block_stop",
+        "content_block_start",  # tool_use block
+        "content_block_delta",  # Tool arguments from the transition chunk
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+
+    assert expected_types == chunk_types
+
+    # Verify the tool arguments are preserved (not dropped)
+    tool_deltas = [
+        c for c in chunks if c.get("type") == "content_block_delta"
+    ]
+    assert len(tool_deltas) == 1
+    assert tool_deltas[0]["delta"]["type"] == "input_json_delta"
+    assert tool_deltas[0]["delta"]["partial_json"] == '{"command": "ls -la"}'
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_stream_wrapper_tool_args_in_first_chunk():
+    """Async version of the regression test for #25321."""
+    responses = [
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    delta=Delta(
+                        tool_calls=[
+                            ChatCompletionDeltaToolCall(
+                                id="call_abc123",
+                                function=Function(
+                                    arguments='{"command": "ls -la"}',
+                                    name="Bash",
+                                ),
+                                index=0,
+                                type="function",
+                            )
+                        ]
+                    ),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    delta=Delta(content="", stop_reason="tool_calls"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=50, completion_tokens=20, total_tokens=70),
+        ),
+    ]
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockCompletionStream(responses),
+        model="gemini-2.5-flash",
+    )
+
+    chunks = []
+    chunk_types = []
+
+    async for chunk in wrapper:
+        chunks.append(chunk)
+        chunk_types.append(chunk.get("type"))
+
+    expected_types = [
+        "message_start",
+        "content_block_start",  # Initial empty text block
+        "content_block_stop",
+        "content_block_start",  # tool_use block
+        "content_block_delta",  # Tool arguments from the transition chunk
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+
+    assert expected_types == chunk_types
+
+    tool_deltas = [
+        c for c in chunks if c.get("type") == "content_block_delta"
+    ]
+    assert len(tool_deltas) == 1
+    assert tool_deltas[0]["delta"]["type"] == "input_json_delta"
+    assert tool_deltas[0]["delta"]["partial_json"] == '{"command": "ls -la"}'


### PR DESCRIPTION
## Relevant issues

Fixes #25321

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

When `_should_start_new_content_block()` triggers a block transition (e.g. text → tool_use), the `/v1/messages` streaming adapter queues `content_block_stop` + `content_block_start` and then returns — discarding the `processed_chunk`. For providers that split tool calls across multiple chunks (OpenAI-style), this is fine because the first chunk only carries the function name with empty arguments. But providers like Gemini send the function name **and** arguments in a single chunk. The discarded `processed_chunk` contains the `input_json_delta` with the actual tool arguments, so every `tool_use` block arrives with `input: {}`.

**Before:** Claude Code using Gemini through the proxy gets `InputValidationError: The required parameter 'command' is missing` on every tool call.

**After:** The adapter queues the delta alongside `content_block_start` when it carries non-empty content (`partial_json`, `text`, or `thinking`). Empty deltas from OpenAI-style split tool calls are still correctly skipped.

The fix is applied to both the sync (`__next__`) and async (`__anext__`) code paths.

### Tests added

- `test_anthropic_stream_wrapper_tool_args_in_first_chunk` — verifies tool arguments are preserved when sent in the same chunk as the function name (sync)
- `test_async_anthropic_stream_wrapper_tool_args_in_first_chunk` — async version of the same
- Updated `test_anthropic_stream_wrapper_interleaved_tool_calls_and_text` — text content during block transitions is now correctly emitted as a `content_block_delta` instead of being silently dropped