### PR TITLE
[Fix] Align v1 guardrail and agent list responses with v2 field handling

### DIFF
--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -28,12 +28,35 @@ from litellm.types.agents import (
     MakeAgentsPublicRequest,
     PatchAgentRequest,
 )
+from litellm.litellm_core_utils.litellm_logging import _get_masked_values
 from litellm.types.llms.custom_http import httpxSpecialProvider
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
 
 router = APIRouter()
+
+
+def _redact_sensitive_agent_fields(
+    agents: List[AgentResponse],
+) -> List[AgentResponse]:
+    """
+    Return copies of the given agents with sensitive configuration fields
+    redacted.  The original objects are not modified.
+    """
+    redacted: List[AgentResponse] = []
+    for agent in agents:
+        copy = agent.model_copy(deep=True)
+        copy.static_headers = None
+        copy.extra_headers = None
+        if copy.litellm_params:
+            copy.litellm_params = _get_masked_values(
+                copy.litellm_params,
+                unmasked_length=4,
+                number_of_asterisks=4,
+            )
+        redacted.append(copy)
+    return redacted
 
 
 def _check_agent_management_permission(user_api_key_dict: UserAPIKeyAuth) -> None:
@@ -182,6 +205,14 @@ async def get_agents(
             ] = litellm.public_agent_groups is not None and (
                 agent.agent_id in litellm.public_agent_groups
             )
+
+        # Redact sensitive fields for non-admin users
+        is_admin = (
+            user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+            or user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
+        )
+        if not is_admin:
+            returned_agents = _redact_sensitive_agent_fields(returned_agents)
 
         if health_check:
             agents_with_url = [
@@ -398,6 +429,14 @@ async def get_agent_by_id(
             raise HTTPException(
                 status_code=404, detail=f"Agent with ID {agent_id} not found"
             )
+
+        # Redact sensitive fields for non-admin users
+        is_admin = (
+            user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+            or user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
+        )
+        if not is_admin:
+            agent = _redact_sensitive_agent_fields([agent])[0]
 
         return agent
     except HTTPException:

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -60,12 +60,20 @@ def _get_guardrails_list_response(
     """
     Helper function to get the guardrails list response
     """
+    from litellm.litellm_core_utils.litellm_logging import _get_masked_values
+
     guardrail_configs: List[GuardrailInfoResponse] = []
     for guardrail in guardrails_config:
+        litellm_params = guardrail.get("litellm_params") or {}
+        masked_params = _get_masked_values(
+            litellm_params,
+            unmasked_length=4,
+            number_of_asterisks=4,
+        )
         guardrail_configs.append(
             GuardrailInfoResponse(
                 guardrail_name=guardrail.get("guardrail_name"),
-                litellm_params=guardrail.get("litellm_params"),
+                litellm_params=masked_params,
                 guardrail_info=guardrail.get("guardrail_info"),
             )
         )


### PR DESCRIPTION
## Summary

The v1 `/guardrails/list` endpoint returned raw `litellm_params` without masking, while the v2 endpoint already applied `_get_masked_values`. Similarly, the `/v1/agents` and `/v1/agents/{agent_id}` endpoints returned full configuration objects including `static_headers` and `extra_headers` to all authenticated users regardless of role.

### Fix

- Apply `_get_masked_values` to `litellm_params` in the v1 `/guardrails/list` response, matching the existing v2 pattern.
- Add `_redact_sensitive_agent_fields` helper that returns copies of agent objects with `static_headers`/`extra_headers` nulled and `litellm_params` masked.
- Apply redaction in both `GET /v1/agents` and `GET /v1/agents/{agent_id}` for non-admin users. Admin users continue to see full unmasked details.

## Testing

- Verified against live proxy: non-admin users receive redacted fields, admin users receive full details.
- `poetry run pytest tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py -v` — 62 passed
- `poetry run pytest tests/test_litellm/proxy/agent_endpoints/test_endpoints.py -v` — 32 passed

## Type

🐛 Bug Fix