### PR TITLE
refactor(ui): reduce Tremor usage in Guardrails Monitor layout

### DIFF
--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx
@@ -5,7 +5,6 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Col, Grid } from "@tremor/react";
 import { Button, Spin, Tabs } from "antd";
 import React, { useMemo, useState } from "react";
 import {
@@ -172,11 +171,11 @@ export function GuardrailDetail({
 
       {activeTab === "overview" && (
         <div className="space-y-6 mt-4">
-          <Grid numItems={2} numItemsMd={5} className="gap-4">
-            <Col>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <div className="min-w-0">
               <MetricCard label="Requests Evaluated" value={data.requestsEvaluated.toLocaleString()} />
-            </Col>
-            <Col>
+            </div>
+            <div className="min-w-0">
               <MetricCard
                 label="Fail Rate"
                 value={`${data.failRate}%`}
@@ -186,13 +185,11 @@ export function GuardrailDetail({
                 subtitle={`${Math.round((data.requestsEvaluated * data.failRate) / 100).toLocaleString()} blocked`}
                 icon={data.failRate > 15 ? <WarningOutlined className="text-red-400" /> : undefined}
               />
-            </Col>
-            <Col>
+            </div>
+            <div className="min-w-0">
               <MetricCard
                 label="Avg. latency added"
-                value={
-                  data.avgLatency != null ? `${Math.round(data.avgLatency)}ms` : "—"
-                }
+                value={data.avgLatency != null ? `${Math.round(data.avgLatency)}ms` : "—"}
                 valueColor={
                   data.avgLatency != null
                     ? data.avgLatency > 150
@@ -204,8 +201,8 @@ export function GuardrailDetail({
                 }
                 subtitle={data.avgLatency != null ? "Per request (avg)" : "No data"}
               />
-            </Col>
-          </Grid>
+            </div>
+          </div>
 
           <LogViewer
             guardrailName={data.name}

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx
@@ -6,8 +6,7 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Card, Col, Grid, Title } from "@tremor/react";
-import { Button, Spin, Table } from "antd";
+import { Button, Card, Spin, Table, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import React, { useMemo, useState } from "react";
 import { getGuardrailsUsageOverview } from "@/components/networking";
@@ -218,27 +217,27 @@ export function GuardrailsOverview({
         </div>
       </div>
 
-      <Grid numItems={2} numItemsLg={5} className="gap-4 mb-6 items-stretch">
-        <Col className="flex flex-col">
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-6 items-stretch">
+        <div className="flex flex-col min-w-0">
           <MetricCard label="Total Evaluations" value={metrics.totalRequests.toLocaleString()} />
-        </Col>
-        <Col className="flex flex-col">
+        </div>
+        <div className="flex flex-col min-w-0">
           <MetricCard
             label="Blocked Requests"
             value={metrics.totalBlocked.toLocaleString()}
             valueColor="text-red-600"
             icon={<WarningOutlined className="text-red-400" />}
           />
-        </Col>
-        <Col className="flex flex-col">
+        </div>
+        <div className="flex flex-col min-w-0">
           <MetricCard
             label="Pass Rate"
             value={`${metrics.passRate}%`}
             valueColor="text-green-600"
             icon={<RiseOutlined className="text-green-400" />}
           />
-        </Col>
-        <Col className="flex flex-col">
+        </div>
+        <div className="flex flex-col min-w-0">
           <MetricCard
             label="Avg. latency added"
             value={`${metrics.avgLatency}ms`}
@@ -250,20 +249,20 @@ export function GuardrailsOverview({
                   : "text-green-600"
             }
           />
-        </Col>
-        <Col className="flex flex-col">
-          <MetricCard
-            label="Active Guardrails"
-            value={metrics.count}
-          />
-        </Col>
-      </Grid>
+        </div>
+        <div className="flex flex-col min-w-0">
+          <MetricCard label="Active Guardrails" value={metrics.count} />
+        </div>
+      </div>
 
       <div className="mb-6">
         <ScoreChart data={chartData} />
       </div>
 
-      <Card className="bg-white border border-gray-200 rounded-lg">
+      <Card
+        className="border border-gray-200 rounded-lg bg-white"
+        styles={{ body: { padding: 0 } }}
+      >
         {(isLoading || error) && (
           <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-2">
             {isLoading && <Spin size="small" />}
@@ -272,9 +271,9 @@ export function GuardrailsOverview({
         )}
         <div className="px-6 py-4 border-b border-gray-200 flex items-start justify-between gap-4">
           <div>
-            <Title className="text-base font-semibold text-gray-900">
+            <Typography.Title level={5} className="!mb-0 text-gray-900">
               Guardrail Performance
-            </Title>
+            </Typography.Title>
             <p className="text-xs text-gray-500 mt-0.5">
               Click a guardrail to view details, logs, and configuration
             </p>

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/ScoreChart.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/ScoreChart.tsx
@@ -11,6 +11,7 @@ interface ScoreChartProps {
 
 export function ScoreChart({ data }: ScoreChartProps) {
   const chartData = data && data.length > 0 ? data : [];
+
   return (
     <Card className="bg-white border border-gray-200">
       <Title className="text-base font-semibold text-gray-900 mb-4">


### PR DESCRIPTION
## Summary
- Reduce Tremor usage in Guardrails Monitor overview/detail by replacing Tremor grid wrappers with Tailwind grid layout.
- Replace Tremor card/title usage in the overview performance section with antd `Card` and `Typography.Title`.
- Keep existing behavior intentionally unchanged for the chart and date picker (Tremor `BarChart` and `AdvancedDatePicker` remain for now).

## Screenshots
### Before
- [ ] Add before screenshot

### After
- [ ] Add after screenshot

## Test plan
- [ ] Open `?page=guardrails-monitor` and verify overview renders correctly.
- [ ] Verify guardrail performance table sorting still works.
- [ ] Click into a guardrail detail and verify metric cards and logs tab behavior.