### PR TITLE
fix(guardrails): ContentFilter streaming hook respects event_hook (#25780)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -212,17 +212,17 @@ class ContentFilterGuardrail(CustomGuardrail):
         self.image_model = image_model
         # Store loaded categories
         self.loaded_categories: Dict[str, CategoryConfig] = {}
-        self.category_keywords: Dict[
-            str, Tuple[str, str, ContentFilterAction]
-        ] = {}  # keyword -> (category, severity, action)
+        self.category_keywords: Dict[str, Tuple[str, str, ContentFilterAction]] = (
+            {}
+        )  # keyword -> (category, severity, action)
         # Always-block keywords are checked after exceptions (exceptions take precedence)
         self.always_block_category_keywords: Dict[
             str, Tuple[str, str, ContentFilterAction]
         ] = {}
         # Store conditional categories (identifier_words + block_words)
-        self.conditional_categories: Dict[
-            str, Dict[str, Any]
-        ] = {}  # category_name -> {identifier_words, block_words, action, severity}
+        self.conditional_categories: Dict[str, Dict[str, Any]] = (
+            {}
+        )  # category_name -> {identifier_words, block_words, action, severity}
 
         # Competitor intent checker (optional; airline uses major_airlines.json, generic requires competitors)
         self._competitor_intent_checker: Optional[BaseCompetitorIntentChecker] = None
@@ -1855,6 +1855,25 @@ class ContentFilterGuardrail(CustomGuardrail):
                 exception_str=exception_str,
             )
 
+    def _runs_on_response(self) -> bool:
+        """
+        Whether this guardrail is configured to scan response content.
+
+        Returns True only when event_hook is post_call or during_call (including
+        when either appears in a list). For pre_call / realtime_input_transcription
+        / unset, the streaming iterator must not modify the response — otherwise
+        a pre_call regex would silently also redact output, contradicting the
+        documented mode contract.
+        """
+        response_hooks = {
+            GuardrailEventHooks.post_call,
+            GuardrailEventHooks.during_call,
+        }
+        hook = self.event_hook
+        if isinstance(hook, list):
+            return any(h in response_hooks for h in hook)
+        return hook in response_hooks
+
     async def async_post_call_streaming_iterator_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -1866,7 +1885,16 @@ class ContentFilterGuardrail(CustomGuardrail):
 
         For BLOCK action: Raises HTTPException immediately when blocked content is detected.
         For MASK action: Content is buffered to handle patterns split across chunks.
+
+        Respects the configured ``event_hook``: if the guardrail is only meant
+        to run on the request (``pre_call``), the response stream is yielded
+        unchanged. Scanning only happens for ``post_call`` / ``during_call``.
         """
+        if not self._runs_on_response():
+            async for item in response:
+                yield item
+            return
+
         accumulated_full_text = ""
         yielded_masked_text_len = 0
         buffer_size = 50  # Increased buffer to catch patterns split across many chunks

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1859,36 +1859,31 @@ class ContentFilterGuardrail(CustomGuardrail):
         """
         Whether this guardrail is configured to scan response content.
 
-        Returns True when ``event_hook`` selects a response-side hook
-        (``post_call`` or ``during_call``). For ``pre_call`` /
-        ``realtime_input_transcription`` / unset, the streaming iterator must
-        not modify the response — otherwise a pre_call regex would silently
-        also redact output, contradicting the documented mode contract.
+        Only ``post_call`` is a response-side hook.  ``during_call`` is
+        dispatched by the framework as ``async_moderation_hook`` (runs in
+        parallel to the LLM call on the *input* side) and never reaches
+        ``async_post_call_streaming_iterator_hook``.  ``pre_call`` /
+        ``realtime_input_transcription`` / unset are input-only as well.
 
         Supports all three accepted ``event_hook`` shapes:
         - single ``GuardrailEventHooks`` value
-        - ``list`` of ``GuardrailEventHooks`` (opt-in if any member matches)
-        - ``Mode`` (tag-routed): opt-in if any tag value or the default
-          resolves to a response hook, since the configured routing could
-          send matching requests to a response-side mode
+        - ``list`` of ``GuardrailEventHooks``
+        - ``Mode`` (tag-routed)
         """
-        response_hook_values = {
-            GuardrailEventHooks.post_call.value,
-            GuardrailEventHooks.during_call.value,
-        }
+        post_call_value = GuardrailEventHooks.post_call.value
         hook = self.event_hook
         if isinstance(hook, list):
-            return any(getattr(h, "value", h) in response_hook_values for h in hook)
+            return any(getattr(h, "value", h) == post_call_value for h in hook)
         if isinstance(hook, Mode):
             candidates: List[Union[str, List[str]]] = list(hook.tags.values())
             if hook.default is not None:
                 candidates.append(hook.default)
             for value in candidates:
                 items = value if isinstance(value, list) else [value]
-                if any(v in response_hook_values for v in items):
+                if any(v == post_call_value for v in items):
                     return True
             return False
-        return getattr(hook, "value", hook) in response_hook_values
+        return getattr(hook, "value", hook) == post_call_value
 
     async def async_post_call_streaming_iterator_hook(
         self,

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1859,20 +1859,36 @@ class ContentFilterGuardrail(CustomGuardrail):
         """
         Whether this guardrail is configured to scan response content.
 
