### PR TITLE
Fix/groq provider specific fields 25595

### DIFF
--- a/litellm/llms/groq/chat/transformation.py
+++ b/litellm/llms/groq/chat/transformation.py
@@ -1,6 +1,7 @@
 """
 Translate from OpenAI's `/v1/chat/completions` to Groq's `/v1/chat/completions`
 """
+
 from typing import (
     Any,
     Coroutine,
@@ -115,8 +116,7 @@ class GroqChatConfig(OpenAILikeChatConfig):
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
-        ...
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
 
     @overload
     def _transform_messages(
@@ -124,8 +124,7 @@ class GroqChatConfig(OpenAILikeChatConfig):
         messages: List[AllMessageValues],
         model: str,
         is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]:
-        ...
+    ) -> List[AllMessageValues]: ...
 
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
@@ -133,6 +132,8 @@ class GroqChatConfig(OpenAILikeChatConfig):
         for idx, message in enumerate(messages):
             """
             1. Don't pass 'null' function_call assistant message to groq - https://github.com/BerriAI/litellm/issues/5839
+            2. Strip LiteLLM-internal provider_specific_fields from assistant history
+               before sending to Groq, which rejects unknown assistant properties.
             """
             if isinstance(message, BaseModel):
                 _message = message.model_dump()
@@ -142,6 +143,8 @@ class GroqChatConfig(OpenAILikeChatConfig):
             if assistant_message:
                 new_message = ChatCompletionAssistantMessage(role="assistant")
                 for k, v in _message.items():
+                    if k == "provider_specific_fields":
+                        continue
                     if v is not None:
                         new_message[k] = v  # type: ignore
                 messages[idx] = new_message
@@ -293,10 +296,10 @@ class GroqChatConfig(OpenAILikeChatConfig):
             json_mode=json_mode,
         )
 
-        mapped_service_tier: Literal[
-            "auto", "default", "flex"
-        ] = self._map_groq_service_tier(
-            original_service_tier=getattr(model_response, "service_tier")
+        mapped_service_tier: Literal["auto", "default", "flex"] = (
+            self._map_groq_service_tier(
+                original_service_tier=getattr(model_response, "service_tier")
+            )
         )
         setattr(model_response, "service_tier", mapped_service_tier)
         return model_response

--- a/litellm/llms/groq/chat/transformation.py
+++ b/litellm/llms/groq/chat/transformation.py
@@ -1,7 +1,6 @@
 """
 Translate from OpenAI's `/v1/chat/completions` to Groq's `/v1/chat/completions`
 """
-
 from typing import (
     Any,
     Coroutine,
@@ -116,7 +115,8 @@ class GroqChatConfig(OpenAILikeChatConfig):
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]:
+        ...
 
     @overload
     def _transform_messages(
@@ -124,7 +124,8 @@ class GroqChatConfig(OpenAILikeChatConfig):
         messages: List[AllMessageValues],
         model: str,
         is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]: ...
+    ) -> List[AllMessageValues]:
+        ...
 
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: bool = False
@@ -132,8 +133,6 @@ class GroqChatConfig(OpenAILikeChatConfig):
         for idx, message in enumerate(messages):
             """
             1. Don't pass 'null' function_call assistant message to groq - https://github.com/BerriAI/litellm/issues/5839
-            2. Strip LiteLLM-internal provider_specific_fields from assistant history
-               before sending to Groq, which rejects unknown assistant properties.
             """
             if isinstance(message, BaseModel):
                 _message = message.model_dump()
@@ -296,10 +295,10 @@ class GroqChatConfig(OpenAILikeChatConfig):
             json_mode=json_mode,
         )
 
