### PR TITLE
fix(utils): raise BadRequestError for missing required field in function_setup

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1033,17 +1033,47 @@ def function_setup(  # noqa: PLR0915
             call_type == CallTypes.image_generation.value
             or call_type == CallTypes.aimage_generation.value
         ):
-            messages = args[0] if len(args) > 0 else kwargs["prompt"]
+            if len(args) > 0:
+                messages = args[0]
+            else:
+                prompt_value = kwargs.get("prompt")
+                if prompt_value is None:
+                    raise BadRequestError(
+                        message="Missing required parameter: 'prompt' for image generation.",
+                        model=kwargs.get("model") or "",
+                        llm_provider="",
+                    )
+                messages = prompt_value
         elif (
             call_type == CallTypes.moderation.value
             or call_type == CallTypes.amoderation.value
         ):
-            messages = args[1] if len(args) > 1 else kwargs["input"]
+            if len(args) > 1:
+                messages = args[1]
+            else:
+                input_value = kwargs.get("input")
+                if input_value is None:
+                    raise BadRequestError(
+                        message="Missing required parameter: 'input' for moderation.",
+                        model=kwargs.get("model") or "",
+                        llm_provider="",
+                    )
+                messages = input_value
         elif (
             call_type == CallTypes.atext_completion.value
             or call_type == CallTypes.text_completion.value
         ):
-            messages = args[0] if len(args) > 0 else kwargs["prompt"]
+            if len(args) > 0:
+                messages = args[0]
+            else:
+                prompt_value = kwargs.get("prompt")
+                if prompt_value is None:
+                    raise BadRequestError(
+                        message="Missing required parameter: 'prompt' for text completion.",
+                        model=kwargs.get("model") or "",
+                        llm_provider="",
+                    )
+                messages = prompt_value
         elif (
             call_type == CallTypes.rerank.value or call_type == CallTypes.arerank.value
         ):
@@ -1052,7 +1082,17 @@ def function_setup(  # noqa: PLR0915
             call_type == CallTypes.atranscription.value
             or call_type == CallTypes.transcription.value
         ):
-            _file_obj: FileTypes = args[1] if len(args) > 1 else kwargs["file"]
+            if len(args) > 1:
+                _file_obj: FileTypes = args[1]
+            else:
+                file_value = kwargs.get("file")
+                if file_value is None:
+                    raise BadRequestError(
+                        message="Missing required parameter: 'file' for transcription.",
+                        model=kwargs.get("model") or "",
+                        llm_provider="",
+                    )
+                _file_obj = file_value
             # Lazy import audio_utils.utils only when needed for transcription calls
             audio_utils = _get_cached_audio_utils()
             file_checksum = audio_utils.get_audio_file_content_hash(file_obj=_file_obj)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3865,3 +3865,60 @@ class TestValidateAndFixThinkingParam:
         validate_and_fix_thinking_param(thinking=thinking)
         assert "budgetTokens" in thinking
         assert "budget_tokens" not in thinking
+
+
+class TestFunctionSetupMissingRequiredField:
+    """
+    Regression tests: function_setup() must raise BadRequestError (status 400)
+    instead of a raw KeyError when the caller omits the required input field
+    for text-completion, image-generation, or moderation.
+    """
+
+    def _call_function_setup(self, original_function: str, **kwargs):
+        import uuid
+        from datetime import datetime
+
+        from litellm.utils import Rules, function_setup
+
+        return function_setup(
+            original_function=original_function,
+            rules_obj=Rules(),
+            start_time=datetime.now(),
+            litellm_call_id=str(uuid.uuid4()),
+            **kwargs,
+        )
+
+    def test_text_completion_missing_prompt_raises_bad_request(self):
+        with pytest.raises(litellm.BadRequestError) as exc_info:
+            self._call_function_setup(
+                original_function="atext_completion",
+                model="text-davinci-003",
+            )
+        assert exc_info.value.status_code == 400
+        assert "prompt" in str(exc_info.value)
+
+    def test_text_completion_with_prompt_succeeds(self):
+        logging_obj, kwargs = self._call_function_setup(
+            original_function="atext_completion",
+            model="text-davinci-003",
+            prompt="hello",
+        )
+        assert kwargs["prompt"] == "hello"
+
+    def test_image_generation_missing_prompt_raises_bad_request(self):
+        with pytest.raises(litellm.BadRequestError) as exc_info:
+            self._call_function_setup(
+                original_function="aimage_generation",
+                model="dall-e-3",
+            )
+        assert exc_info.value.status_code == 400
+        assert "prompt" in str(exc_info.value)
+
+    def test_moderation_missing_input_raises_bad_request(self):
+        with pytest.raises(litellm.BadRequestError) as exc_info:
+            self._call_function_setup(
+                original_function="amoderation",
+                model="text-moderation-latest",
+            )
+        assert exc_info.value.status_code == 400
+        assert "input" in str(exc_info.value)


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory — new `TestFunctionSetupMissingRequiredField` class in `tests/test_litellm/test_utils.py` with 4 tests.
- [x] My PR passes the relevant unit tests — `pytest tests/test_litellm/test_utils.py::TestFunctionSetupMissingRequiredField -v` (4 passed) and `pytest tests/local_testing/test_function_setup.py -v` (5 passed, no regressions).
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.
- [ ] Greptile review — will request after opening the PR.

