### PR TITLE
fix(logging): non-streaming rawPredict requests log spend as $0.00

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1856,6 +1856,16 @@ class Logging(LiteLLMLoggingBaseClass):
                         end_time=end_time,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
+                    # Compute response_cost for dict/list responses (e.g.
+                    # non-streaming rawPredict) that bypass
+                    # _process_hidden_params_and_response_cost.  Without this,
+                    # spend is logged as $0.00.
+                    if self.model_call_details.get("response_cost") is None:
+                        self.model_call_details[
+                            "response_cost"
+                        ] = self._response_cost_calculator(
+                            result=logging_result  # type: ignore[arg-type]
+                        )
                     self.model_call_details[
                         "standard_logging_object"
                     ] = self._build_standard_logging_payload(

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2299,3 +2299,116 @@ def test_merge_hidden_params_from_response_into_metadata_no_op_when_empty():
     assert "hidden_params" not in logging_obj.model_call_details["litellm_params"][
         "metadata"
     ]
+
+
+def test_success_handler_computes_cost_for_dict_responses():
+    """
+    When success_handler receives a dict result (e.g. non-streaming
+    rawPredict), it should compute response_cost via
+    _response_cost_calculator before building the standard logging payload.
+
+    Previously, the dict branch skipped cost calculation entirely, causing
+    spend to be logged as $0.00 for non-streaming Vertex AI Claude requests.
+    """
+    logging_obj = LitellmLogging(
+        model="claude-sonnet-4-6@default",
+        messages=[{"role": "user", "content": "test"}],
+        stream=False,
+        call_type="acompletion",
+        litellm_call_id="test-123",
+        start_time=time.time(),
+        function_id="test",
+    )
+    logging_obj.model_call_details = {
+        "model": "claude-sonnet-4-6@default",
+        "custom_llm_provider": "vertex_ai",
+        "litellm_params": {"metadata": {}},
+        "response_cost": None,
+    }
+
+    mock_cost = 0.42
+
+    with patch.object(
+        logging_obj,
+        "_response_cost_calculator",
+        return_value=mock_cost,
+    ) as mock_calc, patch.object(
+        logging_obj,
+        "_build_standard_logging_payload",
+        return_value={"response_cost": mock_cost},
+    ), patch(
+        "litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"
+    ), patch.object(
+        logging_obj,
+        "_is_recognized_call_type_for_logging",
+        return_value=False,
+    ), patch.object(
+        logging_obj,
+        "_transform_usage_objects",
+        side_effect=lambda result: result,
+    ):
+        dict_result = {"id": "msg_123", "content": [{"text": "hello"}]}
+        logging_obj.success_handler(
+            result=dict_result,
+            start_time=time.time(),
+            end_time=time.time(),
+        )
+
+        mock_calc.assert_called_once()
+        assert logging_obj.model_call_details["response_cost"] == mock_cost
+
+
+def test_success_handler_preserves_precomputed_cost_for_dict_responses():
+    """
+    When response_cost is already set on model_call_details (e.g.
+    precomputed by a pass-through handler), success_handler must NOT
+    overwrite it by calling _response_cost_calculator again.
+    """
+    logging_obj = LitellmLogging(
+        model="claude-sonnet-4-6@default",
+        messages=[{"role": "user", "content": "test"}],
+        stream=False,
+        call_type="acompletion",
+        litellm_call_id="test-456",
+        start_time=time.time(),
+        function_id="test",
+    )
+
+    precomputed_cost = 1.23
+    logging_obj.model_call_details = {
+        "model": "claude-sonnet-4-6@default",
+        "custom_llm_provider": "vertex_ai",
+        "litellm_params": {"metadata": {}},
+        "response_cost": precomputed_cost,
+    }
+
+    with patch.object(
+        logging_obj,
+        "_response_cost_calculator",
+        return_value=9.99,
+    ) as mock_calc, patch.object(
+        logging_obj,
+        "_build_standard_logging_payload",
+        return_value={"response_cost": precomputed_cost},
+    ), patch(
+        "litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"
+    ), patch.object(
+        logging_obj,
+        "_is_recognized_call_type_for_logging",
+        return_value=False,
+    ), patch.object(
+        logging_obj,
+        "_transform_usage_objects",
+        side_effect=lambda result: result,
+    ):
+        dict_result = {"id": "msg_456", "content": [{"text": "hello"}]}
+        logging_obj.success_handler(
+            result=dict_result,
+            start_time=time.time(),
+            end_time=time.time(),
+        )
+
+        # _response_cost_calculator should NOT have been called
+        mock_calc.assert_not_called()
+        # Precomputed cost should be preserved
+        assert logging_obj.model_call_details["response_cost"] == precomputed_cost


### PR DESCRIPTION
## Summary

- Non-streaming Vertex AI Claude requests (`rawPredict`) log `spend: 0.00` because the `success_handler` dict branch skips cost calculation
- Fix: compute `response_cost` via `_response_cost_calculator` for dict/list responses before building the standard logging payload

## Root cause

In `litellm_logging.py`, the `success_handler` has two branches for processing results:

1. **Recognized response types** (line ~1853): calls `_process_hidden_params_and_response_cost` which computes `response_cost` via `_response_cost_calculator`
2. **Dict/list responses** (line ~1858): calls `_build_standard_logging_payload` directly, **skipping cost calculation entirely**

Non-streaming Vertex AI `rawPredict` returns a raw dict (not a `ModelResponse`), so it always hits branch 2 and the spend is logged as `$0.00`. Streaming requests via `streamRawPredict` return a `ModelResponse` and hit branch 1, so they track correctly.

## Impact

On a production deployment with significant Claude Code usage (which sends non-streaming `/v1/messages` requests), this caused **~$6,500 of untracked Claude spend over 14 days**. Budget enforcement via `max_budget` was also bypassed since the spend counter was never incremented for these requests.

## Steps to reproduce

1. Configure a Vertex AI Claude model (note: `model` field does NOT include the `vertex_ai/` prefix — provider is set separately via `custom_llm_provider`):
   ```yaml
   model_list:
     - model_name: claude-sonnet-4-6
       litellm_params:
         model: claude-sonnet-4-6@default
         custom_llm_provider: vertex_ai
         vertex_project: my-project
         vertex_location: global
   ```

2. Send a **non-streaming** request via `/v1/messages` (this is what Claude Code sends by default):
   ```bash
   curl -X POST http://localhost:4000/v1/messages \
     -H "Authorization: Bearer sk-your-key" \
     -H "Content-Type: application/json" \
     -d '{
       "model": "claude-sonnet-4-6",
       "messages": [{"role": "user", "content": "Say hello"}],
       "max_tokens": 100
     }'
   ```

3. Check the spend logs — the request has tokens but `spend: 0.00`:
   ```bash
   curl "http://localhost:4000/spend/logs?api_key=YOUR_KEY_HASH&limit=1" \
     -H "Authorization: Bearer sk-master"
   ```
   Output shows `"spend": 0.0` and `"total_tokens": 150` (non-zero).

4. Send the **same request with streaming** — spend tracks correctly:
   ```bash
   curl -X POST http://localhost:4000/v1/messages \
     -H "Authorization: Bearer sk-your-key" \
     -H "Content-Type: application/json" \
     -d '{
       "model": "claude-sonnet-4-6",
       "messages": [{"role": "user", "content": "Say hello"}],
       "max_tokens": 100,
       "stream": true
     }'
   ```
   Spend logs now show non-zero `spend` for this request.

5. To see the scale of the issue on an existing deployment, query the DB directly:
   ```sql
   SELECT
       CASE WHEN api_base LIKE '%rawPredict' THEN 'rawPredict'
            WHEN api_base LIKE '%streamRawPredict' THEN 'streamRawPredict'
       END AS endpoint,
       COUNT(*) AS requests,
       COUNT(*) FILTER (WHERE spend = 0 AND total_tokens > 0) AS zero_cost_with_tokens,
       ROUND(SUM(spend)::numeric, 2) AS tracked_spend
   FROM "LiteLLM_SpendLogs"
   WHERE model LIKE '%claude%' AND status = 'success'
   GROUP BY endpoint;
   ```

## Fix

Before calling `_build_standard_logging_payload` in the dict/list branch, check if `response_cost` is None and compute it via `_response_cost_calculator`. This mirrors what `_process_hidden_params_and_response_cost` does for ModelResponse results.

## Related

- #24204 — "Spend not tracked for anthropic_messages and passthrough call types" (describes the symptom from a different angle)
- #24205 — Open PR addressing cost preservation in pass-through handlers (complementary fix, not a replacement — see [comment](https://github.com/BerriAI/litellm/pull/25705#issuecomment-4246255120))
- #22906 — Previously merged fix for `custom_llm_provider` not being updated after `base_model` resolution

## Test plan

- [x] `test_success_handler_computes_cost_for_dict_responses` — verifies `_response_cost_calculator` is called and `response_cost` is set for dict results
- [x] `test_success_handler_preserves_precomputed_cost_for_dict_responses` — verifies precomputed `response_cost` is NOT overwritten
- [x] `poetry run black .` applied (only to changed files)

Generated with [Claude Code](https://claude.com/claude-code)
