### PR TITLE
feat(proxy): add include_daily_spend parameter to /key/info endpoint

### DIFF
--- a/docs/my-website/docs/proxy/virtual_keys.md
+++ b/docs/my-website/docs/proxy/virtual_keys.md
@@ -103,7 +103,7 @@ This is automatically updated (in USD) when calls are made to /completions, /cha
     "key": "sk-tXL0wt5-lOOVK9sfY2UacA",
     "info": {
         "token": "sk-tXL0wt5-lOOVK9sfY2UacA",
-        "spend": 0.0001065, # 👈 SPEND
+        "spend": 0.0001065, # 👈 SPEND (cumulative, all-time)
         "expires": "2023-11-24T23:19:11.131000Z",
         "models": [
             "gpt-3.5-turbo",
@@ -117,6 +117,68 @@ This is automatically updated (in USD) when calls are made to /completions, /cha
     }
 }
 ```
+
+#### Daily Spend Breakdown
+
+Use the `include_daily_spend` query parameter to get a per-day, per-model spend breakdown alongside the key info. This is useful for monitoring usage trends, detecting cost anomalies, and reconciling against cloud provider billing.
+
+```bash
+curl 'http://0.0.0.0:4000/key/info?key=<user-key>&include_daily_spend=7' \
+     -X GET \
+     -H 'Authorization: Bearer <your-master-key>'
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `include_daily_spend` | `int` (1-90) | Number of days of daily spend to include |
+
+The response includes a `daily_spend` array in the `info` object with per-model entries:
+
+```python
+{
+    "key": "sk-tXL0wt5-lOOVK9sfY2UacA",
+    "info": {
+        "spend": 1500.00,
+        ...
+        "daily_spend": [  # 👈 DAILY BREAKDOWN
+            {
+                "date": "2026-04-14",
+                "user_id": "user-123",
+                "model": "vertex_ai/claude-opus-4-6@default",
+                "model_group": "claude-opus-4-6",
+                "custom_llm_provider": "vertex_ai",
+                "prompt_tokens": 832429,
+                "completion_tokens": 1485,
+                "cache_read_input_tokens": 800000,
+                "cache_creation_input_tokens": 30000,
+                "spend": 5.34,
+                "api_requests": 150,
+                "successful_requests": 148,
+                "failed_requests": 2
+            },
+            {
+                "date": "2026-04-13",
+                "user_id": "user-123",
+                "model": "vertex_ai/claude-sonnet-4-6@default",
+                "model_group": "claude-sonnet-4-6",
+                "custom_llm_provider": "vertex_ai",
+                "prompt_tokens": 500000,
+                "completion_tokens": 10000,
+                "cache_read_input_tokens": 400000,
+                "cache_creation_input_tokens": 50000,
+                "spend": 12.75,
+                "api_requests": 200,
+                "successful_requests": 200,
+                "failed_requests": 0
+            }
+        ]
+    }
+}
+```
+
+:::info
+Daily spend data is sourced from `LiteLLM_DailyUserSpend`, which is populated on every request. This works for all keys, including keys without a `user_id`.
+:::
 
 </TabItem>
 <TabItem value="user-info" label="User Spend">

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2717,12 +2717,19 @@ async def info_key_fn(
     key: Optional[str] = fastapi.Query(
         default=None, description="Key in the request parameters"
     ),
+    include_daily_spend: Optional[int] = fastapi.Query(
+        default=None,
+        description="Number of days of daily spend breakdown to include (e.g. 7 for last 7 days). Returns per-model daily spend from LiteLLM_DailyUserSpend.",
+        ge=1,
+        le=90,
+    ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
     Retrieve information about a key.
     Parameters:
         key: Optional[str] = Query parameter representing the key in the request
+        include_daily_spend: Optional[int] = Number of days of daily spend to include
         user_api_key_dict: UserAPIKeyAuth = Dependency representing the user's API key
     Returns:
         Dict containing the key and its associated information
@@ -2737,6 +2744,12 @@ async def info_key_fn(
     ```
     curl -X GET "http://0.0.0.0:4000/key/info" \
 -H "Authorization: Bearer sk-test-example-key-123"
+    ```
+
+    Example Curl - include last 7 days of daily spend breakdown
+    ```
+    curl -X GET "http://0.0.0.0:4000/key/info?key=sk-test-example-key-123&include_daily_spend=7" \
+-H "Authorization: Bearer sk-1234"
     ```
     """
     from litellm.proxy.proxy_server import prisma_client
@@ -2788,6 +2801,27 @@ async def info_key_fn(
 
         # Attach object_permission if object_permission_id is set
         key_info = await attach_object_permission_to_dict(key_info, prisma_client)
+
+        # Optionally include daily spend breakdown
+        if include_daily_spend is not None and hashed_key is not None:
+            start_date_str = (
+                datetime.now(timezone.utc) - timedelta(days=include_daily_spend)
+            ).strftime("%Y-%m-%d")
+            daily_spend_rows = await prisma_client.db.litellm_dailyuserspend.find_many(
+                where={
+                    "api_key": hashed_key,
+                    "date": {"gte": start_date_str},
+                },
+                order={"date": "desc"},
+            )
+            key_info["daily_spend"] = [
+                {
+                    k: v
+                    for k, v in row.model_dump().items()
+                    if k not in ("id", "api_key")
+                }
+                for row in daily_spend_rows
+            ]
 
         return {"key": key, "info": key_info}
     except Exception as e:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -8746,3 +8746,196 @@ def test_validate_public_image_url_accepts_http_and_noop_empty():
     _validate_public_image_url(None, "logo_url")
     _validate_public_image_url("", "logo_url")
     _validate_public_image_url("   ", "logo_url")
+
+
+@pytest.mark.asyncio
+async def test_info_key_fn_include_daily_spend():
+    """
+    When include_daily_spend is set, /key/info should return a daily_spend
+    array from LiteLLM_DailyUserSpend alongside the normal key info.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        info_key_fn,
+    )
+
+    hashed_key = "abc123def456"
+    mock_prisma_client = MagicMock()
+
+    # Mock key lookup
+    mock_key_row = MagicMock()
+    mock_key_row.model_dump.return_value = {
+        "token": hashed_key,
+        "key_alias": "test-user@example.com",
+        "spend": 500.0,
+        "max_budget": None,
+        "models": ["gpt-4"],
+        "team_id": "team-1",
+        "user_id": "user-1",
+        "object_permission_id": None,
+    }
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_row
+    )
+
+    # Mock daily spend rows
+    class MockDailySpendRow:
+        def __init__(self, data):
+            self._data = data
+
+        def model_dump(self):
+            return self._data
+
+    mock_daily_rows = [
+        MockDailySpendRow(
+            {
+                "id": "row-1",
+                "user_id": "user-1",
+                "date": "2026-04-13",
+                "api_key": hashed_key,
+                "model": "vertex_ai/claude-sonnet-4-6@default",
+                "model_group": "claude-sonnet-4-6",
+                "custom_llm_provider": "vertex_ai",
+                "prompt_tokens": 1000000,
+                "completion_tokens": 50000,
+                "cache_read_input_tokens": 800000,
+                "cache_creation_input_tokens": 100000,
+                "spend": 3.50,
+                "api_requests": 25,
+                "successful_requests": 24,
+                "failed_requests": 1,
+                "mcp_namespaced_tool_name": None,
+                "endpoint": None,
+                "created_at": "2026-04-13T00:00:00Z",
+                "updated_at": "2026-04-13T23:59:59Z",
+            }
+        ),
+        MockDailySpendRow(
+            {
+                "id": "row-2",
+                "user_id": "user-1",
+                "date": "2026-04-12",
+                "api_key": hashed_key,
+                "model": "vertex_ai/claude-opus-4-6@default",
+                "model_group": "claude-opus-4-6",
+                "custom_llm_provider": "vertex_ai",
+                "prompt_tokens": 500000,
+                "completion_tokens": 10000,
+                "cache_read_input_tokens": 400000,
+                "cache_creation_input_tokens": 50000,
+                "spend": 12.75,
+                "api_requests": 10,
+                "successful_requests": 10,
+                "failed_requests": 0,
+                "mcp_namespaced_tool_name": None,
+                "endpoint": None,
+                "created_at": "2026-04-12T00:00:00Z",
+                "updated_at": "2026-04-12T23:59:59Z",
+            }
+        ),
+    ]
+    mock_prisma_client.db.litellm_dailyuserspend.find_many = AsyncMock(
+        return_value=mock_daily_rows
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.prisma_client",
+        mock_prisma_client,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._can_user_query_key_info",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._hash_token_if_needed",
+        return_value=hashed_key,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.attach_object_permission_to_dict",
+        new_callable=AsyncMock,
+        side_effect=lambda d, _: d,
+    ):
+        result = await info_key_fn(
+            key=hashed_key,
+            include_daily_spend=7,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin",
+            ),
+        )
+
+    assert "daily_spend" in result["info"]
+    daily = result["info"]["daily_spend"]
+    assert len(daily) == 2
+    assert daily[0]["date"] == "2026-04-13"
+    assert daily[0]["spend"] == 3.50
+    assert daily[0]["model_group"] == "claude-sonnet-4-6"
+    assert daily[1]["date"] == "2026-04-12"
+    assert daily[1]["spend"] == 12.75
+    # Sensitive fields should be excluded
+    assert "id" not in daily[0]
+    assert "api_key" not in daily[0]
+
+    # Verify the daily spend query was called with correct params
+    mock_prisma_client.db.litellm_dailyuserspend.find_many.assert_called_once()
+    call_kwargs = (
+        mock_prisma_client.db.litellm_dailyuserspend.find_many.call_args.kwargs
+    )
+    assert call_kwargs["where"]["api_key"] == hashed_key
+    assert "gte" in call_kwargs["where"]["date"]
+
+
+@pytest.mark.asyncio
+async def test_info_key_fn_without_daily_spend():
+    """
+    When include_daily_spend is not set, /key/info should NOT return
+    daily_spend and should NOT query LiteLLM_DailyUserSpend.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        info_key_fn,
+    )
+
+    hashed_key = "abc123def456"
+    mock_prisma_client = MagicMock()
+
+    mock_key_row = MagicMock()
+    mock_key_row.model_dump.return_value = {
+        "token": hashed_key,
+        "key_alias": "test-user@example.com",
+        "spend": 500.0,
+        "max_budget": None,
+        "models": ["gpt-4"],
+        "team_id": "team-1",
+        "user_id": "user-1",
+        "object_permission_id": None,
+    }
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=mock_key_row
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.prisma_client",
+        mock_prisma_client,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._can_user_query_key_info",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._hash_token_if_needed",
+        return_value=hashed_key,
+    ), patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.attach_object_permission_to_dict",
+        new_callable=AsyncMock,
+        side_effect=lambda d, _: d,
+    ):
+        result = await info_key_fn(
+            key=hashed_key,
+            include_daily_spend=None,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+                user_id="admin",
+            ),
+        )
+
+    assert "daily_spend" not in result["info"]
+    # Should not have queried daily spend table at all
+    mock_prisma_client.db.litellm_dailyuserspend.find_many.assert_not_called()


### PR DESCRIPTION
## Summary

- Add optional `include_daily_spend` query parameter to `/key/info` endpoint
- Returns per-model daily spend breakdown from `LiteLLM_DailyUserSpend` alongside existing key info

## Motivation

The `/key/info` endpoint only returns a cumulative all-time `spend` value. Administrators managing LLM costs across multiple users and models need per-day visibility to:

- Monitor usage trends and detect cost anomalies
- Reconcile LiteLLM tracked spend against cloud provider billing (GCP, AWS, Azure)
- Identify which models drive the most cost per key per day
- Validate that budget enforcement is working correctly

The underlying data already exists in `LiteLLM_DailyUserSpend` (written on every request) but was not exposed via the key info API. This change avoids creating a new endpoint by extending the existing one with an optional parameter.

## Usage

```bash
# Get key info with last 7 days of daily spend
curl -X GET "http://localhost:4000/key/info?key=sk-...&include_daily_spend=7" \
  -H "Authorization: Bearer sk-admin"
```

Response includes a `daily_spend` array in the `info` object:
```json
{
  "key": "sk-...",
  "info": {
    "key_alias": "user@example.com",
    "spend": 1500.00,
    "daily_spend": [
      {
        "date": "2026-04-14",
        "model": "vertex_ai/claude-opus-4-6@default",
        "model_group": "claude-opus-4-6",
        "custom_llm_provider": "vertex_ai",
        "spend": 534.16,
        "prompt_tokens": 832429492,
        "completion_tokens": 1485,
        "cache_read_input_tokens": 800000000,
        "cache_creation_input_tokens": 30000000,
        "api_requests": 1485,
        "successful_requests": 1483,
        "failed_requests": 2
      }
    ]
  }
}
```

When `include_daily_spend` is not provided, the response is unchanged (no `daily_spend` field, no additional DB query).

## Implementation details

- Parameter: `include_daily_spend: Optional[int]` with `ge=1, le=90` validation
- Queries `LiteLLM_DailyUserSpend` filtered by `api_key` (uses existing `@@index([api_key])`)
- Strips `id` and `api_key` from each row before returning
- No schema changes, no new endpoints, no new Pydantic models

## Test plan

- [x] `test_info_key_fn_include_daily_spend` — verifies daily_spend is returned with correct data when parameter is set
- [x] `test_info_key_fn_without_daily_spend` — verifies no daily_spend and no DB query when parameter is omitted
- [x] `poetry run black .` applied

Generated with [Claude Code](https://claude.com/claude-code)
