### PR TITLE
fix(ovhcloud): preserve verbose_json fields in audio transcription response

### DIFF
--- a/litellm/llms/ovhcloud/audio_transcription/transformation.py
+++ b/litellm/llms/ovhcloud/audio_transcription/transformation.py
@@ -143,6 +143,10 @@ class OVHCloudAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
     ) -> TranscriptionResponse:
         """
         Transform OVHCloud audio transcription response to OpenAI-compatible TranscriptionResponse.
+
+        For `response_format=verbose_json`, the response includes additional fields
+        such as `segments`, `words`, `language`, `duration`, and `task`, which
+        are preserved alongside the required `text` field.
         """
         try:
             response_json = raw_response.json()
@@ -155,6 +159,11 @@ class OVHCloudAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
 
         text = response_json.get("text") or response_json.get("transcript") or ""
         response = TranscriptionResponse(text=text)
+
+        # Preserve verbose_json fields returned by OVHCloud Whisper API
+        for field in ("segments", "words", "language", "duration", "task"):
+            if field in response_json:
+                response[field] = response_json[field]
 
         response._hidden_params = response_json
         return response

--- a/tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py
@@ -1,11 +1,15 @@
 import os
 from typing import Dict
+from unittest.mock import MagicMock
 
 import litellm
 import pytest
 
 from litellm.llms.base_llm.audio_transcription.transformation import (
     BaseAudioTranscriptionConfig,
+)
+from litellm.llms.ovhcloud.audio_transcription.transformation import (
+    OVHCloudAudioTranscriptionConfig,
 )
 from litellm.utils import ProviderConfigManager
 from tests.llm_translation.base_audio_transcription_unit_tests import (
@@ -56,4 +60,72 @@ def test_ovhcloud_audio_transcription_config_installed():
     assert isinstance(config, BaseAudioTranscriptionConfig)
 
 
+class TestOVHCloudVerboseJsonResponse:
+    """Unit tests for verbose_json response handling (no API key required)."""
 
+    def _make_mock_response(self, body: dict) -> MagicMock:
+        mock = MagicMock()
+        mock.json.return_value = body
+        mock.text = str(body)
+        mock.status_code = 200
+        mock.headers = {}
+        return mock
+
+    def test_plain_json_response_returns_text(self):
+        """Basic response_format=json only returns text."""
+        config = OVHCloudAudioTranscriptionConfig()
+        mock_response = self._make_mock_response({"text": "Hello world"})
+        result = config.transform_audio_transcription_response(mock_response)
+        assert result.text == "Hello world"
+
+    def test_verbose_json_response_preserves_segments(self):
+        """response_format=verbose_json segments must be present in the response."""
+        config = OVHCloudAudioTranscriptionConfig()
+        segments = [
+            {"id": 0, "start": 0.0, "end": 1.5, "text": "Hello"},
+            {"id": 1, "start": 1.5, "end": 3.0, "text": "world"},
+        ]
+        mock_response = self._make_mock_response(
+            {
+                "text": "Hello world",
+                "task": "transcribe",
+                "language": "english",
+                "duration": 3.0,
+                "segments": segments,
+            }
+        )
+        result = config.transform_audio_transcription_response(mock_response)
+        assert result.text == "Hello world"
+        assert result["segments"] == segments
+        assert result["language"] == "english"
+        assert result["duration"] == 3.0
+        assert result["task"] == "transcribe"
+
+    def test_verbose_json_response_preserves_words(self):
+        """timestamp_granularities=['word'] words must be present in the response."""
+        config = OVHCloudAudioTranscriptionConfig()
+        words = [
+            {"word": "Hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.5, "end": 1.0},
+        ]
+        mock_response = self._make_mock_response(
+            {
+                "text": "Hello world",
+                "language": "english",
+                "duration": 1.0,
+                "words": words,
+                "segments": [],
+            }
+        )
+        result = config.transform_audio_transcription_response(mock_response)
+        assert result["words"] == words
+
+    def test_missing_verbose_json_fields_are_not_set(self):
+        """Fields absent from the response must not be added to the result."""
+        config = OVHCloudAudioTranscriptionConfig()
+        mock_response = self._make_mock_response({"text": "Hello"})
+        result = config.transform_audio_transcription_response(mock_response)
+        assert result.text == "Hello"
+        assert result.get("segments") is None
+        assert result.get("words") is None
+        assert result.get("language") is None


### PR DESCRIPTION
## Summary

Fixes #25633.

When `response_format=verbose_json` is requested against the OVHCloud Whisper endpoint, the raw response includes `segments`, `words`, `language`, `duration`, and `task` in addition to `text`. The previous `transform_audio_transcription_response` implementation only extracted `text`, silently dropping all other verbose fields.

**Root cause:** `TranscriptionResponse` was constructed with only `text`; the additional verbose fields in the JSON response were never mapped onto the response object.

**Fix:** After creating the `TranscriptionResponse`, iterate over the known verbose_json fields and set each one on the response object when present. This matches the pattern already used by the Mistral audio transcription provider (`litellm/llms/mistral/audio_transcription/transformation.py`).

## Changes

- `litellm/llms/ovhcloud/audio_transcription/transformation.py` — map `segments`, `words`, `language`, `duration`, `task` from the raw response (4 lines added)
- `tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py` — add `TestOVHCloudVerboseJsonResponse` unit test class (no API key required); covers plain JSON, verbose_json with segments, verbose_json with words, and missing-field handling

## Test plan

- [ ] `pytest tests/test_litellm/llms/ovhcloud/test_ovhcloud_audio_transcription_transformation.py::TestOVHCloudVerboseJsonResponse` — all 4 unit tests pass without an API key
- [ ] Existing OVHCloud transcription integration tests still pass (requires `OVHCLOUD_API_KEY`)