### PR TITLE
fix(ui): pre-select backend default for boolean guardrail provider fields

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_provider_fields.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_provider_fields.tsx
@@ -157,10 +157,10 @@ const GuardrailProviderFields: React.FC<GuardrailProviderFieldsProps> = ({
         );
       }
 
-      const percentageInitialValue =
-        field.type === "percentage" && (fieldValue === undefined || fieldValue === null)
-          ? (field.default_value ?? 0.5)
-          : undefined;
+      const resolvedInitialValue =
+        fieldValue !== undefined
+          ? fieldValue
+          : (field.default_value ?? (field.type === "percentage" ? 0.5 : undefined));
 
       return (
         <Form.Item
@@ -169,7 +169,7 @@ const GuardrailProviderFields: React.FC<GuardrailProviderFieldsProps> = ({
           label={fieldKey}
           tooltip={field.description}
           rules={field.required ? [{ required: true, message: `${fieldKey} is required` }] : undefined}
-          initialValue={percentageInitialValue}
+          initialValue={resolvedInitialValue}
         >
           {field.type === "select" && field.options ? (
             <Select placeholder={field.description} defaultValue={fieldValue || field.default_value}>
@@ -188,12 +188,9 @@ const GuardrailProviderFields: React.FC<GuardrailProviderFieldsProps> = ({
               ))}
             </Select>
           ) : field.type === "bool" || field.type === "boolean" ? (
-            <Select
-              placeholder={field.description}
-              defaultValue={fieldValue !== undefined ? String(fieldValue) : field.default_value}
-            >
-              <Select.Option value="true">True</Select.Option>
-              <Select.Option value="false">False</Select.Option>
+            <Select placeholder={field.description}>
+              <Select.Option value={true}>True</Select.Option>
+              <Select.Option value={false}>False</Select.Option>
             </Select>
           ) : field.type === "percentage" && field.min != null && field.max != null ? (
             <Slider


### PR DESCRIPTION
## Summary

- Boolean fields in the auto-generated guardrail provider form (e.g. Noma `use_v2`) render as empty `Select`s on open, so users can't tell what the backend default is and flags like `use_v2` look inoperative even though the save path already works.
- Root cause: `Form.Item` only populated `initialValue` for `percentage` fields, and the `defaultValue` passed to the `Select` child was silently dropped by antd's controlled-component wrapper.
- Fix unifies `initialValue` to fall back through `fieldValue → field.default_value → (percentage ? 0.5 : undefined)` and switches `Select.Option` values from `"true"`/`"false"` strings to real booleans so the backend default flows through without stringification.

## Screenshots

### Before

_Noma Security → Provider Settings → `use_v2` renders as an empty `Select` (no pre-selected value, just a chevron). Even adjacent `Default On` — wired through a dedicated control — shows a correct "No" selection, which makes the ambiguity on `use_v2` more obvious._
<img width="901" height="643" alt="Screenshot 2026-04-14 at 10 23 00 AM" src="https://github.com/user-attachments/assets/8988231a-dc61-440d-bbf2-aa213210c03b" />

### After

_Same form, same provider. `use_v2` now shows `False` pre-selected (the pydantic default on `NomaGuardrailConfigModel.use_v2`). Picking `True` visibly updates the control, and submission sends a real JSON boolean in `litellm_params.use_v2`._
<img width="861" height="629" alt="Screenshot 2026-04-14 at 10 11 58 AM" src="https://github.com/user-attachments/assets/fea14908-c8f8-46eb-ac7f-49d91e4ccd9d" />

 

## Test plan

- [x] Start the UI dev server (`cd ui/litellm-dashboard && npm run dev`) on `localhost:3000` against a proxy with DB persistence.
- [x] Open **Add Guardrail** → name `noma-after-fix` → provider **Noma Security** → confirm the `use_v2` `Select` pre-selects **False**.
- [x] Change `use_v2` to **True**, fill in a fake `api_key`, click **Create Guardrail**.
- [x] Inspect the POST `/guardrails` request body in DevTools → confirm `litellm_params.use_v2` is a JSON boolean `true`, not the string `"true"`.
- [x] Verify persistence: `curl -s http://localhost:4000/v2/guardrails/list -H "Authorization: Bearer sk-1234"` and confirm the stored guardrail has `use_v2: true`.
- [x] Repeat with **False** to confirm the opposite pick also round-trips as a real boolean.
- [x] Regression check: open a non-Noma provider (e.g. Bedrock) and confirm string/number fields still render and save correctly (percentage and string branches of the initialValue chain are unchanged).