### PR TITLE
fix(proxy): correct Bedrock guardrail_mode in spend logs (pre/during/post)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Dict,
     List,
     Literal,
@@ -81,6 +82,9 @@ class ModifyResponseException(Exception):
 
 
 class CustomGuardrail(CustomLogger):
+    # If True, during_call runs async_moderation_hook instead of the unified apply_guardrail path.
+    use_native_during_call_hook: ClassVar[bool] = False
+
     def __init__(
         self,
         guardrail_name: Optional[str] = None,

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -18,6 +18,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    ClassVar,
     Dict,
     List,
     Literal,
@@ -123,6 +124,10 @@ def _redact_pii_matches(response_json: dict) -> dict:
 
 
 class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
+    # During-call must use async_moderation_hook (not unified apply_guardrail), otherwise
+    # OpenAI translation always passes input_type="request" and spend/UI show PRE-CALL.
+    use_native_during_call_hook: ClassVar[bool] = True
+
     def __init__(
         self,
         guardrailIdentifier: Optional[str] = None,
@@ -413,6 +418,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         messages: Optional[List[AllMessageValues]] = None,
         response: Optional[Union[Any, litellm.ModelResponse]] = None,
         request_data: Optional[dict] = None,
+        logging_event_type: Optional[GuardrailEventHooks] = None,
     ) -> BedrockGuardrailResponse:
         from datetime import datetime
 
@@ -450,11 +456,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             prepared_request.headers,
         )
 
-        event_type = (
-            GuardrailEventHooks.pre_call
-            if source == "INPUT"
-            else GuardrailEventHooks.post_call
-        )
+        # UI / spend logs use event_type. Bedrock's `source` is INPUT vs OUTPUT for the API
+        # body, which must not be confused with the proxy hook (pre_call / during_call /
+        # post_call). When omitted, keep legacy mapping for backward compatibility.
+        if logging_event_type is not None:
+            event_type = logging_event_type
+        else:
+            event_type = (
+                GuardrailEventHooks.pre_call
+                if source == "INPUT"
+                else GuardrailEventHooks.post_call
+            )
 
         try:
             httpx_response = await self.async_handler.post(
@@ -944,7 +956,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         ] = None
         try:
             bedrock_guardrail_response = await self.make_bedrock_api_request(
-                source="INPUT", messages=filtered_messages, request_data=data
+                source="INPUT",
+                messages=filtered_messages,
+                request_data=data,
+                logging_event_type=GuardrailEventHooks.pre_call,
             )
         except GuardrailInterventionNormalStringError as e:
             bedrock_guardrail_response = e.message
@@ -1016,7 +1031,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         ] = None
         try:
             bedrock_guardrail_response = await self.make_bedrock_api_request(
-                source="INPUT", messages=filtered_messages, request_data=data
+                source="INPUT",
+                messages=filtered_messages,
+                request_data=data,
+                logging_event_type=GuardrailEventHooks.during_call,
             )
         except GuardrailInterventionNormalStringError as e:
             bedrock_guardrail_response = e.message
@@ -1120,9 +1138,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 source="INPUT",
                 messages=input_messages,
                 request_data=data,
+                logging_event_type=GuardrailEventHooks.post_call,
             )
             output_task = self.make_bedrock_api_request(
-                source="OUTPUT", response=response, request_data=data
+                source="OUTPUT",
+                response=response,
+                request_data=data,
+                logging_event_type=GuardrailEventHooks.post_call,
             )
 
             # Execute both requests in parallel
@@ -1136,7 +1158,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
             try:
                 output_content_bedrock = await self.make_bedrock_api_request(
-                    source="OUTPUT", response=response, request_data=data
+                    source="OUTPUT",
+                    response=response,
+                    request_data=data,
+                    logging_event_type=GuardrailEventHooks.post_call,
                 )
             except GuardrailInterventionNormalStringError as e:
                 output_content_bedrock = e.message
@@ -1263,9 +1288,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     source="INPUT",
                     messages=input_messages,
                     request_data=request_data,
