### PR TITLE
fix(dashboard): repair policy attachment delete + use confirm modal

### DIFF
--- a/ui/litellm-dashboard/src/components/policies/attachment_table.test.tsx
+++ b/ui/litellm-dashboard/src/components/policies/attachment_table.test.tsx
@@ -111,14 +111,14 @@ describe("AttachmentTable", () => {
     const attachment = makeAttachment({ attachment_id: "att-del-me1" });
     const user = userEvent.setup();
     renderWithProviders(<AttachmentTable {...defaultProps} attachments={[attachment]} />);
-    await user.click(screen.getByRole("button", { name: /TrashIcon/i }));
+    await user.click(screen.getByRole("button", { name: /delete attachment/i }));
     expect(defaultProps.onDeleteClick).toHaveBeenCalledWith("att-del-me1");
   });
 
   it("should not show the delete icon for non-admins", () => {
     const attachment = makeAttachment();
     renderWithProviders(<AttachmentTable {...defaultProps} attachments={[attachment]} isAdmin={false} />);
-    expect(screen.queryByRole("button", { name: /TrashIcon/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete attachment/i })).not.toBeInTheDocument();
   });
 
   it("should show a truncated attachment ID in the table", () => {

--- a/ui/litellm-dashboard/src/components/policies/attachment_table.tsx
+++ b/ui/litellm-dashboard/src/components/policies/attachment_table.tsx
@@ -202,12 +202,17 @@ const AttachmentTable: React.FC<AttachmentTableProps> = ({
             <ImpactPopover attachment={attachment} accessToken={accessToken} />
             {isAdmin && (
               <Tooltip title="Delete attachment">
-                <Icon
-                  icon={TrashIcon}
-                  size="sm"
-                  onClick={() => onDeleteClick(attachment.attachment_id)}
-                  className="cursor-pointer hover:text-red-500"
-                />
+                <button
+                  type="button"
+                  aria-label="Delete attachment"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDeleteClick(attachment.attachment_id);
+                  }}
+                  className="inline-flex items-center justify-center p-0 border-0 bg-transparent text-inherit cursor-pointer hover:text-red-500"
+                >
+                  <Icon icon={TrashIcon} size="sm" />
+                </button>
               </Tooltip>
             )}
           </div>

--- a/ui/litellm-dashboard/src/components/policies/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/policies/index.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../../tests/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as networking from "../networking";
+import PoliciesPanel from "./index";
+import type { PolicyAttachment } from "./types";
+
+vi.mock("./impact_popover", () => ({
+  default: () => <button type="button" aria-label="View blast radius" />,
+}));
+
+vi.mock("@heroicons/react/outline", () => ({
+  TrashIcon: function TrashIcon() {
+    return null;
+  },
+  SwitchVerticalIcon: function SwitchVerticalIcon() {
+    return null;
+  },
+  ChevronUpIcon: function ChevronUpIcon() {
+    return null;
+  },
+  ChevronDownIcon: function ChevronDownIcon() {
+    return null;
+  },
+  EyeIcon: function EyeIcon() {
+    return null;
+  },
+}));
+
+vi.mock("@tremor/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tremor/react")>();
+  return {
+    ...actual,
+    Button: React.forwardRef<HTMLButtonElement, React.ComponentProps<"button">>(
+      ({ children, ...props }, ref) =>
+        React.createElement("button", { ...props, ref, type: props.type ?? "button" }, children)
+    ),
+    Tooltip: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    Switch: ({
+      checked,
+      onChange,
+      className,
+    }: {
+      checked?: boolean;
+      onChange?: (v: boolean) => void;
+      className?: string;
+    }) =>
+      React.createElement("input", {
+        type: "checkbox",
+        role: "switch",
+        checked,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange?.(e.target.checked),
+        className,
+      }),
+    Icon: ({ icon: IconComp, onClick, className }: { icon?: unknown; onClick?: () => void; className?: string }) =>
+      React.createElement(
+        "span",
+        { onClick, className, role: onClick ? "button" : undefined },
+        (IconComp as { displayName?: string; name?: string } | undefined)?.displayName ??
+          (IconComp as { name?: string } | undefined)?.name ??
+          "icon"
+      ),
+  };
+});
+
+vi.mock("./policy_templates", () => ({
+  default: () => null,
+}));
+vi.mock("./policy_table", () => ({
+  default: () => null,
+}));
+vi.mock("./policy_info", () => ({
+  default: () => null,
+}));
+vi.mock("./add_policy_form", () => ({
+  default: () => null,
+}));
+vi.mock("./pipeline_flow_builder", () => ({
+  FlowBuilderPage: () => null,
+}));
+vi.mock("./add_attachment_form", () => ({
+  default: () => null,
+}));
+vi.mock("./policy_test_panel", () => ({
+  default: () => null,
+}));
+vi.mock("./guardrail_selection_modal", () => ({
+  default: () => null,
+}));
+vi.mock("./template_parameter_modal", () => ({
+  default: () => null,
+}));
+vi.mock("./ai_suggestion_modal", () => ({
+  default: () => null,
+}));
+
+vi.mock("../networking", () => ({
+  getPoliciesList: vi.fn(() => Promise.resolve({ policies: [] })),
+  deletePolicyCall: vi.fn(),
+  getPolicyAttachmentsList: vi.fn(() => Promise.resolve({ attachments: [] as PolicyAttachment[] })),
+  deletePolicyAttachmentCall: vi.fn(() => Promise.resolve({})),
+  getGuardrailsList: vi.fn(() => Promise.resolve({ guardrails: [] })),
+  getPolicyInfo: vi.fn(),
+  createPolicyCall: vi.fn(),
+  updatePolicyCall: vi.fn(),
+  createPolicyAttachmentCall: vi.fn(),
+  createGuardrailCall: vi.fn(),
+  enrichPolicyTemplate: vi.fn(),
+}));
+
+describe("PoliciesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.getPoliciesList).mockResolvedValue({ policies: [] });
+    vi.mocked(networking.getPolicyAttachmentsList).mockResolvedValue({ attachments: [] });
+    vi.mocked(networking.getGuardrailsList).mockResolvedValue({ guardrails: [] });
+    vi.mocked(networking.deletePolicyAttachmentCall).mockResolvedValue({});
+  });
+
+  it("should open delete confirmation and call deletePolicyAttachmentCall when delete is confirmed", async () => {
+    const user = userEvent.setup();
+    const attachment: PolicyAttachment = {
+      attachment_id: "att-delete-int-1",
+      policy_name: "policy-under-test",
+      scope: null,
+      teams: [],
+      keys: [],
+      models: [],
+      tags: [],
+    };
+    vi.mocked(networking.getPolicyAttachmentsList).mockResolvedValue({ attachments: [attachment] });
+
+    renderWithProviders(<PoliciesPanel accessToken="test-token" userRole="Admin" />);
+
+    await user.click(screen.getByRole("tab", { name: /^Attachments$/i }));
+
+    await screen.findByText("policy-under-test");
+
+    await user.click(screen.getByRole("button", { name: /delete attachment/i }));
+
+    const modal = await screen.findByRole("dialog");
+    expect(within(modal).getByText("Delete Attachment")).toBeInTheDocument();
+    expect(within(modal).getByText("att-delete-int-1")).toBeInTheDocument();
+
+    await user.click(within(modal).getByRole("button", { name: /^Delete$/i }));
+
+    await waitFor(() => {
+      expect(networking.deletePolicyAttachmentCall).toHaveBeenCalledWith("test-token", "att-delete-int-1");
+    });
+    expect(networking.deletePolicyAttachmentCall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/litellm-dashboard/src/components/policies/index.tsx
+++ b/ui/litellm-dashboard/src/components/policies/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { Button, TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
-import { Modal, Alert } from "antd";
+import { Alert } from "antd";
 import MessageManager from "@/components/molecules/message_manager";
-import { ExclamationCircleOutlined, InfoCircleOutlined } from "@ant-design/icons";
+import { InfoCircleOutlined } from "@ant-design/icons";
 import { isAdminRole } from "@/utils/roles";
 import PolicyTable from "./policy_table";
 import PolicyInfoView from "./policy_info";
@@ -57,6 +57,9 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
   const [isDeleting, setIsDeleting] = useState(false);
   const [policyToDelete, setPolicyToDelete] = useState<Policy | null>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [attachmentToDelete, setAttachmentToDelete] = useState<PolicyAttachment | null>(null);
+  const [isAttachmentDeleteModalOpen, setIsAttachmentDeleteModalOpen] = useState(false);
+  const [isDeletingAttachment, setIsDeletingAttachment] = useState(false);
   const [isGuardrailSelectionModalOpen, setIsGuardrailSelectionModalOpen] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState<any>(null);
   const [existingGuardrailNames, setExistingGuardrailNames] = useState<Set<string>>(new Set());
@@ -166,26 +169,34 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
     setPolicyToDelete(null);
   };
 
-  const handleDeleteAttachment = (attachmentId: string) => {
-    Modal.confirm({
-      title: "Delete Attachment",
-      icon: <ExclamationCircleOutlined />,
-      content: "Are you sure you want to delete this attachment? This action cannot be undone.",
-      okText: "Delete",
-      okType: "danger",
-      cancelText: "Cancel",
-      onOk: async () => {
-        if (!accessToken) return;
-        try {
-          await deletePolicyAttachmentCall(accessToken, attachmentId);
-          MessageManager.success("Attachment deleted successfully");
-          fetchAttachments();
-        } catch (error) {
-          console.error("Error deleting attachment:", error);
-          MessageManager.error("Failed to delete attachment");
-        }
-      },
-    });
+  const handleDeleteAttachmentClick = (attachmentId: string) => {
+    const attachment = attachmentsList.find((a) => a.attachment_id === attachmentId) ?? null;
+    if (!attachment) return;
+    setAttachmentToDelete(attachment);
+    setIsAttachmentDeleteModalOpen(true);
+  };
+
+  const handleAttachmentDeleteConfirm = async () => {
+    if (!attachmentToDelete || !accessToken) return;
+
+    setIsDeletingAttachment(true);
+    try {
+      await deletePolicyAttachmentCall(accessToken, attachmentToDelete.attachment_id);
+      MessageManager.success("Attachment deleted successfully");
+      await fetchAttachments();
+    } catch (error) {
+      console.error("Error deleting attachment:", error);
+      MessageManager.error("Failed to delete attachment");
+    } finally {
+      setIsDeletingAttachment(false);
+      setIsAttachmentDeleteModalOpen(false);
+      setAttachmentToDelete(null);
+    }
+  };
+
+  const handleAttachmentDeleteCancel = () => {
+    setIsAttachmentDeleteModalOpen(false);
+    setAttachmentToDelete(null);
   };
 
   const handleAttachmentSuccess = () => {
@@ -579,9 +590,24 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({
             <AttachmentTable
               attachments={attachmentsList}
               isLoading={isAttachmentsLoading}
-              onDeleteClick={handleDeleteAttachment}
+              onDeleteClick={handleDeleteAttachmentClick}
               isAdmin={isAdmin}
               accessToken={accessToken}
+            />
+
+            <DeleteResourceModal
+              isOpen={isAttachmentDeleteModalOpen}
+              title="Delete Attachment"
+              message="Are you sure you want to delete this policy attachment? This action cannot be undone."
+              resourceInformationTitle="Attachment Information"
+              resourceInformation={[
+                { label: "Policy", value: attachmentToDelete?.policy_name },
+                { label: "Attachment ID", value: attachmentToDelete?.attachment_id, code: true },
+                { label: "Scope", value: attachmentToDelete?.scope || "-" },
+              ]}
+              onCancel={handleAttachmentDeleteCancel}
+              onOk={handleAttachmentDeleteConfirm}
+              confirmLoading={isDeletingAttachment}
             />
 
             <AddAttachmentForm


### PR DESCRIPTION
Description
Policy attachments in the admin UI showed a delete (trash) control, but clicking it often did nothing. This change makes the control a proper button so clicks register, and uses the same DeleteResourceModal pattern as policy deletion so users must confirm before the attachment is removed.

Cause
The delete action was implemented as a Tremor Icon with onClick, wrapped in an Ant Design Tooltip. That combination frequently breaks: the tooltip expects a child that can hold a ref and receive DOM events, and the icon wrapper does not behave like a native interactive element, so the handler often never ran. Separately, Modal.confirm is easy to miss or misconfigure with app-wide Ant Design setup; the rest of the policies screen already uses an explicit DeleteResourceModal for deletes.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Wrap the trash icon in a <button type="button"> with aria-label="Delete attachment", stopPropagation() on click, and keep the tooltip on the button.
Open DeleteResourceModal with the selected attachment’s details; on confirm, call deletePolicyAttachmentCall and refresh the list.
Update attachment_table tests to target the button by its accessible name.
