### PR TITLE
[Refactor] Remove Chat UI link from Swagger docs message

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -669,9 +669,6 @@ ui_message += "\n\n💸 [```LiteLLM Model Cost Map```](https://models.litellm.ai
 
 ui_message += f"\n\n🔎 [```LiteLLM Model Hub```]({model_hub_link}). See available models on the proxy. [**Docs**](https://docs.litellm.ai/docs/proxy/ai_hub)"
 
-chat_link = f"{server_root_path}/ui/chat"
-ui_message += f"\n\n💬 [```LiteLLM Chat UI```]({chat_link}). ChatGPT-like interface for your users to chat with AI models and MCP tools."
-
 custom_swagger_message = "[**Customize Swagger Docs**](https://docs.litellm.ai/docs/proxy/enterprise#swagger-docs---custom-routes--branding)"
 
 ### CUSTOM BRANDING [ENTERPRISE FEATURE] ###


### PR DESCRIPTION
## Relevant issues

## Summary

Removes the `💬 LiteLLM Chat UI` link and its accompanying description from the Swagger docs landing message.

### Changes

Dropped the `chat_link` variable and the line appending the Chat UI entry to `ui_message` in `litellm/proxy/proxy_server.py`.

## Testing

Existing tests cover proxy startup; no behavior change beyond the removed link.

## Type

🧹 Refactoring