### PR TITLE
fix: blog dark mode - text invisible on dark background

### DIFF
--- a/docs/my-website/src/css/custom.css
+++ b/docs/my-website/src/css/custom.css
@@ -899,18 +899,28 @@ video {
   font-size: 0.85rem;
 }
 
-[data-theme='dark'] .blog-wrapper article header h1,
-[data-theme='dark'] .blog-wrapper article .markdown h2,
-[data-theme='dark'] .blog-wrapper article .markdown h3 {
+[data-theme='dark'].blog-wrapper article header h1,
+[data-theme='dark'].blog-wrapper article .markdown h2,
+[data-theme='dark'].blog-wrapper article .markdown h3 {
   color: #f9fafb;
 }
 
-[data-theme='dark'] .blog-wrapper article .markdown {
+[data-theme='dark'].blog-wrapper article .markdown {
   color: #d1d5db;
 }
 
-[data-theme='dark'] .blog-wrapper article .markdown code {
+[data-theme='dark'].blog-wrapper article .markdown code {
   background: #1f2937;
   border-color: #374151;
   color: #f9fafb;
+}
+
+[data-theme='dark'].blog-wrapper article .markdown pre {
+  background: #161b22 !important;
+  border-color: #30363d !important;
+  box-shadow: none;
+}
+
+[data-theme='dark'].blog-wrapper article .markdown a {
+  color: #38bdf8;
 }

--- a/docs/my-website/src/theme/BlogListPage/styles.module.css
+++ b/docs/my-website/src/theme/BlogListPage/styles.module.css
@@ -252,3 +252,32 @@
 [data-theme='dark'] .hiringBtn:hover {
   background: #fff;
 }
+
+[data-theme='dark'] .marqueeItem {
+  color: #9ca3af;
+}
+
+[data-theme='dark'] .marqueeSep {
+  color: #374151;
+}
+
+[data-theme='dark'] .marqueeLabel {
+  color: #6b7280;
+}
+
+[data-theme='dark'] .pageLink {
+  color: #d1d5db;
+}
+
+[data-theme='dark'] .pageLink:hover {
+  color: #38bdf8;
+}
+
+[data-theme='dark'] .meta {
+  color: #9ca3af;
+}
+
+[data-theme='dark'] .metaDash,
+[data-theme='dark'] .authorSep {
+  color: #4b5563;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Fixes blog dark mode readability issue reported via user feedback — text was invisible (dark text on dark background).

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- N/A: CSS-only change to docs site — no backend/library code affected, no unit tests applicable

## Screenshots / Proof of Fix

**Before (reported issue):** Blog post title, headings, and body text are invisible in dark mode — dark text (#111827) rendered on dark background (#0d1117).

**After fix — Blog post page in dark mode:**
[Blog post in dark mode with readable light text](https://cursor.com/agents/bc-ce82dd1b-a45f-574e-95da-e4bbba774c83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dark_mode_fixed.webp)

**After fix — Blog list page in dark mode:**
[Blog list page in dark mode with readable text](https://cursor.com/agents/bc-ce82dd1b-a45f-574e-95da-e4bbba774c83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_list_dark_mode.webp)

**Light mode still works correctly:**
[Blog post in light mode](https://cursor.com/agents/bc-ce82dd1b-a45f-574e-95da-e4bbba774c83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_light_mode.webp)

**Video walkthrough:**
[blog_dark_mode_fix_demo.mp4](https://cursor.com/agents/bc-ce82dd1b-a45f-574e-95da-e4bbba774c83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dark_mode_fix_demo.mp4)

## Type

🐛 Bug Fix

## Changes

### Root cause

Docusaurus applies both `data-theme="dark"` and the `blog-wrapper` class to the **same `<html>` element**. The CSS dark-mode overrides used **descendant selectors** with a space:

```css
/* BROKEN: looks for .blog-wrapper as a DESCENDANT of [data-theme='dark'] */
[data-theme='dark'] .blog-wrapper article header h1 { color: #f9fafb; }
```

Since both attributes are on `<html>`, `.blog-wrapper` is never a descendant of `[data-theme='dark']` — they're on the same element. The dark-mode overrides never applied, leaving the light-mode colors (#111827 dark text) on the dark background (#0d1117).

### Fix

Changed to **compound selectors** (no space) so both conditions match the same `<html>` element:

```css
/* FIXED: matches <html data-theme="dark" class="blog-wrapper"> */
[data-theme='dark'].blog-wrapper article header h1 { color: #f9fafb; }
```

### Additional improvements

- Added missing dark-mode overrides for `pre` code blocks and links in blog posts
- Added dark-mode overrides for blog list page elements: marquee items, pagination links, meta text, and author separators


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C04HP96S19D/p1776050211772189?thread_ts=1776050211.772189&cid=C04HP96S19D)

<div><a href="https://cursor.com/agents/bc-ce82dd1b-a45f-574e-95da-e4bbba774c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce82dd1b-a45f-574e-95da-e4bbba774c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

