### PR TITLE
fix(guardrails): use plural key in get_disable_global_guardrail

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -259,11 +259,11 @@ class CustomGuardrail(CustomLogger):
         """
         Returns True if the global guardrail should be disabled
         """
-        if "disable_global_guardrail" in data:
-            return data["disable_global_guardrail"]
+        if "disable_global_guardrails" in data:
+            return data["disable_global_guardrails"]
         metadata = data.get("litellm_metadata") or data.get("metadata", {})
-        if "disable_global_guardrail" in metadata:
-            return metadata["disable_global_guardrail"]
+        if "disable_global_guardrails" in metadata:
+            return metadata["disable_global_guardrails"]
         return False
 
     def _is_valid_response_type(self, result: Any) -> bool:

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -197,7 +197,7 @@ class TestCustomGuardrailShouldRunGuardrail:
         data_with_disable_root = {
             "model": "gpt-3.5-turbo",
             "messages": [{"role": "user", "content": "test"}],
-            "disable_global_guardrail": True,
+            "disable_global_guardrails": True,
         }
         result = custom_guardrail.should_run_guardrail(
             data=data_with_disable_root, event_type=GuardrailEventHooks.pre_call
@@ -210,7 +210,7 @@ class TestCustomGuardrailShouldRunGuardrail:
         data_with_disable_litellm = {
             "model": "gpt-3.5-turbo",
             "messages": [{"role": "user", "content": "test"}],
-            "litellm_metadata": {"disable_global_guardrail": True},
+            "litellm_metadata": {"disable_global_guardrails": True},
         }
         result = custom_guardrail.should_run_guardrail(
             data=data_with_disable_litellm, event_type=GuardrailEventHooks.pre_call
@@ -223,7 +223,7 @@ class TestCustomGuardrailShouldRunGuardrail:
         data_with_disable_metadata = {
             "model": "gpt-3.5-turbo",
             "messages": [{"role": "user", "content": "test"}],
-            "metadata": {"disable_global_guardrail": True},
+            "metadata": {"disable_global_guardrails": True},
         }
         result = custom_guardrail.should_run_guardrail(
             data=data_with_disable_metadata, event_type=GuardrailEventHooks.pre_call
@@ -236,7 +236,7 @@ class TestCustomGuardrailShouldRunGuardrail:
         data_with_disable_false = {
             "model": "gpt-3.5-turbo",
             "messages": [{"role": "user", "content": "test"}],
-            "disable_global_guardrail": False,
+            "disable_global_guardrails": False,
         }
         result = custom_guardrail.should_run_guardrail(
             data=data_with_disable_false, event_type=GuardrailEventHooks.pre_call

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -2263,7 +2263,7 @@ class TestPanwAirsMcpForceRun:
                 "test_panw_airs",
                 False,
                 "pre_call",
-                _simple_data(disable_global_guardrail=True),
+                _simple_data(disable_global_guardrails=True),
                 GuardrailEventHooks.pre_mcp_call,
                 False,
                 id="honors_disable_global_on_mcp_hooks",


### PR DESCRIPTION
Rename disable_global_guardrail → disable_global_guardrails to match the key name used by litellm_pre_call_utils.py, the API endpoints, and the UI when propagating key/team metadata.

The singular form was introduced in PR #16983 and has never matched the plural form written by the rest of the codebase, so the feature silently did nothing.

## Relevant issues

Fixes #25487 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type
🐛 Bug Fix


## Changes
get_disable_global_guardrail() in custom_guardrail.py checks for the key disable_global_guardrail (singular), but every producer — litellm_pre_call_utils.py (key and team metadata propagation), the 
  API endpoints, and the UI — writes disable_global_guardrails (plural). The keys never match, so setting disable_global_guardrails: true on an API key or team has no effect.
                                                                                                                                                                                                        
  The mismatch was introduced in PR #16983 (2025-11-22) across two commits 10 minutes apart — the method used singular, the propagation used plural.                                                    
  
  Fix: Rename disable_global_guardrail → disable_global_guardrails in the consumer method and update corresponding tests.                                                                               
                                                                                                                                                                                                      
  Files changed:                                                                                                                                                                                        
  - litellm/integrations/custom_guardrail.py — 4 lines: singular → plural in get_disable_global_guardrail()                                                                                           
  - tests/test_litellm/integrations/test_custom_guardrail.py — 4 lines: update test data to use plural key                                                                                              
  - tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py — 1 line: update test param to use plural key