### PR TITLE
fix: a2a create a2a client default 60 second timeout 

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -615,7 +615,7 @@ async def asend_message_streaming(  # noqa: PLR0915
 
 async def create_a2a_client(
     base_url: str,
-    timeout: float = 60.0,
+    timeout: float = DEFAULT_A2A_AGENT_TIMEOUT,
     extra_headers: Optional[Dict[str, str]] = None,
 ) -> "A2AClientType":
     """
@@ -626,7 +626,7 @@ async def create_a2a_client(
 
     Args:
         base_url: The base URL of the A2A agent (e.g., "http://localhost:10001")
-        timeout: Request timeout in seconds (default: 60.0)
+        timeout: Request timeout in seconds (default: ``DEFAULT_A2A_AGENT_TIMEOUT`` / env ``DEFAULT_A2A_AGENT_TIMEOUT``)
         extra_headers: Optional additional headers to include in requests
 
     Returns:
@@ -711,7 +711,7 @@ async def aget_agent_card(
 
     Args:
         base_url: The base URL of the A2A agent (e.g., "http://localhost:10001")
-        timeout: Request timeout in seconds (default: 60.0)
+        timeout: Request timeout in seconds (default: ``DEFAULT_A2A_AGENT_TIMEOUT`` / env ``DEFAULT_A2A_AGENT_TIMEOUT``)
         extra_headers: Optional additional headers to include in requests
 
     Returns:

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_header_isolation.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_header_isolation.py
@@ -4,12 +4,17 @@ Tests that prove header isolation between agents.
 Before the fix these tests FAIL — agent A's headers bleed into agent B
 because create_a2a_client mutates a globally cached httpx client.
 After the fix they pass.
+
+Also includes direct unit tests for create_a2a_client (fresh httpx client
+per call; default timeout uses DEFAULT_A2A_AGENT_TIMEOUT).
 """
 
 import sys
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+
+from litellm.constants import DEFAULT_A2A_AGENT_TIMEOUT
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +204,7 @@ async def test_each_agent_gets_only_its_own_static_headers():
 
 
 # ---------------------------------------------------------------------------
-# Unit test: create_a2a_client uses a fresh httpx client per call
+# Unit tests: create_a2a_client (httpx client per call + timeout defaults)
 # ---------------------------------------------------------------------------
 
 
@@ -246,3 +251,81 @@ async def test_create_a2a_client_uses_fresh_httpx_client():
     assert created_clients[0] is not created_clients[1], (
         "create_a2a_client reused a cached httpx client — headers will bleed between agents"
     )
+
+
+@pytest.mark.asyncio
+async def test_create_a2a_client_default_timeout_matches_constant():
+    """When timeout is omitted, httpx client params must use DEFAULT_A2A_AGENT_TIMEOUT."""
+    from litellm.a2a_protocol.main import create_a2a_client
+
+    captured: dict = {}
+
+    def _capture_get_async_httpx_client(llm_provider, params, **kwargs):
+        captured["params"] = params
+        handler = MagicMock()
+        handler.client = MagicMock()
+        handler.client.headers = MagicMock()
+        return handler
+
+    fake_agent_card = MagicMock()
+    fake_agent_card.name = "test-agent"
+
+    class _FakeResolver:
+        def __init__(self, **kw):
+            pass
+
+        async def get_agent_card(self):
+            return fake_agent_card
+
+    class _FakeA2AClient:
+        def __init__(self, httpx_client, agent_card):
+            pass
+
+    with patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True), patch(
+        "litellm.a2a_protocol.main.get_async_httpx_client",
+        side_effect=_capture_get_async_httpx_client,
+    ), patch("litellm.a2a_protocol.main.A2ACardResolver", _FakeResolver), patch(
+        "litellm.a2a_protocol.main._A2AClient", _FakeA2AClient
+    ):
+        await create_a2a_client(base_url="http://127.0.0.1:9")
+
+    assert captured["params"]["timeout"] == DEFAULT_A2A_AGENT_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_create_a2a_client_explicit_timeout_overrides_default():
+    """Explicit timeout= must be passed through to the httpx client params."""
+    from litellm.a2a_protocol.main import create_a2a_client
+
+    captured: dict = {}
+
+    def _capture_get_async_httpx_client(llm_provider, params, **kwargs):
+        captured["params"] = params
+        handler = MagicMock()
+        handler.client = MagicMock()
+        handler.client.headers = MagicMock()
+        return handler
+
+    fake_agent_card = MagicMock()
+    fake_agent_card.name = "test-agent"
+
+    class _FakeResolver:
+        def __init__(self, **kw):
+            pass
+
+        async def get_agent_card(self):
+            return fake_agent_card
+
+    class _FakeA2AClient:
+        def __init__(self, httpx_client, agent_card):
+            pass
+
+    with patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True), patch(
+        "litellm.a2a_protocol.main.get_async_httpx_client",
+        side_effect=_capture_get_async_httpx_client,
+    ), patch("litellm.a2a_protocol.main.A2ACardResolver", _FakeResolver), patch(
+        "litellm.a2a_protocol.main._A2AClient", _FakeA2AClient
+    ):
+        await create_a2a_client(base_url="http://127.0.0.1:9", timeout=42.5)
+
+    assert captured["params"]["timeout"] == 42.5


