### PR TITLE
fix: support reasoning_effort for Claude models on github_copilot provider

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -157,8 +157,8 @@ class GithubCopilotConfig(OpenAIConfig):
         """
         if "claude" in model.lower():
             # Convert Anthropic-native ``thinking`` -> ``reasoning_effort``.
-            # If the user already set reasoning_effort (e.g. via litellm config
-            # YAML), respect that and don't overwrite.
+            # Work on a shallow copy so we never mutate the caller's dict.
+            non_default_params = {**non_default_params}
             thinking = non_default_params.get("thinking")
             if thinking and "reasoning_effort" not in non_default_params:
                 if self._is_thinking_enabled(thinking):

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Tuple
 
+
 from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
 from litellm.types.llms.openai import AllMessageValues
@@ -150,7 +151,7 @@ class GithubCopilotConfig(OpenAIConfig):
            (``POST /v1/messages``), it may contain a ``thinking`` parameter
            instead of ``reasoning_effort``.  Copilot's API is OpenAI-compatible
            and does not understand ``thinking``, so when thinking is enabled and
-           no explicit ``reasoning_effort`` is set, default to ``"high"``.
+           no explicit ``reasoning_effort`` is set, default to ``"medium"``.
            Users can override this by setting ``reasoning_effort`` in
            ``litellm_params`` in the proxy config YAML.
         """

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -1,4 +1,3 @@
-import re
 from typing import List, Optional, Tuple
 
 from litellm.exceptions import AuthenticationError
@@ -100,70 +99,21 @@ class GithubCopilotConfig(OpenAIConfig):
 
         return validated_headers
 
-    @staticmethod
-    def _is_claude_reasoning_model(model: str) -> bool:
-        """
-        Check if a Claude model supports extended thinking / reasoning_effort.
-
-        GitHub Copilot uses its own model naming (dots instead of hyphens, e.g.
-        ``claude-sonnet-4.5``, ``claude-opus-4.6-fast``), which may not be in
-        the model registry.  This helper uses model-name pattern matching as a
-        fallback so that newly added Copilot models work without waiting for a
-        registry update.
-
-        Models that support reasoning:
-        - Claude 4+ family (sonnet-4, opus-4.5, opus-4.6, haiku-4.5, etc.)
-        - Claude 3-7 Sonnet
-        Models that do NOT support reasoning:
-        - Claude 3.5 and earlier
-        """
-        model_lower = model.lower()
-
-        # Exclude Claude 3.5 and earlier (no extended thinking)
-        if "claude-3.5" in model_lower or "claude-3-5" in model_lower:
-            return False
-        if "claude-3.0" in model_lower or "claude-3-0" in model_lower:
-            return False
-
-        # Claude 3-7 Sonnet supports reasoning
-        if "claude-3-7" in model_lower or "claude-3.7" in model_lower:
-            return True
-
-        # Claude 4+ family: any model containing "claude-<variant>-4"
-        # Matches: claude-sonnet-4, claude-opus-4.5, claude-opus-4.6-fast,
-        #          claude-haiku-4.5, claude-opus-41, etc.
-        if re.search(r"claude-\w+-4", model_lower):
-            return True
-
-        return False
-
     def get_supported_openai_params(self, model: str) -> list:
         """
         Get supported OpenAI parameters for GitHub Copilot.
 
-        For Claude models that support extended thinking (Claude 4 family and
-        Claude 3-7), includes ``thinking`` and ``reasoning_effort`` parameters.
-
-        Uses model-name pattern matching as the primary check (Copilot model
-        names may not be in the model registry), with ``supports_reasoning()``
-        as a fallback for models registered with ``supports_reasoning=True``.
+        For Claude models, always includes ``thinking`` and ``reasoning_effort``
+        since all Claude models available on Copilot support extended thinking.
+        Even if a model doesn't use them, passing these params is harmless —
+        Copilot will simply ignore unsupported ones.
 
         For other models, returns standard OpenAI parameters (which may include
         ``reasoning_effort`` for O-series models via the parent class).
         """
-        from litellm.utils import supports_reasoning
-
-        # Get base OpenAI parameters
         base_params = super().get_supported_openai_params(model)
 
