### PR TITLE
fix(router): use correct metadata key in run_async_fallback for Responses API

### DIFF
--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -130,7 +130,10 @@ async def run_async_fallback(
                 kwargs["model"] = mg
             elif isinstance(mg, dict):
                 kwargs.update(mg)
-            kwargs.setdefault("metadata", {}).update(
+            _metadata_key = (
+                "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
+            )
+            kwargs.setdefault(_metadata_key, {}).update(
                 {"model_group": kwargs.get("model", None)}
             )  # update model_group used, if fallbacks are done
             fallback_depth = fallback_depth + 1

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -1,0 +1,94 @@
+"""
+Tests for run_async_fallback metadata key handling.
+
+Verifies that run_async_fallback uses the correct metadata variable name
+("litellm_metadata" for Responses API routes, "metadata" for others)
+instead of always hardcoding "metadata".
+
+Regression test for https://github.com/BerriAI/litellm/issues/25402
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system-path
+
+from litellm.router_utils.fallback_event_handlers import run_async_fallback
+
+
+@pytest.mark.asyncio
+async def test_fallback_uses_litellm_metadata_when_present():
+    """When kwargs contain 'litellm_metadata' (Responses API), fallback should
+    update that key instead of injecting a new 'metadata' key."""
+    mock_router = MagicMock()
+    mock_router.log_retry = MagicMock(side_effect=lambda kwargs, e: kwargs)
+
+    # Simulate successful fallback response
+    mock_response = MagicMock()
+    mock_router.async_function_with_fallbacks = AsyncMock(return_value=mock_response)
+
+    kwargs = {
+        "model": "gpt-4.1",
+        "litellm_metadata": {"existing_key": "value"},
+        "original_function": AsyncMock(),
+    }
+
+    await run_async_fallback(
+        litellm_router=mock_router,
+        fallback_model_group=["gpt-4.1-paid"],
+        original_model_group="gpt-4.1",
+        original_exception=Exception("mock primary failure"),
+        max_fallbacks=3,
+        fallback_depth=0,
+        **kwargs,
+    )
+
+    # The fallback should have updated litellm_metadata, not created a new metadata key
+    call_kwargs = mock_router.async_function_with_fallbacks.call_args
+    passed_kwargs = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs[1]
+
+    assert (
+        "metadata" not in passed_kwargs
+    ), "run_async_fallback should not inject 'metadata' when 'litellm_metadata' is present"
+    assert "litellm_metadata" in passed_kwargs
+    assert passed_kwargs["litellm_metadata"]["model_group"] == "gpt-4.1-paid"
+    assert passed_kwargs["litellm_metadata"]["existing_key"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_fallback_uses_metadata_when_litellm_metadata_absent():
+    """When kwargs do NOT contain 'litellm_metadata' (standard routes),
+    fallback should use the default 'metadata' key."""
+    mock_router = MagicMock()
+    mock_router.log_retry = MagicMock(side_effect=lambda kwargs, e: kwargs)
+
+    mock_response = MagicMock()
+    mock_router.async_function_with_fallbacks = AsyncMock(return_value=mock_response)
+
+    kwargs = {
+        "model": "gpt-4",
+        "metadata": {"existing_key": "value"},
+        "original_function": AsyncMock(),
+    }
+
+    await run_async_fallback(
+        litellm_router=mock_router,
+        fallback_model_group=["gpt-3.5-turbo"],
+        original_model_group="gpt-4",
+        original_exception=Exception("mock primary failure"),
+        max_fallbacks=3,
+        fallback_depth=0,
+        **kwargs,
+    )
+
+    call_kwargs = mock_router.async_function_with_fallbacks.call_args
+    passed_kwargs = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs[1]
+
+    assert "metadata" in passed_kwargs
+    assert passed_kwargs["metadata"]["model_group"] == "gpt-3.5-turbo"
+    assert passed_kwargs["metadata"]["existing_key"] == "value"


### PR DESCRIPTION
## Relevant issues

Fixes #25402

## What's the problem?

`run_async_fallback` in `fallback_event_handlers.py` hardcodes `"metadata"` when updating the `model_group` during fallback:

```python
kwargs.setdefault("metadata", {}).update(
    {"model_group": kwargs.get("model", None)}
)
```

Responses API routes (`/v1/responses`, `/v1/responses/compact`, etc.) use `"litellm_metadata"` as their metadata key — set by `_update_kwargs_before_fallbacks(metadata_variable_name="litellm_metadata")` in `_ageneric_api_call_with_fallbacks`.

The hardcoded `"metadata"` creates a stale top-level key in kwargs that leaks into the request body. Azure OpenAI rejects it:

**Before** (fallback on `/v1/responses/compact`):
```
400 Unknown parameter: 'metadata'
```

**After** (fallback works correctly):
```
200 OK — metadata written to litellm_metadata, not leaked to provider
```

## Fix

Detect which metadata key is already active in kwargs:

```python
_metadata_key = (
    "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
)
kwargs.setdefault(_metadata_key, {}).update(...)
```

This is consistent with how the rest of the router determines the metadata variable name. Since `_update_kwargs_before_fallbacks` runs before the fallback handler, the correct key is always present in kwargs by the time we reach this code.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

- `litellm/router_utils/fallback_event_handlers.py`: Detect active metadata key (`litellm_metadata` vs `metadata`) instead of hardcoding `"metadata"`
- `tests/test_litellm/router_utils/test_fallback_event_handlers.py`: 2 regression tests — one for Responses API routes (litellm_metadata), one for standard routes (metadata)