### PR TITLE
fix: Fix Redis Sentinel client handling to solve authentication error with password protected sentinel

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -307,6 +307,10 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
+    master_kwargs = {}
+
+    if redis_kwargs.get("password") is not None:
+        master_kwargs["password"] = redis_kwargs.get("password")
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -319,18 +323,24 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel = redis.Sentinel(
         sentinel_nodes,
         socket_timeout=REDIS_SOCKET_TIMEOUT,
-        password=sentinel_password,
+        sentinel_kwargs={"password": sentinel_password}
+        if sentinel_password is not None
+        else None,
     )
 
     # Return the master instance for the given service
 
-    return sentinel.master_for(service_name)
+    return sentinel.master_for(service_name, **master_kwargs)
 
 
 def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
+    master_kwargs = {}
+
+    if redis_kwargs.get("password") is not None:
+        master_kwargs["password"] = redis_kwargs.get("password")
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -343,12 +353,14 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel = async_redis.Sentinel(
         sentinel_nodes,
         socket_timeout=REDIS_SOCKET_TIMEOUT,
-        password=sentinel_password,
+        sentinel_kwargs={"password": sentinel_password}
+        if sentinel_password is not None
+        else None,
     )
 
     # Return the master instance for the given service
 
-    return sentinel.master_for(service_name)
+    return sentinel.master_for(service_name, **master_kwargs)
 
 
 def get_redis_client(**env_overrides):

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -303,14 +303,23 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
     return redis.RedisCluster(startup_nodes=new_startup_nodes, **cluster_kwargs)  # type: ignore
 
 
+def _get_redis_sentinel_connection_kwargs(redis_kwargs: dict) -> dict:
+    connection_kwargs = {}
+    args = _get_redis_cluster_kwargs()
+    for arg in redis_kwargs:
+        if arg in args:
+            connection_kwargs[arg] = redis_kwargs[arg]
+
+    return connection_kwargs
+
+
 def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
-    master_kwargs = {}
-
-    if redis_kwargs.get("password") is not None:
-        master_kwargs["password"] = redis_kwargs.get("password")
+    connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
+    sentinel_kwargs = dict(connection_kwargs)
+    sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -323,24 +332,22 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel = redis.Sentinel(
         sentinel_nodes,
         socket_timeout=REDIS_SOCKET_TIMEOUT,
-        sentinel_kwargs={"password": sentinel_password}
-        if sentinel_password is not None
-        else None,
+        sentinel_kwargs=sentinel_kwargs,
+        **connection_kwargs,
     )
 
     # Return the master instance for the given service
 
-    return sentinel.master_for(service_name, **master_kwargs)
+    return sentinel.master_for(service_name)
 
 
 def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
-    master_kwargs = {}
-
-    if redis_kwargs.get("password") is not None:
-        master_kwargs["password"] = redis_kwargs.get("password")
+    connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
+    sentinel_kwargs = dict(connection_kwargs)
+    sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -353,14 +360,13 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel = async_redis.Sentinel(
         sentinel_nodes,
         socket_timeout=REDIS_SOCKET_TIMEOUT,
-        sentinel_kwargs={"password": sentinel_password}
-        if sentinel_password is not None
-        else None,
+        sentinel_kwargs=sentinel_kwargs,
+        **connection_kwargs,
     )
 
     # Return the master instance for the given service
 
-    return sentinel.master_for(service_name, **master_kwargs)
+    return sentinel.master_for(service_name)
 
 
 def get_redis_client(**env_overrides):

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -77,19 +77,23 @@ def _get_redis_cluster_kwargs(client=None):
     # Only allow primitive arguments
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
 