-        # Add Claude-specific parameters for models that support extended thinking
-        if "claude" in model.lower() and (
-            self._is_claude_reasoning_model(model)
-            or supports_reasoning(
-                model=model.lower(),
-                custom_llm_provider="github_copilot",
-            )
-        ):
+        if "claude" in model.lower():
             if "thinking" not in base_params:
                 base_params.append("thinking")
             if "reasoning_effort" not in base_params:
@@ -172,28 +122,12 @@ class GithubCopilotConfig(OpenAIConfig):
         return base_params
 
     @staticmethod
-    def _translate_thinking_to_reasoning_effort(thinking: dict) -> Optional[str]:
-        """
-        Convert Anthropic ``thinking`` param to OpenAI ``reasoning_effort``.
-
-        GitHub Copilot exposes an OpenAI-compatible API, so the Anthropic-native
-        ``thinking`` parameter must be translated.  The budget-token thresholds
-        mirror ``LiteLLMAnthropicMessagesAdapter.translate_anthropic_thinking_to_reasoning_effort``.
-        """
-        if not isinstance(thinking, dict):
-            return None
-        if thinking.get("type") == "disabled":
-            return None
-        if thinking.get("type") == "enabled":
-            budget = thinking.get("budget_tokens", 0)
-            if budget >= 10000:
-                return "high"
-            if budget >= 5000:
-                return "medium"
-            if budget >= 2000:
-                return "low"
-            return "minimal"
-        return None
+    def _is_thinking_enabled(thinking: dict) -> bool:
+        """Check if an Anthropic ``thinking`` param has thinking enabled."""
+        return (
+            isinstance(thinking, dict)
+            and thinking.get("type") == "enabled"
+        )
 
     def map_openai_params(
         self,
@@ -215,18 +149,19 @@ class GithubCopilotConfig(OpenAIConfig):
         2. When the request arrives from Claude Code's Anthropic adapter
            (``POST /v1/messages``), it may contain a ``thinking`` parameter
            instead of ``reasoning_effort``.  Copilot's API is OpenAI-compatible
-           and does not understand ``thinking``, so convert it to
-           ``reasoning_effort`` and strip ``thinking`` from the output.
+           and does not understand ``thinking``, so when thinking is enabled and
+           no explicit ``reasoning_effort`` is set, default to ``"high"``.
+           Users can override this by setting ``reasoning_effort`` in
+           ``litellm_params`` in the proxy config YAML.
         """
         if "claude" in model.lower():
-            # Convert Anthropic-native ``thinking`` -> ``reasoning_effort``
-            # before mapping params, so _map_openai_params sees it as a
-            # standard OpenAI param.
+            # Convert Anthropic-native ``thinking`` -> ``reasoning_effort``.
+            # If the user already set reasoning_effort (e.g. via litellm config
+            # YAML), respect that and don't overwrite.
             thinking = non_default_params.get("thinking")
             if thinking and "reasoning_effort" not in non_default_params:
-                effort = self._translate_thinking_to_reasoning_effort(thinking)
-                if effort:
-                    non_default_params["reasoning_effort"] = effort
+                if self._is_thinking_enabled(thinking):
+                    non_default_params["reasoning_effort"] = "medium"
             # Remove ``thinking`` -- Copilot's OpenAI API doesn't understand it
             non_default_params.pop("thinking", None)
 

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -1,5 +1,5 @@
+import re
 from typing import List, Optional, Tuple
-
 
 from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
@@ -100,12 +100,56 @@ class GithubCopilotConfig(OpenAIConfig):
 
         return validated_headers
 
+    @staticmethod
+    def _is_claude_reasoning_model(model: str) -> bool:
+        """
+        Check if a Claude model supports extended thinking / reasoning_effort.
+
+        GitHub Copilot uses its own model naming (dots instead of hyphens, e.g.
+        ``claude-sonnet-4.5``, ``claude-opus-4.6-fast``), which may not be in
+        the model registry.  This helper uses model-name pattern matching as a
+        fallback so that newly added Copilot models work without waiting for a
+        registry update.
+
+        Models that support reasoning:
+        - Claude 4+ family (sonnet-4, opus-4.5, opus-4.6, haiku-4.5, etc.)
+        - Claude 3-7 Sonnet
+        Models that do NOT support reasoning:
+        - Claude 3.5 and earlier
+        """
+        model_lower = model.lower()
+
+        # Exclude Claude 3.5 and earlier (no extended thinking)
+        if "claude-3.5" in model_lower or "claude-3-5" in model_lower:
+            return False
+        if "claude-3.0" in model_lower or "claude-3-0" in model_lower:
+            return False
+
+        # Claude 3-7 Sonnet supports reasoning
+        if "claude-3-7" in model_lower or "claude-3.7" in model_lower:
+            return True
+
+        # Claude 4+ family: any model containing "claude-<variant>-4"
+        # Matches: claude-sonnet-4, claude-opus-4.5, claude-opus-4.6-fast,
+        #          claude-haiku-4.5, claude-opus-41, etc.
+        if re.search(r"claude-\w+-4", model_lower):
+            return True
+
+        return False
+
     def get_supported_openai_params(self, model: str) -> list:
         """
         Get supported OpenAI parameters for GitHub Copilot.
 
-        For Claude models that support extended thinking (Claude 4 family and Claude 3-7), includes thinking and reasoning_effort parameters.
-        For other models, returns standard OpenAI parameters (which may include reasoning_effort for o-series models).
+        For Claude models that support extended thinking (Claude 4 family and
+        Claude 3-7), includes ``thinking`` and ``reasoning_effort`` parameters.
+
+        Uses model-name pattern matching as the primary check (Copilot model
+        names may not be in the model registry), with ``supports_reasoning()``
+        as a fallback for models registered with ``supports_reasoning=True``.
+
+        For other models, returns standard OpenAI parameters (which may include
+        ``reasoning_effort`` for O-series models via the parent class).
         """
         from litellm.utils import supports_reasoning
 
@@ -113,16 +157,94 @@ class GithubCopilotConfig(OpenAIConfig):
         base_params = super().get_supported_openai_params(model)
 
         # Add Claude-specific parameters for models that support extended thinking
-        if "claude" in model.lower() and supports_reasoning(
-            model=model.lower(),
+        if "claude" in model.lower() and (
+            self._is_claude_reasoning_model(model)
+            or supports_reasoning(
+                model=model.lower(),
+                custom_llm_provider="github_copilot",
+            )
         ):
             if "thinking" not in base_params:
                 base_params.append("thinking")
-            # reasoning_effort is not included by parent for Claude models, so add it
             if "reasoning_effort" not in base_params:
                 base_params.append("reasoning_effort")
 
         return base_params
+
+    @staticmethod
+    def _translate_thinking_to_reasoning_effort(thinking: dict) -> Optional[str]:
+        """
+        Convert Anthropic ``thinking`` param to OpenAI ``reasoning_effort``.
+
+        GitHub Copilot exposes an OpenAI-compatible API, so the Anthropic-native
+        ``thinking`` parameter must be translated.  The budget-token thresholds
+        mirror ``LiteLLMAnthropicMessagesAdapter.translate_anthropic_thinking_to_reasoning_effort``.
+        """
+        if not isinstance(thinking, dict):
+            return None
+        if thinking.get("type") == "disabled":
+            return None
+        if thinking.get("type") == "enabled":
+            budget = thinking.get("budget_tokens", 0)
+            if budget >= 10000:
+                return "high"
+            if budget >= 5000:
+                return "medium"
+            if budget >= 2000:
+                return "low"
+            return "minimal"
+        return None
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map OpenAI parameters for GitHub Copilot.
+
+        Two fixes over the inherited ``OpenAIConfig.map_openai_params``:
+
+        1. For Claude models, call ``self._map_openai_params`` directly so that
+           ``self.get_supported_openai_params`` (which adds ``reasoning_effort``
+           for Claude) is used instead of the hardcoded ``openAIGPTConfig``
+           singleton which does not know about Claude-specific params.
+
+        2. When the request arrives from Claude Code's Anthropic adapter
+           (``POST /v1/messages``), it may contain a ``thinking`` parameter
+           instead of ``reasoning_effort``.  Copilot's API is OpenAI-compatible
+           and does not understand ``thinking``, so convert it to
+           ``reasoning_effort`` and strip ``thinking`` from the output.
+        """
+        if "claude" in model.lower():
+            # Convert Anthropic-native ``thinking`` -> ``reasoning_effort``
+            # before mapping params, so _map_openai_params sees it as a
+            # standard OpenAI param.
+            thinking = non_default_params.get("thinking")
+            if thinking and "reasoning_effort" not in non_default_params:
+                effort = self._translate_thinking_to_reasoning_effort(thinking)
+                if effort:
+                    non_default_params["reasoning_effort"] = effort
+            # Remove ``thinking`` -- Copilot's OpenAI API doesn't understand it
+            non_default_params.pop("thinking", None)
+
+            mapped = self._map_openai_params(
+                non_default_params=non_default_params,
+                optional_params=optional_params,
+                model=model,
+            )
+            # Belt-and-suspenders: strip ``thinking`` from mapped output too,
+            # in case it was already in optional_params before we got here.
+            mapped.pop("thinking", None)
+            return mapped
+        return super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
 
     def _determine_initiator(self, messages: List[AllMessageValues]) -> str:
         """

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -378,10 +378,11 @@ def test_get_supported_openai_params_claude_model():
     assert "thinking" in supported_params_claude37
     assert "reasoning_effort" in supported_params_claude37
     
-    # Test Claude 3.5 model does NOT support thinking parameters (no extended thinking)
+    # Test Claude 3.5 model — now also gets thinking/reasoning_effort
+    # since all Claude models on Copilot default to supporting reasoning
     supported_params_claude35 = config.get_supported_openai_params("claude-3.5-sonnet")
-    assert "thinking" not in supported_params_claude35
-    assert "reasoning_effort" not in supported_params_claude35
+    assert "thinking" in supported_params_claude35
+    assert "reasoning_effort" in supported_params_claude35
     
     # Test non-Claude model doesn't include thinking parameters but may include reasoning_effort
     supported_params_gpt = config.get_supported_openai_params("gpt-4o")
@@ -410,10 +411,10 @@ def test_get_supported_openai_params_case_insensitive():
     assert "thinking" in supported_params_mixed
     assert "reasoning_effort" in supported_params_mixed
     
-    # Test that Claude 3.5 models don't have thinking support (case insensitive)
+    # Test that Claude 3.5 models also get thinking support on Copilot
     supported_params_35 = config.get_supported_openai_params("CLAUDE-3.5-SONNET")
-    assert "thinking" not in supported_params_35
-    assert "reasoning_effort" not in supported_params_35
+    assert "thinking" in supported_params_35
+    assert "reasoning_effort" in supported_params_35
 
 def test_copilot_vision_request_header_with_image():
     """Test that Copilot-Vision-Request header is added when messages contain images"""
@@ -516,31 +517,10 @@ def test_copilot_vision_request_header_with_type_image_url():
 # ---------------------------------------------------------------------------
 
 
-def test_is_claude_reasoning_model():
-    """Test _is_claude_reasoning_model for various model names."""
-    check = GithubCopilotConfig._is_claude_reasoning_model
-
-    assert check("claude-sonnet-4") is True
-    assert check("claude-sonnet-4.5") is True
-    assert check("claude-opus-4.5") is True
-    assert check("claude-opus-4.6") is True
-    assert check("claude-opus-4.6-fast") is True
-    assert check("claude-opus-4.6-1m") is True
-    assert check("claude-haiku-4.5") is True
-    assert check("claude-opus-41") is True
-    assert check("claude-3-7-sonnet-20250219") is True
-    assert check("claude-3.7-sonnet") is True
-    assert check("claude-3.5-sonnet") is False
-    assert check("claude-3-5-sonnet") is False
-    assert check("claude-3.0-haiku") is False
-    assert check("CLAUDE-SONNET-4.5") is True
-    assert check("Claude-Opus-4.6") is True
-
-
 def test_get_supported_openai_params_copilot_model_names():
-    """Test with actual GitHub Copilot model names (dot notation, not in registry)."""
+    """All Claude models on Copilot should support thinking and reasoning_effort."""
     config = GithubCopilotConfig()
-    for model in ["claude-sonnet-4.5", "claude-opus-4.5", "claude-opus-4.6", "claude-opus-4.6-1m"]:
+    for model in ["claude-sonnet-4.5", "claude-opus-4.5", "claude-opus-4.6", "claude-opus-4.6-1m", "claude-3.5-sonnet"]:
         params = config.get_supported_openai_params(model)
         assert "thinking" in params, f"{model}: missing thinking"
         assert "reasoning_effort" in params, f"{model}: missing reasoning_effort"
@@ -588,7 +568,7 @@ def test_map_openai_params_thinking_converted_to_reasoning_effort():
         model="claude-sonnet-4.5",
         drop_params=False,
     )
-    assert result["reasoning_effort"] == "high"
+    assert result["reasoning_effort"] == "medium"
     assert "thinking" not in result
 
 
@@ -621,20 +601,6 @@ def test_map_openai_params_thinking_disabled():
     assert "thinking" not in result
 
 
-def test_map_openai_params_thinking_budget_tiers():
-    """Test budget_tokens -> reasoning_effort tier mapping."""
-    config = GithubCopilotConfig()
-    for budget, expected in [(50000, "high"), (10000, "high"), (8000, "medium"), (5000, "medium"), (3000, "low"), (2000, "low"), (1000, "minimal"), (100, "minimal")]:
-        result = config.map_openai_params(
-            non_default_params={"thinking": {"type": "enabled", "budget_tokens": budget}},
-            optional_params={},
-            model="claude-sonnet-4.5",
-            drop_params=False,
-        )
-        assert result["reasoning_effort"] == expected, f"budget={budget}: expected '{expected}', got '{result.get('reasoning_effort')}'"
-        assert "thinking" not in result
-
-
 def test_map_openai_params_non_claude_model():
     """Test that map_openai_params still delegates correctly for non-Claude models."""
     config = GithubCopilotConfig()
@@ -661,23 +627,6 @@ def test_map_openai_params_reasoning_effort_not_added_for_gpt4o():
     assert result["temperature"] == 0.5
 
 
-def test_translate_thinking_to_reasoning_effort():
-    """Test _translate_thinking_to_reasoning_effort static method."""
-    tr = GithubCopilotConfig._translate_thinking_to_reasoning_effort
-    assert tr({"type": "enabled", "budget_tokens": 50000}) == "high"
-    assert tr({"type": "enabled", "budget_tokens": 10000}) == "high"
-    assert tr({"type": "enabled", "budget_tokens": 8000}) == "medium"
-    assert tr({"type": "enabled", "budget_tokens": 5000}) == "medium"
-    assert tr({"type": "enabled", "budget_tokens": 3000}) == "low"
-    assert tr({"type": "enabled", "budget_tokens": 2000}) == "low"
-    assert tr({"type": "enabled", "budget_tokens": 1000}) == "minimal"
-    assert tr({"type": "enabled", "budget_tokens": 0}) == "minimal"
-    assert tr({"type": "disabled"}) is None
-    assert tr("not a dict") is None
-    assert tr(None) is None
-    assert tr({"type": "enabled"}) == "minimal"
-
-
 def test_map_openai_params_end_to_end_thinking_only():
     """End-to-end: get_optional_params -> transform_request with thinking param."""
     from litellm.utils import get_optional_params
@@ -698,5 +647,5 @@ def test_map_openai_params_end_to_end_thinking_only():
         headers={},
     )
     assert "reasoning_effort" in body
-    assert body["reasoning_effort"] == "high"
+    assert body["reasoning_effort"] == "medium"
     assert "thinking" not in body

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -509,3 +509,194 @@ def test_copilot_vision_request_header_with_type_image_url():
     
     assert headers["Copilot-Vision-Request"] == "true"
     assert headers["X-Initiator"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Tests for reasoning_effort / thinking fix
+# ---------------------------------------------------------------------------
+
+
+def test_is_claude_reasoning_model():
+    """Test _is_claude_reasoning_model for various model names."""
+    check = GithubCopilotConfig._is_claude_reasoning_model
+
+    assert check("claude-sonnet-4") is True
+    assert check("claude-sonnet-4.5") is True
+    assert check("claude-opus-4.5") is True
+    assert check("claude-opus-4.6") is True
+    assert check("claude-opus-4.6-fast") is True
+    assert check("claude-opus-4.6-1m") is True
+    assert check("claude-haiku-4.5") is True
+    assert check("claude-opus-41") is True
+    assert check("claude-3-7-sonnet-20250219") is True
+    assert check("claude-3.7-sonnet") is True
+    assert check("claude-3.5-sonnet") is False
+    assert check("claude-3-5-sonnet") is False
+    assert check("claude-3.0-haiku") is False
+    assert check("CLAUDE-SONNET-4.5") is True
+    assert check("Claude-Opus-4.6") is True
+
+
+def test_get_supported_openai_params_copilot_model_names():
+    """Test with actual GitHub Copilot model names (dot notation, not in registry)."""
+    config = GithubCopilotConfig()
+    for model in ["claude-sonnet-4.5", "claude-opus-4.5", "claude-opus-4.6", "claude-opus-4.6-1m"]:
+        params = config.get_supported_openai_params(model)
+        assert "thinking" in params, f"{model}: missing thinking"
+        assert "reasoning_effort" in params, f"{model}: missing reasoning_effort"
+
+
+def test_map_openai_params_reasoning_effort_claude():
+    """Test that reasoning_effort passes through for Claude models."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high", "temperature": 0.7},
+        optional_params={},
+        model="claude-sonnet-4.5",
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "high"
+    assert result["temperature"] == 0.7
+
+
+def test_map_openai_params_reasoning_effort_unregistered_model():
+    """Test that reasoning_effort passes through for models NOT in the JSON registry."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model="claude-opus-4.6",
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "high"
+
+    result2 = config.map_openai_params(
+        non_default_params={"reasoning_effort": "medium"},
+        optional_params={},
+        model="claude-opus-4.6-1m",
+        drop_params=False,
+    )
+    assert result2["reasoning_effort"] == "medium"
+
+
+def test_map_openai_params_thinking_converted_to_reasoning_effort():
+    """Test that Anthropic 'thinking' is converted to reasoning_effort and stripped."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled", "budget_tokens": 10000}},
+        optional_params={},
+        model="claude-sonnet-4.5",
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "high"
+    assert "thinking" not in result
+
+
+def test_map_openai_params_thinking_with_existing_reasoning_effort():
+    """Test that explicit reasoning_effort takes precedence over thinking conversion."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={
+            "thinking": {"type": "enabled", "budget_tokens": 10000},
+            "reasoning_effort": "medium",
+        },
+        optional_params={},
+        model="claude-sonnet-4.5",
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "medium"
+    assert "thinking" not in result
+
+
+def test_map_openai_params_thinking_disabled():
+    """Test that thinking with type=disabled does NOT produce reasoning_effort."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={"thinking": {"type": "disabled"}},
+        optional_params={},
+        model="claude-sonnet-4.5",
+        drop_params=False,
+    )
+    assert "reasoning_effort" not in result
+    assert "thinking" not in result
+
+
+def test_map_openai_params_thinking_budget_tiers():
+    """Test budget_tokens -> reasoning_effort tier mapping."""
+    config = GithubCopilotConfig()
+    for budget, expected in [(50000, "high"), (10000, "high"), (8000, "medium"), (5000, "medium"), (3000, "low"), (2000, "low"), (1000, "minimal"), (100, "minimal")]:
+        result = config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled", "budget_tokens": budget}},
+            optional_params={},
+            model="claude-sonnet-4.5",
+            drop_params=False,
+        )
+        assert result["reasoning_effort"] == expected, f"budget={budget}: expected '{expected}', got '{result.get('reasoning_effort')}'"
+        assert "thinking" not in result
+
+
+def test_map_openai_params_non_claude_model():
+    """Test that map_openai_params still delegates correctly for non-Claude models."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={"temperature": 0.5, "max_tokens": 100},
+        optional_params={},
+        model="gpt-4o",
+        drop_params=False,
+    )
+    assert result["temperature"] == 0.5
+    assert result["max_tokens"] == 100
+
+
+def test_map_openai_params_reasoning_effort_not_added_for_gpt4o():
+    """Test that reasoning_effort is NOT passed through for non-reasoning models."""
+    config = GithubCopilotConfig()
+    result = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high", "temperature": 0.5},
+        optional_params={},
+        model="gpt-4o",
+        drop_params=False,
+    )
+    assert "reasoning_effort" not in result
+    assert result["temperature"] == 0.5
+
+
+def test_translate_thinking_to_reasoning_effort():
+    """Test _translate_thinking_to_reasoning_effort static method."""
+    tr = GithubCopilotConfig._translate_thinking_to_reasoning_effort
+    assert tr({"type": "enabled", "budget_tokens": 50000}) == "high"
+    assert tr({"type": "enabled", "budget_tokens": 10000}) == "high"
+    assert tr({"type": "enabled", "budget_tokens": 8000}) == "medium"
+    assert tr({"type": "enabled", "budget_tokens": 5000}) == "medium"
+    assert tr({"type": "enabled", "budget_tokens": 3000}) == "low"
+    assert tr({"type": "enabled", "budget_tokens": 2000}) == "low"
+    assert tr({"type": "enabled", "budget_tokens": 1000}) == "minimal"
+    assert tr({"type": "enabled", "budget_tokens": 0}) == "minimal"
+    assert tr({"type": "disabled"}) is None
+    assert tr("not a dict") is None
+    assert tr(None) is None
+    assert tr({"type": "enabled"}) == "minimal"
+
+
+def test_map_openai_params_end_to_end_thinking_only():
+    """End-to-end: get_optional_params -> transform_request with thinking param."""
+    from litellm.utils import get_optional_params
+
+    config = GithubCopilotConfig()
+    optional_params = get_optional_params(
+        model="claude-sonnet-4.5",
+        custom_llm_provider="github_copilot",
+        thinking={"type": "enabled", "budget_tokens": 10000},
+        max_tokens=200,
+        drop_params=True,
+    )
+    body = config.transform_request(
+        model="claude-sonnet-4.5",
+        messages=[{"role": "user", "content": "test"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert "reasoning_effort" in body
+    assert body["reasoning_effort"] == "high"
+    assert "thinking" not in body


### PR DESCRIPTION
## Relevant issues
Fixes https://github.com/BerriAI/litellm/issues/25666

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before fix** — `reasoning_effort` not present in request to Copilot API:

**After fix** — `reasoning_effort: "medium"` correctly forwarded to Copilot API, response contains reasoning output:

## Type

🐛 Bug Fix

## Changes

### Problem

The `github_copilot` provider does not support `reasoning_effort` for Claude models. Two issues:

1. `GithubCopilotConfig` inherits `OpenAIConfig.map_openai_params`, which delegates to a hardcoded `openAIGPTConfig` singleton. That singleton uses its own `get_supported_openai_params` — not the subclass override — so `reasoning_effort` is filtered out.

2. When requests come from Anthropic-compatible clients (e.g., Claude Code via `POST /v1/messages`), the native `thinking` parameter is not converted to `reasoning_effort`. Copilot's OpenAI-compatible API does not understand `thinking`, so the intent is lost.

### Fix

**`litellm/llms/github_copilot/chat/transformation.py`:**

- Override `get_supported_openai_params` to add `thinking` and `reasoning_effort` for all Claude models.
- Override `map_openai_params` to:
  - Convert Anthropic-native `thinking` → `reasoning_effort` (defaults to `"medium"` when thinking is enabled and no explicit `reasoning_effort` is set).
  - Strip `thinking` from the request (Copilot doesn't understand it).
  - Use `self._map_openai_params()` for Claude models instead of delegating to the singleton, so the correct `get_supported_openai_params` is called.
- Non-Claude models (GPT, O-series) are unaffected — they fall through to the parent implementation.

**`tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py`:**

- Added 11 new tests covering `reasoning_effort` pass-through, `thinking` → `reasoning_effort` conversion, `thinking` stripping, and non-Claude model behavior.