### PR TITLE
fix(noma-v2 + streaming): deepcopy crash on post_call/during_call; bursty Bedrock streaming regression

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -74,6 +74,77 @@ def _next_sync_or_exhausted(it: Any) -> Any:
         return _SYNC_ITER_EXHAUSTED
 
 
+class _SyncToAsyncQueueIterator:
+    """
+    Wraps a synchronous iterator for use in async code via a single producer thread
+    and an asyncio.Queue, providing smooth per-chunk delivery without per-chunk
+    thread-dispatch overhead.
+
+    Background
+    ----------
+    The previous approach (asyncio.to_thread per chunk) dispatches a new thread-pool
+    task for every call to __anext__. Each dispatch cycle has ~1 ms of scheduling
+    overhead during which the upstream TCP socket can accumulate multiple chunks.
+    When the thread wakes up, it reads only the first buffered chunk; the next call
+    to to_thread returns almost instantly because additional chunks are already
+    waiting in the buffer. The result is bursty delivery: 80%+ of chunks arrive
+    with <1 ms between them instead of the smooth ~20 ms spacing of the raw stream.
+
+    This class starts ONE background thread that iterates the sync stream
+    continuously, pushing each item into an asyncio.Queue as it arrives via
+    call_soon_threadsafe. The async consumer awaits the queue one item at a time,
+    receiving chunks as they arrive from the upstream source with no per-chunk
+    thread-dispatch overhead.
+
+    The background thread is daemon=True so it never prevents process exit.
+    """
+
+    __slots__ = ("_sync_iter", "_queue", "_thread", "_loop", "_exhausted")
+
+    def __init__(self, sync_iter: Any) -> None:
+        self._sync_iter = sync_iter
+        self._loop = asyncio.get_running_loop()
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._exhausted = False
+        self._thread = threading.Thread(target=self._producer, daemon=True)
+        self._thread.start()
+
+    def _producer(self) -> None:
+        def _put(item: Any) -> None:
+            try:
+                self._loop.call_soon_threadsafe(self._queue.put_nowait, item)
+            except RuntimeError:
+                # Event loop closed before producer finished (e.g. early cancellation).
+                # Nothing to do — the consumer is gone.
+                pass
+
+        try:
+            for item in self._sync_iter:
+                _put(item)
+        except Exception as exc:
+            _put(exc)
+        finally:
+            _put(_SYNC_ITER_EXHAUSTED)
+
+    def __aiter__(self) -> "_SyncToAsyncQueueIterator":
+        return self
+
+    async def __anext__(self) -> Any:
+        # After the sentinel has been consumed once, raise immediately on all
+        # subsequent calls. Without this guard, calls block forever on an empty
+        # queue — this matters because CustomStreamWrapper detects that the
+        # wrapper is async-iterable and may call __anext__ an extra time.
+        if self._exhausted:
+            raise StopAsyncIteration
+        item = await self._queue.get()
+        if item is _SYNC_ITER_EXHAUSTED:
+            self._exhausted = True
+            raise StopAsyncIteration
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+
 def is_async_iterable(obj: Any) -> bool:
     """
     Check if an object is an async iterable (can be used with 'async for').
@@ -2114,9 +2185,21 @@ class CustomStreamWrapper:
                     ):
                         chunk = self.completion_stream
                     else:
-                        chunk = await asyncio.to_thread(_next_sync_or_exhausted, self.completion_stream)  # type: ignore[arg-type]
-                        if chunk is _SYNC_ITER_EXHAUSTED:
-                            raise StopAsyncIteration
+                        # Lazily upgrade the sync iterator to a queue-based async wrapper
+                        # on the first chunk. This replaces per-chunk asyncio.to_thread
+                        # dispatch, which allows the socket buffer to accumulate multiple
+                        # chunks per dispatch cycle and causes bursty delivery. The queue
+                        # wrapper uses a single producer thread that pushes chunks as they
+                        # arrive, giving smooth per-chunk delivery. Non-blocking property
+                        # of the event loop is preserved — __anext__ awaits the queue.
+                        if not isinstance(
+                            self.completion_stream, _SyncToAsyncQueueIterator
+                        ):
+                            self.completion_stream = _SyncToAsyncQueueIterator(
+                                self.completion_stream
+                            )
+                        chunk = await self.completion_stream.__anext__()
+                        # StopAsyncIteration propagates naturally to the outer handler
                     if chunk is not None and chunk != b"":
                         processed_chunk = self.chunk_creator(chunk=chunk)
                         if processed_chunk is None:

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -8,6 +8,8 @@ import enum
 import json
 import os
 from datetime import datetime
+
+from litellm.litellm_core_utils.core_helpers import safe_deep_copy
 from typing import TYPE_CHECKING, Any, Literal, Optional, Type, cast
 from urllib.parse import urlparse
 
@@ -138,13 +140,14 @@ class NomaV2Guardrail(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"],
         application_id: Optional[str],
     ) -> dict:
-        # JSON round-trip instead of deepcopy: request_data can contain non-serializable
+        # safe_deep_copy instead of deepcopy: request_data can contain non-serializable
         # C-extension objects (e.g. uvloop.Loop) during post_call/during_call hooks,
         # causing deepcopy to crash with "no default __reduce__ due to non-trivial __cinit__".
-        # json.dumps with default=str safely stringifies those objects, and the round-trip
-        # still produces a fully isolated copy for the same reason deepcopy was used.
-        # _sanitize_payload_for_transport() applies the same pattern downstream anyway.
-        payload_request_data = json.loads(json.dumps(request_data, default=str))
+        # safe_deep_copy copies each top-level key independently, falling back to the
+        # original reference on per-key failure, so it never crashes.
+        # _sanitize_payload_for_transport() handles serialization of any remaining
+        # non-serializable values before the payload is sent over the wire.
+        payload_request_data = safe_deep_copy(request_data)
         if logging_obj is not None:
             payload_request_data["litellm_logging_obj"] = getattr(
                 logging_obj, "model_call_details", None

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -7,7 +7,6 @@
 import enum
 import json
 import os
-from copy import deepcopy
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional, Type, cast
 from urllib.parse import urlparse
@@ -139,7 +138,13 @@ class NomaV2Guardrail(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"],
         application_id: Optional[str],
     ) -> dict:
-        payload_request_data = deepcopy(request_data)
+        # JSON round-trip instead of deepcopy: request_data can contain non-serializable
+        # C-extension objects (e.g. uvloop.Loop) during post_call/during_call hooks,
+        # causing deepcopy to crash with "no default __reduce__ due to non-trivial __cinit__".
+        # json.dumps with default=str safely stringifies those objects, and the round-trip
+        # still produces a fully isolated copy for the same reason deepcopy was used.
+        # _sanitize_payload_for_transport() applies the same pattern downstream anyway.
+        payload_request_data = json.loads(json.dumps(request_data, default=str))
         if logging_obj is not None:
             payload_request_data["litellm_logging_obj"] = getattr(
                 logging_obj, "model_call_details", None

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -18,6 +18,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.streaming_handler import (
     AUDIO_ATTRIBUTE,
     CustomStreamWrapper,
+    _SyncToAsyncQueueIterator,
 )
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
@@ -1945,4 +1946,146 @@ def test_gemini_legacy_vertex_tool_calls_finish_reason_with_stop_enum():
     assert final.choices[0].finish_reason == "tool_calls", (
         f"Expected 'tool_calls' but got {final.choices[0].finish_reason!r}. "
         "STOP enum was not normalised through map_finish_reason()."
+    )
+
+
+# ---------------------------------------------------------------------------
+# _SyncToAsyncQueueIterator tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_delivers_items_in_order():
+    """Items produced by the sync iterator arrive in the correct order."""
+    items = [1, 2, 3, 4, 5]
+    wrapper = _SyncToAsyncQueueIterator(iter(items))
+    received = []
+    async for item in wrapper:
+        received.append(item)
+    assert received == items
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_raises_stop_async_iteration_when_exhausted():
+    """StopAsyncIteration is raised cleanly after the last item — no RuntimeError."""
+    wrapper = _SyncToAsyncQueueIterator(iter([42]))
+    assert await wrapper.__anext__() == 42
+    with pytest.raises(StopAsyncIteration):
+        await wrapper.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_propagates_sync_iterator_exceptions():
+    """Exceptions raised inside the sync iterator are re-raised in the async consumer."""
+
+    def _exploding_iter():
+        yield 1
+        raise ValueError("upstream failure")
+
+    wrapper = _SyncToAsyncQueueIterator(_exploding_iter())
+    assert await wrapper.__anext__() == 1
+    with pytest.raises(ValueError, match="upstream failure"):
+        await wrapper.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_does_not_block_event_loop():
+    """
+    The async consumer must not block the event loop while waiting for a slow
+    sync iterator. A concurrent coroutine must be able to run freely.
+    """
+
+    class SlowIter:
+        def __init__(self):
+            self._done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._done:
+                raise StopIteration
+            self._done = True
+            time.sleep(0.2)  # simulate blocking I/O
+            return "chunk"
+
+    wrapper = _SyncToAsyncQueueIterator(SlowIter())
+    tick_ran = asyncio.Event()
+
+    async def background_tick():
+        await asyncio.sleep(0.05)
+        tick_ran.set()
+
+    start = asyncio.get_event_loop().time()
+    item, _ = await asyncio.gather(wrapper.__anext__(), background_tick())
+    elapsed = asyncio.get_event_loop().time() - start
+
+    assert item == "chunk"
+    assert tick_ran.is_set(), "Background coroutine never ran — event loop was blocked"
+    assert elapsed < 0.4, f"Took too long ({elapsed:.2f}s), event loop likely blocked"
+
+
+@pytest.mark.asyncio
+async def test_custom_stream_wrapper_bedrock_path_uses_queue_iterator(
+    logging_obj: Logging,
+):
+    """
+    Regression: asyncio.to_thread per-chunk caused socket-buffer accumulation and
+    bursty delivery for Bedrock (sync-iterator) streams. After the fix, the sync
+    iterator is upgraded to _SyncToAsyncQueueIterator on the first chunk, and
+    completion_stream is replaced in-place so subsequent chunks read from the queue.
+    """
+
+    class FakeSyncIter:
+        def __init__(self, chunks):
+            self._it = iter(chunks)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._it)
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-bedrock-test",
+        created=int(time.time()),
+        model="test-model",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content="hello",
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields={},
+        usage=None,
+    )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=FakeSyncIter([chunk]),
+        model="test-model",
+        logging_obj=logging_obj,
+        custom_llm_provider="cached_response",
+    )
+
+    try:
+        while True:
+            await wrapper.__anext__()
+    except StopAsyncIteration:
+        pass
+
+    # After iteration, completion_stream must have been upgraded to the queue wrapper
+    assert isinstance(wrapper.completion_stream, _SyncToAsyncQueueIterator), (
+        "completion_stream was not upgraded to _SyncToAsyncQueueIterator — "
+        "asyncio.to_thread per-chunk regression may have returned"
     )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
@@ -159,7 +159,7 @@ class TestNomaV2Configuration:
 
     def test_build_scan_payload_handles_non_serializable_request_data(self, noma_v2_guardrail):
         """Regression: deepcopy crashed when request_data contained C-extension objects
