### PR TITLE
[Fix] Flush Tremor Tooltip timers in user_edit_view tests

### DIFF
--- a/ui/litellm-dashboard/src/components/user_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/user_edit_view.test.tsx
@@ -1,6 +1,6 @@
-import { screen, waitFor } from "@testing-library/react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../tests/test-utils";
 import { UserEditView } from "./user_edit_view";
 
@@ -138,6 +138,15 @@ describe("UserEditView", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Tremor's internal Tooltip sets a setTimeout that fires after teardown,
+    // causing "window is not defined". Flush pending timers before cleanup.
+    vi.useFakeTimers();
+    vi.runAllTimers();
+    vi.useRealTimers();
+    cleanup();
   });
 
   it("should render", async () => {


### PR DESCRIPTION
## Summary

### Failure Path (Before Fix)
Tremor's internal Tooltip component sets a `setTimeout` that fires after the jsdom test environment is torn down, causing a `ReferenceError: window is not defined` during vitest runs of `user_edit_view.test.tsx`. This produced a false-positive warning that could mask real test failures.

### Fix
Added an `afterEach` block that switches to fake timers, flushes all pending timers (so the Tooltip callback runs while jsdom is still alive), restores real timers, and calls `cleanup()`.

## Testing
- `npx vitest run src/components/user_edit_view.test.tsx` — all 25 tests pass with no unhandled errors

## Type
🐛 Bug Fix
✅ Test