### PR TITLE
feat(bedrock): combined text+image embedding for Titan and Nova multimodal models

### DIFF
--- a/docs/my-website/docs/embedding/supported_embedding.md
+++ b/docs/my-website/docs/embedding/supported_embedding.md
@@ -162,7 +162,9 @@ curl -X POST 'http://0.0.0.0:4000/v1/embeddings' \
 
 Bedrock multimodal embedding models (`amazon.titan-embed-image-v1` and `amazon.nova-2-multimodal-embeddings-v1:0`) support sending both text and image together in a single embedding request.
 
-Pass the text string **immediately before** its paired image in the `input` list. LiteLLM will detect the adjacent `[text, base64_image]` pair and merge them into a single Bedrock request containing both `inputText` and `inputImage` (Titan) or both `text` and `image` (Nova).
+Pass the text string **immediately before** its paired image in the `input` list and set `combine_text_image_pairs=True`. LiteLLM will detect the adjacent `[text, base64_image]` pair and merge them into a single Bedrock request containing both `inputText` and `inputImage` (Titan) or both `text` and `image` (Nova).
+
+When `combine_text_image_pairs` is omitted or `False` (the default), each element in `input` is sent as a separate request — preserving backward compatibility for existing code.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
@@ -181,6 +183,7 @@ response = embedding(
         "Red leather handbag with gold buckle",       # text
         f"data:image/jpeg;base64,{image_b64}",        # image (immediately after text)
     ],
+    combine_text_image_pairs=True,
     dimensions=1024,
     aws_region_name="us-east-1",
 )
@@ -192,6 +195,7 @@ response = embedding(
         "shoes photo",                                # text
         f"data:image/jpeg;base64,{image_b64}",        # image (immediately after text)
     ],
+    combine_text_image_pairs=True,
     aws_region_name="us-east-1",
 )
 ```
@@ -220,6 +224,7 @@ model_list:
     litellm_params:
       model: bedrock/amazon.titan-embed-image-v1
       aws_region_name: us-east-1
+      combine_text_image_pairs: true
 ```
 
 2. Start proxy

--- a/docs/my-website/docs/embedding/supported_embedding.md
+++ b/docs/my-website/docs/embedding/supported_embedding.md
@@ -158,6 +158,96 @@ curl -X POST 'http://0.0.0.0:4000/v1/embeddings' \
 </TabItem>
 </Tabs>
 
