### PR TITLE
fix: Custom Model pricing / Allow zero‑cost models to stay unblocked when BudgetExceeded is true (#14004)

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -866,35 +866,6 @@ async def _apply_default_budget_to_end_user(
     return end_user_obj
 
 
-def _check_end_user_budget(
-    end_user_obj: LiteLLM_EndUserTable,
-    route: str,
-) -> None:
-    """
-    Check if end user is within their budget limit.
-
-    Args:
-        end_user_obj: The end user object to check
-        route: The request route
-
-    Raises:
-        litellm.BudgetExceededError: If end user has exceeded their budget
-    """
-    if RouteChecks.is_info_route(route):
-        return
-
-    if end_user_obj.litellm_budget_table is None:
-        return
-
-    end_user_budget = end_user_obj.litellm_budget_table.max_budget
-    if end_user_budget is not None and end_user_obj.spend > end_user_budget:
-        raise litellm.BudgetExceededError(
-            current_cost=end_user_obj.spend,
-            max_budget=end_user_budget,
-            message=f"ExceededBudget: End User={end_user_obj.user_id} over budget. Spend={end_user_obj.spend}, Budget={end_user_budget}",
-        )
-
-
 @log_db_metrics
 async def get_end_user_object(
     end_user_id: Optional[str],
@@ -942,9 +913,6 @@ async def get_end_user_object(
             parent_otel_span=parent_otel_span,
         )
 
-        # Check budget limits
-        _check_end_user_budget(end_user_obj=return_obj, route=route)
-
         return return_obj
 
     # Fetch from database
@@ -972,9 +940,6 @@ async def get_end_user_object(
         await user_api_key_cache.async_set_cache(
             key="end_user_id:{}".format(end_user_id), value=_response.dict()
         )
-
-        # Check budget limits
-        _check_end_user_budget(end_user_obj=_response, route=route)
 
         return _response
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -324,6 +324,40 @@ def update_valid_token_with_end_user_params(
     return valid_token
 
 
+async def _enforce_end_user_budget_if_needed(
+    valid_token: UserAPIKeyAuth,
+    end_user_object: Optional[LiteLLM_EndUserTable],
+    request_data: dict,
+    route: str,
+    llm_router: Optional[Any],
+    proxy_logging_obj: ProxyLogging,
+) -> None:
+    model = get_model_from_request(request_data, route)
+    skip_budget_checks = False
+    if model is not None and llm_router is not None:
+        skip_budget_checks = _is_model_cost_zero(model=model, llm_router=llm_router)
+
+    if skip_budget_checks:
+        return
+
+    end_user_mb = valid_token.end_user_max_budget
+    if end_user_mb is None and end_user_object is not None:
+        budget_table = end_user_object.litellm_budget_table
+        end_user_mb = budget_table.max_budget if budget_table is not None else None
+
+    if (
+        end_user_mb is not None
+        and end_user_object is not None
+        and valid_token.end_user_id is not None
+    ):
+        await proxy_logging_obj.max_budget_limiter.is_end_user_within_budget(
+            end_user_id=valid_token.end_user_id,
+            end_user_max_budget=end_user_mb,
+            end_user_spend=end_user_object.spend,
+            route=route,
+        )
+
+
 # Reusable coordinator for global spend to prevent cache stampede
 _global_spend_coordinator = EventDrivenCacheCoordinator(log_prefix="[GLOBAL SPEND]")
 
@@ -1081,6 +1115,15 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     _end_user_object.object_permission
                 )
 
+            await _enforce_end_user_budget_if_needed(
+                valid_token=valid_token,
+                end_user_object=_end_user_object,
+                request_data=request_data,
+                route=route,
+                llm_router=llm_router,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
             return valid_token
 
         if (
@@ -1146,6 +1189,20 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 route=route,
                 start_time=start_time,
             )
+
+            _user_api_key_obj = update_valid_token_with_end_user_params(
+                valid_token=_user_api_key_obj, end_user_params=end_user_params
+            )
+
+            await _enforce_end_user_budget_if_needed(
+                valid_token=_user_api_key_obj,
+                end_user_object=_end_user_object,
+                request_data=request_data,
+                route=route,
+                llm_router=llm_router,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
             asyncio.create_task(
                 _cache_key_object(
                     hashed_token=hash_token(master_key),
@@ -1153,10 +1210,6 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     user_api_key_cache=user_api_key_cache,
                     proxy_logging_obj=proxy_logging_obj,
                 )
-            )
-
-            _user_api_key_obj = update_valid_token_with_end_user_params(
-                valid_token=_user_api_key_obj, end_user_params=end_user_params
             )
 
             return _user_api_key_obj

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -29,6 +29,7 @@ from litellm.proxy.auth.auth_checks import (
     _cache_key_object,
     _delete_cache_key_object,
     _get_user_role,
+    _is_model_cost_zero,
     _is_user_proxy_admin,
     _virtual_key_max_budget_alert_check,
     _virtual_key_max_budget_check,
@@ -879,8 +880,6 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     model = get_model_from_request(request_data, route)
                     skip_budget_checks = False
                     if model is not None and llm_router is not None:
-                        from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
                         skip_budget_checks = _is_model_cost_zero(
                             model=model, llm_router=llm_router
                         )
@@ -1286,8 +1285,6 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             model = get_model_from_request(request_data, route)
             skip_budget_checks = False
             if model is not None and llm_router is not None:
-                from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
                 skip_budget_checks = _is_model_cost_zero(
                     model=model, llm_router=llm_router
                 )
@@ -1924,54 +1921,65 @@ async def _run_post_custom_auth_checks(
             llm_router=llm_router,
         )
 
+    # 2a. Check if model has zero cost - if so, skip all budget checks
+    model = get_model_from_request(request_data, route)
+    skip_budget_checks = False
+    if model is not None and llm_router is not None:
+        skip_budget_checks = _is_model_cost_zero(model=model, llm_router=llm_router)
+        if skip_budget_checks:
+            verbose_proxy_logger.info(
+                f"Skipping all budget checks for zero-cost model: {model}"
+            )
+
     current_model = request_data.get("model", None)
 
-    # 3. Check key-level model_max_budget
-    max_budget_per_model = valid_token.model_max_budget
-    if (
-        max_budget_per_model is not None
-        and isinstance(max_budget_per_model, dict)
-        and len(max_budget_per_model) > 0
-        and current_model is not None
-        and valid_token.token is not None
-    ):
-        await model_max_budget_limiter.is_key_within_model_budget(
-            user_api_key_dict=valid_token,
-            model=current_model,
-        )
+    if not skip_budget_checks:
+        # 3. Check key-level model_max_budget
+        max_budget_per_model = valid_token.model_max_budget
+        if (
+            max_budget_per_model is not None
+            and isinstance(max_budget_per_model, dict)
+            and len(max_budget_per_model) > 0
+            and current_model is not None
+            and valid_token.token is not None
+        ):
+            await model_max_budget_limiter.is_key_within_model_budget(
+                user_api_key_dict=valid_token,
+                model=current_model,
+            )
 
-    # 4. Check end-user model_max_budget
-    end_user_mmb = valid_token.end_user_model_max_budget
-    if (
-        end_user_mmb is not None
-        and isinstance(end_user_mmb, dict)
-        and len(end_user_mmb) > 0
-        and current_model is not None
-        and valid_token.end_user_id is not None
-    ):
-        await model_max_budget_limiter.is_end_user_within_model_budget(
-            end_user_id=valid_token.end_user_id,
-            end_user_model_max_budget=end_user_mmb,
-            model=current_model,
-        )
+        # 4. Check end-user model_max_budget
+        end_user_mmb = valid_token.end_user_model_max_budget
+        if (
+            end_user_mmb is not None
+            and isinstance(end_user_mmb, dict)
+            and len(end_user_mmb) > 0
+            and current_model is not None
+            and valid_token.end_user_id is not None
+        ):
+            await model_max_budget_limiter.is_end_user_within_model_budget(
+                end_user_id=valid_token.end_user_id,
+                end_user_model_max_budget=end_user_mmb,
+                model=current_model,
+            )
 
-    # 4b. Check end-user max_budget
-    end_user_mb = valid_token.end_user_max_budget
-    # Fallback in case end-user max budget not set on token
-    if end_user_mb is None and end_user_object is not None:
-        budget_table = end_user_object.litellm_budget_table
-        end_user_mb = budget_table.max_budget if budget_table is not None else None     
-    if (
-        end_user_mb is not None
-        and end_user_object is not None
-        and valid_token.end_user_id is not None
-    ):
-        await proxy_logging_obj.max_budget_limiter.is_end_user_within_budget(
-            end_user_id=valid_token.end_user_id,
-            end_user_max_budget=end_user_mb,
-            end_user_spend=end_user_object.spend,
-            route=route,
-        )
+        # 4b. Check end-user max_budget
+        end_user_mb = valid_token.end_user_max_budget
+        # Fallback in case end-user max budget not set on token
+        if end_user_mb is None and end_user_object is not None:
+            budget_table = end_user_object.litellm_budget_table
+            end_user_mb = budget_table.max_budget if budget_table is not None else None
+        if (
+            end_user_mb is not None
+            and end_user_object is not None
+            and valid_token.end_user_id is not None
+        ):
+            await proxy_logging_obj.max_budget_limiter.is_end_user_within_budget(
+                end_user_id=valid_token.end_user_id,
+                end_user_max_budget=end_user_mb,
+                end_user_spend=end_user_object.spend,
+                route=route,
+            )
         
     # 5. Look up user object if user_id is set
     user_object = None
@@ -2046,7 +2054,7 @@ async def _run_post_custom_auth_checks(
             llm_router=llm_router,
             proxy_logging_obj=proxy_logging_obj,
             valid_token=valid_token,
-            skip_budget_checks=False,
+            skip_budget_checks=skip_budget_checks,
             project_object=_project_obj,
         )
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1432,6 +1432,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
                     # Check 5c. End user max budget
                     end_user_mb = valid_token.end_user_max_budget
+                    # Fallback in case end-user max budget not set on token
+                    if end_user_mb is None and _end_user_object is not None:
+                        budget_table = _end_user_object.litellm_budget_table
+                        end_user_mb = budget_table.max_budget if budget_table is not None else None         
                     if (
                         end_user_mb is not None
                         and _end_user_object is not None
@@ -1953,6 +1957,10 @@ async def _run_post_custom_auth_checks(
 
     # 4b. Check end-user max_budget
     end_user_mb = valid_token.end_user_max_budget
+    # Fallback in case end-user max budget not set on token
+    if end_user_mb is None and end_user_object is not None:
+        budget_table = end_user_object.litellm_budget_table
+        end_user_mb = budget_table.max_budget if budget_table is not None else None     
     if (
         end_user_mb is not None
         and end_user_object is not None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -318,6 +318,8 @@ def update_valid_token_with_end_user_params(
         valid_token.end_user_model_max_budget = end_user_params[
             "end_user_model_max_budget"
         ]
+    if end_user_params.get("end_user_max_budget") is not None:
+        valid_token.end_user_max_budget = end_user_params["end_user_max_budget"]
     return valid_token
 
 
@@ -1428,6 +1430,20 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                             model=current_model,
                         )
 
+                    # Check 5c. End user max budget
+                    end_user_mb = valid_token.end_user_max_budget
+                    if (
+                        end_user_mb is not None
+                        and _end_user_object is not None
+                        and valid_token.end_user_id is not None
+                    ):
+                        await proxy_logging_obj.max_budget_limiter.is_end_user_within_budget(
+                            end_user_id=valid_token.end_user_id,
+                            end_user_max_budget=end_user_mb,
+                            end_user_spend=_end_user_object.spend,
+                            route=route,
+                        )
+
             # Check 6: Additional Common Checks across jwt + key auth
             if valid_token.team_id is not None:
                 try:
@@ -1935,6 +1951,20 @@ async def _run_post_custom_auth_checks(
             model=current_model,
         )
 
+    # 4b. Check end-user max_budget
+    end_user_mb = valid_token.end_user_max_budget
+    if (
+        end_user_mb is not None
+        and end_user_object is not None
+        and valid_token.end_user_id is not None
+    ):
+        await proxy_logging_obj.max_budget_limiter.is_end_user_within_budget(
+            end_user_id=valid_token.end_user_id,
+            end_user_max_budget=end_user_mb,
+            end_user_spend=end_user_object.spend,
+            route=route,
+        )
+        
     # 5. Look up user object if user_id is set
     user_object = None
     if valid_token.user_id is not None:

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException
 
+import litellm
 from litellm import verbose_logger
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
@@ -11,6 +12,33 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
     # Class variables or attributes
     def __init__(self):
         pass
+
+    async def is_end_user_within_budget(
+        self,
+        end_user_id: str,
+        end_user_max_budget: float,
+        end_user_spend: float,
+        route: str,
+    ) -> bool:
+        """
+        Check if an end-user is within their overall max budget.
+
+        Raises:
+            BudgetExceededError: If the end-user has exceeded overall budget.
+        """
+        from litellm.proxy.auth.route_checks import RouteChecks
+
+        if RouteChecks.is_info_route(route):
+            return True
+
+        if end_user_spend > end_user_max_budget:
+            raise litellm.BudgetExceededError(
+                current_cost=end_user_spend,
+                max_budget=end_user_max_budget,
+                message=f"ExceededBudget: End User={end_user_id} over budget. Spend={end_user_spend}, Budget={end_user_max_budget}",
+            )
+
+        return True
 
     async def async_pre_call_hook(
         self,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7754,6 +7754,8 @@ class Router:
             )
         elif litellm_model_name_model_info is not None:
             model_info = litellm_model_name_model_info
+        elif custom_model_info is not None:
+            model_info = cast(ModelInfo, custom_model_info)
 
         return model_info
 

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -38,7 +38,7 @@ from litellm.proxy.utils import CallInfo
 async def test_get_end_user_object(customer_spend, customer_budget):
     """
     Scenario 1: normal
-    Scenario 2: user over budget
+    Scenario 2: user over budget (should still return object here, as the budget check happens in max_budget_limiter)
     """
     end_user_id = "my-test-customer"
     _budget = LiteLLM_BudgetTable(max_budget=customer_budget)
@@ -51,31 +51,19 @@ async def test_get_end_user_object(customer_spend, customer_budget):
     _cache = DualCache()
     _key = "end_user_id:{}".format(end_user_id)
     _cache.set_cache(key=_key, value=end_user_obj.model_dump())
-    try:
-        await get_end_user_object(
-            end_user_id=end_user_id,
-            prisma_client="RANDOM VALUE",  # type: ignore
-            user_api_key_cache=_cache,
-            route="/v1/chat/completions",
-        )
-        if customer_spend > customer_budget:
-            pytest.fail(
-                "Expected call to fail. Customer Spend={}, Customer Budget={}".format(
-                    customer_spend, customer_budget
-                )
-            )
-    except Exception as e:
-        if (
-            isinstance(e, litellm.BudgetExceededError)
-            and customer_spend > customer_budget
-        ):
-            pass
-        else:
-            pytest.fail(
-                "Expected call to work. Customer Spend={}, Customer Budget={}, Error={}".format(
-                    customer_spend, customer_budget, str(e)
-                )
-            )
+
+    result = await get_end_user_object(
+        end_user_id=end_user_id,
+        prisma_client="RANDOM VALUE",  # type: ignore
+        user_api_key_cache=_cache,
+        route="/v1/chat/completions",
+    )
+
+    assert result is not None
+    assert result.user_id == end_user_id
+    assert result.spend == customer_spend
+    assert result.litellm_budget_table is not None
+    assert result.litellm_budget_table.max_budget == customer_budget
 
 
 @pytest.mark.parametrize(

--- a/tests/proxy_unit_tests/test_default_end_user_budget_simple.py
+++ b/tests/proxy_unit_tests/test_default_end_user_budget_simple.py
@@ -170,13 +170,25 @@ async def test_budget_enforcement_blocks_over_budget_users():
     mock_cache.async_get_cache = AsyncMock(return_value=None)
     mock_cache.async_set_cache = AsyncMock()
     
-    # Should raise BudgetExceededError
+    # 1. Fetch the user object (this no longer throws an exception)
+    result = await get_end_user_object(
+        end_user_id=end_user_id,
+        prisma_client=mock_prisma_client,
+        user_api_key_cache=mock_cache,
+        route="/chat/completions",
+    )
+    
+    from litellm.proxy.hooks.max_budget_limiter import _PROXY_MaxBudgetLimiter
+    budget_limiter = _PROXY_MaxBudgetLimiter()
+    assert default_budget.max_budget is not None
+
+    # 2. Check that the new limiter function correctly enforces the budget using the mocked values
     with pytest.raises(litellm.BudgetExceededError) as exc_info:
-        await get_end_user_object(
+        await budget_limiter.is_end_user_within_budget(
             end_user_id=end_user_id,
-            prisma_client=mock_prisma_client,
-            user_api_key_cache=mock_cache,
-            route="/chat/completions",
+            end_user_max_budget=default_budget.max_budget,
+            end_user_spend=mock_end_user_data["spend"],
+            route="/chat/completions"
         )
     
     assert "ExceededBudget" in str(exc_info.value)

--- a/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
+++ b/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
@@ -5,7 +5,7 @@ from litellm.proxy.auth.user_api_key_auth import (
     _run_post_custom_auth_checks,
     update_valid_token_with_end_user_params,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_EndUserTable, UserAPIKeyAuth
 
 
 @pytest.mark.asyncio
@@ -79,6 +79,71 @@ async def test_custom_auth_run_post_custom_auth_checks_with_end_user_budget_exce
                     parent_otel_span=None,
                 )
             mock_budget_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_custom_auth_zero_cost_model_skips_budget_checks():
+    valid_token = UserAPIKeyAuth(
+        token="test_token",
+        end_user_id="test_user",
+        model_max_budget={"gpt-4": {"budget_limit": 10.0, "time_period": "1d"}},
+        end_user_model_max_budget={
+            "gpt-4": {"budget_limit": 10.0, "time_period": "1d"}
+        },
+        end_user_max_budget=5.0,
+    )
+    request_data = {"model": "gpt-4"}
+    end_user_object = LiteLLM_EndUserTable(
+        user_id="test_user",
+        spend=20.0,
+        litellm_budget_table=LiteLLM_BudgetTable(max_budget=5.0),
+        blocked=False,
+    )
+
+    with patch(
+        "litellm.proxy.auth.user_api_key_auth._lookup_end_user_and_apply_budget",
+        new_callable=AsyncMock,
+    ) as mock_lookup, patch(
+        "litellm.proxy.auth.user_api_key_auth._enforce_key_and_fallback_model_access",
+        new_callable=AsyncMock,
+    ), patch(
+        "litellm.proxy.auth.user_api_key_auth._is_model_cost_zero",
+        return_value=True,
+    ), patch(
+        "litellm.proxy.auth.user_api_key_auth.common_checks", new_callable=AsyncMock
+    ) as mock_common_checks, patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"custom_auth_run_common_checks": True},
+    ), patch(
+        "litellm.proxy.proxy_server.llm_router",
+        object(),
+    ), patch(
+        "litellm.proxy.proxy_server.model_max_budget_limiter.is_key_within_model_budget",
+        new_callable=AsyncMock,
+    ) as mock_key_model_budget, patch(
+        "litellm.proxy.proxy_server.model_max_budget_limiter.is_end_user_within_model_budget",
+        new_callable=AsyncMock,
+    ) as mock_end_user_model_budget, patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj.max_budget_limiter.is_end_user_within_budget",
+        new_callable=AsyncMock,
+    ) as mock_end_user_budget:
+        mock_lookup.return_value = (valid_token, end_user_object)
+        mock_common_checks.return_value = True
+
+        result = await _run_post_custom_auth_checks(
+            valid_token=valid_token,
+            request=None,
+            request_data=request_data,
+            route="/v1/chat/completions",
+            parent_otel_span=None,
+        )
+
+        assert result.token == "test_token"
+        mock_key_model_budget.assert_not_awaited()
+        mock_end_user_model_budget.assert_not_awaited()
+        mock_end_user_budget.assert_not_awaited()
+        mock_common_checks.assert_awaited_once()
+        assert mock_common_checks.await_args.kwargs["skip_budget_checks"] is True
 
 
 def test_update_valid_token_does_not_override_custom_auth_values_with_none():

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1955,6 +1955,25 @@ def test_get_deployment_model_info_base_model_flow():
             # Should return None when no model info is found
             assert result is None
 
+    # Test Case 6: Only custom model info exists (no model-name info)
+    mock_custom_only_info = {
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "mode": "chat",
+        "litellm_provider": "openai",
+    }
+
+    with patch.object(litellm, "model_cost", {"custom-only-id": mock_custom_only_info}):
+        with patch.object(litellm, "get_model_info", return_value=None):
+            result = router.get_deployment_model_info(
+                model_id="custom-only-id", model_name="missing-model-name"
+            )
+
+            assert result is not None
+            assert result["input_cost_per_token"] == 0.0
+            assert result["output_cost_per_token"] == 0.0
+            assert result["litellm_provider"] == "openai"
+
     print("✓ All base model flow test cases passed!")
 
 


### PR DESCRIPTION
## Relevant issues

Fixes #14004

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

This PR fixes critical issues regarding zero-cost models correctly being white listed without triggering budget limits.

*   **Router Pricing Fix:** Updated `get_deployment_model_info` inside `router.py` to return `custom_model_info` when standard `litelll_model_name_model_info` is unavailable. This ensures explicit `input/output_cost_per_token` values (including `0.0`) are preserved for custom deployments, preventing costs from defaulting to `None`.

*   **Auth Budget Refactor:** Moved `_check_end_user_budget` logic from `auth_checks.py` to `max_budget_limiter.py`.
    *   **Why:** The previous implementation triggered checks prematurely, blocking all models (including zero-cost ones) incorrectly.
    *   **Result:** Unifies budget checks within `user_api_key_auth.py`, streamlining the code and fixing the bug where zero-cost models erroneously exceeded budget limits.
    
*   **Updated tests**: reflecting new budget enforcement logic since `_check_end_user_budget` is not called when `get_end_user_object` is executed.