### PR TITLE
Per model budget enforcement

### DIFF
--- a/litellm-js/spend-logs/schema.prisma
+++ b/litellm-js/spend-logs/schema.prisma
@@ -26,4 +26,6 @@ model LiteLLM_SpendLogs {
   request_tags      Json     @default("[]")
   team_id           String?
   end_user          String?
+  @@index([api_key, startTime])
+  @@index([end_user, startTime])
 }

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260415000000_add_spend_logs_budget_indexes/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260415000000_add_spend_logs_budget_indexes/migration.sql
@@ -1,0 +1,6 @@
+-- CreateIndex: support fast per-key and per-end-user spend lookups
+-- used by the cold-cache DB fallback in _PROXY_VirtualKeyModelMaxBudgetLimiter
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx" ON "LiteLLM_SpendLogs"("api_key", "startTime");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_end_user_startTime_idx" ON "LiteLLM_SpendLogs"("end_user", "startTime");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -579,6 +579,8 @@ model LiteLLM_SpendLogs {
   @@index([startTime])
   @@index([startTime, request_id])
   @@index([end_user])
+  @@index([end_user, startTime])
+  @@index([api_key, startTime])
   @@index([session_id])
 }
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -900,6 +900,52 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                             valid_token.project_metadata = _jwt_project_obj.metadata
                             valid_token.project_alias = _jwt_project_obj.project_alias
 
+                    # Apply end-user budget limits so downstream checks work.
+                    # auth_builder already fetched end_user_object (with its
+                    # litellm_budget_table) so we reuse that here rather than
+                    # re-fetching.  When end_user_object is None (user not in
+                    # DB) we still apply the global default budget if one is
+                    # configured — mirroring the key auth path at line ~1032.
+                    if (
+                        end_user_object is not None
+                        and end_user_object.litellm_budget_table is not None
+                    ):
+                        _eu_params: dict = {"end_user_id": end_user_id}
+                        _apply_budget_limits_to_end_user_params(
+                            end_user_params=_eu_params,
+                            budget_info=end_user_object.litellm_budget_table,
+                            end_user_id=end_user_id or "",
+                        )
+                        valid_token = update_valid_token_with_end_user_params(
+                            valid_token=valid_token,
+                            end_user_params=_eu_params,
+                        )
+                    elif (
+                        end_user_object is None
+                        and end_user_id is not None
+                        and litellm.max_end_user_budget_id is not None
+                    ):
+                        from litellm.proxy.auth.auth_checks import (
+                            get_default_end_user_budget,
+                        )
+
+                        _default_budget = await get_default_end_user_budget(
+                            prisma_client=prisma_client,
+                            user_api_key_cache=user_api_key_cache,
+                            parent_otel_span=parent_otel_span,
+                        )
+                        if _default_budget is not None:
+                            _eu_params = {"end_user_id": end_user_id}
+                            _apply_budget_limits_to_end_user_params(
+                                end_user_params=_eu_params,
+                                budget_info=_default_budget,
+                                end_user_id=end_user_id,
+                            )
+                            valid_token = update_valid_token_with_end_user_params(
+                                valid_token=valid_token,
+                                end_user_params=_eu_params,
+                            )
+
                     # run through common checks
                     _ = await common_checks(
                         request=request,
@@ -916,6 +962,26 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         skip_budget_checks=skip_budget_checks,
                         project_object=_jwt_project_obj,
                     )
+
+                    # Check end-user per-model budget (JWT auth path).
+                    # The key auth path handles this in the budget_checks block
+                    # further down the function; we need an explicit check here
+                    # because the JWT path returns before reaching that block.
+                    if not skip_budget_checks and model_max_budget_limiter is not None:
+                        _jwt_current_model = request_data.get("model", None)
+                        _jwt_end_user_mmb = valid_token.end_user_model_max_budget
+                        if (
+                            _jwt_end_user_mmb is not None
+                            and isinstance(_jwt_end_user_mmb, dict)
+                            and len(_jwt_end_user_mmb) > 0
+                            and _jwt_current_model is not None
+                            and valid_token.end_user_id is not None
+                        ):
+                            await model_max_budget_limiter.is_end_user_within_model_budget(
+                                end_user_id=valid_token.end_user_id,
+                                end_user_model_max_budget=_jwt_end_user_mmb,
+                                model=_jwt_current_model,
+                            )
 
                     # return UserAPIKeyAuth object
                     return cast(UserAPIKeyAuth, valid_token)

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -1,10 +1,12 @@
 import json
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import Span
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
 from litellm.types.llms.openai import AllMessageValues