+## Combined Text + Image Embeddings (Bedrock)
+
+Bedrock multimodal embedding models (`amazon.titan-embed-image-v1` and `amazon.nova-2-multimodal-embeddings-v1:0`) support sending both text and image together in a single embedding request.
+
+Pass the text string **immediately before** its paired image in the `input` list. LiteLLM will detect the adjacent `[text, base64_image]` pair and merge them into a single Bedrock request containing both `inputText` and `inputImage` (Titan) or both `text` and `image` (Nova).
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import base64
+from litellm import embedding
+
+with open("product.jpg", "rb") as f:
+    image_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+# Titan multimodal — text + image in one request
+response = embedding(
+    model="bedrock/amazon.titan-embed-image-v1",
+    input=[
+        "Red leather handbag with gold buckle",       # text
+        f"data:image/jpeg;base64,{image_b64}",        # image (immediately after text)
+    ],
+    dimensions=1024,
+    aws_region_name="us-east-1",
+)
+
+# Nova multimodal — same pattern
+response = embedding(
+    model="bedrock/amazon.nova-2-multimodal-embeddings-v1:0",
+    input=[
+        "shoes photo",                                # text
+        f"data:image/jpeg;base64,{image_b64}",        # image (immediately after text)
+    ],
+    aws_region_name="us-east-1",
+)
+```
+
+Single-modality inputs continue to work unchanged:
+
+```python
+# Text only
+response = embedding(model="bedrock/amazon.titan-embed-image-v1", input=["some text"])
+
+# Image only
+response = embedding(
+    model="bedrock/amazon.titan-embed-image-v1",
+    input=[f"data:image/jpeg;base64,{image_b64}"],
+)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+1. Setup config.yaml
+
+```yaml
+model_list:
+  - model_name: titan-multimodal
+    litellm_params:
+      model: bedrock/amazon.titan-embed-image-v1
+      aws_region_name: us-east-1
+```
+
+2. Start proxy
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING on http://0.0.0.0:4000
+```
+
+3. Test it — pass text immediately before its paired image:
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/v1/embeddings' \
+  -H 'Authorization: Bearer <your-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "titan-multimodal",
+    "input": [
+      "Red leather handbag with gold buckle",
+      "data:image/jpeg;base64,<base64_image_string>"
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
 ## Input Params for `litellm.embedding()`
 
 

--- a/litellm/llms/bedrock/embed/amazon_nova_transformation.py
+++ b/litellm/llms/bedrock/embed/amazon_nova_transformation.py
@@ -94,6 +94,7 @@ class AmazonNovaEmbeddingConfig:
         async_invoke_route: bool = False,
         model_id: Optional[str] = None,
         output_s3_uri: Optional[str] = None,
+        input_text: Optional[str] = None,
     ) -> dict:
         """
         Transform OpenAI-style input to Nova format.
@@ -164,6 +165,12 @@ class AmazonNovaEmbeddingConfig:
                         "format": image_format,
                         "source": {"bytes": base64_data},
                     }
+                    # If paired text was provided, include it alongside the image
+                    if input_text is not None:
+                        embedding_params["text"] = {
+                            "value": input_text,
+                            "truncationMode": "END",
+                        }
                 elif media_type.startswith("video/"):
                     # Handle video data URLs
                     video_format = media_type.split("/")[1].lower()

--- a/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py
+++ b/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py
@@ -44,7 +44,10 @@ class AmazonTitanMultimodalEmbeddingG1Config:
         return optional_params
 
     def _transform_request(
-        self, input: str, inference_params: dict
+        self,
+        input: str,
+        inference_params: dict,
+        input_text: Optional[str] = None,
     ) -> AmazonTitanMultimodalEmbeddingRequest:
         ## check if b64 encoded str or not ##
         is_encoded = is_base64_encoded(input)
@@ -53,6 +56,9 @@ class AmazonTitanMultimodalEmbeddingG1Config:
             transformed_request = AmazonTitanMultimodalEmbeddingRequest(
                 inputImage=b64_str
             )
+            # If paired text was provided, include it alongside the image
+            if input_text is not None:
+                transformed_request["inputText"] = input_text
         else:
             transformed_request = AmazonTitanMultimodalEmbeddingRequest(inputText=input)
 

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -464,7 +464,7 @@ class BedrockEmbedding(BaseAWSLLM):
                             and not current.startswith("data:")
                             and next_elem is not None
                             and isinstance(next_elem, str)
-                            and next_elem.startswith("data:")
+                            and next_elem.startswith("data:image/")
                         ):
                             # Text followed by image → combined request
                             transformed_request: (

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -24,7 +24,6 @@ from litellm.types.llms.bedrock import (
     CohereEmbeddingRequest,
 )
 from litellm.types.utils import EmbeddingResponse, LlmProviders
-from litellm.utils import is_base64_encoded
 
 from ..base_aws_llm import BaseAWSLLM
 from ..common_utils import BedrockError
@@ -437,6 +436,9 @@ class BedrockEmbedding(BaseAWSLLM):
         inference_params.pop(
             "user", None
         )  # make sure user is not passed in for bedrock call
+        combine_text_image_pairs: bool = inference_params.pop(
+            "combine_text_image_pairs", False
+        )
 
         data: Optional[CohereEmbeddingRequest] = None
         batch_data: Optional[List] = None
@@ -451,35 +453,46 @@ class BedrockEmbedding(BaseAWSLLM):
         ]:
             batch_data = []
             if model == "amazon.titan-embed-image-v1":
-                # Scan for adjacent [text, base64_image] pairs and combine them
-                idx = 0
-                while idx < len(input):
-                    current = input[idx]
-                    next_elem = input[idx + 1] if idx + 1 < len(input) else None
-                    if (
-                        isinstance(current, str)
-                        and not is_base64_encoded(current)
-                        and next_elem is not None
-                        and is_base64_encoded(next_elem)
-                    ):
-                        # Text followed by image → combined request
-                        transformed_request: (
-                            AmazonEmbeddingRequest
-                        ) = AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
-                            input=next_elem,
-                            inference_params=inference_params,
-                            input_text=current,
-                        )
-                        batch_data.append(transformed_request)
-                        idx += 2
-                    else:
+                if combine_text_image_pairs:
+                    # Scan for adjacent [text, data:image/...] pairs and combine them
+                    idx = 0
+                    while idx < len(input):
+                        current = input[idx]
+                        next_elem = input[idx + 1] if idx + 1 < len(input) else None
+                        if (
+                            isinstance(current, str)
+                            and not current.startswith("data:")
+                            and next_elem is not None
+                            and isinstance(next_elem, str)
+                            and next_elem.startswith("data:")
+                        ):
+                            # Text followed by image → combined request
+                            transformed_request: (
+                                AmazonEmbeddingRequest
+                            ) = AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
+                                input=next_elem,
+                                inference_params=inference_params,
+                                input_text=current,
+                            )
+                            batch_data.append(transformed_request)
+                            idx += 2
+                        else:
+                            transformed_request = (
+                                AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
+                                    input=current, inference_params=inference_params
+                                )
+                            )
+                            batch_data.append(transformed_request)
+                            idx += 1
+                else:
+                    # Default: process each element independently (backward-compatible)
+                    for i in input:
                         transformed_request = (
                             AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
-                                input=current, inference_params=inference_params
+                                input=i, inference_params=inference_params
                             )
                         )
                         batch_data.append(transformed_request)
-                        idx += 1
             else:
                 for i in input:
                     if model == "amazon.titan-embed-text-v1":
@@ -516,39 +529,51 @@ class BedrockEmbedding(BaseAWSLLM):
                 batch_data.append(twelvelabs_request)
         elif provider == "nova":
             batch_data = []
-            # Scan for adjacent [text, data:image/...] pairs and combine them
-            idx = 0
-            while idx < len(input):
-                current = input[idx]
-                next_elem = input[idx + 1] if idx + 1 < len(input) else None
-                if (
-                    isinstance(current, str)
-                    and not current.startswith("data:")
-                    and next_elem is not None
-                    and isinstance(next_elem, str)
-                    and next_elem.startswith("data:image/")
-                ):
-                    # Text followed by image → combined request
+            if combine_text_image_pairs:
+                # Scan for adjacent [text, data:image/...] pairs and combine them
+                idx = 0
+                while idx < len(input):
+                    current = input[idx]
+                    next_elem = input[idx + 1] if idx + 1 < len(input) else None
+                    if (
+                        isinstance(current, str)
+                        and not current.startswith("data:")
+                        and next_elem is not None
+                        and isinstance(next_elem, str)
+                        and next_elem.startswith("data:image/")
+                    ):
+                        # Text followed by image → combined request
+                        nova_request = AmazonNovaEmbeddingConfig()._transform_request(
+                            input=next_elem,
+                            inference_params=inference_params,
+                            async_invoke_route=has_async_invoke,
+                            model_id=modelId,
+                            output_s3_uri=inference_params.get("output_s3_uri"),
+                            input_text=current,
+                        )
+                        batch_data.append(nova_request)
+                        idx += 2
+                    else:
+                        nova_request = AmazonNovaEmbeddingConfig()._transform_request(
+                            input=current,
+                            inference_params=inference_params,
+                            async_invoke_route=has_async_invoke,
+                            model_id=modelId,
+                            output_s3_uri=inference_params.get("output_s3_uri"),
+                        )
+                        batch_data.append(nova_request)
+                        idx += 1
+            else:
+                # Default: process each element independently (backward-compatible)
+                for i in input:
                     nova_request = AmazonNovaEmbeddingConfig()._transform_request(
-                        input=next_elem,
+                        input=i,
                         inference_params=inference_params,
                         async_invoke_route=has_async_invoke,
                         model_id=modelId,
                         output_s3_uri=inference_params.get("output_s3_uri"),
-                        input_text=current,
                     )
                     batch_data.append(nova_request)
-                    idx += 2
-                else:
-                    nova_request = AmazonNovaEmbeddingConfig()._transform_request(
-                        input=current,
-                        inference_params=inference_params,
-                        async_invoke_route=has_async_invoke,
-                        model_id=modelId,
-                        output_s3_uri=inference_params.get("output_s3_uri"),
-                    )
-                    batch_data.append(nova_request)
-                    idx += 1
 
         ### SET RUNTIME ENDPOINT ###
         endpoint_url, proxy_endpoint_url = self.get_runtime_endpoint(

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -24,6 +24,7 @@ from litellm.types.llms.bedrock import (
     CohereEmbeddingRequest,
 )
 from litellm.types.utils import EmbeddingResponse, LlmProviders
+from litellm.utils import is_base64_encoded
 
 from ..base_aws_llm import BaseAWSLLM
 from ..common_utils import BedrockError
@@ -449,33 +450,57 @@ class BedrockEmbedding(BaseAWSLLM):
             "amazon.titan-embed-text-v2:0",
         ]:
             batch_data = []
-            for i in input:
-                if model == "amazon.titan-embed-image-v1":
-                    transformed_request: (
-                        AmazonEmbeddingRequest
-                    ) = AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
-                        input=i, inference_params=inference_params
-                    )
-                elif model == "amazon.titan-embed-text-v1":
-                    transformed_request = AmazonTitanG1Config()._transform_request(
-                        input=i, inference_params=inference_params
-                    )
-                elif model == "amazon.titan-embed-text-v2:0":
-                    transformed_request = AmazonTitanV2Config()._transform_request(
-                        input=i, inference_params=inference_params
-                    )
-                else:
-                    raise Exception(
-                        "Unmapped model. Received={}. Expected={}".format(
-                            model,
-                            [
-                                "amazon.titan-embed-image-v1",
-                                "amazon.titan-embed-text-v1",
-                                "amazon.titan-embed-text-v2:0",
-                            ],
+            if model == "amazon.titan-embed-image-v1":
+                # Scan for adjacent [text, base64_image] pairs and combine them
+                idx = 0
+                while idx < len(input):
+                    current = input[idx]
+                    next_elem = input[idx + 1] if idx + 1 < len(input) else None
+                    if (
+                        isinstance(current, str)
+                        and not is_base64_encoded(current)
+                        and next_elem is not None
+                        and is_base64_encoded(next_elem)
+                    ):
+                        # Text followed by image → combined request
+                        transformed_request: (
+                            AmazonEmbeddingRequest
+                        ) = AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
+                            input=next_elem,
+                            inference_params=inference_params,
+                            input_text=current,
                         )
-                    )
-                batch_data.append(transformed_request)
+                        batch_data.append(transformed_request)
+                        idx += 2
+                    else:
+                        transformed_request = (
+                            AmazonTitanMultimodalEmbeddingG1Config()._transform_request(
+                                input=current, inference_params=inference_params
+                            )
+                        )
+                        batch_data.append(transformed_request)
+                        idx += 1
+            else:
+                for i in input:
+                    if model == "amazon.titan-embed-text-v1":
+                        transformed_request = AmazonTitanG1Config()._transform_request(
+                            input=i, inference_params=inference_params
+                        )
+                    elif model == "amazon.titan-embed-text-v2:0":
+                        transformed_request = AmazonTitanV2Config()._transform_request(
+                            input=i, inference_params=inference_params
+                        )
+                    else:
+                        raise Exception(
+                            "Unmapped model. Received={}. Expected={}".format(
+                                model,
+                                [
+                                    "amazon.titan-embed-text-v1",
+                                    "amazon.titan-embed-text-v2:0",
+                                ],
+                            )
+                        )
+                    batch_data.append(transformed_request)
         elif provider == "twelvelabs":
             batch_data = []
             for i in input:
@@ -491,15 +516,39 @@ class BedrockEmbedding(BaseAWSLLM):
                 batch_data.append(twelvelabs_request)
         elif provider == "nova":
             batch_data = []
-            for i in input:
-                nova_request = AmazonNovaEmbeddingConfig()._transform_request(
-                    input=i,
-                    inference_params=inference_params,
-                    async_invoke_route=has_async_invoke,
-                    model_id=modelId,
-                    output_s3_uri=inference_params.get("output_s3_uri"),
-                )
-                batch_data.append(nova_request)
+            # Scan for adjacent [text, data:image/...] pairs and combine them
+            idx = 0
+            while idx < len(input):
+                current = input[idx]
+                next_elem = input[idx + 1] if idx + 1 < len(input) else None
+                if (
+                    isinstance(current, str)
+                    and not current.startswith("data:")
+                    and next_elem is not None
+                    and isinstance(next_elem, str)
+                    and next_elem.startswith("data:image/")
+                ):
+                    # Text followed by image → combined request
+                    nova_request = AmazonNovaEmbeddingConfig()._transform_request(
+                        input=next_elem,
+                        inference_params=inference_params,
+                        async_invoke_route=has_async_invoke,
+                        model_id=modelId,
+                        output_s3_uri=inference_params.get("output_s3_uri"),
+                        input_text=current,
+                    )
+                    batch_data.append(nova_request)
+                    idx += 2
+                else:
+                    nova_request = AmazonNovaEmbeddingConfig()._transform_request(
+                        input=current,
+                        inference_params=inference_params,
+                        async_invoke_route=has_async_invoke,
+                        model_id=modelId,
+                        output_s3_uri=inference_params.get("output_s3_uri"),
+                    )
+                    batch_data.append(nova_request)
+                    idx += 1
 
         ### SET RUNTIME ENDPOINT ###
         endpoint_url, proxy_endpoint_url = self.get_runtime_endpoint(

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -955,3 +955,199 @@ def test_titan_image_embedding_cost_uses_per_image_rate():
         assert response.usage is not None
         assert response.usage.prompt_tokens_details is not None
         assert response.usage.prompt_tokens_details.image_count == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Combined text + image embedding tests (Titan multimodal)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_titan_multimodal_transform_request_combined():
+    """Unit test: _transform_request with both input (image) and input_text produces both keys."""
+    from litellm.llms.bedrock.embed.amazon_titan_multimodal_transformation import (
+        AmazonTitanMultimodalEmbeddingG1Config,
+    )
+
+    config = AmazonTitanMultimodalEmbeddingG1Config()
+    result = config._transform_request(
+        input='data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+        inference_params={},
+        input_text='A red handbag',
+    )
+
+    assert 'inputImage' in result
+    assert 'inputText' in result
+    assert result['inputText'] == 'A red handbag'
+
+
+def test_titan_multimodal_transform_request_image_only_no_text():
+    """Unit test: _transform_request with image only (no input_text) produces only inputImage."""
+    from litellm.llms.bedrock.embed.amazon_titan_multimodal_transformation import (
+        AmazonTitanMultimodalEmbeddingG1Config,
+    )
+
+    config = AmazonTitanMultimodalEmbeddingG1Config()
+    result = config._transform_request(
+        input='data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+        inference_params={},
+    )
+
+    assert 'inputImage' in result
+    assert 'inputText' not in result
+
+
+def test_titan_multimodal_combined_text_and_image_request():
+    """Integration test: passing [text, image] list produces one HTTP call with both keys."""
+    client = HTTPHandler()
+    embed_response = {
+        'embedding': [0.1, 0.2, 0.3],
+        'inputTextTokenCount': 5,
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(embed_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.titan-embed-image-v1',
+            input=[
+                'Red leather handbag',
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+            ],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        # Only one HTTP call should have been made (text+image merged)
+        assert mock_post.call_count == 1
+
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        assert 'inputText' in request_body
+        assert 'inputImage' in request_body
+        assert request_body['inputText'] == 'Red leather handbag'
+
+
+def test_titan_multimodal_text_only_unchanged():
+    """Backward compat: text-only input still produces only inputText."""
+    client = HTTPHandler()
+    embed_response = {
+        'embedding': [0.1, 0.2, 0.3],
+        'inputTextTokenCount': 5,
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(embed_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.titan-embed-image-v1',
+            input=['just some text'],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        assert 'inputText' in request_body
+        assert 'inputImage' not in request_body
+
+
+def test_titan_multimodal_image_only_unchanged():
+    """Backward compat: image-only input still produces only inputImage."""
+    client = HTTPHandler()
+    embed_response = {
+        'embedding': [0.1, 0.2, 0.3],
+        'inputTextTokenCount': 0,
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(embed_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.titan-embed-image-v1',
+            input=['data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=='],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        assert 'inputImage' in request_body
+        assert 'inputText' not in request_body
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Combined text + image embedding tests (Nova multimodal)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_nova_combined_text_and_image_request():
+    """Unit test: Nova _transform_request with input_text alongside image produces both keys."""
+    from litellm.llms.bedrock.embed.amazon_nova_transformation import (
+        AmazonNovaEmbeddingConfig,
+    )
+
+    config = AmazonNovaEmbeddingConfig()
+    result = config._transform_request(
+        input='data:image/jpeg;base64,/9j/4AAQSkZJRgAB',
+        inference_params={},
+        input_text='shoes photo',
+    )
+
+    params = result.get('singleEmbeddingParams', {})
+    assert 'image' in params
+    assert 'text' in params
+    assert params['text']['value'] == 'shoes photo'
+
+
+def test_nova_combined_text_and_image_http_request():
+    """Integration test: passing [text, image] list to Nova produces one call with both keys."""
+    client = HTTPHandler()
+    nova_response = {
+        'embeddings': [
+            {'embeddingType': 'IMAGE', 'embedding': [0.1, 0.2, 0.3]},
+        ]
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(nova_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.nova-2-multimodal-embeddings-v1:0',
+            input=['shoes photo', 'data:image/jpeg;base64,/9j/4AAQSkZJRgAB'],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        # Only one HTTP call (text+image merged)
+        assert mock_post.call_count == 1
+
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        params = request_body.get('singleEmbeddingParams', {})
+        assert 'image' in params
+        assert 'text' in params
+        assert params['text']['value'] == 'shoes photo'

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -1295,3 +1295,92 @@ def test_nova_image_only_standalone():
         params = request_body.get('singleEmbeddingParams', {})
         assert 'image' in params
         assert 'text' not in params
+
+def test_titan_combine_flag_unpaired_elements():
+    """With combine_text_image_pairs=True, [text, image, lone_text] → 2 calls: 1 fused + 1 standalone."""
+    client = HTTPHandler()
+    embed_response = {
+        'embedding': [0.1, 0.2, 0.3],
+        'inputTextTokenCount': 5,
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(embed_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.titan-embed-image-v1',
+            input=[
+                'Red leather handbag',
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+                'lone text without image partner',
+            ],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+            combine_text_image_pairs=True,
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        # 2 HTTP calls: 1 fused (text+image) + 1 standalone (lone text)
+        assert mock_post.call_count == 2
+
+        # First call: fused
+        first_body = json.loads(mock_post.call_args_list[0].kwargs.get('data', '{}'))
+        assert 'inputText' in first_body
+        assert 'inputImage' in first_body
+
+        # Second call: standalone text
+        second_body = json.loads(mock_post.call_args_list[1].kwargs.get('data', '{}'))
+        assert 'inputText' in second_body
+        assert 'inputImage' not in second_body
+
+def test_nova_combine_flag_unpaired_elements():
+    """With combine_text_image_pairs=True, [text, image, lone_text] → 2 calls: 1 fused + 1 standalone."""
+    client = HTTPHandler()
+    nova_response = {
+        'embeddings': [
+            {'embeddingType': 'TEXT', 'embedding': [0.1, 0.2, 0.3]},
+        ]
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(nova_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.nova-2-multimodal-embeddings-v1:0',
+            input=[
+                'shoes photo',
+                'data:image/jpeg;base64,/9j/4AAQSkZJRgAB',
+                'lone text without image partner',
+            ],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+            combine_text_image_pairs=True,
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        # 2 HTTP calls: 1 fused (text+image) + 1 standalone (lone text)
+        assert mock_post.call_count == 2
+
+        # First call: fused
+        first_body = json.loads(mock_post.call_args_list[0].kwargs.get('data', '{}'))
+        params = first_body.get('singleEmbeddingParams', {})
+        assert 'image' in params
+        assert 'text' in params
+
+        # Second call: standalone text
+        second_body = json.loads(mock_post.call_args_list[1].kwargs.get('data', '{}'))
+        params2 = second_body.get('singleEmbeddingParams', {})
+        assert 'text' in params2
+        assert 'image' not in params2

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -1021,6 +1021,7 @@ def test_titan_multimodal_combined_text_and_image_request():
             aws_access_key_id='fake',
             aws_secret_access_key='fake',
             aws_region_name='us-east-1',
+            combine_text_image_pairs=True,
         )
 
         assert isinstance(response, litellm.EmbeddingResponse)
@@ -1140,6 +1141,7 @@ def test_nova_combined_text_and_image_http_request():
             aws_access_key_id='fake',
             aws_secret_access_key='fake',
             aws_region_name='us-east-1',
+            combine_text_image_pairs=True,
         )
 
         assert isinstance(response, litellm.EmbeddingResponse)
@@ -1151,3 +1153,145 @@ def test_nova_combined_text_and_image_http_request():
         assert 'image' in params
         assert 'text' in params
         assert params['text']['value'] == 'shoes photo'
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# combine_text_image_pairs opt-in flag tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_titan_multimodal_no_combine_flag_returns_separate():
+    """Without combine_text_image_pairs, [text, image] must produce 2 separate HTTP calls (backward compat)."""
+    client = HTTPHandler()
+    embed_response = {
+        'embedding': [0.1, 0.2, 0.3],
+        'inputTextTokenCount': 5,
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(embed_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.titan-embed-image-v1',
+            input=[
+                'Red leather handbag',
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+            ],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+            # NOTE: combine_text_image_pairs NOT passed — default False
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        # Each element processed independently → 2 separate HTTP calls
+        assert mock_post.call_count == 2
+
+
+def test_titan_multimodal_combine_flag_returns_fused():
+    """With combine_text_image_pairs=True, [text, image] must produce 1 fused HTTP call."""
+    client = HTTPHandler()
+    embed_response = {
+        'embedding': [0.1, 0.2, 0.3],
+        'inputTextTokenCount': 5,
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(embed_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.titan-embed-image-v1',
+            input=[
+                'Red leather handbag',
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+            ],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+            combine_text_image_pairs=True,
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        assert mock_post.call_count == 1
+
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        assert 'inputText' in request_body
+        assert 'inputImage' in request_body
+
+
+def test_nova_text_only_standalone():
+    """Nova with a single text input (no pairing) produces 1 call with only text in singleEmbeddingParams."""
+    client = HTTPHandler()
+    nova_response = {
+        'embeddings': [
+            {'embeddingType': 'TEXT', 'embedding': [0.1, 0.2, 0.3]},
+        ]
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(nova_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.nova-2-multimodal-embeddings-v1:0',
+            input=['just some text'],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        assert mock_post.call_count == 1
+
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        params = request_body.get('singleEmbeddingParams', {})
+        assert 'text' in params
+        assert 'image' not in params
+
+
+def test_nova_image_only_standalone():
+    """Nova with a single data:image/... input (no pairing) produces 1 call with only image in singleEmbeddingParams."""
+    client = HTTPHandler()
+    nova_response = {
+        'embeddings': [
+            {'embeddingType': 'IMAGE', 'embedding': [0.1, 0.2, 0.3]},
+        ]
+    }
+
+    with patch.object(client, 'post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(nova_response)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+
+        response = litellm.embedding(
+            model='bedrock/amazon.nova-2-multimodal-embeddings-v1:0',
+            input=['data:image/jpeg;base64,/9j/4AAQSkZJRgAB'],
+            client=client,
+            aws_access_key_id='fake',
+            aws_secret_access_key='fake',
+            aws_region_name='us-east-1',
+        )
+
+        assert isinstance(response, litellm.EmbeddingResponse)
+        assert mock_post.call_count == 1
+
+        request_body = json.loads(mock_post.call_args.kwargs.get('data', '{}'))
+        params = request_body.get('singleEmbeddingParams', {})
+        assert 'image' in params
+        assert 'text' not in params


### PR DESCRIPTION
Bedrock's `amazon.titan-embed-image-v1` and `amazon.nova-2-multimodal-embeddings-v1:0` support sending `inputText` + `inputImage` in one request, but LiteLLM's transformation layer used a binary `if/else` — routing each input to **either** text **or** image, never both.

## Changes

- **`amazon_titan_multimodal_transformation.py`** — `_transform_request` accepts `input_text: Optional[str] = None`; when a base64 image is paired with `input_text`, both `inputImage` and `inputText` are set in the request body
- **`amazon_nova_transformation.py`** — same pattern: `input_text: Optional[str] = None`; when a `data:image/...` input is paired with `input_text`, both `image` and `text` keys populate `singleEmbeddingParams`
- **`embedding.py`** — new opt-in `combine_text_image_pairs` parameter (default `False`); when enabled, a while-loop scanner detects adjacent `[text, image]` pairs and merges them into a single Bedrock request; when disabled (default), each element is processed independently — **fully backward-compatible**
- **`docs/embedding/supported_embedding.md`** — new "Combined Text + Image Embeddings (Bedrock)" section with SDK and proxy examples

### Usage

```python
# Opt-in to fused text+image embedding (new behavior)
response = litellm.embedding(
    model="bedrock/amazon.titan-embed-image-v1",
    input=["Red leather handbag", "data:image/jpeg;base64,..."],
    combine_text_image_pairs=True,   # explicit opt-in
)
# → 1 embedding (text + image fused)

