### PR TITLE
fix: default invite user modal global role to least-privilege

### DIFF
--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -175,7 +175,14 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
   // Modify the return statement to handle embedded mode
   if (isEmbedded) {
     return (
-      <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
+      <Form
+        form={form}
+        onFinish={handleCreate}
+        labelCol={{ span: 8 }}
+        wrapperCol={{ span: 16 }}
+        labelAlign="left"
+        initialValues={{ user_role: "internal_user_viewer" }}
+      >
         <Alert
           message="Email invitations"
           description={
@@ -257,7 +264,14 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
             className="mb-4"
           />
         </Space>
-        <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
+        <Form
+          form={form}
+          onFinish={handleCreate}
+          labelCol={{ span: 8 }}
+          wrapperCol={{ span: 16 }}
+          labelAlign="left"
+          initialValues={{ user_role: "internal_user_viewer" }}
+        >
           <Form.Item label="User Email" name="user_email">
             <Input />
           </Form.Item>


### PR DESCRIPTION
## Summary

The Global Proxy Role dropdown in the Invite User modal had no default value, so admins had to remember to pick a role before submitting. If they forgot, the form posted `user_role: undefined` to `/user/new`.

This PR pre-selects `internal_user_viewer` — the least-privileged of the four roles returned by `/user/available_roles` — on both the standalone modal (used on the Users page) and the embedded form (used inside the Create Key flow). Defaulting to least privilege means an admin has to opt into granting more access rather than opting out.

Role options available on the endpoint:
- `proxy_admin`
- `proxy_admin_viewer`
- `internal_user`
- `internal_user_viewer` ← new default

circleci: https://app.circleci.com/pipelines/github/BerriAI/litellm/73620/workflows/83c1d890-896e-46ac-93b2-8658761b0a50

## Screenshots

before - default doesnt show 

<img width="1128" height="680" alt="Screenshot 2026-04-14 at 3 05 08 PM" src="https://github.com/user-attachments/assets/4528233c-53d6-4a28-90aa-003e90f0f0f5" />


after - least privilege default shows  
<img width="1122" height="739" alt="Screenshot 2026-04-14 at 3 44 07 PM" src="https://github.com/user-attachments/assets/ae110a3c-19a6-4850-b47c-265777aeb862" />



## Test plan

- [x] Open the Users page, click **+ Invite User**, confirm "Internal User Viewer" is pre-selected in the Global Proxy Role dropdown
- [x] Submit the form without touching the role dropdown and confirm the user is created with `internal_user_viewer`
- [x] Change the role to something else and confirm the override is respected
- [x] Open the Create Key flow and use the embedded invite user form; confirm the same default applies there