### PR TITLE
fix(proxy): fix virtual key projected-spend soft budget alerts

### DIFF
--- a/docs/my-website/docs/proxy/ui_team_soft_budget_alerts.md
+++ b/docs/my-website/docs/proxy/ui_team_soft_budget_alerts.md
@@ -2,6 +2,16 @@ import Image from '@theme/IdealImage';
 
 # Team Soft Budget Alerts
 
+:::info
+
+✨ This is an Enterprise feature. Email budget alerts require an enterprise license.
+
+[Enterprise Pricing](https://www.litellm.ai/#pricing)
+
+[Get free 7-day trial key](https://www.litellm.ai/enterprise#trial)
+
+:::
+
 Set a soft budget on a team and get email alerts when spending crosses the threshold — without blocking any requests.
 
 ## Overview

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1870,26 +1870,20 @@ async def update_cache(  # noqa: PLR0915
         ## CHECK IF USER PROJECTED SPEND > SOFT LIMIT
         if (
             existing_spend_obj.soft_budget_cooldown is False
-            and existing_spend_obj.litellm_budget_table is not None
+            and existing_spend_obj.soft_budget is not None
             and (
                 _is_projected_spend_over_limit(
                     current_spend=new_spend,
-                    soft_budget_limit=existing_spend_obj.litellm_budget_table[
-                        "soft_budget"
-                    ],
+                    soft_budget_limit=existing_spend_obj.soft_budget,
                 )
                 is True
             )
         ):
             projected_spend, projected_exceeded_date = _get_projected_spend_over_limit(
                 current_spend=new_spend,
-                soft_budget_limit=existing_spend_obj.litellm_budget_table.get(
-                    "soft_budget", None
-                ),
+                soft_budget_limit=existing_spend_obj.soft_budget,
             )  # type: ignore
-            soft_limit = existing_spend_obj.litellm_budget_table.get(
-                "soft_budget", float("inf")
-            )
+            soft_limit = existing_spend_obj.soft_budget
             call_info = CallInfo(
                 token=existing_spend_obj.token or "",
                 spend=new_spend,
@@ -1897,7 +1891,7 @@ async def update_cache(  # noqa: PLR0915
                 max_budget=soft_limit,
                 user_id=existing_spend_obj.user_id,
                 projected_spend=projected_spend,
-                projected_exceeded_date=projected_exceeded_date,
+                projected_exceeded_date=str(projected_exceeded_date),
                 event_group=Litellm_EntityType.KEY,
             )
             # alert user


### PR DESCRIPTION
## Summary
- The projected-spend alert in `_update_key_cache` (`proxy_server.py`) read from `existing_spend_obj.litellm_budget_table["soft_budget"]` — a nested dict that is **never populated** for virtual keys. The combined_view SQL maps budget fields to flat top-level attributes (`soft_budget`, `max_budget`, etc.) but never constructs the dict. This made the projected-spend check dead code that silently short-circuited on every request.
- When unblocked by reading from the correct flat field, the code crashed with a Pydantic `ValidationError` because `_get_projected_spend_over_limit` returns a `date` object but `CallInfo.projected_exceeded_date` expects `str`.
- Also marks team soft budget email alerts as an enterprise feature in docs.

## Fix
- Read from `existing_spend_obj.soft_budget` (the flat field that IS populated via the combined_view SQL mapping) instead of `existing_spend_obj.litellm_budget_table["soft_budget"]`
- Stringify `projected_exceeded_date` before passing to `CallInfo`

## Screenshots 

before 
<img width="1707" height="825" alt="Screenshot 2026-04-15 at 9 43 30 PM" src="https://github.com/user-attachments/assets/9d6f91fa-d276-4328-895e-456d906fece4" />


after 
<img width="1710" height="676" alt="Screenshot 2026-04-15 at 9 43 49 PM" src="https://github.com/user-attachments/assets/ffac1571-4810-4b19-a28c-e972c966373b" />
<img width="1490" height="602" alt="Screenshot 2026-04-15 at 9 45 12 PM" src="https://github.com/user-attachments/assets/4f0bf09e-a811-4120-8162-be6c875d4c0b" />


## Test plan
- [x] Start proxy with mock model, create key with `soft_budget=0.0001` assigned to a user with email
- [x] Make 15 requests (~$0.0000135/req) to cross the soft budget threshold
- [x] Verify spend increments correctly in cache (was broken before — `update_cache` crashed and spend stopped accumulating)
- [x] Verify email alert delivered to mailpit (local SMTP) with correct subject and recipient
- [x] Verify no Pydantic `ValidationError` in logs

Closes #20324