### PR TITLE
fix(proxy): enforce team membership in team-scoped key management checks

### DIFF
--- a/litellm/proxy/management_helpers/team_member_permission_checks.py
+++ b/litellm/proxy/management_helpers/team_member_permission_checks.py
@@ -98,11 +98,20 @@ class TeamMemberPermissionChecks:
         )
 
         # 5. Check if the team member has permissions for the endpoint
-        TeamMemberPermissionChecks.does_team_member_have_permissions_for_endpoint(
-            team_member_object=key_assigned_user_in_team,
-            team_table=team_table,
-            route=route,
+        has_permission = (
+            TeamMemberPermissionChecks.does_team_member_have_permissions_for_endpoint(
+                team_member_object=key_assigned_user_in_team,
+                team_table=team_table,
+                route=route,
+            )
         )
+        if not has_permission:
+            raise ProxyException(
+                message=f"User {user_api_key_dict.user_id} does not belong to team {team_table.team_id}. Team-scoped key management endpoints can only be used for keys in your own team.",
+                type=ProxyErrorTypes.team_member_permission_error,
+                param=route,
+                code=401,
+            )
 
     @staticmethod
     def does_team_member_have_permissions_for_endpoint(

--- a/tests/test_litellm/proxy/management_helpers/test_team_member_permission_checks.py
+++ b/tests/test_litellm/proxy/management_helpers/test_team_member_permission_checks.py
@@ -8,7 +8,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm.proxy._types import KeyManagementRoutes, Member
+from litellm.proxy._types import KeyManagementRoutes, Member, ProxyException
 from litellm.proxy.management_helpers.team_member_permission_checks import (
     BASELINE_TEAM_MEMBER_PERMISSIONS,
     TeamMemberPermissionChecks,
@@ -188,3 +188,74 @@ class TestGetDefaultTeamParam:
         assert _get_default_team_param("budget_duration") == "7d"
         assert _get_default_team_param("tpm_limit") == 1000
         assert _get_default_team_param("rpm_limit") == 100
+
+
+class TestCanTeamMemberExecuteKeyManagementEndpoint:
+    @pytest.mark.asyncio
+    async def test_raises_when_user_not_in_keys_team(self, monkeypatch):
+        """Non-members should be blocked from team-scoped key management endpoints."""
+        from litellm.proxy.management_endpoints import key_management_endpoints
+        from litellm.proxy.management_helpers import team_member_permission_checks as module
+
+        async def _mock_get_team_object(**kwargs):
+            team = MagicMock()
+            team.team_id = "team-b"
+            team.team_member_permissions = ["/key/update"]
+            return team
+
+        monkeypatch.setattr(module, "get_team_object", _mock_get_team_object)
+        monkeypatch.setattr(key_management_endpoints, "_get_user_in_team", lambda **kwargs: None)
+
+        user_api_key_dict = MagicMock()
+        user_api_key_dict.user_role = "internal_user"
+        user_api_key_dict.user_id = "user-a"
+        user_api_key_dict.parent_otel_span = None
+
+        existing_key_row = MagicMock()
+        existing_key_row.team_id = "team-b"
+
+        with pytest.raises(ProxyException) as exc:
+            await TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint(
+                user_api_key_dict=user_api_key_dict,
+                route=KeyManagementRoutes.KEY_UPDATE,
+                prisma_client=MagicMock(),
+                user_api_key_cache=MagicMock(),
+                existing_key_row=existing_key_row,
+            )
+        assert str(exc.value.code) == "401"
+        assert exc.value.type == "team_member_permission_error"
+
+    @pytest.mark.asyncio
+    async def test_allows_team_admin_in_keys_team(self, monkeypatch):
+        """Team admins of the key's team should be allowed."""
+        from litellm.proxy.management_endpoints import key_management_endpoints
+        from litellm.proxy.management_helpers import team_member_permission_checks as module
+
+        async def _mock_get_team_object(**kwargs):
+            team = MagicMock()
+            team.team_id = "team-a"
+            team.team_member_permissions = ["/key/update"]
+            return team
+
+        monkeypatch.setattr(module, "get_team_object", _mock_get_team_object)
+        monkeypatch.setattr(
+            key_management_endpoints,
+            "_get_user_in_team",
+            lambda **kwargs: Member(role="admin", user_id="user-a"),
+        )
+
+        user_api_key_dict = MagicMock()
+        user_api_key_dict.user_role = "internal_user"
+        user_api_key_dict.user_id = "user-a"
+        user_api_key_dict.parent_otel_span = None
+
+        existing_key_row = MagicMock()
+        existing_key_row.team_id = "team-a"
+
+        await TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint(
+            user_api_key_dict=user_api_key_dict,
+            route=KeyManagementRoutes.KEY_UPDATE,
+            prisma_client=MagicMock(),
+            user_api_key_cache=MagicMock(),
+            existing_key_row=existing_key_row,
+        )


### PR DESCRIPTION
## Relevant issues

Fixes cross-team authorization bypass on `/key/update` and `/key/regenerate` for team-scoped key management checks.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(ran targeted unit suites listed below)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
      Link:

- [ ] **CI run for the last commit**  
      Link:

- [ ] **Merge / cherry-pick CI run**  
      Links:

### Problem
Team-scoped management keys could update/regenerate keys belonging to other teams because the permission helper returned `False` for non-membership but the caller did not enforce that result.

### Repro (before fix)
- Team A admin key calling `POST /key/update` on Team B key returned `200` and modified Team B key metadata.

### Behavior after fix
- Team A admin key calling `POST /key/update` on Team B key now returns `401 team_member_permission_error`.
- Team A admin key calling `POST /key/regenerate` on Team B key now returns `401 team_member_permission_error`.
- Same-team admin operations continue to succeed.

### Tests run
- `pytest tests/test_litellm/proxy/management_helpers/test_team_member_permission_checks.py -v` ✅
- `pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k "team_member or update_key" -v` ✅

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Enforced non-membership denial in `TeamMemberPermissionChecks.can_team_member_execute_key_management_endpoint()`:
  - Capture result of `does_team_member_have_permissions_for_endpoint(...)`
  - Raise `ProxyException(team_member_permission_error, 401)` when result is falsey
- Added unit tests in existing helper test file:
  - `test_raises_when_user_not_in_keys_team`
  - `test_allows_team_admin_in_keys_team`
- No endpoint contract changes; this tightens auth enforcement for existing team-scoped routes.