-    available_args = [x for x in arg_spec.args if x not in exclude_args]
-    available_args.append("password")
-    available_args.append("username")
-    available_args.append("ssl")
-    available_args.append("ssl_cert_reqs")
-    available_args.append("ssl_check_hostname")
-    available_args.append("ssl_ca_certs")
-    available_args.append(
-        "redis_connect_func"
-    )  # Needed for sync clusters and IAM detection
-    available_args.append("gcp_service_account")
-    available_args.append("gcp_ssl_ca_certs")
-    available_args.append("max_connections")
+    available_args = {x for x in arg_spec.args if x not in exclude_args}
+    available_args |= {
+        "password",
+        "username",
+        "ssl",
+        "ssl_cert_reqs",
+        "ssl_check_hostname",
+        "ssl_ca_certs",
+        "redis_connect_func",  # Needed for sync clusters and IAM detection
+        "gcp_service_account",
+        "gcp_ssl_ca_certs",
+        "max_connections",
+        "socket_timeout",
+        "socket_connect_timeout",
+        "socket_keepalive",
+        "socket_keepalive_options",
+    }
 
     return available_args
 
@@ -319,6 +323,8 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     service_name = redis_kwargs.get("service_name")
     connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
     sentinel_kwargs = dict(connection_kwargs)
+    connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
+    sentinel_kwargs.setdefault("socket_timeout", connection_kwargs["socket_timeout"])
     sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:
@@ -331,14 +337,12 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     # Set up the Sentinel client
     sentinel = redis.Sentinel(
         sentinel_nodes,
-        socket_timeout=REDIS_SOCKET_TIMEOUT,
         sentinel_kwargs=sentinel_kwargs,
-        **connection_kwargs,
     )
 
     # Return the master instance for the given service
 
-    return sentinel.master_for(service_name)
+    return sentinel.master_for(service_name, **connection_kwargs)
 
 
 def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
@@ -347,6 +351,8 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     service_name = redis_kwargs.get("service_name")
     connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
     sentinel_kwargs = dict(connection_kwargs)
+    connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
+    sentinel_kwargs.setdefault("socket_timeout", connection_kwargs["socket_timeout"])
     sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:
@@ -359,14 +365,12 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     # Set up the Sentinel client
     sentinel = async_redis.Sentinel(
         sentinel_nodes,
-        socket_timeout=REDIS_SOCKET_TIMEOUT,
         sentinel_kwargs=sentinel_kwargs,
-        **connection_kwargs,
     )
 
     # Return the master instance for the given service
 
-    return sentinel.master_for(service_name)
+    return sentinel.master_for(service_name, **connection_kwargs)
 
 
 def get_redis_client(**env_overrides):

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -89,10 +89,6 @@ def _get_redis_cluster_kwargs(client=None):
         "gcp_service_account",
         "gcp_ssl_ca_certs",
         "max_connections",
-        "socket_timeout",
-        "socket_connect_timeout",
-        "socket_keepalive",
-        "socket_keepalive_options",
     }
 
     return available_args
@@ -309,7 +305,7 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
 
 def _get_redis_sentinel_connection_kwargs(redis_kwargs: dict) -> dict:
     connection_kwargs = {}
-    args = _get_redis_cluster_kwargs()
+    args = _get_redis_kwargs()
     for arg in redis_kwargs:
         if arg in args:
             connection_kwargs[arg] = redis_kwargs[arg]
@@ -322,9 +318,8 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
     connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
-    sentinel_kwargs = dict(connection_kwargs)
     connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
-    sentinel_kwargs.setdefault("socket_timeout", connection_kwargs["socket_timeout"])
+    sentinel_kwargs = dict(connection_kwargs)
     sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:
@@ -350,9 +345,8 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
     connection_kwargs = _get_redis_sentinel_connection_kwargs(redis_kwargs)
-    sentinel_kwargs = dict(connection_kwargs)
     connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
-    sentinel_kwargs.setdefault("socket_timeout", connection_kwargs["socket_timeout"])
+    sentinel_kwargs = dict(connection_kwargs)
     sentinel_kwargs["password"] = sentinel_password
 
     if not sentinel_nodes or not service_name:

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -410,31 +410,6 @@ def test_sync_sentinel_uses_sentinel_password_and_master_password(mock_sentinel_
     )
 
 
