### PR TITLE
Update cache stale resurrection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ STABILIZATION_TODO.md
 **/playwright-report
 **/*.storageState.json
 **/coverage
+.venv312/
+litellm/proxy/_experimental/out/

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2916,17 +2916,26 @@ async def _virtual_key_soft_budget_check(
     Triggers a budget alert if the token is over it's soft budget.
 
     """
+    if valid_token.soft_budget is None:
+        return
 
-    if valid_token.soft_budget and valid_token.spend >= valid_token.soft_budget:
+    from litellm.proxy.proxy_server import get_current_spend
+
+    spend = await get_current_spend(
+        counter_key=f"spend:key:{valid_token.token}",
+        fallback_spend=valid_token.spend or 0.0,
+    )
+
+    if spend >= valid_token.soft_budget:
         verbose_proxy_logger.debug(
             "Crossed Soft Budget for token %s, spend %s, soft_budget %s",
             valid_token.token,
-            valid_token.spend,
+            spend,
             valid_token.soft_budget,
         )
         call_info = CallInfo(
             token=valid_token.token,
-            spend=valid_token.spend,
+            spend=spend,
             max_budget=valid_token.max_budget,
             soft_budget=valid_token.soft_budget,
             user_id=valid_token.user_id,
@@ -2957,31 +2966,33 @@ async def _virtual_key_max_budget_alert_check(
     This is a warning alert before the token actually exceeds the max budget.
 
     """
+    if valid_token.max_budget is None:
+        return
 
-    if (
-        valid_token.max_budget is not None
-        and valid_token.spend is not None
-        and valid_token.spend > 0
-    ):
+    from litellm.proxy.proxy_server import get_current_spend
+
+    spend = await get_current_spend(
+        counter_key=f"spend:key:{valid_token.token}",
+        fallback_spend=valid_token.spend or 0.0,
+    )
+
+    if spend > 0:
         alert_threshold = (
             valid_token.max_budget * EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE
         )
 
         # Only alert if we've crossed the threshold but haven't exceeded max_budget yet
-        if (
-            valid_token.spend >= alert_threshold
-            and valid_token.spend < valid_token.max_budget
-        ):
+        if spend >= alert_threshold and spend < valid_token.max_budget:
             verbose_proxy_logger.debug(
                 "Reached Max Budget Alert Threshold for token %s, spend %s, max_budget %s, alert_threshold %s",
                 valid_token.token,
-                valid_token.spend,
+                spend,
                 valid_token.max_budget,
                 alert_threshold,
             )
             call_info = CallInfo(
                 token=valid_token.token,
-                spend=valid_token.spend,
+                spend=spend,
                 max_budget=valid_token.max_budget,
                 soft_budget=valid_token.soft_budget,
                 user_id=valid_token.user_id,
@@ -3104,16 +3115,21 @@ async def _team_soft_budget_check(
     """
     Triggers a budget alert if the team is over it's soft budget.
     """
-    if (
-        team_object is not None
-        and team_object.soft_budget is not None
-        and team_object.spend is not None
-        and team_object.spend >= team_object.soft_budget
-    ):
+    if team_object is None or team_object.soft_budget is None:
+        return
+
+    from litellm.proxy.proxy_server import get_current_spend
+
+    team_spend = await get_current_spend(
+        counter_key=f"spend:team:{team_object.team_id}",
+        fallback_spend=team_object.spend or 0.0,
+    )
+
+    if team_spend >= team_object.soft_budget:
         verbose_proxy_logger.debug(
             "Crossed Soft Budget for team %s, spend %s, soft_budget %s",
             team_object.team_id,
-            team_object.spend,
+            team_spend,
             team_object.soft_budget,
         )
         if valid_token:
@@ -3156,7 +3172,7 @@ async def _team_soft_budget_check(
 
             call_info = CallInfo(
                 token=valid_token.token,
-                spend=team_object.spend,
+                spend=team_spend,
                 max_budget=team_object.max_budget,
                 soft_budget=team_object.soft_budget,
                 user_id=valid_token.user_id,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -54,7 +54,7 @@ from litellm.constants import (
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
     LITELLM_UI_ALLOW_HEADERS,
     LITELLM_UI_SESSION_DURATION,
-    DAILY_TAG_SPEND_BATCH_MULTIPLIER
+    DAILY_TAG_SPEND_BATCH_MULTIPLIER,
 )
 from litellm.litellm_core_utils.litellm_logging import (
     _init_custom_logger_compatible_class,
@@ -637,9 +637,9 @@ except ImportError:
 server_root_path = get_server_root_path()
 _license_check = LicenseCheck()
 premium_user: bool = _license_check.is_premium()
-premium_user_data: Optional["EnterpriseLicenseData"] = (
-    _license_check.airgapped_license_data
-)
+premium_user_data: Optional[
+    "EnterpriseLicenseData"
+] = _license_check.airgapped_license_data
 global_max_parallel_request_retries_env: Optional[str] = os.getenv(
     "LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRIES"
 )
@@ -1534,9 +1534,9 @@ master_key: Optional[str] = None
 config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
-shared_aiohttp_session: Optional["ClientSession"] = (
-    None  # Global shared session for connection reuse
-)
+shared_aiohttp_session: Optional[
+    "ClientSession"
+] = None  # Global shared session for connection reuse
 user_api_key_cache = DualCache(
     default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value
 )
@@ -1547,13 +1547,13 @@ model_max_budget_limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(
     dual_cache=user_api_key_cache
 )
 litellm.logging_callback_manager.add_litellm_callback(model_max_budget_limiter)
-redis_usage_cache: Optional[RedisCache] = (
-    None  # redis cache used for tracking spend, tpm/rpm limits
-)
+redis_usage_cache: Optional[
+    RedisCache
+] = None  # redis cache used for tracking spend, tpm/rpm limits
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
-native_background_mode: List[str] = (
-    []
-)  # Models that should use native provider background mode instead of polling
+native_background_mode: List[
+    str
+] = []  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -1910,59 +1910,16 @@ async def update_cache(  # noqa: PLR0915
             )
             # set cooldown on alert
 
-        if (
-            existing_spend_obj is not None
-            and getattr(existing_spend_obj, "team_spend", None) is not None
-        ):
-            existing_team_spend = existing_spend_obj.team_spend or 0
-            # Calculate the new cost by adding the existing cost and response_cost
-            existing_spend_obj.team_spend = existing_team_spend + response_cost
-
-        if (
-            existing_spend_obj is not None
-            and getattr(existing_spend_obj, "team_member_spend", None) is not None
-        ):
-            existing_team_member_spend = existing_spend_obj.team_member_spend or 0
-            # Calculate the new cost by adding the existing cost and response_cost
-            existing_spend_obj.team_member_spend = (
-                existing_team_member_spend + response_cost
-            )
-
-        # Update the cost column for the given token
-        existing_spend_obj.spend = new_spend
-        values_to_update_in_cache.append((hashed_token, existing_spend_obj))
+        # Do NOT write the key object back to cache — spend is tracked via
+        # spend_counter_cache (atomic increments) to avoid stale-resurrection
+        # when another pod has invalidated and reloaded the key object.
 
     ### UPDATE USER SPEND ###
     async def _update_user_cache():
-        ## UPDATE CACHE FOR USER ID + GLOBAL PROXY
-        user_ids = [user_id]
+        ## UPDATE CACHE FOR GLOBAL PROXY SPEND COUNTER ##
+        # User entity objects are no longer written back — spend is tracked via
+        # spend_counter_cache (atomic increments) to avoid stale-resurrection.
         try:
-            for _id in user_ids:
-                # Fetch the existing cost for the given user
-                if _id is None:
-                    continue
-                existing_spend_obj = await user_api_key_cache.async_get_cache(key=_id)
-                if existing_spend_obj is None:
-                    # do nothing if there is no cache value
-                    return
-                verbose_proxy_logger.debug(
-                    f"_update_user_db: existing spend: {existing_spend_obj}; response_cost: {response_cost}"
-                )
-
-                if isinstance(existing_spend_obj, dict):
-                    existing_spend = existing_spend_obj["spend"]
-                else:
-                    existing_spend = existing_spend_obj.spend
-                # Calculate the new cost by adding the existing cost and response_cost
-                new_spend = existing_spend + response_cost
-
-                # Update the cost column for the given user
-                if isinstance(existing_spend_obj, dict):
-                    existing_spend_obj["spend"] = new_spend
-                    values_to_update_in_cache.append((_id, existing_spend_obj))
-                else:
-                    existing_spend_obj.spend = new_spend
-                    values_to_update_in_cache.append((_id, existing_spend_obj.json()))
             ## UPDATE GLOBAL PROXY ##
             global_proxy_spend = await user_api_key_cache.async_get_cache(
                 key="{}:spend".format(litellm_proxy_admin_name)
@@ -1977,173 +1934,31 @@ async def update_cache(  # noqa: PLR0915
                 )
         except Exception as e:
             verbose_proxy_logger.warning(
-                "Spend tracking - failed to update user spend in cache. "
-                "Budget enforcement may use stale spend values. "
-                "user_id=%s, response_cost=%s - %s\n%s",
-                user_id,
+                "Spend tracking - failed to update global proxy spend counter. "
+                "response_cost=%s - %s\n%s",
                 response_cost,
                 str(e),
                 traceback.format_exc(),
             )
 
-    ### UPDATE END-USER SPEND ###
-    async def _update_end_user_cache():
-        if end_user_id is None or response_cost is None:
-            return
-
-        _id = "end_user_id:{}".format(end_user_id)
-        try:
-            # Fetch the existing cost for the given user
-            existing_spend_obj = await user_api_key_cache.async_get_cache(key=_id)
-            if existing_spend_obj is None:
-                # if user does not exist in LiteLLM_UserTable, create a new user
-                # do nothing if end-user not in api key cache
-                return
-            verbose_proxy_logger.debug(
-                f"_update_end_user_db: existing spend: {existing_spend_obj}; response_cost: {response_cost}"
-            )
-            if existing_spend_obj is None:
-                existing_spend = 0
-            else:
-                if isinstance(existing_spend_obj, dict):
-                    existing_spend = existing_spend_obj["spend"]
-                else:
-                    existing_spend = existing_spend_obj.spend
-            # Calculate the new cost by adding the existing cost and response_cost
-            new_spend = existing_spend + response_cost
-
-            # Update the cost column for the given user
-            if isinstance(existing_spend_obj, dict):
-                existing_spend_obj["spend"] = new_spend
-                values_to_update_in_cache.append((_id, existing_spend_obj))
-            else:
-                existing_spend_obj.spend = new_spend
-                values_to_update_in_cache.append((_id, existing_spend_obj.json()))
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "Spend tracking - failed to update end user spend in cache. "
-                "Budget enforcement may use stale spend values. "
-                "end_user_id=%s, response_cost=%s - %s\n%s",
-                end_user_id,
-                response_cost,
-                str(e),
-                traceback.format_exc(),
-            )
-
-    ### UPDATE TEAM SPEND ###
-    async def _update_team_cache():
-        if team_id is None or response_cost is None:
-            return
-
-        _id = "team_id:{}".format(team_id)
-        try:
-            # Fetch the existing cost for the given user
-            existing_spend_obj: Optional[LiteLLM_TeamTable] = (
-                await user_api_key_cache.async_get_cache(key=_id)
-            )
-            if existing_spend_obj is None:
-                # do nothing if team not in api key cache
-                return
-            verbose_proxy_logger.debug(
-                f"_update_team_db: existing spend: {existing_spend_obj}; response_cost: {response_cost}"
-            )
-            if existing_spend_obj is None:
-                existing_spend: Optional[float] = 0.0
-            else:
-                if isinstance(existing_spend_obj, dict):
-                    existing_spend = existing_spend_obj["spend"]
-                else:
-                    existing_spend = existing_spend_obj.spend
-
-            if existing_spend is None:
-                existing_spend = 0.0
-            # Calculate the new cost by adding the existing cost and response_cost
-            new_spend = existing_spend + response_cost
-
-            # Update the cost column for the given user
-            if isinstance(existing_spend_obj, dict):
-                existing_spend_obj["spend"] = new_spend
-                values_to_update_in_cache.append((_id, existing_spend_obj))
-            else:
-                existing_spend_obj.spend = new_spend
-                values_to_update_in_cache.append((_id, existing_spend_obj))
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "Spend tracking - failed to update team spend in cache. "
-                "Budget enforcement may use stale spend values. "
-                "team_id=%s, response_cost=%s - %s\n%s",
-                team_id,
-                response_cost,
-                str(e),
-                traceback.format_exc(),
-            )
-
-    ### UPDATE TAG SPEND ###
-    async def _update_tag_cache():
-        """
-        Update the tag cache with the new spend.
-        """
-        if tags is None or response_cost is None:
-            return
-
-        try:
-            for tag_name in tags:
-                if not tag_name or not isinstance(tag_name, str):
-                    continue
-
-                cache_key = f"tag:{tag_name}"
-                # Fetch the existing tag object from cache
-                existing_tag_obj = await user_api_key_cache.async_get_cache(
-                    key=cache_key
-                )
-                if existing_tag_obj is None:
-                    # do nothing if tag not in api key cache
-                    continue
-
-                verbose_proxy_logger.debug(
-                    f"_update_tag_cache: existing spend for tag={tag_name}: {existing_tag_obj}; response_cost: {response_cost}"
-                )
-
-                if isinstance(existing_tag_obj, dict):
-                    existing_spend = existing_tag_obj.get("spend", 0) or 0
-                else:
-                    existing_spend = getattr(existing_tag_obj, "spend", 0) or 0
-
-                # Calculate the new cost by adding the existing cost and response_cost
-                new_spend = existing_spend + response_cost
-
-                # Update the spend column for the given tag
-                if isinstance(existing_tag_obj, dict):
-                    existing_tag_obj["spend"] = new_spend
-                    values_to_update_in_cache.append((cache_key, existing_tag_obj))
-                else:
-                    existing_tag_obj.spend = new_spend
-                    values_to_update_in_cache.append((cache_key, existing_tag_obj))
-        except Exception as e:
-            verbose_proxy_logger.warning(
-                "Spend tracking - failed to update tag spend in cache. "
-                "Budget enforcement may use stale spend values. "
-                "tags=%s, response_cost=%s - %s\n%s",
-                tags,
-                response_cost,
-                str(e),
-                traceback.format_exc(),
-            )
+    # End-user, team, and tag entity objects are intentionally NOT written back
+    # to cache. Removing the writeback prevents stale-resurrection: a
+    # fire-and-forget write after a long LLM call can overwrite a freshly
+    # invalidated cache entry, causing /key/update changes to be ignored
+    # indefinitely under load.
+    #
+    # - end-user: no spend_counter_cache counter yet; .spend is DB-loaded at
+    #   auth time and read directly by _check_end_user_budget().
+    # - team: spend tracked via spend_counter_cache; budget checks use
+    #   get_current_spend().
+    # - tag: no spend_counter_cache counter yet; tag spend is written to DB
+    #   asynchronously and not used for budget enforcement.
 
     if token is not None and response_cost is not None:
         await _update_key_cache(token=token, response_cost=response_cost)
 
     if user_id is not None:
         await _update_user_cache()
-
-    if end_user_id is not None:
-        await _update_end_user_cache()
-
-    if team_id is not None:
-        await _update_team_cache()
-
-    if tags is not None:
-        await _update_tag_cache()
 
     asyncio.create_task(
         user_api_key_cache.async_set_cache_pipeline(
@@ -2161,9 +1976,11 @@ def run_ollama_serve():
         with open(os.devnull, "w") as devnull:
             subprocess.Popen(command, stdout=devnull, stderr=devnull)
     except Exception as e:
-        verbose_proxy_logger.debug(f"""
+        verbose_proxy_logger.debug(
+            f"""
             LiteLLM Warning: proxy started with `ollama` model\n`ollama serve` failed with Exception{e}. \nEnsure you run `ollama serve`
-        """)
+        """
+        )
 
 
 def _get_process_rss_mb() -> Optional[float]:
@@ -2316,9 +2133,13 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
-            if llm_router.health_check_ignore_transient_errors and exception_status in (
-                429,
-                408,
+            if (
+                llm_router.health_check_ignore_transient_errors
+                and exception_status
+                in (
+                    429,
+                    408,
+                )
             ):
                 continue
 
@@ -5290,10 +5111,10 @@ class ProxyConfig:
         )
 
         try:
-            guardrails_in_db: List[Guardrail] = (
-                await GuardrailRegistry.get_all_guardrails_from_db(
-                    prisma_client=prisma_client
-                )
+            guardrails_in_db: List[
+                Guardrail
+            ] = await GuardrailRegistry.get_all_guardrails_from_db(
+                prisma_client=prisma_client
             )
             verbose_proxy_logger.debug(
                 "guardrails from the DB %s", str(guardrails_in_db)
@@ -5675,9 +5496,9 @@ async def initialize(  # noqa: PLR0915
         user_api_base = api_base
         dynamic_config[user_model]["api_base"] = api_base
     if api_version:
-        os.environ["AZURE_API_VERSION"] = (
-            api_version  # set this for azure - litellm can read this from the env
-        )
+        os.environ[
+            "AZURE_API_VERSION"
+        ] = api_version  # set this for azure - litellm can read this from the env
     if max_tokens:  # model-specific param
         dynamic_config[user_model]["max_tokens"] = max_tokens
     if temperature:  # model-specific param
@@ -6019,9 +5840,9 @@ class ProxyStartupEvent:
         """
         from litellm.secret_managers.main import str_to_bool
 
-        _use_redis_transaction_buffer: Optional[Union[bool, str]] = (
-            general_settings.get("use_redis_transaction_buffer", False)
-        )
+        _use_redis_transaction_buffer: Optional[
+            Union[bool, str]
+        ] = general_settings.get("use_redis_transaction_buffer", False)
         if isinstance(_use_redis_transaction_buffer, str):
             _use_redis_transaction_buffer = str_to_bool(_use_redis_transaction_buffer)
 
@@ -6287,7 +6108,9 @@ class ProxyStartupEvent:
 
         ### UPDATE DAILY TAG SPEND (separate scheduler job with longer interval) ###
         ## Reduces QPS as there are more tags for a single request
-        tag_spend_update_interval = int(batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER)
+        tag_spend_update_interval = int(
+            batch_writing_interval * DAILY_TAG_SPEND_BATCH_MULTIPLIER
+        )
         from litellm.proxy.utils import update_daily_tag_spend
 
         scheduler.add_job(
@@ -7132,9 +6955,9 @@ async def chat_completion(  # noqa: PLR0915
             hasattr(user_api_key_dict, "organization_alias")
             and user_api_key_dict.organization_alias is not None
         ):
-            data["metadata"]["user_api_key_org_alias"] = (
-                user_api_key_dict.organization_alias
-            )
+            data["metadata"][
+                "user_api_key_org_alias"
+            ] = user_api_key_dict.organization_alias
         if (
             hasattr(user_api_key_dict, "agent_id")
             and user_api_key_dict.agent_id is not None
@@ -7313,9 +7136,9 @@ async def completion(  # noqa: PLR0915
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"]["user_api_key_org_alias"] = (
-                    user_api_key_dict.organization_alias
-                )
+                data["metadata"][
+                    "user_api_key_org_alias"
+                ] = user_api_key_dict.organization_alias
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -7562,9 +7385,9 @@ async def embeddings(  # noqa: PLR0915
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"]["user_api_key_org_alias"] = (
-                    user_api_key_dict.organization_alias
-                )
+                data["metadata"][
+                    "user_api_key_org_alias"
+                ] = user_api_key_dict.organization_alias
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -12745,9 +12568,9 @@ async def get_config_list(
                             hasattr(sub_field_info, "description")
                             and sub_field_info.description is not None
                         ):
-                            nested_fields[idx].field_description = (
-                                sub_field_info.description
-                            )
+                            nested_fields[
+                                idx
+                            ].field_description = sub_field_info.description
                         idx += 1
 
                     _stored_in_db = None

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1341,9 +1341,7 @@ async def test_get_all_team_models_with_access_groups():
     mock_db.litellm_teamtable = mock_litellm_teamtable
     mock_litellm_teamtable.find_many = AsyncMock(return_value=[mock_team1])
     mock_db.litellm_accessgrouptable = MagicMock()
-    mock_db.litellm_accessgrouptable.find_many = AsyncMock(
-        return_value=[mock_ag_row]
-    )
+    mock_db.litellm_accessgrouptable.find_many = AsyncMock(return_value=[mock_ag_row])
 
     mock_router = MagicMock()
 
@@ -3414,113 +3412,139 @@ def test_should_load_db_object_with_supported_db_objects():
 @pytest.mark.asyncio
 async def test_tag_cache_update_called():
     """
-    Test that update_cache updates tag cache when tags are provided.
+    Test that update_cache does NOT write tag objects back to the pipeline
+    (stale resurrection fix: _update_tag_cache is a no-op).
     """
     from litellm.caching.caching import DualCache
-    from litellm.proxy.proxy_server import user_api_key_cache
 
     cache = DualCache()
-
-    setattr(
-        litellm.proxy.proxy_server,
-        "user_api_key_cache",
-        cache,
-    )
-
-    mock_tag_obj = {
-        "tag_name": "test-tag",
-        "spend": 10.0,
-    }
+    setattr(litellm.proxy.proxy_server, "user_api_key_cache", cache)
 
     with patch.object(
-        cache, "async_get_cache", new=AsyncMock(return_value=mock_tag_obj)
-    ) as mock_get_cache:
-        with patch.object(
-            cache, "async_set_cache_pipeline", new=AsyncMock()
-        ) as mock_set_cache:
-            await litellm.proxy.proxy_server.update_cache(
-                token=None,
-                user_id=None,
-                end_user_id=None,
-                team_id=None,
-                response_cost=5.0,
-                parent_otel_span=None,
-                tags=["test-tag"],
-            )
+        cache, "async_set_cache_pipeline", new=AsyncMock()
+    ) as mock_set_cache:
+        await litellm.proxy.proxy_server.update_cache(
+            token=None,
+            user_id=None,
+            end_user_id=None,
+            team_id=None,
+            response_cost=5.0,
+            parent_otel_span=None,
+            tags=["test-tag"],
+        )
 
-            await asyncio.sleep(0.1)
+        await asyncio.sleep(0.1)
 
-            mock_get_cache.assert_awaited_once_with(key="tag:test-tag")
-            mock_set_cache.assert_awaited_once()
-
-            call_args = mock_set_cache.call_args
-            cache_list = call_args.kwargs["cache_list"]
-
-            assert len(cache_list) == 1
-            cache_key, cache_value = cache_list[0]
-            assert cache_key == "tag:test-tag"
-            assert cache_value["spend"] == 15.0
+        mock_set_cache.assert_awaited_once()
+        cache_list = mock_set_cache.call_args.kwargs["cache_list"]
+        tag_keys = {k for k, _ in cache_list if k.startswith("tag:")}
+        assert tag_keys == set(), (
+            f"Tag object was written back to cache: {tag_keys} "
+            f"— this causes stale resurrection in multi-pod deployments"
+        )
 
 
 @pytest.mark.asyncio
 async def test_tag_cache_update_multiple_tags():
     """
-    Test that multiple tags are updated in cache.
+    Test that update_cache does NOT write any tag objects back for multiple tags
+    (stale resurrection fix: _update_tag_cache is a no-op).
     """
     from litellm.caching.caching import DualCache
-    from litellm.proxy.proxy_server import user_api_key_cache
 
     cache = DualCache()
+    setattr(litellm.proxy.proxy_server, "user_api_key_cache", cache)
 
-    setattr(
-        litellm.proxy.proxy_server,
-        "user_api_key_cache",
-        cache,
+    with patch.object(
+        cache, "async_set_cache_pipeline", new=AsyncMock()
+    ) as mock_set_cache:
+        await litellm.proxy.proxy_server.update_cache(
+            token=None,
+            user_id=None,
+            end_user_id=None,
+            team_id=None,
+            response_cost=5.0,
+            parent_otel_span=None,
+            tags=["tag1", "tag2"],
+        )
+
+        await asyncio.sleep(0.1)
+
+        mock_set_cache.assert_awaited_once()
+        cache_list = mock_set_cache.call_args.kwargs["cache_list"]
+        tag_keys = {k for k, _ in cache_list if k.startswith("tag:")}
+        assert tag_keys == set(), (
+            f"Tag objects were written back to cache: {tag_keys} "
+            f"— this causes stale resurrection in multi-pod deployments"
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_cache_no_entity_object_writeback():
+    """
+    Regression test for stale resurrection bug:
+    update_cache() must NOT write key/user/end-user/team/tag objects back to the
+    user_api_key_cache pipeline. Only the global proxy spend counter (a numeric
+    value) may be written. Writing stale objects back overwrites a freshly-loaded
+    DB value on another pod, causing budget checks to use wrong spend totals.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from litellm.caching.caching import DualCache
+
+    cache = DualCache()
+    setattr(litellm.proxy.proxy_server, "user_api_key_cache", cache)
+
+    hashed_token = "hashed-test-token"
+    fake_key = MagicMock()
+    fake_key.spend = 10.0
+    fake_key.soft_budget_cooldown = False
+    fake_key.litellm_budget_table = None
+
+    litellm_proxy_admin_name = getattr(
+        litellm.proxy.proxy_server, "litellm_proxy_admin_name", "default_user_id"
     )
 
-    mock_tag1_obj = {"tag_name": "tag1", "spend": 10.0}
-    mock_tag2_obj = {"tag_name": "tag2", "spend": 20.0}
-
-    async def mock_get_cache_side_effect(key):
-        if key == "tag:tag1":
-            return mock_tag1_obj
-        elif key == "tag:tag2":
-            return mock_tag2_obj
+    async def fake_get_cache(key):
+        if key == hashed_token:
+            return fake_key
+        if key == f"{litellm_proxy_admin_name}:spend":
+            return 100.0
         return None
 
     with patch.object(
-        cache, "async_get_cache", new=AsyncMock(side_effect=mock_get_cache_side_effect)
-    ) as mock_get_cache:
+        cache, "async_get_cache", new=AsyncMock(side_effect=fake_get_cache)
+    ):
         with patch.object(
             cache, "async_set_cache_pipeline", new=AsyncMock()
-        ) as mock_set_cache:
+        ) as mock_pipeline:
             await litellm.proxy.proxy_server.update_cache(
-                token=None,
-                user_id=None,
-                end_user_id=None,
-                team_id=None,
-                response_cost=5.0,
+                token=hashed_token,
+                user_id="user-123",
+                end_user_id="eu-456",
+                team_id="team-789",
+                response_cost=1.0,
                 parent_otel_span=None,
-                tags=["tag1", "tag2"],
+                tags=["billing"],
             )
-
             await asyncio.sleep(0.1)
 
-            assert mock_get_cache.call_count == 2
-            mock_set_cache.assert_awaited_once()
+    mock_pipeline.assert_awaited_once()
+    cache_list = mock_pipeline.call_args.kwargs["cache_list"]
 
-            call_args = mock_set_cache.call_args
-            cache_list = call_args.kwargs["cache_list"]
+    written_keys = {k for k, _ in cache_list}
 
-            assert len(cache_list) == 2
+    # Key object must never be written back
+    assert (
+        hashed_token not in written_keys
+    ), "Key object was written back — stale resurrection risk"
 
-            tag_updates = {
-                cache_key: cache_value for cache_key, cache_value in cache_list
-            }
-            assert "tag:tag1" in tag_updates
-            assert "tag:tag2" in tag_updates
-            assert tag_updates["tag:tag1"]["spend"] == 15.0
-            assert tag_updates["tag:tag2"]["spend"] == 25.0
+    # Only numeric counters (global proxy spend) may be in the pipeline
+    for k, v in cache_list:
+        assert isinstance(v, (int, float)), (
+            f"Non-numeric value written to cache for key {k!r}: {type(v).__name__}. "
+            "Only numeric counters (e.g. global proxy spend) should be in the pipeline."
+        )
 
 
 @pytest.mark.asyncio
@@ -4913,9 +4937,7 @@ async def test_increment_spend_counters_team_and_member():
             response_cost=0.30,
         )
 
-        team_counter = counter_cache.in_memory_cache.get_cache(
-            key="spend:team:team-1"
-        )
+        team_counter = counter_cache.in_memory_cache.get_cache(key="spend:team:team-1")
         assert team_counter == 2.30
 
         member_counter = counter_cache.in_memory_cache.get_cache(


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`update_cache()` fires after every successful LLM request to track spend. It was doing a read-modify-write on the full cached object for every entity type (key, user, team, tag):

1. Read the cached object
2. Bump `.spend`
3. Write the entire object back with a fresh 60s TTL

If `/key/update` invalidates the cache between steps 1 and 3, step 3 resurrects the stale object — overwriting the fresh DB-loaded entry. Under continuous traffic this repeats on every request, so the stale entry never expires. Changes to `blocked`, `max_budget`, `models`, `metadata`, etc. are silently ignored.

This is worst in multi-pod deployments (Cloud Run, k8s) — confirmed in production where one instance enforced a `max_budget` change while another kept serving requests indefinitely because its in-flight requests kept resurrecting the old object.

A secondary issue: the soft budget and alert checks (`_virtual_key_soft_budget_check`, `_virtual_key_max_budget_alert_check`, `_team_soft_budget_check`) were reading spend from the cached object's `.spend` field instead of the cross-pod atomic counters, so alerts could fire on stale or per-pod-only spend values.


### Fix - Stop writing entity objects back to cache (`proxy_server.py`)

`update_cache()` no longer writes key/user/end-user/team/tag objects back to `user_api_key_cache`. Cached objects are now read-only after initial DB load — they expire naturally via TTL and reload fresh from DB on the next cache miss. The only thing still written to the pipeline is the global proxy spend counter (a plain number, not an object).

The projected-spend alert in `_update_key_cache` is kept — it reads the cached object to fire the alert, it just no longer writes it back. The end-user, team, and tag sub-functions are removed entirely since their only purpose was the writeback.

### Use cross-pod spend counters for alerts (`auth_checks.py`)

Three alert functions now call `get_current_spend()` (Redis-first atomic counters) instead of reading `.spend` off the cached object:

- `_virtual_key_soft_budget_check`
- `_virtual_key_max_budget_alert_check`
- `_team_soft_budget_check`

This matches how `_virtual_key_max_budget_check` (hard limit) already worked since PR #24682.

### Trade-offs

@krrish-berri-2 

The user and end-user budget checks are slightly less precise within a 60s window — a user could marginally overspend before the cache refreshes from DB. This was already broken in multi-pod deployments, so it's only a regression for single-pod. The proper fix is a follow-up (add spend counters for users/end-users like we did for keys and teams).

### Tests (`test_proxy_server.py`)

Added `test_update_cache_no_entity_object_writeback` as a regression guard — calls `update_cache()` with all entity types and asserts only numeric values appear in the pipeline. Two existing tests that asserted the old writeback behavior were updated to match.

Also manually verified on a running proxy: blocked a key via `/key/update`, confirmed subsequent requests returned `401` immediately with no resurrection.