### PR TITLE
fix(proxy): allow /update/ui_settings when STORE_MODEL_IN_DB is disabled

### DIFF
--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1246,7 +1246,6 @@ async def update_ui_settings(
     from litellm.proxy.proxy_server import (
         create_config_audit_log,
         prisma_client,
-        store_model_in_db,
     )
 
     if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
@@ -1258,12 +1257,6 @@ async def update_ui_settings(
             detail={"error": "Database not connected. Please connect a database."},
         )
 
-    if store_model_in_db is not True:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": "Set `'STORE_MODEL_IN_DB='True'` in your env to enable this feature."},
-        )
-
     # Validate against the same effective class GET advertises, so
     # enterprise-registered fields are typed consistently on both sides.
     effective_cls = _get_effective_ui_settings_class()
@@ -1271,7 +1264,6 @@ async def update_ui_settings(
         settings = effective_cls.model_validate(settings_body)
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
-
     # Only include fields the caller actually sent (not Pydantic defaults).
     settings_dict = settings.model_dump(exclude_unset=True)
 

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1423,7 +1423,6 @@ async def update_ui_settings(
     from litellm.proxy.proxy_server import (
         create_config_audit_log,
         prisma_client,
-        store_model_in_db,
     )
 
     if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
@@ -1433,12 +1432,6 @@ async def update_ui_settings(
         raise HTTPException(
             status_code=500,
             detail={"error": "Database not connected. Please connect a database."},
-        )
-
-    if store_model_in_db is not True:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": "Set `'STORE_MODEL_IN_DB='True'` in your env to enable this feature."},
         )
 
     conflicting_keys: Final = sorted(
@@ -1454,7 +1447,6 @@ async def update_ui_settings(
                 "and cannot be changed from the UI."
             ),
         )
-
     # Validate against the same effective class GET advertises, so
     # enterprise-registered fields are typed consistently on both sides.
     effective_cls: Final = _get_effective_ui_settings_class()
@@ -1462,7 +1454,6 @@ async def update_ui_settings(
         settings: Final = effective_cls.model_validate(settings_body)
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
-
     # Only include fields the caller actually sent (not Pydantic defaults).
     settings_dict: Final[Mapping[str, JsonValue]] = settings.model_dump(exclude_unset=True)
 

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1334,6 +1334,42 @@ class TestProxySettingEndpoints:
         stored_settings = json.loads(create_data["ui_settings"])
         assert stored_settings["disable_model_add_for_internal_users"] is True
 
+    def test_update_ui_settings_allows_db_backed_updates_without_store_model_in_db(
+        self, mock_auth, monkeypatch
+    ):
+        """Test UI settings update succeeds with a DB connection even when store_model_in_db is disabled."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+        mock_user_auth = UserAPIKeyAuth(
+            user_id="test-user-123",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_uisettings.upsert = AsyncMock()
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        payload = {"disable_model_add_for_internal_users": True}
+
+        try:
+            response = client.patch("/update/ui_settings", json=payload)
+        finally:
+            # Clean up the dependency override
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["settings"]["disable_model_add_for_internal_users"] is True
+
+        mock_prisma.db.litellm_uisettings.upsert.assert_called_once()
+
     def test_update_ui_settings_ignores_non_allowlisted_value(
         self, mock_auth, monkeypatch
     ):

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1403,6 +1403,42 @@ class TestProxySettingEndpoints:
         stored_settings = json.loads(create_data["ui_settings"])
         assert stored_settings["disable_model_add_for_internal_users"] is True
 
+    def test_update_ui_settings_allows_db_backed_updates_without_store_model_in_db(
+        self, mock_auth, monkeypatch
+    ):
+        """Test UI settings update succeeds with a DB connection even when store_model_in_db is disabled."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+        mock_user_auth = UserAPIKeyAuth(
+            user_id="test-user-123",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_uisettings.upsert = AsyncMock()
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        payload = {"disable_model_add_for_internal_users": True}
+
+        try:
+            response = client.patch("/update/ui_settings", json=payload)
+        finally:
+            # Clean up the dependency override
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["settings"]["disable_model_add_for_internal_users"] is True
+
+        mock_prisma.db.litellm_uisettings.upsert.assert_called_once()
+
     def test_update_ui_settings_ignores_non_allowlisted_value(
         self, mock_auth, monkeypatch
     ):


### PR DESCRIPTION
## Relevant issues

Fixes #25770

## Type

🐛 Bug Fix

## Root cause

`/update/ui_settings` persists through the dedicated `LiteLLM_UISettings` table, but the endpoint still hard-required `STORE_MODEL_IN_DB=True`. That gate is appropriate for DB-backed model management, not for UI settings writes that only need a connected Prisma client.

## Changes

- remove the unnecessary `store_model_in_db` gate from `/update/ui_settings`
- keep the existing proxy-admin authorization check
- keep the existing database-required behavior
- add a regression test covering `store_model_in_db=False` with a connected mocked DB client

## Tests run

Passed:
- `./.venv/bin/pytest tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py -k allows_db_backed_updates_without_store_model_in_db -vv`
- `./.venv/bin/pytest tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py -vv`

Blocked by unrelated repo baseline issues:
- `make lint` -> fails because Black reports `356 files would be reformatted` in the existing checkout
- `make test-unit` -> stops on unrelated existing failure in `tests/test_litellm/test_main.py::test_url_with_format_param[False-bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0]` after `12337 passed, 108 skipped`

## Scope out

- no changes to other settings endpoints that still use `store_model_in_db`
- no refactor of shared settings persistence logic
- no UI/dashboard code changes
