### PR TITLE
fix(openai): pass `user` param for all OpenAI-compatible endpoints

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -166,6 +166,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             "prompt_cache_key",
             "prompt_cache_retention",
             "store",
+            "user",  # standard OpenAI Chat Completions API param; passed for all OpenAI-compatible endpoints
         ]  # works across all models
 
         model_specific_params = []
@@ -178,12 +179,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         model_for_check = (
             model.split("responses/", 1)[1] if "responses/" in model else model
         )
-        if (
-            model_for_check in litellm.open_ai_chat_completion_models
-        ) or model_for_check in litellm.open_ai_text_completion_models:
-            model_specific_params.append(
-                "user"
-            )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
+        _ = model_for_check  # retained for future model-specific logic
         return base_params + model_specific_params
 
     def _map_openai_params(


### PR DESCRIPTION
## Problem

Closes #25753

When using `litellm.completion()` with a custom OpenAI-compatible endpoint (e.g. `model="openai/my-custom-model"`), the `user` parameter is silently dropped from the request body. No warning or error is raised.

**Root cause:** In `get_supported_openai_params()`, `user` was only appended to `model_specific_params` when the model name appeared in the official `litellm.open_ai_chat_completion_models` or `litellm.open_ai_text_completion_models` lists. Any custom model name (local proxies, self-hosted models, etc.) would therefore never include `user` in its supported params.

## Fix

Move `user` into `base_params` so it is forwarded for **all** models using the OpenAI provider path.

**Why this is safe:**
- `user` is a standard field in the [OpenAI Chat Completions API spec](https://platform.openai.com/docs/api-reference/chat/create#chat-create-user)
- Azure AI uses its own `litellm/llms/azure/chat/gpt_transformation.py` which already overrides `get_supported_openai_params()` and explicitly includes `user` — so Azure behaviour is **unchanged**
- If a specific endpoint doesn't support `user`, callers can use `drop_params=True` as they do today

## Before / After

```python
# Before — user silently dropped for custom models
litellm.completion(
    model="openai/my-custom-model",
    messages=[{"role": "user", "content": "Hello"}],
    user="my-user-id",          # ← dropped, no warning
    api_base="http://my-proxy:8080/v1",
)

# After — user forwarded correctly
litellm.completion(
    model="openai/my-custom-model",
    messages=[{"role": "user", "content": "Hello"}],
    user="my-user-id",          # ← forwarded as expected
    api_base="http://my-proxy:8080/v1",
)
```

## Changes

- `litellm/llms/openai/chat/gpt_transformation.py`: add `"user"` to `base_params`; remove the now-unnecessary model-whitelist conditional