### PR TITLE
refactor(ui): reduce Tremor usage in Guardrails Monitor layout

### DIFF
--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx
@@ -5,7 +5,7 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Button, Spin, Tabs } from "antd";
+import { Button, Col, Row, Spin, Tabs } from "antd";
 import React, { useMemo, useState } from "react";
 import {
   getGuardrailsUsageDetail,
@@ -171,11 +171,11 @@ export function GuardrailDetail({
 
       {activeTab === "overview" && (
         <div className="space-y-6 mt-4">
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            <div className="min-w-0">
+          <Row gutter={[16, 16]}>
+            <Col xs={12} md={8}>
               <MetricCard label="Requests Evaluated" value={data.requestsEvaluated.toLocaleString()} />
-            </div>
-            <div className="min-w-0">
+            </Col>
+            <Col xs={12} md={8}>
               <MetricCard
                 label="Fail Rate"
                 value={`${data.failRate}%`}
@@ -185,8 +185,8 @@ export function GuardrailDetail({
                 subtitle={`${Math.round((data.requestsEvaluated * data.failRate) / 100).toLocaleString()} blocked`}
                 icon={data.failRate > 15 ? <WarningOutlined className="text-red-400" /> : undefined}
               />
-            </div>
-            <div className="min-w-0">
+            </Col>
+            <Col xs={12} md={8}>
               <MetricCard
                 label="Avg. latency added"
                 value={data.avgLatency != null ? `${Math.round(data.avgLatency)}ms` : "—"}
@@ -201,8 +201,8 @@ export function GuardrailDetail({
                 }
                 subtitle={data.avgLatency != null ? "Per request (avg)" : "No data"}
               />
-            </div>
-          </div>
+            </Col>
+          </Row>
 
           <LogViewer
             guardrailName={data.name}

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx
@@ -5,7 +5,6 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Col, Grid } from "@tremor/react";
 import { Button, Spin, Tabs } from "antd";
 import React, { useMemo, useState } from "react";
 import {
@@ -172,11 +171,11 @@ export function GuardrailDetail({
 
       {activeTab === "overview" && (
         <div className="space-y-6 mt-4">
-          <Grid numItems={2} numItemsMd={5} className="gap-4">
-            <Col>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <div className="min-w-0">
               <MetricCard label="Requests Evaluated" value={data.requestsEvaluated.toLocaleString()} />
-            </Col>
-            <Col>
+            </div>
+            <div className="min-w-0">
               <MetricCard
                 label="Fail Rate"
                 value={`${data.failRate}%`}
@@ -186,13 +185,11 @@ export function GuardrailDetail({
                 subtitle={`${Math.round((data.requestsEvaluated * data.failRate) / 100).toLocaleString()} blocked`}
                 icon={data.failRate > 15 ? <WarningOutlined className="text-red-400" /> : undefined}
               />
-            </Col>
-            <Col>
+            </div>
+            <div className="min-w-0">
               <MetricCard
                 label="Avg. latency added"
-                value={
-                  data.avgLatency != null ? `${Math.round(data.avgLatency)}ms` : "—"
-                }
+                value={data.avgLatency != null ? `${Math.round(data.avgLatency)}ms` : "—"}
                 valueColor={
                   data.avgLatency != null
                     ? data.avgLatency > 150
@@ -204,8 +201,8 @@ export function GuardrailDetail({
                 }
                 subtitle={data.avgLatency != null ? "Per request (avg)" : "No data"}
               />
-            </Col>
-          </Grid>
+            </div>
+          </div>
 
           <LogViewer
             guardrailName={data.name}

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx
@@ -6,8 +6,7 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Card, Col, Grid, Title } from "@tremor/react";
-import { Button, Spin, Table } from "antd";
+import { Button, Card, Spin, Table, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import React, { useMemo, useState } from "react";
 import { getGuardrailsUsageOverview } from "@/components/networking";
@@ -218,27 +217,27 @@ export function GuardrailsOverview({
         </div>
       </div>
 
-      <Grid numItems={2} numItemsLg={5} className="gap-4 mb-6 items-stretch">
-        <Col className="flex flex-col">
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-6 items-stretch">
+        <div className="flex flex-col min-w-0">
           <MetricCard label="Total Evaluations" value={metrics.totalRequests.toLocaleString()} />
-        </Col>
-        <Col className="flex flex-col">
+        </div>
+        <div className="flex flex-col min-w-0">
           <MetricCard
             label="Blocked Requests"
             value={metrics.totalBlocked.toLocaleString()}
             valueColor="text-red-600"
             icon={<WarningOutlined className="text-red-400" />}
           />
-        </Col>
-        <Col className="flex flex-col">
+        </div>
+        <div className="flex flex-col min-w-0">
           <MetricCard
             label="Pass Rate"
             value={`${metrics.passRate}%`}
             valueColor="text-green-600"
             icon={<RiseOutlined className="text-green-400" />}
           />
-        </Col>
-        <Col className="flex flex-col">
+        </div>
+        <div className="flex flex-col min-w-0">
           <MetricCard
             label="Avg. latency added"
             value={`${metrics.avgLatency}ms`}
@@ -250,20 +249,20 @@ export function GuardrailsOverview({
                   : "text-green-600"
             }
           />
-        </Col>
-        <Col className="flex flex-col">
-          <MetricCard
-            label="Active Guardrails"
-            value={metrics.count}
-          />
-        </Col>
-      </Grid>
+        </div>
+        <div className="flex flex-col min-w-0">
+          <MetricCard label="Active Guardrails" value={metrics.count} />
+        </div>
+      </div>
 
       <div className="mb-6">
         <ScoreChart data={chartData} />
       </div>
 
-      <Card className="bg-white border border-gray-200 rounded-lg">
+      <Card
+        className="border border-gray-200 rounded-lg bg-white"
+        styles={{ body: { padding: 0 } }}
+      >
         {(isLoading || error) && (
           <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-2">
             {isLoading && <Spin size="small" />}
@@ -272,9 +271,9 @@ export function GuardrailsOverview({
         )}
         <div className="px-6 py-4 border-b border-gray-200 flex items-start justify-between gap-4">
           <div>
-            <Title className="text-base font-semibold text-gray-900">
+            <Typography.Title level={5} className="!mb-0 text-gray-900">
               Guardrail Performance
-            </Title>
+            </Typography.Title>
             <p className="text-xs text-gray-500 mt-0.5">
               Click a guardrail to view details, logs, and configuration
             </p>

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx
@@ -6,7 +6,7 @@ import {
   WarningOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Button, Card, Spin, Table, Typography } from "antd";
+import { Button, Card, Col, Row, Spin, Table, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import React, { useMemo, useState } from "react";
 import { getGuardrailsUsageOverview } from "@/components/networking";
@@ -217,27 +217,27 @@ export function GuardrailsOverview({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-6 items-stretch">
-        <div className="flex flex-col min-w-0">
+      <Row gutter={[16, 16]} className="mb-6">
+        <Col xs={12} sm={12} md={8} flex="1 0 20%">
           <MetricCard label="Total Evaluations" value={metrics.totalRequests.toLocaleString()} />
-        </div>
-        <div className="flex flex-col min-w-0">
+        </Col>
+        <Col xs={12} sm={12} md={8} flex="1 0 20%">
           <MetricCard
             label="Blocked Requests"
             value={metrics.totalBlocked.toLocaleString()}
             valueColor="text-red-600"
             icon={<WarningOutlined className="text-red-400" />}
           />
-        </div>
-        <div className="flex flex-col min-w-0">
+        </Col>
+        <Col xs={12} sm={12} md={8} flex="1 0 20%">
           <MetricCard
             label="Pass Rate"
             value={`${metrics.passRate}%`}
             valueColor="text-green-600"
             icon={<RiseOutlined className="text-green-400" />}
           />
-        </div>
-        <div className="flex flex-col min-w-0">
+        </Col>
+        <Col xs={12} sm={12} md={8} flex="1 0 20%">
           <MetricCard
             label="Avg. latency added"
             value={`${metrics.avgLatency}ms`}
@@ -249,11 +249,11 @@ export function GuardrailsOverview({
                   : "text-green-600"
             }
           />
-        </div>
-        <div className="flex flex-col min-w-0">
+        </Col>
+        <Col xs={12} sm={12} md={8} flex="1 0 20%">
           <MetricCard label="Active Guardrails" value={metrics.count} />
-        </div>
-      </div>
+        </Col>
+      </Row>
 
       <div className="mb-6">
         <ScoreChart data={chartData} />

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/ScoreChart.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/ScoreChart.tsx
@@ -11,6 +11,7 @@ interface ScoreChartProps {
 
 export function ScoreChart({ data }: ScoreChartProps) {
   const chartData = data && data.length > 0 ? data : [];
+
   return (
     <Card className="bg-white border border-gray-200">
       <Title className="text-base font-semibold text-gray-900 mb-4">


### PR DESCRIPTION
## Relevant issues

None — part of the ongoing `@tremor/react` → antd migration per `CLAUDE.md`.

## Changes

Migrates selected Guardrails Monitor surfaces off `@tremor/react`:

- `ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailsOverview.tsx`
  - Tremor `Grid`/`Col` KPI layout → antd grid
  - Tremor `Card`/`Title` wrapper around the performance section → antd `Card` + `Typography.Title`
- `ui/litellm-dashboard/src/components/GuardrailsMonitor/GuardrailDetail.tsx`
  - Tremor `Grid`/`Col` metric layout → antd grid


- `ui/litellm-dashboard/src/components/GuardrailsMonitor/ScoreChart.tsx`
  - Kept on Tremor `BarChart` intentionally (deferred to a follow-up to keep this PR low-risk)

Behavior is intentionally unchanged for chart rendering and date-range interaction.

## Type

🧹 Refactoring

## Screenshots / Proof of Fix

### Before
<img width="969" height="747" alt="Screenshot 2026-04-15 at 11 29 24 AM" src="https://github.com/user-attachments/assets/bd10a28c-b539-47a4-bf33-e9165852b919" />


### After
<img width="950" height="728" alt="Screenshot 2026-04-15 at 11 34 37 AM" src="https://github.com/user-attachments/assets/84752e60-2fc5-4856-be8e-92c5155a2a31" />



## Pre-Submission checklist

- [x] Open `?page=guardrails-monitor` and verify overview renders correctly
- [x] Verify guardrail performance table sorting still works
- [x] Click into guardrail detail and verify metric cards + logs behavior
- [x] Confirm chart and date picker behavior are unchanged