-def test_sync_sentinel_socket_timeout_in_connection_kwargs_no_longer_raises():
-    """socket_timeout should be applied through master_for without duplicating constructor kwargs."""
-    mock_sentinel = MagicMock()
-    with patch(
-        "litellm._redis._get_redis_sentinel_connection_kwargs",
-        return_value={"password": "redis-secret", "socket_timeout": 5},
-    ), patch("litellm._redis.redis.Sentinel", return_value=mock_sentinel) as mock_cls:
-        get_redis_client(
-            sentinel_nodes=[("sentinel-1", 26379)],
-            sentinel_password="sentinel-secret",
-            service_name="mymaster",
-        )
-
-    sentinel_call_kwargs = mock_cls.call_args[1]
-    assert "socket_timeout" not in sentinel_call_kwargs
-    assert sentinel_call_kwargs["sentinel_kwargs"] == {
-        "password": "sentinel-secret",
-        "socket_timeout": 5,
-    }
-    assert "password" not in sentinel_call_kwargs
-    mock_sentinel.master_for.assert_called_once_with(
-        "mymaster", password="redis-secret", socket_timeout=5
-    )
-
-
 @patch("litellm._redis.async_redis.Sentinel")
 def test_async_sentinel_uses_sentinel_password_and_master_password(
     mock_sentinel_cls,

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -365,15 +365,36 @@ def test_sync_sentinel_uses_sentinel_password_and_master_password(mock_sentinel_
         sentinel_password="sentinel-secret",
         service_name="mymaster",
         password="redis-secret",
+        username="redis-user",
+        ssl=True,
+        ssl_cert_reqs="required",
+        ssl_check_hostname=True,
+        ssl_ca_certs="/tmp/test-ca.pem",
+        max_connections=17,
     )
 
     mock_sentinel_cls.assert_called_once()
     sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
-    assert sentinel_call_kwargs["sentinel_kwargs"] == {"password": "sentinel-secret"}
-    assert "password" not in sentinel_call_kwargs
-    mock_sentinel.master_for.assert_called_once_with(
-        "mymaster", password="redis-secret"
-    )
+    assert sentinel_call_kwargs["password"] == "redis-secret"
+    assert sentinel_call_kwargs["username"] == "redis-user"
+    assert sentinel_call_kwargs["ssl"] is True
+    assert sentinel_call_kwargs["ssl_cert_reqs"] == "required"
+    assert sentinel_call_kwargs["ssl_check_hostname"] is True
+    assert sentinel_call_kwargs["ssl_ca_certs"] == "/tmp/test-ca.pem"
+    assert sentinel_call_kwargs["max_connections"] == 17
+    assert sentinel_call_kwargs["sentinel_kwargs"] == {
+        "password": "sentinel-secret",
+        "username": "redis-user",
+        "ssl": True,
+        "ssl_cert_reqs": "required",
+        "ssl_check_hostname": True,
+        "ssl_ca_certs": "/tmp/test-ca.pem",
+        "max_connections": 17,
+    }
+    assert "service_name" not in sentinel_call_kwargs["sentinel_kwargs"]
+    assert "sentinel_nodes" not in sentinel_call_kwargs["sentinel_kwargs"]
+    assert "sentinel_password" not in sentinel_call_kwargs["sentinel_kwargs"]
+    mock_sentinel.master_for.assert_called_once_with("mymaster")
 
 
 @patch("litellm._redis.async_redis.Sentinel")
@@ -389,15 +410,36 @@ def test_async_sentinel_uses_sentinel_password_and_master_password(
         sentinel_password="sentinel-secret",
         service_name="mymaster",
         password="redis-secret",
+        username="redis-user",
+        ssl=True,
+        ssl_cert_reqs="required",
+        ssl_check_hostname=True,
+        ssl_ca_certs="/tmp/test-ca.pem",
+        max_connections=17,
     )
 
     mock_sentinel_cls.assert_called_once()
     sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
-    assert sentinel_call_kwargs["sentinel_kwargs"] == {"password": "sentinel-secret"}
-    assert "password" not in sentinel_call_kwargs
-    mock_sentinel.master_for.assert_called_once_with(
-        "mymaster", password="redis-secret"
-    )
+    assert sentinel_call_kwargs["password"] == "redis-secret"
+    assert sentinel_call_kwargs["username"] == "redis-user"
+    assert sentinel_call_kwargs["ssl"] is True
+    assert sentinel_call_kwargs["ssl_cert_reqs"] == "required"
+    assert sentinel_call_kwargs["ssl_check_hostname"] is True
+    assert sentinel_call_kwargs["ssl_ca_certs"] == "/tmp/test-ca.pem"
+    assert sentinel_call_kwargs["max_connections"] == 17
+    assert sentinel_call_kwargs["sentinel_kwargs"] == {
+        "password": "sentinel-secret",
+        "username": "redis-user",
+        "ssl": True,
+        "ssl_cert_reqs": "required",
+        "ssl_check_hostname": True,
+        "ssl_ca_certs": "/tmp/test-ca.pem",
+        "max_connections": 17,
+    }
+    assert "service_name" not in sentinel_call_kwargs["sentinel_kwargs"]
+    assert "sentinel_nodes" not in sentinel_call_kwargs["sentinel_kwargs"]
+    assert "sentinel_password" not in sentinel_call_kwargs["sentinel_kwargs"]
+    mock_sentinel.master_for.assert_called_once_with("mymaster")
 
 
 @patch("litellm._redis.init_redis_cluster")

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -371,17 +371,19 @@ def test_sync_sentinel_uses_sentinel_password_and_master_password(mock_sentinel_
         ssl_check_hostname=True,
         ssl_ca_certs="/tmp/test-ca.pem",
         max_connections=17,
+        socket_timeout=5,
     )
 
     mock_sentinel_cls.assert_called_once()
     sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
-    assert sentinel_call_kwargs["password"] == "redis-secret"
-    assert sentinel_call_kwargs["username"] == "redis-user"
-    assert sentinel_call_kwargs["ssl"] is True
-    assert sentinel_call_kwargs["ssl_cert_reqs"] == "required"
-    assert sentinel_call_kwargs["ssl_check_hostname"] is True
-    assert sentinel_call_kwargs["ssl_ca_certs"] == "/tmp/test-ca.pem"
-    assert sentinel_call_kwargs["max_connections"] == 17
+    assert "password" not in sentinel_call_kwargs
+    assert "username" not in sentinel_call_kwargs
+    assert "ssl" not in sentinel_call_kwargs
+    assert "ssl_cert_reqs" not in sentinel_call_kwargs
+    assert "ssl_check_hostname" not in sentinel_call_kwargs
+    assert "ssl_ca_certs" not in sentinel_call_kwargs
+    assert "max_connections" not in sentinel_call_kwargs
+    assert "socket_timeout" not in sentinel_call_kwargs
     assert sentinel_call_kwargs["sentinel_kwargs"] == {
         "password": "sentinel-secret",
         "username": "redis-user",
@@ -390,11 +392,47 @@ def test_sync_sentinel_uses_sentinel_password_and_master_password(mock_sentinel_
         "ssl_check_hostname": True,
         "ssl_ca_certs": "/tmp/test-ca.pem",
         "max_connections": 17,
+        "socket_timeout": 5,
     }
     assert "service_name" not in sentinel_call_kwargs["sentinel_kwargs"]
     assert "sentinel_nodes" not in sentinel_call_kwargs["sentinel_kwargs"]
     assert "sentinel_password" not in sentinel_call_kwargs["sentinel_kwargs"]
-    mock_sentinel.master_for.assert_called_once_with("mymaster")
+    mock_sentinel.master_for.assert_called_once_with(
+        "mymaster",
+        password="redis-secret",
+        username="redis-user",
+        ssl=True,
+        ssl_cert_reqs="required",
+        ssl_check_hostname=True,
+        ssl_ca_certs="/tmp/test-ca.pem",
+        max_connections=17,
+        socket_timeout=5,
+    )
+
+
+def test_sync_sentinel_socket_timeout_in_connection_kwargs_no_longer_raises():
+    """socket_timeout should be applied through master_for without duplicating constructor kwargs."""
+    mock_sentinel = MagicMock()
+    with patch(
+        "litellm._redis._get_redis_sentinel_connection_kwargs",
+        return_value={"password": "redis-secret", "socket_timeout": 5},
+    ), patch("litellm._redis.redis.Sentinel", return_value=mock_sentinel) as mock_cls:
+        get_redis_client(
+            sentinel_nodes=[("sentinel-1", 26379)],
+            sentinel_password="sentinel-secret",
+            service_name="mymaster",
+        )
+
+    sentinel_call_kwargs = mock_cls.call_args[1]
+    assert "socket_timeout" not in sentinel_call_kwargs
+    assert sentinel_call_kwargs["sentinel_kwargs"] == {
+        "password": "sentinel-secret",
+        "socket_timeout": 5,
+    }
+    assert "password" not in sentinel_call_kwargs
+    mock_sentinel.master_for.assert_called_once_with(
+        "mymaster", password="redis-secret", socket_timeout=5
+    )
 
 
 @patch("litellm._redis.async_redis.Sentinel")
@@ -416,17 +454,19 @@ def test_async_sentinel_uses_sentinel_password_and_master_password(
         ssl_check_hostname=True,
         ssl_ca_certs="/tmp/test-ca.pem",
         max_connections=17,
+        socket_timeout=5,
     )
 
     mock_sentinel_cls.assert_called_once()
     sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
-    assert sentinel_call_kwargs["password"] == "redis-secret"
-    assert sentinel_call_kwargs["username"] == "redis-user"
-    assert sentinel_call_kwargs["ssl"] is True
-    assert sentinel_call_kwargs["ssl_cert_reqs"] == "required"
-    assert sentinel_call_kwargs["ssl_check_hostname"] is True
-    assert sentinel_call_kwargs["ssl_ca_certs"] == "/tmp/test-ca.pem"
-    assert sentinel_call_kwargs["max_connections"] == 17
+    assert "password" not in sentinel_call_kwargs
+    assert "username" not in sentinel_call_kwargs
+    assert "ssl" not in sentinel_call_kwargs
+    assert "ssl_cert_reqs" not in sentinel_call_kwargs
+    assert "ssl_check_hostname" not in sentinel_call_kwargs
+    assert "ssl_ca_certs" not in sentinel_call_kwargs
+    assert "max_connections" not in sentinel_call_kwargs
+    assert "socket_timeout" not in sentinel_call_kwargs
     assert sentinel_call_kwargs["sentinel_kwargs"] == {
         "password": "sentinel-secret",
         "username": "redis-user",
@@ -435,11 +475,22 @@ def test_async_sentinel_uses_sentinel_password_and_master_password(
         "ssl_check_hostname": True,
         "ssl_ca_certs": "/tmp/test-ca.pem",
         "max_connections": 17,
+        "socket_timeout": 5,
     }
     assert "service_name" not in sentinel_call_kwargs["sentinel_kwargs"]
     assert "sentinel_nodes" not in sentinel_call_kwargs["sentinel_kwargs"]
     assert "sentinel_password" not in sentinel_call_kwargs["sentinel_kwargs"]
-    mock_sentinel.master_for.assert_called_once_with("mymaster")
+    mock_sentinel.master_for.assert_called_once_with(
+        "mymaster",
+        password="redis-secret",
+        username="redis-user",
+        ssl=True,
+        ssl_cert_reqs="required",
+        ssl_check_hostname=True,
+        ssl_ca_certs="/tmp/test-ca.pem",
+        max_connections=17,
+        socket_timeout=5,
+    )
 
 
 @patch("litellm._redis.init_redis_cluster")

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -163,7 +163,6 @@ def test_get_redis_async_client_with_connection_pool():
     with patch("litellm._redis.async_redis.Redis") as mock_redis, patch(
         "litellm._redis._get_redis_client_logic"
     ) as mock_logic:
-
         # Configure mock to return basic redis kwargs
         mock_logic.return_value = {"host": "localhost", "port": 6379, "db": 0}
 
@@ -185,7 +184,6 @@ def test_get_redis_async_client_without_connection_pool():
     with patch("litellm._redis.async_redis.Redis") as mock_redis, patch(
         "litellm._redis._get_redis_client_logic"
     ) as mock_logic:
-
         # Configure mock to return basic redis kwargs
         mock_logic.return_value = {"host": "localhost", "port": 6379, "db": 0}
 
@@ -354,6 +352,52 @@ def test_sync_client_prefers_cluster_over_url_via_env_var(
         "startup_nodes" in call_kwargs
     ), "startup_nodes must be forwarded to init_redis_cluster"
     assert len(call_kwargs["startup_nodes"]) == 1
+
+
+@patch("litellm._redis.redis.Sentinel")
+def test_sync_sentinel_uses_sentinel_password_and_master_password(mock_sentinel_cls):
+    """Sentinel auth must be passed to the sentinel, not the Redis master client."""
+    mock_sentinel = MagicMock()
+    mock_sentinel_cls.return_value = mock_sentinel
+
+    get_redis_client(
+        sentinel_nodes=[("sentinel-1", 26379)],
+        sentinel_password="sentinel-secret",
+        service_name="mymaster",
+        password="redis-secret",
+    )
+
+    mock_sentinel_cls.assert_called_once()
+    sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+    assert sentinel_call_kwargs["sentinel_kwargs"] == {"password": "sentinel-secret"}
+    assert "password" not in sentinel_call_kwargs
+    mock_sentinel.master_for.assert_called_once_with(
+        "mymaster", password="redis-secret"
+    )
+
+
+@patch("litellm._redis.async_redis.Sentinel")
+def test_async_sentinel_uses_sentinel_password_and_master_password(
+    mock_sentinel_cls,
+):
+    """Async sentinel auth must mirror the sync sentinel password routing."""
+    mock_sentinel = MagicMock()
+    mock_sentinel_cls.return_value = mock_sentinel
+
+    get_redis_async_client(
+        sentinel_nodes=[("sentinel-1", 26379)],
+        sentinel_password="sentinel-secret",
+        service_name="mymaster",
+        password="redis-secret",
+    )
+
+    mock_sentinel_cls.assert_called_once()
+    sentinel_call_kwargs = mock_sentinel_cls.call_args[1]
+    assert sentinel_call_kwargs["sentinel_kwargs"] == {"password": "sentinel-secret"}
+    assert "password" not in sentinel_call_kwargs
+    mock_sentinel.master_for.assert_called_once_with(
+        "mymaster", password="redis-secret"
+    )
 
 
 @patch("litellm._redis.init_redis_cluster")


### PR DESCRIPTION
## Relevant issues

- Resolves https://github.com/BerriAI/litellm/pull/6154
- Continuation of PR #7718

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

- Targeted verification: `poetry run pytest tests/test_litellm/test_redis.py -v`
- Result: `23 passed`
- The new tests assert that shared connection kwargs are threaded to both Sentinel and the discovered Redis master, while `sentinel_password` is only used for `sentinel_kwargs`
- It worked with a Redis sentinel cluster deployed on Kubernetes.

[Screencast_20260415_160722_compressed.webm](https://github.com/user-attachments/assets/c4742581-7dc1-41af-a4ba-4933eb29dd2f)

## Type

🐛 Bug Fix

## Changes

I have hit the Redis sentinel authentication issue when deploying LiteLLM. The Redis it connects to was deployed using [DHI Redis Chart](https://hub.docker.com/hardened-images/catalog/dhi/redis-chart) with replication mode enabled. The sentinels and redis instances were both protected by password. I hit the problem and searched the project issue/PR list and found that there were users hitting the exact same problem before, and there was a PR #7718 for fixing it. Unfortunately, it was closed by the author.

This PR is a continuation of #7718 to resolve the problem.

* sentinel_password is now passed to sentinel_kwargs instead connection_kwargs
* added additional connection_kwargs as it was done with redis_cluster implementation to support more redis parameters
* Comment https://github.com/BerriAI/litellm/pull/7718#issuecomment-2782818339 was also addressed (using proposed approach 2.). The newly added test has covered this case.