### PR TITLE
[Docs] Add missing MCP per-user token env vars to config_settings

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -602,6 +602,8 @@ router_settings:
 | MCP_OAUTH2_TOKEN_CACHE_MAX_SIZE | Maximum number of entries in MCP OAuth2 token cache. Default is 200
 | MCP_OAUTH2_TOKEN_CACHE_MIN_TTL | Minimum TTL in seconds for MCP OAuth2 token cache. Default is 10
 | MCP_OAUTH2_TOKEN_EXPIRY_BUFFER_SECONDS | Seconds to subtract from token expiry when computing cache TTL. Default is 60
+| MCP_PER_USER_TOKEN_DEFAULT_TTL | Default TTL in seconds for per-user MCP OAuth tokens stored in Redis. Default is 43200 (12 hours)
+| MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS | Seconds to subtract from per-user MCP OAuth token expiry when computing Redis TTL. Default is 60
 | DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT | Default token count for mock response completions. Default is 20
 | DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT | Default token count for mock response prompts. Default is 10
 | DEFAULT_MODEL_CREATED_AT_TIME | Default creation timestamp for models. Default is 1677610602


### PR DESCRIPTION
## Summary

`MCP_PER_USER_TOKEN_DEFAULT_TTL` and `MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS` were introduced in #25441 but not added to the environment variables reference doc, causing `test_env_keys.py` to fail on all PRs branched from main after that merge.

## Changes

Added both env vars to the `environment variables - Reference` table in `docs/my-website/docs/proxy/config_settings.md`, grouped with the existing MCP OAuth entries.

## Testing

Ran `poetry run python ./tests/documentation_tests/test_env_keys.py` locally — passes.

## Type

📖 Documentation