### PR TITLE
fix(ollama): strip provider suffix from api_base before /api/show call

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -236,12 +236,20 @@ class OllamaConfig(BaseConfig):
         api_base = (
             api_base or get_secret_str("OLLAMA_API_BASE") or "http://localhost:11434"
         )
+        # Strip provider-specific suffixes that may have been appended to
+        # api_base before this method is called (e.g. /api/chat, /api/generate).
+        # Without this, the URL becomes /api/chat/api/show → 404.
+        _base = api_base.rstrip("/")
+        for _suffix in ("/api/chat", "/api/generate"):
+            if _base.endswith(_suffix):
+                _base = _base[: -len(_suffix)]
+                break
         api_key = self.get_api_key()
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
         try:
             response = litellm.module_level_client.post(
-                url=f"{api_base}/api/show",
+                url=f"{_base}/api/show",
                 json={"name": model},
                 headers=headers,
             )


### PR DESCRIPTION
## Summary

Fixes #25567

`get_model_info` receives `api_base` that may already contain a provider suffix like `/api/chat` (appended by the completion path). Appending `/api/show` to this produces `/api/chat/api/show`, which returns 404 on the Ollama server.

### Ollama logs showing the bug:
```
POST "/api/chat"         → 200
POST "/api/chat/api/show" → 404
```

## Fix

Strip known provider suffixes (`/api/chat`, `/api/generate`) from `api_base` before constructing the `/api/show` URL:

```python
_base = api_base.rstrip('/')
for _suffix in ('/api/chat', '/api/generate'):
    if _base.endswith(_suffix):
        _base = _base[:-len(_suffix)]
        break
url = f'{_base}/api/show'
```