### PR TITLE
fix: replace mutable default arguments (= [] and = {}) with None

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5954,7 +5954,9 @@ def select_data_generator(
     )
 
 
-def get_litellm_model_info(model: dict = {}):
+def get_litellm_model_info(model: Optional[dict] = None):
+    if model is None:
+        model = {}
     model_info = model.get("model_info", {})
     model_to_lookup = model.get("litellm_params", {}).get("model", None)
     try:

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -15,7 +15,7 @@ class LowestCostLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
         self.router_cache = router_cache
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -31,8 +31,10 @@ class LowestLatencyLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
         self.router_cache = router_cache
+        if routing_args is None:
+            routing_args = {}
         self.routing_args = RoutingArgs(**routing_args)
 
     def log_success_event(  # noqa: PLR0915

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -22,8 +22,10 @@ class LowestTPMLoggingHandler(CustomLogger):
     logged_failure: int = 0
     default_cache_time_seconds: int = 1 * 60 * 60  # 1 hour
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
         self.router_cache = router_cache
+        if routing_args is None:
+            routing_args = {}
         self.routing_args = RoutingArgs(**routing_args)
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -47,8 +47,10 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
     logged_failure: int = 0
     default_cache_time_seconds: int = 1 * 60 * 60  # 1 hour
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
         self.router_cache = router_cache
+        if routing_args is None:
+            routing_args = {}
         self.routing_args = RoutingArgs(**routing_args)
         BaseRoutingStrategy.__init__(
             self,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2236,7 +2236,9 @@ def encode(model="", text="", custom_tokenizer: Optional[dict] = None):
     return enc
 
 
-def decode(model="", tokens: List[int] = [], custom_tokenizer: Optional[dict] = None):
+def decode(model="", tokens: Optional[List[int]] = None, custom_tokenizer: Optional[dict] = None):
+    if tokens is None:
+        tokens = []
     tokenizer_json = custom_tokenizer or _select_tokenizer(model=model)
     dec = tokenizer_json["tokenizer"].decode(tokens)
     return dec

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -106,8 +106,8 @@ class VectorStoreIndexRegistry:
 
 
 class VectorStoreRegistry:
-    def __init__(self, vector_stores: List[LiteLLM_ManagedVectorStore] = []):
-        self.vector_stores: List[LiteLLM_ManagedVectorStore] = vector_stores
+    def __init__(self, vector_stores: Optional[List[LiteLLM_ManagedVectorStore]] = None):
+        self.vector_stores: List[LiteLLM_ManagedVectorStore] = vector_stores or []
         self.vector_store_ids_to_vector_store_map: Dict[
             str, LiteLLM_ManagedVectorStore
         ] = {}

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -22,11 +22,11 @@ else:
 
 class VectorStoreIndexRegistry:
     def __init__(
-        self, vector_store_indexes: List[LiteLLM_ManagedVectorStoreIndex] = []
+        self, vector_store_indexes: Optional[List[LiteLLM_ManagedVectorStoreIndex]] = None
     ):
         self.vector_store_indexes: List[
             LiteLLM_ManagedVectorStoreIndex
-        ] = vector_store_indexes
+        ] = vector_store_indexes or []
 
     def get_vector_store_indexes(self) -> List[LiteLLM_ManagedVectorStoreIndex]:
         """


### PR DESCRIPTION
## Summary
Replace mutable default arguments with `None` defaults, following [Python best practices](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments).

Mutable defaults (`= []`, `= {}`) are shared across all calls to a function — if the object is ever mutated, the mutation persists in subsequent calls.

## Changes

| File | Function | Before | After |
|------|----------|--------|-------|
| `litellm/utils.py` | `decode()` | `tokens: List[int] = []` | `Optional[List[int]] = None` |
| `vector_store_registry.py` | `__init__()` | `vector_stores = []` | `Optional[...] = None` |
| `proxy_server.py` | `get_litellm_model_info()` | `model: dict = {}` | `Optional[dict] = None` |
| `lowest_cost.py` | `__init__()` | `routing_args = {}` | `Optional[dict] = None` |
| `lowest_latency.py` | `__init__()` | `routing_args = {}` | `Optional[dict] = None` |
| `lowest_tpm_rpm.py` | `__init__()` | `routing_args = {}` | `Optional[dict] = None` |
| `lowest_tpm_rpm_v2.py` | `__init__()` | `routing_args = {}` | `Optional[dict] = None` |

All callers continue to work identically — the default behavior is preserved via `if arg is None: arg = ...` inside the function body.