### PR TITLE
fix(vertex): strip version suffix from model name in count_tokens requests

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -78,6 +78,19 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
 
         return endpoint
 
+    @staticmethod
+    def _strip_version_suffix(model: str) -> str:
+        """
+        Strip version suffixes (e.g. @default, @20251001) from model names.
+
+        The Vertex AI count-tokens endpoint rejects model names that include
+        version suffixes — for example, "claude-sonnet-4-6@default" returns
+        "not supported for token counting" while "claude-sonnet-4-6" works.
+        """
+        if "@" in model:
+            return model.split("@")[0]
+        return model
+
     async def handle_count_tokens_request(
         self,
         model: str,
@@ -98,6 +111,15 @@ class VertexAIPartnerModelsTokenCounter(VertexBase):
         Raises:
             ValueError: If required parameters are missing or invalid
         """
+        # Strip version suffixes (@default, @20251001, etc.) — the Vertex AI
+        # count-tokens endpoint does not accept versioned model names.
+        model = self._strip_version_suffix(model)
+        if "model" in request_data:
+            request_data = {
+                **request_data,
+                "model": self._strip_version_suffix(request_data["model"]),
+            }
+
         # Validate request
         if "messages" not in request_data:
             raise ValueError("messages required for token counting")

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/test_count_tokens_location.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/test_count_tokens_location.py
@@ -162,3 +162,69 @@ class TestCountTokensLocationResolution:
         )
 
         assert captured["vertex_location"] == "asia-southeast1"
+
+
+class TestCountTokensVersionSuffixStripping:
+    """Verify that version suffixes (@default, @20251001, etc.) are stripped
+    from model names before sending to the Vertex AI count-tokens endpoint.
+
+    The Vertex AI count-tokens API rejects versioned model names with:
+    "claude-sonnet-4-6@default is not supported for token counting"
+    while "claude-sonnet-4-6" (without suffix) works correctly.
+    """
+
+    def test_strip_version_suffix_at_default(self):
+        counter = VertexAIPartnerModelsTokenCounter()
+        assert counter._strip_version_suffix("claude-sonnet-4-6@default") == "claude-sonnet-4-6"
+
+    def test_strip_version_suffix_at_date(self):
+        counter = VertexAIPartnerModelsTokenCounter()
+        assert counter._strip_version_suffix("claude-haiku-4-5@20251001") == "claude-haiku-4-5"
+
+    def test_strip_version_suffix_no_suffix(self):
+        counter = VertexAIPartnerModelsTokenCounter()
+        assert counter._strip_version_suffix("claude-sonnet-4-6") == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_handle_count_tokens_strips_version_from_request_data(self, monkeypatch):
+        """The model name in request_data sent to the API must have @suffix stripped."""
+        counter = VertexAIPartnerModelsTokenCounter()
+        captured_json = {}
+
+        async def fake_ensure_access_token(self, credentials, project_id, custom_llm_provider):
+            return "fake-token", "fake-project"
+
+        def fake_build_endpoint(self, model, project_id, vertex_location, api_base=None):
+            return "https://fake-endpoint"
+
+        monkeypatch.setattr(
+            VertexAIPartnerModelsTokenCounter, "_ensure_access_token_async", fake_ensure_access_token
+        )
+        monkeypatch.setattr(
+            VertexAIPartnerModelsTokenCounter, "_build_count_tokens_endpoint", fake_build_endpoint
+        )
+
+        class FakeResponse:
+            status_code = 200
+            def json(self):
+                return {"input_tokens": 10}
+
+        class FakeClient:
+            async def post(self, url, headers=None, json=None, **kwargs):
+                captured_json.update(json or {})
+                return FakeResponse()
+
+        import litellm.llms.vertex_ai.vertex_ai_partner_models.count_tokens.handler as handler_mod
+        monkeypatch.setattr(handler_mod, "get_async_httpx_client", lambda **kwargs: FakeClient())
+
+        await counter.handle_count_tokens_request(
+            model="claude-sonnet-4-6@default",
+            request_data={
+                "model": "claude-sonnet-4-6@default",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            litellm_params={"vertex_location": "us-east5"},
+        )
+
+        # The model name sent to the API must NOT have the @default suffix
+        assert captured_json["model"] == "claude-sonnet-4-6"


### PR DESCRIPTION
## Summary

- Vertex AI count-tokens endpoint rejects model names with version suffixes (`@default`, `@20251001`)
- Fix: strip `@suffix` from model name and request body before sending to the API

Fixes #25798

## Root cause

The `handle_count_tokens_request` method in `VertexAIPartnerModelsTokenCounter` passes the model name through to the Vertex AI API without stripping version suffixes. The Vertex AI count-tokens endpoint does not accept versioned model names:

```
"claude-sonnet-4-6@default is not supported for token counting"
```

While `"claude-sonnet-4-6"` (without suffix) returns a successful 200 response.

Note: the completion path already strips `@` suffixes for Mistral/Codestral models (`main.py` lines 174-175) but not for Claude, and the count_tokens path doesn't strip for any model.

## Dependency

This fix requires PR #23907 (merged in v1.83.3-stable) as a prerequisite. Without the location fix, count_tokens requests hit `us-central1` (unsupported for Claude count_tokens) and fail with a different error before ever reaching the model name issue.

### Supported count_tokens regions

We tested the following regions directly against the Vertex AI API:

| Region | Status | Notes |
|--------|:------:|-------|
| `global` | 200 | Works (not listed in Google docs but functional) |
| `us-east5` | 200 | Works (documented) |
| `us-east1` | 404 | Not supported for count_tokens |

Models using `vertex_location: global` or `us-east5` will work with just this fix. Models using unsupported regions like `us-east1` will additionally need `vertex_count_tokens_location: us-east5` in their config.

## Steps to reproduce

1. Configure a Vertex AI Claude model with a version suffix:
   ```yaml
   model_list:
     - model_name: claude-sonnet-4-6
       litellm_params:
         model: claude-sonnet-4-6@default
         custom_llm_provider: vertex_ai
         vertex_project: my-project
         vertex_location: us-east5
   ```

2. Send a count_tokens request:
   ```bash
   curl -X POST http://localhost:4000/v1/messages/count_tokens \
     -H "Authorization: Bearer sk-key" \
     -H "Content-Type: application/json" \
     -H "anthropic-version: 2023-06-01" \
     -d '{"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "Hello"}]}'
   ```

3. Observe 400 error: `"claude-sonnet-4-6@default is not supported for token counting"`

4. Verified directly against Vertex AI API:
   - `"model": "claude-sonnet-4-6@default"` → 400 error
   - `"model": "claude-sonnet-4-6"` → 200 with `{"input_tokens": 13}`

## Fix

Add `_strip_version_suffix()` to `VertexAIPartnerModelsTokenCounter` that removes `@suffix` from model names. Called at the top of `handle_count_tokens_request` for both the `model` parameter and `request_data["model"]` (using dict spread to avoid mutating the caller's dict).

## Related

- #25798 — Issue tracking this bug
- #23907 — Location fix prerequisite (in v1.83.3-stable)
- #21748 — Broader count_tokens issues for Vertex AI

## Test plan

- [x] `test_strip_version_suffix_at_default` — `@default` stripped
- [x] `test_strip_version_suffix_at_date` — `@20251001` stripped
- [x] `test_strip_version_suffix_no_suffix` — no-op when no suffix
- [x] `test_handle_count_tokens_strips_version_from_request_data` — end-to-end: model name in API request body has suffix stripped
- [x] All 3 existing location tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)
