### PR TITLE
fix: harden CORS credentials, create_views exception handling, and spend log cleanup loop

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -803,6 +803,8 @@ router_settings:
 | LITELLM_ASSETS_PATH | Path to directory for UI assets and logos. Used when running with read-only filesystem (e.g., Kubernetes). Default is `/var/lib/litellm/assets` in Docker.
 | LITELLM_BLOG_POSTS_URL | Custom URL for fetching LiteLLM blog posts JSON. Default is the GitHub main branch URL
 | LITELLM_CLI_JWT_EXPIRATION_HOURS | Expiration time in hours for CLI-generated JWT tokens. Default is 24 hours
+| LITELLM_CORS_ALLOW_CREDENTIALS | Set to `true` to explicitly allow credentials in CORS responses. When not set, credentials are disabled automatically if `LITELLM_CORS_ORIGINS` is `*` (wildcard) to prevent the browser security misconfiguration of reflecting any origin with credentials
+| LITELLM_CORS_ORIGINS | Comma-separated list of allowed CORS origins (e.g. `https://app.example.com,https://admin.example.com`). Defaults to `*` (all origins) when not set
 | LITELLM_DD_AGENT_HOST | Hostname or IP of DataDog agent for LiteLLM-specific logging. When set, logs are sent to agent instead of direct API
 | LITELLM_DEPLOYMENT_ENVIRONMENT | Environment name for the deployment (e.g., "production", "staging"). Used as a fallback when OTEL_ENVIRONMENT_NAME is not set. Sets the `environment` tag in telemetry data
 | LITELLM_DETAILED_TIMING | When true, adds detailed per-phase timing headers to responses (`x-litellm-timing-{pre-processing,llm-api,post-processing,message-copy}-ms`). Default is false. See [latency overhead docs](../troubleshoot/latency_overhead.md)

--- a/litellm/proxy/db/create_views.py
+++ b/litellm/proxy/db/create_views.py
@@ -18,14 +18,17 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
 
     If the view doesn't exist, one will be created.
     """
+
     try:
         # Try to select one row from the view
         await db.query_raw("""SELECT 1 FROM "LiteLLM_VerificationTokenView" LIMIT 1""")
-        print("LiteLLM_VerificationTokenView Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("LiteLLM_VerificationTokenView Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         # If an error occurs, the view does not exist, so create it
-        await db.execute_raw(
-            """
+        await db.execute_raw("""
                 CREATE VIEW "LiteLLM_VerificationTokenView" AS
                 SELECT
                 v.*,
@@ -37,15 +40,17 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
                 FROM "LiteLLM_VerificationToken" v
                 LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id
                 LEFT JOIN "LiteLLM_ProjectTable" p ON v.project_id = p.project_id;
-            """
-        )
+            """)
 
-        print("LiteLLM_VerificationTokenView Created!")  # noqa
+        verbose_logger.debug("LiteLLM_VerificationTokenView Created!")
 
     try:
         await db.query_raw("""SELECT 1 FROM "MonthlyGlobalSpend" LIMIT 1""")
-        print("MonthlyGlobalSpend Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("MonthlyGlobalSpend Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
         CREATE OR REPLACE VIEW "MonthlyGlobalSpend" AS 
         SELECT
@@ -60,12 +65,15 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("MonthlyGlobalSpend Created!")  # noqa
+        verbose_logger.debug("MonthlyGlobalSpend Created!")
 
     try:
         await db.query_raw("""SELECT 1 FROM "Last30dKeysBySpend" LIMIT 1""")
-        print("Last30dKeysBySpend Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("Last30dKeysBySpend Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
         CREATE OR REPLACE VIEW "Last30dKeysBySpend" AS
         SELECT 
@@ -88,12 +96,15 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("Last30dKeysBySpend Created!")  # noqa
+        verbose_logger.debug("Last30dKeysBySpend Created!")
 
     try:
         await db.query_raw("""SELECT 1 FROM "Last30dModelsBySpend" LIMIT 1""")
-        print("Last30dModelsBySpend Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("Last30dModelsBySpend Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
         CREATE OR REPLACE VIEW "Last30dModelsBySpend" AS
         SELECT
@@ -111,11 +122,14 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("Last30dModelsBySpend Created!")  # noqa
+        verbose_logger.debug("Last30dModelsBySpend Created!")
     try:
         await db.query_raw("""SELECT 1 FROM "MonthlyGlobalSpendPerKey" LIMIT 1""")
-        print("MonthlyGlobalSpendPerKey Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("MonthlyGlobalSpendPerKey Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
             CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerKey" AS 
             SELECT
@@ -132,13 +146,16 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("MonthlyGlobalSpendPerKey Created!")  # noqa
+        verbose_logger.debug("MonthlyGlobalSpendPerKey Created!")
     try:
         await db.query_raw(
             """SELECT 1 FROM "MonthlyGlobalSpendPerUserPerKey" LIMIT 1"""
         )
-        print("MonthlyGlobalSpendPerUserPerKey Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("MonthlyGlobalSpendPerUserPerKey Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
             CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerUserPerKey" AS 
             SELECT
@@ -157,12 +174,15 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("MonthlyGlobalSpendPerUserPerKey Created!")  # noqa
+        verbose_logger.debug("MonthlyGlobalSpendPerUserPerKey Created!")
 
     try:
         await db.query_raw("""SELECT 1 FROM "DailyTagSpend" LIMIT 1""")
-        print("DailyTagSpend Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("DailyTagSpend Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
         CREATE OR REPLACE VIEW "DailyTagSpend" AS
         SELECT
@@ -175,12 +195,15 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("DailyTagSpend Created!")  # noqa
+        verbose_logger.debug("DailyTagSpend Created!")
 
     try:
         await db.query_raw("""SELECT 1 FROM "Last30dTopEndUsersSpend" LIMIT 1""")
-        print("Last30dTopEndUsersSpend Exists!")  # noqa
-    except Exception:
+        verbose_logger.debug("Last30dTopEndUsersSpend Exists!")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "does not exist" not in error_msg and "undefined" not in error_msg:
+            raise
         sql_query = """
         CREATE VIEW "Last30dTopEndUsersSpend" AS
         SELECT end_user, COUNT(*) AS total_events, SUM(spend) AS total_spend
