### PR TITLE
fix(streaming): capture TTFT for /v1/messages (Anthropic, Bedrock, Vertex AI)

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -27,6 +27,7 @@ class BaseAnthropicMessagesStreamingIterator:
         self.litellm_logging_obj = litellm_logging_obj
         self.request_body = request_body
         self.start_time = datetime.now()
+        self.completion_start_time: datetime | None = None
 
     async def _handle_streaming_logging(self, collected_chunks: List[bytes]):
         """Handle the logging after all chunks have been collected."""
@@ -35,6 +36,15 @@ class BaseAnthropicMessagesStreamingIterator:
         )
 
         end_time = datetime.now()
+        # Set completion_start_time so TTFT is calculated from the first
+        # chunk rather than falling back to end_time in async_success_handler.
+        if self.completion_start_time is not None:
+            self.litellm_logging_obj.completion_start_time = (
+                self.completion_start_time
+            )
+            self.litellm_logging_obj.model_call_details[
+                "completion_start_time"
+            ] = self.completion_start_time
         asyncio.create_task(
             PassThroughStreamingHandler._route_streaming_logging_to_handler(
                 litellm_logging_obj=self.litellm_logging_obj,
@@ -100,6 +110,8 @@ class BaseAnthropicMessagesStreamingIterator:
         collected_chunks = []
 
         async for chunk in completion_stream:
+            if self.completion_start_time is None:
+                self.completion_start_time = datetime.now()
             encoded_chunk = self._convert_chunk_to_sse_format(chunk)
             collected_chunks.append(encoded_chunk)
             yield encoded_chunk


### PR DESCRIPTION
The pass-through streaming path for `/v1/messages` logged `completion_start_time` only after the full stream finished. `async_success_handler` then fell back to `end_time`, making TTFT equal to total duration or `null` in the UI and Prometheus.

Record the timestamp of the first chunk in `async_sse_wrapper` and propagate it to `litellm_logging_obj.completion_start_time` / `model_call_details` before the logging handler runs.

Fixes #25598