### PR TITLE
fix(ui): prevent infinite re-render loop in VirtualKeysTable

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -94,11 +94,14 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
   });
   const [expandedAccordions, setExpandedAccordions] = useState<Record<string, boolean>>({});
 
-  // Use the filter logic hook
+  // Stable reference: `|| []` creates a new array literal on every render, which
+  // causes the useEffect in useFilterLogic to fire on every render → infinite loop.
+  const keysList = useMemo(() => keys?.keys ?? [], [keys?.keys]);
 
+  // Use the filter logic hook
   const { filters, filteredKeys, filteredTotalCount, allTeams, allOrganizations, handleFilterChange, handleFilterReset } =
     useFilterLogic({
-      keys: keys?.keys || [],
+      keys: keysList,
       teams,
       organizations,
     });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx
@@ -32,6 +32,52 @@ const makeApiResponse = (overrides: { keys?: any[]; total_count?: number; total_
   total_pages: overrides.total_pages ?? 1,
 });
 
+describe("useFilterLogic – stability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(keyListCall).mockResolvedValue(makeApiResponse());
+  });
+
+  it("should not enter an infinite render loop when keys prop is re-rendered with a new empty-array reference", async () => {
+    // Regression: callers that write `keys?.keys || []` produce a fresh `[]`
+    // on every render (when keys is undefined/null).  The useEffect([keys, filters])
+    // must not treat every new-reference empty array as a change that requires
+    // another setFilteredKeys call, which would re-render the consumer, which
+    // would produce yet another new `[]`, ad infinitum.
+    const { result, rerender } = renderHook(
+      ({ keys }) => useFilterLogic({ keys, teams: [], organizations: [] }),
+      { initialProps: { keys: [] as any[] } },
+    );
+
+    // Simulate the || [] pattern: each rerender gets a brand-new [] literal
+    act(() => {
+      rerender({ keys: [] });
+      rerender({ keys: [] });
+      rerender({ keys: [] });
+    });
+
+    // If we reach here the hook did not loop.
+    // filteredKeys should reflect the empty input.
+    expect(result.current.filteredKeys).toEqual([]);
+  });
+
+  it("should update filteredKeys when keys prop changes from empty to populated", async () => {
+    const { result, rerender } = renderHook(
+      ({ keys }) => useFilterLogic({ keys, teams: [], organizations: [] }),
+      { initialProps: { keys: [] as any[] } },
+    );
+
+    expect(result.current.filteredKeys).toEqual([]);
+
+    act(() => {
+      rerender({ keys: [mockKey as any] });
+    });
+
+    expect(result.current.filteredKeys).toHaveLength(1);
+    expect(result.current.filteredKeys[0]).toBe(mockKey);
+  });
+});
+
 describe("useFilterLogic – filteredTotalCount", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
# PR: fix(ui): prevent infinite re-render loop in VirtualKeysTable

## Relevant issues

<!-- No open issue found; bug reproduced locally in dev mode. -->

## Pre-Submission checklist

- [x] Added tests in `ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx`
- [x] `npm run test` passes for affected files (34/34)
- [x] Scope is isolated: one source file changed, one test file updated
- [x] Comment `@greptileai` on the PR and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Root cause

`VirtualKeysTable.tsx` passed `keys?.keys || []` directly into `useFilterLogic`:

```tsx
useFilterLogic({
  keys: keys?.keys || [],   // ← new [] literal on every render
  ...
})
```

While `keys` is loading (`keys?.keys` is `undefined`), the `|| []` fallback
produces a **new array reference on every render**.  The `useEffect([keys, filters])`
inside `useFilterLogic` treats each new reference as a change, calls
`setFilteredKeys`, which triggers a re-render, which produces another new `[]`…
resulting in an infinite loop.

In development mode this surfaces as:

```
Maximum update depth exceeded.
src/components/key_team_helpers/filter_logic.tsx (102:5) @ useFilterLogic.useEffect
```

In the production build React's production runtime silences the warning, but
the excess re-renders still occur on every page load.

### Fix

Stabilise the reference with `useMemo` before passing it to the hook
(`VirtualKeysTable.tsx`):

```tsx
// Before
useFilterLogic({
  keys: keys?.keys || [],
  ...
})

// After
const keysList = useMemo(() => keys?.keys ?? [], [keys?.keys]);

useFilterLogic({
  keys: keysList,
  ...
})
```

`useMemo` returns the **same** `[]` across renders until `keys?.keys` actually
changes, breaking the loop.  `??` is used instead of `||` to correctly handle
`null` as well as `undefined`.

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx` | Add `useMemo` to stabilise `keys` reference |
| `ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.test.tsx` | Add 2 regression tests |

### Tests added (`filter_logic.test.tsx`)

| Test | What it verifies |
|------|-----------------|
| `should not enter an infinite render loop when keys prop is re-rendered with a new empty-array reference` | Simulates the `\|\| []` pattern: calls `rerender({ keys: [] })` three times; the hook must complete without hanging |
| `should update filteredKeys when keys prop changes from empty to populated` | Verifies `filteredKeys` correctly reflects new data when `keys` transitions from `[]` to a populated array |