@@ -193,7 +216,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         """
         await db.execute_raw(query=sql_query)
 
-        print("Last30dTopEndUsersSpend Created!")  # noqa
+        verbose_logger.debug("Last30dTopEndUsersSpend Created!")
 
     return
 

--- a/litellm/proxy/db/create_views.py
+++ b/litellm/proxy/db/create_views.py
@@ -4,6 +4,12 @@ from litellm import verbose_logger
 
 _db = Any
 
+# Markers that indicate a view/relation does not yet exist in the database.
+# Keeping these in one place avoids repeating the check across all view blocks
+# and prevents overly broad matches (e.g. bare 'undefined' would also match
+# 'undefined function' or 'column undefined_col referenced in query').
+_VIEW_NOT_FOUND_MARKERS = ("does not exist", "no such table", "undefined table")
+
 
 async def create_missing_views(db: _db):  # noqa: PLR0915
     """
@@ -25,7 +31,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("LiteLLM_VerificationTokenView Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         # If an error occurs, the view does not exist, so create it
         await db.execute_raw("""
@@ -49,7 +55,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("MonthlyGlobalSpend Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
         CREATE OR REPLACE VIEW "MonthlyGlobalSpend" AS 
@@ -72,7 +78,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("Last30dKeysBySpend Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
         CREATE OR REPLACE VIEW "Last30dKeysBySpend" AS
@@ -103,7 +109,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("Last30dModelsBySpend Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
         CREATE OR REPLACE VIEW "Last30dModelsBySpend" AS
@@ -128,7 +134,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("MonthlyGlobalSpendPerKey Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
             CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerKey" AS 
@@ -154,7 +160,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("MonthlyGlobalSpendPerUserPerKey Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
             CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerUserPerKey" AS 
@@ -181,7 +187,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("DailyTagSpend Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
         CREATE OR REPLACE VIEW "DailyTagSpend" AS
@@ -202,7 +208,7 @@ async def create_missing_views(db: _db):  # noqa: PLR0915
         verbose_logger.debug("Last30dTopEndUsersSpend Exists!")
     except Exception as e:
         error_msg = str(e).lower()
-        if "does not exist" not in error_msg and "undefined" not in error_msg:
+        if not any(marker in error_msg for marker in _VIEW_NOT_FOUND_MARKERS):
             raise
         sql_query = """
         CREATE VIEW "Last30dTopEndUsersSpend" AS

--- a/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
@@ -82,7 +82,7 @@ class SpendLogCleanup:
                 break
             # Step 1: Find logs and delete them in one go without fetching to application
             # Delete in batches, limited by self.batch_size
-            deleted_count = await prisma_client.db.execute_raw(
+            deleted_result = await prisma_client.db.execute_raw(
                 """
                 DELETE FROM "LiteLLM_SpendLogs"
                 WHERE "request_id" IN (
@@ -94,6 +94,17 @@ class SpendLogCleanup:
                 cutoff_date,
                 self.batch_size,
             )
+
+            deleted_count = 0
+            if isinstance(deleted_result, int):
+                deleted_count = deleted_result
+            else:
+                verbose_proxy_logger.error(
+                    f"Unexpected execute_raw return type for spend log cleanup: {type(deleted_result)}; "
+                    "aborting cleanup to avoid infinite loop"
+                )
+                break
+
             verbose_proxy_logger.info(f"Deleted {deleted_count} logs in this batch")
 
             if deleted_count == 0:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -54,7 +54,7 @@ from litellm.constants import (
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
     LITELLM_UI_ALLOW_HEADERS,
     LITELLM_UI_SESSION_DURATION,
-    DAILY_TAG_SPEND_BATCH_MULTIPLIER
+    DAILY_TAG_SPEND_BATCH_MULTIPLIER,
 )
 from litellm.litellm_core_utils.litellm_logging import (
     _init_custom_logger_compatible_class,
@@ -1140,7 +1140,13 @@ async def openai_exception_handler(request: Request, exc: ProxyException):
 
 
 router = APIRouter()
-origins = ["*"]
+_cors_origins_env = os.getenv("LITELLM_CORS_ORIGINS")
+if _cors_origins_env is None or _cors_origins_env.strip() == "":
+    origins = ["*"]
+else:
+    origins = [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
+
+allow_cors_credentials = "*" not in origins
 
 
 # get current directory
@@ -1467,7 +1473,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
-    allow_credentials=True,
+    allow_credentials=allow_cors_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
     expose_headers=LITELLM_UI_ALLOW_HEADERS,
@@ -2316,9 +2322,13 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
-            if llm_router.health_check_ignore_transient_errors and exception_status in (
-                429,
-                408,
+            if (
+                llm_router.health_check_ignore_transient_errors
+                and exception_status
+                in (
+                    429,
+                    408,
+                )
             ):
                 continue
 
@@ -6287,7 +6297,9 @@ class ProxyStartupEvent:
 
         ### UPDATE DAILY TAG SPEND (separate scheduler job with longer interval) ###
         ## Reduces QPS as there are more tags for a single request
-        tag_spend_update_interval = int(batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER)
+        tag_spend_update_interval = int(
+            batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER
+        )
         from litellm.proxy.utils import update_daily_tag_spend
 
         scheduler.add_job(
@@ -7132,9 +7144,9 @@ async def chat_completion(  # noqa: PLR0915
             hasattr(user_api_key_dict, "organization_alias")
             and user_api_key_dict.organization_alias is not None
         ):
-            data["metadata"]["user_api_key_org_alias"] = (
-                user_api_key_dict.organization_alias
-            )
+            data["metadata"][
+                "user_api_key_org_alias"
+            ] = user_api_key_dict.organization_alias
         if (
             hasattr(user_api_key_dict, "agent_id")
             and user_api_key_dict.agent_id is not None
@@ -7313,9 +7325,9 @@ async def completion(  # noqa: PLR0915
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"]["user_api_key_org_alias"] = (
-                    user_api_key_dict.organization_alias
-                )
+                data["metadata"][
+                    "user_api_key_org_alias"
+                ] = user_api_key_dict.organization_alias
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -7562,9 +7574,9 @@ async def embeddings(  # noqa: PLR0915
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"]["user_api_key_org_alias"] = (
-                    user_api_key_dict.organization_alias
-                )
+                data["metadata"][
+                    "user_api_key_org_alias"
+                ] = user_api_key_dict.organization_alias
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1146,7 +1146,17 @@ if _cors_origins_env is None or _cors_origins_env.strip() == "":
 else:
     origins = [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
 
-allow_cors_credentials = "*" not in origins
+# Disable credentials by default when wildcard origins are used — combining
+# allow_origins=["*"] with allow_credentials=True causes Starlette to reflect
+# the incoming Origin header, allowing any site to make credentialed requests.
+# Set LITELLM_CORS_ALLOW_CREDENTIALS=true to explicitly restore the old behaviour
+# (e.g. for non-browser clients that relied on the Access-Control-Allow-Credentials
+# header being present regardless of origin).
+_cors_credentials_env = os.getenv("LITELLM_CORS_ALLOW_CREDENTIALS")
+if _cors_credentials_env is not None:
+    allow_cors_credentials = _cors_credentials_env.strip().lower() == "true"
+else:
+    allow_cors_credentials = "*" not in origins
 
 
 # get current directory

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1140,23 +1140,54 @@ async def openai_exception_handler(request: Request, exc: ProxyException):
 
 
 router = APIRouter()
-_cors_origins_env = os.getenv("LITELLM_CORS_ORIGINS")
-if _cors_origins_env is None or _cors_origins_env.strip() == "":
-    origins = ["*"]
-else:
-    origins = [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
 
-# Disable credentials by default when wildcard origins are used — combining
-# allow_origins=["*"] with allow_credentials=True causes Starlette to reflect
-# the incoming Origin header, allowing any site to make credentialed requests.
-# Set LITELLM_CORS_ALLOW_CREDENTIALS=true to explicitly restore the old behaviour
-# (e.g. for non-browser clients that relied on the Access-Control-Allow-Credentials
-# header being present regardless of origin).
-_cors_credentials_env = os.getenv("LITELLM_CORS_ALLOW_CREDENTIALS")
-if _cors_credentials_env is not None:
-    allow_cors_credentials = _cors_credentials_env.strip().lower() == "true"
-else:
-    allow_cors_credentials = "*" not in origins
+
+def _get_cors_config(
+    cors_origins_env: Optional[str] = None,
+    cors_credentials_env: Optional[str] = None,
+):
+    """
+    Compute CORS allowed origins and credentials flag from environment variables.
+
+    Extracted into a function so it can be unit-tested without reloading the module.
+
+    Args:
+        cors_origins_env: Value of LITELLM_CORS_ORIGINS (defaults to os.getenv).
+        cors_credentials_env: Value of LITELLM_CORS_ALLOW_CREDENTIALS (defaults to os.getenv).
+
+    Returns:
+        Tuple[List[str], bool]: (origins, allow_credentials)
+    """
+    _origins_raw = (
+        cors_origins_env
+        if cors_origins_env is not None
+        else os.getenv("LITELLM_CORS_ORIGINS")
+    )
+    if _origins_raw is None or _origins_raw.strip() == "":
+        computed_origins = ["*"]
+    else:
+        computed_origins = [o.strip() for o in _origins_raw.split(",") if o.strip()]
+
+    # Disable credentials by default when wildcard origins are used — combining
+    # allow_origins=["*"] with allow_credentials=True causes Starlette to reflect
+    # the incoming Origin header, allowing any site to make credentialed requests.
+    # Set LITELLM_CORS_ALLOW_CREDENTIALS=true to explicitly restore the old behaviour
+    # (e.g. for non-browser clients that relied on the Access-Control-Allow-Credentials
+    # header being present regardless of origin).
+    _credentials_raw = (
+        cors_credentials_env
+        if cors_credentials_env is not None
+        else os.getenv("LITELLM_CORS_ALLOW_CREDENTIALS")
+    )
+    if _credentials_raw is not None:
+        computed_credentials = _credentials_raw.strip().lower() == "true"
+    else:
+        computed_credentials = "*" not in computed_origins
+
+    return computed_origins, computed_credentials
+
+
+origins, allow_cors_credentials = _get_cors_config()
 
 
 # get current directory

--- a/tests/test_litellm/proxy/db/test_create_views.py
+++ b/tests/test_litellm/proxy/db/test_create_views.py
@@ -110,3 +110,46 @@ async def test_create_views_skips_creation_when_view_exists():
     await create_missing_views(mock_db)
 
     mock_db.execute_raw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_views_reraises_undefined_function_error():
+    """should re-raise 'undefined function' errors — bare 'undefined' is too broad
+    and would previously misclassify DB function errors as missing-view signals."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(
+        side_effect=Exception("ERROR: undefined function pg_get_viewdef()")
+    )
+    mock_db.execute_raw = AsyncMock()
+
+    with pytest.raises(Exception, match="undefined function"):
+        await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_views_creates_view_on_undefined_table_error():
+    """should treat 'undefined table' as a missing-view signal and attempt creation."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(
+        side_effect=[
+            Exception('undefined table "LiteLLM_VerificationTokenView"'),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]
+    )
+    mock_db.execute_raw = AsyncMock(return_value=None)
+
+    await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_called_once()

--- a/tests/test_litellm/proxy/db/test_create_views.py
+++ b/tests/test_litellm/proxy/db/test_create_views.py
@@ -1,0 +1,112 @@
+"""
+Tests for create_missing_views exception handling fix.
+
+Verifies that real DB errors (auth failures, connection errors, etc.)
+are re-raised instead of being silently swallowed, while genuine
+"view not found" errors still trigger view creation.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, call
+
+
+@pytest.mark.asyncio
+async def test_create_views_reraises_connection_error():
+    """should re-raise exceptions that are NOT 'does not exist' errors (e.g. connection errors)."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(
+        side_effect=Exception("connection refused: unable to connect to database")
+    )
+    mock_db.execute_raw = AsyncMock()
+
+    with pytest.raises(Exception, match="connection refused"):
+        await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_views_reraises_permission_error():
+    """should re-raise permission denied errors, not treat them as missing views."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(
+        side_effect=Exception(
+            "permission denied for table LiteLLM_VerificationTokenView"
+        )
+    )
+    mock_db.execute_raw = AsyncMock()
+
+    with pytest.raises(Exception, match="permission denied"):
+        await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_views_creates_view_on_does_not_exist():
+    """should call execute_raw to create view when error contains 'does not exist'."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(
+        side_effect=[
+            Exception('relation "LiteLLM_VerificationTokenView" does not exist'),
+            None,  # MonthlyGlobalSpend exists
+            None,  # Last30dKeysBySpend exists
+            None,  # Last30dModelsBySpend exists
+            None,  # MonthlyGlobalSpendPerKey exists
+            None,  # MonthlyGlobalSpendPerUserPerKey exists
+            None,  # DailyTagSpend exists
+            None,  # Last30dTopEndUsersSpend exists
+        ]
+    )
+    mock_db.execute_raw = AsyncMock(return_value=None)
+
+    await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_called_once()
+    created_sql = mock_db.execute_raw.call_args[0][0]
+    assert 'CREATE VIEW "LiteLLM_VerificationTokenView"' in created_sql
+
+
+@pytest.mark.asyncio
+async def test_create_views_creates_view_on_undefined_error():
+    """should treat 'undefined' errors as 'view not found' and attempt creation."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(
+        side_effect=[
+            Exception("undefined table LiteLLM_VerificationTokenView"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]
+    )
+    mock_db.execute_raw = AsyncMock(return_value=None)
+
+    await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_views_skips_creation_when_view_exists():
+    """should not call execute_raw when all views already exist."""
+    from litellm.proxy.db.create_views import create_missing_views
+
+    mock_db = MagicMock()
+    mock_db.query_raw = AsyncMock(return_value=[{"?column?": 1}])
+    mock_db.execute_raw = AsyncMock()
+
+    await create_missing_views(mock_db)
+
+    mock_db.execute_raw.assert_not_called()

--- a/tests/test_litellm/proxy/test_cors_config.py
+++ b/tests/test_litellm/proxy/test_cors_config.py
@@ -1,38 +1,28 @@
 """
 Tests for CORS configuration security fix.
 
-Verifies that allow_credentials is automatically disabled when
-allow_origins=["*"] (wildcard) to prevent credentialed cross-origin
-requests from arbitrary origins.
+All tests import _get_cors_config directly from proxy_server so they exercise
+real production code rather than a local mirror.
 """
 
 import pytest
 
 
-def _compute_cors_config(cors_origins_env):
-    """
-    Mirror of the CORS config logic in proxy_server.py.
-    Kept here so tests remain isolated from module-level side-effects.
-    """
-    if cors_origins_env is None or cors_origins_env.strip() == "":
-        origins = ["*"]
-    else:
-        origins = [o.strip() for o in cors_origins_env.split(",") if o.strip()]
-    allow_cors_credentials = "*" not in origins
-    return origins, allow_cors_credentials
-
-
 def test_cors_wildcard_disables_credentials():
     """should disable credentials when LITELLM_CORS_ORIGINS is not set (defaults to wildcard)."""
-    origins, allow_credentials = _compute_cors_config(None)
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(cors_origins_env="")
     assert origins == ["*"]
     assert allow_credentials is False
 
 
 def test_cors_empty_string_disables_credentials():
-    """should disable credentials when LITELLM_CORS_ORIGINS is an empty or whitespace string."""
+    """should disable credentials when LITELLM_CORS_ORIGINS is empty or whitespace."""
+    from litellm.proxy.proxy_server import _get_cors_config
+
     for empty in ("", "   ", "\t"):
-        origins, allow_credentials = _compute_cors_config(empty)
+        origins, allow_credentials = _get_cors_config(cors_origins_env=empty)
         assert origins == ["*"], f"Expected wildcard for input {repr(empty)}"
         assert (
             allow_credentials is False
@@ -41,15 +31,21 @@ def test_cors_empty_string_disables_credentials():
 
 def test_cors_single_specific_origin_enables_credentials():
     """should enable credentials when a single explicit origin is configured."""
-    origins, allow_credentials = _compute_cors_config("https://admin.example.com")
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(
+        cors_origins_env="https://admin.example.com"
+    )
     assert origins == ["https://admin.example.com"]
     assert allow_credentials is True
 
 
 def test_cors_multiple_specific_origins_enables_credentials():
     """should enable credentials and correctly parse comma-separated origins."""
-    origins, allow_credentials = _compute_cors_config(
-        "https://app.example.com, https://admin.example.com, https://api.example.com"
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(
+        cors_origins_env="https://app.example.com, https://admin.example.com, https://api.example.com"
     )
     assert origins == [
         "https://app.example.com",
@@ -61,50 +57,79 @@ def test_cors_multiple_specific_origins_enables_credentials():
 
 def test_cors_wildcard_string_in_env_disables_credentials():
     """should disable credentials when LITELLM_CORS_ORIGINS is explicitly set to '*'."""
-    origins, allow_credentials = _compute_cors_config("*")
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(cors_origins_env="*")
     assert "*" in origins
     assert allow_credentials is False
 
 
 def test_cors_origins_strips_whitespace():
     """should strip surrounding whitespace from each origin entry."""
-    origins, _ = _compute_cors_config("  https://a.com  ,  https://b.com  ")
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, _ = _get_cors_config(
+        cors_origins_env="  https://a.com  ,  https://b.com  "
+    )
     assert origins == ["https://a.com", "https://b.com"]
 
 
 def test_cors_origins_skips_blank_entries():
     """should skip blank entries caused by trailing/double commas."""
-    origins, allow_credentials = _compute_cors_config("https://a.com,,https://b.com,")
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(
+        cors_origins_env="https://a.com,,https://b.com,"
+    )
     assert origins == ["https://a.com", "https://b.com"]
     assert allow_credentials is True
 
 
-def test_cors_explicit_credentials_override_true(monkeypatch):
-    """should allow LITELLM_CORS_ALLOW_CREDENTIALS=true to explicitly re-enable
-    credentials even when wildcard origins are used (opt-in for existing deployments).
-    """
-    monkeypatch.setenv("LITELLM_CORS_ALLOW_CREDENTIALS", "true")
-    _cors_credentials_env = "true"
-    _cors_credentials_env = _cors_credentials_env.strip().lower() == "true"
-    assert _cors_credentials_env is True
+def test_cors_explicit_credentials_true_overrides_wildcard():
+    """should enable credentials when LITELLM_CORS_ALLOW_CREDENTIALS=true even
+    if wildcard origins are in use (opt-in for existing deployments)."""
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(
+        cors_origins_env="",
+        cors_credentials_env="true",
+    )
+    assert "*" in origins
+    assert allow_credentials is True
 
 
-def test_cors_explicit_credentials_override_false(monkeypatch):
-    """should allow LITELLM_CORS_ALLOW_CREDENTIALS=false to explicitly disable
-    credentials even when specific origins are configured."""
-    monkeypatch.setenv("LITELLM_CORS_ALLOW_CREDENTIALS", "false")
-    _cors_credentials_env = "false"
-    result = _cors_credentials_env.strip().lower() == "true"
-    assert result is False
+def test_cors_explicit_credentials_false_overrides_specific_origins():
+    """should disable credentials when LITELLM_CORS_ALLOW_CREDENTIALS=false even
+    if specific origins are configured."""
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    origins, allow_credentials = _get_cors_config(
+        cors_origins_env="https://admin.example.com",
+        cors_credentials_env="false",
+    )
+    assert origins == ["https://admin.example.com"]
+    assert allow_credentials is False
+
+
+def test_cors_explicit_credentials_case_insensitive():
+    """should accept TRUE/FALSE case-insensitively for LITELLM_CORS_ALLOW_CREDENTIALS."""
+    from litellm.proxy.proxy_server import _get_cors_config
+
+    _, allow_true = _get_cors_config(cors_origins_env="", cors_credentials_env="TRUE")
+    _, allow_false = _get_cors_config(
+        cors_origins_env="https://x.com", cors_credentials_env="FALSE"
+    )
+    assert allow_true is True
+    assert allow_false is False
 
 
 def test_proxy_server_cors_invariant():
-    """should verify that proxy_server.allow_cors_credentials is always consistent
-    with proxy_server.origins — catches any future drift between the two variables."""
-    import litellm.proxy.proxy_server as proxy_server
-
-    # When LITELLM_CORS_ALLOW_CREDENTIALS is not explicitly set, the invariant must hold
+    """should verify that proxy_server module-level origins and allow_cors_credentials
+    are consistent — catches any future drift in the module-level call to _get_cors_config.
+    """
     import os
+
+    import litellm.proxy.proxy_server as proxy_server
 
     if os.getenv("LITELLM_CORS_ALLOW_CREDENTIALS") is None:
         assert proxy_server.allow_cors_credentials == (

--- a/tests/test_litellm/proxy/test_cors_config.py
+++ b/tests/test_litellm/proxy/test_cors_config.py
@@ -77,3 +77,15 @@ def test_cors_origins_skips_blank_entries():
     origins, allow_credentials = _compute_cors_config("https://a.com,,https://b.com,")
     assert origins == ["https://a.com", "https://b.com"]
     assert allow_credentials is True
+
+
+def test_proxy_server_cors_invariant():
+    """should verify that proxy_server.allow_cors_credentials is always consistent
+    with proxy_server.origins — catches any future drift between the two variables."""
+    import litellm.proxy.proxy_server as proxy_server
+
+    assert proxy_server.allow_cors_credentials == ("*" not in proxy_server.origins), (
+        f"Invariant broken: allow_cors_credentials={proxy_server.allow_cors_credentials} "
+        f"but origins={proxy_server.origins}. "
+        "When origins contains '*', allow_credentials must be False."
+    )

--- a/tests/test_litellm/proxy/test_cors_config.py
+++ b/tests/test_litellm/proxy/test_cors_config.py
@@ -79,13 +79,38 @@ def test_cors_origins_skips_blank_entries():
     assert allow_credentials is True
 
 
+def test_cors_explicit_credentials_override_true(monkeypatch):
+    """should allow LITELLM_CORS_ALLOW_CREDENTIALS=true to explicitly re-enable
+    credentials even when wildcard origins are used (opt-in for existing deployments).
+    """
+    monkeypatch.setenv("LITELLM_CORS_ALLOW_CREDENTIALS", "true")
+    _cors_credentials_env = "true"
+    _cors_credentials_env = _cors_credentials_env.strip().lower() == "true"
+    assert _cors_credentials_env is True
+
+
+def test_cors_explicit_credentials_override_false(monkeypatch):
+    """should allow LITELLM_CORS_ALLOW_CREDENTIALS=false to explicitly disable
+    credentials even when specific origins are configured."""
+    monkeypatch.setenv("LITELLM_CORS_ALLOW_CREDENTIALS", "false")
+    _cors_credentials_env = "false"
+    result = _cors_credentials_env.strip().lower() == "true"
+    assert result is False
+
+
 def test_proxy_server_cors_invariant():
     """should verify that proxy_server.allow_cors_credentials is always consistent
     with proxy_server.origins — catches any future drift between the two variables."""
     import litellm.proxy.proxy_server as proxy_server
 
-    assert proxy_server.allow_cors_credentials == ("*" not in proxy_server.origins), (
-        f"Invariant broken: allow_cors_credentials={proxy_server.allow_cors_credentials} "
-        f"but origins={proxy_server.origins}. "
-        "When origins contains '*', allow_credentials must be False."
-    )
+    # When LITELLM_CORS_ALLOW_CREDENTIALS is not explicitly set, the invariant must hold
+    import os
+
+    if os.getenv("LITELLM_CORS_ALLOW_CREDENTIALS") is None:
+        assert proxy_server.allow_cors_credentials == (
+            "*" not in proxy_server.origins
+        ), (
+            f"Invariant broken: allow_cors_credentials={proxy_server.allow_cors_credentials} "
+            f"but origins={proxy_server.origins}. "
+            "When origins contains '*', allow_credentials must be False."
+        )

--- a/tests/test_litellm/proxy/test_cors_config.py
+++ b/tests/test_litellm/proxy/test_cors_config.py
@@ -1,0 +1,79 @@
+"""
+Tests for CORS configuration security fix.
+
+Verifies that allow_credentials is automatically disabled when
+allow_origins=["*"] (wildcard) to prevent credentialed cross-origin
+requests from arbitrary origins.
+"""
+
+import pytest
+
+
+def _compute_cors_config(cors_origins_env):
+    """
+    Mirror of the CORS config logic in proxy_server.py.
+    Kept here so tests remain isolated from module-level side-effects.
+    """
+    if cors_origins_env is None or cors_origins_env.strip() == "":
+        origins = ["*"]
+    else:
+        origins = [o.strip() for o in cors_origins_env.split(",") if o.strip()]
+    allow_cors_credentials = "*" not in origins
+    return origins, allow_cors_credentials
+
+
+def test_cors_wildcard_disables_credentials():
+    """should disable credentials when LITELLM_CORS_ORIGINS is not set (defaults to wildcard)."""
+    origins, allow_credentials = _compute_cors_config(None)
+    assert origins == ["*"]
+    assert allow_credentials is False
+
+
+def test_cors_empty_string_disables_credentials():
+    """should disable credentials when LITELLM_CORS_ORIGINS is an empty or whitespace string."""
+    for empty in ("", "   ", "\t"):
+        origins, allow_credentials = _compute_cors_config(empty)
+        assert origins == ["*"], f"Expected wildcard for input {repr(empty)}"
+        assert (
+            allow_credentials is False
+        ), f"Expected no credentials for input {repr(empty)}"
+
+
+def test_cors_single_specific_origin_enables_credentials():
+    """should enable credentials when a single explicit origin is configured."""
+    origins, allow_credentials = _compute_cors_config("https://admin.example.com")
+    assert origins == ["https://admin.example.com"]
+    assert allow_credentials is True
+
+
+def test_cors_multiple_specific_origins_enables_credentials():
+    """should enable credentials and correctly parse comma-separated origins."""
+    origins, allow_credentials = _compute_cors_config(
+        "https://app.example.com, https://admin.example.com, https://api.example.com"
+    )
+    assert origins == [
+        "https://app.example.com",
+        "https://admin.example.com",
+        "https://api.example.com",
+    ]
+    assert allow_credentials is True
+
+
+def test_cors_wildcard_string_in_env_disables_credentials():
+    """should disable credentials when LITELLM_CORS_ORIGINS is explicitly set to '*'."""
+    origins, allow_credentials = _compute_cors_config("*")
+    assert "*" in origins
+    assert allow_credentials is False
+
+
+def test_cors_origins_strips_whitespace():
+    """should strip surrounding whitespace from each origin entry."""
+    origins, _ = _compute_cors_config("  https://a.com  ,  https://b.com  ")
+    assert origins == ["https://a.com", "https://b.com"]
+
+
+def test_cors_origins_skips_blank_entries():
+    """should skip blank entries caused by trailing/double commas."""
+    origins, allow_credentials = _compute_cors_config("https://a.com,,https://b.com,")
+    assert origins == ["https://a.com", "https://b.com"]
+    assert allow_credentials is True

--- a/tests/test_litellm/proxy/test_spend_log_cleanup.py
+++ b/tests/test_litellm/proxy/test_spend_log_cleanup.py
@@ -287,9 +287,48 @@ def test_string_retention_still_works():
             general_settings={"maximum_spend_logs_retention_period": setting}
         )
         assert cleaner._should_delete_spend_logs() is True, f"Failed for {setting}"
-        assert cleaner.retention_seconds == expected_seconds, (
-            f"Expected {expected_seconds} for {setting}, got {cleaner.retention_seconds}"
-        )
+        assert (
+            cleaner.retention_seconds == expected_seconds
+        ), f"Expected {expected_seconds} for {setting}, got {cleaner.retention_seconds}"
+
+
+@pytest.mark.asyncio
+async def test_delete_old_logs_aborts_on_non_int_execute_raw_return():
+    """should abort deletion loop immediately when execute_raw returns a non-int
+    (e.g. None or dict), preventing an infinite loop."""
+    mock_prisma_client = MagicMock()
+    mock_db = MagicMock()
+    mock_db.execute_raw = AsyncMock(return_value=None)
+    mock_prisma_client.db = mock_db
+
+    cleaner = SpendLogCleanup(
+        general_settings={"maximum_spend_logs_retention_period": "7d"}
+    )
+
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=7)
+    total_deleted = await cleaner._delete_old_logs(mock_prisma_client, cutoff_date)
+
+    assert mock_db.execute_raw.call_count == 1
+    assert total_deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_old_logs_continues_on_valid_int_return():
+    """should continue deletion loop across batches when execute_raw returns valid int counts."""
+    mock_prisma_client = MagicMock()
+    mock_db = MagicMock()
+    mock_db.execute_raw = AsyncMock(side_effect=[500, 300, 0])
+    mock_prisma_client.db = mock_db
+
+    cleaner = SpendLogCleanup(
+        general_settings={"maximum_spend_logs_retention_period": "7d"}
+    )
+
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=7)
+    total_deleted = await cleaner._delete_old_logs(mock_prisma_client, cutoff_date)
+
+    assert mock_db.execute_raw.call_count == 3
+    assert total_deleted == 800
 
 
 def test_cleanup_batch_size_env_var(monkeypatch):


### PR DESCRIPTION


## Type
 Bug Fix

## Changes

**1. CORS security fix ([proxy_server.py](cci:7://file:///Users/apple/Documents/OSS/litellm/litellm/proxy/proxy_server.py:0:0-0:0))**  
`allow_origins=["*"]` + `allow_credentials=True` is a browser security misconfiguration — any origin can make credentialed cross-origin requests. Credentials are now automatically disabled when wildcard origins are used. Set `LITELLM_CORS_ORIGINS=https://your-ui.com` to re-enable credentials with specific origins.

**2. [create_views.py](cci:7://file:///Users/apple/Documents/OSS/litellm/litellm/proxy/db/create_views.py:0:0-0:0) — exception masking**  
Broad `except Exception: pass` silently swallowed real DB errors (auth failures, connection errors) and blindly attempted `CREATE VIEW`. Now only genuine "view does not exist"/"undefined" errors proceed to view creation; all others are re-raised.

**3. [spend_log_cleanup.py](cci:7://file:///Users/apple/Documents/OSS/litellm/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py:0:0-0:0) — infinite loop guard**  
`execute_raw()` return type is now validated as `int` before use as a deletion count. An unexpected return type (e.g. `None`) previously made `deleted_count == 0` evaluate `False`, causing an infinite deletion loop.
