### PR TITLE
fix(router): prevent request_timeout from being shadowed by router_settings.timeout

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -32,6 +32,21 @@ from litellm.constants import (
     AIOHTTP_TTL_DNS_CACHE,
     DEFAULT_SSL_CIPHERS,
 )
+from litellm.constants import request_timeout as _DEFAULT_REQUEST_TIMEOUT
+
+_HARDCODED_HTTPX_FALLBACK_TIMEOUT = 600.0
+
+
+def _get_default_httpx_client_timeout() -> float:
+    """Return the default timeout for cached httpx clients when no params are provided.
+
+    Uses litellm.request_timeout when it was explicitly configured (different from the
+    default constant), otherwise falls back to the historical 600s to preserve
+    backwards compatibility.
+    """
+    if litellm.request_timeout != _DEFAULT_REQUEST_TIMEOUT:
+        return float(litellm.request_timeout)
+    return _HARDCODED_HTTPX_FALLBACK_TIMEOUT
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.types.llms.custom_http import *
 
@@ -1244,7 +1259,9 @@ def get_async_httpx_client(
         _new_client = AsyncHTTPHandler(**handler_params)
     else:
         _new_client = AsyncHTTPHandler(
-            timeout=httpx.Timeout(timeout=float(litellm.request_timeout), connect=5.0),
+            timeout=httpx.Timeout(
+                timeout=_get_default_httpx_client_timeout(), connect=5.0
+            ),
             shared_session=shared_session,
         )
 
@@ -1293,7 +1310,11 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
         }
         _new_client = HTTPHandler(**handler_params)
     else:
-        _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=float(litellm.request_timeout), connect=5.0))
+        _new_client = HTTPHandler(
+            timeout=httpx.Timeout(
+                timeout=_get_default_httpx_client_timeout(), connect=5.0
+            )
+        )
 
     cache.set_cache(
         key=_cache_key_name,

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1244,7 +1244,7 @@ def get_async_httpx_client(
         _new_client = AsyncHTTPHandler(**handler_params)
     else:
         _new_client = AsyncHTTPHandler(
-            timeout=httpx.Timeout(timeout=600.0, connect=5.0),
+            timeout=httpx.Timeout(timeout=float(litellm.request_timeout), connect=5.0),
             shared_session=shared_session,
         )
 
@@ -1293,7 +1293,7 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
         }
         _new_client = HTTPHandler(**handler_params)
     else:
-        _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
+        _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=float(litellm.request_timeout), connect=5.0))
 
     cache.set_cache(
         key=_cache_key_name,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1400,12 +1400,11 @@ def completion(  # type: ignore # noqa: PLR0915
             )  # support region-based pricing for bedrock
 
         ### TIMEOUT LOGIC ###
-        timeout = timeout or kwargs.get("request_timeout", 600) or 600
-        # set timeout for 10 minutes by default
+        timeout = timeout or kwargs.get("request_timeout", litellm.request_timeout) or litellm.request_timeout
         if isinstance(timeout, httpx.Timeout) and not supports_httpx_timeout(
             custom_llm_provider
         ):
-            timeout = timeout.read or 600  # default 10 min timeout
+            timeout = timeout.read or litellm.request_timeout
         elif not isinstance(timeout, httpx.Timeout):
             timeout = float(timeout)  # type: ignore
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -69,6 +69,9 @@ from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
 )
+from litellm.constants import request_timeout as _DEFAULT_REQUEST_TIMEOUT
+
+_HARDCODED_COMPLETION_FALLBACK_TIMEOUT = 600
 from litellm.exceptions import LiteLLMUnknownProvider
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
@@ -1400,11 +1403,24 @@ def completion(  # type: ignore # noqa: PLR0915
             )  # support region-based pricing for bedrock
 
         ### TIMEOUT LOGIC ###