### PR DESCRIPTION
## Relevant issues

N/A, support finding: A2A `message/send` via the proxy used a **60s** HTTP read timeout from `create_a2a_client()` while `aget_agent_card()` already honored **`DEFAULT_A2A_AGENT_TIMEOUT`** (env `DEFAULT_A2A_AGENT_TIMEOUT`, default **6000s** in `constants.py`). Long-running agents succeeded when called **directly** but failed through LiteLLM around ~60s with `ReadTimeout` / `A2AClientTimeoutError`.

---

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

---

## Type

🐛 Bug Fix  
✅ Test

---

## Changes

**Problem**  
`create_a2a_client()` in `litellm/a2a_protocol/main.py` defaulted `timeout` to **`60.0`**, so the cached httpx client used for A2A JSON-RPC (including proxy `asend_message` → `create_a2a_client`) enforced a **~60s read timeout**, independent of **`DEFAULT_A2A_AGENT_TIMEOUT`**. That was inconsistent with `aget_agent_card()`, which already defaults to **`DEFAULT_A2A_AGENT_TIMEOUT`**.

**Fix**  
- Default `timeout` for `create_a2a_client()` is now **`DEFAULT_A2A_AGENT_TIMEOUT`** (still overridable via the `timeout` argument).  
- Docstrings updated for `create_a2a_client` and `aget_agent_card` timeout parameter where they incorrectly implied a 60s default.

**Tests**  
- In `tests/test_litellm/proxy/agent_endpoints/test_agent_header_isolation.py`, added mocked tests that patch `get_async_httpx_client` and assert:
  - omitted `timeout` → `params["timeout"] == DEFAULT_A2A_AGENT_TIMEOUT`
  - explicit `timeout=42.5` → passed through to httpx params

**Files touched**  
- `litellm/a2a_protocol/main.py`  
- `tests/test_litellm/proxy/agent_endpoints/test_agent_header_isolation.py`

---

## Reproduction (local verification)

Use any **mock A2A backend** that returns an agent card and answers JSON-RPC `message/send`, but **waits longer than 60 seconds** before sending the HTTP response when the prompt asks for it (for example a **61s** delay). Point LiteLLM at that URL.

**Direct SDK:** call `asend_message` with `api_base` set to the mock (and no pre-built client), so `create_a2a_client` uses its **default** timeout.

**Through the proxy:** register an agent whose URL is that mock, then call `POST /a2a/{agent_id}/message/send` with JSON-RPC `message/send` and a message that triggers the slow path.

### Before the fix (60s default in `create_a2a_client`)

- **Direct SDK:** error after **~60s** — `ReadTimeout` / `A2AClientTimeoutError` → `A2AError: Timeout Error: Client Request timed out`.
- **Proxy:** **HTTP 500**, same error message, **~60s** total time.

### After the fix (default `DEFAULT_A2A_AGENT_TIMEOUT`)

- Same **61s** (or any) mock delay within your configured default: request **completes successfully** in roughly the mock delay plus overhead (**~61s** in our check).
- **Proxy:** **HTTP 200** with the agent response body, **~61s** total time in the same scenario.
