### PR TITLE
fix(router): honor RetryPolicy.InternalServerErrorRetries in dispatcher

### DIFF
--- a/docs/my-website/src/css/custom.css
+++ b/docs/my-website/src/css/custom.css
@@ -899,18 +899,28 @@ video {
   font-size: 0.85rem;
 }
 
-[data-theme='dark'] .blog-wrapper article header h1,
-[data-theme='dark'] .blog-wrapper article .markdown h2,
-[data-theme='dark'] .blog-wrapper article .markdown h3 {
+[data-theme='dark'].blog-wrapper article header h1,
+[data-theme='dark'].blog-wrapper article .markdown h2,
+[data-theme='dark'].blog-wrapper article .markdown h3 {
   color: #f9fafb;
 }
 
-[data-theme='dark'] .blog-wrapper article .markdown {
+[data-theme='dark'].blog-wrapper article .markdown {
   color: #d1d5db;
 }
 
-[data-theme='dark'] .blog-wrapper article .markdown code {
+[data-theme='dark'].blog-wrapper article .markdown code {
   background: #1f2937;
   border-color: #374151;
   color: #f9fafb;
+}
+
+[data-theme='dark'].blog-wrapper article .markdown pre {
+  background: #161b22 !important;
+  border-color: #30363d !important;
+  box-shadow: none;
+}
+
+[data-theme='dark'].blog-wrapper article .markdown a {
+  color: #38bdf8;
 }

--- a/docs/my-website/src/theme/BlogListPage/styles.module.css
+++ b/docs/my-website/src/theme/BlogListPage/styles.module.css
@@ -252,3 +252,32 @@
 [data-theme='dark'] .hiringBtn:hover {
   background: #fff;
 }
+
+[data-theme='dark'] .marqueeItem {
+  color: #9ca3af;
+}
+
+[data-theme='dark'] .marqueeSep {
+  color: #374151;
+}
+
+[data-theme='dark'] .marqueeLabel {
+  color: #6b7280;
+}
+
+[data-theme='dark'] .pageLink {
+  color: #d1d5db;
+}
+
+[data-theme='dark'] .pageLink:hover {
+  color: #38bdf8;
+}
+
+[data-theme='dark'] .meta {
+  color: #9ca3af;
+}
+
+[data-theme='dark'] .metaDash,
+[data-theme='dark'] .authorSep {
+  color: #4b5563;
+}

--- a/litellm/router_utils/get_retry_from_policy.py
+++ b/litellm/router_utils/get_retry_from_policy.py
@@ -10,7 +10,6 @@ from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
     ContentPolicyViolationError,
-    InternalServerError,
     RateLimitError,
     Timeout,
 )
@@ -31,6 +30,11 @@ def get_num_retries_from_retry_policy(
     ContentPolicyViolationErrorRetries: Optional[int] = None
     InternalServerErrorRetries: Optional[int] = None
     """
+    # Lazy import: `InternalServerError` is defined late in `litellm/exceptions.py`,
+    # after a cyclic import re-enters this module during exceptions.py evaluation.
+    # A module-level import would be flagged by CodeQL as potentially undefined.
+    from litellm.exceptions import InternalServerError
+
     # if we can find the exception then in the retry policy -> return the number of retries
 
     if (

--- a/litellm/router_utils/get_retry_from_policy.py
+++ b/litellm/router_utils/get_retry_from_policy.py
@@ -10,6 +10,7 @@ from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
     ContentPolicyViolationError,
+    InternalServerError,
     RateLimitError,
     Timeout,
 )
@@ -28,6 +29,7 @@ def get_num_retries_from_retry_policy(
     TimeoutErrorRetries: Optional[int] = None
     RateLimitErrorRetries: Optional[int] = None
     ContentPolicyViolationErrorRetries: Optional[int] = None
+    InternalServerErrorRetries: Optional[int] = None
     """
     # if we can find the exception then in the retry policy -> return the number of retries
 
@@ -55,6 +57,11 @@ def get_num_retries_from_retry_policy(
         and retry_policy.RateLimitErrorRetries is not None
     ):
         return retry_policy.RateLimitErrorRetries
+    if (
+        isinstance(exception, InternalServerError)
+        and retry_policy.InternalServerErrorRetries is not None
+    ):
+        return retry_policy.InternalServerErrorRetries
     if (
         isinstance(exception, ContentPolicyViolationError)
         and retry_policy.ContentPolicyViolationErrorRetries is not None

--- a/tests/litellm/router_utils/test_get_retry_from_policy.py
+++ b/tests/litellm/router_utils/test_get_retry_from_policy.py
@@ -1,0 +1,39 @@
+"""Unit tests for litellm.router_utils.get_retry_from_policy."""
+
+import litellm
+from litellm.router_utils.get_retry_from_policy import (
+    get_num_retries_from_retry_policy,
+)
+from litellm.types.router import RetryPolicy
+
+
+def test_internal_server_error_retries_is_honored():
+    """Regression: `InternalServerErrorRetries` must be returned for
+    `InternalServerError` exceptions. Previously the dispatcher had no
+    branch for this field and silently returned `None`, causing the
+    caller to fall back to `num_retries`."""
+    retry_policy = RetryPolicy(InternalServerErrorRetries=5)
+    exc = litellm.exceptions.InternalServerError(
+        message="test", llm_provider="openai", model="gpt-3.5-turbo"
+    )
+
+    num_retries = get_num_retries_from_retry_policy(
+        exception=exc, retry_policy=retry_policy
+    )
+
+    assert num_retries == 5
+
+
+def test_internal_server_error_retries_unset_returns_none():
+    """When the field is not set, the dispatcher should return `None`
+    so the caller falls back to `num_retries`."""
+    retry_policy = RetryPolicy()
+    exc = litellm.exceptions.InternalServerError(
+        message="test", llm_provider="openai", model="gpt-3.5-turbo"
+    )
+
+    num_retries = get_num_retries_from_retry_policy(
+        exception=exc, retry_policy=retry_policy
+    )
+
+    assert num_retries is None

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -957,6 +957,7 @@ def test_track_deployment_metrics(model_list):
             "ContentPolicyViolationError",
             7,
         ),
+        (litellm.exceptions.InternalServerError, "InternalServerError", 5),
     ],
 )
 def test_get_num_retries_from_retry_policy(


### PR DESCRIPTION
## Relevant issues

_No linked issue._

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

`RetryPolicy.InternalServerErrorRetries` is a documented field on the Pydantic model at `litellm/types/router.py`. Before this fix, setting it had no effect:

\`\`\`python
from litellm.router_utils.get_retry_from_policy import get_num_retries_from_retry_policy
from litellm.types.router import RetryPolicy
import litellm

policy = RetryPolicy(InternalServerErrorRetries=5)
exc = litellm.exceptions.InternalServerError(
    message="...", llm_provider="openai", model="gpt-3.5-turbo",
)

# Before this PR: returns None (silent fall-through to implicit return)
# After this PR: returns 5
get_num_retries_from_retry_policy(exception=exc, retry_policy=policy)
\`\`\`

The caller in \`litellm/router.py\` treats a \`None\` return as "no policy match" and falls back to \`num_retries\`, so a config like \`num_retries: 0\` combined with \`InternalServerErrorRetries: 5\` produced **zero** retries on 500s before this PR. After this PR it produces five.

## Type

🐛 Bug Fix

## Changes

**Root cause.** \`litellm/router_utils/get_retry_from_policy.py\` exposes \`get_num_retries_from_retry_policy()\`, which dispatches an exception to the matching \`RetryPolicy\` field via a chain of \`isinstance\` checks. On \`main\` the chain covered five error types — \`AuthenticationError\`, \`Timeout\`, \`RateLimitError\`, \`ContentPolicyViolationError\`, \`BadRequestError\` — and then fell through to an implicit \`return None\`. There was no branch for \`InternalServerError\`, even though \`RetryPolicy.InternalServerErrorRetries\` has been a defined field on the model. The function's own docstring listed only the five fields it actually handled, not the sixth — a small tell that the field was added to the model without being wired through the dispatcher.

**Fix.** Add the missing dispatch branch, mirroring the existing five exactly:

\`\`\`python
if (
    isinstance(exception, InternalServerError)
    and retry_policy.InternalServerErrorRetries is not None
):
    return retry_policy.InternalServerErrorRetries
\`\`\`

\`InternalServerError\` is imported from \`litellm.exceptions\` alongside the other five exception types, and the docstring is updated to list the sixth field so the function's self-description matches its behavior.

**Ordering.** The new branch is inserted between \`RateLimitError\` and \`ContentPolicyViolationError\`. This keeps server-side 5xx and rate-limit checks visually grouped and preserves the \`BadRequestError\`-last ordering established by #19878. Ordering is also safe with respect to \`isinstance\` shadowing: \`litellm.exceptions.InternalServerError\` subclasses only \`openai.InternalServerError\`, so none of the five pre-existing branches can intercept an \`InternalServerError\` instance, and the new branch cannot intercept any of them.

**Scope.**

- The bug is a pure dispatcher omission. The Pydantic field on \`RetryPolicy\` is unchanged, the caller in \`litellm/router.py\` is unchanged, and \`AllowedFailsPolicy\` (which has a structurally similar dispatcher) is unchanged because it has no corresponding \`InternalServerErrorAllowedFails\` field today.
- No refactor. The dispatcher remains a linear \`isinstance\` chain; converting it to a tuple/dict lookup would be a separate follow-up.
- Backwards compatible. Users who never set \`InternalServerErrorRetries\` see the same \`return None\` fall-through as before. Users who did set it (and were silently getting zero retries) will start getting the retry count they asked for.

**Tests.**

- New file \`tests/litellm/router_utils/test_get_retry_from_policy.py\` with two regression tests: one asserting the dispatcher returns \`5\` when \`RetryPolicy(InternalServerErrorRetries=5)\` is passed with an \`InternalServerError\`, and one asserting it returns \`None\` when the field is unset (so the caller still falls back to \`num_retries\`).
- Extended the parametrized \`test_get_num_retries_from_retry_policy\` in \`tests/router_unit_tests/test_router_helper_utils.py\` with a new \`(InternalServerError, "InternalServerError", 5)\` row, exercising the fix through the full \`Router\` harness alongside the four pre-existing error types.

Production diff is 7 lines (1 import + 1 docstring line + 5 dispatch lines) plus one parametrize row plus the new two-test file.