# Default — backward compatible
response = litellm.embedding(
    model="bedrock/amazon.titan-embed-image-v1",
    input=["Red leather handbag", "data:image/jpeg;base64,..."],
)
# → 2 embeddings (each element sent independently)
```

Single-modality inputs (text-only or image-only) are fully backward-compatible.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of 5/5** ✅

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

15 new mocked tests in `tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py` (39 total, all passing):

| Test | Validates |
|---|---|
| `test_titan_multimodal_transform_request_combined` | `_transform_request` sets both `inputText` + `inputImage` |
| `test_titan_multimodal_transform_request_image_only_no_text` | image-only still produces only `inputImage` |
| `test_titan_multimodal_combined_text_and_image_request` | `[text, image]` + `combine_text_image_pairs=True` → 1 HTTP call with both keys |
| `test_titan_multimodal_text_only_unchanged` | text-only backward compat |
| `test_titan_multimodal_image_only_unchanged` | image-only backward compat |
| `test_titan_multimodal_no_combine_flag_returns_separate` | `[text, image]` without flag → 2 separate HTTP calls (backward compat) |
| `test_titan_multimodal_combine_flag_returns_fused` | `[text, image]` + `combine_text_image_pairs=True` → 1 fused HTTP call |
| `test_titan_combine_flag_unpaired_elements` | `[text, image, lone_text]` + flag → 2 calls: 1 fused + 1 standalone |
| `test_nova_combined_text_and_image_request` | Nova `_transform_request` sets both `image` + `text` |
| `test_nova_combined_text_and_image_http_request` | Nova `[text, image]` + flag → 1 HTTP call with both keys |
| `test_nova_text_only_standalone` | Nova text-only → 1 call, only `text` in params |
| `test_nova_image_only_standalone` | Nova image-only → 1 call, only `image` in params |
| `test_nova_combine_flag_unpaired_elements` | Nova `[text, image, lone_text]` + flag → 2 calls: 1 fused + 1 standalone |
| `test_titan_multimodal_embedding_image_cost_tracking` | image input populates `image_count` in Usage |
| `test_titan_image_embedding_cost_uses_per_image_rate` | end-to-end image embedding cost tracking |

```
39 passed, 0 failed in 1.01s
```

## Type

🆕 New Feature  
📖 Documentation