### PR TITLE
Preserve original vendor response headers alongside llm_provider- prefix

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -253,6 +253,9 @@ def process_response_headers(response_headers: Union[httpx.Headers, dict]) -> di
         ):  # return raw provider headers (incl. openai-compatible ones)
             processed_headers[k] = v
         else:
+            # Preserve original header name so consumers can look it up
+            # by the key the vendor actually sent (e.g. TRAFFIC-TYPE).
+            additional_headers[k] = v
             additional_headers["{}-{}".format("llm_provider", k)] = v
 
     additional_headers = {

--- a/litellm/litellm_core_utils/llm_response_utils/get_headers.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_headers.py
@@ -41,14 +41,21 @@ def get_response_headers(_response_headers: Optional[dict] = None) -> dict:
 
 def _get_llm_provider_headers(response_headers: dict) -> dict:
     """
-    Adds a llm_provider-{header} to all headers that are not already prefixed with llm_provider
+    Forward all headers as llm_provider-{header} while also preserving originals.
 
-    Forward all headers as llm_provider-{header}
+    Every vendor header is stored twice:
+      1. Under its original key (e.g. ``TRAFFIC-TYPE``) so consumers
+         can look it up by the name the vendor actually sent.
+      2. Under a ``llm_provider-`` prefixed key (e.g.
+         ``llm_provider-TRAFFIC-TYPE``) for backwards-compatibility with
+         existing litellm consumers that rely on the prefix convention.
 
+    Headers that are already prefixed with ``llm_provider`` are kept as-is.
     """
     llm_provider_headers = {}
     for k, v in response_headers.items():
         if "llm_provider" not in k:
+            llm_provider_headers[k] = v
             _key = "{}-{}".format("llm_provider", k)
             llm_provider_headers[_key] = v
         else:

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -56,9 +56,10 @@ def process_azure_headers(headers: Union[httpx.Headers, dict]) -> dict:
         openai_headers["x-ratelimit-remaining-tokens"] = headers[
             "x-ratelimit-remaining-tokens"
         ]
-    llm_response_headers = {
-        "{}-{}".format("llm_provider", k): v for k, v in headers.items()
-    }
+    llm_response_headers = {}
+    for k, v in headers.items():
+        llm_response_headers[k] = v
+        llm_response_headers["{}-{}".format("llm_provider", k)] = v
 
     return {**llm_response_headers, **openai_headers}
 

--- a/tests/litellm_core_utils/test_response_headers.py
+++ b/tests/litellm_core_utils/test_response_headers.py
@@ -1,0 +1,158 @@
+"""
+Tests for vendor response header preservation in litellm.
+
+Verifies that custom vendor headers (e.g., TRAFFIC-TYPE) are preserved
+with their original names alongside the llm_provider-prefixed versions.
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.llm_response_utils.get_headers import (
+    _get_llm_provider_headers,
+    get_response_headers,
+)
+from litellm.litellm_core_utils.core_helpers import process_response_headers
+from litellm.llms.azure.common_utils import process_azure_headers
+
+
+class TestGetLlmProviderHeaders:
+    """Tests for _get_llm_provider_headers in get_headers.py"""
+
+    def test_custom_header_preserved_with_original_name(self):
+        """TRAFFIC-TYPE should be accessible by its original key."""
+        headers = {"TRAFFIC-TYPE": "synthetic", "content-type": "application/json"}
+        result = _get_llm_provider_headers(headers)
+        assert "TRAFFIC-TYPE" in result
+        assert result["TRAFFIC-TYPE"] == "synthetic"
+
+    def test_custom_header_also_has_llm_provider_prefix(self):
+        """TRAFFIC-TYPE should also exist with the llm_provider- prefix."""
+        headers = {"TRAFFIC-TYPE": "synthetic"}
+        result = _get_llm_provider_headers(headers)
+        assert "llm_provider-TRAFFIC-TYPE" in result
+        assert result["llm_provider-TRAFFIC-TYPE"] == "synthetic"
+
+    def test_already_prefixed_header_not_double_prefixed(self):
+        """Headers already prefixed with llm_provider should not be re-prefixed."""
+        headers = {"llm_provider-some-header": "value"}
+        result = _get_llm_provider_headers(headers)
+        assert "llm_provider-some-header" in result
+        assert "llm_provider-llm_provider-some-header" not in result
+
+    def test_empty_headers_returns_empty_dict(self):
+        result = _get_llm_provider_headers({})
+        assert result == {}
+
+    def test_multiple_custom_headers_all_preserved(self):
+        """All vendor-specific headers should be preserved with original names."""
+        headers = {
+            "TRAFFIC-TYPE": "synthetic",
+            "x-custom-vendor": "some-value",
+            "x-request-id": "abc-123",
+        }
+        result = _get_llm_provider_headers(headers)
+        for original_key in headers:
+            assert original_key in result, f"Original header '{original_key}' missing"
+            assert f"llm_provider-{original_key}" in result
+
+
+class TestGetResponseHeaders:
+    """Tests for get_response_headers in get_headers.py"""
+
+    def test_none_input_returns_empty_dict(self):
+        assert get_response_headers(None) == {}
+
+    def test_traffic_type_preserved_in_final_output(self):
+        """TRAFFIC-TYPE should appear by original name in get_response_headers output."""
+        headers = {
+            "TRAFFIC-TYPE": "live",
+            "x-ratelimit-remaining-requests": "100",
+        }
+        result = get_response_headers(headers)
+        assert "TRAFFIC-TYPE" in result
+        assert result["TRAFFIC-TYPE"] == "live"
+        assert "llm_provider-TRAFFIC-TYPE" in result
+        assert result["x-ratelimit-remaining-requests"] == "100"
+
+    def test_openai_ratelimit_headers_preserved_without_prefix(self):
+        """Standard OpenAI rate-limit headers should keep their original name."""
+        headers = {
+            "x-ratelimit-limit-requests": "60",
+            "x-ratelimit-remaining-tokens": "5000",
+        }
+        result = get_response_headers(headers)
+        assert result["x-ratelimit-limit-requests"] == "60"
+        assert result["x-ratelimit-remaining-tokens"] == "5000"
+
+
+class TestProcessResponseHeaders:
+    """Tests for process_response_headers in core_helpers.py (streaming path)."""
+
+    def test_custom_header_preserved_with_original_name(self):
+        """Streaming path should also preserve TRAFFIC-TYPE by original name."""
+        headers = {"TRAFFIC-TYPE": "synthetic", "content-type": "application/json"}
+        result = process_response_headers(headers)
+        assert "TRAFFIC-TYPE" in result
+        assert result["TRAFFIC-TYPE"] == "synthetic"
+
+    def test_custom_header_also_has_llm_provider_prefix(self):
+        headers = {"TRAFFIC-TYPE": "synthetic"}
+        result = process_response_headers(headers)
+        assert "llm_provider-TRAFFIC-TYPE" in result
+        assert result["llm_provider-TRAFFIC-TYPE"] == "synthetic"
+
+    def test_already_prefixed_header_not_double_prefixed(self):
+        headers = {"llm_provider-some-header": "value"}
+        result = process_response_headers(headers)
+        assert "llm_provider-some-header" in result
+        assert "llm_provider-llm_provider-some-header" not in result
+
+    def test_openai_headers_preserved(self):
+        headers = {"x-ratelimit-limit-requests": "60", "TRAFFIC-TYPE": "live"}
+        result = process_response_headers(headers)
+        assert result["x-ratelimit-limit-requests"] == "60"
+        assert "TRAFFIC-TYPE" in result
+
+
+class TestProcessAzureHeaders:
+    """Tests for process_azure_headers in azure/common_utils.py."""
+
+    def test_traffic_type_preserved_with_original_name(self):
+        """Azure-specific header processing should preserve TRAFFIC-TYPE."""
+        headers = {
+            "TRAFFIC-TYPE": "synthetic",
+            "x-ratelimit-remaining-requests": "50",
+        }
+        result = process_azure_headers(headers)
+        assert "TRAFFIC-TYPE" in result
+        assert result["TRAFFIC-TYPE"] == "synthetic"
+        assert "llm_provider-TRAFFIC-TYPE" in result
+
+    def test_ratelimit_headers_accessible_by_original_name(self):
+        headers = {
+            "x-ratelimit-limit-requests": "60",
+            "x-ratelimit-remaining-requests": "50",
+            "x-ratelimit-limit-tokens": "10000",
+            "x-ratelimit-remaining-tokens": "5000",
+        }
+        result = process_azure_headers(headers)
+        assert result["x-ratelimit-limit-requests"] == "60"
+        assert result["x-ratelimit-remaining-requests"] == "50"
+        assert result["x-ratelimit-limit-tokens"] == "10000"
+        assert result["x-ratelimit-remaining-tokens"] == "5000"
+
+    def test_empty_headers(self):
+        result = process_azure_headers({})
+        assert result == {}
+
+    def test_multiple_custom_headers_preserved(self):
+        headers = {
+            "TRAFFIC-TYPE": "live",
+            "x-custom-header": "val",
+            "x-ratelimit-limit-requests": "60",
+        }
+        result = process_azure_headers(headers)
+        assert "TRAFFIC-TYPE" in result
+        assert "x-custom-header" in result
+        assert "llm_provider-TRAFFIC-TYPE" in result
+        assert "llm_provider-x-custom-header" in result


### PR DESCRIPTION
Vendor-specific HTTP response headers (e.g. TRAFFIC-TYPE) were only accessible under the llm_provider- prefixed key, making them invisible to consumers that look them up by their original name. This change stores every vendor header under both its original key and the prefixed key across all three header-processing functions:

- _get_llm_provider_headers  (get_headers.py)
- process_response_headers   (core_helpers.py)
- process_azure_headers      (azure/common_utils.py)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