-        like uvloop.Loop (post_call/during_call hooks). The JSON-safe copy must not raise."""
+        like uvloop.Loop (post_call/during_call hooks). safe_deep_copy must not raise."""
 
         class _UndeepCopyable:
             """Simulates uvloop.Loop: a Cython type whose __cinit__ prevents deepcopy."""
@@ -170,9 +170,10 @@ class TestNomaV2Configuration:
             def __repr__(self):
                 return "<UndeepCopyable>"
 
+        loop_obj = _UndeepCopyable()
         request_data = {
             "messages": [{"role": "user", "content": "hello"}],
-            "metadata": {"event_loop": _UndeepCopyable()},
+            "metadata": {"event_loop": loop_obj},
         }
 
         # Must not raise even though request_data contains a non-serializable object.
@@ -185,8 +186,10 @@ class TestNomaV2Configuration:
         )
 
         assert payload["request_data"]["messages"][0]["content"] == "hello"
-        # Non-serializable object is safely stringified rather than crashing.
-        assert isinstance(payload["request_data"]["metadata"]["event_loop"], str)
+        # safe_deep_copy falls back to the original reference for keys that cannot
+        # be deepcopied — the object is preserved (not crashed, not stringified).
+        # _sanitize_payload_for_transport handles serialization before transport.
+        assert payload["request_data"]["metadata"]["event_loop"] is loop_obj
 
     def test_build_scan_payload_passes_model_call_details_as_is(self, noma_v2_guardrail):
         class _LoggingObj:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
