### PR TITLE
fix(router): support Responses API 'input' field in complexity and au…

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3846,6 +3846,7 @@ class Router:
                     model=model,
                     request_kwargs=kwargs,
                     messages=kwargs.get("messages", None),
+                    input=kwargs.get("input", None),
                     specific_deployment=kwargs.pop("specific_deployment", None),
                 )
             except Exception as e:

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_router_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.router_strategy.utils import extract_text_from_input
 
 if TYPE_CHECKING:
     from semantic_router.routers.base import Route
@@ -81,44 +82,6 @@ class AutoRouter(CustomLogger):
             )
         return auto_router_routes
 
-    @staticmethod
-    def _extract_text_from_input(input: Union[str, List]) -> Optional[str]:
-        """
-        Extract plain text from a Responses API ``input`` field.
-
-        Handles bare strings, ``{type: "text", text: ...}`` items, and
-        ``{type: "message", content: ...}`` items (where ``content`` may
-        itself be a string or a list of ``{type, text}`` parts).
-        """
-        if isinstance(input, str):
-            return input.strip() or None
-
-        if not isinstance(input, list):
-            return None
-
-        parts: List[str] = []
-        for item in input:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                item_type = item.get("type", "")
-                if item_type == "text":
-                    text = item.get("text") or ""
-                    if text:
-                        parts.append(text)
-                elif item_type == "message":
-                    content = item.get("content") or ""
-                    if isinstance(content, str):
-                        if content:
-                            parts.append(content)
-                    elif isinstance(content, list):
-                        for part in content:
-                            if isinstance(part, dict) and part.get("type") == "text":
-                                t = part.get("text") or ""
-                                if t:
-                                    parts.append(t)
-        return " ".join(parts).strip() or None
-
     async def async_pre_routing_hook(
         self,
         model: str,
@@ -132,12 +95,6 @@ class AutoRouter(CustomLogger):
 
         Used for the litellm auto-router to modify the request before the routing decision is made.
         """
-        from semantic_router.routers import SemanticRouter
-        from semantic_router.schema import RouteChoice
-
-        from litellm.router_strategy.auto_router.litellm_encoder import (
-            LiteLLMRouterEncoder,
-        )
         from litellm.types.router import PreRoutingHookResponse
 
         has_messages = messages is not None and len(messages) > 0
@@ -146,6 +103,23 @@ class AutoRouter(CustomLogger):
         if not has_messages and not has_input:
             # do nothing, return same inputs
             return None
+
+        # Responses API: if input is present but yields no usable text, fall
+        # back to the default model without touching the semantic router.
+        if not has_messages and has_input:
+            extracted_early = extract_text_from_input(input)  # type: ignore[arg-type]
+            if extracted_early is None:
+                return PreRoutingHookResponse(
+                    model=self.default_model,
+                    messages=messages,
+                )
+
+        from semantic_router.routers import SemanticRouter
+        from semantic_router.schema import RouteChoice
+
+        from litellm.router_strategy.auto_router.litellm_encoder import (
+            LiteLLMRouterEncoder,
+        )
 
         if self.routelayer is None:
             #######################
@@ -164,8 +138,8 @@ class AutoRouter(CustomLogger):
             user_message_dict: Dict[str, str] = messages[-1]  # type: ignore[index]
             message_content: str = user_message_dict.get("content", "")
         else:
-            # Responses API: extract plain text from ``input``
-            message_content = self._extract_text_from_input(input) or ""  # type: ignore[arg-type]
+            # extracted_early is guaranteed non-None here (None case returned above)
+            message_content = extracted_early  # type: ignore[assignment]
         route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(
             text=message_content
         )

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -81,6 +81,44 @@ class AutoRouter(CustomLogger):
             )
         return auto_router_routes
 
+    @staticmethod
+    def _extract_text_from_input(input: Union[str, List]) -> Optional[str]:
+        """
+        Extract plain text from a Responses API ``input`` field.
+
+        Handles bare strings, ``{type: "text", text: ...}`` items, and
+        ``{type: "message", content: ...}`` items (where ``content`` may
+        itself be a string or a list of ``{type, text}`` parts).
+        """
+        if isinstance(input, str):
+            return input.strip() or None
+
+        if not isinstance(input, list):
+            return None
+
+        parts: List[str] = []
+        for item in input:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                item_type = item.get("type", "")
+                if item_type == "text":
+                    text = item.get("text") or ""
+                    if text:
+                        parts.append(text)
+                elif item_type == "message":
+                    content = item.get("content") or ""
+                    if isinstance(content, str):
+                        if content:
+                            parts.append(content)
+                    elif isinstance(content, list):
+                        for part in content:
+                            if isinstance(part, dict) and part.get("type") == "text":
+                                t = part.get("text") or ""
+                                if t:
+                                    parts.append(t)
+        return " ".join(parts).strip() or None
+
     async def async_pre_routing_hook(
         self,
         model: str,
@@ -102,7 +140,10 @@ class AutoRouter(CustomLogger):
         )
         from litellm.types.router import PreRoutingHookResponse
 
-        if messages is None:
+        has_messages = messages is not None and len(messages) > 0
+        has_input = input is not None
+
+        if not has_messages and not has_input:
             # do nothing, return same inputs
             return None
 
@@ -119,8 +160,12 @@ class AutoRouter(CustomLogger):
                 auto_sync=self.auto_sync_value,
             )
 
-        user_message: Dict[str, str] = messages[-1]
-        message_content: str = user_message.get("content", "")
+        if has_messages:
+            user_message_dict: Dict[str, str] = messages[-1]  # type: ignore[index]
+            message_content: str = user_message_dict.get("content", "")
+        else:
+            # Responses API: extract plain text from ``input``
+            message_content = self._extract_text_from_input(input) or ""  # type: ignore[arg-type]
         route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(
             text=message_content
         )

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from litellm._logging import verbose_router_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.router_strategy.utils import extract_text_from_input
 
 from .config import (
     DEFAULT_CODE_KEYWORDS,
@@ -331,52 +332,6 @@ class ComplexityRouter(CustomLogger):
             f"No model configured for tier {tier_key} and no default_model set"
         )
 
-    @staticmethod
-    def _extract_text_from_input(input: Union[str, List]) -> Optional[str]:
-        """
-        Extract plain text from a Responses API ``input`` field.
-
-        The Responses API accepts either a bare string or a list of input
-        items (``ResponseInputParam``).  Each item may be:
-
-        * A plain ``str``.
-        * A dict with ``type="text"`` and a ``text`` key.
-        * A dict with ``type="message"`` whose ``content`` is itself a list
-          of content parts (same ``{type, text}`` shape).
-
-        Returns the concatenated text, or ``None`` when nothing extractable
-        is found.
-        """
-        if isinstance(input, str):
-            return input.strip() or None
-
-        if not isinstance(input, list):
-            return None
-
-        parts: List[str] = []
-        for item in input:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                item_type = item.get("type", "")
-                if item_type == "text":
-                    text = item.get("text") or ""
-                    if text:
-                        parts.append(text)
-                elif item_type == "message":
-                    # { type: "message", role: "...", content: str | list }
-                    content = item.get("content") or ""
-                    if isinstance(content, str):
-                        if content:
-                            parts.append(content)
-                    elif isinstance(content, list):
-                        for part in content:
-                            if isinstance(part, dict) and part.get("type") == "text":
-                                t = part.get("text") or ""
-                                if t:
-                                    parts.append(t)
-        return " ".join(parts).strip() or None
-
     async def async_pre_routing_hook(
         self,
         model: str,
@@ -436,7 +391,7 @@ class ComplexityRouter(CustomLogger):
                         system_prompt = content
         elif has_input:
             # Responses API: extract text from the input field
-            user_message = self._extract_text_from_input(input)  # type: ignore[arg-type]
+            user_message = extract_text_from_input(input)  # type: ignore[arg-type]
             verbose_router_logger.debug(
                 f"ComplexityRouter: extracted text from Responses API input: {user_message!r}"
             )

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -331,6 +331,52 @@ class ComplexityRouter(CustomLogger):
             f"No model configured for tier {tier_key} and no default_model set"
         )
 
+    @staticmethod
+    def _extract_text_from_input(input: Union[str, List]) -> Optional[str]:
+        """
+        Extract plain text from a Responses API ``input`` field.
+
+        The Responses API accepts either a bare string or a list of input
+        items (``ResponseInputParam``).  Each item may be:
+
+        * A plain ``str``.
+        * A dict with ``type="text"`` and a ``text`` key.
+        * A dict with ``type="message"`` whose ``content`` is itself a list
+          of content parts (same ``{type, text}`` shape).
+
+        Returns the concatenated text, or ``None`` when nothing extractable
+        is found.
+        """
+        if isinstance(input, str):
+            return input.strip() or None
+
+        if not isinstance(input, list):
+            return None
+
+        parts: List[str] = []
+        for item in input:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                item_type = item.get("type", "")
+                if item_type == "text":
+                    text = item.get("text") or ""
+                    if text:
+                        parts.append(text)
+                elif item_type == "message":
+                    # { type: "message", role: "...", content: str | list }
+                    content = item.get("content") or ""
+                    if isinstance(content, str):
+                        if content:
+                            parts.append(content)
+                    elif isinstance(content, list):
+                        for part in content:
+                            if isinstance(part, dict) and part.get("type") == "text":
+                                t = part.get("text") or ""
+                                if t:
+                                    parts.append(t)
+        return " ".join(parts).strip() or None
+
     async def async_pre_routing_hook(
         self,
         model: str,
@@ -343,12 +389,14 @@ class ComplexityRouter(CustomLogger):
         Pre-routing hook called before the routing decision.
 
         Classifies the request by complexity and returns the appropriate model.
+        Supports both the Chat Completions API (``messages``) and the Responses
+        API (``input``).
 
         Args:
             model: The original model name requested.
             request_kwargs: The request kwargs.
-            messages: The messages in the request.
-            input: Optional input for embeddings.
+            messages: The messages in the request (Chat Completions API).
+            input: The input field from a Responses API request.
             specific_deployment: Whether a specific deployment was requested.
 
         Returns:
@@ -356,9 +404,12 @@ class ComplexityRouter(CustomLogger):
         """
         from litellm.types.router import PreRoutingHookResponse
 
-        if messages is None or len(messages) == 0:
+        has_messages = messages is not None and len(messages) > 0
+        has_input = input is not None
+
+        if not has_messages and not has_input:
             verbose_router_logger.debug(
-                "ComplexityRouter: No messages provided, skipping routing"
+                "ComplexityRouter: No messages or input provided, skipping routing"
             )
             return None
 
@@ -366,22 +417,29 @@ class ComplexityRouter(CustomLogger):
         user_message: Optional[str] = None
         system_prompt: Optional[str] = None
 
-        for msg in reversed(messages):
-            role = msg.get("role", "")
-            content = msg.get("content") or ""
-            # content may be a list of content parts (e.g. [{"type": "text", "text": "..."}])
-            if isinstance(content, list):
-                text_parts = [
-                    part.get("text", "")
-                    for part in content
-                    if isinstance(part, dict) and part.get("type") == "text"
-                ]
-                content = " ".join(text_parts).strip()
-            if isinstance(content, str) and content:
-                if role == "user" and user_message is None:
-                    user_message = content
-                elif role == "system" and system_prompt is None:
-                    system_prompt = content
+        if has_messages:
+            for msg in reversed(messages):  # type: ignore[arg-type]
+                role = msg.get("role", "")
+                content = msg.get("content") or ""
+                # content may be a list of content parts (e.g. [{"type": "text", "text": "..."}])
+                if isinstance(content, list):
+                    text_parts = [
+                        part.get("text", "")
+                        for part in content
+                        if isinstance(part, dict) and part.get("type") == "text"
+                    ]
+                    content = " ".join(text_parts).strip()
+                if isinstance(content, str) and content:
+                    if role == "user" and user_message is None:
+                        user_message = content
+                    elif role == "system" and system_prompt is None:
+                        system_prompt = content
+        elif has_input:
+            # Responses API: extract text from the input field
+            user_message = self._extract_text_from_input(input)  # type: ignore[arg-type]
+            verbose_router_logger.debug(
+                f"ComplexityRouter: extracted text from Responses API input: {user_message!r}"
+            )
 
         if user_message is None:
             verbose_router_logger.debug(

--- a/litellm/router_strategy/utils.py
+++ b/litellm/router_strategy/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for router strategies."""
+from typing import List, Optional, Union
+
+
+def extract_text_from_input(input: Union[str, List]) -> Optional[str]:
+    """
+    Extract plain text from a Responses API ``input`` field.
+
+    The Responses API accepts either a bare string or a list of input
+    items (``ResponseInputParam``).  Each item may be:
+
+    * A plain ``str``.
+    * A dict with ``type="text"`` and a ``text`` key.
+    * A dict with ``type="message"`` whose ``content`` is itself a string
+      or a list of content parts (same ``{type, text}`` shape).
+
+    Returns the concatenated text, or ``None`` when nothing extractable
+    is found.
+    """
+    if isinstance(input, str):
+        return input.strip() or None
+
+    if not isinstance(input, list):
+        return None
+
+    parts: List[str] = []
+    for item in input:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            item_type = item.get("type", "")
+            if item_type == "text":
+                text = item.get("text") or ""
+                if text:
+                    parts.append(text)
+            elif item_type == "message":
+                content = item.get("content") or ""
+                if isinstance(content, str):
+                    if content:
+                        parts.append(content)
+                elif isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            t = part.get("text") or ""
+                            if t:
+                                parts.append(t)
+    return " ".join(parts).strip() or None

--- a/litellm/router_strategy/utils.py
+++ b/litellm/router_strategy/utils.py
@@ -40,7 +40,11 @@ def extract_text_from_input(input: Union[str, List]) -> Optional[str]:
                         parts.append(content)
                 elif isinstance(content, list):
                     for part in content:
-                        if isinstance(part, dict) and part.get("type") == "text":
+                        # Responses API uses "input_text"; Chat Completions uses "text"
+                        if isinstance(part, dict) and part.get("type") in (
+                            "text",
+                            "input_text",
+                        ):
                             t = part.get("text") or ""
                             if t:
                                 parts.append(t)

--- a/tests/test_litellm/router_strategy/test_auto_router_responses_api.py
+++ b/tests/test_litellm/router_strategy/test_auto_router_responses_api.py
@@ -3,11 +3,12 @@ Tests for AutoRouter Responses API (input field) support.
 
 These tests cover the new ``has_messages / has_input`` branching logic and the
 empty-string guard in ``AutoRouter.async_pre_routing_hook``.  They do NOT
-require ``semantic_router`` to be installed because they only exercise code
-paths that return before any SemanticRouter call.
+require ``semantic_router`` to be installed because they stub it out via
+``sys.modules`` patching.
 """
 import os
 import sys
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,94 +17,201 @@ sys.path.insert(0, os.path.abspath("../../.."))
 
 # semantic_router is an optional dependency (beta feature). Stub it out so
 # these tests can run in environments where it is not installed.
+class _FakeRouteChoice:
+    """Minimal stand-in so ``isinstance(x, RouteChoice)`` is a valid check."""
+    pass
+
+
 _SEMANTIC_ROUTER_MOCK = MagicMock()
+# RouteChoice must be a real class for isinstance() to work
+_SEMANTIC_ROUTER_MOCK.schema.RouteChoice = _FakeRouteChoice
+
+_LITELLM_ENCODER_MOCK = MagicMock()
 _SEMANTIC_ROUTER_STUBS = {
+    # semantic_router and every sub-module that async_pre_routing_hook imports
     "semantic_router": _SEMANTIC_ROUTER_MOCK,
     "semantic_router.routers": _SEMANTIC_ROUTER_MOCK.routers,
     "semantic_router.schema": _SEMANTIC_ROUTER_MOCK.schema,
     "semantic_router.routers.base": _SEMANTIC_ROUTER_MOCK.routers.base,
+    "semantic_router.encoders": _SEMANTIC_ROUTER_MOCK.encoders,
+    "semantic_router.encoders.base": _SEMANTIC_ROUTER_MOCK.encoders.base,
+    # litellm_encoder imports semantic_router internally; stub the whole module
+    # so tests that pre-set routelayer never instantiate LiteLLMRouterEncoder
+    "litellm.router_strategy.auto_router.litellm_encoder": _LITELLM_ENCODER_MOCK,
 }
 
 
-def _make_auto_router(default_model: str = "default-model") -> "AutoRouter":  # type: ignore[name-defined]
-    """Create an AutoRouter instance without requiring semantic_router."""
+@contextmanager
+def _semantic_router_patched():
+    """Context manager that stubs semantic_router for both init and method calls."""
     with patch.dict(sys.modules, _SEMANTIC_ROUTER_STUBS):
-        from litellm.router_strategy.auto_router.auto_router import AutoRouter
+        yield
 
-        with patch.object(AutoRouter, "_load_semantic_routing_routes", return_value=[]):
-            return AutoRouter(
-                model_name="test-auto-router",
-                default_model=default_model,
-                embedding_model="text-embedding-model",
-                litellm_router_instance=MagicMock(),
-            )
+
+def _make_auto_router(default_model: str = "default-model"):
+    """
+    Create an AutoRouter instance without requiring semantic_router.
+
+    Must be called inside a ``_semantic_router_patched()`` context when the
+    returned instance will be used in a method call that reaches the
+    ``from semantic_router...`` imports (i.e. non-early-return paths).
+    """
+    from litellm.router_strategy.auto_router.auto_router import AutoRouter
+
+    with patch.object(AutoRouter, "_load_semantic_routing_routes", return_value=[]):
+        return AutoRouter(
+            model_name="test-auto-router",
+            default_model=default_model,
+            embedding_model="text-embedding-model",
+            litellm_router_instance=MagicMock(),
+        )
+
+
+def _mock_routelayer(routed_model: str = "routed-model") -> MagicMock:
+    """Return a mock routelayer that yields ``routed_model`` via a list RouteChoice."""
+    mock_choice = MagicMock()
+    mock_choice.name = routed_model
+    return MagicMock(return_value=[mock_choice])
 
 
 class TestAutoRouterResponsesAPIEarlyReturns:
     """
     Tests for async_pre_routing_hook paths that return before calling the
-    semantic router — safe to run without semantic_router installed.
+    semantic router (before ``from semantic_router...`` imports fire).
     """
 
     @pytest.mark.asyncio
     async def test_no_messages_no_input_returns_none(self):
         """When both messages and input are absent, the hook skips routing."""
-        auto_router = _make_auto_router()
-        result = await auto_router.async_pre_routing_hook(
-            model="test-model",
-            request_kwargs={},
-            messages=None,
-            input=None,
-        )
+        with _semantic_router_patched():
+            auto_router = _make_auto_router()
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=None,
+                input=None,
+            )
         assert result is None
 
     @pytest.mark.asyncio
     async def test_empty_messages_no_input_returns_none(self):
         """An empty messages list with no input also skips routing."""
-        auto_router = _make_auto_router()
-        result = await auto_router.async_pre_routing_hook(
-            model="test-model",
-            request_kwargs={},
-            messages=[],
-            input=None,
-        )
+        with _semantic_router_patched():
+            auto_router = _make_auto_router()
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=[],
+                input=None,
+            )
         assert result is None
 
     @pytest.mark.asyncio
     async def test_empty_string_input_returns_default_model(self):
         """An empty string input falls back to the default model (not routelayer)."""
