### PR TITLE
fix(azure/passthrough): populate standard_logging_object via logging hook

### DIFF
--- a/litellm/llms/azure/passthrough/transformation.py
+++ b/litellm/llms/azure/passthrough/transformation.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import httpx
+from httpx import Response
 
+from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.azure.common_utils import BaseAzureLLM
 from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
 from litellm.secret_managers.main import get_secret_str
@@ -10,6 +12,8 @@ from litellm.types.router import GenericLiteLLMParams
 
 if TYPE_CHECKING:
     from httpx import URL
+
+    from litellm.types.utils import CostResponseTypes
 
 
 class AzurePassthroughConfig(BasePassthroughConfig):
@@ -83,3 +87,36 @@ class AzurePassthroughConfig(BasePassthroughConfig):
         self, api_key: Optional[str] = None, api_base: Optional[str] = None
     ) -> List[str]:
         return super().get_models(api_key, api_base)
+
+    def logging_non_streaming_response(
+        self,
+        model: str,
+        custom_llm_provider: str,
+        httpx_response: Response,
+        request_data: dict,
+        logging_obj: Logging,
+        endpoint: str,
+    ) -> Optional["CostResponseTypes"]:
+        from litellm import encoding
+        from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+        from litellm.types.utils import ModelResponse
+
+        if "chat/completions" not in endpoint:
+            return None
+
+        openai_chat_config = OpenAIGPTConfig()
+
+        litellm_model_response: ModelResponse = openai_chat_config.transform_response(
+            model=model,
+            messages=[{"role": "user", "content": "no-message-pass-through-endpoint"}],
+            raw_response=httpx_response,
+            model_response=ModelResponse(),
+            logging_obj=logging_obj,
+            optional_params={},
+            litellm_params={},
+            api_key="",
+            request_data=request_data,
+            encoding=encoding,
+        )
+
+        return litellm_model_response

