### PR TITLE
fix(gemini): assign correct indices in batch embedding response

### DIFF
--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -292,10 +292,10 @@ def process_response(
     _predictions: VertexAIBatchEmbeddingsResponseObject,
 ) -> EmbeddingResponse:
     openai_embeddings: List[Embedding] = []
-    for embedding in _predictions["embeddings"]:
+    for idx, embedding in enumerate(_predictions["embeddings"]):
         openai_embedding = Embedding(
             embedding=embedding["values"],
-            index=0,
+            index=idx,
             object="embedding",
         )
         openai_embeddings.append(openai_embedding)

--- a/tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py
+++ b/tests/litellm/llms/vertex_ai/test_gemini_batch_embeddings.py
@@ -22,6 +22,7 @@ from litellm.llms.vertex_ai.gemini_embeddings.batch_embed_content_transformation
     _is_multimodal_input,
     _parse_data_url,
     process_embed_content_response,
+    process_response,
     transform_openai_input_gemini_content,
     transform_openai_input_gemini_embed_content,
 )
@@ -562,4 +563,33 @@ def test_vertex_ai_text_only_embedding_uses_embed_content():
         assert len(data["content"]["parts"]) == 1
         assert data["content"]["parts"][0]["text"] == "Hello, world!"
         assert len(response.data) == 1
+
+
+def test_batch_embeddings_response_has_correct_indices_and_order():
+    """Test that process_response assigns sequential indices and preserves order."""
+    response_json = {
+        "embeddings": [
+            {"values": [0.1, 0.2, 0.3]},
+            {"values": [0.4, 0.5, 0.6]},
+            {"values": [0.7, 0.8, 0.9]},
+        ]
+    }
+    expected_values = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+
+    model_response = EmbeddingResponse()
+    result = process_response(
+        input=["first", "second", "third"],
+        model_response=model_response,
+        model="text-embedding-004",
+        _predictions=response_json,
+    )
+
+    assert len(result.data) == 3
+    for i, embedding in enumerate(result.data):
+        assert (
+            embedding.index == i
+        ), f"embedding {i} has index={embedding.index}, expected {i}"
+        assert (
+            embedding.embedding == expected_values[i]
+        ), f"embedding {i} has wrong values: {embedding.embedding}"
 


### PR DESCRIPTION
## Relevant issues

The Gemini batchEmbedContents response handler hardcoded `index=0` for every embedding in the response. Any consumer relying on the OpenAI-format `index` field to match embeddings back to inputs would silently get wrong associations.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

Added unit test asserting sequential indices and correct vector ordering for a batch response.


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Use `enumerate` in `process_response` so each embedding gets its positional index instead of 0.