-        Returns True only when event_hook is post_call or during_call (including
-        when either appears in a list). For pre_call / realtime_input_transcription
-        / unset, the streaming iterator must not modify the response — otherwise
-        a pre_call regex would silently also redact output, contradicting the
-        documented mode contract.
+        Returns True when ``event_hook`` selects a response-side hook
+        (``post_call`` or ``during_call``). For ``pre_call`` /
+        ``realtime_input_transcription`` / unset, the streaming iterator must
+        not modify the response — otherwise a pre_call regex would silently
+        also redact output, contradicting the documented mode contract.
+
+        Supports all three accepted ``event_hook`` shapes:
+        - single ``GuardrailEventHooks`` value
+        - ``list`` of ``GuardrailEventHooks`` (opt-in if any member matches)
+        - ``Mode`` (tag-routed): opt-in if any tag value or the default
+          resolves to a response hook, since the configured routing could
+          send matching requests to a response-side mode
         """
-        response_hooks = {
-            GuardrailEventHooks.post_call,
-            GuardrailEventHooks.during_call,
+        response_hook_values = {
+            GuardrailEventHooks.post_call.value,
+            GuardrailEventHooks.during_call.value,
         }
         hook = self.event_hook
         if isinstance(hook, list):
-            return any(h in response_hooks for h in hook)
-        return hook in response_hooks
+            return any(getattr(h, "value", h) in response_hook_values for h in hook)
+        if isinstance(hook, Mode):
+            candidates: List[Union[str, List[str]]] = list(hook.tags.values())
+            if hook.default is not None:
+                candidates.append(hook.default)
+            for value in candidates:
+                items = value if isinstance(value, list) else [value]
+                if any(v in response_hook_values for v in items):
+                    return True
+            return False
+        return getattr(hook, "value", hook) in response_hook_values
 
     async def async_post_call_streaming_iterator_hook(
         self,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -22,6 +22,7 @@ from litellm.types.guardrails import (
     ContentFilterAction,
     ContentFilterPattern,
     GuardrailEventHooks,
+    Mode,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.litellm_content_filter import (
     ContentFilterCategoryConfig,
@@ -2194,3 +2195,54 @@ class TestStreamingHookRespectsEventHook:
 
         assert "test@example.com" in content
         assert "[EMAIL_REDACTED]" not in content
+
+    @pytest.mark.asyncio
+    async def test_mode_tag_routing_with_post_call_masks(self):
+        """Mode tag routing: any tag resolving to post_call opts into response scanning."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mode-tag-post-call",
+            patterns=self._patterns(),
+            event_hook=Mode(
+                tags={"sensitive": "post_call", "internal": "pre_call"},
+                default="pre_call",
+            ),
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" not in content
+        assert "[EMAIL_REDACTED]" in content
+
+    @pytest.mark.asyncio
+    async def test_mode_tag_routing_all_pre_call_does_not_mask(self):
+        """Mode tag routing: all tags pre_call and default pre_call must not scan response."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mode-tag-all-pre-call",
+            patterns=self._patterns(),
+            event_hook=Mode(
+                tags={"a": "pre_call", "b": "pre_call"},
+                default="pre_call",
+            ),
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" in content
+        assert "[EMAIL_REDACTED]" not in content
+
+    @pytest.mark.asyncio
+    async def test_mode_default_post_call_masks(self):
+        """Mode with default=post_call opts into response scanning."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mode-default-post-call",
+            patterns=self._patterns(),
+            event_hook=Mode(
+                tags={"a": "pre_call"},
+                default="post_call",
+            ),
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" not in content
+        assert "[EMAIL_REDACTED]" in content

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -408,7 +408,7 @@ class TestContentFilterGuardrail:
         guardrail = ContentFilterGuardrail(
             guardrail_name="test-streaming-mask",
             patterns=patterns,
-            event_hook=GuardrailEventHooks.during_call,
+            event_hook=GuardrailEventHooks.post_call,
         )
 
         # Create mock streaming chunks that split an email