-        auto_router = _make_auto_router(default_model="my-default")
-        result = await auto_router.async_pre_routing_hook(
-            model="test-model",
-            request_kwargs={},
-            messages=None,
-            input="",
-        )
+        with _semantic_router_patched():
+            auto_router = _make_auto_router(default_model="my-default")
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=None,
+                input="",
+            )
         assert result is not None
         assert result.model == "my-default"
 
     @pytest.mark.asyncio
     async def test_whitespace_only_input_returns_default_model(self):
         """A whitespace-only input is treated the same as empty — use default."""
-        auto_router = _make_auto_router(default_model="my-default")
-        result = await auto_router.async_pre_routing_hook(
-            model="test-model",
-            request_kwargs={},
-            messages=None,
-            input="   ",
-        )
+        with _semantic_router_patched():
+            auto_router = _make_auto_router(default_model="my-default")
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=None,
+                input="   ",
+            )
         assert result is not None
         assert result.model == "my-default"
 
     @pytest.mark.asyncio
     async def test_empty_list_input_returns_default_model(self):
         """An empty list input falls back to the default model."""
-        auto_router = _make_auto_router(default_model="my-default")
-        result = await auto_router.async_pre_routing_hook(
-            model="test-model",
-            request_kwargs={},
-            messages=None,
-            input=[],
-        )
+        with _semantic_router_patched():
+            auto_router = _make_auto_router(default_model="my-default")
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=None,
+                input=[],
+            )
         assert result is not None
         assert result.model == "my-default"