--- a/tests/test_litellm/llms/azure/passthrough/test_azure_passthrough_transformation.py
+++ b/tests/test_litellm/llms/azure/passthrough/test_azure_passthrough_transformation.py
@@ -1,0 +1,97 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import httpx
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.azure.passthrough.transformation import AzurePassthroughConfig
+from litellm.types.utils import ModelResponse
+
+
+def _azure_chat_completion_body():
+    return {
+        "id": "chatcmpl-abc123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gpt-4.1-mini-2025-04-14",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I assist you today?",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 8,
+            "total_tokens": 18,
+        },
+    }
+
+
+def _make_httpx_response(body: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        headers={"content-type": "application/json"},
+        content=json.dumps(body).encode("utf-8"),
+        request=httpx.Request(
+            "POST",
+            "https://example.openai.azure.com/openai/deployments/gpt-4.1-mini/chat/completions",
+        ),
+    )
+
+
+def test_azure_passthrough_logging_non_streaming_response_chat_completions():
+    """
+    Returns a populated ModelResponse (with usage + content) for a chat/completions
+    endpoint. This is what _success_handler_helper_fn needs to build
+    standard_logging_object — without it, Datadog/cost-tracking/router-success all
+    raise on every Azure passthrough request.
+    """
+    config = AzurePassthroughConfig()
+    logging_obj = MagicMock()
+
+    result = config.logging_non_streaming_response(
+        model="gpt-4.1-mini",
+        custom_llm_provider="azure",
+        httpx_response=_make_httpx_response(_azure_chat_completion_body()),
+        request_data={
+            "model": "gpt-4.1-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        logging_obj=logging_obj,
+        endpoint="openai/deployments/gpt-4.1-mini/chat/completions",
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.choices[0].message.content == "Hello! How can I assist you today?"
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 8
+    assert result.usage.total_tokens == 18
+
+
+def test_azure_passthrough_logging_non_streaming_response_unknown_endpoint_returns_none():
+    """
+    Endpoints other than chat/completions (responses, messages, images) fall
+    through to None — matches base-class behavior and Bedrock's "unknown
+    endpoint" handling. Not a regression; just scoping.
+    """
+    config = AzurePassthroughConfig()
+    logging_obj = MagicMock()
+
+    result = config.logging_non_streaming_response(
+        model="gpt-4.1-mini",
+        custom_llm_provider="azure",
+        httpx_response=_make_httpx_response(_azure_chat_completion_body()),
+        request_data={},
+        logging_obj=logging_obj,
+        endpoint="openai/responses",
+    )
+
+    assert result is None


### PR DESCRIPTION
## Relevant issues

No existing GitHub issue — bug reported directly by a customer using Azure passthrough (`use_in_pass_through: true`) with the Datadog callback enabled.

## Pre-Submission checklist

- [x] I have added testing in [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) — new file `tests/test_litellm/llms/azure/passthrough/test_azure_passthrough_transformation.py` with two unit tests (populated `ModelResponse` on `chat/completions`, `None` fall-through on other endpoints).
- [ ] My PR passes all unit tests on `make test-unit` — the new tests pass locally via `uv run pytest tests/test_litellm/llms/azure/passthrough/test_azure_passthrough_transformation.py -v` (2 passed). Full `make test-unit` was not runnable on my machine due to a `pyproject.toml` parse error in current main (`exclude-newer = "3 days"`) unrelated to this change; relying on CI for the full sweep.
- [x] My PR's scope is as isolated as possible — one production file changed, one new test file, one endpoint touched (`chat/completions`). `/openai/responses` and `/openai/messages` still return `None` from the hook, unchanged from today.
- [ ] I have requested a Greptile review — will do after PR is open.

## Screenshots / Proof of Fix

Minimal reproduction: real Azure `gpt-4.1-mini` deployment with `use_in_pass_through: true` and `callbacks: [\"datadog\"]`. Requesting `POST /azure/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2025-01-01-preview`.

### Before fix

Request returns 200 to the client, but three callbacks raise on missing \`standard_logging_object\` on every request — a silent observability + cost-tracking drop:

\`\`\`
litellm.router.Router::deployment_callback_on_success(): Exception occured - standard_logging_object is None

Error in tracking cost callback - Cost tracking failed for model=gpt-4.1-mini.
Debug info - standard_logging_object not found

Datadog Layer Error - standard_logging_object not found in kwargs
Traceback (most recent call last):
  File \".../integrations/datadog/datadog.py\", line 480, in create_datadog_logging_payload
    raise ValueError(\"standard_logging_object not found in kwargs\")
ValueError: standard_logging_object not found in kwargs
\`\`\`

### After fix

Same request, same config — all three errors gone. Cost is calculated, and Datadog builds + queues a payload with real usage:

\`\`\`
response_cost: 1.92e-05

Datadog: Logger - Logging payload = {\"id\": \"chatcmpl-DURD...\", \"call_type\": \"allm_passthrough_route\", \"custom_llm_provider\": \"azure\", \"usage_object\": {\"completion_tokens\": 10, \"prompt_tokens\": 8, \"total_tokens\": 18, ...}, \"response_cost\": 1.92e-05, ...}

Datadog, event added to queue. Will flush in 5 seconds...
\`\`\`

The subsequent \`403 Forbidden\` on the Datadog intake flush is expected — the repro uses \`DD_API_KEY=fake\`. It confirms the payload reached the shipping layer, which was never possible before the fix.

## Type

🐛 Bug Fix

## Changes

**Root cause.** Requests routed through \`Router.allm_passthrough_route\` on Azure with \`use_in_pass_through: true\` never populate \`kwargs[\"standard_logging_object\"]\`. \`_success_handler_helper_fn\` in \`litellm_logging.py\` delegates to the provider's \`logging_non_streaming_response\` hook to build it; \`AzurePassthroughConfig\` inherits the base-class no-op which returns \`None\`, so no standard logging object ever gets attached. Every callback that hard-requires it then raises:

- \`litellm/integrations/datadog/datadog.py:480\` — \`create_datadog_logging_payload\` raises \`ValueError\`
- \`litellm/proxy/hooks/proxy_track_cost_callback.py:262\` — cost tracking aborts
- \`litellm/router.py:6213\` — \`deployment_callback_on_success\` logs \`standard_logging_object is None\`

**Fix.** Implement \`AzurePassthroughConfig.logging_non_streaming_response\` for the \`chat/completions\` endpoint, mirroring the existing Bedrock pattern in \`litellm/llms/bedrock/passthrough/transformation.py:121-162\`. When the hook returns a \`ModelResponse\`, the existing consumer branch in \`_success_handler_helper_fn\` builds \`standard_logging_object\` with real usage data and the triple-symptom disappears on one code path.

One deliberate difference from Bedrock: the method parses the raw response via \`OpenAIGPTConfig().transform_response\` rather than \`ProviderConfigManager.get_provider_chat_config(AZURE, model)\`. The latter returns \`AzureOpenAIConfig\`, whose \`transform_response\` raises \`NotImplementedError\` because Azure is normally routed through the OpenAI SDK rather than the BaseConfig path. Azure's \`chat/completions\` body is OpenAI-format JSON, so \`OpenAIGPTConfig\` parses it cleanly — including for o-series and GPT-5 model names.

**Scope:**
- Only \`chat/completions\` is wired. \`/openai/responses\` and \`/openai/messages\` still return \`None\` from the hook — unchanged from today, strictly additive.
- VLLM passthrough has the same defect shape and is out of scope for this PR; flagging as a follow-up.

**Files changed:**
- \`litellm/llms/azure/passthrough/transformation.py\` — new \`logging_non_streaming_response\` method, plus \`Response\` / \`Logging\` / \`CostResponseTypes\` imports.
- \`tests/test_litellm/llms/azure/passthrough/test_azure_passthrough_transformation.py\` (new) — two unit tests covering populated \`ModelResponse\` on \`chat/completions\` and \`None\` fall-through on other endpoints.