### PR TITLE
fix: isolate logs team filter dropdown from root teams state bleed

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/logs/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/logs/page.tsx
@@ -2,11 +2,9 @@
 
 import SpendLogsTable from "@/components/view_logs";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import useTeams from "@/app/(dashboard)/hooks/useTeams";
 
 const LogsPage = () => {
   const { accessToken, token, userRole, userId, premiumUser } = useAuthorized();
-  const { teams } = useTeams();
 
   return (
     <SpendLogsTable
@@ -14,7 +12,6 @@ const LogsPage = () => {
       token={token}
       userRole={userRole}
       userID={userId}
-      allTeams={teams || []}
       premiumUser={premiumUser}
     />
   );

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -620,7 +620,6 @@ function CreateKeyPageContent() {
                       userRole={userRole}
                       token={token}
                       accessToken={accessToken}
-                      allTeams={(teams as Team[]) ?? []}
                       premiumUser={premiumUser}
                     />
                   ) : page == "mcp-servers" ? (

--- a/ui/litellm-dashboard/src/components/common_components/FilterTeamDropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/FilterTeamDropdown.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import TeamDropdown from "./team_dropdown";
+import type { FilterOptionCustomComponentProps } from "../molecules/filter";
+
+const FilterTeamDropdown: React.FC<FilterOptionCustomComponentProps> = ({
+  value,
+  onChange,
+}) => <TeamDropdown value={value} onChange={onChange} />;
+
+export default FilterTeamDropdown;

--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import SpendLogsTable, { RequestViewer } from "./index";
 import type { LogEntry } from "./columns";
 import type { Row } from "@tanstack/react-table";
-import type { Team } from "../key_team_helpers/key_list";
 import { renderWithProviders } from "../../../tests/test-utils";
 
 const mockHandleFilterResetFromHook = vi.fn();
@@ -178,7 +177,6 @@ describe("SpendLogsTable", () => {
     token: "test-token",
     userRole: "Admin",
     userID: "user-1",
-    allTeams: [] as Team[],
     premiumUser: false,
   };
 

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -11,7 +11,8 @@ import { Button, Tag, Tooltip } from "antd";
 import { internalUserRoles } from "../../utils/roles";
 import DeletedKeysPage from "../DeletedKeysPage/DeletedKeysPage";
 import DeletedTeamsPage from "../DeletedTeamsPage/DeletedTeamsPage";
-import { KeyResponse, Team } from "../key_team_helpers/key_list";
+import FilterTeamDropdown from "../common_components/FilterTeamDropdown";
+import { KeyResponse } from "../key_team_helpers/key_list";
 import { PaginatedKeyAliasSelect } from "../KeyAliasSelect/PaginatedKeyAliasSelect/PaginatedKeyAliasSelect";
 import { PaginatedModelSelect } from "../ModelSelect/PaginatedModelSelect/PaginatedModelSelect";
 import FilterComponent, { FilterOption } from "../molecules/filter";
@@ -36,7 +37,6 @@ interface SpendLogsTableProps {
   token: string | null;
   userRole: string | null;
   userID: string | null;
-  allTeams: Team[];
   premiumUser: boolean;
 }
 
@@ -53,7 +53,6 @@ export default function SpendLogsTable({
   token,
   userRole,
   userID,
-  allTeams,
   premiumUser,
 }: SpendLogsTableProps) {
   const [searchTerm, setSearchTerm] = useState("");
@@ -241,7 +240,7 @@ export default function SpendLogsTable({
     filters,
     filteredLogs,
     hasBackendFilters,
-    allTeams: hookAllTeams,
+    allTeams,
     handleFilterChange,
     handleFilterReset: handleFilterResetFromHook,
   } = useLogFilterLogic({
@@ -394,20 +393,7 @@ export default function SpendLogsTable({
     {
       name: "Team ID",
       label: "Team ID",
-      isSearchable: true,
-      searchFn: async (searchText: string) => {
-        if (!allTeams || allTeams.length === 0) return [];
-        const filtered = allTeams.filter((team: Team) => {
-          return (
-            team.team_id.toLowerCase().includes(searchText.toLowerCase()) ||
-            (team.team_alias && team.team_alias.toLowerCase().includes(searchText.toLowerCase()))
-          );
-        });
-        return filtered.map((team: Team) => ({
-          label: `${team.team_alias || team.team_id} (${team.team_id})`,
-          value: team.team_id,
-        }));
-      },
+      customComponent: FilterTeamDropdown,
     },
     {
       name: "Status",
@@ -506,7 +492,7 @@ export default function SpendLogsTable({
               <KeyInfoView
                 keyId={selectedKeyIdInfoView}
                 keyData={selectedKeyInfo}
-                teams={allTeams}
+                teams={allTeams ?? []}
                 onClose={() => setSelectedKeyIdInfoView(null)}
                 backButtonText="Back to Logs"
               />


### PR DESCRIPTION
## Summary

- The Logs view's **Team ID** filter dropdown was reading `allTeams` from the root `teams` state in `app/page.tsx`, which `OldTeams` overwrites with the filtered subset whenever a user searches on the Teams page. Applying a team search on the Teams page made filtered-out teams disappear from the Logs filter dropdown in a separate part of the app.
- Swap the Team ID filter to use the existing `TeamDropdown` component via a small `FilterTeamDropdown` wrapper that adapts it to the filter slot's `FilterOptionCustomComponentProps` contract. The dropdown now drives its own `useInfiniteTeams` query against `/v2/team/list` with server-side `team_alias` search and an isolated react-query cache, unreachable from root state.
- Rename the now-unused `hookAllTeams` destructure in `SpendLogsTable` to `allTeams` so the `KeyInfoView` passthrough receives the hook's unpolluted fetch instead of the polluted prop, and drop the dead `allTeams` prop from `SpendLogsTable` and both of its call sites (`app/page.tsx`, `app/(dashboard)/logs/page.tsx`).

## screenshots 

before 
<img width="904" height="384" alt="Screenshot 2026-04-14 at 1 44 47 PM" src="https://github.com/user-attachments/assets/3ac3a304-0d58-4d2d-ae3c-b09fb07c2cd1" />
<img width="942" height="210" alt="Screenshot 2026-04-14 at 1 44 57 PM" src="https://github.com/user-attachments/assets/531f1eb0-8b5e-493c-a6a3-3d7bf8d7015c" />


after 
<img width="893" height="394" alt="Screenshot 2026-04-14 at 2 27 19 PM" src="https://github.com/user-attachments/assets/6e21e736-0857-4db0-b465-b69ba8c939f4" />
<img width="937" height="378" alt="Screenshot 2026-04-14 at 2 27 34 PM" src="https://github.com/user-attachments/assets/89eb1d14-319e-4770-ad4d-4be59165f332" />


## Test plan

- [x] Seed 5 `bleed-*` teams via `/team/new`, fire one request through the proxy to produce a log entry
- [x] **Baseline:** Observability → Logs → open Team ID filter → type `bleed` → all 5 teams appear
- [x] **Trigger:** Access Control → Teams → search `bleed-acme` → table narrows to one row (root `teams` state now polluted)
- [x] **Fix verified:** Observability → Logs → open Team ID filter → type `bleed` → all 5 teams still appear (dropdown reads from its own `useInfiniteTeams` cache, not root state)
- [x] Select a team in the filter, click Apply Filters → logs table narrows to that team
- [x] Click Reset Filters → dropdown clears, logs table returns to unfiltered
- [x] Click a log row → `KeyInfoView` panel opens and renders correctly (now receives the hook's unpolluted `allTeams`)
- [x] `npx vitest run src/components/view_logs/index.test.tsx src/components/view_logs/log_filter_logic.test.tsx` → 38/38 passing
- [x] `tsc --noEmit` → zero new errors on touched files