### PR TITLE
feat: add Z.AI provider to UI dashboard

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -3057,6 +3057,34 @@
     "default_model_placeholder": "gpt-3.5-turbo"
   },
   {
+    "provider": "ZAI",
+    "provider_display_name": "Z.AI",
+    "litellm_provider": "zai",
+    "credential_fields": [
+      {
+        "key": "api_key",
+        "label": "API Key",
+        "placeholder": "your-zai-api-key",
+        "tooltip": "Z.AI API Key from https://z.ai/manage-apikey/apikey-list",
+        "required": true,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://api.z.ai/api/paas/v4",
+        "tooltip": "General: https://api.z.ai/api/paas/v4. GLM Coding Plan: https://api.z.ai/api/coding/paas/v4. Override for self-hosted endpoints.",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": "https://api.z.ai/api/paas/v4"
+      }
+    ],
+    "default_model_placeholder": "zai/glm-4.6"
+  },
+  {
     "provider": "CURSOR",
     "provider_display_name": "Cursor",
     "litellm_provider": "cursor",

--- a/ui/litellm-dashboard/public/assets/logos/zai.svg
+++ b/ui/litellm-dashboard/public/assets/logos/zai.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Z.ai</title><path d="M12.105 2L9.927 4.953H.653L2.83 2h9.276zM23.254 19.048L21.078 22h-9.242l2.174-2.952h9.244zM24 2L9.264 22H0L14.736 2H24z"></path></svg>

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -103,6 +103,7 @@ export enum Providers {
   WATSONX_TEXT = "Watsonx Text",
   xAI = "xAI",
   XINFERENCE = "Xinference",
+  ZAI = "Z.AI",
 }
 
 export const provider_map: Record<string, string> = {
@@ -210,6 +211,7 @@ export const provider_map: Record<string, string> = {
   WATSONX_TEXT: "watsonx_text",
   xAI: "xai",
   XINFERENCE: "xinference",
+  ZAI: "zai",
 };
 
 const asset_logos_folder = "../ui/assets/logos/";
@@ -299,6 +301,7 @@ export const providerLogoMap: Record<string, string> = {
   [Providers.WATSONX_TEXT]: `${asset_logos_folder}watsonx.svg`,
   [Providers.xAI]: `${asset_logos_folder}xai.svg`,
   [Providers.XINFERENCE]: `${asset_logos_folder}xinference.svg`,
+  [Providers.ZAI]: `${asset_logos_folder}zai.svg`,
 };
 
 export const getProviderLogoAndName = (providerValue: string): { logo: string; displayName: string } => {


### PR DESCRIPTION
## Relevant issues

Fixes #25482

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

New Feature

## Changes

### Summary

Registers Z.AI (Zhipu AI) in the LiteLLM dashboard's provider dropdown so users can configure Z.AI models from the UI without editing `config.yaml`. Backend support for the `zai/` provider prefix already exists in `litellm/llms/zai/`; this PR only adds the UI-layer registration.

Follows the pattern established by the MiniMax provider PR #18496.

### What was added

**1. Backend metadata (`provider_create_fields.json`)**

- Added `ZAI` provider entry with:
  - `api_key` — required password field. Tooltip links to https://z.ai/manage-apikey/apikey-list (where users create API keys).
  - `api_base` — optional text field. Default: `https://api.z.ai/api/paas/v4`. Tooltip also documents the alternative GLM Coding Plan endpoint `https://api.z.ai/api/coding/paas/v4` for Coding Plan subscribers (per the [Z.AI API reference](https://docs.z.ai/api-reference)).
  - `default_model_placeholder`: `zai/glm-4.6` (Z.AI's documented flagship model).

**2. Frontend (`provider_info_helpers.tsx`)**

- Added `ZAI = "Z.AI"` to the `Providers` enum.
- Registered `ZAI: "zai"` in `provider_map`.
- Added `[Providers.ZAI]: \`${asset_logos_folder}zai.svg\`` in `providerLogoMap`.

**3. Assets**

- Added `ui/litellm-dashboard/public/assets/logos/zai.svg` — sourced from [LobeHub icons](https://lobehub.com/icons/zai), which matches the logo used on https://chat.z.ai.

### Files modified

- `litellm/proxy/public_endpoints/provider_create_fields.json` (+28 lines)
- `ui/litellm-dashboard/src/components/provider_info_helpers.tsx` (+3 lines)
- `ui/litellm-dashboard/public/assets/logos/zai.svg` (new, 319 bytes)

### Verification

- `npm run build` passes (TypeScript compile + Next.js static page generation succeed).
- Both modified files pass `npx prettier --check`.
- Dev server confirmed the logo file is served correctly at `/assets/logos/zai.svg`.
- No backend code is modified; existing `zai/` provider routing in `litellm/llms/zai/` is unaffected.