### PR TITLE
fix(together_ai): support reasoning_effort for gpt-oss models

### DIFF
--- a/litellm/llms/together_ai/chat.py
+++ b/litellm/llms/together_ai/chat.py
@@ -8,8 +8,8 @@ Docs: https://docs.together.ai/reference/completions-1
 
 from typing import Optional
 
-from litellm.utils import get_model_info
 from litellm._logging import verbose_logger
+from litellm.utils import get_model_info
 
 from ..openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -22,11 +22,13 @@ class TogetherAIConfig(OpenAIGPTConfig):
         Docs: https://docs.together.ai/docs/json-mode
         """
         supports_function_calling: Optional[bool] = None
+        supports_reasoning: Optional[bool] = None
         try:
             model_info = get_model_info(model, custom_llm_provider="together_ai")
             supports_function_calling = model_info.get(
                 "supports_function_calling", False
             )
+            supports_reasoning = model_info.get("supports_reasoning", False)
         except Exception as e:
             verbose_logger.debug(f"Error getting supported openai params: {e}")
             pass
@@ -40,6 +42,8 @@ class TogetherAIConfig(OpenAIGPTConfig):
             optional_params.remove("tool_choice")
             optional_params.remove("function_call")
             optional_params.remove("response_format")
+        if supports_reasoning is True and "reasoning_effort" not in optional_params:
+            optional_params.append("reasoning_effort")
         return optional_params
 
     def map_openai_params(

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -28668,6 +28668,7 @@
         "source": "https://www.together.ai/models/gpt-oss-20b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28653,6 +28653,7 @@
         "source": "https://www.together.ai/models/gpt-oss-20b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },

--- a/tests/test_litellm/llms/together_ai/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/test_together_ai_chat_transformation.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+# Add litellm to path
+sys.path.insert(0, os.path.abspath("../../../.."))
+import litellm
+from litellm.llms.together_ai.chat import TogetherAIConfig
+
+
+def _use_local_model_cost_map() -> None:
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+
+def test_together_ai_gpt_oss_supports_reasoning_effort():
+    """
+    gpt-oss models on together_ai support reasoning. Regression test for #25132.
+    """
+    _use_local_model_cost_map()
+
+    supported_params = TogetherAIConfig().get_supported_openai_params(
+        model="together_ai/openai/gpt-oss-120b"
+    )
+    assert "reasoning_effort" in supported_params
+
+    supported_params_20b = TogetherAIConfig().get_supported_openai_params(
+        model="together_ai/openai/gpt-oss-20b"
+    )
+    assert "reasoning_effort" in supported_params_20b
+
+
+def test_together_ai_non_reasoning_model_does_not_expose_reasoning_effort():
+    """
+    Non-reasoning together_ai models should not advertise reasoning_effort.
+    """
+    _use_local_model_cost_map()
+
+    supported_params = TogetherAIConfig().get_supported_openai_params(
+        model="together_ai/meta-llama/Llama-3-70b-chat-hf"
+    )
+    assert "reasoning_effort" not in supported_params
+
+
+def test_together_ai_gpt_oss_reasoning_effort_flows_through_get_optional_params():
+    """
+    End-to-end: the exact call from issue #25132 must not raise
+    UnsupportedParamsError, and reasoning_effort must land in optional_params.
+    """
+    _use_local_model_cost_map()
+
+    optional_params = litellm.get_optional_params(
+        model="openai/gpt-oss-120b",
+        custom_llm_provider="together_ai",
+        reasoning_effort="low",
+    )
+    assert optional_params.get("reasoning_effort") == "low"


### PR DESCRIPTION
## Relevant issues

Fixes #25132

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on `make test-unit` (for the files I touched)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`together_ai` hosts `openai/gpt-oss-120b` and `openai/gpt-oss-20b`. Both support reasoning, but `TogetherAIConfig.get_supported_openai_params` never advertised `reasoning_effort`, so calling `completion(reasoning_effort=...)` on those models raised `UnsupportedParamsError` — even though the upstream API accepts the parameter. #25160 and #25263 fixed this for other gpt-oss hosts but missed the `together_ai` entries.

This PR:

1. Reads `supports_reasoning` from the model info inside `TogetherAIConfig.get_supported_openai_params` and appends `reasoning_effort` to the supported params list when the flag is set. This mirrors the existing `supports_function_calling` lookup in the same method.
2. Sets `"supports_reasoning": true` on `together_ai/openai/gpt-oss-120b` and `together_ai/openai/gpt-oss-20b` in `litellm/model_prices_and_context_window_backup.json` and `model_prices_and_context_window.json`.
3. Adds three unit tests in `tests/test_litellm/llms/together_ai/test_together_ai_chat_transformation.py`:
   - `reasoning_effort` appears in supported params for `gpt-oss-120b` and `gpt-oss-20b`
   - `reasoning_effort` is **not** advertised for non-reasoning together_ai models (Llama-3-70b)
   - end-to-end through `litellm.get_optional_params(..., reasoning_effort="low")` — exactly the call path that raised in the original report

### Before

```python
>>> litellm.completion(
...     model="together_ai/openai/gpt-oss-120b",
...     messages=[{"role": "user", "content": "hi"}],
...     reasoning_effort="low",
... )
litellm.exceptions.UnsupportedParamsError: together_ai does not support parameters:
['reasoning_effort'], for model=openai/gpt-oss-120b. ...
```

### After

```python
>>> params = litellm.get_optional_params(
...     model="openai/gpt-oss-120b",
...     custom_llm_provider="together_ai",
...     reasoning_effort="low",
... )
>>> params["reasoning_effort"]
'low'
```

## Local verification

```
$ poetry run pytest tests/test_litellm/llms/together_ai/test_together_ai_chat_transformation.py -v
========================= 3 passed in 0.27s =========================

$ poetry run black --check litellm/llms/together_ai/chat.py \
    tests/test_litellm/llms/together_ai/test_together_ai_chat_transformation.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.

$ poetry run ruff check litellm/llms/together_ai/chat.py \
    tests/test_litellm/llms/together_ai/test_together_ai_chat_transformation.py
All checks passed!
```

Also reproduced the exact `completion(..., reasoning_effort="low")` call from #25132 against the local build with `mock_response` — no `UnsupportedParamsError` and the response is returned normally.