### PR TITLE
fix(proxy): add shared path utilities, prevent directory traversal

### DIFF
--- a/litellm/proxy/common_utils/path_utils.py
+++ b/litellm/proxy/common_utils/path_utils.py
@@ -1,0 +1,57 @@
+"""
+Safe filesystem path construction for user-controlled inputs.
+
+Use safe_join() instead of os.path.join() whenever a path component
+comes from user input (request parameters, uploaded filenames, etc.)
+to prevent directory traversal attacks.
+"""
+
+import os
+from pathlib import Path
+
+
+def safe_join(base_dir: str, *parts: str) -> str:
+    """
+    Join path components and verify the result stays within base_dir.
+
+    Resolves symlinks and '..' sequences, then checks the final path
+    is a descendant of base_dir. Raises ValueError if traversal is
+    detected.
+
+    Args:
+        base_dir: The trusted base directory.
+        *parts: User-controlled path components to append.
+
+    Returns:
+        The resolved absolute path as a string.
+
+    Raises:
+        ValueError: If the resolved path escapes base_dir.
+    """
+    base = os.path.realpath(base_dir)
+    resolved = os.path.realpath(os.path.join(base, *parts))
+    if not (resolved.startswith(base + os.sep) or resolved == base):
+        raise ValueError(f"Path escapes base directory")
+    return resolved
+
+
+def safe_filename(filename: str) -> str:
+    """
+    Extract a safe filename from a user-supplied path.
+
+    Strips all directory components, returning only the final name.
+    Use this for uploaded file names before writing to disk.
+
+    Args:
+        filename: User-supplied filename (may contain path separators).
+
+    Returns:
+        The basename only, with no directory components.
+
+    Raises:
+        ValueError: If the resulting filename is empty.
+    """
+    name = Path(filename).name
+    if not name:
+        raise ValueError("Empty filename")
+    return name

--- a/litellm/proxy/common_utils/path_utils.py
+++ b/litellm/proxy/common_utils/path_utils.py
@@ -28,10 +28,13 @@ def safe_join(base_dir: str, *parts: str) -> str:
     Raises:
         ValueError: If the resolved path escapes base_dir.
     """
+    for part in parts:
+        if "\x00" in part:
+            raise ValueError("Path contains null byte")
     base = os.path.realpath(base_dir)
     resolved = os.path.realpath(os.path.join(base, *parts))
     if not (resolved.startswith(base + os.sep) or resolved == base):
-        raise ValueError(f"Path escapes base directory")
+        raise ValueError(f"Path {resolved!r} escapes base directory {base!r}")
     return resolved
 
 
@@ -39,8 +42,9 @@ def safe_filename(filename: str) -> str:
     """
     Extract a safe filename from a user-supplied path.
 
-    Strips all directory components, returning only the final name.
-    Use this for uploaded file names before writing to disk.
+    Strips all directory components (both Unix and Windows separators),
+    returning only the final name. Use this for uploaded file names
+    before writing to disk.
 
     Args:
         filename: User-supplied filename (may contain path separators).
@@ -49,9 +53,12 @@ def safe_filename(filename: str) -> str:
         The basename only, with no directory components.
 
     Raises:
-        ValueError: If the resulting filename is empty.
+        ValueError: If the resulting filename is empty or contains null bytes.
     """
-    name = Path(filename).name
-    if not name:
-        raise ValueError("Empty filename")
+    if "\x00" in filename:
+        raise ValueError("Filename contains null byte")
+    # Normalize backslash separators for cross-platform safety
+    name = filename.replace("\\", "/").rsplit("/", 1)[-1]
+    if not name or name in (".", ".."):
+        raise ValueError("Empty or unsafe filename")
     return name

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -5,14 +5,15 @@ CRUD ENDPOINTS FOR GUARDRAILS
 import concurrent.futures
 import inspect
 import json
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 
 from litellm.proxy.common_utils.path_utils import safe_join
-from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
@@ -1350,8 +1351,6 @@ async def get_category_yaml(category_name: str):
     Returns:
         The raw YAML or JSON content of the category file with file type indicator
     """