-        timeout = timeout or kwargs.get("request_timeout", litellm.request_timeout) or litellm.request_timeout
+        # Use litellm.request_timeout as the fallback only when it was explicitly
+        # configured (different from the default constant); otherwise preserve the
+        # historical 600s hardcoded fallback for backwards compatibility.
+        _completion_fallback_timeout = (
+            litellm.request_timeout
+            if litellm.request_timeout != _DEFAULT_REQUEST_TIMEOUT
+            else _HARDCODED_COMPLETION_FALLBACK_TIMEOUT
+        )
+        timeout = (
+            timeout
+            or kwargs.get("request_timeout", _completion_fallback_timeout)
+            or _completion_fallback_timeout
+        )
+        # set timeout for 10 minutes by default
         if isinstance(timeout, httpx.Timeout) and not supports_httpx_timeout(
             custom_llm_provider
         ):
-            timeout = timeout.read or litellm.request_timeout
+            timeout = timeout.read or _completion_fallback_timeout
         elif not isinstance(timeout, httpx.Timeout):
             timeout = float(timeout)  # type: ignore
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -59,6 +59,7 @@ from litellm.constants import (
     DEFAULT_HEALTH_CHECK_STALENESS_MULTIPLIER,
     DEFAULT_MAX_LRU_CACHE_SIZE,
 )
+from litellm.constants import request_timeout as _DEFAULT_REQUEST_TIMEOUT
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.core_helpers import (
@@ -533,9 +534,7 @@ class Router:
         # Store request_timeout independently when explicitly configured via
         # litellm_settings (i.e., different from the default constant), so it's
         # not shadowed by router_settings.timeout in the fallback chain.
-        from litellm.constants import request_timeout as _default_request_timeout
-
-        if timeout is not None and litellm.request_timeout != _default_request_timeout:
+        if timeout is not None and litellm.request_timeout != _DEFAULT_REQUEST_TIMEOUT:
             self.request_timeout = litellm.request_timeout
         else:
             self.request_timeout = None

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -530,6 +530,16 @@ class Router:
         self.timeout = timeout or litellm.request_timeout
         self.stream_timeout = stream_timeout
 
+        # Store request_timeout independently when explicitly configured via
+        # litellm_settings (i.e., different from the default constant), so it's
+        # not shadowed by router_settings.timeout in the fallback chain.
+        from litellm.constants import request_timeout as _default_request_timeout
+
+        if timeout is not None and litellm.request_timeout != _default_request_timeout:
+            self.request_timeout = litellm.request_timeout
+        else:
+            self.request_timeout = None
+
         self.retry_after = retry_after
         self.routing_strategy = routing_strategy
 
@@ -2477,7 +2487,8 @@ class Router:
             or data.get(
                 "request_timeout", None
             )  # timeout set on litellm_params for this deployment
-            or self.timeout  # timeout set on router
+            or self.request_timeout  # litellm_settings.request_timeout (per-attempt)
+            or self.timeout  # timeout set on router (router_settings.timeout)
             or self.default_litellm_params.get("timeout", None)
         )
         return timeout

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -3200,3 +3200,101 @@ async def test_multiregion_team_failover_between_regions():
         "response from us-east-1",
         "response from us-west-2",
     ]
