### PR TITLE
feat(router): skip order-based fallback for transient errors when health_check_ignore_transient_errors=True

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3864,7 +3864,7 @@ class Router:
             self._add_deployment_model_to_endpoint_for_llm_passthrough_route(
                 kwargs=kwargs, model=model, model_name=model_name
             )
-            
+
             # Get custom_llm_provider from deployment params
             try:
                 custom_llm_provider = data.get("custom_llm_provider")
@@ -3872,10 +3872,12 @@ class Router:
                     model=data["model"],
                     custom_llm_provider=custom_llm_provider,
                 )
-                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+                custom_llm_provider = (
+                    custom_llm_provider or inferred_custom_llm_provider
+                )
             except Exception:
                 custom_llm_provider = None
-            
+
             # Build response kwargs
             response_kwargs = {
                 **data,
@@ -3885,7 +3887,7 @@ class Router:
             # Only set custom_llm_provider if it's not None
             if custom_llm_provider is not None:
                 response_kwargs["custom_llm_provider"] = custom_llm_provider
-            
+
             response = original_generic_function(**response_kwargs)
 
             rpm_semaphore = self._get_client(
@@ -3981,7 +3983,9 @@ class Router:
                     model=data["model"],
                     custom_llm_provider=custom_llm_provider,
                 )
-                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+                custom_llm_provider = (
+                    custom_llm_provider or inferred_custom_llm_provider
+                )
             except Exception:
                 custom_llm_provider = None
 
@@ -4246,7 +4250,9 @@ class Router:
                     custom_llm_provider=custom_llm_provider,
                 )
                 # Preserve explicitly stored provider, fallback to inferred
-                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+                custom_llm_provider = (
+                    custom_llm_provider or inferred_custom_llm_provider
+                )
 
                 ## REPLACE MODEL IN FILE WITH SELECTED DEPLOYMENT ##
                 purpose = cast(Optional[OpenAIFilesPurpose], kwargs.get("purpose"))
@@ -5355,9 +5361,18 @@ class Router:
             e,
             (litellm.ContextWindowExceededError, litellm.ContentPolicyViolationError),
         )
-        _request_team_id: Optional[str] = (
-            kwargs.get("metadata", {}) or {}
-        ).get("user_api_key_team_id")
+
+        # When health_check_ignore_transient_errors is enabled, transient errors
+        # (429, 408, 529) should not trigger order-based fallback — return the
+        # error to the caller instead.
+        if not _skip_order_fallback and self.health_check_ignore_transient_errors:
+            _exc_status = getattr(e, "status_code", None)
+            if _exc_status in (429, 408, 529):
+                _skip_order_fallback = True
+
+        _request_team_id: Optional[str] = (kwargs.get("metadata", {}) or {}).get(
+            "user_api_key_team_id"
+        )
         all_deployments = self._get_all_deployments(
             model_name=original_model_group, team_id=_request_team_id
         )

