### PR TITLE
fix(ovhcloud): preserve segments/words/language in verbose_json transcription response

### DIFF
--- a/litellm/llms/ovhcloud/audio_transcription/transformation.py
+++ b/litellm/llms/ovhcloud/audio_transcription/transformation.py
@@ -143,6 +143,11 @@ class OVHCloudAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
     ) -> TranscriptionResponse:
         """
         Transform OVHCloud audio transcription response to OpenAI-compatible TranscriptionResponse.
+
+        OVHCloud returns the full verbose_json format (including `segments`, `words`,
+        `language`, `duration`, etc.) when `response_format=verbose_json` is requested.
+        We pass the entire response JSON to TranscriptionResponse so all fields are
+        preserved rather than discarding everything except `text`.
         """
         try:
             response_json = raw_response.json()
@@ -153,8 +158,19 @@ class OVHCloudAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
                 headers=raw_response.headers,
             )
 
-        text = response_json.get("text") or response_json.get("transcript") or ""
-        response = TranscriptionResponse(text=text)
+        # Normalise: OVHCloud may return `transcript` instead of `text`
+        if "transcript" in response_json and "text" not in response_json:
+            response_json["text"] = response_json.pop("transcript")
+
+        # Build a TranscriptionResponse that preserves all OpenAI-compatible fields
+        # (text, segments, words, language, duration, …) returned by the provider.
+        if any(
+            key in response_json
+            for key in TranscriptionResponse.model_fields.keys()
+        ):
+            response = TranscriptionResponse(**response_json)
+        else:
+            response = TranscriptionResponse(text=response_json.get("text", ""))
 
         response._hidden_params = response_json
         return response

--- a/tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py
@@ -1,11 +1,17 @@
+import json
 import os
 from typing import Dict
+from unittest.mock import MagicMock
 
+import httpx
 import litellm
 import pytest
 
 from litellm.llms.base_llm.audio_transcription.transformation import (
     BaseAudioTranscriptionConfig,
+)
+from litellm.llms.ovhcloud.audio_transcription.transformation import (
+    OVHCloudAudioTranscriptionConfig,
 )
 from litellm.utils import ProviderConfigManager
 from tests.llm_translation.base_audio_transcription_unit_tests import (
@@ -56,4 +62,71 @@ def test_ovhcloud_audio_transcription_config_installed():
     assert isinstance(config, BaseAudioTranscriptionConfig)
 
 
+def _make_mock_response(body: dict) -> httpx.Response:
+    """Helper to build a mock httpx.Response with a JSON body."""
+    mock = MagicMock(spec=httpx.Response)
+    mock.json.return_value = body
+    mock.text = json.dumps(body)
+    mock.status_code = 200
+    mock.headers = {}
+    return mock
 
+
+class TestOVHCloudTranscriptionResponseTransformation:
+    """Unit tests for OVHCloudAudioTranscriptionConfig.transform_audio_transcription_response."""
+
+    def setup_method(self):
+        self.config = OVHCloudAudioTranscriptionConfig()
+
+    def test_verbose_json_segments_preserved(self):
+        """
+        Regression test for https://github.com/BerriAI/litellm/issues/25633.
+
+        When response_format=verbose_json, the OVHCloud Whisper endpoint returns
+        `segments` (and optionally `words`, `language`, `duration`).  The
+        transformer must pass all fields through to TranscriptionResponse.
+        """
+        verbose_response = {
+            "task": "transcribe",
+            "language": "english",
+            "duration": 3.14,
+            "text": "Hello world.",
+            "segments": [
+                {
+                    "id": 0,
+                    "seek": 0,
+                    "start": 0.0,
+                    "end": 1.5,
+                    "text": "Hello world.",
+                    "tokens": [50364, 2425, 1002, 13],
+                    "temperature": 0.0,
+                    "avg_logprob": -0.3,
+                    "compression_ratio": 1.0,
+                    "no_speech_prob": 0.01,
+                }
+            ],
+        }
+
+        raw_response = _make_mock_response(verbose_response)
+        result = self.config.transform_audio_transcription_response(raw_response)
+
+        assert result.text == "Hello world."
+        # segments must be preserved
+        assert hasattr(result, "segments") or "segments" in result._hidden_params
+        segments = getattr(result, "segments", None) or result._hidden_params.get(
+            "segments"
+        )
+        assert segments is not None
+        assert len(segments) == 1
+
+    def test_plain_text_response(self):
+        """A minimal JSON response with only `text` should still work."""
+        raw_response = _make_mock_response({"text": "Simple transcript."})
+        result = self.config.transform_audio_transcription_response(raw_response)
+        assert result.text == "Simple transcript."
+
+    def test_transcript_field_normalised_to_text(self):
+        """If OVHCloud returns `transcript` instead of `text`, it should be normalised."""
+        raw_response = _make_mock_response({"transcript": "Normalised text."})
+        result = self.config.transform_audio_transcription_response(raw_response)
+        assert result.text == "Normalised text."


### PR DESCRIPTION
## Problem

Fixes #25633

When using  with the OVHCloud Whisper endpoint, the API returns a full verbose response containing `segments`, `words`, `language`, `duration`, etc. — but only the `text` field was being returned to callers.

**Root cause:** `OVHCloudAudioTranscriptionConfig.transform_audio_transcription_response` manually extracted only the `text` (or `transcript`) field, discarding everything else.

## Fix

Mirror the approach used by the OpenAI Whisper implementation: pass the full response JSON to `TranscriptionResponse(**response_json)` so all OpenAI-compatible fields are preserved.

A normalisation step handles the case where OVHCloud returns `transcript` instead of `text` (backwards compatible).

## Changes

- `litellm/llms/ovhcloud/audio_transcription/transformation.py` — updated `transform_audio_transcription_response` to pass through all fields
- `tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py` — added unit tests covering:
  - `verbose_json` response with segments preserved
  - plain-text response (no regression)
  - `transcript` field normalised to `text`

## Testing

The new unit tests run without an API key and cover the fixed code path directly.