### PR TITLE
fix: include tool_choice (toolConfig) in vertex AI context caching

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -93,9 +93,9 @@ class ContextCachingEndpoints(VertexBase):
             model=model,
             vertex_project=vertex_project,
             vertex_location=vertex_location,
-            vertex_api_version="v1beta1"
-            if custom_llm_provider == "vertex_ai_beta"
-            else "v1",
+            vertex_api_version=(
+                "v1beta1" if custom_llm_provider == "vertex_ai_beta" else "v1"
+            ),
         )
 
     def check_cache(

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -402,7 +402,8 @@ class ContextCachingEndpoints(VertexBase):
         )
 
         cached_content_request_body["tools"] = tools
-        cached_content_request_body["tool_choice"] = tool_choice
+        if tool_choice is not None:
+            cached_content_request_body["toolConfig"] = tool_choice
 
         ## LOGGING
         logging_obj.pre_call(
@@ -550,7 +551,8 @@ class ContextCachingEndpoints(VertexBase):
         )
 
         cached_content_request_body["tools"] = tools
-        cached_content_request_body["tool_choice"] = tool_choice
+        if tool_choice is not None:
+            cached_content_request_body["toolConfig"] = tool_choice
 
         ## LOGGING
         logging_obj.pre_call(

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -338,6 +338,7 @@ class ContextCachingEndpoints(VertexBase):
             return messages, optional_params, None
 
         tools = optional_params.pop("tools", None)
+        tool_choice = optional_params.pop("tool_choice", None)
 
         ## AUTHORIZATION ##
         token, url = self._get_token_and_url_context_caching(
@@ -370,7 +371,7 @@ class ContextCachingEndpoints(VertexBase):
 
         ## CHECK IF CACHED ALREADY
         generated_cache_key = local_cache_obj.get_cache_key(
-            messages=cached_messages, tools=tools, model=model
+            messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
         google_cache_name = self.check_cache(
             cache_key=generated_cache_key,
@@ -401,6 +402,7 @@ class ContextCachingEndpoints(VertexBase):
         )
 
         cached_content_request_body["tools"] = tools
+        cached_content_request_body["tool_choice"] = tool_choice
 
         ## LOGGING
         logging_obj.pre_call(
@@ -486,6 +488,7 @@ class ContextCachingEndpoints(VertexBase):
             return messages, optional_params, None
 
         tools = optional_params.pop("tools", None)
+        tool_choice = optional_params.pop("tool_choice", None)
 
         ## AUTHORIZATION ##
         token, url = self._get_token_and_url_context_caching(
@@ -515,7 +518,7 @@ class ContextCachingEndpoints(VertexBase):
 
         ## CHECK IF CACHED ALREADY
         generated_cache_key = local_cache_obj.get_cache_key(
-            messages=cached_messages, tools=tools, model=model
+            messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
         google_cache_name = await self.async_check_cache(
             cache_key=generated_cache_key,
@@ -547,6 +550,7 @@ class ContextCachingEndpoints(VertexBase):
         )
 
         cached_content_request_body["tools"] = tools
+        cached_content_request_body["tool_choice"] = tool_choice
 
         ## LOGGING
         logging_obj.pre_call(

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -201,9 +201,9 @@ class TestContextCachingEndpoints:
         assert returned_params == optional_params
         assert returned_cache == "existing_cache_name"
 
-        # Verify cache key was generated with tools and model
+        # Verify cache key was generated with tools, tool_choice, and model
         mock_cache_obj.get_cache_key.assert_called_once_with(
-            messages=cached_messages, tools=self.sample_tools, model="gemini-1.5-pro"
+            messages=cached_messages, tools=self.sample_tools, tool_choice=None, model="gemini-1.5-pro"
         )
 
     @pytest.mark.parametrize(
@@ -280,6 +280,8 @@ class TestContextCachingEndpoints:
         call_args = self.mock_client.post.call_args
         assert "tools" in call_args.kwargs["json"]
         assert call_args.kwargs["json"]["tools"] == self.sample_tools
+        assert "tool_choice" in call_args.kwargs["json"]
+        assert call_args.kwargs["json"]["tool_choice"] is None
 
     @pytest.mark.parametrize(
         "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
@@ -474,9 +476,9 @@ class TestContextCachingEndpoints:
         assert returned_params == optional_params
         assert returned_cache == "existing_cache_name"
 
-        # Verify cache key was generated with tools and model
+        # Verify cache key was generated with tools, tool_choice, and model
         mock_cache_obj.get_cache_key.assert_called_once_with(
-            messages=cached_messages, tools=self.sample_tools, model="gemini-1.5-pro"
+            messages=cached_messages, tools=self.sample_tools, tool_choice=None, model="gemini-1.5-pro"
         )
 
     @pytest.mark.asyncio
@@ -558,6 +560,8 @@ class TestContextCachingEndpoints:
         call_args = self.mock_async_client.post.call_args
         assert "tools" in call_args.kwargs["json"]
         assert call_args.kwargs["json"]["tools"] == self.sample_tools
+        assert "tool_choice" in call_args.kwargs["json"]
+        assert call_args.kwargs["json"]["tool_choice"] is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -905,6 +909,165 @@ class TestContextCachingEndpoints:
 
         # Restart the patcher so teardown_method can stop it cleanly
         self._token_check_patcher.start()
+
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    def test_check_and_create_cache_with_tool_choice(
+        self,
+        mock_get_token_url,
+        mock_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """Test that tool_choice is popped from optional_params, included in cache key, and set in request body"""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_check_cache.return_value = None
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_client.post.return_value = mock_response
+
+        tool_choice_value = {"type": "function", "function": {"name": "get_weather"}}
+        optional_params = {
+            "tools": self.sample_tools.copy(),
+            "tool_choice": tool_choice_value,
+        }
+
+        result = self.context_caching.check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        # tool_choice should be popped from optional_params
+        assert "tool_choice" not in optional_params
+        assert "tools" not in optional_params
+
+        # tool_choice should be passed to get_cache_key
+        mock_cache_obj.get_cache_key.assert_called_once_with(
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=tool_choice_value,
+            model="gemini-1.5-pro",
+        )
+
+        # tool_choice should be in the request body
+        call_args = self.mock_client.post.call_args
+        assert call_args.kwargs["json"]["tool_choice"] == tool_choice_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.separate_cached_messages"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.local_cache_obj"
+    )
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "async_check_cache")
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.get_async_httpx_client"
+    )
+    async def test_async_check_and_create_cache_with_tool_choice(
+        self,
+        mock_get_client,
+        mock_get_token_url,
+        mock_async_check_cache,
+        mock_transform,
+        mock_cache_obj,
+        mock_separate,
+        custom_llm_provider,
+    ):
+        """Test that tool_choice is popped, included in cache key, and set in request body (async)"""
+        cached_messages = [self.sample_messages[0]]
+        non_cached_messages = [self.sample_messages[1]]
+        mock_separate.return_value = (cached_messages, non_cached_messages)
+
+        mock_cache_obj.get_cache_key.return_value = "test_cache_key"
+        mock_async_check_cache.return_value = None
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "name": "new_cache_name",
+            "model": "gemini-1.5-pro",
+        }
+        self.mock_async_client.post = AsyncMock(return_value=mock_response)
+
+        tool_choice_value = {"type": "function", "function": {"name": "get_weather"}}
+        optional_params = {
+            "tools": self.sample_tools.copy(),
+            "tool_choice": tool_choice_value,
+        }
+
+        result = await self.context_caching.async_check_and_create_cache(
+            messages=self.sample_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_async_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project="test_project",
+            vertex_location="test_location",
+            vertex_auth_header="vertext_test_token",
+        )
+
+        # tool_choice should be popped from optional_params
+        assert "tool_choice" not in optional_params
+        assert "tools" not in optional_params
+
+        # tool_choice should be passed to get_cache_key
+        mock_cache_obj.get_cache_key.assert_called_once_with(
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=tool_choice_value,
+            model="gemini-1.5-pro",
+        )
+
+        # tool_choice should be in the request body
+        call_args = self.mock_async_client.post.call_args
+        assert call_args.kwargs["json"]["tool_choice"] == tool_choice_value
 
 
 class TestCheckCachePagination:

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -280,8 +280,7 @@ class TestContextCachingEndpoints:
         call_args = self.mock_client.post.call_args
         assert "tools" in call_args.kwargs["json"]
         assert call_args.kwargs["json"]["tools"] == self.sample_tools
-        assert "tool_choice" in call_args.kwargs["json"]
-        assert call_args.kwargs["json"]["tool_choice"] is None
+        assert "toolConfig" not in call_args.kwargs["json"]
 
     @pytest.mark.parametrize(
         "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
@@ -560,8 +559,7 @@ class TestContextCachingEndpoints:
         call_args = self.mock_async_client.post.call_args
         assert "tools" in call_args.kwargs["json"]
         assert call_args.kwargs["json"]["tools"] == self.sample_tools
-        assert "tool_choice" in call_args.kwargs["json"]
-        assert call_args.kwargs["json"]["tool_choice"] is None
+        assert "toolConfig" not in call_args.kwargs["json"]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -983,9 +981,9 @@ class TestContextCachingEndpoints:
             model="gemini-1.5-pro",
         )
 
-        # tool_choice should be in the request body
+        # tool_choice should be mapped to toolConfig in the request body
         call_args = self.mock_client.post.call_args
-        assert call_args.kwargs["json"]["tool_choice"] == tool_choice_value
+        assert call_args.kwargs["json"]["toolConfig"] == tool_choice_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -1065,9 +1063,9 @@ class TestContextCachingEndpoints:
             model="gemini-1.5-pro",
         )
 
-        # tool_choice should be in the request body
+        # tool_choice should be mapped to toolConfig in the request body
         call_args = self.mock_async_client.post.call_args
-        assert call_args.kwargs["json"]["tool_choice"] == tool_choice_value
+        assert call_args.kwargs["json"]["toolConfig"] == tool_choice_value
 
 
 class TestCheckCachePagination:

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -203,7 +203,10 @@ class TestContextCachingEndpoints:
 
         # Verify cache key was generated with tools, tool_choice, and model
         mock_cache_obj.get_cache_key.assert_called_once_with(
-            messages=cached_messages, tools=self.sample_tools, tool_choice=None, model="gemini-1.5-pro"
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=None,
+            model="gemini-1.5-pro",
         )
 
     @pytest.mark.parametrize(
@@ -477,7 +480,10 @@ class TestContextCachingEndpoints:
 
         # Verify cache key was generated with tools, tool_choice, and model
         mock_cache_obj.get_cache_key.assert_called_once_with(
-            messages=cached_messages, tools=self.sample_tools, tool_choice=None, model="gemini-1.5-pro"
+            messages=cached_messages,
+            tools=self.sample_tools,
+            tool_choice=None,
+            model="gemini-1.5-pro",
         )
 
     @pytest.mark.asyncio
@@ -1428,7 +1434,11 @@ class TestVertexAIGlobalLocation:
         caching = ContextCachingEndpoints()
 
         # Mock the _check_custom_proxy to return the URL unchanged
-        with patch.object(caching, '_check_custom_proxy', side_effect=lambda **kwargs: (kwargs.get('auth_header'), kwargs.get('url'))):
+        with patch.object(
+            caching,
+            "_check_custom_proxy",
+            side_effect=lambda **kwargs: (kwargs.get("auth_header"), kwargs.get("url")),
+        ):
             auth_header, url = caching._get_token_and_url_context_caching(
                 gemini_api_key=None,
                 custom_llm_provider="vertex_ai",
@@ -1441,13 +1451,19 @@ class TestVertexAIGlobalLocation:
             # Assert correct URL format for global
             expected_url = "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/cachedContents"
             assert url == expected_url, f"Expected {expected_url}, got {url}"
-            assert "global-aiplatform" not in url, "URL should not contain 'global-aiplatform' prefix"
+            assert (
+                "global-aiplatform" not in url
+            ), "URL should not contain 'global-aiplatform' prefix"
 
     def test_regional_location_url_construction_v1(self):
         """Test that regional location uses correct URL (with location prefix) for v1 API."""
         caching = ContextCachingEndpoints()
 
-        with patch.object(caching, '_check_custom_proxy', side_effect=lambda **kwargs: (kwargs.get('auth_header'), kwargs.get('url'))):
+        with patch.object(
+            caching,
+            "_check_custom_proxy",
+            side_effect=lambda **kwargs: (kwargs.get("auth_header"), kwargs.get("url")),
+        ):
             auth_header, url = caching._get_token_and_url_context_caching(
                 gemini_api_key=None,
                 custom_llm_provider="vertex_ai",
@@ -1465,7 +1481,11 @@ class TestVertexAIGlobalLocation:
         """Test that global location uses correct URL for v1beta1 API."""
         caching = ContextCachingEndpoints()
 
-        with patch.object(caching, '_check_custom_proxy', side_effect=lambda **kwargs: (kwargs.get('auth_header'), kwargs.get('url'))):
+        with patch.object(
+            caching,
+            "_check_custom_proxy",
+            side_effect=lambda **kwargs: (kwargs.get("auth_header"), kwargs.get("url")),
+        ):
             auth_header, url = caching._get_token_and_url_context_caching(
                 gemini_api_key=None,
                 custom_llm_provider="vertex_ai_beta",
@@ -1478,7 +1498,9 @@ class TestVertexAIGlobalLocation:
             # Assert correct URL format for global with beta API
             expected_url = "https://aiplatform.googleapis.com/v1beta1/projects/test-project/locations/global/cachedContents"
             assert url == expected_url, f"Expected {expected_url}, got {url}"
-            assert "global-aiplatform" not in url, "URL should not contain 'global-aiplatform' prefix"
+            assert (
+                "global-aiplatform" not in url
+            ), "URL should not contain 'global-aiplatform' prefix"
 
     def test_gemini_context_caching_with_custom_api_base_passes_model(self):
         """Gemini context caching with custom api_base must pass model to _check_custom_proxy.


### PR DESCRIPTION
## Summary

When passing both `cache_control` and `tool_choice` together in a Gemini request, the following error is returned:

> "Tool config, tools and system instruction should not be set in the request when using cached content."

This happens because `tool_choice` (`toolConfig` in Gemini API) was not being included in the cached content creation request. As a result, it remained in the subsequent completion request alongside `cachedContent`, which Gemini does not allow.

### Changes

- Pop `tool_choice` from `optional_params` (same as `tools`) in both `check_and_create_cache` and `async_check_and_create_cache`
- Include `tool_choice` in `get_cache_key()` so that different `tool_choice` values produce different cache keys
- Set `toolConfig` in the cached content request body (only when `tool_choice` is not `None`), following the [CachedContent API schema](https://ai.google.dev/api/caching?hl=ko#cache_get-JAVASCRIPT)

## Test plan

- [x] Existing 80 tests pass
- [x] Added sync/async tests verifying `tool_choice` is popped, included in cache key, and mapped to `toolConfig` in request body
- [x] Updated existing assertions to reflect `tool_choice` in `get_cache_key` calls

<details>
<summary>이 작업을 진행하는데 사용된 프롬프트</summary>

> vertex_ai_context_caching async_check_and_create_cache 에서 local_cache_obj.get_cache_key 에 "tool" 과 동일하게 "tool_choice" 도 pop 한 후 전달해야돼
> 그리고 get_cache_key 에서 "tool_choice" 도 cacheKey 에 포함시켜줘.
> cached_content_request_body["tools"] = tools 할당시 "tool_choice" 도 같이 할당되어야 돼
>
> cached_content_request_body 에 셋팅되어야 되는 key 는 "tool_choice" 가 아니라 "toolConfig" 여야 될거 같아
> 문서 확인하고 검증한 후 맞다면 수정해줘

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)