### PR TITLE
fix(ui): org_admin unable to view organization-wide usage data in UI Dashboard

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/page.tsx
@@ -3,12 +3,14 @@
 import UsagePageView from "@/components/UsagePage/components/UsagePageView";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
+import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 
 const UsagePage = () => {
   const { accessToken, userRole, userId, premiumUser } = useAuthorized();
   const { teams } = useTeams();
+  const { data: organizations } = useOrganizations();
 
-  return <UsagePageView teams={teams ?? []} organizations={[]} />;
+  return <UsagePageView teams={teams ?? []} organizations={organizations ?? []} />;
 };
 
 export default UsagePage;


### PR DESCRIPTION
## Relevant issues

Fixes #25493

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before:** `org_admin` navigates to Usage → "Your Organization Usage" → sees $0.00 / 0 requests / empty charts / no organization filter dropdown.

**After:** `useOrganizations()` hook fetches the user's organizations via `/organization/list`, populating the filter dropdown and enabling the usage data display.

## Type

🐛 Bug Fix

## Changes

### Problem
`org_admin` users see completely empty organization usage data in the UI Dashboard. The Usage page (`usage/page.tsx`) hardcodes `organizations={[]}` instead of fetching real organization data, so `EntityUsage` receives an empty list, hides the filter dropdown, and cannot display any data.

### Root Cause
`usage/page.tsx:11` passes `organizations={[]}` to `UsagePageView`. The `useOrganizations()` hook (already used in `users/page.tsx`) was never imported or called.

### Fix
- Added `useOrganizations()` hook import and call in `usage/page.tsx`
- Pass `organizations ?? []` to `UsagePageView`

This is a 2-line change that mirrors the existing pattern in `users/page.tsx`. No backend changes needed — both `/organization/list` and `/organization/daily/activity` already handle `org_admin` authorization correctly.

### Files Changed
- `ui/litellm-dashboard/src/app/(dashboard)/usage/page.tsx` — Import and use `useOrganizations()` hook instead of hardcoding `[]`