+
+
+class TestRouterRequestTimeoutPropagation:
+    """Tests for litellm_settings.request_timeout propagation through the Router.
+
+    Covers the fix for: litellm_settings.request_timeout being shadowed by
+    router_settings.timeout when both are configured.
+    """
+
+    def _make_router(self, timeout=None):
+        """Create a minimal Router for testing timeout resolution."""
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {
+                        "model": "openai/gpt-4",
+                        "api_key": "sk-test",
+                    },
+                }
+            ],
+            timeout=timeout,
+        )
+
+    def test_request_timeout_stored_independently_when_both_set(self):
+        """request_timeout should be stored separately when router timeout is also set."""
+        original = litellm.request_timeout
+        try:
+            litellm.request_timeout = 300
+            router = self._make_router(timeout=330)
+            assert router.timeout == 330
+            assert router.request_timeout == 300
+        finally:
+            litellm.request_timeout = original
+
+    def test_request_timeout_none_when_only_router_timeout_set(self):
+        """request_timeout should be None when only router_settings.timeout is set (default request_timeout)."""
+        router = self._make_router(timeout=330)
+        assert router.timeout == 330
+        assert router.request_timeout is None
+
+    def test_request_timeout_none_when_only_request_timeout_set(self):
+        """When only request_timeout is set (no router timeout), it flows into self.timeout."""
+        original = litellm.request_timeout
+        try:
+            litellm.request_timeout = 300
+            router = self._make_router(timeout=None)
+            assert router.timeout == 300  # via timeout or litellm.request_timeout
+            assert router.request_timeout is None  # timeout param was None
+        finally:
+            litellm.request_timeout = original
+
+    def test_request_timeout_none_when_neither_set(self):
+        """Default state: request_timeout should be None."""
+        router = self._make_router(timeout=None)
+        assert router.request_timeout is None
+
+    def test_get_non_stream_timeout_prefers_request_timeout_over_router_timeout(self):
+        """_get_non_stream_timeout should return request_timeout (300) not router timeout (330)."""
+        original = litellm.request_timeout
+        try:
+            litellm.request_timeout = 300
+            router = self._make_router(timeout=330)
+            # Simulate a request with no per-request or per-deployment timeout
+            result = router._get_non_stream_timeout(kwargs={}, data={})
+            assert result == 300
+        finally:
+            litellm.request_timeout = original
+
+    def test_get_non_stream_timeout_falls_through_to_router_timeout(self):
+        """When request_timeout is not explicitly set, should fall through to router timeout."""
+        router = self._make_router(timeout=330)
+        result = router._get_non_stream_timeout(kwargs={}, data={})
+        assert result == 330
+
+    def test_per_deployment_timeout_overrides_request_timeout(self):
+        """Per-deployment timeout in litellm_params should override request_timeout."""
+        original = litellm.request_timeout
+        try:
+            litellm.request_timeout = 300
+            router = self._make_router(timeout=330)
+            result = router._get_non_stream_timeout(kwargs={}, data={"timeout": 120})
+            assert result == 120
+        finally:
+            litellm.request_timeout = original
+
+    def test_per_request_timeout_overrides_all(self):
+        """Per-request kwargs timeout should override everything."""
+        original = litellm.request_timeout
+        try:
+            litellm.request_timeout = 300
+            router = self._make_router(timeout=330)
+            result = router._get_non_stream_timeout(
+                kwargs={"timeout": 60}, data={"timeout": 120}
+            )
+            assert result == 60
+        finally:
+            litellm.request_timeout = original


### PR DESCRIPTION
## Relevant issues

Fixes #23375

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Before fix** — `request_timeout=5` ignored, times out at 8s (router timeout):
```
timeout value=8.0, time taken=8.17 seconds
--> Timed out at ~8s — request_timeout=5 was SHADOWED by router timeout
```

**After fix** — `request_timeout=5` correctly enforced:
```
timeout value=5.0, time taken=5.16 seconds
--> Timed out at ~5s — request_timeout=5 (WORKING CORRECTLY)
```

## Type

🐛 Bug Fix

## Changes

### Problem

When both `litellm_settings.request_timeout` and `router_settings.timeout` are configured, `request_timeout` is silently ignored. The Router stores only one timeout slot via `self.timeout = timeout or litellm.request_timeout` — since `router_settings.timeout` is truthy, `request_timeout` is shadowed by the `or` short-circuit. Additionally, hardcoded `600` fallbacks in `completion()` and the httpx client factory never consult `litellm.request_timeout`.

### Fix

- **`litellm/router.py`** — Add an independent `self.request_timeout` attribute that stores `litellm.request_timeout` when it was explicitly configured (different from the default constant) and a router timeout is also present. Insert it into the `_get_non_stream_timeout()` fallback chain before `self.timeout`, giving it correct priority: per-request → per-deployment → `request_timeout` → `router_settings.timeout`.
- **`litellm/main.py`** — Replace hardcoded `600` fallbacks in `completion()` with `litellm.request_timeout`.
- **`litellm/llms/custom_httpx/http_handler.py`** — Replace hardcoded `600.0` in the async and sync httpx client factories with `float(litellm.request_timeout)`.
- **`tests/test_litellm/test_router.py`** — Add `TestRouterRequestTimeoutPropagation` with 8 tests covering: independent storage, fallback chain priority, per-deployment override, per-request override, and default behavior when only one timeout is set.