### PR TITLE
fix(main.py): pass custom_llm_provider to get_litellm_params in embedding/transcription/speech

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4797,7 +4797,9 @@ def embedding(  # noqa: PLR0915
             }
         )
 
-    litellm_params_dict = get_litellm_params(**kwargs)
+    litellm_params_dict = get_litellm_params(
+        custom_llm_provider=custom_llm_provider, **kwargs
+    )
 
     logging: LiteLLMLoggingObj = litellm_logging_obj  # type: ignore
     logging.update_environment_variables(
@@ -6488,7 +6490,9 @@ def transcription(
         **non_default_params,
     )
 
-    litellm_params_dict = get_litellm_params(**kwargs)
+    litellm_params_dict = get_litellm_params(
+        custom_llm_provider=custom_llm_provider, **kwargs
+    )
 
     litellm_logging_obj.update_environment_variables(
         model=model,
@@ -6717,7 +6721,9 @@ def speech(  # noqa: PLR0915
 
     if max_retries is None:
         max_retries = litellm.num_retries or openai.DEFAULT_MAX_RETRIES
-    litellm_params_dict = get_litellm_params(**kwargs)
+    litellm_params_dict = get_litellm_params(
+        custom_llm_provider=custom_llm_provider, **kwargs
+    )
 
     # Get provider-specific text-to-speech config and map parameters
     text_to_speech_provider_config = (

--- a/tests/test_litellm/litellm_core_utils/test_get_litellm_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_litellm_params.py
@@ -95,6 +95,30 @@ class TestGetLitellmParamsBaseModel:
         assert result["base_model"] is None
 
 
+class TestGetLitellmParamsCustomLlmProvider:
+    """Verify custom_llm_provider handling — explicit value vs kwargs."""
+
+    def test_explicit_custom_llm_provider(self):
+        """Explicit custom_llm_provider should appear in result."""
+        result = get_litellm_params(custom_llm_provider="hosted_vllm")
+        assert result["custom_llm_provider"] == "hosted_vllm"
+
+    def test_custom_llm_provider_not_in_kwargs(self):
+        """When custom_llm_provider is not passed, it defaults to None.
+
+        This mirrors the bug in embedding()/transcription()/speech() where
+        custom_llm_provider was extracted as a named parameter and thus
+        removed from **kwargs before being passed to get_litellm_params().
+        """
+        result = get_litellm_params(**{"api_key": "test"})
+        assert result["custom_llm_provider"] is None
+
+    def test_explicit_custom_llm_provider_with_kwargs(self):
+        """Explicit custom_llm_provider should not be overridden by kwargs."""
+        result = get_litellm_params(custom_llm_provider="hosted_vllm", api_key="test")
+        assert result["custom_llm_provider"] == "hosted_vllm"
+
+
 class TestGetLitellmParamsExplicitFields:
     """Verify explicit parameters are always present in the result."""
 
@@ -125,4 +149,3 @@ class TestGetLitellmParamsExplicitFields:
     def test_no_log_from_explicit_param(self):
         result = get_litellm_params(no_log=True)
         assert result["no-log"] is True
-


### PR DESCRIPTION
## Relevant issues

Fixes the root cause behind #25240 and #23347 — `custom_llm_provider` is `None` in `litellm_params` for non-completion call paths.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### What

`embedding()`, `transcription()`, and `speech()` call `get_litellm_params(**kwargs)` without passing `custom_llm_provider`. Since it's extracted as a named parameter in each function signature, it's no longer in `**kwargs` — so `litellm_params["custom_llm_provider"]` is always `None`.

### Why it happens

PR #7989 (Jan 2025) refactored these functions to use `get_litellm_params(**kwargs)` instead of an inline dict. The `completion()` path passes `custom_llm_provider` explicitly, but the other three don't — the parameter was lost during the refactor.

### Impact

`custom_llm_provider=None` in `litellm_params` causes downstream issues in observability integrations that read it:
- **OpenTelemetry**: `gen_ai.system` attribute is `None` → SDK logs `Invalid type NoneType` warnings on every request (#25240, #23347)
- **OpenTelemetry**: `set_raw_request_attributes` produces `llm.None.*` attribute keys
- **Prometheus/Langtrace/Arize**: incorrect or missing provider labels

### Fix

Pass `custom_llm_provider=custom_llm_provider` explicitly in all three call sites, matching what `completion()` already does.

## Screenshots / Proof of Fix

Before (embedding request via hosted_vllm):
```
Invalid type NoneType for attribute 'gen_ai.system' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

After: no warnings, `gen_ai.system` correctly set to `"hosted_vllm"`.