### PR TITLE
Fix: Currently database_connection_timeout pulls value from the datab…

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -803,8 +803,11 @@ def run_server(  # noqa: PLR0915
                 LiteLLMDatabaseConnectionPool.database_connection_pool_limit.value,
             )
             db_connection_timeout = general_settings.get(
-                "database_connection_pool_timeout",
-                LiteLLMDatabaseConnectionPool.database_connection_pool_timeout.value,
+                "database_connection_timeout",
+                general_settings.get(
+                    "database_connection_pool_timeout",
+                    LiteLLMDatabaseConnectionPool.database_connection_pool_timeout.value,
+                ),
             )
             if database_url and database_url.startswith("os.environ/"):
                 original_dir = os.getcwd()

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import fastapi
 import pytest
@@ -419,6 +419,81 @@ class TestProxyInitializationHelpers:
             # Check that uvicorn.run was called with limit_max_requests parameter
             call_args = mock_uvicorn_run.call_args
             assert call_args[1]["limit_max_requests"] == 123
+
+    @patch("subprocess.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch("litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False)
+    def test_database_connection_timeout_key_is_used_for_pool_timeout(
+        self,
+        mock_should_update,
+        mock_setup_db,
+        mock_atexit_register,
+        mock_subprocess_run,
+    ):
+        from click.testing import CliRunner
+
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+        mock_subprocess_run.return_value = MagicMock(returncode=0)
+
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        mock_proxy_module.ProxyConfig.return_value.get_config = AsyncMock(
+            return_value={
+                "general_settings": {
+                    "database_url": "postgresql://test:test@localhost:5432/test",
+                    "database_connection_pool_limit": 5,
+                    "database_connection_timeout": 30,
+                }
+            }
+        )
+
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+
+        with patch.dict(
+            os.environ, clean_env, clear=True
+        ), patch.dict(
+            "sys.modules",
+            {
+                "proxy_server": mock_proxy_module,
+                "litellm.proxy.proxy_server": mock_proxy_module,
+            },
+        ), patch(
+            "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+        ) as mock_get_args, patch(
+            "litellm.proxy.proxy_cli.append_query_params",
+            side_effect=lambda url, params: (
+                f"{url}?connection_limit={params['connection_limit']}&pool_timeout={params['pool_timeout']}"
+            ),
+        ) as mock_append_query_params:
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            result = runner.invoke(
+                run_server,
+                ["--local", "--config", "test-config.yaml", "--skip_server_startup"],
+            )
+
+            assert (
+                result.exit_code == 0
+            ), f"exit_code={result.exit_code}, output={result.output}"
+            mock_append_query_params.assert_called()
+            appended_params = mock_append_query_params.call_args.args[1]
+            assert appended_params["connection_limit"] == 5
+            assert appended_params["pool_timeout"] == 30
 
     @patch.dict(os.environ, {}, clear=True)
     def test_construct_database_url_from_env_vars(self):


### PR DESCRIPTION
## Summary

`proxy_cli.py` was only reading the legacy `database_connection_pool_timeout` key from `general_settings`, even though the documented config uses `database_connection_timeout`. This change updates the CLI startup path to honor `database_connection_timeout` first, while still falling back to `database_connection_pool_timeout` for backward compatibility.

This mismatch is visible in the docs today:

- `docs/my-website/docs/proxy/config_settings.md` documents `database_connection_timeout` as the supported setting and also references the DB pool timeout behavior.
- `docs/my-website/docs/proxy/configs.md` shows `database_connection_timeout` in example proxy config.

Before this fix, the CLI startup path still pulled `database_connection_pool_timeout`, so documented configs using `database_connection_timeout` were silently ignored unless the legacy key was also set.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ X] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🐛 Bug Fix
✅ Test

## Changes

- Updated `litellm/proxy/proxy_cli.py` to read `general_settings["database_connection_timeout"]` first.
- Preserved backward compatibility by falling back to `general_settings["database_connection_pool_timeout"]` when the new key is not set.
- Added a regression test in `tests/test_litellm/proxy/test_proxy_cli.py` proving the CLI uses `database_connection_timeout` when constructing the Prisma `pool_timeout` query param.
- Documented in this PR that the fix aligns runtime behavior with the existing docs in `docs/my-website/docs/proxy/config_settings.md` and `docs/my-website/docs/proxy/configs.md`.
