### PR TITLE
scope /global/spend/report for non-admins; default to user-wide spend; allow /spend/logs/v2 for internal users

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -572,6 +572,7 @@ class LiteLLMRoutes(enum.Enum):
         "/spend/tags",
         "/spend/calculate",
         "/spend/logs",
+        "/spend/logs/v2",
         "/spend/logs/ui",
         "/spend/logs/session/ui",
         "/cost/estimate",

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3,7 +3,7 @@ import collections
 import json
 import os
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -945,7 +945,6 @@ async def get_global_spend_provider(
 @router.get(
     "/global/spend/report",
     tags=["Budget & Spend Tracking"],
-    dependencies=[Depends(user_api_key_auth)],
     responses={
         200: {"model": List[LiteLLM_SpendLogs]},
     },
@@ -979,6 +978,7 @@ async def get_global_spend_report(
         default=None,
         description="View spend for a specific customer_id. Example customer_id='1234. Can be used in conjunction with team_id as well.",
     ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
     Get Daily Spend per Team, based on specific startTime and endTime. Per team, view usage by each key, model
@@ -1033,6 +1033,16 @@ async def get_global_spend_report(
             raise ValueError(
                 "/spend/report endpoint " + CommonProxyErrors.not_premium_user.value
             )
+
+        api_key, internal_user_id = await _apply_global_spend_report_rbac(
+            user_api_key_dict=user_api_key_dict,
+            api_key=api_key,
+            internal_user_id=internal_user_id,
+            team_id=team_id,
+            customer_id=customer_id,
+            prisma_client=prisma_client,
+        )
+
         if api_key is not None:
             verbose_proxy_logger.debug(
                 "Getting /spend for api_key: [set=%s]", api_key is not None
@@ -3540,6 +3550,95 @@ async def _can_team_member_view_log(
         team_obj=team_obj,
         permission=KeyManagementRoutes.SPEND_LOGS.value,
     )
+
+
+async def _apply_global_spend_report_rbac(
+    user_api_key_dict: UserAPIKeyAuth,
+    api_key: Optional[str],
+    internal_user_id: Optional[str],
+    team_id: Optional[str],
+    customer_id: Optional[str],
+    prisma_client: Any,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    For non-proxy-admin callers, enforce that global spend report cannot return
+    deployment-wide data unless explicitly filtered.
+
+    Returns ``(effective_api_key, effective_internal_user_id)``. When the caller
+    does not specify filters, defaults to all spend for their ``user_id`` (all
+    keys owned by that user) if ``user_id`` is set; otherwise to the caller's
+    virtual key hash only.
+    """
+    from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+
+    if _user_has_admin_view(user_api_key_dict):
+        return api_key, internal_user_id
+
+    if team_id is not None and customer_id is not None:
+        if not await _can_team_member_view_log(
+            prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
+            team_id=team_id,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Not authorized to view spend for this team and customer."
+                },
+            )
+
+    if internal_user_id is not None:
+        if user_api_key_dict.user_id != internal_user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Not authorized to view another user's spend (internal_user_id mismatch)."
+                },
+            )
+
+    if api_key is not None:
+        requested_hash = (
+            hash_token(token=api_key) if api_key.startswith("sk-") else api_key
+        )
+        if user_api_key_dict.api_key != requested_hash:
+            if user_api_key_dict.user_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Not authorized to view spend for this API key."
+                    },
+                )
+            key_row = await prisma_client.db.litellm_verificationtoken.find_first(
+                where={"token": requested_hash}
+            )
+            if (
+                key_row is None
+                or getattr(key_row, "user_id", None) != user_api_key_dict.user_id
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "Not authorized to view spend for this API key."
+                    },
+                )
+
+    if (
+        api_key is None
+        and internal_user_id is None
+        and not (team_id is not None and customer_id is not None)
+    ):
+        if user_api_key_dict.user_id is not None:
+            return None, user_api_key_dict.user_id
+        if not user_api_key_dict.api_key:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "Cannot resolve caller API key or user id for spend report scoping."
+                },
+            )
+        return user_api_key_dict.api_key, None
+
+    return api_key, internal_user_id
 
 
 def _can_user_view_spend_log(user_api_key_dict: UserAPIKeyAuth) -> bool:

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -318,6 +318,135 @@ async def test_assert_user_can_view_request_id_rejects_both_users_none():
     assert exc_info.value.status_code == 403
 
 
+@pytest.mark.asyncio
+async def test_global_spend_report_rbac_admin_passes_through_api_key():
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin",
+        api_key="hashed-admin",
+    )
+    out_key, out_uid = await spend_management_endpoints._apply_global_spend_report_rbac(
+        user_api_key_dict=auth,
+        api_key=None,
+        internal_user_id=None,
+        team_id=None,
+        customer_id=None,
+        prisma_client=MagicMock(),
+    )
+    assert out_key is None
+    assert out_uid is None
+
+
+@pytest.mark.asyncio
+async def test_global_spend_report_rbac_internal_defaults_to_user_scope():
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="u1",
+        api_key="abc123hash",
+    )
+    out_key, out_uid = await spend_management_endpoints._apply_global_spend_report_rbac(
+        user_api_key_dict=auth,
+        api_key=None,
+        internal_user_id=None,
+        team_id=None,
+        customer_id=None,
+        prisma_client=MagicMock(),
+    )
+    assert out_key is None
+    assert out_uid == "u1"
+
+
+@pytest.mark.asyncio
+async def test_global_spend_report_rbac_internal_allows_self_internal_user_id():
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="u1",
+        api_key="abc123hash",
+    )
+    out_key, out_uid = await spend_management_endpoints._apply_global_spend_report_rbac(
+        user_api_key_dict=auth,
+        api_key=None,
+        internal_user_id="u1",
+        team_id=None,
+        customer_id=None,
+        prisma_client=MagicMock(),
+    )
+    assert out_key is None
+    assert out_uid == "u1"
+
+
+@pytest.mark.asyncio
+async def test_global_spend_report_rbac_internal_no_user_id_defaults_to_callers_key():
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id=None,
+        api_key="onlyhash",
+    )
+    out_key, out_uid = await spend_management_endpoints._apply_global_spend_report_rbac(
+        user_api_key_dict=auth,
+        api_key=None,
+        internal_user_id=None,
+        team_id=None,
+        customer_id=None,
+        prisma_client=MagicMock(),
+    )
+    assert out_key == "onlyhash"
+    assert out_uid is None
+
+
+@pytest.mark.asyncio
+async def test_global_spend_report_rbac_internal_rejects_other_user_id():
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="u1",
+        api_key="abc123hash",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await spend_management_endpoints._apply_global_spend_report_rbac(
+            user_api_key_dict=auth,
+            api_key=None,
+            internal_user_id="u2",
+            team_id=None,
+            customer_id=None,
+            prisma_client=MagicMock(),
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_global_spend_report_rbac_internal_rejects_foreign_api_key():
+    class KeyRow:
+        user_id = "other"
+
+    class MockDB:
+        class VT:
+            async def find_first(self, where):
+                return KeyRow()
+
+        def __init__(self):
+            self.litellm_verificationtoken = self.VT()
+
+    class MockPrisma:
+        def __init__(self):
+            self.db = MockDB()
+
+    auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="u1",
+        api_key="myhash",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await spend_management_endpoints._apply_global_spend_report_rbac(
+            user_api_key_dict=auth,
+            api_key="otherhash_literal",
+            internal_user_id=None,
+            team_id=None,
+            customer_id=None,
+            prisma_client=MockPrisma(),
+        )
+    assert exc_info.value.status_code == 403
+
+
 def test_ui_view_request_response_forbids_non_admin_without_db(client, monkeypatch):
     """
     Without prisma, non-admins cannot be authorized to read request/response


### PR DESCRIPTION
Summary
Locks down GET /global/spend/report so callers who are not proxy admin or proxy admin (view only) no longer receive deployment-wide spend when the request is otherwise unscoped.
Default (non-admin): if the auth object has a user_id, the report uses that user’s internal_user_id filter so spend is aggregated across all virtual keys tied to that user (same user, multiple keys). If there is no user_id, it falls back to the caller’s virtual key only.
Explicit api_key query: allowed only for the Bearer key or for keys whose DB user_id matches the caller’s user_id; otherwise 403.
Explicit internal_user_id: allowed only when it matches the caller’s user_id; otherwise 403.
team_id + customer_id: allowed for non-admins only when the caller may view that team’s spend (same idea as spend logs: team admin or team /spend/logs permission); otherwise 403.
Route allowlist: add /spend/logs/v2 to spend_tracking_routes so internal users are not blocked with an admin-only error (aligned with /spend/logs/ui).
Implementation notes
Injects UserAPIKeyAuth into get_global_spend_report and centralizes checks in _apply_global_spend_report_rbac (returns effective (api_key, internal_user_id)).
Removes duplicate router-level Depends(user_api_key_auth) on this route so auth runs once via the handler dependency.
Tests
Unit tests for admin passthrough, user-wide default, self internal_user_id, no-user_id key fallback, foreign internal_user_id / foreign key 403.
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
