### PR TITLE
fix(anthropic-adapter): preserve image blocks in tool results during format conversion

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -480,7 +480,12 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 tool_call_id=content.get(
                                                     "tool_use_id", ""
                                                 ),
-                                                content=openai_image_url,
+                                                content=[ChatCompletionImageObject(
+                                                    type="image_url",
+                                                    image_url=ChatCompletionImageUrlObject(
+                                                        url=openai_image_url
+                                                    ),
+                                                )],
                                             )
                                             self._add_cache_control_if_applicable(
                                                 content, tool_result, model

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -750,10 +750,12 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_base64_image():
             break
 
     assert tool_message is not None, "Tool message not found in result"
-    # Tool messages in OpenAI format have string content (data URL), not list
-    assert isinstance(tool_message["content"], str)
-    assert tool_message["content"].startswith("data:image/jpeg;base64,")
-    assert "/9j/4AAQSkZJRgABAQAAAQABAAD" in tool_message["content"]
+    # Tool messages with single image should have structured image_url content
+    assert isinstance(tool_message["content"], list)
+    assert len(tool_message["content"]) == 1
+    assert tool_message["content"][0]["type"] == "image_url"
+    assert tool_message["content"][0]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    assert "/9j/4AAQSkZJRgABAQAAAQABAAD" in tool_message["content"][0]["image_url"]["url"]
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_with_url_image():
@@ -806,10 +808,12 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_url_image():
             break
 
     assert tool_message is not None, "Tool message not found in result"
-    # Tool messages in OpenAI format have string content (URL), not list
-    assert isinstance(tool_message["content"], str)
+    # Tool messages with single image should have structured image_url content
+    assert isinstance(tool_message["content"], list)
+    assert len(tool_message["content"]) == 1
+    assert tool_message["content"][0]["type"] == "image_url"
     assert (
-        tool_message["content"]
+        tool_message["content"][0]["image_url"]["url"]
         == "https://i0.wp.com/picjumbo.com/wp-content/uploads/amazing-stone-path-in-forest-free-image.jpg"
     )
 


### PR DESCRIPTION
## Summary

When converting Anthropic `/v1/messages` to OpenAI `/v1/chat/completions` format, single-image tool results have their image data stored as a plain URL string in `ChatCompletionToolMessage.content`, instead of a structured `ChatCompletionImageObject` list. This causes downstream models (e.g. vLLM's `/v1/chat/completions`) to treat the base64 data URI as plain text, making image recognition fail silently — the model sees a long string instead of an actual image.

## Root Cause

In `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`, the single-item image tool result case (line 483) sets:
```python
content=openai_image_url,  # plain string like "data:image/png;base64,..."
```

While the multi-item case (line 522-529) correctly creates a structured object:
```python
content=[ChatCompletionImageObject(
    type="image_url",
    image_url=ChatCompletionImageUrlObject(url=openai_image_url),
)]
```

## Fix

Apply the same structured `ChatCompletionImageObject` pattern to the single-item case, consistent with the multi-item path.

## How to Reproduce

1. Set up litellm proxy with `custom_llm_provider: "hosted_vllm"` pointing to a vLLM instance with multimodal support
2. Send a `/v1/messages` request containing a tool result with a single image block:
```json
{"type": "tool_result", "tool_use_id": "xxx", "content": [
  {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0K..."}}
]}
```
3. Observe that vLLM receives the image as a plain text string in `/v1/chat/completions`, not as a structured `image_url` object
4. The model fails to recognize the image content (guesses from filename instead)

This is the exact flow when Claude Code CLI reads a local image file via the `Read` tool and the response is proxied through litellm to a vLLM backend.

## Test Plan

- [x] Verified fix with vLLM multimodal backend (Kimi-K2.5): tool result images now correctly recognized
- [x] Verified multi-item tool results still work (no regression)
- [x] Verified plain text tool results unaffected