### PR TITLE
fix(responses-ws): append ?model= to backend WebSocket URL

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5027,6 +5027,10 @@ class BaseLLMHTTPHandler:
             litellm_params={},
         )
         ws_url = http_url.replace("https://", "wss://").replace("http://", "ws://")
+        # OpenAI's WebSocket responses endpoint requires ?model= in the URL,
+        # matching the Realtime API convention (wss://.../v1/realtime?model=...).
+        if "?" not in ws_url:
+            ws_url = f"{ws_url}?model={model}"
 
         try:
             ssl_context = get_shared_realtime_ssl_context()

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -971,3 +971,35 @@ class TestWebSocketChunkTypes:
         )
         assert len(messages) == 1
         assert messages[0]["content"][0]["text"] == "Part 1Part 2"
+
+
+class TestNativeWebSocketUrlConstruction:
+    """Test that native WebSocket URLs include the model query parameter."""
+
+    def test_openai_ws_url_includes_model(self):
+        """ws_url for OpenAI native WebSocket must include ?model= so OpenAI
+        knows which model to use before the first response.create event."""
+        config = OpenAIResponsesAPIConfig()
+        http_url = config.get_complete_url(api_base=None, litellm_params={})
+        base_ws_url = http_url.replace("https://", "wss://").replace("http://", "ws://")
+
+        # get_complete_url should not include query params
+        assert "?" not in base_ws_url
+
+        # The handler appends ?model= when none is present
+        model = "gpt-4o-mini"
+        ws_url = f"{base_ws_url}?model={model}" if "?" not in base_ws_url else base_ws_url
+        assert ws_url == "wss://api.openai.com/v1/responses?model=gpt-4o-mini"
+
+    def test_ws_url_model_not_duplicated_if_query_already_present(self):
+        """If api_base already has query params, the ?model= should not be appended."""
+        http_url = "https://custom.example.com/v1/responses?api-version=2024-05-01"
+        ws_url = http_url.replace("https://", "wss://").replace("http://", "ws://")
+
+        # Fix: only append when no query string present
+        if "?" not in ws_url:
+            ws_url = f"{ws_url}?model=gpt-4o"
+
+        assert "api-version=2024-05-01" in ws_url
+        assert ws_url.count("?") == 1
+        assert "model=gpt-4o" not in ws_url


### PR DESCRIPTION
## Summary

- OpenAI's WebSocket responses endpoint requires the model as a query parameter (`wss://.../v1/responses?model=gpt-4o-mini`), matching the Realtime API convention
- Without it the handshake succeeds but OpenAI never sends events, causing the client to time out after 15s
- Fixes `test_responses_websocket_proxy_basic` and `test_responses_websocket_proxy_multi_turn` in `e2e_openai_endpoints` CI

## Test plan

- [ ] `e2e_openai_endpoints` CI passes
- [ ] `TestNativeWebSocketUrlConstruction` unit tests pass locally