@@ -473,7 +473,7 @@ class TestContentFilterGuardrail:
         guardrail = ContentFilterGuardrail(
             guardrail_name="test-streaming-block",
             patterns=patterns,
-            event_hook=GuardrailEventHooks.during_call,
+            event_hook=GuardrailEventHooks.post_call,
         )
 
         # Create mock streaming chunks with SSN
@@ -2060,10 +2060,11 @@ class TestTracingFieldsE2E:
 class TestStreamingHookRespectsEventHook:
     """
     The streaming iterator hook must only scan response content when the
-    guardrail is configured for post_call or during_call. With pre_call
-    (request-only), the stream must pass through unchanged — otherwise a
-    request-scoped regex silently also redacts LLM output, contradicting
-    the documented contract of ``mode: pre_call``.
+    guardrail is configured for ``post_call``.  ``during_call`` is
+    dispatched by the framework as ``async_moderation_hook`` (input-side,
+    parallel to the LLM call) and never reaches the streaming iterator.
+    ``pre_call`` is request-only.  In all non-``post_call`` modes the
+    stream must pass through unchanged.
     """
 
     def _patterns(self):
@@ -2139,18 +2140,18 @@ class TestStreamingHookRespectsEventHook:
         assert "[EMAIL_REDACTED]" in content
 
     @pytest.mark.asyncio
-    async def test_during_call_masks_response(self):
-        """during_call guards mask matches in streamed response text (regression)."""
+    async def test_during_call_does_not_mask_response(self):
+        """during_call is input-side (async_moderation_hook) — must not scan response."""
         guardrail = ContentFilterGuardrail(
-            guardrail_name="test-during-call-masks",
+            guardrail_name="test-during-call-no-response-scan",
             patterns=self._patterns(),
             event_hook=GuardrailEventHooks.during_call,
         )
 
         content = await self._collect_stream(guardrail)
 
-        assert "test@example.com" not in content
-        assert "[EMAIL_REDACTED]" in content
+        assert "test@example.com" in content
+        assert "[EMAIL_REDACTED]" not in content
 
     @pytest.mark.asyncio
     async def test_default_event_hook_does_not_mask_response(self):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -2054,3 +2054,143 @@ class TestTracingFieldsE2E:
         # No detections, so these should be None
         assert slg.get("detection_method") is None
         assert slg.get("match_details") is None
