### PR TITLE
fix(ci): increase test-server-root-path timeout to 30m

### DIFF
--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-server-root-path:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- The `test-server-root-path` workflow has a 15-minute job timeout that's too tight for cold runners
- Setup overhead (~75s) + Docker build (~13m 45s) exceeds the limit, causing the build step to be cancelled mid-run
- Both matrix jobs (`/api/v1` and `/llmproxy`) are affected, resulting in spurious cancellations across multiple PRs

## Fix
Increase `timeout-minutes` from 15 to 30 to give the Docker build sufficient headroom on cold runners.