### PR TITLE
fix(responses-ws): make model query param optional, extract from first message

### DIFF
--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -935,12 +935,37 @@ async def cancel_response(
         )
 
 
+
+class _ReplayWebSocket:
+    """Thin wrapper that replays one pre-read message on the first ``receive_text`` call.
+
+    Used when ``model`` is extracted from the first client message instead of
+    the URL query parameter, so the message is not lost for downstream handlers.
+    """
+
+    def __init__(self, websocket: WebSocket, first_message: str):
+        self._ws = websocket
+        self._replay: Optional[str] = first_message
+
+    async def receive_text(self) -> str:
+        if self._replay is not None:
+            msg = self._replay
+            self._replay = None
+            return msg
+        return await self._ws.receive_text()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._ws, name)
+
+
 @router.websocket("/v1/responses")
 @router.websocket("/responses")
 async def responses_websocket_endpoint(
     websocket: WebSocket,
-    model: str = fastapi.Query(
-        ..., description="The model to use for the responses WebSocket session."
+    model: Optional[str] = fastapi.Query(
+        None,
+        description="The model to use for the responses WebSocket session. "
+        "If omitted, extracted from the first response.create message.",
     ),
     user_api_key_dict=Depends(user_api_key_auth_websocket),
 ):
@@ -976,6 +1001,54 @@ async def responses_websocket_endpoint(
     if requested_protocols:
         accept_kwargs["subprotocol"] = requested_protocols[0]
     await websocket.accept(**accept_kwargs)
+
+    # If model was not provided as a query parameter, read the first
+    # client message to extract it.  The OpenAI WebSocket spec sends
+    # model inside the response.create payload, not as a URL param.
+    # Wrap the websocket so the consumed message is replayed for
+    # downstream handlers that read from receive_text().
+    if model is None:
+        try:
+            first_message = await asyncio.wait_for(
+                websocket.receive_text(), timeout=30.0
+            )
+            first_msg_obj = json.loads(first_message)
+            # Support both nested and flat response.create formats:
+            #   {"type": "response.create", "response": {"model": "..."}}
+            #   {"type": "response.create", "model": "..."}
+            model = (
+                (first_msg_obj.get("response") or {}).get("model")
+                or first_msg_obj.get("model")
+            )
+            if not model:
+                await websocket.send_text(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "error": {
+                                "type": "invalid_request_error",
+                                "message": (
+                                    "model is required as a ?model= query parameter "
+                                    "or inside the first response.create message"
+                                ),
+                            },
+                        }
+                    )
+                )
+                await websocket.close(code=1008, reason="Missing model")
+                return
+            websocket = _ReplayWebSocket(websocket, first_message)  # type: ignore[assignment]
+        except asyncio.TimeoutError:
+            await websocket.close(
+                code=1008, reason="Timeout waiting for first message with model"
+            )
+            return
+        except Exception:
+            verbose_proxy_logger.exception(
+                "Failed to extract model from first WebSocket message"
+            )
+            await websocket.close(code=1008, reason="Invalid first message")
+            return
 
     data: Dict[str, Any] = {
         "model": model,


### PR DESCRIPTION
## Summary

The WebSocket endpoint for `/v1/responses` requires `model` as a mandatory URL query parameter (`fastapi.Query(...)`). However, the [OpenAI WebSocket spec](https://developers.openai.com/api/docs/guides/websocket-mode/) sends `model` inside the `response.create` message payload, not as a URL query param.

This means any spec-compliant client (e.g. [Codex CLI](https://github.com/openai/codex)) connecting to `ws://.../v1/responses` without `?model=` gets a **403 Forbidden**, because FastAPI rejects the missing required query param before the handler or auth logic even runs.

## Changes

1. **`_ReplayWebSocket` wrapper class**: thin wrapper that replays one pre-read message on the first `receive_text()` call, so downstream handlers (`ManagedResponsesWebSocketHandler`, `ResponsesWebSocketStreaming`) see the message as normal.

2. **Make `model` query param optional** (default `None`): clients can still pass `?model=` for backward compatibility.

3. **Extract model from first message**: when `model` is `None`, the handler reads the first WebSocket message after `accept()`, extracts the model from the `response.create` payload (supporting both nested `{"response": {"model": "..."}}` and flat `{"model": "..."}` formats), wraps the websocket with `_ReplayWebSocket` so the message is not lost, then proceeds with normal pre-call processing and routing.

## Reproduction

```python
import asyncio
from websockets.asyncio.client import connect

async def main():
    # Before fix: 403 Forbidden
    # After fix: connects and streams normally
    async with connect(
        "ws://localhost:4000/v1/responses",
        additional_headers={"Authorization": "Bearer sk-1234"},
    ) as ws:
        await ws.send('{"type":"response.create","response":{"model":"gpt-4o","input":"say hi"}}')
        async for msg in ws:
            print(msg)

asyncio.run(main())
```

## Testing

Verified end-to-end on a live GKE cluster:
- Deployed patched LiteLLM v1.82.3 pod using init-container overlay
- Pointed Codex CLI 0.118.0 at the patched proxy
- Codex connected via WebSocket (no 403), model extracted from first `response.create` message
- LLM call routed successfully, full response received (`input_tokens: 31496, output_tokens: 178`)
- `?model=` query param still works (backward compatible)

## Related

- Fixes #25532
- Related to #22051 (WebSocket mode support)