## Screenshots / Proof of Fix

E2E against a local proxy: `POST /v1/completions` with a body missing `prompt` now returns `HTTP 400 {"error":{"message":"litellm.BadRequestError: Missing required parameter: 'prompt' for text completion.", ...}}` instead of the previous `HTTP 500 {"message":"'prompt'"}`, and the well-formed path is unchanged.

## Type

🐛 Bug Fix

## Changes

**`litellm/utils.py`** — `function_setup()`

Four branches replaced their unguarded `kwargs[...]` subscript with a `.get()` + explicit `BadRequestError` raise:

- **`image_generation` / `aimage_generation`** (was: `messages = args[0] if len(args) > 0 else kwargs["prompt"]`) — now raises `BadRequestError("Missing required parameter: 'prompt' for image generation.")` when `prompt` is absent.
- **`moderation` / `amoderation`** (was: `messages = args[1] if len(args) > 1 else kwargs["input"]`) — now raises `BadRequestError("Missing required parameter: 'input' for moderation.")` when `input` is absent.
- **`atext_completion` / `text_completion`** (was: `messages = args[0] if len(args) > 0 else kwargs["prompt"]`) — now raises `BadRequestError("Missing required parameter: 'prompt' for text completion.")` when `prompt` is absent. This is the primary bug site: any request that reaches `function_setup` on the text-completion path without a `prompt` kwarg was crashing with `KeyError: 'prompt'` at `utils.py:1046`.
- **`atranscription` / `transcription`** (was: `_file_obj: FileTypes = args[1] if len(args) > 1 else kwargs["file"]`) — now raises `BadRequestError("Missing required parameter: 'file' for transcription.")` when `file` is absent, before the audio-utils file-hashing path runs.

`BadRequestError` is already imported at `utils.py:401` and carries `status_code = 400`, so the proxy's generic exception handler turns it into a clean 4XX response with a descriptive message via the existing `getattr(exception, "message", ...)` path. The four guards are independent (separate `elif` arms) and the well-formed happy path (required field present) is unchanged — the new code is a strict superset of the old code on that branch.

`model=kwargs.get("model") or ""` is passed through to `BadRequestError` to avoid a secondary `None`-surprise in downstream logging. `llm_provider=""` is acceptable because the failure is pre-provider-dispatch — no provider has been chosen yet.

**`tests/test_litellm/test_utils.py`** — added `TestFunctionSetupMissingRequiredField`

Four regression tests directly exercising `function_setup()`:

- `test_text_completion_missing_prompt_raises_bad_request` — asserts `litellm.BadRequestError` with `status_code == 400` and `"prompt"` in the message when `atext_completion` is called without `prompt`.
- `test_text_completion_with_prompt_succeeds` — control: the happy path still returns the expected `(logging_obj, kwargs)` tuple with `kwargs["prompt"]` preserved.
- `test_image_generation_missing_prompt_raises_bad_request` — same shape, `aimage_generation` branch.
- `test_moderation_missing_input_raises_bad_request` — same shape, `amoderation` branch, asserts `"input"` in the message.

The transcription branch is not covered by a new unit test because its non-trivial audio-utils path (`_get_cached_audio_utils`, file checksum) would require heavy mocking; the three tests above prove the `.get() + BadRequestError` pattern works and the transcription fix is the same shape, verifiable by inspection.

## Follow-ups (out of scope for this PR)

- Failed 4XX requests still write a failure row to `LiteLLM_SpendLogs` because `_handle_llm_api_exception` unconditionally calls `post_call_failure_hook` regardless of status code. Worth a separate PR to skip the spend-log write for pre-dispatch validation errors.
- Schema-driven request-body validation at the proxy handler (e.g. Pydantic models for `/v1/completions`, `/v1/images/generations`, `/v1/moderations`, `/v1/audio/transcriptions`) would catch missing required fields earlier and with a nicer error shape, but that's a larger refactor and is deliberately out of scope here — the `function_setup` guards also protect SDK callers, which proxy-layer validation would not.