### PR TITLE
fix(proxy): model_max_budget silently broken for routed models

### DIFF
--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -255,7 +255,16 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             return
 
         response_cost: float = standard_logging_payload.get("response_cost", 0)
-        model = standard_logging_payload.get("model")
+        # Use model_group (the user-facing model alias, e.g. "gpt-4o") when
+        # available.  The enforcement path (is_key_within_model_budget) receives
+        # the model name from request_data["model"] which is the model group
+        # alias, so the spend tracking cache key must use the same name.
+        # Falling back to the deployment-level "model" field preserves
+        # behaviour for non-proxy or non-router deployments where model_group
+        # is None.
+        model = standard_logging_payload.get(
+            "model_group"
+        ) or standard_logging_payload.get("model")
         virtual_key = standard_logging_payload.get("metadata", {}).get(
             "user_api_key_hash"
         )

--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -220,6 +220,155 @@ async def test_get_end_user_spend_for_model(budget_limiter):
 
 
 @pytest.mark.asyncio
+async def test_async_log_success_event_uses_model_group_for_cache_key(budget_limiter):
+    """
+    When model_group is present in StandardLoggingPayload (proxy/router
+    deployments), spend must be tracked under the model_group name — not the
+    deployment-level model name — so the cache key matches the one used by
+    is_key_within_model_budget (which receives request_data["model"], the
+    model group alias).
+
+    Without this, providers that decorate model names (e.g. Vertex AI
+    "vertex_ai/claude-opus-4-6@default") track spend under a different cache
+    key than enforcement reads, silently disabling budget limits.
+    """
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX,
+    )
+
+    virtual_key = "test-key-hash"
+    model_group = "claude-opus-4-6"
+    deployment_model = "vertex_ai/claude-opus-4-6@default"
+    budget_duration = "1d"
+    user_api_key_model_max_budget = {
+        model_group: {"budget_limit": 50.0, "time_period": budget_duration},
+    }
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 0.10,
+            "model": deployment_model,
+            "model_group": model_group,
+            "metadata": {"user_api_key_hash": virtual_key},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_model_max_budget": user_api_key_model_max_budget,
+            },
+        },
+    }
+    with patch.object(
+        budget_limiter,
+        "_increment_spend_for_key",
+        new_callable=AsyncMock,
+    ) as mock_increment:
+        await budget_limiter.async_log_success_event(
+            kwargs, response_obj=None, start_time=None, end_time=None
+        )
+        mock_increment.assert_awaited_once()
+        call_kwargs = mock_increment.call_args.kwargs
+        spend_key = call_kwargs["spend_key"]
+        # The cache key must use the model_group name, NOT the deployment name
+        assert spend_key == (
+            f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:{virtual_key}:{model_group}:{budget_duration}"
+        )
+        assert call_kwargs["response_cost"] == 0.10
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_falls_back_to_model_when_no_model_group(
+    budget_limiter,
+):
+    """
+    When model_group is None (non-proxy / non-router usage), spend tracking
+    must fall back to using the model field so existing behaviour is preserved.
+    """
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX,
+    )
+
+    virtual_key = "test-key-hash"
+    model = "gpt-4"
+    budget_duration = "1d"
+    user_api_key_model_max_budget = {
+        model: {"budget_limit": 100.0, "time_period": budget_duration},
+    }
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 0.05,
+            "model": model,
+            "model_group": None,
+            "metadata": {"user_api_key_hash": virtual_key},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_model_max_budget": user_api_key_model_max_budget,
+            },
+        },
+    }
+    with patch.object(
+        budget_limiter,
+        "_increment_spend_for_key",
+        new_callable=AsyncMock,
+    ) as mock_increment:
+        await budget_limiter.async_log_success_event(
+            kwargs, response_obj=None, start_time=None, end_time=None
+        )
+        mock_increment.assert_awaited_once()
+        call_kwargs = mock_increment.call_args.kwargs
+        spend_key = call_kwargs["spend_key"]
+        assert spend_key == (
+            f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:{virtual_key}:{model}:{budget_duration}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_end_user_uses_model_group(budget_limiter):
+    """
+    End-user model budget tracking must also use model_group when available,
+    matching the enforcement path in is_end_user_within_model_budget.
+    """
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        END_USER_SPEND_CACHE_KEY_PREFIX,
+    )
+
+    end_user_id = "test-user"
+    model_group = "claude-sonnet-4-6"
+    deployment_model = "vertex_ai/claude-sonnet-4-6@default"
+    budget_duration = "1d"
+    user_api_key_end_user_model_max_budget = {
+        model_group: {"budget_limit": 25.0, "time_period": budget_duration},
+    }
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": 0.03,
+            "model": deployment_model,
+            "model_group": model_group,
+            "end_user": end_user_id,
+            "metadata": {"user_api_key_end_user_id": end_user_id},
+        },
+        "litellm_params": {
+            "metadata": {
+                "user_api_key_end_user_model_max_budget": user_api_key_end_user_model_max_budget,
+            },
+        },
+    }
+    with patch.object(
+        budget_limiter,
+        "_increment_spend_for_key",
+        new_callable=AsyncMock,
+    ) as mock_increment:
+        await budget_limiter.async_log_success_event(
+            kwargs, response_obj=None, start_time=None, end_time=None
+        )
+        mock_increment.assert_awaited_once()
+        call_kwargs = mock_increment.call_args.kwargs
+        spend_key = call_kwargs["spend_key"]
+        assert spend_key == (
+            f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model_group}:{budget_duration}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_async_log_success_event_uses_end_user_model_budget_duration(
     budget_limiter,
 ):


