### PR TITLE
Http connection reset

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -113,6 +113,23 @@ def _prepare_request_data_and_content(
     return request_data, request_content
 
 
+def _is_connection_reset_error(e: Exception) -> bool:
+    error_text = getattr(e, "text", str(e))
+    error_response = getattr(e, "response", None)
+    if error_response and hasattr(error_response, "text"):
+        error_text = getattr(error_response, "text", error_text)
+
+    if isinstance(error_text, bytes):
+        error_text = error_text.decode("utf-8", errors="ignore")
+
+    normalized_error_text = str(error_text).lower()
+    return (
+        "errno 104" in normalized_error_text
+        or "connection reset by peer" in normalized_error_text
+        or "connection reset" in normalized_error_text
+    )
+
+
 # Cache for SSL contexts to avoid creating duplicate contexts with the same configuration
 # Key: tuple of (cafile, ssl_security_level, ssl_ecdh_curve)
 # Value: ssl.SSLContext
@@ -482,7 +499,14 @@ class AsyncHTTPHandler:
                     params=params,
                     headers=headers,
                     stream=stream,
+                    content=content,
                 )
+            except Exception as retry_error:
+                verbose_logger.debug(
+                    "httpx.ConnectError retry failed in AsyncHTTPHandler.post(): %s",
+                    str(retry_error),
+                )
+                raise
             finally:
                 await new_client.aclose()
         except httpx.TimeoutException as e:
@@ -512,6 +536,32 @@ class AsyncHTTPHandler:
 
             raise e
         except Exception as e:
+            if _is_connection_reset_error(e):
+                verbose_logger.debug(
+                    "Detected connection reset error in AsyncHTTPHandler.post(); retrying with a new client"
+                )
+                new_client = self.create_client(
+                    timeout=timeout, event_hooks=self.event_hooks
+                )
+                try:
+                    return await self.single_connection_post_request(
+                        url=url,
+                        client=new_client,
+                        data=data,
+                        json=json,
+                        params=params,
+                        headers=headers,
+                        stream=stream,
+                        content=content,
+                    )
+                except Exception as retry_error:
+                    verbose_logger.debug(
+                        "Connection reset retry failed in AsyncHTTPHandler.post(): %s",
+                        str(retry_error),
+                    )
+                    raise
+                finally:
+                    await new_client.aclose()
             raise e
 
     async def put(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -468,7 +468,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -540,7 +540,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -606,7 +606,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -672,7 +672,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -485,7 +485,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -590,7 +590,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -656,7 +656,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks
@@ -722,7 +722,7 @@ class AsyncHTTPHandler:
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
             return response
-        except (httpx.RemoteProtocolError, httpx.ConnectError, httpx.ReadError):
+        except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
                 timeout=timeout, event_hooks=self.event_hooks

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import ssl
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import certifi
 import httpx
@@ -656,5 +656,45 @@ async def test_httpx_handler_uses_env_user_agent(monkeypatch):
     try:
         req = handler.client.build_request("GET", "https://example.com")
         assert req.headers.get("User-Agent") == "Claude Code"
+    finally:
+        await handler.close()
+
+
+@pytest.mark.asyncio
+async def test_async_http_handler_retries_on_connection_reset_error_text():
+    handler = AsyncHTTPHandler()
+    retry_client = MagicMock()
+    retry_client.aclose = AsyncMock()
+    retry_response = MagicMock(spec=httpx.Response)
+
+    handler.client.send = AsyncMock(
+        side_effect=Exception("[Errno 104] Connection reset by peer")
+    )
+    handler.create_client = MagicMock(return_value=retry_client)
+    handler.single_connection_post_request = AsyncMock(return_value=retry_response)
+
+    try:
+        response = await handler.post(
+            url="https://example.com",
+            data={"hello": "world"},
+            headers={"x-test": "1"},
+            content="payload",
+        )
+
+        assert response is retry_response
+        handler.create_client.assert_called_once_with(
+            timeout=handler.timeout, event_hooks=handler.event_hooks
+        )
+        handler.single_connection_post_request.assert_awaited_once_with(
+            url="https://example.com",
+            client=retry_client,
+            data={"hello": "world"},
+            json=None,
+            params=None,
+            headers={"x-test": "1"},
+            stream=False,
+            content="payload",
+        )
+        retry_client.aclose.assert_awaited_once()
     finally:
         await handler.close()


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

The PR attempts to mitigate ```[Errno 104] Connection reset by peer``` failures seen when model completion requests return large responses. Today, this error is not surfaced or handled cleanly, so this change adds two targeted mitigations: first, it broadens the transport retry path to include httpx.ReadError, which can cover reset failures during larger reads; second, it adds a one-time manual retry when the caught exception text indicates a connection reset.

The PR also adds debug logging around both paths so it is easier to confirm when these retry branches are triggered and how the request flows through them.

This does not fix the underlying cause of the connection resets. At the moment, the source of the upstream reset is still unclear, so this PR focuses on improving resilience and observability rather than claiming a root-cause fix.