--- a/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
+++ b/tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py
@@ -48,7 +48,8 @@ class TestHealthCheckEndpointExceptionPropagation:
     @pytest.mark.asyncio
     async def test_unhealthy_endpoint_dict_exception_in_map(self):
         """When ahealth_check returns {"error": ..., "exception": e}, the exception
-        must appear in exceptions_by_model_id keyed by model_id — not in the endpoint dict."""
+        must appear in exceptions_by_model_id keyed by model_id — not in the endpoint dict.
+        """
         from unittest.mock import AsyncMock, patch
 
         from litellm.proxy.health_check import _perform_health_check
@@ -66,7 +67,9 @@ class TestHealthCheckEndpointExceptionPropagation:
 
         with patch(
             "litellm.proxy.health_check.litellm.ahealth_check",
-            new=AsyncMock(return_value={"error": "auth failed", "exception": auth_error}),
+            new=AsyncMock(
+                return_value={"error": "auth failed", "exception": auth_error}
+            ),
         ):
             healthy, unhealthy, exc_map = await _perform_health_check(model_list)
 
@@ -787,3 +790,131 @@ class TestSharedCacheTransientErrorFilter:
 
         unhealthy_ids = router.health_state_cache.get_unhealthy_deployment_ids()
         assert "deploy-1" in unhealthy_ids
+
+
+def _make_ordered_model(
+    model_id: str, model_name: str, order: int, api_key: str = "fake-key"
+) -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {
+            "model": model_name,
+            "api_key": api_key,
+            "order": order,
+        },
+        "model_info": {"id": model_id},
+    }
+
+
+class TestTransientErrorSkipsOrderFallback:
+    """
+    When health_check_ignore_transient_errors=True and the error is transient
+    (429, 408, 529), order-based fallback should be skipped — the error is
+    returned directly to the caller instead of falling back to the next order.
+    """
+
+    @pytest.mark.asyncio
+    async def test_529_no_order_fallback_when_flag_enabled(self):
+        """529 from order-1 should NOT fallback to order-2 when flag is True."""
+        router = Router(
+            model_list=[
+                _make_ordered_model("deploy-1", "openai/gpt-4", order=1),
+                _make_ordered_model("deploy-2", "openai/gpt-4", order=2),
+            ],
+            health_check_ignore_transient_errors=True,
+            num_retries=0,
+        )
+
+        overloaded_exc = litellm.InternalServerError(
+            message="Overloaded",
+            model="openai/gpt-4",
+            llm_provider="openai",
+        )
+        overloaded_exc.status_code = 529
+
+        async def mock_make_call(*args, **kwargs):
+            raise overloaded_exc
+
+        with patch.object(router, "make_call", side_effect=mock_make_call):
+            with pytest.raises(litellm.InternalServerError) as exc_info:
+                await router.acompletion(
+                    model="openai/gpt-4",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            assert exc_info.value.status_code == 529
+
+    @pytest.mark.asyncio
+    async def test_529_falls_back_when_flag_disabled(self):
+        """529 from order-1 SHOULD fallback to order-2 when flag is False (default)."""
+        router = Router(
+            model_list=[
+                _make_ordered_model("deploy-1", "openai/gpt-4", order=1),
+                _make_ordered_model("deploy-2", "openai/gpt-4", order=2),
+            ],
+            health_check_ignore_transient_errors=False,
+            num_retries=0,
+        )
+
+        overloaded_exc = litellm.InternalServerError(
+            message="Overloaded",
+            model="openai/gpt-4",
+            llm_provider="openai",
+        )
+        overloaded_exc.status_code = 529
+
+        success_response = litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hello"},
+                    "finish_reason": "stop",
+                }
+            ],
+            model="openai/gpt-4",
+        )
+
+        call_count = 0
+
+        async def mock_make_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise overloaded_exc
+            return success_response
+
+        with patch.object(router, "make_call", side_effect=mock_make_call):
+            response = await router.acompletion(
+                model="openai/gpt-4",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            assert response.id == "chatcmpl-123"
+
+    @pytest.mark.asyncio
+    async def test_429_no_order_fallback_when_flag_enabled(self):
+        """429 from order-1 should NOT fallback to order-2 when flag is True."""
+        router = Router(
+            model_list=[
+                _make_ordered_model("deploy-1", "openai/gpt-4", order=1),
+                _make_ordered_model("deploy-2", "openai/gpt-4", order=2),
+            ],
+            health_check_ignore_transient_errors=True,
+            num_retries=0,
+        )
+
+        rate_limit_exc = litellm.RateLimitError(
+            message="Rate limited",
+            model="openai/gpt-4",
+            llm_provider="openai",
+        )
+
+        async def mock_make_call(*args, **kwargs):
+            raise rate_limit_exc
+
+        with patch.object(router, "make_call", side_effect=mock_make_call):
+            with pytest.raises(Exception) as exc_info:
+                await router.acompletion(
+                    model="openai/gpt-4",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            assert getattr(exc_info.value, "status_code", None) == 429


### PR DESCRIPTION
## What

When `health_check_ignore_transient_errors: true` is set and a deployment returns a transient error (429, 408, or 529), the router now raises the error directly to the caller instead of falling back to the next order-level deployment.

## Why

Previously, a 529 overloaded error from an order-1 deployment would silently trigger order-based fallback to the order-2 deployment. This contradicts the intent of `health_check_ignore_transient_errors` — if you've declared that transient errors shouldn't affect routing state, they also shouldn't trigger fallover to lower-priority deployments.

## Changes

**`litellm/router.py`** — In `async_function_with_fallbacks_common_utils`, extended `_skip_order_fallback` to also be `True` when `health_check_ignore_transient_errors=True` and the exception status code is in `(429, 408, 529)`.

**`tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py`** — Added 3 tests:
- `test_529_no_order_fallback_when_flag_enabled` — 529 raises directly, no fallback to order-2
- `test_529_falls_back_when_flag_disabled` — 529 still falls back when flag is off (default behavior preserved)
- `test_429_no_order_fallback_when_flag_enabled` — 429 also skips fallback with the flag

## Test plan

- [x] `poetry run pytest tests/test_litellm/router_utils/test_health_check_allowed_fails_integration.py -v` — all 32 tests pass