### PR TITLE
fix(proxy): cache invalidation double-hashes token in bulk update and key rotation

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1849,7 +1849,7 @@ async def _process_single_key_update(
 
     # Delete cache
     await _delete_cache_key_object(
-        hashed_token=hash_token(key_update_item.key),
+        hashed_token=_hash_token_if_needed(key_update_item.key),
         user_api_key_cache=user_api_key_cache,
         proxy_logging_obj=proxy_logging_obj,
     )
@@ -3721,7 +3721,7 @@ async def _execute_virtual_key_regeneration(
 
     if hashed_api_key or key:
         await _delete_cache_key_object(
-            hashed_token=hash_token(key),
+            hashed_token=_hash_token_if_needed(key),
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -8746,3 +8746,167 @@ def test_validate_public_image_url_accepts_http_and_noop_empty():
     _validate_public_image_url(None, "logo_url")
     _validate_public_image_url("", "logo_url")
     _validate_public_image_url("   ", "logo_url")
+
+
+@pytest.mark.asyncio
+async def test_process_single_key_update_cache_invalidation_with_token_hash():
+    """
+    _process_single_key_update must pass the token hash as-is (not
+    double-hashed) to _delete_cache_key_object when the key is already a
+    pre-hashed token ID rather than an sk- prefixed key.
+
+    Without this, cache invalidation silently fails: the wrong cache entry
+    is deleted while the stale entry (with outdated fields) persists and
+    gets refreshed indefinitely by update_cache on every successful request.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _process_single_key_update,
+    )
+    from litellm.types.proxy.management_endpoints.key_management_endpoints import (
+        BulkUpdateKeyRequestItem,
+    )
+
+    token_hash = "abc123def456"
+
+    existing_key = LiteLLM_VerificationToken(
+        token=token_hash,
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=existing_key
+    )
+    mock_updated = MagicMock()
+    mock_updated.model_dump.return_value = {"max_budget": 100.0}
+    mock_prisma_client.update_data = AsyncMock(return_value={"data": mock_updated})
+
+    mock_user_api_key_cache = MagicMock()
+    mock_proxy_logging_obj = MagicMock()
+    mock_llm_router = MagicMock()
+
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.prepare_key_update_data",
+        return_value={"max_budget": 100.0},
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint",
+        return_value=None,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+        new_callable=AsyncMock,
+    ) as mock_delete_cache, patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_updated_hook",
+        new_callable=AsyncMock,
+    ):
+        key_update_item = BulkUpdateKeyRequestItem(
+            key=token_hash,
+            max_budget=100.0,
+        )
+
+        user_api_key_dict = UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-admin",
+            user_id="admin-user",
+        )
+
+        await _process_single_key_update(
+            key_update_item=key_update_item,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=mock_user_api_key_cache,
+            proxy_logging_obj=mock_proxy_logging_obj,
+            llm_router=mock_llm_router,
+        )
+
+        mock_delete_cache.assert_called_once()
+        call_kwargs = mock_delete_cache.call_args.kwargs
+        # The token hash should be passed as-is, NOT double-hashed
+        assert call_kwargs["hashed_token"] == token_hash
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_cache_invalidation_with_token_hash():
+    """
+    _execute_virtual_key_regeneration must pass the token hash as-is (not
+    double-hashed) to _delete_cache_key_object when the key is a
+    pre-hashed token ID.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    token_hash = "abc123def456"
+
+    existing_key = LiteLLM_VerificationToken(
+        token=token_hash,
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+    )
+
+    mock_prisma_client = AsyncMock()
+    # _execute_virtual_key_regeneration calls dict(updated_token) which
+    # needs the return value to be iterable as key-value pairs.
+    class DictLikeResult:
+        def __init__(self, data):
+            self._data = data
+        def __iter__(self):
+            return iter(self._data.items())
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(
+        return_value=DictLikeResult({"token": "new-hashed-token", "key_name": "sk-...ab12", "user_id": "user-1"})
+    )
+    mock_prisma_client.db.litellm_verificationtoken.create = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.jsonify_object = MagicMock(side_effect=lambda data: data)
+
+    mock_user_api_key_cache = MagicMock()
+    mock_proxy_logging_obj = MagicMock()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-admin",
+        user_id="admin-user",
+    )
+
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+        new_callable=AsyncMock,
+        return_value="sk-newtoken1234ab12",
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+        new_callable=AsyncMock,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+        new_callable=AsyncMock,
+    ) as mock_delete_cache, patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+        new_callable=AsyncMock,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.prepare_key_update_data",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma_client,
+            key_in_db=existing_key,
+            hashed_api_key=token_hash,
+            key=token_hash,
+            data=None,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+            user_api_key_cache=mock_user_api_key_cache,
+            proxy_logging_obj=mock_proxy_logging_obj,
+        )
+
+        mock_delete_cache.assert_called_once()
+        call_kwargs = mock_delete_cache.call_args.kwargs
+        # The token hash should be passed as-is, NOT double-hashed
+        assert call_kwargs["hashed_token"] == token_hash


### PR DESCRIPTION
## Summary

- Two remaining `hash_token()` calls in cache invalidation paths double-hash pre-hashed token IDs, causing cache invalidation to silently fail
- Fix: use `_hash_token_if_needed()` (which passes pre-hashed tokens through unchanged), matching the pattern established by PR #24969

## Root cause

When `/key/update` or `/key/bulk_update` is called with a pre-hashed token ID (not an `sk-` prefixed key), `hash_token()` produces a hash-of-hash that does not match the actual cache key. The `_delete_cache_key_object` call deletes nothing, and the stale cached key object (with outdated fields) remains.

This is compounded by `update_cache()` in `proxy_server.py`, which writes the stale cached key object back to `user_api_key_cache` with a fresh 60s TTL after every successful LLM request. As long as requests keep flowing, the stale entry never expires — the updated fields (e.g. `max_budget`, `models`, `metadata`) are never picked up.

PR #24969 fixed this in `update_key_fn` but missed two other call sites:

| Location | Line | Before | After |
|---|---|---|---|
| `_process_single_key_update` | 1852 | `hash_token(key_update_item.key)` | `_hash_token_if_needed(key_update_item.key)` |
| `_execute_virtual_key_regeneration` | 3724 | `hash_token(key)` | `_hash_token_if_needed(key)` |

## Reproduction steps

1. Create a virtual key and note the token hash from the response
2. Update the key using the token hash (not the `sk-` key):
   ```bash
   curl -X POST http://localhost:4000/key/update \
     -H "Authorization: Bearer sk-master" \
     -d '{"key": "<token_hash>", "max_budget": 100}'
   ```
3. Verify via `/key/info` that the DB was updated (shows `max_budget: 100`)
4. Send requests using the key — **the budget is not enforced** because the cached key object still has `max_budget: null`
5. The stale cache entry persists indefinitely as long as requests keep flowing (each successful request refreshes the TTL via `update_cache`)

## Related

- #24969 — fixed the same bug in `update_key_fn` (merged April 3, 2026)
- #25286 — similar stale-cache issue for team objects

## Test plan

- [x] New test: `test_process_single_key_update_cache_invalidation_with_token_hash` — verifies the token hash is passed as-is (not double-hashed) to `_delete_cache_key_object`
- [x] Existing `test_process_single_key_update` continues to pass

Generated with [Claude Code](https://claude.com/claude-code)
