### PR TITLE
test(ui): add getCookie to cookieUtils mock in user_dashboard test

### DIFF
--- a/ui/litellm-dashboard/src/components/user_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.test.tsx
@@ -45,6 +45,7 @@ vi.mock("jwt-decode", () => ({
 // Mock cookie utility
 vi.mock("@/utils/cookieUtils", () => ({
   clearTokenCookies: vi.fn(),
+  getCookie: vi.fn().mockReturnValue("fake-jwt-token"),
 }));
 
 // Mock fetchTeams


### PR DESCRIPTION
## Summary

Fixes three failing tests in `src/components/user_dashboard.test.tsx`:

- `registers exactly one beforeunload listener on mount`
- `does not add duplicate listeners on re-render`
- `removes the beforeunload listener on unmount`

`user_dashboard.tsx` imports `getCookie` from `@/utils/cookieUtils`, but the `vi.mock` factory in the test only exported `clearTokenCookies`. Vitest's strict mock factory then throws:

\`\`\`
Error: [vitest] No "getCookie" export is defined on the "@/utils/cookieUtils" mock.
\`\`\`

...causing the source file to error during render and all three tests to fail.

Added `getCookie: vi.fn().mockReturnValue("fake-jwt-token")` to the mock factory so it matches the current set of imports from `cookieUtils`.

## Test plan

- [x] `vitest run src/components/user_dashboard.test.tsx` — 3/3 passing locally