### PR TITLE
fix(caching): add Responses API params to cache key allow-list

### DIFF
--- a/litellm/litellm_core_utils/model_param_helper.py
+++ b/litellm/litellm_core_utils/model_param_helper.py
@@ -11,6 +11,10 @@ from openai.types.completion_create_params import (
     CompletionCreateParamsStreaming as TextCompletionCreateParamsStreaming,
 )
 from openai.types.embedding_create_params import EmbeddingCreateParams
+from openai.types.responses.response_create_params import (
+    ResponseCreateParamsNonStreaming,
+    ResponseCreateParamsStreaming,
+)
 
 from litellm._logging import verbose_logger
 from litellm.types.rerank import RerankRequest
@@ -65,6 +69,9 @@ class ModelParamHelper:
             ModelParamHelper._get_litellm_supported_transcription_kwargs()
         )
         rerank_kwargs = ModelParamHelper._get_litellm_supported_rerank_kwargs()
+        responses_api_kwargs = (
+            ModelParamHelper._get_litellm_supported_responses_api_kwargs()
+        )
         exclude_kwargs = ModelParamHelper._get_exclude_kwargs()
 
         combined_kwargs = chat_completion_kwargs.union(
@@ -72,6 +79,7 @@ class ModelParamHelper:
             embedding_kwargs,
             transcription_kwargs,
             rerank_kwargs,
+            responses_api_kwargs,
         )
         combined_kwargs = combined_kwargs.difference(exclude_kwargs)
         return combined_kwargs
@@ -166,6 +174,21 @@ class ModelParamHelper:
         except Exception as e:
             verbose_logger.debug("Error getting transcription kwargs %s", str(e))
             return set()
+
+    @staticmethod
+    def _get_litellm_supported_responses_api_kwargs() -> Set[str]:
+        """
+        Get the litellm supported responses API kwargs
+
+        This follows the OpenAI API Spec
+        """
+        non_streaming_params: Set[str] = set(
+            getattr(ResponseCreateParamsNonStreaming, "__annotations__", {}).keys()
+        )
+        streaming_params: Set[str] = set(
+            getattr(ResponseCreateParamsStreaming, "__annotations__", {}).keys()
+        )
+        return non_streaming_params.union(streaming_params)
 
     @staticmethod
     def _get_exclude_kwargs() -> Set[str]:

--- a/tests/local_testing/test_unit_test_caching.py
+++ b/tests/local_testing/test_unit_test_caching.py
@@ -131,6 +131,57 @@ def test_get_cache_key_text_completion():
     assert cache_key_2 == cache_key_3
 
 
+def test_get_cache_key_responses_api():
+    """
+    Regression test: two /v1/responses calls that differ only in
+    `instructions` (or any Responses-API-only param) must produce
+    different cache keys. Mirrors the chat / embedding / text-completion
+    cache-key tests above.
+    """
+    cache = Cache()
+
+    base_kwargs = {
+        "model": "openai/gpt-4.1",
+        "input": [{"role": "user", "content": "what is the weather"}],
+        "temperature": 0.3,
+    }
+
+    kwargs_a = {
+        **base_kwargs,
+        "instructions": "summarize the weather on 10th May",
+    }
+    kwargs_b = {
+        **base_kwargs,
+        "instructions": "summarize the weather on 7th May",
+    }
+
+    key_a = cache.get_cache_key(**kwargs_a)
+    key_b = cache.get_cache_key(**kwargs_b)
+
+    assert isinstance(key_a, str) and len(key_a) > 0
+    assert key_a != key_b, (
+        "instructions must be part of the Responses API cache key"
+    )
+
+    # Sanity: identical payloads must still collide (cache hits still work)
+    key_a_again = cache.get_cache_key(**kwargs_a)
+    assert key_a == key_a_again
+
+    # Spot-check a handful of other Responses-only params individually.
+    for param, value_x, value_y in [
+        ("previous_response_id", "resp_aaa", "resp_bbb"),
+        ("reasoning", {"effort": "low"}, {"effort": "high"}),
+        ("include", ["reasoning.encrypted_content"], []),
+        ("max_output_tokens", 100, 500),
+        ("background", True, False),
+    ]:
+        kx = {**base_kwargs, param: value_x}
+        ky = {**base_kwargs, param: value_y}
+        assert cache.get_cache_key(**kx) != cache.get_cache_key(**ky), (
+            f"Responses-API param `{param}` is not part of the cache key"
+        )
+
+
 def test_get_hashed_cache_key():
     cache = Cache()
     cache_key = "model:gpt-3.5-turbo,messages:Hello world"

--- a/tests/test_litellm/test_model_param_helper.py
+++ b/tests/test_litellm/test_model_param_helper.py
@@ -31,3 +31,32 @@ def test_get_standard_logging_model_parameters_excludes_prompt_content():
     assert "prompt" not in result
     assert "input" not in result
     assert result == {"temperature": 0.5}
