### PR TITLE
fix(credentials): sync in-memory credential_list after update

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -341,9 +341,8 @@ async def update_credential(
             },
         )
 
-        # Sync in-memory credential_list so GET calls reflect the update
-        # immediately. Build a plaintext merged credential from the existing
-        # in-memory entry (plaintext) + the incoming patch values.
+        # Sync in-memory credential_list (skip if not in memory - e.g., proxy restarted)
+        new_name = merged_credential.credential_name
         existing_in_memory: Optional[CredentialItem] = None
         for cred in litellm.credential_list:
             if cred.credential_name == credential_name:
@@ -357,16 +356,21 @@ async def update_credential(
             in_memory_info = dict(existing_in_memory.credential_info or {})
             if credential.credential_info:
                 in_memory_info.update(credential.credential_info)
-        else:
-            in_memory_values = credential.credential_values or {}
-            in_memory_info = credential.credential_info or {}
-
-        updated_in_memory = CredentialItem(
-            credential_name=credential_name,
-            credential_values=in_memory_values,
-            credential_info=in_memory_info,
-        )
-        CredentialAccessor.upsert_credentials([updated_in_memory])
+            updated_in_memory = CredentialItem(
+                credential_name=new_name,
+                credential_values=in_memory_values,
+                credential_info=in_memory_info,
+            )
+            # Remove old entry if renamed, then append updated one
+            if new_name != credential_name:
+                litellm.credential_list = [
+                    c for c in litellm.credential_list
+                    if c.credential_name != credential_name
+                ]
+            else:
+                CredentialAccessor.upsert_credentials([updated_in_memory])
+                return {"success": True, "message": "Credential updated successfully"}
+            litellm.credential_list.append(updated_in_memory)
 
         return {"success": True, "message": "Credential updated successfully"}
     except Exception as e:

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -340,6 +340,34 @@ async def update_credential(
                 "updated_by": user_api_key_dict.user_id,
             },
         )
+
+        # Sync in-memory credential_list so GET calls reflect the update
+        # immediately. Build a plaintext merged credential from the existing
+        # in-memory entry (plaintext) + the incoming patch values.
+        existing_in_memory: Optional[CredentialItem] = None
+        for cred in litellm.credential_list:
+            if cred.credential_name == credential_name:
+                existing_in_memory = cred
+                break
+
+        if existing_in_memory is not None:
+            in_memory_values = dict(existing_in_memory.credential_values or {})
+            if credential.credential_values:
+                in_memory_values.update(credential.credential_values)
+            in_memory_info = dict(existing_in_memory.credential_info or {})
+            if credential.credential_info:
+                in_memory_info.update(credential.credential_info)
+        else:
+            in_memory_values = credential.credential_values or {}
+            in_memory_info = credential.credential_info or {}
+
+        updated_in_memory = CredentialItem(
+            credential_name=credential_name,
+            credential_values=in_memory_values,
+            credential_info=in_memory_info,
+        )
+        CredentialAccessor.upsert_credentials([updated_in_memory])
+
         return {"success": True, "message": "Credential updated successfully"}
     except Exception as e:
         return handle_exception_on_proxy(e)


### PR DESCRIPTION
**Description**

**Problem:** When updating a credential via PATCH /credentials/{name}, the in-memory litellm.credential_list was not updated. Since all GET credential endpoints read directly from this in-memory list (not the DB), the updated values would not be visible until the process restarted.

**Root Cause:** create_credential correctly called CredentialAccessor.upsert_credentials() to sync the in-memory list after writing to DB, but update_credential in `litellm/proxy/credential_endpoints/endpoints.py` was missing this step.

**Fix:** After the DB update succeeds, merge the existing plaintext in-memory credential values with the incoming patch values and call `CredentialAccessor.upsert_credentials()` to update `litellm.credential_list` in-place.

**Files changed**:

- litellm/proxy/credential_endpoints/endpoints.py — fixed upstream PATCH /credentials/{name}