### PR TITLE
fix(ollama): propagate done_reason='length' as finish_reason for max_tokens truncation

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -349,7 +349,7 @@ class OllamaChatConfig(BaseConfig):
         response_json = raw_response.json()
 
         ## RESPONSE OBJECT
-        _done_reason = response_json.get("done_reason", "stop")
+        _done_reason = response_json.get("done_reason") or "stop"
         model_response.choices[0].finish_reason = _done_reason
         response_json_message = response_json.get("message")
         if response_json_message is not None:

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -349,7 +349,8 @@ class OllamaChatConfig(BaseConfig):
         response_json = raw_response.json()
 
         ## RESPONSE OBJECT
-        model_response.choices[0].finish_reason = "stop"
+        _done_reason = response_json.get("done_reason", "stop")
+        model_response.choices[0].finish_reason = _done_reason
         response_json_message = response_json.get("message")
         if response_json_message is not None:
             if "thinking" in response_json_message:
@@ -535,7 +536,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             )
 
             if chunk["done"] is True:
-                finish_reason = chunk.get("done_reason", "stop")
+                finish_reason = chunk.get("done_reason") or "stop"
                 # Override finish_reason when tool_calls are present
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
                 if tool_calls is not None:

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -15,6 +15,12 @@ from litellm.llms.ollama.chat.transformation import OllamaChatConfig, OllamaChat
 from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import get_optional_params
 
+import json
+from unittest.mock import MagicMock
+
+import litellm
+from litellm.types.utils import Choices, Message, ModelResponse
+
 
 class TestEvent(BaseModel):
     name: str
@@ -427,12 +433,6 @@ class TestOllamaToolCalling:
 
     def test_finish_reason_stop_when_no_tool_calls(self):
         """Test that finish_reason remains 'stop' when no tool_calls present."""
-        import json
-        from unittest.mock import MagicMock
-
-        import litellm
-        from litellm.types.utils import Choices, Message, ModelResponse
-
         config = OllamaChatConfig()
 
         # Simulated Ollama response without tool_calls
@@ -486,11 +486,6 @@ class TestOllamaFinishReasonLength:
 
     def test_finish_reason_length_non_streaming(self):
         """Non-streaming: done_reason='length' must propagate as finish_reason='length'."""