+
+
+def test_get_all_llm_api_params_includes_responses_api():
+    """
+    Regression guard for the Responses API cache-key bug:
+    Responses-API-only kwargs must be present in the cache-key allow-list,
+    otherwise Cache.get_cache_key() silently drops them and two requests
+    that differ only in (e.g.) `instructions` collide on the same key.
+    """
+    all_params = ModelParamHelper._get_all_llm_api_params()
+    responses_only_params = {
+        "instructions",
+        "previous_response_id",
+        "reasoning",
+        "include",
+        "store",
+        "background",
+        "max_output_tokens",
+        "max_tool_calls",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "context_management",
+        "conversation",
+        "safety_identifier",
+    }
+    missing = responses_only_params - all_params
+    assert missing == set(), (
+        f"Responses-API kwargs missing from cache-key allow-list: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Relevant issues

No linked GitHub issue. Reported by a customer via Slack with a full Postman reproduction; I verified the bug against current `main` before sending this PR.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** — `tests/test_litellm/test_model_param_helper.py::test_get_all_llm_api_params_includes_responses_api`. A second cache-key behavioral test is also added in `tests/local_testing/test_unit_test_caching.py::test_get_cache_key_responses_api`, mirroring the existing chat / embedding / text-completion cache-key tests in that file.
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — targeted and adjacent suites pass locally (`tests/test_litellm/test_model_param_helper.py`, `tests/local_testing/test_unit_test_caching.py::test_get_cache_key_*`, `tests/test_litellm/caching/test_caching_handler.py`, ruff-clean on `litellm/litellm_core_utils/model_param_helper.py`).
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem — one source file touched (`litellm/litellm_core_utils/model_param_helper.py`), strictly additive union into the cache-key allow-list. No chat / text / embedding / transcription / rerank behavior changes.
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review — will do immediately after this PR is open.

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Reproduced against current `main` on a local proxy (in-memory cache, `gpt-4.1`, native OpenAI `/v1/responses` path, no DB). Two `POST /v1/responses` calls with identical `model` / `input` / `temperature`, differing only in `instructions`:

- Call A — `instructions: \"summarize the weather on 10th May\"`
- Call B — `instructions: \"summarize the weather on 7th May\"`

### Before fix

```
Call A-10May: HTTP 200, total=0.046513s
  \"On **10th May 2018**, the weather was **chilly** with a temperature of **-2°C (29°F)**.\"
Call B-7May:  HTTP 200, total=0.027232s
  \"On **10th May 2018**, the weather was **chilly** with a temperature of **-2°C (29°F)**.\"
Diff: IDENTICAL
```

Both calls return the 10 May body; call B is served from cache in 27 ms. The proxy debug log shows the same pre-hash key and the same SHA-256 on both requests:

```
Created cache key: model: openai/gpt-4.1input: [{'role': 'user', ...}]temperature: 0.3
Hashed cache key (SHA-256): f2dc610942bd00aaecde317cf7844550d33a464d4af53b94ea6ab8f144ab8af2
Cache Hit!
```

`instructions` is absent from the pre-hash key string on both requests — that is the bug.

### After fix

```
Call A-10May -> payload-A.json
HTTP 200  total=2.486610s  ttfb=2.486447s
  On **10th May 2018**, the weather was **chilly** with a temperature of **-2°C (29°F)**.

Call B-7May  -> payload-B.json
HTTP 200  total=1.625355s  ttfb=1.625228s
  On **7th May 2018**, the weather was **bracing** with a temperature of **14°C (57°F)**.

Diff: DIFFERENT
```

Both calls are now real upstream round trips (>1.6 s) and each returns the body for the correct `instructions`. Three independent signals of the fix: (1) call-B latency goes from 27 ms to 1.6 s, (2) call-B body flips from the 10 May content to the 7 May content, (3) the normalized-body diff verdict flips from IDENTICAL to DIFFERENT. No regression on call A.

Added test run (local):

```
tests/test_litellm/test_model_param_helper.py::test_get_all_llm_api_params_includes_responses_api PASSED
tests/local_testing/test_unit_test_caching.py::test_get_cache_key_responses_api PASSED
tests/local_testing/test_unit_test_caching.py::test_get_cache_key_chat_completion PASSED
tests/local_testing/test_unit_test_caching.py::test_get_cache_key_embedding PASSED
tests/local_testing/test_unit_test_caching.py::test_get_cache_key_text_completion PASSED
tests/local_testing/test_unit_test_caching.py::test_get_kwargs_for_cache_key PASSED
tests/test_litellm/test_model_param_helper.py::test_cached_relevant_logging_args_matches_dynamic PASSED
tests/test_litellm/test_model_param_helper.py::test_get_standard_logging_model_parameters_filters PASSED
tests/test_litellm/test_model_param_helper.py::test_get_standard_logging_model_parameters_excludes_prompt_content PASSED
```

## Type

🐛 Bug Fix

## Changes

### The bug

`Cache.get_cache_key()` (`litellm/caching/caching.py:294`) builds the key from `ModelParamHelper._get_all_llm_api_params()`, which today unions the supported kwargs for chat / text / embedding / transcription / rerank — and nothing else. Native-OpenAI `/v1/responses` requests pass through the caching handler unchanged, so every Responses-API-only top-level kwarg is silently dropped from the key.

Under `openai==2.30.0` (the hard-pinned version in `pyproject.toml` and `requirements.txt`), the Responses-only top-level kwargs that are currently being dropped are:

```
background, context_management, conversation, include, instructions,
max_output_tokens, max_tool_calls, parallel_tool_calls, previous_response_id,
prompt, prompt_cache_key, prompt_cache_retention, reasoning,
safety_identifier, service_tier, store, text, partial_images
```

`model`, `input`, `temperature`, `top_p`, `stream`, `tools`, `tool_choice`, `user`, `metadata`, `top_logprobs`, `truncation`, `stream_options` happen to survive because they collide with names in the chat / text / embedding TypedDicts — pure name coincidence. That is exactly the pattern the Pfizer customer noticed: changing `input` invalidates their cache, but changing `instructions` does not.

The user-facing effect is a silent correctness bug on `/v1/responses`: two requests that differ only in (e.g.) `instructions` collapse to the same cache entry and the second is served a stale 200. No error, no warning — just the wrong body.

### The fix

Add a sixth helper, `_get_litellm_supported_responses_api_kwargs()`, on `ModelParamHelper` that sources Responses-API kwargs from `openai.types.responses.response_create_params.ResponseCreateParamsNonStreaming` / `Streaming` — a one-to-one mirror of the existing `_get_litellm_supported_chat_completion_kwargs()` helper — and union the returned set into `_get_all_llm_api_params()`.

```python
from openai.types.responses.response_create_params import (
    ResponseCreateParamsNonStreaming,
    ResponseCreateParamsStreaming,
)

# ...

@staticmethod
def _get_litellm_supported_responses_api_kwargs() -> Set[str]:
    \"\"\"
    Get the litellm supported responses API kwargs

    This follows the OpenAI API Spec
    \"\"\"
    non_streaming_params: Set[str] = set(
        getattr(ResponseCreateParamsNonStreaming, \"__annotations__\", {}).keys()
    )
    streaming_params: Set[str] = set(
        getattr(ResponseCreateParamsStreaming, \"__annotations__\", {}).keys()
    )
    return non_streaming_params.union(streaming_params)
```

### Why this shape

- **Strictly additive.** Chat / text / embedding / transcription / rerank cache keys are byte-identical before and after. Only `/v1/responses` requests see a change, and that change is the intended correctness fix. One-time cache-miss surge on first run after upgrade as previously-collapsed entries split into real per-kwarg entries; steady state recovers immediately.
- **Sourced from the openai SDK, not duplicated.** Same convention used for chat / text / embedding / transcription; no drift between LiteLLM's allow-list and OpenAI's own spec. Future additions to `ResponseCreateParamsNonStreaming` / `Streaming` flow through automatically.
- **No `try/except` import wrapper.** `openai = \"2.30.0\"` is **hard-pinned** in `pyproject.toml` and `requirements.txt` (no `^`/`~`/`>=`), so there is no resolver path under which `ResponseCreateParamsNonStreaming` could be missing. Top-level import matches chat / text / embedding. (The transcription helper uses a `try/except` only because typed transcription params landed later in the openai SDK timeline — not relevant here.)
- **`metadata` is still excluded.** The existing `_get_exclude_kwargs() == {\"metadata\"}` step still runs, so `metadata` behavior is unchanged for every call type including Responses. Whether `metadata` should be part of the Responses cache key is a separate discussion.

### Files touched

- `litellm/litellm_core_utils/model_param_helper.py` — add the import, add the helper, union the helper's output into `_get_all_llm_api_params()`.
- `tests/test_litellm/test_model_param_helper.py` — new test `test_get_all_llm_api_params_includes_responses_api`: asserts 13 Responses-API-only kwargs are present in the allow-list. Failure message names exactly what regressed.
- `tests/local_testing/test_unit_test_caching.py` — new test `test_get_cache_key_responses_api`: mirrors the existing chat / embedding / text-completion cache-key tests in this file. Asserts `instructions` yields a distinct cache key from a baseline payload, plus a parametric loop over `previous_response_id`, `reasoning`, `include`, `max_output_tokens`, `background`, plus a sanity-check that identical payloads still collide (so cache hits still work).

Three files, 103 net additions, zero deletions.