@@ -137,7 +137,8 @@ class TestNomaV2Configuration:
         assert "x-noma-context" not in payload
         assert "input" not in payload
 
-    def test_build_scan_payload_deep_copies_request_data(self, noma_v2_guardrail):
+    def test_build_scan_payload_isolates_request_data(self, noma_v2_guardrail):
+        """Mutations to the payload copy must not affect the original request_data."""
         request_data = {
             "metadata": {"headers": {"x-noma-application-id": "header-app"}},
             "messages": [{"role": "user", "content": "hello"}],
@@ -155,6 +156,37 @@ class TestNomaV2Configuration:
 
         assert request_data["metadata"]["headers"]["x-noma-application-id"] == "header-app"
         assert request_data["messages"][0]["content"] == "hello"
+
+    def test_build_scan_payload_handles_non_serializable_request_data(self, noma_v2_guardrail):
+        """Regression: deepcopy crashed when request_data contained C-extension objects
+        like uvloop.Loop (post_call/during_call hooks). The JSON-safe copy must not raise."""
+
+        class _UndeepCopyable:
+            """Simulates uvloop.Loop: a Cython type whose __cinit__ prevents deepcopy."""
+
+            def __deepcopy__(self, memo):
+                raise TypeError("no default __reduce__ due to non-trivial __cinit__")
+
+            def __repr__(self):
+                return "<UndeepCopyable>"
+
+        request_data = {
+            "messages": [{"role": "user", "content": "hello"}],
+            "metadata": {"event_loop": _UndeepCopyable()},
+        }
+
+        # Must not raise even though request_data contains a non-serializable object.
+        payload = noma_v2_guardrail._build_scan_payload(
+            inputs={"texts": ["hello"]},
+            request_data=request_data,
+            input_type="request",
+            logging_obj=None,
+            application_id="test-app",
+        )
+
+        assert payload["request_data"]["messages"][0]["content"] == "hello"
+        # Non-serializable object is safely stringified rather than crashing.
+        assert isinstance(payload["request_data"]["metadata"]["event_loop"], str)
 
     def test_build_scan_payload_passes_model_call_details_as_is(self, noma_v2_guardrail):
         class _LoggingObj:


### PR DESCRIPTION
## Relevant issues

Fixes #25773 (Noma v2 deepcopy crash)
Fixes #25785 (Bedrock streaming bursty delivery regression)

## Changes

### Bug 1 — Noma v2 post_call/during_call 500 crash (fixes #25773)

`_build_scan_payload()` in `noma_v2.py` called `deepcopy(request_data)` which crashes during `post_call`/`during_call`/`during_mcp_call` hooks because `request_data` contains a `uvloop.Loop` object at those stages — a Cython extension type that cannot be deepcopied:

```
no default __reduce__ due to non-trivial __cinit__
```

**Fix:** replace `deepcopy` with `safe_deep_copy()` (the existing LiteLLM utility in `core_helpers.py`), which copies each top-level key independently with a fallback to the original reference on per-key failure. `_sanitize_payload_for_transport()` handles serialization of any remaining non-serializable values before transport. *(Updated per reviewer feedback from @krrish — thanks!)*

### Bug 2 — Bedrock streaming bursty chunk delivery (fixes #25785)

PR #24177 replaced `next(self.completion_stream)` with `await asyncio.to_thread(...)` to avoid blocking the event loop. Correct intent, but each `to_thread` dispatch has ~1ms thread-pool overhead during which the Bedrock TCP socket buffers multiple chunks — causing 80–84% of chunks to arrive <1ms apart instead of the smooth ~20ms spacing of the raw stream.

**Fix:** introduce `_SyncToAsyncQueueIterator` — a single producer thread that iterates the sync stream continuously and pushes each chunk into an `asyncio.Queue` via `call_soon_threadsafe`. The async consumer awaits the queue one item at a time.
- Non-blocking guarantee preserved (`await queue.get()` suspends the coroutine, not the loop)
- PEP 479 / StopIteration handling preserved (producer uses a for-loop sentinel)
- `_exhausted` flag prevents hang on subsequent `__anext__` calls after the sentinel is consumed
- One thread per stream instead of one thread dispatch per chunk

## Files changed

- `litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py` — `safe_deep_copy` instead of `deepcopy`
- `litellm/litellm_core_utils/streaming_handler.py` — `_SyncToAsyncQueueIterator` class + lazy upgrade in Bedrock path
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py` — regression test updated for `safe_deep_copy` behaviour
- `tests/test_litellm/litellm_core_utils/test_streaming_handler.py` — 4 unit tests for `_SyncToAsyncQueueIterator` + integration regression test

## Pre-Submission checklist

- [x] Tests added in `tests/litellm/` directory
- [x] All unit tests pass (`85 passed in 8.82s`)
- [x] PR scope is isolated to two related bugs in the same code path

## Type

🐛 Bug Fix (×2)