### PR TITLE
refactor(ui/logs): remove dead useQuery for allTeams in log filter hook

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -241,7 +241,6 @@ export default function SpendLogsTable({
     filters,
     filteredLogs,
     hasBackendFilters,
-    allTeams: hookAllTeams,
     handleFilterChange,
     handleFilterReset: handleFilterResetFromHook,
   } = useLogFilterLogic({

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -1,9 +1,6 @@
 import moment from "moment";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { uiSpendLogsCall } from "../networking";
-import { Team } from "../key_team_helpers/key_list";
-import { useQuery } from "@tanstack/react-query";
-import { fetchAllTeams } from "../../components/key_team_helpers/filter_helpers";
 import { debounce } from "lodash";
 import { defaultPageSize } from "../constants";
 import { PaginatedResponse } from ".";
@@ -249,19 +246,6 @@ export function useLogFilterLogic({
     return clientDerivedFilteredLogs;
   }, [hasBackendFilters, backendFilteredLogs, clientDerivedFilteredLogs]);
 
-  // Fetch all teams and users for potential filter dropdowns (optional, can be adapted)
-  const { data: allTeams } = useQuery<Team[], Error>({
-    queryKey: ["allTeamsForLogFilters", accessToken],
-    queryFn: async () => {
-      if (!accessToken) return [];
-      // Use fetchAllTeams helper function for consistency and abstraction
-      // Assuming fetchAllTeams returns Team[] directly
-      const teamsData = await fetchAllTeams(accessToken);
-      return teamsData || []; // Ensure it returns an array
-    },
-    enabled: !!accessToken,
-  });
-
   // Update filters state
   const handleFilterChange = (newFilters: Partial<LogFilterState>) => {
     setFilters((prev) => {
@@ -303,7 +287,6 @@ export function useLogFilterLogic({
     filters,
     filteredLogs,
     hasBackendFilters,
-    allTeams,
     handleFilterChange,
     handleFilterReset,
   };


### PR DESCRIPTION
## Summary

- Removes a `useQuery` in `useLogFilterLogic` whose result (`allTeams`) was destructured in `SpendLogsTable` as `hookAllTeams` but never read anywhere
- The Team ID filter dropdown on the Logs page sources its data from the `allTeams` prop passed from `app/page.tsx` (via `v2TeamListCall`), not from this hook
- Stops a `GET /team/list 401` from firing on every Logs page load for non-admin users (`fetchAllTeams` hardcodes \`null\` for \`user_id\`, which the backend rejects unless the caller is a proxy admin)

No user-visible behavior change. Pure dead-code removal — 18 lines deleted, 0 added, 2 files touched, all in \`view_logs/\`.

## Why this is safe

The deleted useQuery's only consumer was the destructure at \`view_logs/index.tsx:244\`:

\`\`\`tsx
const { ..., allTeams: hookAllTeams, ... } = useLogFilterLogic(...);
\`\`\`

A grep across the file confirms \`hookAllTeams\` is **never referenced anywhere else**. The dropdown filter at \`view_logs/index.tsx:399\` reads from the \`allTeams\` *prop*, which comes from \`app/page.tsx:618-625\` and is fetched correctly with role-based scoping via \`v2TeamListCall\`.

## Test plan

- [ ] Load Logs page as a proxy admin → Team ID dropdown still populated with all teams
- [ ] Load Logs page as a non-admin internal user (e.g. one that's a member of one team) → Team ID dropdown still populated with their team
- [ ] Apply a Team ID filter → table filters correctly
- [ ] Apply other filters (Model, Status, Key Hash) → still work
- [ ] Reset Filters → clears state correctly
- [ ] Watch proxy stdout while loading the Logs page as a non-admin → confirm \`GET /team/list HTTP/1.1 401\` line is **gone** (it used to fire on every page load)
- [ ] Compare network tab before/after on the Logs page as a non-admin → one fewer \`/team/list\` request

## Out of scope

This is the first in a series of PRs cleaning up team-fetching across the UI. Touching only the Logs page in this PR for QA-ability. Follow-ups will address Virtual Keys, Internal Users, and Tools separately.