### PR TITLE
[Fix] Test - Together AI: replace deprecated Mixtral with serverless Qwen3.5-9B

### DIFF
--- a/tests/llm_translation/test_together_ai.py
+++ b/tests/llm_translation/test_together_ai.py
@@ -20,7 +20,7 @@ import pytest
 class TestTogetherAI(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
         litellm.set_verbose = True
-        return {"model": "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1"}
+        return {"model": "together_ai/Qwen/Qwen3.5-9B"}
 
     def test_tool_call_no_arguments(self, tool_call_no_arguments):
         """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -65,7 +65,7 @@ def test_completion_custom_provider_model_name():
     try:
         litellm.cache = None
         response = completion(
-            model="together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1",
+            model="together_ai/Qwen/Qwen3.5-9B",
             messages=messages,
             logger_fn=logger_fn,
         )
@@ -2815,7 +2815,7 @@ def test_customprompt_together_ai():
         print(litellm.success_callback)
         print(litellm._async_success_callback)
         response = completion(
-            model="together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1",
+            model="together_ai/Qwen/Qwen3.5-9B",
             messages=messages,
             roles={
                 "system": {
@@ -3682,7 +3682,7 @@ def test_completion_together_ai_stream():
     messages = [{"content": user_message, "role": "user"}]
     try:
         response = completion(
-            model="together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1",
+            model="together_ai/Qwen/Qwen3.5-9B",
             messages=messages,
             stream=True,
             max_tokens=5,

--- a/tests/local_testing/test_multiple_deployments.py
+++ b/tests/local_testing/test_multiple_deployments.py
@@ -25,7 +25,7 @@ model_list = [
     {
         "model_name": "mistral-7b-instruct",
         "litellm_params": {  # params for litellm completion/embedding call
-            "model": "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "model": "together_ai/Qwen/Qwen3.5-9B",
             "api_key": os.getenv("TOGETHERAI_API_KEY"),
         },
     },

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -4034,7 +4034,7 @@ def test_async_text_completion_together_ai():
     async def test_get_response():
         try:
             response = await litellm.atext_completion(
-                model="together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1",
+                model="together_ai/Qwen/Qwen3.5-9B",
                 prompt="good morning",
                 max_tokens=10,
             )


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

Multiple Together AI tests fail in CI with:

```
litellm.BadRequestError: Together_aiException - Unable to access non-serverless model
mistralai/Mixtral-8x7B-Instruct-v0.1. Please visit
https://api.together.ai/models/mistralai/Mixtral-8x7B-Instruct-v0.1 to create and
start a new dedicated endpoint for the model.
```

Affected tests:
- `tests/llm_translation/test_together_ai.py::TestTogetherAI::test_empty_tools`
- `tests/local_testing/test_completion.py::test_completion_together_ai_stream`
- `tests/local_testing/test_completion.py::test_customprompt_together_ai`
- `tests/local_testing/test_completion.py::test_completion_custom_provider_model_name`
- `tests/local_testing/test_text_completion.py::test_async_text_completion_together_ai`

Together AI removed `Mixtral-8x7B-Instruct-v0.1` from their serverless tier — it now requires a dedicated endpoint.

### Fix

Replace every `together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1` reference across the test suite with `together_ai/Qwen/Qwen3.5-9B`, which is currently on Together AI's serverless tier and supports function calling (required by `BaseLLMChatTest.test_empty_tools`). The tests exercise the `together_ai` provider code path, not Mixtral-specific behavior, so provider coverage is unchanged.

## Testing

Relies on the existing affected tests listed above.

## Type

🐛 Bug Fix
✅ Test