### PR TITLE
fix: drain datadog batches safely

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -301,7 +301,7 @@ class DataDogLogger(
             self.log_queue.append(dd_payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
         except Exception as e:
             verbose_logger.exception(
                 f"Datadog: async_post_call_failure_hook - {str(e)}\n{traceback.format_exc()}"
@@ -324,9 +324,12 @@ class DataDogLogger(
                 verbose_logger.exception("Datadog: log_queue does not exist")
                 return
 
+            batch_to_send = self.log_queue[:]
+            self.log_queue = []
+
             verbose_logger.debug(
                 "Datadog - about to flush %s events on %s",
-                len(self.log_queue),
+                len(batch_to_send),
                 self.intake_url,
             )
 
@@ -335,7 +338,7 @@ class DataDogLogger(
                     "[DATADOG MOCK] Mock mode enabled - API calls will be intercepted"
                 )
 
-            response = await self.async_send_compressed_data(self.log_queue)
+            response = await self.async_send_compressed_data(batch_to_send)
             if response.status_code == 413:
                 verbose_logger.exception(DD_ERRORS.DATADOG_413_ERROR.value)
                 return
@@ -348,7 +351,7 @@ class DataDogLogger(
 
             if self.is_mock_mode:
                 verbose_logger.debug(
-                    f"[DATADOG MOCK] Batch of {len(self.log_queue)} events successfully mocked"
+                    f"[DATADOG MOCK] Batch of {len(batch_to_send)} events successfully mocked"
                 )
             else:
                 verbose_logger.debug(
@@ -356,10 +359,24 @@ class DataDogLogger(
                     response.status_code,
                     response.text,
                 )
+
         except Exception as e:
+            self.log_queue = batch_to_send + self.log_queue
             verbose_logger.exception(
                 f"Datadog Error sending batch API - {str(e)}\n{traceback.format_exc()}"
             )
+
+    async def flush_queue(self):
+        if self.flush_lock is None:
+            return
+
+        async with self.flush_lock:
+            if self.log_queue:
+                verbose_logger.debug(
+                    "CustomLogger: Flushing batch of %s events", len(self.log_queue)
+                )
+                await self.async_send_batch()
+                self.last_flush_time = datetime.datetime.now().timestamp()
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -429,7 +446,7 @@ class DataDogLogger(
         )
 
         if len(self.log_queue) >= self.batch_size:
-            await self.async_send_batch()
+            await self.flush_queue()
 
     def _create_datadog_logging_payload_helper(
         self,

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -378,7 +378,8 @@ class DataDogLogger(
                     "Datadog: Flushing batch of %s events", len(self.log_queue)
                 )
                 await self.async_send_batch()
-                self.last_flush_time = time.time()
+                if not self.log_queue:
+                    self.last_flush_time = time.time()
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         """

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -341,6 +341,7 @@ class DataDogLogger(
             response = await self.async_send_compressed_data(batch_to_send)
             if response.status_code == 413:
                 verbose_logger.exception(DD_ERRORS.DATADOG_413_ERROR.value)
+                self.log_queue = batch_to_send + self.log_queue
                 return
 
             response.raise_for_status()
@@ -373,10 +374,10 @@ class DataDogLogger(
         async with self.flush_lock:
             if self.log_queue:
                 verbose_logger.debug(
-                    "CustomLogger: Flushing batch of %s events", len(self.log_queue)
+                    "Datadog: Flushing batch of %s events", len(self.log_queue)
                 )
                 await self.async_send_batch()
-                self.last_flush_time = datetime.datetime.now().timestamp()
+                self.last_flush_time = time.time()
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         """

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -16,6 +16,7 @@ For batching specific details see CustomBatchLogger class
 import asyncio
 import datetime
 import os
+import time
 import traceback
 from datetime import datetime as datetimeObj
 from typing import Any, Dict, List, Optional, Union

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -107,3 +107,27 @@ async def test_async_send_batch_requeues_events_on_413(datadog_env):
         '{"event": 0}',
         '{"event": 1}',
     ]
+
+
+@pytest.mark.asyncio
+async def test_flush_queue_updates_last_flush_time(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = [
+        DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message='{"event": 0}',
+            service="svc",
+            status="info",
+        )
+    ]
+    logger.last_flush_time = 0
+    logger.async_send_batch = AsyncMock()
+
+    await logger.flush_queue()
+
+    logger.async_send_batch.assert_awaited_once()
+    assert logger.last_flush_time > 0

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -72,3 +72,38 @@ async def test_failure_hook_threshold_flush_uses_flush_queue(datadog_env):
     )
 
     logger.flush_queue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_requeues_events_on_413(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = [
+        DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message=f'{{"event": {i}}}',
+            service="svc",
+            status="info",
+        )
+        for i in range(2)
+    ]
+
+    logger.async_send_compressed_data = AsyncMock(
+        return_value=Response(
+            413,
+            request=Request("POST", "https://example.com"),
+            text="Payload Too Large",
+        )
+    )
+
+    await logger.async_send_batch()
+
+    assert logger.async_send_compressed_data.await_count == 1
+    assert len(logger.log_queue) == 2
+    assert [event["message"] for event in logger.log_queue] == [
+        '{"event": 0}',
+        '{"event": 1}',
+    ]

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from httpx import Request, Response
@@ -156,7 +156,7 @@ async def test_log_async_event_threshold_flush_uses_flush_queue(datadog_env):
 
     logger.batch_size = 1
     logger.flush_queue = AsyncMock()
-    logger.create_datadog_logging_payload = AsyncMock(
+    logger.create_datadog_logging_payload = Mock(
         return_value=DatadogPayload(
             ddsource="litellm",
             ddtags="env:test",

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import Request, Response
+
+from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.types.integrations.datadog import DatadogPayload
+
+
+@pytest.fixture
+def datadog_env(monkeypatch):
+    monkeypatch.setenv("DD_API_KEY", "test_api_key")
+    monkeypatch.setenv("DD_SITE", "test.datadoghq.com")
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_keeps_events_appended_during_send(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = [
+        DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message=f'{{"event": {i}}}',
+            service="svc",
+            status="info",
+        )
+        for i in range(2)
+    ]
+
+    async def _mock_send(data):
+        logger.log_queue.append(
+            DatadogPayload(
+                ddsource="litellm",
+                ddtags="env:test",
+                hostname="host",
+                message='{"event": 2}',
+                service="svc",
+                status="info",
+            )
+        )
+        return Response(
+            202, request=Request("POST", "https://example.com"), text="Accepted"
+        )
+
+    logger.async_send_compressed_data = AsyncMock(side_effect=_mock_send)
+
+    await logger.async_send_batch()
+
+    assert logger.async_send_compressed_data.await_count == 1
+    sent_batch = logger.async_send_compressed_data.await_args.args[0]
+    assert len(sent_batch) == 2
+    assert len(logger.log_queue) == 1
+    assert logger.log_queue[0]["message"] == '{"event": 2}'
+
+
+@pytest.mark.asyncio
+async def test_failure_hook_threshold_flush_uses_flush_queue(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.batch_size = 1
+    logger.flush_queue = AsyncMock()
+
+    await logger.async_post_call_failure_hook(
+        request_data={},
+        original_exception=Exception("boom"),
+        user_api_key_dict=type("UserKey", (), {})(),
+        traceback_str="trace",
+    )
+
+    logger.flush_queue.assert_awaited_once()

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -193,9 +193,75 @@ async def test_flush_queue_updates_last_flush_time(datadog_env):
         )
     ]
     logger.last_flush_time = 0
-    logger.async_send_batch = AsyncMock()
+
+    async def _successful_send():
+        logger.log_queue = []
+
+    logger.async_send_batch = AsyncMock(side_effect=_successful_send)
 
     await logger.flush_queue()
 
     logger.async_send_batch.assert_awaited_once()
     assert logger.last_flush_time > 0
+
+
+@pytest.mark.asyncio
+async def test_flush_queue_does_not_update_last_flush_time_when_send_requeues(
+    datadog_env,
+):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = [
+        DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message='{"event": 0}',
+            service="svc",
+            status="info",
+        )
+    ]
+    logger.last_flush_time = 123.0
+
+    async def _requeue_batch():
+        logger.log_queue = [
+            DatadogPayload(
+                ddsource="litellm",
+                ddtags="env:test",
+                hostname="host",
+                message='{"event": 0}',
+                service="svc",
+                status="info",
+            )
+        ]
+
+    logger.async_send_batch = AsyncMock(side_effect=_requeue_batch)
+
+    await logger.flush_queue()
+
+    logger.async_send_batch.assert_awaited_once()
+    assert logger.last_flush_time == 123.0
+
+
+@pytest.mark.asyncio
+async def test_flush_queue_returns_without_lock(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.flush_lock = None
+    logger.log_queue = [
+        DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message='{"event": 0}',
+            service="svc",
+            status="info",
+        )
+    ]
+    logger.async_send_batch = AsyncMock()
+
+    await logger.flush_queue()
+
+    logger.async_send_batch.assert_not_awaited()

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -110,6 +110,74 @@ async def test_async_send_batch_requeues_events_on_413(datadog_env):
 
 
 @pytest.mark.asyncio
+async def test_async_send_batch_handles_empty_queue(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = []
+    logger.async_send_compressed_data = AsyncMock()
+
+    await logger.async_send_batch()
+
+    logger.async_send_compressed_data.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_send_batch_requeues_events_on_exception(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = [
+        DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message=f'{{"event": {i}}}',
+            service="svc",
+            status="info",
+        )
+        for i in range(2)
+    ]
+
+    logger.async_send_compressed_data = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await logger.async_send_batch()
+
+    assert [event["message"] for event in logger.log_queue] == [
+        '{"event": 0}',
+        '{"event": 1}',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_log_async_event_threshold_flush_uses_flush_queue(datadog_env):
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.batch_size = 1
+    logger.flush_queue = AsyncMock()
+    logger.create_datadog_logging_payload = AsyncMock(
+        return_value=DatadogPayload(
+            ddsource="litellm",
+            ddtags="env:test",
+            hostname="host",
+            message='{"event": 0}',
+            service="svc",
+            status="info",
+        )
+    )
+
+    await logger._log_async_event(
+        kwargs={},
+        response_obj={},
+        start_time=None,
+        end_time=None,
+    )
+
+    logger.flush_queue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_flush_queue_updates_last_flush_time(datadog_env):
     with patch("asyncio.create_task"):
         logger = DataDogLogger()


### PR DESCRIPTION
## Summary
- detach and drain the Datadog batch queue before sending so threshold flushes do not keep growing memory or resend old events
- route threshold-based flushes through the logger flush lock and requeue unsent events on send failures
- add focused regression tests for concurrent appends during flush and failure-hook threshold flushing

Fixes #25660