### PR TITLE
[Infra] Guard main to only accept PRs from staging and hotfix branches

### DIFF
--- a/.github/workflows/guard-main-branch.yml
+++ b/.github/workflows/guard-main-branch.yml
@@ -25,8 +25,15 @@ jobs:
       - name: Check head branch name
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
+          echo "PR head repo: $HEAD_REPO"
           echo "PR head branch: $HEAD_REF"
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::PRs to main must originate from the canonical repository ($BASE_REPO), not a fork ($HEAD_REPO)."
+            exit 1
+          fi
           if [ "$HEAD_REF" = "litellm_internal_staging" ] || [[ "$HEAD_REF" == litellm_hotfix_?* ]]; then
             echo "Allowed source branch."
             exit 0

--- a/.github/workflows/guard-main-branch.yml
+++ b/.github/workflows/guard-main-branch.yml
@@ -31,12 +31,12 @@ jobs:
           echo "PR head repo: $HEAD_REPO"
           echo "PR head branch: $HEAD_REF"
           if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
-            echo "::error::PRs to main must originate from the canonical repository ($BASE_REPO), not a fork ($HEAD_REPO)."
+            echo "::error::PRs to main must originate from the canonical repository ($BASE_REPO), not a fork ($HEAD_REPO). External contributors should open PRs against the 'litellm_oss_branch' branch instead."
             exit 1
           fi
           if [ "$HEAD_REF" = "litellm_internal_staging" ] || [[ "$HEAD_REF" == litellm_hotfix_?* ]]; then
             echo "Allowed source branch."
             exit 0
           fi
-          echo "::error::PRs to main must originate from 'litellm_internal_staging' or a 'litellm_hotfix_*' branch. Got: '$HEAD_REF'."
+          echo "::error::PRs to main must originate from 'litellm_internal_staging' or a 'litellm_hotfix_*' branch. Got: '$HEAD_REF'. If this is a contribution, retarget the PR against 'litellm_oss_branch' instead."
           exit 1

--- a/.github/workflows/guard-main-branch.yml
+++ b/.github/workflows/guard-main-branch.yml
@@ -1,0 +1,35 @@
+name: Guard main branch
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+permissions: {}
+
+# DO NOT RENAME the job's `name:` — it is referenced by GitHub branch
+# protection as a required status check on `main`. Renaming silently
+# breaks the gate.
+jobs:
+  guard:
+    name: Verify PR source branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Reject merge_group events
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "::error::Merge queue is not supported for main. Disable merge queue or update this guard."
+          exit 1
+      - name: Check head branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "PR head branch: $HEAD_REF"
+          if [ "$HEAD_REF" = "litellm_internal_staging" ] || [[ "$HEAD_REF" == litellm_hotfix_?* ]]; then
+            echo "Allowed source branch."
+            exit 0
+          fi
+          echo "::error::PRs to main must originate from 'litellm_internal_staging' or a 'litellm_hotfix_*' branch. Got: '$HEAD_REF'."
+          exit 1


### PR DESCRIPTION
## Relevant issues

## Summary

As part of a new SDLC flow where `litellm_internal_staging` is the promotion source for `main`, this PR adds a GitHub Actions workflow that enforces which branches may open PRs against `main`.

### Failure Path (Before Fix)

No automated check existed to prevent PRs from arbitrary dev branches landing on `main`.

### Fix

Adds `.github/workflows/guard-main-branch.yml`, which runs on `pull_request` to `main` and passes only when the head branch is `litellm_internal_staging` or matches `litellm_hotfix_*`. Any other source branch fails the check. `merge_group` events are explicitly rejected since merge queue is not in use.

Security posture:
- No secrets or env vars required.
- `permissions: {}` — no token scopes granted.
- `github.head_ref` is consumed via an `env:` mapping, not inline interpolation, avoiding script injection.

To take effect, the job `Verify PR source branch` must be added as a required status check in `main`'s branch protection rule.

## Testing

Manual review of trigger conditions and branch-name matching. To validate end-to-end, open a test PR from a non-allowlisted branch and confirm the check fails, then from `litellm_internal_staging` or `litellm_hotfix_test` and confirm it passes.

## Type

🚄 Infrastructure

## Screenshots