### PR TITLE
fix(datadog): clear log_queue after successful batch send in async_send_batch

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -356,6 +356,7 @@ class DataDogLogger(
                     response.status_code,
                     response.text,
                 )
+            self.log_queue.clear()
         except Exception as e:
             verbose_logger.exception(
                 f"Datadog Error sending batch API - {str(e)}\n{traceback.format_exc()}"


### PR DESCRIPTION
## Summary

`DataDogLogger.async_send_batch()` sent log events to the DataDog API but never cleared `self.log_queue`, causing two related problems:

1. **Unbounded memory growth** — every log event was retained in memory indefinitely; at 1,000 req/s and a 5 s flush interval, this grows at ~18 MB/flush cycle.
2. **Quadratic duplicate sends** — when the batch-size threshold is reached in the hot path (`_log_async_event`, `async_post_call_failure_hook`), `async_send_batch()` is called directly (bypassing `flush_queue()`). Without a clear, the same events are re-transmitted on every subsequent hot-path trigger.

The base class `CustomBatchLogger.flush_queue()` already calls `log_queue.clear()` after `async_send_batch()` (`custom_batch_logger.py:54`), but the two hot-path call sites in `DataDogLogger` bypass `flush_queue()` and therefore never benefit from that clear.

## Fix

Add `self.log_queue.clear()` at the end of the **success path** in `async_send_batch()` (after a confirmed `202` response):

- 413 responses and exception paths intentionally skip the clear so events remain for potential retry.
- The `flush_queue()` path is unaffected (double-clearing an empty list is a no-op).

Fixes #25660

## Checklist

- [x] No competing PR for this specific issue
- [x] Change is restricted to the confirmed success path; error/retry paths are unaffected
- [x] Pattern matches the existing `flush_queue()` contract in the base class