### PR TITLE
fix(aiohttp_transport): set total=None in per-request ClientTimeout to prevent silent 300s cap

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -272,6 +272,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             "allow_redirects": False,
             "auto_decompress": False,
             "timeout": ClientTimeout(
+                total=None,
                 sock_connect=timeout.get("connect"),
                 sock_read=timeout.get("read"),
                 connect=timeout.get("pool"),

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -544,3 +544,71 @@ async def test_handle_session_closed_during_request():
     assert counts["requests"] == 2  # First request failed, second succeeded
     assert counts["sessions"] == 2  # Created 2 sessions for retry
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_per_request_timeout_sets_total_to_none():
+    """
+    Verify that the per-request ClientTimeout sets total=None explicitly.
+
+    When total is left as sentinel (unset), aiohttp resolves it to
+    DEFAULT_TIMEOUT.total (300s).  Since the per-request timeout replaces
+    the session-level timeout entirely, this silently caps every request
+    at 300 seconds — even when the caller configured a much longer timeout
+    (e.g. 3600s via sock_read).  Setting total=None disables the overall
+    duration limit so that per-operation timeouts (sock_read, etc.) and
+    the caller's own asyncio.wait_for deadline control the lifetime.
+    """
+    captured_timeouts: list = []
+
+    class CapturingSession:
+        def __init__(self):
+            self.closed = False
+            try:
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = None
+
+        def request(self, *args, **kwargs):
+            captured_timeouts.append(kwargs.get("timeout"))
+
+            class Resp:
+                status = 200
+                headers = {}
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *a):
+                    pass
+
+                @property
+                def content(self):
+                    class C:
+                        async def iter_chunked(self, size):
+                            yield b""
+
+                    return C()
+
+            return Resp()
+
+    transport = LiteLLMAiohttpTransport(client=lambda: CapturingSession())  # type: ignore
+
+    request = httpx.Request("GET", "http://example.com")
+    request.extensions["timeout"] = {
+        "connect": 3600.0,
+        "read": 3600.0,
+        "pool": 3600.0,
+    }
+
+    await transport.handle_async_request(request)
+
+    assert len(captured_timeouts) == 1
+    ct = captured_timeouts[0]
+    assert ct.total is None, (
+        f"Expected total=None but got {ct.total}; sentinel total resolves "
+        f"to aiohttp DEFAULT_TIMEOUT.total (300s), silently capping requests"
+    )
+    assert ct.sock_read == 3600.0
+    assert ct.sock_connect == 3600.0
+    assert ct.connect == 3600.0


### PR DESCRIPTION
## Summary

When `LiteLLMAiohttpTransport._make_aiohttp_request` builds a per-request `ClientTimeout`, it sets `sock_connect`, `sock_read`, and `connect` from the httpx timeout extensions but leaves `total` unset (sentinel). aiohttp resolves the sentinel value to `DEFAULT_TIMEOUT.total` which is **300 seconds**, silently capping every request at 300s — even when the caller configured a much longer timeout (e.g. `timeout=3600`).

Combined with retries, this manifests as requests timing out after **600 seconds** (300s × 2 attempts) instead of the configured timeout.

### The fix

Set `total=None` explicitly in the per-request `ClientTimeout`. This disables the overall duration limit, letting:
- Per-operation timeouts (`sock_read`, `sock_connect`, `connect`) control individual operation deadlines
- The caller's `asyncio.wait_for` provide the overall request deadline

This is consistent with the existing streaming behavior — the streaming test (`test_handle_async_request_streaming_does_not_timeout_on_total_duration`) already relies on `total` not capping long-running streams, and continues to pass.

### How to reproduce

1. Pass `timeout=3600` to `litellm.acompletion()` with a `shared_session` that has `ClientTimeout(total=3600)`
2. Make a request to a slow backend that takes >300 seconds to respond
3. Observe the request times out after ~300s (or ~600s with 1 retry) instead of 3600s

### Changes

| File | Change |
|------|--------|
| `litellm/llms/custom_httpx/aiohttp_transport.py` | Add `total=None` to per-request `ClientTimeout` |
| `tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py` | Add test verifying `total` is `None`, not sentinel |

## Test plan

- [x] New test `test_per_request_timeout_sets_total_to_none` — verifies `total` is explicitly `None`
- [x] Existing test `test_handle_async_request_streaming_does_not_timeout_on_total_duration` — still passes
- [x] Existing test `test_handle_async_request_sock_read_timeout_triggers` — still passes
- [x] All 16 tests in `test_aiohttp_transport.py` pass