### PR TITLE
Restrict /global/spend/report to proxy admin roles; allow explicit virtual-key allowed_routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -586,10 +586,13 @@ class LiteLLMRoutes(enum.Enum):
         "/global/spend/end_users",
         "/global/spend/models",
         "/global/predict/spend/logs",
-        "/global/spend/report",
         "/global/spend/provider",
         "/global/spend/tags",
         "/global/spend/all_tag_names",
+    ]
+
+    global_spend_report_routes = [
+        "/global/spend/report",
     ]
 
     public_routes = set(
@@ -4191,6 +4194,7 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
         "management_routes",
         "spend_tracking_routes",
         "global_spend_tracking_routes",
+        "global_spend_report_routes",
         "info_routes",
     ]
     team_id_jwt_field: Optional[str] = None

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -665,6 +665,11 @@ class RouteChecks:
             # Allow access to global spend tracking routes (read-only spend endpoints)
             # proxy_admin_viewer role description: "view all keys, view all spend"
             return
+        elif RouteChecks.check_route_access(
+            route=route, allowed_routes=LiteLLMRoutes.global_spend_report_routes.value
+        ):
+            # Global spend report: proxy_admin + proxy_admin_viewer only (not org admin)
+            return
         else:
             # For other routes, block access
             raise HTTPException(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -12,6 +12,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
 from litellm.proxy._types import ProviderBudgetResponse, ProviderBudgetResponseObject
+from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 # NOTE: Avoid module-level import from common_utils: proxy_server imports this
@@ -31,12 +32,28 @@ else:
 router = APIRouter()
 
 
-def _require_proxy_admin_or_viewer(user_api_key_dict: UserAPIKeyAuth) -> None:
+_GLOBAL_SPEND_REPORT_ROUTE = "/global/spend/report"
+
+
+def _require_global_spend_report_access(user_api_key_dict: UserAPIKeyAuth) -> None:
+    """
+    Allow proxy admin roles, or any role when the virtual key allowlists this route
+    (same matching rules as RouteChecks.is_virtual_key_allowed_to_call_route).
+    """
     if user_api_key_dict.user_role in (
         LitellmUserRoles.PROXY_ADMIN,
         LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
     ):
         return
+    if user_api_key_dict.allowed_routes:
+        try:
+            RouteChecks.is_virtual_key_allowed_to_call_route(
+                route=_GLOBAL_SPEND_REPORT_ROUTE,
+                valid_token=user_api_key_dict,
+            )
+            return
+        except HTTPException:
+            pass
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
         detail={"error": CommonProxyErrors.not_allowed_access.value},
@@ -1021,7 +1038,7 @@ async def get_global_spend_report(
         ]
     }
     """
-    _require_proxy_admin_or_viewer(user_api_key_dict)
+    _require_global_spend_report_access(user_api_key_dict)
 
     if start_date is None or end_date is None:
         raise HTTPException(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -31,6 +31,18 @@ else:
 router = APIRouter()
 
 
+def _require_proxy_admin_or_viewer(user_api_key_dict: UserAPIKeyAuth) -> None:
+    if user_api_key_dict.user_role in (
+        LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+    ):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={"error": CommonProxyErrors.not_allowed_access.value},
+    )
+
+
 @router.get(
     "/spend/keys",
     tags=["Budget & Spend Tracking"],
@@ -945,12 +957,12 @@ async def get_global_spend_provider(
 @router.get(
     "/global/spend/report",
     tags=["Budget & Spend Tracking"],
-    dependencies=[Depends(user_api_key_auth)],
     responses={
         200: {"model": List[LiteLLM_SpendLogs]},
     },
 )
 async def get_global_spend_report(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     start_date: Optional[str] = fastapi.Query(
         default=None,
         description="Time from which to start viewing spend",
@@ -1009,6 +1021,8 @@ async def get_global_spend_report(
         ]
     }
     """
+    _require_proxy_admin_or_viewer(user_api_key_dict)
+
     if start_date is None or end_date is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1004,6 +1004,58 @@ def test_proxy_admin_viewer_can_access_global_spend_tags():
         )
 
 