+                    logging_event_type=GuardrailEventHooks.post_call,
                 )  # Only input messages
                 output_task = self.make_bedrock_api_request(
-                    source="OUTPUT", response=assembled_model_response
+                    source="OUTPUT",
+                    response=assembled_model_response,
+                    logging_event_type=GuardrailEventHooks.post_call,
                 )  # Only response
 
                 # Execute both requests in parallel
@@ -1279,7 +1307,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
                 try:
                     output_guardrail_response = await self.make_bedrock_api_request(
-                        source="OUTPUT", response=assembled_model_response
+                        source="OUTPUT",
+                        response=assembled_model_response,
+                        logging_event_type=GuardrailEventHooks.post_call,
                     )
                 except GuardrailInterventionNormalStringError as e:
                     output_guardrail_response = e.message
@@ -1554,10 +1584,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
             # Bedrock will throw an error if there is no text to process
             if filtered_messages:
+                _log_hook = (
+                    GuardrailEventHooks.pre_call
+                    if input_type == "request"
+                    else GuardrailEventHooks.post_call
+                )
                 bedrock_response = await self.make_bedrock_api_request(
                     source="INPUT",
                     messages=filtered_messages,
                     request_data=request_data,
+                    logging_event_type=_log_hook,
                 )
 
                 # Apply any masking that was applied by the guardrail

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -940,7 +940,11 @@ class ProxyLogging:
             Result from the guardrail execution
         """
         # Use unified_guardrail if callback has apply_guardrail method
-        use_unified = "apply_guardrail" in type(callback).__dict__
+        has_apply_guardrail = "apply_guardrail" in type(callback).__dict__
+        use_unified = has_apply_guardrail and not (
+            hook_type == "during_call"
+            and getattr(callback, "use_native_during_call_hook", False)
+        )
         if use_unified:
             data["guardrail_to_apply"] = callback
 
@@ -1537,10 +1541,12 @@ class ProxyLogging:
                 else:
                     user_api_key_auth_dict = user_api_key_dict
                 # Add task to list for parallel execution
-                if (
+                use_unified_during = (
                     "apply_guardrail" in type(callback).__dict__
                     and user_api_key_dict is not None
-                ):
+                    and not getattr(callback, "use_native_during_call_hook", False)
+                )
+                if use_unified_during:
                     data["guardrail_to_apply"] = callback
                     guardrail_task = self._run_guardrail_task_with_enrichment(
                         callback,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -1204,6 +1204,11 @@ def _make_guardrail() -> BedrockGuardrail:
     )
 
 
+def test_bedrock_guardrail_uses_native_during_call_hook():
+    """during_call must use async_moderation_hook, not unified apply_guardrail(input=request)."""
+    assert BedrockGuardrail.use_native_during_call_hook is True
+
+
 def test_extract_blocked_assessments_pii_entity():
     """L3: PII entity match (BLOCKED) is surfaced with category, type, and matched term."""
     g = _make_guardrail()

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -6,16 +6,20 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import litellm
 import pytest
 from fastapi import HTTPException
 
 sys.path.insert(0, os.path.abspath("../../../../../.."))
 
+from litellm.caching.caching import DualCache
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockGuardrail,
     _redact_pii_matches,
 )
+from litellm.proxy.utils import ProxyLogging
+from litellm.types.guardrails import GuardrailEventHooks
 
 
 @pytest.mark.asyncio
@@ -1207,6 +1211,96 @@ def _make_guardrail() -> BedrockGuardrail:
 def test_bedrock_guardrail_uses_native_during_call_hook():
     """during_call must use async_moderation_hook, not unified apply_guardrail(input=request)."""
     assert BedrockGuardrail.use_native_during_call_hook is True
+
+
+@pytest.mark.asyncio
+async def test_make_bedrock_api_request_logging_event_type_for_spend_logs():
+    """
+    Spend/UI use event_type from the proxy hook, not Bedrock's INPUT/OUTPUT alone.
+    When logging_event_type is set, it must be forwarded to standard guardrail logging.
+    When omitted, INPUT maps to pre_call (legacy).
+    """
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT"
+    )
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "test-access-key"
+    mock_credentials.secret_key = "test-secret-key"
+    mock_credentials.token = None
+
+    mock_bedrock_response = MagicMock()
+    mock_bedrock_response.status_code = 200
+    mock_bedrock_response.json.return_value = {"action": "NONE", "assessments": []}
+
+    request_data = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    with patch.object(
+        guardrail.async_handler, "post", new_callable=AsyncMock
+    ) as mock_post, patch.object(
+        guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+    ), patch.object(guardrail, "_prepare_request", return_value=MagicMock()), patch.object(
+        guardrail,
+        "add_standard_logging_guardrail_information_to_request_data",
+    ) as mock_log:
+        mock_post.return_value = mock_bedrock_response
+
+        await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=request_data["messages"],
+            request_data=request_data,
+            logging_event_type=GuardrailEventHooks.during_call,
+        )
+        assert mock_log.call_args.kwargs["event_type"] == GuardrailEventHooks.during_call
+
+        mock_log.reset_mock()
+
+        await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=request_data["messages"],
+            request_data=request_data,
+        )
+        assert mock_log.call_args.kwargs["event_type"] == GuardrailEventHooks.pre_call
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_invokes_bedrock_async_moderation_hook():
+    """
+    Bedrock sets use_native_during_call_hook so ProxyLogging runs the real
+    async_moderation_hook (unified apply_guardrail would log INPUT as pre_call).
+    """
+    cache = DualCache()
+    proxy_logging = ProxyLogging(user_api_key_cache=cache)
+
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-during-test",
+        guardrailIdentifier="gid",
+        guardrailVersion="1",
+        event_hook=GuardrailEventHooks.during_call,
+        default_on=True,
+    )
+    mock_mod = AsyncMock(return_value=None)
+    guardrail.async_moderation_hook = mock_mod  # type: ignore[method-assign]
+
+    original_callbacks = litellm.callbacks.copy() if litellm.callbacks else []
+    try:
+        litellm.callbacks = [guardrail]
+        await proxy_logging.during_call_hook(
+            data={
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "test"}],
+            },
+            user_api_key_dict=UserAPIKeyAuth(
+                api_key="test_key", user_id="test_user"
+            ),
+            call_type="completion",
+        )
+    finally:
+        litellm.callbacks = original_callbacks
+
+    mock_mod.assert_awaited_once()
 
 
 def test_extract_blocked_assessments_pii_entity():

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -9,10 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-import litellm
-
 sys.path.insert(0, os.path.abspath("../../../../../.."))
 
+import litellm
 from litellm.caching.caching import DualCache
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -6,9 +6,10 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import litellm
 import pytest
 from fastapi import HTTPException
+
+import litellm
 
 sys.path.insert(0, os.path.abspath("../../../../../.."))
 
@@ -1195,17 +1196,8 @@ async def test_bedrock_guardrail_blocked_content_with_masking_enabled():
 
 
 # ---------------------------------------------------------------------------
-# L3: _extract_blocked_assessments + _get_http_exception_for_blocked_guardrail
-# Regression coverage for case 2026-04-10-internal-bedrock-guardrail-streaming-error.
+# Spend logs: guardrail_mode (pre/during/post) vs Bedrock INPUT/OUTPUT
 # ---------------------------------------------------------------------------
-
-
-def _make_guardrail() -> BedrockGuardrail:
-    return BedrockGuardrail(
-        guardrail_name="bedrock-pii-guard",
-        guardrailIdentifier="amgllac6xf3r",
-        guardrailVersion="1",
-    )
 
 
 def test_bedrock_guardrail_uses_native_during_call_hook():
@@ -1282,25 +1274,38 @@ async def test_during_call_hook_invokes_bedrock_async_moderation_hook():
         default_on=True,
     )
     mock_mod = AsyncMock(return_value=None)
-    guardrail.async_moderation_hook = mock_mod  # type: ignore[method-assign]
-
     original_callbacks = litellm.callbacks.copy() if litellm.callbacks else []
     try:
         litellm.callbacks = [guardrail]
-        await proxy_logging.during_call_hook(
-            data={
-                "model": "gpt-4",
-                "messages": [{"role": "user", "content": "test"}],
-            },
-            user_api_key_dict=UserAPIKeyAuth(
-                api_key="test_key", user_id="test_user"
-            ),
-            call_type="completion",
-        )
+        with patch.object(guardrail, "async_moderation_hook", new=mock_mod):
+            await proxy_logging.during_call_hook(
+                data={
+                    "model": "gpt-4",
+                    "messages": [{"role": "user", "content": "test"}],
+                },
+                user_api_key_dict=UserAPIKeyAuth(
+                    api_key="test_key", user_id="test_user"
+                ),
+                call_type="completion",
+            )
     finally:
         litellm.callbacks = original_callbacks
 
     mock_mod.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# L3: _extract_blocked_assessments + _get_http_exception_for_blocked_guardrail
+# Regression coverage for case 2026-04-10-internal-bedrock-guardrail-streaming-error.
+# ---------------------------------------------------------------------------
+
+
+def _make_guardrail() -> BedrockGuardrail:
+    return BedrockGuardrail(
+        guardrail_name="bedrock-pii-guard",
+        guardrailIdentifier="amgllac6xf3r",
+        guardrailVersion="1",
+    )
 
 
 def test_extract_blocked_assessments_pii_entity():


### PR DESCRIPTION
Fixes incorrect **`guardrail_mode`** / spend-log labels for Bedrock guardrails when **`mode`** is `during_call` or `post_call` but the UI showed **PRE-CALL** because logging followed Bedrock **`INPUT`**/`OUTPUT` instead of the proxy hook.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(CI will confirm; locally: `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py` + related `during_call_hook` tests in `tests/proxy_unit_tests/test_proxy_utils.py` were run.)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Before:** Spend / evaluation UI showed Bedrock guardrails (including `during_call` and `post_call` configs) with **PRE-CALL** when the Bedrock request used **`source: INPUT`**, because `event_type` for standard logging was derived from **`INPUT` → pre_call**.
<img width="735" height="391" alt="image" src="https://github.com/user-attachments/assets/1d576df8-2650-43ab-b2e3-79492710c93d" />


**After:** Evaluation details show **PRE-CALL** / **DURING-CALL** / **POST-CALL** consistent with proxy hooks (e.g. OpenAI moderation pre/post unchanged; Bedrock pre/during/post match configuration). *(Attach your screenshot from the LiteLLM UI Spend log row if you want it in the PR.)*
<img width="691" height="354" alt="image" src="https://github.com/user-attachments/assets/f9aceb5c-507f-4f00-b5ef-383547c852f8" />

## Type

🐛 Bug Fix  
✅ Test

## Changes

### Problem

Bedrock **ApplyGuardrail** uses **`INPUT`** / **`OUTPUT`** for the HTTP body. That must not drive **`guardrail_mode`** in spend logs: **`during_call`** and some **`post_call`** paths still use **`INPUT`**, so spend/UI incorrectly labeled those runs as **pre_call** (e.g. **PRE-CALL** badge).

### Fix

1. **`make_bedrock_api_request`** — Optional **`logging_event_type`** selects the **`event_type`** passed into **`add_standard_logging_guardrail_information_to_request_data`**. If omitted, keep legacy mapping from **`source`** (backward compatible).
2. **Hooks** — Pass explicit **`logging_event_type`** from **`async_pre_call_hook`**, **`async_moderation_hook`**, and **`async_post_call_success_hook`** (and streaming paths where applicable).
3. **`BedrockGuardrail.use_native_during_call_hook`** — During **`during_call_hook`**, the unified `apply_guardrail(..., input_type="request")` path always logged **pre_call**. Bedrock now uses the native **`async_moderation_hook`** for **`during_call`** so spend logs record **`during_call`**. **`ProxyLogging.during_call_hook`** and **`_execute_guardrail_hook`** skip the unified path for **`during_call`** only when this flag is set (**`CustomGuardrail`** default **`False`**).

### Tests

- Extended **`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py`**: assert **`logging_event_type`** forwarded to standard logging; **`during_call_hook`** invokes Bedrock **`async_moderation_hook`**; class flag; import order (**isort**).

### Files

- `litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py`
- `litellm/proxy/utils.py`
- `litellm/integrations/custom_guardrail.py`
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py`
