### PR TITLE
fix(ui): stale filters applied after sort/page/time change on Request…

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -71,6 +71,14 @@ export function useLogFilterLogic({
   const [filters, setFilters] = useState<LogFilterState>(defaultFilters);
   const [backendFilteredLogs, setBackendFilteredLogs] = useState<PaginatedResponse | null>(null);
   const lastSearchTimestamp = useRef(0);
+
+  // Refs that always hold the latest filters and hasBackendFilters values.
+  // The sort/page/time effect below intentionally omits these from its dep array
+  // to avoid double-fetches when a filter changes; reading from refs instead of
+  // the closure prevents stale-closure bugs (e.g. the effect using a snapshot of
+  // filters taken before the user selected Key Alias).
+  const filtersRef = useRef(filters);
+  const hasBackendFiltersRef = useRef(false);
   const performSearch = useCallback(
     async (filters: LogFilterState, page = 1) => {
       if (!accessToken) return;
@@ -152,18 +160,25 @@ export function useLogFilterLogic({
     [filters],
   );
 
+  // Keep refs in sync on every render so the sort/page/time effect always reads
+  // the latest values without those values being in its dep array.
+  useEffect(() => {
+    filtersRef.current = filters;
+    hasBackendFiltersRef.current = hasBackendFilters;
+  }, [filters, hasBackendFilters]);
+
   // Refetch when sort, page, or time range changes (backend filters use their own fetch, not the main query)
   useEffect(() => {
-    if (hasBackendFilters && accessToken) {
+    if (hasBackendFiltersRef.current && accessToken) {
       // Cancel any pending debounced search to prevent it from overwriting this page's results
       debouncedSearch.cancel();
-      performSearch(filters, currentPage);
+      performSearch(filtersRef.current, currentPage);
     }
-    // Intentionally omitted from deps:
-    // - `filters` / `debouncedSearch` / `performSearch`: filter changes are handled by
-    //   handleFilterChange → debouncedSearch; adding them here would double-fetch on filter apply.
-    // - `hasBackendFilters` / `accessToken`: stable across sort/page/time changes; including them
-    //   would cause spurious re-runs when the filter state first becomes active.
+    // filters / hasBackendFilters are read via refs — avoids stale-closure bugs
+    // when sort/page/time changes after a filter (e.g. Key Alias) was set.
+    // debouncedSearch / performSearch: filter changes go through handleFilterChange
+    // → debouncedSearch; adding them here would cause double-fetches on filter apply.
+    // accessToken: stable across sort/page/time changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortBy, sortOrder, currentPage, startTime, endTime, isCustomDate]);
 


### PR DESCRIPTION
# PR 2: fix(ui): stale filters applied after sort/page/time change on Request Logs

> **Branch**: `Bytechoreographer:fix/logs-stale-filters-on-sort-page-time`
> **Target**: `BerriAI:litellm_oss_branch`
> **PR link**: https://github.com/Bytechoreographer/litellm/pull/new/fix/logs-stale-filters-on-sort-page-time

---

## Relevant issues

<!-- No open issue found; reproduced locally. -->

## Pre-Submission checklist

- [x] `npm run test` passes for affected files (29/29)
- [x] Scope is isolated: one file changed, no new dependencies
- [x] Comment `@greptileai` and get Confidence Score ≥ 4/5 before requesting maintainer review

## Type

🐛 Bug Fix

## Changes

### Root cause

`useLogFilterLogic` has a `useEffect` that re-fetches logs whenever sort,
page, or time range changes while backend filters are active:

```ts
useEffect(() => {
  if (hasBackendFilters && accessToken) {
    debouncedSearch.cancel();
    performSearch(filters, currentPage);   // ← stale closure!
  }
  // eslint-disable-next-line react-hooks/exhaustive-deps
}, [sortBy, sortOrder, currentPage, startTime, endTime, isCustomDate]);
```

`filters` and `hasBackendFilters` are intentionally **omitted** from the dep
array to prevent double-fetches when a filter is applied (filter changes are
handled by `handleFilterChange → debouncedSearch`).

The side-effect is a **stale-closure bug**: React captures `filters` and
`hasBackendFilters` from the render where the effect was last recreated —
i.e., when `sortBy`, `sortOrder`, `currentPage`, `startTime`, `endTime`, or
`isCustomDate` last changed.  If the user sets a filter (e.g. Key Alias)
*after* that point, the effect still holds the old snapshot that predates
the filter selection.

**Reproduce**:
1. Open Request Logs → set Key Alias filter → filtered results appear ✓  
2. Change page, sort column, or time range  
3. The effect fires with the stale `filters` (no `key_alias`) → API request
   sent without the filter → table shows **unfiltered** data ✗

This is why the filter appears to "sometimes work, sometimes not": the initial
debounce-triggered search uses the correct filters, but any subsequent
sort/page/time interaction resets the results.

### Fix

Store the latest `filters` and `hasBackendFilters` in refs kept in sync on
every render.  The sort/page/time effect reads from the refs instead of the
closure, so it always uses the **current** filter state without requiring
those values to be in the dep array:

```ts
// Always-current refs — updated every render
const filtersRef = useRef(filters);
const hasBackendFiltersRef = useRef(false);

useEffect(() => {
  filtersRef.current = filters;
  hasBackendFiltersRef.current = hasBackendFilters;
}, [filters, hasBackendFilters]);

// Sort/page/time effect now reads from refs → no stale closure
useEffect(() => {
  if (hasBackendFiltersRef.current && accessToken) {
    debouncedSearch.cancel();
    performSearch(filtersRef.current, currentPage);
  }
  // eslint-disable-next-line react-hooks/exhaustive-deps
}, [sortBy, sortOrder, currentPage, startTime, endTime, isCustomDate]);
```

### Files changed

| File | Change |
|------|--------|
| `ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx` | Add `filtersRef` / `hasBackendFiltersRef`, sync effect, update sort/page/time effect to read from refs |
