### PR TITLE
Add pricing entry for azure/gpt-5.2-chat-latest

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4136,6 +4136,40 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure/gpt-5.2-chat-latest": {
+        "cache_read_input_token_cost": 1.75e-07,
+        "cache_read_input_token_cost_priority": 3.5e-07,
+        "input_cost_per_token": 1.75e-06,
+        "input_cost_per_token_priority": 3.5e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_cost_per_token_priority": 2.8e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure/gpt-5.2-codex": {
         "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,


### PR DESCRIPTION
## Summary

Adds a missing cost entry for `azure/gpt-5.2-chat-latest` in `model_prices_and_context_window.json`.

The OpenAI variant `gpt-5.2-chat-latest` is already registered, and the dated Azure siblings `azure/gpt-5.2-chat` and `azure/gpt-5.2-chat-2025-12-11` exist as well — only the `-chat-latest` Azure alias was missing. Without this entry, cost tracking for the `gpt-5.2-chat-latest` deployment on Azure falls back to defaults.

Pricing, context window, modality support, and capability flags exactly mirror the existing `azure/gpt-5.2-chat` / `azure/gpt-5.2-chat-2025-12-11` entries so the whole `gpt-5.2` chat family stays consistent.

## Changes
- Insert `azure/gpt-5.2-chat-latest` between `azure/gpt-5.2-chat-2025-12-11` and `azure/gpt-5.2-codex` in `model_prices_and_context_window.json`.

## Test plan
- [x] JSON validates (`python -c "import json; json.load(open('model_prices_and_context_window.json'))"`).
- [x] Key `azure/gpt-5.2-chat-latest` resolves to the expected fields when loaded.