+
+
+class TestAutoRouterMessagesAndInputRouting:
+    """
+    Tests for the has_messages and else (input) branches that reach the
+    semantic router.  routelayer is pre-set on the instance to skip the
+    lazy-init block and avoid LiteLLMRouterEncoder instantiation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_messages_branch_passes_content_to_routelayer(self):
+        """has_messages=True: last message content is passed to routelayer."""
+        with _semantic_router_patched():
+            auto_router = _make_auto_router(default_model="my-default")
+            auto_router.routelayer = _mock_routelayer("chat-model")
+
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=[{"role": "user", "content": "Hello world"}],
+                input=None,
+            )
+
+        assert result is not None
+        assert result.model == "chat-model"
+        auto_router.routelayer.assert_called_once_with(text="Hello world")
+
+    @pytest.mark.asyncio
+    async def test_input_branch_passes_extracted_text_to_routelayer(self):
+        """has_input=True, has_messages=False: extracted input text sent to routelayer."""
+        with _semantic_router_patched():
+            auto_router = _make_auto_router(default_model="my-default")
+            auto_router.routelayer = _mock_routelayer("responses-model")
+
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=None,
+                input="Hello from Responses API",
+            )
+
+        assert result is not None
+        assert result.model == "responses-model"
+        auto_router.routelayer.assert_called_once_with(text="Hello from Responses API")
+
+    @pytest.mark.asyncio
+    async def test_input_list_branch_passes_extracted_text_to_routelayer(self):
+        """Responses API list input: extracted text from input_text parts sent to routelayer."""
+        with _semantic_router_patched():
+            auto_router = _make_auto_router(default_model="my-default")
+            auto_router.routelayer = _mock_routelayer("responses-model")
+
+            result = await auto_router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=None,
+                input=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Hello from list"}],
+                    }
+                ],
+            )
+
+        assert result is not None
+        assert result.model == "responses-model"
+        auto_router.routelayer.assert_called_once_with(text="Hello from list")

--- a/tests/test_litellm/router_strategy/test_auto_router_responses_api.py
+++ b/tests/test_litellm/router_strategy/test_auto_router_responses_api.py
@@ -1,0 +1,109 @@
+"""
+Tests for AutoRouter Responses API (input field) support.
+
+These tests cover the new ``has_messages / has_input`` branching logic and the
+empty-string guard in ``AutoRouter.async_pre_routing_hook``.  They do NOT
+require ``semantic_router`` to be installed because they only exercise code
+paths that return before any SemanticRouter call.
+"""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+# semantic_router is an optional dependency (beta feature). Stub it out so
+# these tests can run in environments where it is not installed.
+_SEMANTIC_ROUTER_MOCK = MagicMock()
+_SEMANTIC_ROUTER_STUBS = {
+    "semantic_router": _SEMANTIC_ROUTER_MOCK,
+    "semantic_router.routers": _SEMANTIC_ROUTER_MOCK.routers,
+    "semantic_router.schema": _SEMANTIC_ROUTER_MOCK.schema,
+    "semantic_router.routers.base": _SEMANTIC_ROUTER_MOCK.routers.base,
+}
+
+
+def _make_auto_router(default_model: str = "default-model") -> "AutoRouter":  # type: ignore[name-defined]
+    """Create an AutoRouter instance without requiring semantic_router."""
+    with patch.dict(sys.modules, _SEMANTIC_ROUTER_STUBS):
+        from litellm.router_strategy.auto_router.auto_router import AutoRouter
+
+        with patch.object(AutoRouter, "_load_semantic_routing_routes", return_value=[]):
+            return AutoRouter(
+                model_name="test-auto-router",
+                default_model=default_model,
+                embedding_model="text-embedding-model",
+                litellm_router_instance=MagicMock(),
+            )
+
+
+class TestAutoRouterResponsesAPIEarlyReturns:
+    """
+    Tests for async_pre_routing_hook paths that return before calling the
+    semantic router — safe to run without semantic_router installed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_messages_no_input_returns_none(self):
+        """When both messages and input are absent, the hook skips routing."""
+        auto_router = _make_auto_router()
+        result = await auto_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input=None,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_messages_no_input_returns_none(self):
+        """An empty messages list with no input also skips routing."""
+        auto_router = _make_auto_router()
+        result = await auto_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[],
+            input=None,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_string_input_returns_default_model(self):
+        """An empty string input falls back to the default model (not routelayer)."""
+        auto_router = _make_auto_router(default_model="my-default")
+        result = await auto_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input="",
+        )
+        assert result is not None
+        assert result.model == "my-default"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_input_returns_default_model(self):
+        """A whitespace-only input is treated the same as empty — use default."""
+        auto_router = _make_auto_router(default_model="my-default")
+        result = await auto_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input="   ",
+        )
+        assert result is not None
+        assert result.model == "my-default"
+
+    @pytest.mark.asyncio
+    async def test_empty_list_input_returns_default_model(self):
+        """An empty list input falls back to the default model."""
+        auto_router = _make_auto_router(default_model="my-default")
+        result = await auto_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input=[],
+        )
+        assert result is not None
+        assert result.model == "my-default"

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -728,8 +728,8 @@ class TestExtractTextFromInput:
         )
         assert result == "Hello world"
 
