### PR TITLE
fix(credentials): sync in-memory credential_list after update

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -340,6 +340,38 @@ async def update_credential(
                 "updated_by": user_api_key_dict.user_id,
             },
         )
+
+        # Sync in-memory credential_list (skip if not in memory - e.g., proxy restarted)
+        new_name = merged_credential.credential_name
+        existing_in_memory: Optional[CredentialItem] = None
+        for cred in litellm.credential_list:
+            if cred.credential_name == credential_name:
+                existing_in_memory = cred
+                break
+
+        if existing_in_memory is not None:
+            in_memory_values = dict(existing_in_memory.credential_values or {})
+            if credential.credential_values:
+                in_memory_values.update(credential.credential_values)
+            in_memory_info = dict(existing_in_memory.credential_info or {})
+            if credential.credential_info:
+                in_memory_info.update(credential.credential_info)
+            updated_in_memory = CredentialItem(
+                credential_name=new_name,
+                credential_values=in_memory_values,
+                credential_info=in_memory_info,
+            )
+            # Remove old entry if renamed, then append updated one
+            if new_name != credential_name:
+                litellm.credential_list = [
+                    c for c in litellm.credential_list
+                    if c.credential_name != credential_name
+                ]
+            else:
+                CredentialAccessor.upsert_credentials([updated_in_memory])
+                return {"success": True, "message": "Credential updated successfully"}
+            litellm.credential_list.append(updated_in_memory)
+
         return {"success": True, "message": "Credential updated successfully"}
     except Exception as e:
         return handle_exception_on_proxy(e)

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -349,7 +349,13 @@ async def update_credential(
                 existing_in_memory = cred
                 break
 
-        if existing_in_memory is not None:
+        if existing_in_memory is None:
+            verbose_proxy_logger.warning(
+                "Credential '%s' updated in DB but not found in litellm.credential_list; "
+                "GET endpoints will return stale data until the proxy reloads credentials.",
+                credential_name,
+            )
+        else:
             in_memory_values = dict(existing_in_memory.credential_values or {})
             if credential.credential_values:
                 in_memory_values.update(credential.credential_values)
@@ -361,16 +367,13 @@ async def update_credential(
                 credential_values=in_memory_values,
                 credential_info=in_memory_info,
             )
-            # Remove old entry if renamed, then append updated one
+            # Remove old entry if renamed, then use upsert_credentials to handle duplicates
             if new_name != credential_name:
                 litellm.credential_list = [
                     c for c in litellm.credential_list
                     if c.credential_name != credential_name
                 ]
-            else:
-                CredentialAccessor.upsert_credentials([updated_in_memory])
-                return {"success": True, "message": "Credential updated successfully"}
-            litellm.credential_list.append(updated_in_memory)
+            CredentialAccessor.upsert_credentials([updated_in_memory])
 
         return {"success": True, "message": "Credential updated successfully"}
     except Exception as e:


### PR DESCRIPTION
**Problem**
When updating a credential via `PATCH /credentials/{credential_name}`, the change was persisted to the database but the in-memory `litellm.credential_list` was not updated. Since all GET credential endpoints (`GET /credentials`, `GET /credentials/by_name/{name}`, etc.) read directly from this in-memory list rather than querying the DB, the updated values would not be visible until the process restarted.

**Root Cause**
`create_credential` correctly calls `CredentialAccessor.upsert_credentials()` to sync the in-memory list after writing to the DB, but update_credential was missing this step entirely.

**Fix**
After the DB `update` succeeds in `update_credential`, build a plaintext merged `CredentialItem` by combining the existing in-memory values with the incoming patch, then call `CredentialAccessor.upsert_credentials()` to update `litellm.credential_list` in-place immediately.

This makes `create`, `update`, and `delete` consistent — all three now keep the in-memory list in sync with the DB after every write.