### PR TITLE
feat(prometheus): add api_provider label to spend metric

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -410,6 +410,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_input_tokens_metric = [

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -396,6 +396,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_spend_metric = [

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -69,6 +69,21 @@ def test_model_id_in_required_metrics():
         print(f"✅ {metric_name} contains model_id label")
 
 
+def test_api_provider_in_spend_and_requests_metrics():
+    """
+    Test that api_provider label is present in spend and requests metrics
+    so users can build spend-by-provider and request-count-by-provider dashboards.
+    """
+    api_provider_label = UserAPIKeyLabelNames.API_PROVIDER.value
+
+    for metric_name in ["litellm_spend_metric", "litellm_requests_metric"]:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert (
+            api_provider_label in labels
+        ), f"Metric {metric_name} should contain api_provider label"
+        print(f"✅ {metric_name} contains api_provider label")
+
+
 def test_user_email_label_exists():
     """Test that the USER_EMAIL label is properly defined"""
     assert UserAPIKeyLabelNames.USER_EMAIL.value == "user_email"


### PR DESCRIPTION
## Summary

Closes https://github.com/BerriAI/litellm/issues/25692

- Add `UserAPIKeyLabelNames.API_PROVIDER` to the `litellm_spend_metric` label list in `PrometheusMetricLabels`
- This enables Grafana dashboards to break down spend by cloud provider (e.g. `bedrock`, `anthropic`, `openai`, `azure`, `vertex_ai`)
- The `api_provider` value is already populated from `standard_logging_payload["custom_llm_provider"]` — this just adds it to the metric's label set

## Motivation

The `model` label on `litellm_spend_metric` contains the raw model name with the provider prefix stripped (e.g. `gpt-5.1` instead of `openai/gpt-5.1`, `global.anthropic.claude-opus-4-6-v1` instead of `bedrock/global.anthropic...`). This makes it impossible to build spend-by-provider dashboards, and impossible to distinguish providers that share model names (e.g. OpenAI direct vs Azure OpenAI).

## Test plan

- [ ] Verify `litellm_spend_metric_total` includes `api_provider` label after the change
- [ ] Verify existing dashboards using `litellm_spend_metric` are not broken (new label is additive)
- [ ] Verify `api_provider` values match expected providers (e.g. `bedrock`, `anthropic`, `openai`, `azure`, `vertex_ai`)