-        mapped_service_tier: Literal["auto", "default", "flex"] = (
-            self._map_groq_service_tier(
-                original_service_tier=getattr(model_response, "service_tier")
-            )
+        mapped_service_tier: Literal[
+            "auto", "default", "flex"
+        ] = self._map_groq_service_tier(
+            original_service_tier=getattr(model_response, "service_tier")
         )
         setattr(model_response, "service_tier", mapped_service_tier)
         return model_response

--- a/tests/llm_translation/test_groq.py
+++ b/tests/llm_translation/test_groq.py
@@ -18,7 +18,6 @@ from litellm.llms.groq.chat.transformation import (
 )
 from litellm.types.llms.openai import AllMessageValues
 
-
 class TestGroq(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
         return {
@@ -32,10 +31,7 @@ class TestGroq(BaseLLMChatTest):
     def test_tool_call_with_empty_enum_property(self):
         pass
 
-    @pytest.mark.parametrize(
-        "model",
-        ["groq/qwen/qwen3-32b", "groq/openai/gpt-oss-20b", "groq/openai/gpt-oss-120b"],
-    )
+    @pytest.mark.parametrize("model", ["groq/qwen/qwen3-32b", "groq/openai/gpt-oss-20b", "groq/openai/gpt-oss-120b"])
     def test_reasoning_effort_in_supported_params(self, model):
         """Test that reasoning_effort is in the list of supported parameters for Groq"""
         supported_params = GroqChatConfig().get_supported_openai_params(model=model)
@@ -98,19 +94,19 @@ class TestGroqStructuredOutputs:
                     "schema": {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
-                        "required": ["name"],
-                    },
-                },
+                        "required": ["name"]
+                    }
+                }
             },
             "tools": [
                 {
                     "type": "function",
                     "function": {
                         "name": "get_weather",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
+                        "parameters": {"type": "object", "properties": {}}
+                    }
                 }
-            ],
+            ]
         }
 
         with pytest.raises(litellm.BadRequestError) as exc_info:
@@ -124,9 +120,7 @@ class TestGroqStructuredOutputs:
         assert "does not support native structured outputs" in str(exc_info.value)
         assert "incompatible with user-provided tools" in str(exc_info.value)
 
-    def test_structured_output_without_tools_uses_workaround_for_non_native_models(
-        self,
-    ):
+    def test_structured_output_without_tools_uses_workaround_for_non_native_models(self):
         """
         Test that structured outputs without tools works using the json_tool_call workaround
         for models that don't support native json_schema.
@@ -143,9 +137,9 @@ class TestGroqStructuredOutputs:
                     "schema": {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
-                        "required": ["name"],
-                    },
-                },
+                        "required": ["name"]
+                    }
+                }
             }
         }
 
@@ -181,9 +175,9 @@ class TestGroqStructuredOutputs:
                     "schema": {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
-                        "required": ["name"],
-                    },
-                },
+                        "required": ["name"]
+                    }
+                }
             }
         }
 
@@ -206,7 +200,7 @@ class TestGroqStructuredOutputs:
 class TestGroqReasoning:
     """
     Tests for Groq reasoning field mapping.
