### PR TITLE
feat(proxy): add NO_OPENAPI env var to disable /openapi.json endpoint

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -495,6 +495,7 @@ from litellm.proxy.utils import (
     _get_docs_url,
     _get_projected_spend_over_limit,
     _get_redoc_url,
+    _get_openapi_url,
     _is_projected_spend_over_limit,
     _is_valid_team_configs,
     get_custom_url,
@@ -1000,6 +1001,7 @@ async def proxy_startup_event(app: FastAPI):  # noqa: PLR0915
 app = FastAPI(
     docs_url=_get_docs_url(),
     redoc_url=_get_redoc_url(),
+    openapi_url=_get_openapi_url(),
     title=_title,
     description=_description,
     version=version,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5354,6 +5354,22 @@ def _get_docs_url() -> Optional[str]:
 
     return "/"
 
+def _get_openapi_url() -> Optional[str]:
+    """
+    Get the OpenAPI JSON URL from the environment variables.
+
+    - If OPENAPI_URL is set, return it.
+    - If NO_OPENAPI is True, return None.
+    - Otherwise, default to "/openapi.json".
+    """
+    if openapi_url := os.getenv("OPENAPI_URL"):
+        return openapi_url
+
+    if str_to_bool(os.getenv("NO_OPENAPI")) is True:
+        return None
+
+    return "/openapi.json"
+
 
 def handle_exception_on_proxy(e: Exception) -> ProxyException:
     """

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi import Request
 from starlette.datastructures import State
 
-from litellm.proxy.utils import _get_docs_url, _get_redoc_url
+from litellm.proxy.utils import _get_docs_url, _get_openapi_url, _get_redoc_url
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -733,6 +733,30 @@ def test_get_docs_url(env_vars, expected_url):
         os.environ[key] = value
 
     result = _get_docs_url()
+    assert result == expected_url
+
+@pytest.mark.parametrize(
+    "env_vars, expected_url",
+    [
+        ({}, "/openapi.json"),  # default case
+        ({"OPENAPI_URL": "/custom-openapi.json"}, "/custom-openapi.json"),  # custom URL
+        (
+            {"OPENAPI_URL": "https://example.com/openapi.json"},
+            "https://example.com/openapi.json",
+        ),  # full URL
+        ({"NO_OPENAPI": "True"}, None),  # openapi disabled
+    ],
+)
+def test_get_openapi_url(env_vars, expected_url):
+    # Clear relevant environment variables
+    for key in ["OPENAPI_URL", "NO_OPENAPI"]:
+        os.environ.pop(key, None)
+
+    # Set test environment variables
+    for key, value in env_vars.items():
+        os.environ[key] = value
+
+    result = _get_openapi_url()
     assert result == expected_url
 
 


### PR DESCRIPTION
## Relevant issues
Fixes #25538

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] I have Added testing in the `tests/proxy_unit_tests/test_proxy_utils.py` file
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?
If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)
- [ ] **Branch creation CI run**
- [ ] **CI run for the last commit**
- [ ] **Merge / cherry-pick CI run**

## Screenshots / Proof of Fix
Feature adds a new env var `NO_OPENAPI=true` which disables the `/openapi.json` endpoint by passing `openapi_url=None` to the FastAPI constructor. No screenshot needed as this is a configuration-only change following the existing `NO_DOCS` and `NO_REDOC` pattern.

## Type
🆕 New Feature

## Changes
- Added `_get_openapi_url()` helper function in `litellm/proxy/utils.py` following the exact same pattern as the existing `_get_docs_url()` and `_get_redoc_url()` functions
- Added `openapi_url=_get_openapi_url()` to the `FastAPI()` constructor in `litellm/proxy/proxy_server.py`
- Added `_get_openapi_url` to the import block in `proxy_server.py`
- Added 4 parametrized tests in `tests/proxy_unit_tests/test_proxy_utils.py` covering default, custom URL, disabled, and false cases