@@ -145,6 +147,16 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         model: str,
         key_budget_config: BudgetConfig,
     ) -> Optional[float]:
+        """
+        Get the current spend for an end-user for a model.
+
+        Lookup order:
+            1. Cache keyed by exact `model`
+            2. Cache keyed by model without custom_llm_provider prefix
+            3. DB fallback (cold-cache guard) — sums LiteLLM_SpendLogs within
+               the current budget window so budget limits are enforced even on
+               the first request after a cache flush or proxy restart.
+        """
         # 1. model: directly look up `model`
         end_user_model_spend_cache_key = f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model}:{key_budget_config.budget_duration}"
         _current_spend = await self.dual_cache.async_get_cache(
@@ -157,6 +169,26 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             _current_spend = await self.dual_cache.async_get_cache(
                 key=end_user_model_spend_cache_key,
             )
+
+        if _current_spend is None and key_budget_config.budget_duration:
+            # 3. Both cache tiers cold — query DB so we don't accidentally pass
+            #    through a request that has already exceeded its budget.
+            _current_spend = await self._get_spend_from_db(
+                model=model,
+                budget_duration=key_budget_config.budget_duration,
+                budget_start_time_key=f"end_user_budget_start_time:{end_user_id}",
+                entity_filter={"end_user": end_user_id},
+            )
+            # Seed the canonical cache key so subsequent requests don't hit DB
+            # again until async_log_success_event writes the first increment.
+            if _current_spend is not None and key_budget_config.budget_duration:
+                ttl = duration_in_seconds(key_budget_config.budget_duration)
+                await self.dual_cache.async_set_cache(
+                    key=end_user_model_spend_cache_key,
+                    value=_current_spend,
+                    ttl=ttl,
+                )
+
         return _current_spend
 
     async def _get_virtual_key_spend_for_model(
@@ -166,11 +198,14 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         key_budget_config: BudgetConfig,
     ) -> Optional[float]:
         """
-        Get the current spend for a virtual key for a model
+        Get the current spend for a virtual key for a model.
 
-        Lookup model in this order:
-            1. model: directly look up `model`
-            2. If 1, does not exist, check if passed as {custom_llm_provider}/model
+        Lookup order:
+            1. Cache keyed by exact `model`
+            2. Cache keyed by model without custom_llm_provider prefix
+            3. DB fallback (cold-cache guard) — sums LiteLLM_SpendLogs within
+               the current budget window so budget limits are enforced even on
+               the first request after a cache flush or proxy restart.
         """
 
         # 1. model: directly look up `model`
@@ -186,6 +221,30 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             _current_spend = await self.dual_cache.async_get_cache(
                 key=virtual_key_model_spend_cache_key,
             )
+
+        if (
+            _current_spend is None
+            and user_api_key_hash is not None
+            and key_budget_config.budget_duration
+        ):
+            # 3. Both cache tiers cold — query DB so we don't accidentally pass
+            #    through a request that has already exceeded its budget.
+            _current_spend = await self._get_spend_from_db(
+                model=model,
+                budget_duration=key_budget_config.budget_duration,
+                budget_start_time_key=f"virtual_key_budget_start_time:{user_api_key_hash}",
+                entity_filter={"api_key": user_api_key_hash},
+            )
+            # Seed the canonical cache key so subsequent requests don't hit DB
+            # again until async_log_success_event writes the first increment.
+            if _current_spend is not None and key_budget_config.budget_duration:
+                ttl = duration_in_seconds(key_budget_config.budget_duration)
+                await self.dual_cache.async_set_cache(
+                    key=virtual_key_model_spend_cache_key,
+                    value=_current_spend,
+                    ttl=ttl,
+                )
+
         return _current_spend
 
     def _get_request_model_budget_config(
@@ -207,6 +266,62 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         if "/" in model:
             return model.split("/")[-1]
         return model
+
+    async def _get_spend_from_db(
+        self,
+        model: str,
+        budget_duration: str,
+        budget_start_time_key: str,
+        entity_filter: dict,
+    ) -> Optional[float]:
+        """
+        DB fallback when cache is cold.
+
+        Queries LiteLLM_SpendLogs and sums spend for the given entity + model
+        within the current budget window. This prevents requests from slipping
+        through unenforced on the very first call after a cache flush or proxy
+        restart.
+
+        Returns None if prisma_client is unavailable (budget check is skipped
+        gracefully — same behaviour as before this fallback was added).
+        """
+        from litellm.proxy.proxy_server import prisma_client  # circular-import exception
+
+        if prisma_client is None:
+            return None
+
+        if not budget_duration:
+            return None
+
+        ttl_seconds = duration_in_seconds(budget_duration)
+        budget_start = await self.dual_cache.async_get_cache(budget_start_time_key)
+        if budget_start is not None:
+            window_start = datetime.fromtimestamp(float(budget_start), tz=timezone.utc)
+        else:
+            window_start = datetime.now(timezone.utc) - timedelta(seconds=ttl_seconds)
+
+        model_without_provider = self._get_model_without_custom_llm_provider(model)
+        # Match model_group (preferred — what spend logger writes) with a
+        # fallback to the raw model field for rows written before model_group
+        # was populated. Also strip provider prefix so a budget keyed on
+        # "gpt-4o" matches logs written as "openai/gpt-4o".
+        model_candidates = list(dict.fromkeys([model, model_without_provider]))
+        model_or_clauses = [{"model_group": m} for m in model_candidates] + [
+            {"model": m} for m in model_candidates
+        ]
+
+        where: dict = {
+            **entity_filter,
+            "OR": model_or_clauses,
+            "startTime": {"gte": window_start},
+        }
+
+        rows = await prisma_client.db.litellm_spendlogs.group_by(
+            by=["model_group"],
+            where=where,
+            sum={"spend": True},
+        )
+        return sum((row.get("_sum") or {}).get("spend") or 0.0 for row in rows)
 
     async def async_filter_deployments(
         self,

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -579,6 +579,8 @@ model LiteLLM_SpendLogs {
   @@index([startTime])
   @@index([startTime, request_id])
   @@index([end_user])
+  @@index([end_user, startTime])
+  @@index([api_key, startTime])
   @@index([session_id])
 }
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -579,6 +579,8 @@ model LiteLLM_SpendLogs {
   @@index([startTime])
   @@index([startTime, request_id])
   @@index([end_user])
+  @@index([end_user, startTime])
+  @@index([api_key, startTime])
   @@index([session_id])
 }
 

--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -413,3 +413,137 @@ async def test_async_log_success_event_uses_end_user_model_budget_duration(
             f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model}:{budget_duration}"
         )
         assert call_kwargs["response_cost"] == 0.05
+
+
+# ---------------------------------------------------------------------------
+# DB fallback tests (Bug 2 — cold cache = no enforcement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_virtual_key_spend_db_fallback_enforces_budget(budget_limiter):
+    """
+    When both cache lookups return None (cold cache), _get_virtual_key_spend_for_model
+    must fall back to _get_spend_from_db and return that value so the caller can
+    raise BudgetExceededError rather than silently passing the request through.
+    """
+    budget_config = GenericBudgetInfo(budget_limit=100.0, time_period="1d")
+
+    # Both cache tiers cold
+    with patch.object(
+        budget_limiter.dual_cache, "async_get_cache", return_value=None
+    ):
+        with patch.object(
+            budget_limiter,
+            "_get_spend_from_db",
+            new_callable=AsyncMock,
+            return_value=120.0,  # over budget
+        ) as mock_db:
+            spend = await budget_limiter._get_virtual_key_spend_for_model(
+                user_api_key_hash="hash-abc",
+                model="gpt-4o",
+                key_budget_config=budget_config,
+            )
+
+    assert spend == 120.0
+    mock_db.assert_awaited_once()
+    call_kwargs = mock_db.call_args.kwargs
+    assert call_kwargs["model"] == "gpt-4o"
+    assert call_kwargs["budget_duration"] == "1d"
+    assert "hash-abc" in call_kwargs["budget_start_time_key"]
+    assert call_kwargs["entity_filter"] == {"api_key": "hash-abc"}
+
+
+@pytest.mark.asyncio
+async def test_get_end_user_spend_db_fallback_enforces_budget(budget_limiter):
+    """
+    When both cache lookups return None, _get_end_user_spend_for_model must
+    fall back to _get_spend_from_db and return the DB value.
+    """
+    budget_config = GenericBudgetInfo(budget_limit=50.0, time_period="7d")
+
+    with patch.object(
+        budget_limiter.dual_cache, "async_get_cache", return_value=None
+    ):
+        with patch.object(
+            budget_limiter,
+            "_get_spend_from_db",
+            new_callable=AsyncMock,
+            return_value=55.0,
+        ) as mock_db:
+            spend = await budget_limiter._get_end_user_spend_for_model(
+                end_user_id="user-xyz",
+                model="claude-3",
+                key_budget_config=budget_config,
+            )
+
+    assert spend == 55.0
+    mock_db.assert_awaited_once()
+    call_kwargs = mock_db.call_args.kwargs
+    assert call_kwargs["entity_filter"] == {"end_user": "user-xyz"}
+    assert "user-xyz" in call_kwargs["budget_start_time_key"]
+
+
+@pytest.mark.asyncio
+async def test_get_virtual_key_spend_cache_hit_skips_db(budget_limiter):
+    """
+    When cache returns a value, _get_spend_from_db must NOT be called.
+    The DB fallback is only for cold-cache scenarios.
+    """
+    budget_config = GenericBudgetInfo(budget_limit=100.0, time_period="1d")
+
+    with patch.object(
+        budget_limiter.dual_cache, "async_get_cache", return_value=30.0
+    ):
+        with patch.object(
+            budget_limiter, "_get_spend_from_db", new_callable=AsyncMock
+        ) as mock_db:
+            spend = await budget_limiter._get_virtual_key_spend_for_model(
+                user_api_key_hash="hash-abc",
+                model="gpt-4o",
+                key_budget_config=budget_config,
+            )
+
+    assert spend == 30.0
+    mock_db.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_db_fallback_seeds_cache(budget_limiter):
+    """
+    After a successful DB fallback, the result must be written to cache so
+    subsequent requests don't hit the DB on every call.
+    """
+    budget_config = GenericBudgetInfo(budget_limit=100.0, time_period="1d")
+
+    set_cache_calls = []
+
+    async def fake_get_cache(key):
+        return None  # always cold
+
+    async def fake_set_cache(key, value, ttl=None):
+        set_cache_calls.append((key, value, ttl))
+
+    with patch.object(
+        budget_limiter.dual_cache, "async_get_cache", side_effect=fake_get_cache
+    ):
+        with patch.object(
+            budget_limiter.dual_cache, "async_set_cache", side_effect=fake_set_cache
+        ):
+            with patch.object(
+                budget_limiter,
+                "_get_spend_from_db",
+                new_callable=AsyncMock,
+                return_value=75.0,
+            ):
+                await budget_limiter._get_virtual_key_spend_for_model(
+                    user_api_key_hash="hash-abc",
+                    model="gpt-4o",
+                    key_budget_config=budget_config,
+                )
+
+    assert len(set_cache_calls) == 1, "Expected exactly one cache write to seed the result"
+    cached_key, cached_value, cached_ttl = set_cache_calls[0]
+    assert cached_value == 75.0
+    assert "gpt-4o" in cached_key
+    assert "1d" in cached_key


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Addresses the following query

<img width="2048" height="772" alt="image" src="https://github.com/user-attachments/assets/53d69416-bb3a-4c56-b089-f7cebee13cbb" />

### Problem
Per-model spend budgets (for both virtual keys and end-users) had two holes where requests could slip through without enforcement:

1. **Cold cache** — budget checks only read from cache. On a fresh proxy start or after a cache flush, cache returns `None` and the check silently passes the request through unchecked, regardless of how much the entity had already spent.

2. **JWT auth path** — the standard JWT auth code path returned before ever reaching the model budget check block. End-users with per-model budgets would never have those limits enforced when authenticating via JWT.

### Solution

1. Added a DB fallback tier to `_get_virtual_key_spend_for_model` and `_get_end_user_spend_for_model` — when both cache lookups miss, query `LiteLLM_SpendLogs` directly for spend within the current budget window. The result is seeded back into cache so subsequent requests don't repeat the DB hit.

2. In the JWT auth path, applied end-user budget limits from the already-fetched `end_user_object` onto `valid_token`, then added the `is_end_user_within_model_budget` check before the path returns — mirroring what the key auth path already did, including the global default budget fallback.