### PR TITLE
[Fix] Responses WebSocket Duplicate Keyword Argument Error

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1967,11 +1967,18 @@ async def _aresponses_websocket(
     )
 
     # Extract params that we're passing explicitly to avoid duplicates in **kwargs
-    remaining_kwargs = {
-        k: v
-        for k, v in kwargs.items()
-        if k not in {"user_api_key_dict", "litellm_metadata"}
+    _explicit_keys = {
+        "user_api_key_dict",
+        "litellm_metadata",
+        "custom_llm_provider",
+        "model",
+        "websocket",
+        "litellm_logging_obj",
+        "api_base",
+        "api_key",
+        "timeout",
     }
+    remaining_kwargs = {k: v for k, v in kwargs.items() if k not in _explicit_keys}
 
     await base_llm_http_handler.async_responses_websocket(
         model=model,


### PR DESCRIPTION
## Summary

### Failure Path

PR #25334 changed the router to inject `custom_llm_provider` into kwargs when calling downstream functions. In `_aresponses_websocket`, `custom_llm_provider` is passed both explicitly and via `**remaining_kwargs`, causing `TypeError: got multiple values for keyword argument 'custom_llm_provider'`. This breaks all WebSocket-mode Responses API calls.

### Fix

Expand the `remaining_kwargs` filter in `_aresponses_websocket` to exclude all keys that are already passed as explicit arguments to `async_responses_websocket()`: `custom_llm_provider`, `model`, `websocket`, `litellm_logging_obj`, `api_base`, `api_key`, and `timeout`.

## Testing

- Fixes failing CI tests: `test_responses_websocket_proxy_basic` and `test_responses_websocket_proxy_multi_turn`

## Type

🐛 Bug Fix