### PR TITLE
fix(proxy): filter unresolved key/team model strings from /v1/models

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -4,12 +4,11 @@ from typing import Dict, List, Optional, Set
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
 from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
 from litellm.types.router import LiteLLM_Params
-from litellm.types.utils import LlmProvidersSet
 from litellm.utils import get_valid_models
 
 
@@ -66,24 +65,22 @@ def _get_models_from_access_groups(
     return all_models
 
 
-def _is_known_provider_qualified_model(model: str) -> bool:
+def _is_resolvable_dynamic_model(model: str) -> bool:
     """
-    Return True for provider-qualified model identifiers such as:
-    - openai/gpt-4o-mini
-    - bedrock/us.amazon.nova-micro-v1:0
-    - openrouter/auto
+    Return True for model identifiers that LiteLLM can still resolve even when
+    they are not present in the static model list.
 
-    This intentionally allows provider-prefixed models even when the exact
-    model name is not yet in LiteLLM's static model list, since those routes
-    may still be valid for pass-through / BYOK flows.
+    This covers:
+    - provider-qualified routes such as `bedrock/us.amazon.nova-micro-v1:0`
+      or JSON-registry providers such as `publicai/some-new-model`
+    - dynamic model identifiers such as OpenAI fine-tunes
+      (`ft:gpt-4o:my-org:custom:id`)
     """
-    if "/" not in model:
+    try:
+        get_llm_provider(model=model)
+        return True
+    except Exception:
         return False
-
-    provider_prefix = model.split("/", 1)[0]
-    return provider_prefix in LlmProvidersSet or JSONProviderRegistry.exists(
-        provider_prefix
-    )
 
 
 def _should_include_model_in_complete_list(
@@ -99,11 +96,12 @@ def _should_include_model_in_complete_list(
     - configured proxy model groups
     - configured access group names
     - known base model IDs (e.g. gpt-4o-mini)
-    - known provider-qualified routes (e.g. openai/gpt-4o-mini, bedrock/*)
+    - provider-qualified or other dynamically resolvable model IDs
+      (e.g. openai/gpt-4o-mini, publicai/foo, ft:gpt-4o:org:suffix:id)
 
     Drop:
     - arbitrary strings that don't resolve to a proxy model, access group, or
-      a recognized LiteLLM/provider model route.
+      a recognized LiteLLM model route.
     """
     if model in (
         SpecialModelNames.all_proxy_models.value,
@@ -120,7 +118,7 @@ def _should_include_model_in_complete_list(
     if model == "*":
         return True
 
-    if _is_known_provider_qualified_model(model):
+    if _is_resolvable_dynamic_model(model):
         return True
 
     return False

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -4,10 +4,12 @@ from typing import Dict, List, Optional, Set
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
 from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
 from litellm.types.router import LiteLLM_Params
+from litellm.types.utils import LlmProvidersSet
 from litellm.utils import get_valid_models
 
 
@@ -62,6 +64,82 @@ def _get_models_from_access_groups(
 
     all_models.extend(new_models)
     return all_models
+
+
+def _is_known_provider_qualified_model(model: str) -> bool:
+    """
+    Return True for provider-qualified model identifiers such as:
+    - openai/gpt-4o-mini
+    - bedrock/us.amazon.nova-micro-v1:0
+    - openrouter/auto
+
+    This intentionally allows provider-prefixed models even when the exact
+    model name is not yet in LiteLLM's static model list, since those routes
+    may still be valid for pass-through / BYOK flows.
+    """
+    if "/" not in model:
+        return False
+
+    provider_prefix = model.split("/", 1)[0]
+    return provider_prefix in LlmProvidersSet or JSONProviderRegistry.exists(
+        provider_prefix
+    )
+
+
+def _should_include_model_in_complete_list(
+    model: str,
+    proxy_model_list: List[str],
+    model_access_groups: Dict[str, List[str]],
+) -> bool:
+    """
+    Filter out unresolved strings from the final model list returned by
+    /v1/models and related endpoints.
+
+    Keep:
+    - configured proxy model groups
+    - configured access group names
+    - known base model IDs (e.g. gpt-4o-mini)
+    - known provider-qualified routes (e.g. openai/gpt-4o-mini, bedrock/*)
+
+    Drop:
+    - arbitrary strings that don't resolve to a proxy model, access group, or
+      a recognized LiteLLM/provider model route.
+    """
+    if model in (
+        SpecialModelNames.all_proxy_models.value,
+        SpecialModelNames.all_team_models.value,
+    ):
+        return False
+
+    if model in proxy_model_list or model in model_access_groups:
+        return True
+
+    if model in litellm.model_list_set:
+        return True
+
+    if model == "*":
+        return True
+
+    if _is_known_provider_qualified_model(model):
+        return True
+
+    return False
+
+
+def _filter_complete_model_list(
+    models: List[str],
+    proxy_model_list: List[str],
+    model_access_groups: Dict[str, List[str]],
+) -> List[str]:
+    return [
+        model
+        for model in models
+        if _should_include_model_in_complete_list(
+            model=model,
+            proxy_model_list=proxy_model_list,
+            model_access_groups=model_access_groups,
+        )
+    ]
 
 
 async def get_mcp_server_ids(
@@ -210,6 +288,12 @@ def get_complete_model_list(
         if infer_model_from_keys:
             valid_models = get_valid_models()
             append_unique(valid_models)
+
+    unique_models = _filter_complete_model_list(
+        models=unique_models,
+        proxy_model_list=proxy_model_list,
+        model_access_groups=model_access_groups,
+    )
 
     if only_model_access_groups:
         model_access_groups_to_return: List[str] = []

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Set
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
 from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
@@ -74,8 +73,18 @@ def _is_resolvable_dynamic_model(model: str) -> bool:
     - provider-qualified routes such as `bedrock/us.amazon.nova-micro-v1:0`
       or JSON-registry providers such as `publicai/some-new-model`
     - dynamic model identifiers such as OpenAI fine-tunes
-      (`ft:gpt-4o:my-org:custom:id`)
+      (`ft:gpt-4o:my-org:custom:id`, `ft:davinci-002:org:suffix:id`)
     """
+    # OpenAI fine-tuned model ids are valid dynamic models, including legacy
+    # bases such as `ft:davinci-002:...` and `ft:babbage-002:...`.
+    # Keep them without calling get_llm_provider(), which currently does not
+    # recognize every historical fine-tune base and prints provider-help text
+    # on failure.
+    if model.startswith("ft:"):
+        return True
+
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
     try:
         get_llm_provider(model=model)
         return True

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -1,9 +1,4 @@
-from unittest.mock import AsyncMock, patch
-
 import pytest
-
-from litellm.proxy._types import LiteLLM_TeamTable, LiteLLM_UserTable, Member
-from litellm.proxy.auth.handle_jwt import JWTAuthManager
 
 
 def test_get_team_models_for_all_models_and_team_only_models():

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -347,3 +347,31 @@ def test_get_complete_model_list_keeps_openai_finetune_model_ids():
     )
 
     assert result == [finetuned_model]
+
+
+@pytest.mark.parametrize(
+    "finetuned_model",
+    [
+        "ft:davinci-002:my-org:custom-suffix:model-id",
+        "ft:babbage-002:my-org:custom-suffix:model-id",
+    ],
+)
+def test_get_complete_model_list_keeps_legacy_openai_finetune_model_ids(
+    finetuned_model: str,
+):
+    """
+    Legacy OpenAI fine-tuned model IDs should also remain visible even though
+    get_llm_provider() does not recognize all historical fine-tune base names.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=[finetuned_model],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == [finetuned_model]

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -312,3 +312,43 @@ def test_get_complete_model_list_keeps_provider_qualified_models():
     )
 
     assert result == ["bedrock/very_new_model"]
+
+
+def test_get_complete_model_list_keeps_json_registry_provider_models():
+    """
+    JSON-registry-only providers should also survive filtering even when the
+    exact model name is not present in LiteLLM's static model list.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["publicai/some-new-model"],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["publicai/some-new-model"]
+
+
+def test_get_complete_model_list_keeps_openai_finetune_model_ids():
+    """
+    OpenAI fine-tuned model IDs are dynamic valid models and should remain in
+    the final list even though they are not in LiteLLM's static model list.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    finetuned_model = "ft:gpt-4o:my-org:custom-suffix:model-id"
+
+    result = get_complete_model_list(
+        key_models=[finetuned_model],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == [finetuned_model]

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -37,7 +37,10 @@ def test_get_team_models_all_proxy_models_includes_access_groups():
     }
 
     result = get_team_models(
-        team_models, proxy_model_list, model_access_groups, include_model_access_groups=True
+        team_models,
+        proxy_model_list,
+        model_access_groups,
+        include_model_access_groups=True,
     )
     assert "group-a" in result
     assert "group-b" in result
@@ -61,7 +64,10 @@ def test_get_team_models_all_proxy_models_without_include_flag():
     }
 
     result = get_team_models(
-        team_models, proxy_model_list, model_access_groups, include_model_access_groups=False
+        team_models,
+        proxy_model_list,
+        model_access_groups,
+        include_model_access_groups=False,
     )
     assert "group-a" not in result
     assert "group-b" not in result
@@ -159,43 +165,66 @@ def test_get_key_models_does_not_mutate_input():
     "key_models,team_models,proxy_model_list,model_list,expected",
     [
         (
-            ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-haiku-20241022"],
+            [
+                "anthropic/claude-3-haiku-20240307",
+                "anthropic/claude-3-5-haiku-20241022",
+            ],
             [],
             [],
             [{"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*"}}],
-            ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-haiku-20241022"]
+            [
+                "anthropic/claude-3-haiku-20240307",
+                "anthropic/claude-3-5-haiku-20241022",
+            ],
         ),
         (
             [],
-            ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-haiku-20241022"],
+            [
+                "anthropic/claude-3-haiku-20240307",
+                "anthropic/claude-3-5-haiku-20241022",
+            ],
             [],
             [{"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*"}}],
-            ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-haiku-20241022"]
+            [
+                "anthropic/claude-3-haiku-20240307",
+                "anthropic/claude-3-5-haiku-20241022",
+            ],
         ),
         (
             [],
             [],
-            ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-haiku-20241022"],
+            [
+                "anthropic/claude-3-haiku-20240307",
+                "anthropic/claude-3-5-haiku-20241022",
+            ],
             [{"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*"}}],
-            ["anthropic/claude-3-haiku-20240307", "anthropic/claude-3-5-haiku-20241022"]
+            [
+                "anthropic/claude-3-haiku-20240307",
+                "anthropic/claude-3-5-haiku-20241022",
+            ],
         ),
     ],
 )
-def test_get_complete_model_list_order(key_models, team_models, proxy_model_list, model_list, expected):
+def test_get_complete_model_list_order(
+    key_models, team_models, proxy_model_list, model_list, expected
+):
     """
     Test that get_complete_model_list preserves order
     """
     from litellm.proxy.auth.model_checks import get_complete_model_list
     from litellm import Router
 
-    assert get_complete_model_list(
-        proxy_model_list=proxy_model_list,
-        key_models=key_models,
-        team_models=team_models,
-        user_model=None,
-        infer_model_from_keys=False,
-        llm_router=Router(model_list=model_list),
-    ) == expected
+    assert (
+        get_complete_model_list(
+            proxy_model_list=proxy_model_list,
+            key_models=key_models,
+            team_models=team_models,
+            user_model=None,
+            infer_model_from_keys=False,
+            llm_router=Router(model_list=model_list),
+        )
+        == expected
+    )
 
 
 def test_get_complete_model_list_byok_wildcard_expansion():
@@ -220,3 +249,66 @@ def test_get_complete_model_list_byok_wildcard_expansion():
     assert len(result) > 0
     assert all(m.startswith("openai/") for m in result)
     assert "openai/*" not in result
+
+
+def test_get_complete_model_list_filters_unknown_non_model_strings():
+    """
+    If a key contains an arbitrary string that is neither:
+    - a configured proxy model
+    - a configured access group
+    - a known LiteLLM model id
+    - nor a recognized provider-qualified route
+
+    it should not leak into the final /v1/models response.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["team-sales-api"],
+        team_models=[],
+        proxy_model_list=["gpt-4o-mini"],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert "team-sales-api" not in result
+    assert result == []
+
+
+def test_get_complete_model_list_keeps_known_base_model_ids():
+    """
+    Exact model IDs can be valid even when they are not configured as proxy
+    model groups, so known LiteLLM model ids should remain in the final list.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["gpt-4o-mini"],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["gpt-4o-mini"]
+
+
+def test_get_complete_model_list_keeps_provider_qualified_models():
+    """
+    Provider-qualified model identifiers should survive filtering even if the
+    exact model name is newer than LiteLLM's baked-in model list.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+
+    result = get_complete_model_list(
+        key_models=["bedrock/very_new_model"],
+        team_models=[],
+        proxy_model_list=[],
+        user_model=None,
+        infer_model_from_keys=False,
+        model_access_groups={},
+    )
+
+    assert result == ["bedrock/very_new_model"]


### PR DESCRIPTION
## Relevant issues

Fixes #25550

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix  
✅ Test

## Changes

This fixes a proxy bug where unresolved key/team model strings could leak into `/v1/models`.

### Problem

If a virtual key or team was created with a model restriction like `team-sales-api` that did not resolve to:

- a configured proxy model,
- a configured model group,
- a known LiteLLM base model, or
- a recognized provider-qualified model,

that raw string could still show up in `/v1/models` and `client.models.list()`.

This made unresolved access-control strings look like real available models.

### Fix

Filter the final model list returned by `get_complete_model_list()` so that `/v1/models` only includes entries that are actually resolvable/valid for model listing:

- configured proxy model groups
- configured access groups
- known LiteLLM model ids
- recognized provider-qualified models

This preserves valid provider-qualified/BYOK-style model names while excluding arbitrary unresolved strings.

### Tests added

Added regression coverage for:

- unresolved key/team model strings are excluded from `/v1/models`
- valid access groups remain visible
- valid provider-qualified model names still remain visible