-    def test_message_type_item_list_content(self):
-        """A {type: message} item whose content is a list of text parts."""
+    def test_message_type_item_list_content_text(self):
+        """A {type: message} item whose content uses Chat Completions 'text' parts."""
         result = extract_text_from_input(
             [
                 {
@@ -739,6 +739,23 @@ class TestExtractTextFromInput:
                         {"type": "text", "text": "Hello"},
                         {"type": "image_url", "image_url": {"url": "data:..."}},
                         {"type": "text", "text": "world"},
+                    ],
+                }
+            ]
+        )
+        assert result == "Hello world"
+
+    def test_message_type_item_list_content_input_text(self):
+        """A {type: message} item whose content uses Responses API 'input_text' parts."""
+        result = extract_text_from_input(
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Hello"},
+                        {"type": "input_image", "image_url": "data:..."},
+                        {"type": "input_text", "text": "world"},
                     ],
                 }
             ]

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -698,6 +698,186 @@ class TestEdgeCases:
         assert any("multi-step" in s.lower() for s in signals), f"Expected multi-step signal, got {signals}"
 
 
+class TestExtractTextFromInput:
+    """Tests for ComplexityRouter._extract_text_from_input."""
+
+    def test_plain_string(self, complexity_router):
+        """A plain string is returned as-is."""
+        assert complexity_router._extract_text_from_input("Hello world") == "Hello world"
+
+    def test_empty_string(self, complexity_router):
+        """An empty / whitespace-only string returns None."""
+        assert complexity_router._extract_text_from_input("") is None
+        assert complexity_router._extract_text_from_input("   ") is None
+
+    def test_text_type_item(self, complexity_router):
+        """A list with a single {type: text, text: ...} item."""
+        result = complexity_router._extract_text_from_input(
+            [{"type": "text", "text": "Hello world"}]
+        )
+        assert result == "Hello world"
+
+    def test_message_type_item_string_content(self, complexity_router):
+        """A list with a {type: message, content: str} item."""
+        result = complexity_router._extract_text_from_input(
+            [{"type": "message", "role": "user", "content": "Hello world"}]
+        )
+        assert result == "Hello world"
+
+    def test_message_type_item_list_content(self, complexity_router):
+        """A {type: message} item whose content is a list of text parts."""
+        result = complexity_router._extract_text_from_input(
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Hello"},
+                        {"type": "image_url", "image_url": {"url": "data:..."}},
+                        {"type": "text", "text": "world"},
+                    ],
+                }
+            ]
+        )
+        assert result == "Hello world"
+
+    def test_multiple_items_concatenated(self, complexity_router):
+        """Multiple text items are joined with spaces."""
+        result = complexity_router._extract_text_from_input(
+            [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "world"},
+            ]
+        )
+        assert result == "Hello world"
+
+    def test_empty_list(self, complexity_router):
+        """An empty list returns None."""
+        assert complexity_router._extract_text_from_input([]) is None
+
+    def test_list_with_no_text(self, complexity_router):
+        """A list with only non-text items returns None."""
+        result = complexity_router._extract_text_from_input(
+            [{"type": "image_url", "image_url": {"url": "data:..."}}]
+        )
+        assert result is None
+
+    def test_non_list_non_string(self, complexity_router):
+        """Non-string, non-list input returns None."""
+        assert complexity_router._extract_text_from_input(42) is None  # type: ignore[arg-type]
+
+
+class TestPreRoutingHookResponsesAPI:
+    """Tests for async_pre_routing_hook with the Responses API ``input`` field."""
+
+    @pytest.mark.asyncio
+    async def test_responses_api_plain_string_simple(self, complexity_router):
+        """Responses API with a simple plain-string input routes to SIMPLE tier."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input="Hello!",
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_responses_api_plain_string_reasoning(self, complexity_router):
+        """Responses API routes a reasoning-heavy input to REASONING tier."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input=(
+                "Let's think step by step and reason through this: "
+                "analyze the architecture carefully."
+            ),
+        )
+        assert result is not None
+        assert result.model == "o1-preview"
+
+    @pytest.mark.asyncio
+    async def test_responses_api_text_type_item(self, complexity_router):
+        """Responses API with a list of text-type items routes correctly."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input=[{"type": "text", "text": "Hello!"}],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_responses_api_message_type_item(self, complexity_router):
+        """Responses API with a message-type item (list content) routes correctly."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input=[
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello!"}],
+                }
+            ],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_responses_api_no_messages_no_input_returns_none(
+        self, complexity_router
+    ):
+        """When both messages and input are absent, the hook skips routing."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input=None,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_responses_api_empty_input_returns_default(self, complexity_router):
+        """An empty string input falls back to the default model."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=None,
+            input="",
+        )
+        assert result is not None
+        assert result.model in [
+            "gpt-4o-mini",
+            "gpt-4o",
+            "claude-sonnet-4-20250514",
+            "o1-preview",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_messages_take_priority_over_input(self, complexity_router):
+        """When both messages and input are present, messages are used."""
+        # messages says REASONING but input says SIMPLE — messages should win
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        "Think step by step and reason through: design a distributed system."
+                    ),
+                }
+            ],
+            input="Hello!",
+        )
+        assert result is not None
+        assert result.model == "o1-preview"
+
+
 class TestRouterComplexityDeploymentMethods:
     """Tests for Router._is_complexity_router_deployment and Router.init_complexity_router_deployment."""
 

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -24,6 +24,7 @@ from litellm.router_strategy.complexity_router.config import (
     ComplexityRouterConfig,
     ComplexityTier,
 )
