### PR TITLE
fix: remove non-existent litellm_mcps_tests_coverage from coverage combine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2911,7 +2911,7 @@ jobs:
             rm -f /tmp/uv-install.sh
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
-            uv tool run --from 'coverage[toml]==7.10.6' coverage combine realtime_translation_coverage ocr_coverage search_coverage mcp_coverage litellm_mcps_tests_coverage logging_coverage audio_coverage local_testing_part1_coverage local_testing_part2_coverage pass_through_unit_tests_coverage batches_coverage guardrails_coverage redis_caching_coverage
+            uv tool run --from 'coverage[toml]==7.10.6' coverage combine realtime_translation_coverage ocr_coverage search_coverage mcp_coverage logging_coverage audio_coverage local_testing_part1_coverage local_testing_part2_coverage pass_through_unit_tests_coverage batches_coverage guardrails_coverage redis_caching_coverage
             uv tool run --from 'coverage[toml]==7.10.6' coverage xml
       - codecov/upload:
           file: ./coverage.xml


### PR DESCRIPTION
## Summary

- Removes `litellm_mcps_tests_coverage` from the `coverage combine` command in `.circleci/config.yml`
- This path was never produced by any CI job, causing the `upload-coverage` step to consistently fail with `Couldn't combine from non-existent path 'litellm_mcps_tests_coverage'`

## Test plan
- [ ] Verify `upload-coverage` CircleCI job passes after this change