-    import os
-
     # Get the categories directory path
     categories_dir = os.path.join(
         os.path.dirname(__file__),
@@ -1408,8 +1407,6 @@ async def get_major_airlines():
     Get the major airlines list from IATA (competitor intent, airline type).
     Returns airline id, match variants (pipe-separated), and tags.
     """
-    import os
-
     airlines_path = os.path.join(
         os.path.dirname(__file__),
         "guardrail_hooks",

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
+
+from litellm.proxy.common_utils.path_utils import safe_join
 from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
@@ -1357,8 +1359,6 @@ async def get_category_yaml(category_name: str):
         "litellm_content_filter",
         "categories",
     )
-
-    from litellm.proxy.common_utils.path_utils import safe_join
 
     # Try to find the file with either .yaml or .json extension
     try:

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -1358,9 +1358,14 @@ async def get_category_yaml(category_name: str):
         "categories",
     )
 
+    from litellm.proxy.common_utils.path_utils import safe_join
+
     # Try to find the file with either .yaml or .json extension
-    yaml_path = os.path.join(categories_dir, f"{category_name}.yaml")
-    json_path = os.path.join(categories_dir, f"{category_name}.json")
+    try:
+        yaml_path = safe_join(categories_dir, f"{category_name}.yaml")
+        json_path = safe_join(categories_dir, f"{category_name}.json")
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid category name")
 
     category_file_path = None
     file_type = None

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -1356,8 +1356,10 @@ async def convert_prompt_file_to_json(
         # Read file content
         file_content = await file.read()
 
-        # Create temporary file
-        temp_file_path = Path(tempfile.mkdtemp()) / file.filename
+        from litellm.proxy.common_utils.path_utils import safe_filename
+
+        # Create temporary file — use safe_filename to prevent path traversal
+        temp_file_path = Path(tempfile.mkdtemp()) / safe_filename(file.filename)
         temp_file_path.write_bytes(file_content)
 
         # Create a PromptManager instance just for conversion

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -6,8 +6,6 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
-from litellm.proxy.common_utils.path_utils import safe_filename
-
 from fastapi import (
     APIRouter,
     Depends,
@@ -22,6 +20,7 @@ from pydantic import BaseModel
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.path_utils import safe_filename
 from litellm.types.prompts.init_prompts import (
     ListPromptsResponse,
     PromptInfo,

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -6,6 +6,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
+from litellm.proxy.common_utils.path_utils import safe_filename
+
 from fastapi import (
     APIRouter,
     Depends,
@@ -1355,8 +1357,6 @@ async def convert_prompt_file_to_json(
     try:
         # Read file content
         file_content = await file.read()
-
-        from litellm.proxy.common_utils.path_utils import safe_filename
 
         # Create temporary file — use safe_filename to prevent path traversal
         temp_file_path = Path(tempfile.mkdtemp()) / safe_filename(file.filename)

--- a/tests/test_litellm/proxy/common_utils/test_path_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_path_utils.py
@@ -1,0 +1,46 @@
+import os
+
+import pytest
+
+from litellm.proxy.common_utils.path_utils import safe_filename, safe_join
+
+
+class TestSafeJoin:
+    def test_normal_path(self, tmp_path):
+        result = safe_join(str(tmp_path), "subdir", "file.yaml")
+        assert result == os.path.join(str(tmp_path), "subdir", "file.yaml")
+
+    def test_traversal_blocked(self, tmp_path):
+        with pytest.raises(ValueError, match="escapes base directory"):
+            safe_join(str(tmp_path), "../../etc/passwd.yaml")
+
+    def test_null_byte_blocked(self, tmp_path):
+        with pytest.raises(ValueError, match="null byte"):
+            safe_join(str(tmp_path), "file\x00.yaml")
+
+    def test_base_dir_itself(self, tmp_path):
+        result = safe_join(str(tmp_path))
+        assert result == str(tmp_path.resolve())
+
+
+class TestSafeFilename:
+    def test_normal_filename(self):
+        assert safe_filename("document.prompt") == "document.prompt"
+
+    def test_strips_unix_path(self):
+        assert safe_filename("../../etc/passwd.prompt") == "passwd.prompt"
+
+    def test_strips_windows_path(self):
+        assert safe_filename("..\\..\\etc\\passwd.prompt") == "passwd.prompt"
+
+    def test_null_byte_blocked(self):
+        with pytest.raises(ValueError, match="null byte"):
+            safe_filename("file\x00.prompt")
+
+    def test_dotdot_rejected(self):
+        with pytest.raises(ValueError, match="unsafe filename"):
+            safe_filename("..")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError):
+            safe_filename("")


### PR DESCRIPTION
## Relevant issues

Fixes unsafe path construction in guardrail category endpoint and dotprompt file converter.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### 1. New shared utility: `proxy/common_utils/path_utils.py`

- `safe_join(base_dir, *parts)` — joins path components and verifies the resolved path stays within base_dir. Rejects null bytes and resolves symlinks.
- `safe_filename(filename)` — extracts the basename from a user-supplied path, normalizing both Unix and Windows separators. Rejects null bytes and unsafe names.

### 2. Guardrail category YAML endpoint

`GET /guardrails/ui/category_yaml/{category_name}` now uses `safe_join()` instead of raw `os.path.join()` to construct the category file path. Returns 400 for invalid category names.

### 3. Dotprompt file converter

`POST /utils/dotprompt_json_converter` now uses `safe_filename()` on the uploaded filename before writing to the temp directory.