-        import json
-        from unittest.mock import MagicMock
-
-        from litellm.types.utils import Choices, Message, ModelResponse
-
         config = OllamaChatConfig()
 
         ollama_response = {
@@ -535,11 +530,6 @@ class TestOllamaFinishReasonLength:
 
     def test_finish_reason_stop_non_streaming(self):
         """Non-streaming: done_reason='stop' (natural finish) must stay 'stop'."""
-        import json
-        from unittest.mock import MagicMock
-
-        from litellm.types.utils import Choices, Message, ModelResponse
-
         config = OllamaChatConfig()
 
         ollama_response = {

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -476,6 +476,150 @@ class TestOllamaToolCalling:
         assert result.choices[0].message.tool_calls is None
 
 
+class TestOllamaFinishReasonLength:
+    """Tests for done_reason 'length' → finish_reason 'length' mapping.
+
+    Ollama returns done_reason='length' when a response is truncated by num_predict
+    (max_tokens). Previously finish_reason was hardcoded to 'stop', hiding truncation.
+    The Anthropic pass-through adapter then maps OpenAI 'length' → 'max_tokens'.
+    """
+
+    def test_finish_reason_length_non_streaming(self):
+        """Non-streaming: done_reason='length' must propagate as finish_reason='length'."""
+        import json
+        from unittest.mock import MagicMock
+
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        config = OllamaChatConfig()
+
+        ollama_response = {
+            "model": "qwen3:2b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "A neural network learns through",
+            },
+            "done": True,
+            "done_reason": "length",
+            "prompt_eval_count": 20,
+            "eval_count": 20,
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = ollama_response
+        mock_response.text = json.dumps(ollama_response)
+
+        mock_logging = MagicMock()
+
+        model_response = ModelResponse()
+        model_response.choices = [Choices(message=Message(content=""), index=0)]
+
+        result = config.transform_response(
+            model="qwen3:2b",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=mock_logging,
+            request_data={},
+            messages=[{"role": "user", "content": "Explain neural networks."}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+            api_key=None,
+            json_mode=False,
+        )
+
+        assert result.choices[0].finish_reason == "length", (
+            f"Expected 'length' when done_reason='length', got '{result.choices[0].finish_reason}'"
+        )
+
+    def test_finish_reason_stop_non_streaming(self):
+        """Non-streaming: done_reason='stop' (natural finish) must stay 'stop'."""
+        import json
+        from unittest.mock import MagicMock
+
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        config = OllamaChatConfig()
+
+        ollama_response = {
+            "model": "qwen3:2b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": "2 + 2 = 4."},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 8,
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = ollama_response
+        mock_response.text = json.dumps(ollama_response)
+
+        mock_logging = MagicMock()
+
+        model_response = ModelResponse()
+        model_response.choices = [Choices(message=Message(content=""), index=0)]
+
+        result = config.transform_response(
+            model="qwen3:2b",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=mock_logging,
+            request_data={},
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+            api_key=None,
+            json_mode=False,
+        )
+
+        assert result.choices[0].finish_reason == "stop", (
+            f"Expected 'stop' for natural finish, got '{result.choices[0].finish_reason}'"
+        )
+
+    def test_finish_reason_length_streaming(self):
+        """Streaming: done_reason='length' in final chunk must produce finish_reason='length'."""
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        done_chunk = {
+            "model": "qwen3:2b",
+            "message": {"role": "assistant", "content": "A neural network learns through"},
+            "done": True,
+            "done_reason": "length",
+        }
+
+        result = iterator.chunk_parser(done_chunk)
+
+        assert result.choices[0].finish_reason == "length", (
+            f"Expected 'length' when done_reason='length', got '{result.choices[0].finish_reason}'"
+        )
+
+    def test_finish_reason_stop_streaming(self):
+        """Streaming: done_reason='stop' in final chunk must produce finish_reason='stop'."""
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        done_chunk = {
+            "model": "qwen3:2b",
+            "message": {"role": "assistant", "content": "2 + 2 = 4."},
+            "done": True,
+            "done_reason": "stop",
+        }
+
+        result = iterator.chunk_parser(done_chunk)
+
+        assert result.choices[0].finish_reason == "stop", (
+            f"Expected 'stop' for natural finish, got '{result.choices[0].finish_reason}'"
+        )
+
+
 class TestOllamaReasoningContentStreaming:
     """Test that reasoning_content is properly extracted from all thinking chunks."""
 


### PR DESCRIPTION
Fixes #25825

## What does this PR do?

Fixes Ollama's `done_reason='length'` not being propagated as `finish_reason='length'` when a response is truncated by the `max_tokens` / `num_predict` limit.

## Root cause

Two separate bugs in `litellm/llms/ollama/chat/transformation.py`:

**Non-streaming** (`transform_response`): `finish_reason` was hardcoded to `"stop"` before reading the response JSON — Ollama's actual `done_reason` field was never consulted.

**Streaming** (`chunk_parser`): `chunk.get("done_reason", "stop")` defaulted to `"stop"`, so if `done_reason` was missing from the chunk it silently masked truncation.

The result: the Anthropic pass-through adapter (which maps OpenAI `"length"` → Anthropic `"max_tokens"`) always received `"stop"`, so `stop_reason` was always `"end_turn"` even for truncated responses.

## Fix

- Non-streaming: read `done_reason` from `response_json` and use it directly as `finish_reason`.
- Streaming: use `chunk.get("done_reason") or "stop"` so the actual `done_reason` passes through.

Both fixes let `done_reason='length'` propagate correctly through the adapter chain.

## Tests

Added `TestOllamaFinishReasonLength` in `tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py` covering:
- Non-streaming `done_reason='length'` → `finish_reason='length'`
- Non-streaming `done_reason='stop'` → `finish_reason='stop'` (no regression)
- Streaming `done_reason='length'` → `finish_reason='length'`
- Streaming `done_reason='stop'` → `finish_reason='stop'` (no regression)

## Checklist

- [x] At least 1 test added in `tests/litellm/`
- [x] `make test-unit` passes for the affected test file