### PR TITLE
add NO_OPENAPI env var to disable /openapi.json endpoint

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -912,6 +912,7 @@ router_settings:
 | MODEL_COST_MAP_MAX_SHRINK_RATIO | Maximum allowed shrinkage ratio when validating a fetched model cost map against the local backup. Rejects the fetched map if it is smaller than this fraction of the backup. Default is 0.5
 | MODEL_COST_MAP_MIN_MODEL_COUNT | Minimum number of models a fetched cost map must contain to be considered valid. Default is 50
 | NO_DOCS | Flag to disable Swagger UI documentation
+| NO_OPENAPI | Flag to disable the /openapi.json endpoint
 | NO_REDOC | Flag to disable Redoc documentation
 | NO_PROXY | List of addresses to bypass proxy
 | NON_LLM_CONNECTION_TIMEOUT | Timeout in seconds for non-LLM service connections. Default is 15

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -493,6 +493,7 @@ from litellm.proxy.utils import (
     ProxyUpdateSpend,
     _cache_user_row,
     _get_docs_url,
+    _get_openapi_url,
     _get_projected_spend_over_limit,
     _get_redoc_url,
     _is_projected_spend_over_limit,
@@ -1000,6 +1001,7 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 app = FastAPI(
     docs_url=_get_docs_url(),
     redoc_url=_get_redoc_url(),
+    openapi_url=_get_openapi_url(),
     title=_title,
     description=_description,
     version=version,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5243,6 +5243,19 @@ def get_error_message_str(e: Exception) -> str:
     return error_message
 
 
+def _get_openapi_url() -> Optional[str]:
+    """
+    Get the OpenAPI schema URL from the environment variables.
+
+    - If NO_OPENAPI is True, return None.
+    - Otherwise, default to "/openapi.json".
+    """
+    if str_to_bool(os.getenv("NO_OPENAPI")) is True:
+        return None
+
+    return "/openapi.json"
+
+
 def _get_redoc_url() -> Optional[str]:
     """
     Get the Redoc URL from the environment variables.

--- a/tests/test_litellm/proxy/test_utils.py
+++ b/tests/test_litellm/proxy/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from litellm.proxy.utils import _get_openapi_url
+
+
+@pytest.mark.parametrize(
+    "env_vars, expected_url",
+    [
+        ({}, "/openapi.json"),  # default case
+        ({"NO_OPENAPI": "True"}, None),  # OpenAPI disabled
+    ],
+)
+def test_get_openapi_url(monkeypatch, env_vars, expected_url):
+    # Clear relevant environment variables
+    monkeypatch.delenv("NO_OPENAPI", raising=False)
+
+    # Set test environment variables
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    result = _get_openapi_url()
+    assert result == expected_url


### PR DESCRIPTION
## Relevant issues

Fixes 25538

## Pre-Submission checklist

Note: I was a bit confused about where to put the tests. The checklist says tests belong in `tests/test_litellm`, but all test coverage for similar features is in `tests/proxy_unit_tests/test_proxy_utils.py`.

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🆕 New Feature

## Changes

Adds a NO_OPENAPI environment variable (or similar) that sets openapi_url=None on the FastAPI app constructor, disabling the /openapi.json endpoint.