### PR TITLE
Feat(dashscope): add image generation support for qwen-image-2.0 and qwen-image-2.0-pro

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -407,6 +407,7 @@ def image_generation(  # noqa: PLR0915
             litellm.LlmProviders.RUNWAYML,
             litellm.LlmProviders.VERTEX_AI,
             litellm.LlmProviders.OPENROUTER,
+            litellm.LlmProviders.DASHSCOPE,
         ):
             if image_generation_config is None:
                 raise ValueError(

--- a/litellm/llms/dashscope/image_generation/__init__.py
+++ b/litellm/llms/dashscope/image_generation/__init__.py
@@ -1,0 +1,9 @@
+from litellm.llms.base_llm.image_generation.transformation import BaseImageGenerationConfig
+
+from .transformation import DashScopeImageGenerationConfig
+
+__all__ = ["DashScopeImageGenerationConfig"]
+
+
+def get_dashscope_image_generation_config(model: str) -> BaseImageGenerationConfig:
+    return DashScopeImageGenerationConfig()

--- a/litellm/llms/dashscope/image_generation/transformation.py
+++ b/litellm/llms/dashscope/image_generation/transformation.py
@@ -1,0 +1,187 @@
+"""
+DashScope Image Generation Configuration
+
+Handles transformation between OpenAI-compatible format and DashScope multimodal-generation API.
+
+API endpoint: POST https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation
+
+Request format:
+{
+    "model": "qwen-image-2.0-pro",
+    "input": {
+        "messages": [{"role": "user", "content": [{"text": "<prompt>"}]}]
+    },
+    "parameters": {"size": "1024*1024", ...}
+}
+
+Response format:
+{
+    "output": {
+        "choices": [{"message": {"content": [{"image": "<url>"}]}}]
+    },
+    "usage": {"input_tokens": 0, "output_tokens": 0, "width": 1024, "height": 1024, "image_count": 1}
+}
+"""
+
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+import httpx
+
+from litellm.llms.base_llm.image_generation.transformation import BaseImageGenerationConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllMessageValues, OpenAIImageGenerationOptionalParams
+from litellm.types.utils import ImageObject, ImageResponse
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+DEFAULT_API_BASE = "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
+
+# Maps OpenAI size strings (WxH) to DashScope size strings (W*H)
+OPENAI_TO_DASHSCOPE_SIZE: dict = {
+    "256x256": "256*256",
+    "512x512": "512*512",
+    "1024x1024": "1024*1024",
+    "1792x1024": "1792*1024",
+    "1024x1792": "1024*1792",
+    "2048x2048": "2048*2048",
+}
+
+
+class DashScopeImageGenerationConfig(BaseImageGenerationConfig):
+    """
+    Configuration for DashScope image generation (qwen-image-2.0, qwen-image-2.0-pro).
+    """
+
+    def get_supported_openai_params(
+        self, model: str
+    ) -> List[OpenAIImageGenerationOptionalParams]:
+        return ["n", "size"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+        mapped: dict = {}
+        for k, v in non_default_params.items():
+            if k in optional_params:
+                continue
+            if k not in supported_params:
+                continue
+            if k == "size":
+                # Convert "WxH" → "W*H"
+                mapped["size"] = OPENAI_TO_DASHSCOPE_SIZE.get(v, v.replace("x", "*"))
+            elif k == "n":
+                mapped["image_count"] = v
+        return mapped
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        return (
+            api_base
+            or get_secret_str("DASHSCOPE_API_BASE_IMAGE")
+            or DEFAULT_API_BASE
+        )
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        final_api_key = api_key or get_secret_str("DASHSCOPE_API_KEY")
+        if not final_api_key:
+            raise ValueError("DASHSCOPE_API_KEY is not set")
+        headers["Authorization"] = f"Bearer {final_api_key}"
+        headers["Content-Type"] = "application/json"
+        return headers
+
+    def transform_image_generation_request(
+        self,
+        model: str,
+        prompt: str,
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        """
+        Transform OpenAI-style image generation request to DashScope multimodal-generation format.
+        """
+        parameters: dict = {}
+        for k, v in optional_params.items():
+            parameters[k] = v
+
+        return {
+            "model": model,
+            "input": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"text": prompt}],
+                    }
+                ]
+            },
+            "parameters": parameters,
+        }
+
+    def transform_image_generation_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: ImageResponse,
+        logging_obj: LiteLLMLoggingObj,
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+        encoding: Any,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ImageResponse:
+        """
+        Transform DashScope response to litellm ImageResponse.
+
+        DashScope response: output.choices[0].message.content[0].image
+        OpenAI response:    data[0].url
+        """
+        try:
+            response_data = raw_response.json()
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=f"Failed to parse DashScope image generation response: {e}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        if not model_response.data:
+            model_response.data = []
+
+        choices = response_data.get("output", {}).get("choices", [])
+        for choice in choices:
+            content_list = (
+                choice.get("message", {}).get("content", [])
+            )
+            for content_item in content_list:
+                image_url = content_item.get("image")
+                if image_url:
+                    model_response.data.append(ImageObject(url=image_url))
+
+        return model_response

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10112,6 +10112,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "dashscope/qwen-image-2.0": {
+        "litellm_provider": "dashscope",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "dashscope/qwen-image-2.0-pro": {
+        "litellm_provider": "dashscope",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "databricks/databricks-bge-large-en": {
         "input_cost_per_token": 1.0003e-07,
         "input_dbu_cost_per_token": 1.429e-06,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7057,6 +7057,51 @@ async def model_info(
     )
 
 
+def _get_model_mode(model: str) -> Optional[str]:
+    """
+    Safely look up the mode ('chat', 'image_generation', etc.) for a model.
+    Returns None if the model is not found in the model cost map.
+    """
+    try:
+        info = litellm.get_model_info(model=model)
+        return info.get("mode")
+    except Exception:
+        return None
+
+
+def _image_response_to_chat_response(image_response: Any, model: str) -> dict:
+    """
+    Convert an ImageResponse to a chat completion dict so that clients that
+    only speak /chat/completions (e.g. OpenWebUI) can receive image results.
+    Each generated image URL is rendered as a Markdown image.
+    """
+    import time
+    import uuid
+
+    images = getattr(image_response, "data", None) or []
+    parts: List[str] = []
+    for img in images:
+        url = getattr(img, "url", None)
+        if url:
+            parts.append(f"![image]({url})")
+    content = "\n\n".join(parts) if parts else "Image generation completed."
+
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:10]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
 @router.post(
     "/v1/chat/completions",
     dependencies=[Depends(user_api_key_auth)],
@@ -7140,6 +7185,34 @@ async def chat_completion(  # noqa: PLR0915
             and user_api_key_dict.agent_id is not None
         ):
             data["metadata"]["agent_id"] = user_api_key_dict.agent_id
+
+    # Auto-route qwen-image series models: when a client (e.g. OpenWebUI) sends a
+    # /chat/completions request for a qwen-image model, extract the prompt from messages
+    # and route to the image generation handler instead. Intentionally scoped to
+    # qwen-image series only — other image_generation providers are not affected.
+    _model_name = data.get("model") or ""
+    if (
+        _model_name
+        and "qwen-image" in _model_name.lower()
+        and _get_model_mode(_model_name) == "image_generation"
+    ):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            get_str_from_messages,
+        )
+
+        _messages = data.get("messages") or []
+        _prompt = get_str_from_messages(_messages) if _messages else data.get("prompt", "")
+        _image_data = {k: v for k, v in data.items() if k != "messages"}
+        _image_data["prompt"] = _prompt
+        _llm_call = await route_request(
+            data=_image_data,
+            route_type="aimage_generation",
+            llm_router=llm_router,
+            user_model=user_model,
+        )
+        _image_response = await _llm_call
+        return _image_response_to_chat_response(_image_response, model=_model_name)
+
     base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
         result = await base_llm_response_processor.base_process_llm_request(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8919,6 +8919,12 @@ class ProviderConfigManager:
             )
 
             return get_openrouter_image_generation_config(model)
+        elif LlmProviders.DASHSCOPE == provider:
+            from litellm.llms.dashscope.image_generation import (
+                get_dashscope_image_generation_config,
+            )
+
+            return get_dashscope_image_generation_config(model)
         return None
 
     @staticmethod

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10112,6 +10112,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "dashscope/qwen-image-2.0": {
+        "litellm_provider": "dashscope",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "dashscope/qwen-image-2.0-pro": {
+        "litellm_provider": "dashscope",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "databricks/databricks-bge-large-en": {
         "input_cost_per_token": 1.0003e-07,
         "input_dbu_cost_per_token": 1.429e-06,

--- a/tests/test_litellm/test_dashscope_image_generation.py
+++ b/tests/test_litellm/test_dashscope_image_generation.py
@@ -1,0 +1,327 @@
+"""
+Unit tests for DashScope image generation support (qwen-image-2.0, qwen-image-2.0-pro).
+
+Run in docker: pytest tests/test_litellm/test_dashscope_image_generation.py -v
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import litellm
+from litellm.llms.dashscope.image_generation.transformation import (
+    DashScopeImageGenerationConfig,
+    DEFAULT_API_BASE,
+)
+from litellm.types.utils import ImageObject, ImageResponse
+from litellm.utils import get_llm_provider
+
+
+# ---------------------------------------------------------------------------
+# 1. Provider detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_string",
+    [
+        "dashscope/qwen-image-2.0",
+        "dashscope/qwen-image-2.0-pro",
+    ],
+)
+def test_get_llm_provider_returns_dashscope(model_string: str):
+    model, provider, _, _ = get_llm_provider(model_string)
+    assert provider == "dashscope", f"Expected 'dashscope', got '{provider}'"
+    assert "qwen-image" in model
+
+
+# ---------------------------------------------------------------------------
+# 2. Model info: mode == "image_generation"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_string, custom_provider",
+    [
+        ("dashscope/qwen-image-2.0", "dashscope"),
+        ("dashscope/qwen-image-2.0-pro", "dashscope"),
+    ],
+)
+def test_get_model_info_mode_is_image_generation(model_string: str, custom_provider: str):
+    import os
+
+    prev_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    prev_model_cost = litellm.model_cost
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+
+        info = litellm.get_model_info(model=model_string, custom_llm_provider=custom_provider)
+        assert info["mode"] == "image_generation", (
+            f"Expected mode='image_generation', got '{info['mode']}'"
+        )
+    finally:
+        if prev_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = prev_env
+        litellm.model_cost = prev_model_cost
+
+
+# ---------------------------------------------------------------------------
+# 3. Request transformation
+# ---------------------------------------------------------------------------
+
+
+class TestDashScopeImageGenerationConfig:
+    def setup_method(self):
+        self.cfg = DashScopeImageGenerationConfig()
+
+    def test_get_complete_url_default(self):
+        url = self.cfg.get_complete_url(None, None, "qwen-image-2.0", {}, {})
+        assert url == DEFAULT_API_BASE
+
+    def test_get_complete_url_custom(self):
+        custom = "https://custom.endpoint/generate"
+        url = self.cfg.get_complete_url(custom, None, "qwen-image-2.0", {}, {})
+        assert url == custom
+
+    def test_validate_environment_sets_auth_header(self):
+        headers = self.cfg.validate_environment(
+            headers={},
+            model="qwen-image-2.0",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            api_key="sk-test-key",
+        )
+        assert headers["Authorization"] == "Bearer sk-test-key"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_validate_environment_raises_without_key(self):
+        with patch("litellm.llms.dashscope.image_generation.transformation.get_secret_str", return_value=None):
+            with pytest.raises(ValueError, match="DASHSCOPE_API_KEY"):
+                self.cfg.validate_environment(
+                    headers={},
+                    model="qwen-image-2.0",
+                    messages=[],
+                    optional_params={},
+                    litellm_params={},
+                    api_key=None,
+                )
+
+    def test_transform_request_structure(self):
+        req = self.cfg.transform_image_generation_request(
+            model="qwen-image-2.0",
+            prompt="a puppy on green grass",
+            optional_params={"size": "1024*1024"},
+            litellm_params={},
+            headers={},
+        )
+        assert req["model"] == "qwen-image-2.0"
+        messages = req["input"]["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"][0]["text"] == "a puppy on green grass"
+        assert req["parameters"]["size"] == "1024*1024"
+
+    def test_transform_request_empty_params(self):
+        req = self.cfg.transform_image_generation_request(
+            model="qwen-image-2.0-pro",
+            prompt="sunset over the ocean",
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        assert req["parameters"] == {}
+
+    # ---------------------------------------------------------------------------
+    # 4. Response transformation
+    # ---------------------------------------------------------------------------
+
+    def _make_mock_response(self, image_url: str) -> httpx.Response:
+        body = {
+            "status_code": 200,
+            "request_id": "test-request-id",
+            "output": {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"image": image_url}],
+                        },
+                    }
+                ]
+            },
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "width": 1024,
+                "height": 1024,
+                "image_count": 1,
+            },
+        }
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.json.return_value = body
+        return mock_resp
+
+    def test_transform_response_extracts_url(self):
+        image_url = "https://example.oss.aliyuncs.com/generated/test.png"
+        mock_resp = self._make_mock_response(image_url)
+        model_response = ImageResponse()
+        result = self.cfg.transform_image_generation_response(
+            model="qwen-image-2.0",
+            raw_response=mock_resp,
+            model_response=model_response,
+            logging_obj=MagicMock(),
+            request_data={},
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        assert result.data is not None
+        assert len(result.data) == 1
+        assert result.data[0].url == image_url
+
+    def test_transform_response_multiple_images(self):
+        body = {
+            "output": {
+                "choices": [
+                    {"finish_reason": "stop", "message": {"role": "assistant", "content": [{"image": "https://example.com/img1.png"}]}},
+                    {"finish_reason": "stop", "message": {"role": "assistant", "content": [{"image": "https://example.com/img2.png"}]}},
+                ]
+            },
+            "usage": {},
+        }
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.json.return_value = body
+
+        model_response = ImageResponse()
+        result = self.cfg.transform_image_generation_response(
+            model="qwen-image-2.0",
+            raw_response=mock_resp,
+            model_response=model_response,
+            logging_obj=MagicMock(),
+            request_data={},
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+        assert len(result.data) == 2
+        assert result.data[0].url == "https://example.com/img1.png"
+        assert result.data[1].url == "https://example.com/img2.png"
+
+    # ---------------------------------------------------------------------------
+    # 5. OpenAI → DashScope parameter mapping
+    # ---------------------------------------------------------------------------
+
+    def test_map_openai_params_size_conversion(self):
+        mapped = self.cfg.map_openai_params(
+            non_default_params={"size": "1024x1024"},
+            optional_params={},
+            model="qwen-image-2.0",
+            drop_params=False,
+        )
+        assert mapped["size"] == "1024*1024"
+
+    def test_map_openai_params_n_to_image_count(self):
+        mapped = self.cfg.map_openai_params(
+            non_default_params={"n": 2},
+            optional_params={},
+            model="qwen-image-2.0",
+            drop_params=False,
+        )
+        assert mapped["image_count"] == 2
+
+    def test_map_openai_params_unknown_size_uses_asterisk(self):
+        mapped = self.cfg.map_openai_params(
+            non_default_params={"size": "768x768"},
+            optional_params={},
+            model="qwen-image-2.0",
+            drop_params=False,
+        )
+        assert mapped["size"] == "768*768"
+
+    @pytest.mark.parametrize(
+        "openai_size, expected",
+        [
+            ("256x256", "256*256"),
+            ("512x512", "512*512"),
+            ("1024x1024", "1024*1024"),
+            ("1792x1024", "1792*1024"),
+            ("1024x1792", "1024*1792"),
+            ("2048x2048", "2048*2048"),
+        ],
+    )
+    def test_map_openai_params_size_table(self, openai_size: str, expected: str):
+        mapped = self.cfg.map_openai_params(
+            non_default_params={"size": openai_size},
+            optional_params={},
+            model="qwen-image-2.0",
+            drop_params=False,
+        )
+        assert mapped["size"] == expected
+
+
+# ---------------------------------------------------------------------------
+# 6. End-to-end flow via litellm.image_generation (HTTP mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_litellm_image_generation_dashscope_end_to_end():
+    mock_response_body = {
+        "output": {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"image": "https://dashscope-result.oss.aliyuncs.com/test.png"}
+                        ],
+                    },
+                }
+            ]
+        },
+        "usage": {"input_tokens": 0, "output_tokens": 0, "width": 1024, "height": 1024, "image_count": 1},
+    }
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.HTTPHandler.post"
+    ) as mock_post:
+        mock_http_response = MagicMock()
+        mock_http_response.json.return_value = mock_response_body
+        mock_http_response.status_code = 200
+        mock_http_response.headers = {}
+        mock_post.return_value = mock_http_response
+
+        response = litellm.image_generation(
+            model="dashscope/qwen-image-2.0",
+            prompt="a puppy playing on green grass",
+            api_key="sk-test-key",
+            size="1024x1024",
+        )
+
+        assert response is not None
+        assert response.data is not None
+        assert len(response.data) == 1
+        assert response.data[0].url == "https://dashscope-result.oss.aliyuncs.com/test.png"
+
+        # Verify the HTTP call was made to the DashScope endpoint
+        call_args = mock_post.call_args
+        called_url = call_args[0][0] if call_args[0] else call_args.kwargs.get("url", "")
+        assert "dashscope" in called_url or "aliyuncs" in called_url
+
+        # Verify request body contains DashScope format
+        call_kwargs = call_args[1] if call_args[1] else {}
+        if "json" in call_kwargs:
+            body = call_kwargs["json"]
+            assert "input" in body
+            assert "messages" in body["input"]


### PR DESCRIPTION
## Relevant issues

[Feature]: qwen-image-2.0-pro is not supported by litellm #25319

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
  Link:

- [ ] **CI run for the last commit**  
  Link:

- [ ] **Merge / cherry-pick CI run**  
  Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

🆕 New Feature

## Changes

### Add DashScope qwen-image series image generation support

DashScope (`qwen-image-2.0` / `qwen-image-2.0-pro`) uses a different API format from OpenAI. Clients such as OpenWebUI also send requests via `/chat/completions` for image models, requiring automatic routing to the image generation handler.

---

### `model_prices_and_context_window.json` + `model_prices_and_context_window_backup.json`

Added two new model entries:

```json
"dashscope/qwen-image-2.0": {
    "litellm_provider": "dashscope",
    "mode": "image_generation",
    "supported_endpoints": ["/v1/images/generations"]
},
"dashscope/qwen-image-2.0-pro": {
    "litellm_provider": "dashscope",
    "mode": "image_generation",
    "supported_endpoints": ["/v1/images/generations"]
}
```

---

### `litellm/llms/dashscope/image_generation/transformation.py` (new file)

Implements `DashScopeImageGenerationConfig` extending `BaseImageGenerationConfig`:

- **Request transform**: converts OpenAI-style `prompt` string to DashScope multimodal format (`input.messages[].content[].text`)
- **Size mapping**: `"1024x1024"` → `"1024*1024"` (replaces `x` with `*`)
- **Parameter mapping**: `n` → `image_count`
- **Response transform**: extracts image URLs from `output.choices[].message.content[].image` into `ImageResponse`
- **Auth**: `Authorization: Bearer <DASHSCOPE_API_KEY>`
- **Endpoint**: `https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`

---

### `litellm/utils.py`

Registers DashScope in `ProviderConfigManager.get_provider_image_generation_config()`:

```python
elif LlmProviders.DASHSCOPE == provider:
    from litellm.llms.dashscope.image_generation import get_dashscope_image_generation_config
    return get_dashscope_image_generation_config(model)
```

---

### `litellm/images/main.py`

Adds `LlmProviders.DASHSCOPE` to the image generation provider routing list.

---

### `litellm/proxy/proxy_server.py`

Adds two helper functions and auto-routing logic:

- `_get_model_mode(model)` — looks up the `mode` field from the model cost map
- `_image_response_to_chat_response(image_response, model)` — converts `ImageResponse` to chat completion format with Markdown image rendering for OpenWebUI compatibility

Inside `chat_completion()`, requests are automatically routed to `/images/generations` when both conditions are met:

1. model name contains `"qwen-image"`
2. model cost map has `mode == "image_generation"`

Only affects the qwen-image series; no other providers are impacted.

---

### `tests/test_litellm/test_dashscope_image_generation.py` (new file)

22 unit tests covering:

- Provider detection via `get_llm_provider`
- Model info `mode` field validation
- URL construction, auth header injection, missing API key error
- Request structure transformation (single image, multiple params)
- Response parsing (single image, multiple images)
- Size mapping (6 size variants), `n` → `image_count`
- End-to-end flow with mocked HTTP
