### PR TITLE
ui(teams): migrate available_teams panel from tremor to antd

### DIFF
--- a/ui/litellm-dashboard/src/components/team/available_teams.tsx
+++ b/ui/litellm-dashboard/src/components/team/available_teams.tsx
@@ -1,16 +1,6 @@
 import React, { useState, useEffect } from "react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeaderCell,
-  TableRow,
-  Card,
-  Button,
-  Text,
-  Badge,
-} from "@tremor/react";
+import { Table, TableBody, TableCell, TableHead, TableHeaderCell, TableRow } from "@tremor/react";
+import { Button, Card, Tag } from "antd";
 import { availableTeamListCall, teamMemberAddCall } from "../networking";
 import NotificationsManager from "../molecules/notifications_manager";
 
@@ -79,32 +69,24 @@ const AvailableTeamsPanel: React.FC<AvailableTeamsProps> = ({ accessToken, userI
         <TableBody>
           {availableTeams.map((team) => (
             <TableRow key={team.team_id}>
+              <TableCell>{team.team_alias}</TableCell>
+              <TableCell>{team.description || "No description available"}</TableCell>
+              <TableCell>{team.members_with_roles.length} members</TableCell>
               <TableCell>
-                <Text>{team.team_alias}</Text>
-              </TableCell>
-              <TableCell>
-                <Text>{team.description || "No description available"}</Text>
-              </TableCell>
-              <TableCell>
-                <Text>{team.members_with_roles.length} members</Text>
-              </TableCell>
-              <TableCell>
-                <div className="flex flex-col">
+                <div className="flex flex-col items-start">
                   {!team.models || team.models.length === 0 ? (
-                    <Badge size="xs" color="red">
-                      <Text>All Proxy Models</Text>
-                    </Badge>
+                    <Tag color="red">All Proxy Models</Tag>
                   ) : (
                     team.models.map((model, index) => (
-                      <Badge key={index} size="xs" className="mb-1" color="blue">
-                        <Text>{model.length > 30 ? `${model.slice(0, 30)}...` : model}</Text>
-                      </Badge>
+                      <Tag key={index} color="blue" className="mb-1">
+                        {model.length > 30 ? `${model.slice(0, 30)}...` : model}
+                      </Tag>
                     ))
                   )}
                 </div>
               </TableCell>
               <TableCell>
-                <Button size="xs" variant="secondary" onClick={() => handleJoinTeam(team.team_id)}>
+                <Button size="small" type="primary" ghost onClick={() => handleJoinTeam(team.team_id)}>
                   Join Team
                 </Button>
               </TableCell>
@@ -113,16 +95,16 @@ const AvailableTeamsPanel: React.FC<AvailableTeamsProps> = ({ accessToken, userI
           {availableTeams.length === 0 && (
             <TableRow>
               <TableCell colSpan={5} className="text-center">
-                <Text>No available teams to join. See how to set available teams{" "}
-                  <a
-                    href="https://docs.litellm.ai/docs/proxy/self_serve#all-settings-for-self-serve--sso-flow"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-500 hover:text-blue-700 underline"
-                  >
-                    here
-                  </a>.
-                </Text>
+                No available teams to join. See how to set available teams{" "}
+                <a
+                  href="https://docs.litellm.ai/docs/proxy/self_serve#all-settings-for-self-serve--sso-flow"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-500 hover:text-blue-700 underline"
+                >
+                  here
+                </a>
+                .
               </TableCell>
             </TableRow>
           )}


### PR DESCRIPTION
## Summary

- Migrates `Card`, `Button`, `Text`, and `Badge` on the Available Teams panel (`team/available_teams.tsx`) from `@tremor/react` to `antd`, per the ongoing tremor→antd migration called out in `CLAUDE.md`.
- Drops 7 `<Text>` wrappers that were only adding noise inside table cells, and replaces `<Badge>` with antd `<Tag>` (blue for model names, red for the "All Proxy Models" fallback).
- Join Team button uses `type="primary" ghost` to preserve the visually-actionable look that the tremor `variant="secondary"` provided — a plain antd default button was too muted for a primary row action.
- Table primitives (`Table`, `TableHead`, `TableRow`, etc.) are intentionally **left on tremor** for a follow-up so this PR stays a pure visual-layer swap with no structural change to the table.

Net: −39 / +21 lines on a single file, no logic changes, no test changes.

## Screenshots

<img width="1200" height="1048" alt="02-after-empty" src="https://github.com/user-attachments/assets/1f6e81b4-3ef0-4f40-be76-5313b8dc49bb" />
<img width="2692" height="2096" alt="05-after-button-tweak" src="https://github.com/user-attachments/assets/9509e185-253e-4af0-acd2-44cbc9783383" />


## Test plan

- [x] `available_teams.test.tsx` — all 6 existing tests still pass (they assert by rendered text, which is preserved)
- [x] Manual QA via Chrome DevTools MCP: populated state rendered with 3 mock teams (blue model tags, red "All Proxy Models" tag, long-name truncation), Join Team button shows ghost-primary styling
- [x] Manual QA of empty state: docs link still renders correctly
- [ ] Reviewer eyeball the before/after screenshots for visual regression