-
+    
     Groq returns 'reasoning' field in delta, but LiteLLM expects 'reasoning_content'.
     """
 
@@ -241,10 +235,7 @@ class TestGroqReasoning:
         parsed_chunk = handler.chunk_parser(groq_chunk)
 
         # Verify that reasoning was mapped to reasoning_content
-        assert (
-            parsed_chunk.choices[0].delta.reasoning_content
-            == "This is reasoning content"
-        )
+        assert parsed_chunk.choices[0].delta.reasoning_content == "This is reasoning content"
         # Verify that the original 'reasoning' field was removed
         assert not hasattr(parsed_chunk.choices[0].delta, "reasoning")
 
@@ -305,10 +296,7 @@ class TestGroqReasoning:
                             {
                                 "index": 0,
                                 "id": "call_123",
-                                "function": {
-                                    "name": "test_function",
-                                    "arguments": "{}",
-                                },
+                                "function": {"name": "test_function", "arguments": "{}"},
                                 "type": "function",
                             }
                         ],
@@ -323,14 +311,8 @@ class TestGroqReasoning:
         parsed_chunk = handler.chunk_parser(groq_chunk)
 
         # Verify that reasoning was mapped to reasoning_content
-        assert (
-            parsed_chunk.choices[0].delta.reasoning_content
-            == "Reasoning before tool call"
-        )
+        assert parsed_chunk.choices[0].delta.reasoning_content == "Reasoning before tool call"
         # Verify tool_calls are still present
         assert parsed_chunk.choices[0].delta.tool_calls is not None
         assert len(parsed_chunk.choices[0].delta.tool_calls) == 1
-        assert (
-            parsed_chunk.choices[0].delta.tool_calls[0]["function"]["name"]
-            == "test_function"
-        )
+        assert parsed_chunk.choices[0].delta.tool_calls[0]["function"]["name"] == "test_function"

--- a/tests/llm_translation/test_groq.py
+++ b/tests/llm_translation/test_groq.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import List, cast
 
 
 import pytest
@@ -15,6 +16,8 @@ from litellm.llms.groq.chat.transformation import (
     GroqChatConfig,
     GroqChatCompletionStreamingHandler,
 )
+from litellm.types.llms.openai import AllMessageValues
+
 
 class TestGroq(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
@@ -29,11 +32,40 @@ class TestGroq(BaseLLMChatTest):
     def test_tool_call_with_empty_enum_property(self):
         pass
 
-    @pytest.mark.parametrize("model", ["groq/qwen/qwen3-32b", "groq/openai/gpt-oss-20b", "groq/openai/gpt-oss-120b"])
+    @pytest.mark.parametrize(
+        "model",
+        ["groq/qwen/qwen3-32b", "groq/openai/gpt-oss-20b", "groq/openai/gpt-oss-120b"],
+    )
     def test_reasoning_effort_in_supported_params(self, model):
         """Test that reasoning_effort is in the list of supported parameters for Groq"""
         supported_params = GroqChatConfig().get_supported_openai_params(model=model)
         assert "reasoning_effort" in supported_params
+
+    def test_transform_messages_strips_assistant_provider_specific_fields(self):
+        """Groq rejects unknown assistant fields like provider_specific_fields."""
+        config = GroqChatConfig()
+        messages = cast(
+            List[AllMessageValues],
+            [
+                {
+                    "role": "assistant",
+                    "content": "Tool metadata",
+                    "provider_specific_fields": {
+                        "mcp_list_tools": [{"name": "weather"}],
+                        "mcp_tool_calls": [{"id": "call_123"}],
+                    },
+                }
+            ],
+        )
+
+        transformed = cast(
+            List[AllMessageValues],
+            config._transform_messages(messages=messages, model="qwen/qwen3-32b"),
+        )
+
+        assert transformed[0]["role"] == "assistant"
+        assert transformed[0].get("content") == "Tool metadata"
+        assert "provider_specific_fields" not in transformed[0]
 
 
 class TestGroqStructuredOutputs:
@@ -66,19 +98,19 @@ class TestGroqStructuredOutputs:
                     "schema": {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
-                        "required": ["name"]
-                    }
-                }
+                        "required": ["name"],
+                    },
+                },
             },
             "tools": [
                 {
                     "type": "function",
                     "function": {
                         "name": "get_weather",
-                        "parameters": {"type": "object", "properties": {}}
-                    }
+                        "parameters": {"type": "object", "properties": {}},
+                    },
                 }
-            ]
+            ],
         }
 
         with pytest.raises(litellm.BadRequestError) as exc_info:
@@ -92,7 +124,9 @@ class TestGroqStructuredOutputs:
         assert "does not support native structured outputs" in str(exc_info.value)
         assert "incompatible with user-provided tools" in str(exc_info.value)
 
-    def test_structured_output_without_tools_uses_workaround_for_non_native_models(self):
+    def test_structured_output_without_tools_uses_workaround_for_non_native_models(
+        self,
+    ):
         """
         Test that structured outputs without tools works using the json_tool_call workaround
         for models that don't support native json_schema.
