### PR TITLE
fix(sso): fix typo in variable name generic_role_mappoings -> mappings

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -712,7 +712,7 @@ async def _setup_role_mappings() -> Optional["RoleMappings"]:
     generic_role_mappings_group_claim = os.getenv(
         "GENERIC_ROLE_MAPPINGS_GROUP_CLAIM", None
     )
-    generic_role_mappoings_default_role = os.getenv(
+    generic_role_mappings_default_role = os.getenv(
         "GENERIC_ROLE_MAPPINGS_DEFAULT_ROLE", None
     )
     if generic_role_mappings is not None:
@@ -731,7 +731,7 @@ async def _setup_role_mappings() -> Optional["RoleMappings"]:
                 role_mappings_data = {
                     "provider": "generic",
                     "group_claim": generic_role_mappings_group_claim,
-                    "default_role": generic_role_mappoings_default_role,
+                    "default_role": generic_role_mappings_default_role,
                     "roles": generic_user_role_mappings_data,
                 }
 


### PR DESCRIPTION
## Summary

Fix a typo in `litellm/proxy/management_endpoints/ui_sso.py` inside `_setup_role_mappings()`.

The variable was named `generic_role_mappoings_default_role` (note: "mappoings") instead of `generic_role_mappings_default_role`. Fixed in 2 places (lines 715 and 734).

Functionally equivalent — this is purely a cosmetic consistency fix to match the correctly-spelled env var `GENERIC_ROLE_MAPPINGS_DEFAULT_ROLE`.

Fixes #25245

## Test plan
- [ ] No logic change; verify variable reads env var `GENERIC_ROLE_MAPPINGS_DEFAULT_ROLE` correctly (it did before and after)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)