+def test_proxy_admin_viewer_can_access_global_spend_report():
+    """proxy_admin_viewer should pass route checks for /global/spend/report."""
+
+    user_obj = LiteLLM_UserTable(
+        user_id="viewer_user",
+        user_email="viewer@example.com",
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="viewer_user",
+        user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {"start_date": "2025-05-12", "end_date": "2025-10-09"}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY.value,
+        route="/global/spend/report",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
+def test_internal_user_cannot_access_global_spend_report_route():
+    """Internal users must not use /global/spend/report (proxy admin roles only)."""
+
+    user_obj = LiteLLM_UserTable(
+        user_id="internal_user",
+        user_email="user@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="internal_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    with pytest.raises(Exception) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=LitellmUserRoles.INTERNAL_USER.value,
+            route="/global/spend/report",
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+    assert "Only proxy admin can be used to generate" in str(exc_info.value)
+
+
 @pytest.mark.parametrize("route", ["/audit", "/audit/some-log-id"])
 def test_proxy_admin_viewer_can_access_audit_logs(route):
     """

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1030,7 +1030,7 @@ def test_proxy_admin_viewer_can_access_global_spend_report():
 
 
 def test_internal_user_cannot_access_global_spend_report_route():
-    """Internal users must not use /global/spend/report (proxy admin roles only)."""
+    """Without key allowlisting, internal users cannot use /global/spend/report."""
 
     user_obj = LiteLLM_UserTable(
         user_id="internal_user",
@@ -1054,6 +1054,32 @@ def test_internal_user_cannot_access_global_spend_report_route():
             request_data={},
         )
     assert "Only proxy admin can be used to generate" in str(exc_info.value)
+
+
+def test_internal_user_can_access_global_spend_report_when_key_allowlists_route():
+    """Virtual key with allowed_routes including /global/spend/report passes route check."""
+
+    user_obj = LiteLLM_UserTable(
+        user_id="internal_user",
+        user_email="user@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="internal_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        allowed_routes=["/global/spend/report"],
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER.value,
+        route="/global/spend/report",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
 
 
 @pytest.mark.parametrize("route", ["/audit", "/audit/some-log-id"])

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -2761,3 +2761,34 @@ async def test_ui_view_spend_logs_team_member_no_permission_blocked(
         assert response.status_code == 403
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_require_global_spend_report_access_internal_with_allowed_routes():
+    spend_management_endpoints._require_global_spend_report_access(
+        UserAPIKeyAuth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            user_id="u1",
+            allowed_routes=["/global/spend/report"],
+        )
+    )
+
+
+def test_require_global_spend_report_access_internal_with_route_bundle_name():
+    spend_management_endpoints._require_global_spend_report_access(
+        UserAPIKeyAuth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            user_id="u1",
+            allowed_routes=["global_spend_report_routes"],
+        )
+    )
+
+
+def test_require_global_spend_report_access_internal_without_allowed_routes_fails():
+    with pytest.raises(HTTPException) as exc_info:
+        spend_management_endpoints._require_global_spend_report_access(
+            UserAPIKeyAuth(
+                user_role=LitellmUserRoles.INTERNAL_USER,
+                user_id="u1",
+            )
+        )
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
Tightens access to GET /global/spend/report so it is not part of the broad internal-user global spend route bundle. proxy_admin and proxy_admin_viewer keep full access. Other callers (e.g. internal users) may only use the endpoint if their virtual key’s allowed_routes explicitly permits it, using the same matching rules as the rest of the proxy (exact path, wildcards, or the global_spend_report_routes bundle name). JWT default admin_allowed_routes includes the new route bundle so admin JWT configs keep working.

Cause
Cause: /global/spend/report lived under global_spend_tracking_routes, which is merged into internal user / viewer route lists and related permission paths, so organization-wide spend reporting was reachable by broader roles than intended.
Made-with: Cursor

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Remove /global/spend/report from global_spend_tracking_routes and introduce global_spend_report_routes.
Route checks: allow proxy_admin_viewer for that path via a dedicated branch; add global_spend_report_routes to default JWT admin_allowed_routes.
Handler: _require_global_spend_report_access — allow proxy admin roles, otherwise require allowed_routes to match via RouteChecks.is_virtual_key_allowed_to_call_route.
Tests for route checks and the handler (admin viewer, internal without allowlist denied, internal with allowlist allowed).