+from litellm.router_strategy.utils import extract_text_from_input
 
 
 @pytest.fixture
@@ -699,34 +700,37 @@ class TestEdgeCases:
 
 
 class TestExtractTextFromInput:
-    """Tests for ComplexityRouter._extract_text_from_input."""
+    """Tests for the shared extract_text_from_input utility."""
 
-    def test_plain_string(self, complexity_router):
+    def test_plain_string(self):
         """A plain string is returned as-is."""
-        assert complexity_router._extract_text_from_input("Hello world") == "Hello world"
+        assert extract_text_from_input("Hello world") == "Hello world"
 
-    def test_empty_string(self, complexity_router):
+    def test_empty_string(self):
         """An empty / whitespace-only string returns None."""
-        assert complexity_router._extract_text_from_input("") is None
-        assert complexity_router._extract_text_from_input("   ") is None
+        assert extract_text_from_input("") is None
+        assert extract_text_from_input("   ") is None
 
-    def test_text_type_item(self, complexity_router):
+    def test_text_type_item(self):
         """A list with a single {type: text, text: ...} item."""
-        result = complexity_router._extract_text_from_input(
-            [{"type": "text", "text": "Hello world"}]
-        )
+        result = extract_text_from_input([{"type": "text", "text": "Hello world"}])
         assert result == "Hello world"
 