+
+
+class TestStreamingHookRespectsEventHook:
+    """
+    The streaming iterator hook must only scan response content when the
+    guardrail is configured for post_call or during_call. With pre_call
+    (request-only), the stream must pass through unchanged — otherwise a
+    request-scoped regex silently also redacts LLM output, contradicting
+    the documented contract of ``mode: pre_call``.
+    """
+
+    def _patterns(self):
+        return [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+    async def _collect_stream(self, guardrail):
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Contact me at test@ex"), index=0
+                    )
+                ],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="chunk2",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="ample.com for info"),
+                        index=0,
+                        finish_reason="stop",
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        collected = ""
+        async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=MagicMock(),
+            response=mock_stream(),
+            request_data={},
+        ):
+            if chunk.choices[0].delta.content:
+                collected += chunk.choices[0].delta.content
+        return collected
+
+    @pytest.mark.asyncio
+    async def test_pre_call_does_not_mask_response(self):
+        """pre_call guards must leave streamed response text untouched."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-pre-call-no-response-scan",
+            patterns=self._patterns(),
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" in content
+        assert "[EMAIL_REDACTED]" not in content
+
+    @pytest.mark.asyncio
+    async def test_post_call_masks_response(self):
+        """post_call guards mask matches in streamed response text."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-post-call-masks",
+            patterns=self._patterns(),
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" not in content
+        assert "[EMAIL_REDACTED]" in content
+
+    @pytest.mark.asyncio
+    async def test_during_call_masks_response(self):
+        """during_call guards mask matches in streamed response text (regression)."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-during-call-masks",
+            patterns=self._patterns(),
+            event_hook=GuardrailEventHooks.during_call,
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" not in content
+        assert "[EMAIL_REDACTED]" in content
+
+    @pytest.mark.asyncio
+    async def test_default_event_hook_does_not_mask_response(self):
+        """Unset event_hook defaults to pre_call — must not scan response."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-default-no-response-scan",
+            patterns=self._patterns(),
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" in content
+        assert "[EMAIL_REDACTED]" not in content
+
+    @pytest.mark.asyncio
+    async def test_list_event_hook_with_post_call_masks(self):
+        """List containing post_call opts into response scanning."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-list-post-call-masks",
+            patterns=self._patterns(),
+            event_hook=[
+                GuardrailEventHooks.pre_call,
+                GuardrailEventHooks.post_call,
+            ],
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" not in content
+        assert "[EMAIL_REDACTED]" in content
+
+    @pytest.mark.asyncio
+    async def test_list_event_hook_only_pre_call_does_not_mask(self):
+        """List containing only pre_call must not scan response."""
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-list-only-pre-call",
+            patterns=self._patterns(),
+            event_hook=[GuardrailEventHooks.pre_call],
+        )
+
+        content = await self._collect_stream(guardrail)
+
+        assert "test@example.com" in content
+        assert "[EMAIL_REDACTED]" not in content

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T16:01:27.663665Z"
+exclude-newer = "2026-04-12T13:20:31.65424Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3602,7 +3602,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.6"
+version = "1.83.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Fixes #25780. Related: #13222, #8756.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) — 6 new tests in `TestStreamingHookRespectsEventHook`
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) — full content_filter suite: 227 passed locally
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem — single-function change with a helper
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Local test run against the new test class + existing streaming tests (regression):

```
$ uv run --no-sync pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py \
    -x -vv -k "StreamingHookRespectsEventHook or streaming_hook_mask or streaming_hook_block"

tests/.../test_content_filter.py::TestStreamingHookRespectsEventHook::test_default_event_hook_does_not_mask_response PASSED
tests/.../test_content_filter.py::TestStreamingHookRespectsEventHook::test_during_call_masks_response PASSED
tests/.../test_content_filter.py::TestStreamingHookRespectsEventHook::test_list_event_hook_only_pre_call_does_not_mask PASSED
tests/.../test_content_filter.py::TestStreamingHookRespectsEventHook::test_list_event_hook_with_post_call_masks PASSED
tests/.../test_content_filter.py::TestStreamingHookRespectsEventHook::test_post_call_masks_response PASSED
tests/.../test_content_filter.py::TestStreamingHookRespectsEventHook::test_pre_call_does_not_mask_response PASSED
tests/.../test_content_filter.py::TestContentFilterGuardrail::test_streaming_hook_block PASSED
tests/.../test_content_filter.py::TestContentFilterGuardrail::test_streaming_hook_mask PASSED

======================= 8 passed, 46 deselected in 0.26s =======================
```

Full `content_filter/` suite:

```
$ uv run --no-sync pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/ -q
227 passed in 6.32s
```

## Type

🐛 Bug Fix

## Changes

### Problem

`async_post_call_streaming_iterator_hook` in `litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py` applied regex masking / blocking to every streamed chunk unconditionally. There was no check of `self.event_hook`, so a guardrail configured as `mode: pre_call` (documented to scan only the request) silently also redacted matches in the LLM response.

Result: users with a `pre_call` PII regex saw model names / technical identifiers masked out of streamed responses when those strings incidentally matched.

### Fix

New private helper `_runs_on_response()` encodes the mode contract: the response iterator only scans when `event_hook` is `post_call` or `during_call` (including when either appears in a list form). For `pre_call`, unset (which defaults to `pre_call`), or `realtime_input_transcription`, the iterator now yields the stream unchanged.

```python
def _runs_on_response(self) -> bool:
    response_hooks = {
        GuardrailEventHooks.post_call,
        GuardrailEventHooks.during_call,
    }
    hook = self.event_hook
    if isinstance(hook, list):
        return any(h in response_hooks for h in hook)
    return hook in response_hooks

async def async_post_call_streaming_iterator_hook(self, ...):
    ...
    if not self._runs_on_response():
        async for item in response:
            yield item
        return
    # existing masking/blocking logic, unchanged
```

### Tests

New class `TestStreamingHookRespectsEventHook` (6 cases) covering:

| Case | `event_hook` | Response masked? |
|------|--------------|------------------|
| `test_pre_call_does_not_mask_response` | `pre_call` | no |
| `test_post_call_masks_response` | `post_call` | yes |
| `test_during_call_masks_response` | `during_call` | yes (regression) |
| `test_default_event_hook_does_not_mask_response` | unset → `pre_call` | no |
| `test_list_event_hook_with_post_call_masks` | `[pre_call, post_call]` | yes |
| `test_list_event_hook_only_pre_call_does_not_mask` | `[pre_call]` | no |

Existing `test_streaming_hook_mask` and `test_streaming_hook_block` both use `during_call` and continue to pass — no behavior change for the already-correct path.

### Lint / Types

- `uv run black --check` — clean on both modified files
- `uv run ruff check` — clean on both modified files
- `uv run mypy litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py` — success, no issues