### PR TITLE
fix(responses-ws): route OpenAI/Azure WebSocket through managed HTTP path

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -424,6 +424,11 @@ disable_aiohttp_trust_env: bool = (
 )
 force_ipv4: bool = False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
 network_mock: bool = False  # When True, use mock transport — no real network calls
+# When True, proxy Responses API WebSocket sessions directly to
+# wss://api.openai.com/v1/responses instead of the managed HTTP-streaming path.
+# Only enable this if your OpenAI deployment / reverse proxy reliably responds to
+# response.create events over the native WebSocket protocol.
+openai_responses_native_websocket: bool = False
 
 ####### STOP SEQUENCE LIMIT #######
 disable_stop_sequence_limit: bool = False  # when True, stop sequence limit is disabled

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -360,8 +360,6 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         to the native WebSocket path (e.g. when using a private deployment or
         reverse proxy that reliably honours the native wss:// protocol).
         """
-        import litellm
-
         return bool(getattr(litellm, "openai_responses_native_websocket", False))
 
     #########################################################

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -348,15 +348,21 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         return False
 
     def supports_native_websocket(self) -> bool:
-        """Use managed HTTP-streaming path for Responses API WebSocket mode.
+        """Use managed HTTP-streaming path for Responses API WebSocket mode by default.
 
         OpenAI's wss://api.openai.com/v1/responses endpoint exists but does not
         reliably stream events back in response to response.create messages in all
         deployment contexts. The ManagedResponsesWebSocketHandler makes a normal
         HTTP streaming call to /v1/responses and forwards the events over the
         WebSocket, which is proven to work.
+
+        Set ``litellm.openai_responses_native_websocket = True`` to opt back in
+        to the native WebSocket path (e.g. when using a private deployment or
+        reverse proxy that reliably honours the native wss:// protocol).
         """
-        return False
+        import litellm
+
+        return bool(getattr(litellm, "openai_responses_native_websocket", False))
 
     #########################################################
     ########## DELETE RESPONSE API TRANSFORMATION ##############

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -348,8 +348,15 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         return False
 
     def supports_native_websocket(self) -> bool:
-        """OpenAI supports native WebSocket for Responses API"""
-        return True
+        """Use managed HTTP-streaming path for Responses API WebSocket mode.
+
+        OpenAI's wss://api.openai.com/v1/responses endpoint exists but does not
+        reliably stream events back in response to response.create messages in all
+        deployment contexts. The ManagedResponsesWebSocketHandler makes a normal
+        HTTP streaming call to /v1/responses and forwards the events over the
+        WebSocket, which is proven to work.
+        """
+        return False
 
     #########################################################
     ########## DELETE RESPONSE API TRANSFORMATION ##############

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -38,19 +38,19 @@ from litellm.llms.xai.responses.transformation import XAIResponsesAPIConfig
 class TestResponsesAPIWebSocketSupport:
     """Test that all providers have websocket support configured correctly"""
 
-    def test_openai_supports_native_websocket(self):
-        """OpenAI should support native websocket"""
+    def test_openai_uses_managed_websocket(self):
+        """OpenAI uses managed WebSocket handler (HTTP streaming path)"""
         config = OpenAIResponsesAPIConfig()
         assert (
-            config.supports_native_websocket() is True
-        ), "OpenAI should support native websocket"
+            config.supports_native_websocket() is False
+        ), "OpenAI should use managed websocket handler"
 
-    def test_azure_supports_native_websocket(self):
-        """Azure should support native websocket (inherits from OpenAI)"""
+    def test_azure_uses_managed_websocket(self):
+        """Azure uses managed WebSocket handler (inherits from OpenAI)"""
         config = AzureOpenAIResponsesAPIConfig()
         assert (
-            config.supports_native_websocket() is True
-        ), "Azure should support native websocket"
+            config.supports_native_websocket() is False
+        ), "Azure should use managed websocket handler"
 
     def test_xai_uses_managed_websocket(self):
         """XAI should use managed websocket handler"""
@@ -1000,7 +1000,9 @@ class TestNativeWebSocketUrlConstruction:
 
         mock_config = MagicMock(spec=OpenAIResponsesAPIConfig)
         mock_config.supports_native_websocket.return_value = True
-        mock_config.get_complete_url.return_value = "https://api.openai.com/v1/responses"
+        mock_config.get_complete_url.return_value = (
+            "https://api.openai.com/v1/responses"
+        )
         mock_config.validate_environment.return_value = {}
 
         mock_logging = MagicMock()
@@ -1024,8 +1026,11 @@ class TestNativeWebSocketUrlConstruction:
 
         assert len(captured_urls) == 1
         from urllib.parse import parse_qs, urlparse
+
         qs = parse_qs(urlparse(captured_urls[0]).query)
-        assert qs.get("model") == ["gpt-4o-mini"], f"Expected model in URL, got: {captured_urls[0]}"
+        assert qs.get("model") == [
+            "gpt-4o-mini"
+        ], f"Expected model in URL, got: {captured_urls[0]}"
 
     @pytest.mark.asyncio
     async def test_ws_url_preserves_existing_params_and_adds_model(self):
@@ -1071,6 +1076,11 @@ class TestNativeWebSocketUrlConstruction:
 
         assert len(captured_urls) == 1
         from urllib.parse import parse_qs, urlparse
+
         qs = parse_qs(urlparse(captured_urls[0]).query)
-        assert qs.get("model") == ["gpt-4o"], f"model missing from URL: {captured_urls[0]}"
-        assert qs.get("api-version") == ["2024-05-01"], f"existing param lost: {captured_urls[0]}"
+        assert qs.get("model") == [
+            "gpt-4o"
+        ], f"model missing from URL: {captured_urls[0]}"
+        assert qs.get("api-version") == [
+            "2024-05-01"
+        ], f"existing param lost: {captured_urls[0]}"


### PR DESCRIPTION
## Summary

- `supports_native_websocket()` now returns `False` for OpenAI and Azure (which inherits), routing Responses API WebSocket sessions through `ManagedResponsesWebSocketHandler` (HTTP streaming) instead of the native `wss://api.openai.com/v1/responses` endpoint
- Updates unit tests to reflect the new behavior
- `TestNativeWebSocketUrlConstruction` tests are unchanged — they mock the flag to `True` and continue to cover URL construction logic for providers that may enable native WebSocket in the future

## Why

The native WebSocket path accepted connections but never sent events back in response to `response.create` messages, causing `test_responses_websocket_proxy_basic` and `test_responses_websocket_proxy_multi_turn` to time out consistently.

`ManagedResponsesWebSocketHandler` makes a standard HTTP streaming request to `/v1/responses`, forwards the events over the WebSocket, and handles multi-turn via in-memory session history — this path is proven to work in CI.

## Test plan

- [ ] `e2e_openai_endpoints / test_responses_websocket_proxy_basic` passes
- [ ] `e2e_openai_endpoints / test_responses_websocket_proxy_multi_turn` passes
- [ ] `TestResponsesAPIWebSocketSupport` unit tests pass
- [ ] `TestNativeWebSocketUrlConstruction` unit tests pass