### PR DESCRIPTION
## Summary

- `model_max_budget` spend tracking and enforcement use different model name formats, causing budgets to never be enforced for providers that decorate model names (Vertex AI, Bedrock, etc.)
- Fix: use `model_group` (the user-facing alias) from `StandardLoggingPayload` for spend tracking cache keys, aligning them with the enforcement path

## Root cause

The `_PROXY_VirtualKeyModelMaxBudgetLimiter` has two code paths that must use the **same cache key** for budget enforcement to work:

1. **Spend tracking** (`async_log_success_event`): called after a successful LLM call, increments spend in `DualCache` using a cache key derived from the model name
2. **Budget enforcement** (`is_key_within_model_budget` via `user_api_key_auth`): called before each request, reads current spend from `DualCache` using a cache key derived from the model name

The problem: these paths derive the model name from different sources:

| Path | Source | Example value |
|------|--------|---------------|
| Tracking | `standard_logging_payload["model"]` | `vertex_ai/claude-opus-4-6@default` |
| Enforcement | `request_data["model"]` | `claude-opus-4-6` |

The existing fallback (`_get_model_without_custom_llm_provider`) strips the provider prefix (`vertex_ai/`) but **not** version suffixes (`@default`), so the stripped value `claude-opus-4-6@default` still doesn't match `claude-opus-4-6`.

**Result**: spend is tracked under cache key `virtual_key_spend:{hash}:vertex_ai/claude-opus-4-6@default:86400` but enforcement reads from `virtual_key_spend:{hash}:claude-opus-4-6:86400` — always returning `None`, silently allowing all requests through regardless of budget.

## Reproduction steps

1. Configure a proxy with a Vertex AI model deployment:
   ```yaml
   model_list:
     - model_name: claude-opus-4-6
       litellm_params:
         model: vertex_ai/claude-opus-4-6@default
         vertex_project: my-project
         vertex_location: us-east4
   ```

2. Create a virtual key with `model_max_budget`:
   ```bash
   curl -X POST http://localhost:4000/key/generate \
     -H "Authorization: Bearer sk-master" \
     -d '{
       "model_max_budget": {
         "claude-opus-4-6": {"budget_limit": "1.00", "time_period": "1d"}
       }
     }'
   ```

3. Send requests exceeding the $1.00 budget — **all succeed** because spend tracking and enforcement use mismatched cache keys

4. Confirm via `/key/info` that `model_spend` remains `{}` (empty) despite recorded spend in `/spend/logs`

## Fix

In `async_log_success_event`, use `standard_logging_payload["model_group"]` (the user-facing model alias, e.g. `claude-opus-4-6`) instead of `standard_logging_payload["model"]` (the deployment name). Falls back to `model` when `model_group` is `None` (non-proxy/non-router usage).

This aligns the tracking cache key with the enforcement cache key so budgets are actually enforced.

## Affected providers

Any provider where the deployment model name differs from the model group alias:
- **Vertex AI**: `vertex_ai/claude-opus-4-6@default` vs `claude-opus-4-6`
- **Bedrock**: `bedrock/anthropic.claude-v2` vs `claude-v2`
- **Azure**: `azure/gpt-4` vs `gpt-4`
- Any custom model name with provider prefix or version suffix

## Related issues

- #15223 — "Virtual Key Budget tracking does not work properly for routing" (same root cause, closed as stale)
- #10052 — "Issues with Key-Level Model Limits Enforcement" (same root cause, closed without fix)

## Test plan

- [x] New test: `test_async_log_success_event_uses_model_group_for_cache_key` — verifies spend is tracked under model_group name when present
- [x] New test: `test_async_log_success_event_falls_back_to_model_when_no_model_group` — verifies fallback to model field when model_group is None
- [x] New test: `test_async_log_success_event_end_user_uses_model_group` — verifies end-user budget tracking also uses model_group
- [x] All 11 existing + new tests pass: `make test-unit` on `test_unit_test_max_model_budget_limiter.py`

Generated with [Claude Code](https://claude.com/claude-code)
