### PR TITLE
Handle error responses embedded in SSE streams

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -803,6 +803,18 @@ class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):
 
     def chunk_parser(self, chunk: dict) -> ModelResponseStream:
         try:
+            # Handle error responses embedded in SSE streams (e.g. from sglang)
+            if "error" in chunk:
+                error_data = chunk["error"]
+                error_message = error_data.get("message", str(error_data))
+                error_type = error_data.get("type", "")
+                error_code = error_data.get("code", 500)
+                raise litellm.BadRequestError(
+                    message=f"Received error in stream: {error_message}",
+                    model=chunk.get("model", ""),
+                    llm_provider=self.custom_llm_provider,
+                )
+
             choices = chunk.get("choices", [])
             choices = self._map_reasoning_to_reasoning_content(choices)
 

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -806,13 +806,17 @@ class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):
             # Handle error responses embedded in SSE streams (e.g. from sglang)
             if "error" in chunk:
                 error_data = chunk["error"]
-                error_message = error_data.get("message", str(error_data))
-                error_type = error_data.get("type", "")
-                error_code = error_data.get("code", 500)
+                if isinstance(error_data, dict):
+                    error_message = error_data.get("message", str(error_data))
+                    error_code = error_data.get("code", 400)
+                else:
+                    error_message = str(error_data)
+                    error_code = 400
                 raise litellm.BadRequestError(
                     message=f"Received error in stream: {error_message}",
                     model=chunk.get("model", ""),
                     llm_provider=self.custom_llm_provider,
+                    response=httpx.Response(status_code=error_code, request=httpx.Request(method="POST", url="")),
                 )
 
             choices = chunk.get("choices", [])


### PR DESCRIPTION
## Summary

When an upstream provider (e.g. sglang) returns an error inside an HTTP 200 SSE stream as `{"error": {"type": "BadRequestError", "code": 400, ...}}`, the `chunk_parser` tried to construct a `ModelResponseStream` from the error dict. This failed because the error chunk lacks standard completion fields (`id`, `choices`, etc.), causing a misleading 503 `MidStreamFallbackError` instead of the actual 400 `BadRequestError`.

## Fix

Added an early `"error" in chunk` guard at the top of `chunk_parser()`. When an error chunk is detected, it raises `litellm.BadRequestError` with the upstream error message, giving callers the correct error type and status code.

## Test plan

- Error chunks in SSE streams now raise `BadRequestError` with the upstream message
- Normal completion chunks are unaffected (the guard only triggers on `"error"` key)
- The 503 `MidStreamFallbackError` cascade no longer occurs for upstream 400 errors

Closes #25492