-    def test_message_type_item_string_content(self, complexity_router):
+    def test_plain_string_item_in_list(self):
+        """A list containing a bare string item is appended directly."""
+        result = extract_text_from_input(["Hello", "world"])
+        assert result == "Hello world"
+
+    def test_message_type_item_string_content(self):
         """A list with a {type: message, content: str} item."""
-        result = complexity_router._extract_text_from_input(
+        result = extract_text_from_input(
             [{"type": "message", "role": "user", "content": "Hello world"}]
         )
         assert result == "Hello world"
 
-    def test_message_type_item_list_content(self, complexity_router):
+    def test_message_type_item_list_content(self):
         """A {type: message} item whose content is a list of text parts."""
-        result = complexity_router._extract_text_from_input(
+        result = extract_text_from_input(
             [
                 {
                     "type": "message",
@@ -741,9 +745,9 @@ class TestExtractTextFromInput:
         )
         assert result == "Hello world"
 
-    def test_multiple_items_concatenated(self, complexity_router):
+    def test_multiple_items_concatenated(self):
         """Multiple text items are joined with spaces."""
-        result = complexity_router._extract_text_from_input(
+        result = extract_text_from_input(
             [
                 {"type": "text", "text": "Hello"},
                 {"type": "text", "text": "world"},
@@ -751,20 +755,20 @@ class TestExtractTextFromInput:
         )
         assert result == "Hello world"
 
-    def test_empty_list(self, complexity_router):
+    def test_empty_list(self):
         """An empty list returns None."""
-        assert complexity_router._extract_text_from_input([]) is None
+        assert extract_text_from_input([]) is None
 
-    def test_list_with_no_text(self, complexity_router):
+    def test_list_with_no_text(self):
         """A list with only non-text items returns None."""
-        result = complexity_router._extract_text_from_input(
+        result = extract_text_from_input(
             [{"type": "image_url", "image_url": {"url": "data:..."}}]
         )
         assert result is None
 
-    def test_non_list_non_string(self, complexity_router):
+    def test_non_list_non_string(self):
         """Non-string, non-list input returns None."""
-        assert complexity_router._extract_text_from_input(42) is None  # type: ignore[arg-type]
+        assert extract_text_from_input(42) is None  # type: ignore[arg-type]
 
 
 class TestPreRoutingHookResponsesAPI:


### PR DESCRIPTION
…to routers

- Pass 'input' parameter through _ageneric_api_call_with_fallbacks_helper
- Implement _extract_text_from_input in Complexity and Auto routers
- Handle various Responses API input schemas (string, list of dicts)
- Fixes 'Unmapped LLM provider' error for /v1/responses endpoint

Closes #25134

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
# Local test run output:
tests/test_litellm/router_strategy/test_complexity_router.py::TestExtractTextFromInput PASSED
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI PASSED
...
72 passed in 4.52s

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->
BEFORE FIX:
=========================================== short test summary info ============================================
FAILED tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_empty_input_returns_default - assert None is not None
FAILED tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_message_type_item - assert None is not None
FAILED tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_plain_string_reasoning - assert None is not None
FAILED tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_plain_string_simple - assert None is not None
FAILED tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_text_type_item - assert None is not None
========================================= 5 failed, 2 passed in 0.31s ==========================================

AFTER FIX：
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_messages_take_priority_over_input PASSED [ 14%]
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_empty_input_returns_default PASSED [ 28%]
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_message_type_item PASSED [ 42%]
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_no_messages_no_input_returns_none PASSED [ 57%]
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_plain_string_reasoning PASSED [ 71%]
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_plain_string_simple PASSED [ 85%]
tests/test_litellm/router_strategy/test_complexity_router.py::TestPreRoutingHookResponsesAPI::test_responses_api_text_type_item PASSED [100%]

============================================== 7 passed in 0.19s ===============================================


## Type
🐛 Bug Fix
✅ Test

## Changes
Key Changes:

1. litellm/router.py: Updated _ageneric_api_call_with_fallbacks_helper to pass the input parameter into async_get_available_deployment.

2. ComplexityRouter & AutoRouter:

    a. Implemented _extract_text_from_input() static method to normalize inputs from the Responses API (supporting strings, simple text objects, and complex message lists).
    
    b. Updated async_pre_routing_hook to prioritize messages but fallback to input if messages is null.

3. Comprehensive Testing: Added 17 new test cases covering various input schemas and edge cases to ensure robust text extraction and routing.
