### PR TITLE
Add "Screenshots / Proof of Fix" section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,13 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 - [ ] **Merge / cherry-pick CI run**  
        Links:
 
+## Screenshots / Proof of Fix
+
+<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
+     For bug fixes: show reproduction before the fix and passing behavior after.
+     For new features: show the feature working end-to-end.
+     For UI changes: include before/after screenshots. -->
+
 ## Type
 
 <!-- Select the type of Pull Request -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Prompted by Slack discussion about ensuring contributors demonstrate their fixes work.

## Changes

Adds a new **"Screenshots / Proof of Fix"** section to the GitHub pull request template (`.github/pull_request_template.md`).

The section prompts contributors to include visual or log-based evidence that their changes work as expected, with guidance for different PR types:

- **Bug fixes**: show reproduction before the fix and passing behavior after
- **New features**: show the feature working end-to-end
- **UI changes**: include before/after screenshots

The section is placed between the CI checklist and the Type selector, so contributors encounter it naturally while filling out the template.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D092E9K4EMP/p1773108831937859?thread_ts=1773108831.937859&cid=D092E9K4EMP)

<div><a href="https://cursor.com/agents/bc-a85c7b9e-c163-5966-8d2c-3898d9cf0c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a85c7b9e-c163-5966-8d2c-3898d9cf0c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

