### PR TITLE
fix: [Bug]: Cost tracking is not working with Vercel Models (closes #20412)

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -670,11 +670,20 @@ def convert_to_model_response_object(  # noqa: PLR0915
                     "/" in model_response_object.model
                     and response_object["model"] is not None
                 ):
-                    openai_compatible_provider = model_response_object.model.split("/")[
-                        0
-                    ]
+                    # Extract the full provider prefix (everything before the base model name).
+                    # For gateway-style providers like "vercel_ai_gateway/anthropic/claude-opus-4.5",
+                    # we need to preserve the full prefix "vercel_ai_gateway/anthropic",
+                    # not just "vercel_ai_gateway".
+                    response_model = response_object["model"]
+                    preset_model = model_response_object.model
+                    if preset_model.endswith("/" + response_model):
+                        # The response model is the suffix of the preset model,
+                        # so the prefix is everything before it.
+                        openai_compatible_provider = preset_model[: -(len(response_model) + 1)]
+                    else:
+                        openai_compatible_provider = preset_model.rsplit("/", 1)[0]
                     model_response_object.model = (
-                        openai_compatible_provider + "/" + response_object["model"]
+                        openai_compatible_provider + "/" + response_model
                     )
 
             if start_time is not None and end_time is not None:

--- a/tests/test_litellm/llms/vercel_ai_gateway/chat/test_vercel_ai_gateway_transformation.py
+++ b/tests/test_litellm/llms/vercel_ai_gateway/chat/test_vercel_ai_gateway_transformation.py
@@ -99,6 +99,92 @@ def test_vercel_ai_gateway_error_class():
     assert error_class.headers == headers
 
 
+def test_vercel_ai_gateway_model_name_preserved_in_response():
+    """Test that multi-segment provider prefixes like 'vercel_ai_gateway/anthropic' are
+    preserved when reconstructing the model name from the API response.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/20412
+    """
+    from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+        convert_to_model_response_object,
+    )
+    from litellm.types.utils import ModelResponse
+
+    # Simulate: preset model is "vercel_ai_gateway/anthropic/claude-opus-4.5"
+    # and the Vercel API response returns model="claude-opus-4.5"
+    model_response = ModelResponse()
+    model_response.model = "vercel_ai_gateway/anthropic/claude-opus-4.5"
+
+    response_object = {
+        "id": "chatcmpl-abc123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "claude-opus-4.5",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+    result = convert_to_model_response_object(
+        response_object=response_object,
+        model_response_object=model_response,
+    )
+
+    # The full provider prefix must be preserved
+    assert result.model == "vercel_ai_gateway/anthropic/claude-opus-4.5", (
+        f"Expected 'vercel_ai_gateway/anthropic/claude-opus-4.5', got '{result.model}'"
+    )
+
+
+def test_vercel_ai_gateway_single_segment_provider_still_works():
+    """Verify that single-segment providers like 'openai/gpt-4o' still work
+    after the multi-segment fix."""
+    from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+        convert_to_model_response_object,
+    )
+    from litellm.types.utils import ModelResponse
+
+    model_response = ModelResponse()
+    model_response.model = "openai/gpt-4o"
+
+    response_object = {
+        "id": "chatcmpl-xyz789",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gpt-4o-2024-08-06",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hi!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        },
+    }
+
+    result = convert_to_model_response_object(
+        response_object=response_object,
+        model_response_object=model_response,
+    )
+
+    assert result.model == "openai/gpt-4o-2024-08-06", (
+        f"Expected 'openai/gpt-4o-2024-08-06', got '{result.model}'"
+    )
+
+
 def test_vercel_ai_gateway_exception_inheritance():
     """Test that VercelAIGatewayException inherits from BaseLLMException"""
     from litellm.llms.base_llm.chat.transformation import BaseLLMException


### PR DESCRIPTION
Closes #20412

**Summary:** Cost tracking returns $0 for Vercel AI Gateway models because the model name is incorrectly reconstructed after the API response, losing the nested provider prefix (e.g., 'anthropic/') needed for pricing lookup.

**Root cause:** In convert_dict_to_response.py lines 673-678, when reconstructing the model name from the API response, the code uses model.split('/')[0] to extract the provider prefix. For vercel_ai_gateway models like 'vercel_ai_gateway/anthropic/claude-opus-4.5', this only captures 'vercel_ai_gateway' and drops the intermediate 'anthropic/' segment. If the Vercel API response returns just 'claude-opus-4.5' (without the 'anthropic/' prefix) as the model field, the reconstructed name becomes 'vercel_ai_gateway/claude-opus-4.5' instead of 'vercel_ai_gateway/anthropic/claude-opus-4.5'. This corrupted name doesn't match any entry in model_prices_and_context_window.json, so cost_per_token() returns 0.

**Approach:** Fix the model name reconstruction in convert_dict_to_response.py to preserve multi-segment provider prefixes. Instead of using split('/')[0] which only gets the first segment, extract all provider prefix segments (everything before the base model name). One approach: compare the response model with the original model to determine how many prefix segments exist, or use split('/', 1) to preserve the full prefix when the provider is a gateway-style provider with nested paths. Additionally, consider adding a dedicated transform_response method in VercelAIGatewayConfig that correctly handles the model name mapping.

*Automated fix by BugBot*