### PR TITLE
fix: strip stale Content-Length in pass-through after gzip decompression

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -320,7 +320,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         litellm_call_id: Optional[str] = None,
         custom_headers: Optional[dict] = None,
     ) -> dict:
-        excluded_headers = {"transfer-encoding", "content-encoding"}
+        excluded_headers = {"transfer-encoding", "content-encoding", "content-length"}
 
         return_headers = {
             key: value


### PR DESCRIPTION
## Summary

Fixes #25624

When a pass-through endpoint proxies a gzip-compressed upstream response, httpx auto-decompresses the body but `response.headers["content-length"]` still reflects the **compressed** size. `get_response_headers()` strips `content-encoding` but keeps the now-stale `content-length`, causing a mismatch between the header and actual body size.

**The fix:** Add `"content-length"` to `excluded_headers` in `get_response_headers()`. FastAPI's `Response(content=bytes)` auto-calculates the correct value from the actual body.

This is safe for all cases:
- **Gzip responses:** Fixes the mismatch
- **Non-gzip responses:** FastAPI calculates the same value as upstream
- **Streaming responses:** `StreamingResponse` does not use `Content-Length`

## Changes

- `litellm/proxy/pass_through_endpoints/pass_through_endpoints.py`: Added `"content-length"` to `excluded_headers` set

## Test plan

- [ ] Verify pass-through with gzip-compressed upstream (e.g. BytePlus Ark API) returns correct Content-Length
- [ ] Verify non-gzip pass-through responses are unaffected
- [ ] Verify streaming pass-through responses are unaffected