### PR TITLE
fix(openai): include 'user' in base_params for all OpenAI-compatible endpoints

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -175,10 +175,6 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         ):  # gpt-4 does not support 'response_format'
             model_specific_params.append("response_format")
 
-        # Normalize model name for responses API (e.g., "responses/gpt-4.1" -> "gpt-4.1")
-        model_for_check = (
-            model.split("responses/", 1)[1] if "responses/" in model else model
-        )
         return base_params + model_specific_params
 
     def _map_openai_params(

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -166,6 +166,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             "prompt_cache_key",
             "prompt_cache_retention",
             "store",
+            "user",
         ]  # works across all models
 
         model_specific_params = []
@@ -178,12 +179,6 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         model_for_check = (
             model.split("responses/", 1)[1] if "responses/" in model else model
         )
-        if (
-            model_for_check in litellm.open_ai_chat_completion_models
-        ) or model_for_check in litellm.open_ai_text_completion_models:
-            model_specific_params.append(
-                "user"
-            )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
         return base_params + model_specific_params
 
     def _map_openai_params(

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -550,3 +550,26 @@ class TestGPT5ReasoningEffortPreservation:
 
         assert optional_params.get("temperature") == 0.5
         assert non_default_params.get("reasoning_effort") == "none"
+
+    def test_user_param_supported_for_custom_openai_compatible_models(self):
+        """Test that 'user' param is in supported params for custom OpenAI-compatible endpoints.
+
+        Regression test for: https://github.com/BerriAI/litellm/issues/25753
+        When using a custom OpenAI-compatible endpoint (e.g., model="openai/my-custom-model"),
+        the 'user' parameter must be in supported_params so it is passed through to the API.
+        Previously, 'user' was only added for models in the hardcoded open_ai_chat_completion_models
+        whitelist, causing it to be silently dropped for all custom/unknown model names.
+        """
+        # Custom OpenAI-compatible endpoint - NOT in open_ai_chat_completion_models
+        supported_params = self.config.get_supported_openai_params("my-custom-model")
+        assert "user" in supported_params, (
+            "'user' should be in supported_params for custom OpenAI-compatible endpoints"
+        )
+
+        # Another common custom model name pattern
+        supported_params = self.config.get_supported_openai_params("openclaw")
+        assert "user" in supported_params
+
+        # Also verify standard models still support 'user' (no regression)
+        supported_params = self.config.get_supported_openai_params("gpt-4o")
+        assert "user" in supported_params


### PR DESCRIPTION
## Problem

The `user` parameter is silently dropped when using a custom OpenAI-compatible endpoint (e.g. `model="openai/my-custom-model"`). No warning or error is raised.

Fixes #25753.

## Root Cause

In `litellm/llms/openai/chat/gpt_transformation.py`, `get_supported_openai_params()` only appended `"user"` to supported params when the model name was in a hardcoded whitelist (`litellm.open_ai_chat_completion_models` / `litellm.open_ai_text_completion_models`). Custom endpoint models are not in that whitelist, so `"user"` was silently excluded.

## Fix

Move `"user"` from the model-specific conditional block to `base_params`, which are always included regardless of model name. 

**Why this is safe**: Azure AI (`azure/...`) uses its own provider class (`litellm/llms/azure/chat/gpt_transformation.py`) with a separate `get_supported_openai_params` that already includes `"user"`. Changing the OpenAI provider class does not affect Azure. The `user` field is part of the [OpenAI Chat Completions API spec](https://platform.openai.com/docs/api-reference/chat/create#chat-create-user) and is appropriate for all OpenAI-compatible endpoints.

## Changes

- `litellm/llms/openai/chat/gpt_transformation.py`: move `"user"` into `base_params`, remove now-redundant conditional
- `tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py`: add regression test for custom model names

## Testing

Added `test_user_param_supported_for_custom_openai_compatible_models` to the existing `TestOpenAIGPTConfig` test class. Verifies:
- Custom model names (e.g. `"my-custom-model"`, `"openclaw"`) now include `"user"` in supported params
- Standard models (`gpt-4o`) still include `"user"` (no regression)