### PR TITLE
[WIP] aiohttp timeout issue. timeout is being enforced correctly, investigate timeout configs passed during initialization

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -553,6 +553,9 @@ class BaseAzureLLM(BaseOpenAILLM):
 
         max_retries = litellm_params.get("max_retries")
         timeout = litellm_params.get("timeout")
+        verbose_logger.debug(
+            "Azure initialize_azure_sdk_client litellm_params timeout=%s", timeout
+        )
         if (
             not api_key
             and azure_ad_token_provider is None

--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -292,6 +292,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
     ) -> httpx.Response:
         timeout = request.extensions.get("timeout", {})
         sni_hostname = request.extensions.get("sni_hostname")
+        verbose_logger.debug("AiohttpTransport.handle_async_request timeout=%s", timeout)
 
         # Use helper to ensure we have a valid session for the current event loop
         client_session = self._get_valid_client_session()

--- a/scripts/test_aiohttp_timeout.py
+++ b/scripts/test_aiohttp_timeout.py
@@ -1,0 +1,54 @@
+import argparse
+import asyncio
+import time
+
+import aiohttp
+import httpx
+
+from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Single httpbin delay test for LiteLLM aiohttp transport timeouts."
+    )
+    parser.add_argument("--delay-seconds", type=int, default=5)
+    parser.add_argument("--timeout-seconds", type=float, default=2.0)
+    parser.add_argument("--pass-timeout", type=bool, default=False)
+    args = parser.parse_args()
+
+    url = f"https://httpbin.org/delay/{args.delay_seconds}"
+    timeout = httpx.Timeout(args.timeout_seconds)
+    transport = LiteLLMAiohttpTransport(
+        client=lambda: aiohttp.ClientSession(trust_env=True)
+    )
+
+    print(f"url={url}")
+    print(f"timeout={args.timeout_seconds}s")
+
+    started_at = time.perf_counter()
+    try:
+        request = httpx.Request(
+            method="GET",
+            url=url,
+            extensions={"timeout": timeout.as_dict() if args.pass_timeout else {}},
+        )
+        print(timeout.as_dict() if args.pass_timeout else {})
+        print(f"request.extensions['timeout']={request.extensions.get('timeout')}")
+
+        response = await transport.handle_async_request(request)
+
+        elapsed = time.perf_counter() - started_at
+        print(f"SUCCESS status_code={response.status_code} elapsed_s={elapsed:.2f}")
+        print("If elapsed is much greater than timeout, timeout is not respected.")
+    except Exception as e:
+        elapsed = time.perf_counter() - started_at
+        print(
+            f"EXCEPTION type={type(e).__name__} elapsed_s={elapsed:.2f} detail={e}"
+        )
+    finally:
+        await transport.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

Suspect timeout object being passed from the client during SDK init might be empty. Created a standalone script, which uses the handle_async_request function to trigger a request and enforce timeout error, which works as intended.