@@ -109,9 +143,9 @@ class TestGroqStructuredOutputs:
                     "schema": {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
-                        "required": ["name"]
-                    }
-                }
+                        "required": ["name"],
+                    },
+                },
             }
         }
 
@@ -147,9 +181,9 @@ class TestGroqStructuredOutputs:
                     "schema": {
                         "type": "object",
                         "properties": {"name": {"type": "string"}},
-                        "required": ["name"]
-                    }
-                }
+                        "required": ["name"],
+                    },
+                },
             }
         }
 
@@ -172,7 +206,7 @@ class TestGroqStructuredOutputs:
 class TestGroqReasoning:
     """
     Tests for Groq reasoning field mapping.
-    
+
     Groq returns 'reasoning' field in delta, but LiteLLM expects 'reasoning_content'.
     """
 
@@ -207,7 +241,10 @@ class TestGroqReasoning:
         parsed_chunk = handler.chunk_parser(groq_chunk)
 
         # Verify that reasoning was mapped to reasoning_content
-        assert parsed_chunk.choices[0].delta.reasoning_content == "This is reasoning content"
+        assert (
+            parsed_chunk.choices[0].delta.reasoning_content
+            == "This is reasoning content"
+        )
         # Verify that the original 'reasoning' field was removed
         assert not hasattr(parsed_chunk.choices[0].delta, "reasoning")
 
@@ -268,7 +305,10 @@ class TestGroqReasoning:
                             {
                                 "index": 0,
                                 "id": "call_123",
-                                "function": {"name": "test_function", "arguments": "{}"},
+                                "function": {
+                                    "name": "test_function",
+                                    "arguments": "{}",
+                                },
                                 "type": "function",
                             }
                         ],
@@ -283,8 +323,14 @@ class TestGroqReasoning:
         parsed_chunk = handler.chunk_parser(groq_chunk)
 
         # Verify that reasoning was mapped to reasoning_content
-        assert parsed_chunk.choices[0].delta.reasoning_content == "Reasoning before tool call"
+        assert (
+            parsed_chunk.choices[0].delta.reasoning_content
+            == "Reasoning before tool call"
+        )
         # Verify tool_calls are still present
         assert parsed_chunk.choices[0].delta.tool_calls is not None
         assert len(parsed_chunk.choices[0].delta.tool_calls) == 1
-        assert parsed_chunk.choices[0].delta.tool_calls[0]["function"]["name"] == "test_function"
+        assert (
+            parsed_chunk.choices[0].delta.tool_calls[0]["function"]["name"]
+            == "test_function"
+        )

--- a/tests/test_litellm/llms/groq/chat/test_groq_chat_transformation.py
+++ b/tests/test_litellm/llms/groq/chat/test_groq_chat_transformation.py
@@ -1,0 +1,31 @@
+from typing import List, cast
+
+from litellm.llms.groq.chat.transformation import GroqChatConfig
+from litellm.types.llms.openai import AllMessageValues
+
+
+def test_transform_messages_strips_assistant_provider_specific_fields() -> None:
+    """Groq payloads should not include LiteLLM internal assistant metadata."""
+    config = GroqChatConfig()
+    messages = cast(
+        List[AllMessageValues],
+        [
+            {
+                "role": "assistant",
+                "content": "Tool metadata",
+                "provider_specific_fields": {
+                    "mcp_list_tools": [{"name": "weather"}],
+                    "mcp_tool_calls": [{"id": "call_123"}],
+                },
+            }
+        ],
+    )
+
+    transformed = cast(
+        List[AllMessageValues],
+        config._transform_messages(messages=messages, model="qwen/qwen3-32b"),
+    )
+
+    assert transformed[0]["role"] == "assistant"
+    assert transformed[0].get("content") == "Tool metadata"
+    assert "provider_specific_fields" not in transformed[0]


### PR DESCRIPTION
## Relevant issues

Fixes #25595 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
- Fix Groq assistant message sanitization by removing provider_specific_fields during _transform_messages
- Add regression test for provider_specific_fields stripping in Groq message transformation
- Resolve issue Fixes #25595