### PR TITLE
fix(anthropic): drop orphan tool_choice when tools are absent

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1081,6 +1081,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             non_default_params=non_default_params, optional_params=optional_params
         )
 
+        # Anthropic requires tools to be specified if tool_choice is specified.
+        # If tools were stripped out (e.g. intercepted), we must also remove tool_choice.
+        if "tool_choice" in optional_params and not optional_params.get("tools"):
+            optional_params.pop("tool_choice", None)
+
         return optional_params
 
     def _create_json_tool_call_for_response_format(

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -626,6 +626,74 @@ def test_map_tool_choice_dict_type_function_without_name():
     assert result is None
 
 
+def _get_showtimes_tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_showtimes",
+            "description": "Get current showtimes",
+            "parameters": {
+                "type": "object",
+                "properties": {"movie": {"type": "string"}},
+                "required": ["movie"],
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "auto",
+        "none",
+        {"type": "function", "function": {"name": "get_showtimes"}},
+    ],
+)
+def test_map_openai_params_drops_tool_choice_when_tools_empty(tool_choice):
+    config = AnthropicConfig()
+
+    mapped_params = config.map_openai_params(
+        non_default_params={"tools": [], "tool_choice": tool_choice},
+        optional_params={},
+        model="claude-sonnet-4-5-20250929",
+        drop_params=False,
+    )
+
+    assert mapped_params == {"tools": []}
+
+
+@pytest.mark.parametrize(
+    "tool_choice,expected_type",
+    [
+        ("auto", "auto"),
+        ("none", "none"),
+        (
+            {"type": "function", "function": {"name": "get_showtimes"}},
+            "tool",
+        ),
+    ],
+)
+def test_map_openai_params_preserves_tool_choice_when_tools_valid(
+    tool_choice, expected_type
+):
+    config = AnthropicConfig()
+
+    mapped_params = config.map_openai_params(
+        non_default_params={
+            "tools": [_get_showtimes_tool()],
+            "tool_choice": tool_choice,
+        },
+        optional_params={},
+        model="claude-sonnet-4-5-20250929",
+        drop_params=False,
+    )
+
+    assert len(mapped_params["tools"]) == 1
+    assert mapped_params["tool_choice"]["type"] == expected_type
+    if expected_type == "tool":
+        assert mapped_params["tool_choice"]["name"] == "get_showtimes"
+
+
 def test_transform_response_with_prefix_prompt():
     import httpx
 


### PR DESCRIPTION
Fixes #25477

## What changed

- Drops Anthropic `tool_choice` when `tools` are absent or empty after proxy/provider parameter mapping.
- Preserves `tool_choice` when valid tools remain.
- Adds serialization tests for `auto`, `none`, and specific tool-choice modes.

## Validation

Environment used for validation: A100 host, Ubuntu 22.04.5, Python 3.10.12. LiteLLM source was checked out at the relevant base/head/fixed SHAs; package metadata reported `litellm 1.85.0`, `openai 2.36.0`, `pydantic 2.13.4`, `httpx 0.28.1`, and `aiohttp 3.13.5`.

Command:

```bash
PYTHONPATH=. python validate_litellm_prs.py --pr 25515
PYTHONPATH=. python -m pytest -q tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_map_openai_params_drops_tool_choice_when_tools_empty tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_map_openai_params_preserves_tool_choice_when_tools_valid
```

Results:

- Base `d0e347af32c6495719ae81e13edfeae091357333`: failed; serialized orphan `tool_choice` for empty and absent tools in `auto`, `none`, and specific modes.
- PR head `5aa56f318c09ef89407fbb01b2d7a745ce0c9910`: passed targeted serialization validation.
- Fixed branch: passed targeted validation with added tests.
- Focused tests: `6 passed`.

Representative redacted fixed request shape:

```json
{"empty_tools_specific":{"tools":[]},"valid_tools_specific":{"tool_choice":{"name":"get_showtimes","type":"tool"},"tools":[{"name":"get_showtimes","type":"custom"}]}}
```

## Scope

This validates the Anthropic request-serialization invariant that `tool_choice` must not be sent without tools. It does not claim to restore web search behavior if earlier proxy logic stripped all tools.
