### PR TITLE
fix(langfuse_otel): include Responses API input in observation payload

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -8,6 +8,7 @@ from litellm._logging import verbose_logger
 from litellm.integrations.arize import _utils
 from litellm.integrations.langfuse.langfuse_otel_attributes import (
     LangfuseLLMObsOTELAttributes,
+    get_langfuse_observation_input_by_type,
 )
 from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
 from litellm.types.integrations.langfuse_otel import (
@@ -243,12 +244,12 @@ class LangfuseOtelLogger(OpenTelemetry):
         metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
         LangfuseOtelLogger._set_metadata_attributes(span=span, metadata=metadata)
 
-        messages = kwargs.get("messages")
-        if messages:
+        input_payload = get_langfuse_observation_input_by_type(kwargs)
+        if input_payload is not None:
             safe_set_attribute(
                 span,
                 LangfuseSpanAttributes.OBSERVATION_INPUT.value,
-                safe_dumps(messages),
+                safe_dumps(input_payload),
             )
 
         LangfuseOtelLogger._set_observation_output(span=span, response_obj=response_obj)

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -8,7 +8,6 @@ from litellm._logging import verbose_logger
 from litellm.integrations.arize import _utils
 from litellm.integrations.langfuse.langfuse_otel_attributes import (
     LangfuseLLMObsOTELAttributes,
-    get_langfuse_observation_input_by_type,
 )
 from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
 from litellm.types.integrations.langfuse_otel import (
@@ -243,14 +242,6 @@ class LangfuseOtelLogger(OpenTelemetry):
 
         metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
         LangfuseOtelLogger._set_metadata_attributes(span=span, metadata=metadata)
-
-        input_payload = get_langfuse_observation_input_by_type(kwargs)
-        if input_payload is not None:
-            safe_set_attribute(
-                span,
-                LangfuseSpanAttributes.OBSERVATION_INPUT.value,
-                safe_dumps(input_payload),
-            )
 
         LangfuseOtelLogger._set_observation_output(span=span, response_obj=response_obj)
 

--- a/litellm/integrations/langfuse/langfuse_otel_attributes.py
+++ b/litellm/integrations/langfuse/langfuse_otel_attributes.py
@@ -15,7 +15,10 @@ from litellm.integrations.opentelemetry_utils.base_otel_llm_obs_attributes impor
     safe_set_attribute,
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
-from litellm.types.llms.openai import HttpxBinaryResponseContent, ResponsesAPIResponse
+from litellm.types.llms.openai import (
+    HttpxBinaryResponseContent,
+    ResponsesAPIResponse,
+)
 from litellm.types.utils import (
     EmbeddingResponse,
     ImageResponse,
@@ -102,18 +105,22 @@ def get_langfuse_observation_input_by_type(
     response_input = kwargs.get("input")
     if response_input is not None:
         prompt: dict[str, Any] = {"input": response_input}
+        # Keep the Responses observation focused on request fields that affect
+        # model context, tool behavior, or response shape.
         for key in (
             "instructions",
-            "functions",
             "tools",
             "tool_choice",
             "reasoning",
             "max_output_tokens",
+            "max_tool_calls",
             "text",
             "parallel_tool_calls",
             "truncation",
             "temperature",
             "top_p",
+            "previous_response_id",
+            "prompt",
         ):
             value = optional_params.get(key)
             if value is not None:

--- a/litellm/integrations/langfuse/langfuse_otel_attributes.py
+++ b/litellm/integrations/langfuse/langfuse_otel_attributes.py
@@ -128,7 +128,9 @@ def get_langfuse_observation_input_by_type(
         return prompt
 
     prompt: dict[str, Any] = {}
-    if "messages" in kwargs:
+    # Preserve explicit empty chat message lists without serializing `null`
+    # when callers pass `messages=None`.
+    if messages is not None:
         prompt["messages"] = messages
     for key in ("functions", "tools"):
         value = optional_params.get(key)

--- a/litellm/integrations/langfuse/langfuse_otel_attributes.py
+++ b/litellm/integrations/langfuse/langfuse_otel_attributes.py
@@ -14,6 +14,7 @@ from litellm.integrations.opentelemetry_utils.base_otel_llm_obs_attributes impor
     BaseLLMObsOTELAttributes,
     safe_set_attribute,
 )
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.types.llms.openai import HttpxBinaryResponseContent, ResponsesAPIResponse
 from litellm.types.utils import (
     EmbeddingResponse,
@@ -82,21 +83,65 @@ def get_output_content_by_type(
         return ""
 
 
+def get_langfuse_observation_input_by_type(
+    kwargs: Dict[str, Any],
+) -> Optional[Union[list[Any], dict[str, Any]]]:
+    """
+    Build the Langfuse observation input payload for both chat- and
+    Responses-style requests.
+
+    Chat requests preserve the existing observation shape of the raw messages
+    list. Responses requests snapshot the model-visible request fields under a
+    single `input` payload for prompt debugging.
+    """
+    messages = kwargs.get("messages")
+    if messages:
+        return messages
+
+    optional_params = kwargs.get("optional_params", {}) or {}
+    response_input = kwargs.get("input")
+    if response_input is not None:
+        prompt: dict[str, Any] = {"input": response_input}
+        for key in (
+            "instructions",
+            "functions",
+            "tools",
+            "tool_choice",
+            "reasoning",
+            "max_output_tokens",
+            "text",
+            "parallel_tool_calls",
+            "truncation",
+            "temperature",
+            "top_p",
+        ):
+            value = optional_params.get(key)
+            if value is not None:
+                prompt[key] = value
+        return prompt
+
+    prompt: dict[str, Any] = {}
+    if "messages" in kwargs:
+        prompt["messages"] = messages
+    for key in ("functions", "tools"):
+        value = optional_params.get(key)
+        if value is not None:
+            prompt[key] = value
+
+    return prompt or None
+
+
 class LangfuseLLMObsOTELAttributes(BaseLLMObsOTELAttributes):
     @staticmethod
     @override
     def set_messages(span: "Span", kwargs: Dict[str, Any]):
-        prompt = {"messages": kwargs.get("messages")}
-        optional_params = kwargs.get("optional_params", {})
-        functions = optional_params.get("functions")
-        tools = optional_params.get("tools")
-        if functions is not None:
-            prompt["functions"] = functions
-        if tools is not None:
-            prompt["tools"] = tools
-
-        input = prompt
-        safe_set_attribute(span, "langfuse.observation.input", json.dumps(input))
+        input_payload = get_langfuse_observation_input_by_type(kwargs)
+        if input_payload is not None:
+            safe_set_attribute(
+                span,
+                "langfuse.observation.input",
+                safe_dumps(input_payload),
+            )
 
     @staticmethod
     @override

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -441,9 +441,9 @@ class TestLangfuseOtelResponsesAPI:
 
         kwargs = {
             "call_type": "responses",
-            "messages": [{"role": "user", "content": "Hello"}],
+            "input": [{"role": "user", "content": "Hello"}],
             "model": "gpt-4o",
-            "optional_params": {},
+            "optional_params": {"instructions": "Reply briefly."},
             "litellm_params": {"metadata": test_metadata},
         }
 
@@ -474,6 +474,80 @@ class TestLangfuseOtelResponsesAPI:
                 mock_safe_set_attribute.assert_any_call(
                     mock_span, "langfuse.trace.name", "responses_api_trace"
                 )
+
+    def test_responses_api_observation_input_uses_input_items(self):
+        """Responses API calls should log the actual `input` items in observation.input."""
+        response_input = [
+            {
+                "role": "user",
+                "content": "show me connected applications with high risk",
+            }
+        ]
+        kwargs = {
+            "call_type": "responses",
+            "model": "gpt-4.1",
+            "input": response_input,
+            "optional_params": {
+                "instructions": "You are a security analyst.",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "list_applications",
+                        "description": "List applications",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ],
+                "tool_choice": "auto",
+                "reasoning": {"effort": "low"},
+                "stream": False,
+            },
+            "litellm_params": {"custom_llm_provider": "openai", "metadata": {}},
+            "standard_logging_object": {
+                "metadata": {},
+                "call_type": "responses",
+                "model_parameters": {
+                    "instructions": "You are a security analyst.",
+                    "tools": [{"type": "function", "name": "list_applications"}],
+                    "tool_choice": "auto",
+                    "reasoning": {"effort": "low"},
+                    "stream": False,
+                },
+            },
+        }
+        response_obj = ResponsesAPIResponse(
+            id="response-456",
+            created_at=1234567891,
+            output=[
+                {
+                    "type": "message",
+                    "content": [{"type": "text", "text": "Hello from responses API"}],
+                }
+            ],
+            parallel_tool_calls=False,
+            tool_choice="auto",
+            tools=[],
+            top_p=1.0,
+        )
+
+        mock_span = MagicMock()
+
+        LangfuseOtelLogger.set_langfuse_otel_attributes(mock_span, kwargs, response_obj)
+
+        actual_attributes = {
+            call.args[0]: call.args[1]
+            for call in mock_span.set_attribute.call_args_list
+        }
+        observation_input = json.loads(actual_attributes["langfuse.observation.input"])
+
+        assert observation_input["input"] == response_input
+        assert observation_input["instructions"] == "You are a security analyst."
+        assert observation_input["tool_choice"] == "auto"
+        assert observation_input["reasoning"] == {"effort": "low"}
+        assert observation_input["tools"][0]["name"] == "list_applications"
+        assert (
+            "show me connected applications with high risk"
+            in actual_attributes["langfuse.observation.input"]
+        )
 
     def test_responses_api_metadata_extraction(self):
         """Test that metadata is correctly extracted from ResponsesAPI kwargs."""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -257,21 +257,14 @@ class TestLangfuseOtelIntegration:
             ],
         )
 
-        kwargs = {
-            "messages": [{"role": "user", "content": "What's the weather in Tokyo?"}],
-        }
-
         with patch(
             "litellm.integrations.arize._utils.safe_set_attribute"
         ) as mock_safe_set_attribute:
             LangfuseOtelLogger._set_langfuse_specific_attributes(
-                MagicMock(), kwargs, response_obj
+                MagicMock(), {}, response_obj
             )
 
             expect_output = {
-                LangfuseSpanAttributes.OBSERVATION_INPUT.value: [
-                    {"role": "user", "content": "What's the weather in Tokyo?"}
-                ],
                 LangfuseSpanAttributes.OBSERVATION_OUTPUT.value: {
                     "role": "assistant",
                     "content": "The weather in Tokyo is sunny.",
@@ -571,6 +564,46 @@ class TestLangfuseOtelResponsesAPI:
             "show me connected applications with high risk"
             in actual_attributes["langfuse.observation.input"]
         )
+
+    def test_langfuse_observation_input_skips_null_messages(self):
+        """Explicit null messages should not serialize as `{\"messages\": null}`."""
+        kwargs = {
+            "messages": None,
+            "optional_params": {
+                "tools": [{"type": "function", "name": "list_applications"}]
+            },
+        }
+
+        from litellm.integrations.langfuse.langfuse_otel_attributes import (
+            get_langfuse_observation_input_by_type,
+        )
+
+        assert get_langfuse_observation_input_by_type(kwargs) == {
+            "tools": [{"type": "function", "name": "list_applications"}]
+        }
+
+    def test_langfuse_specific_attributes_do_not_rewrite_observation_input(self):
+        """Observation input should be owned by set_messages, not rewritten later."""
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+
+        kwargs = {
+            "input": [{"role": "user", "content": "hello"}],
+            "optional_params": {"instructions": "Reply briefly."},
+            "litellm_params": {"metadata": {"generation_name": "gen-name"}},
+        }
+
+        with patch(
+            "litellm.integrations.arize._utils.safe_set_attribute"
+        ) as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(
+                MagicMock(), kwargs, None
+            )
+
+            actual_keys = [
+                call.args[1] for call in mock_safe_set_attribute.call_args_list
+            ]
+            assert LangfuseSpanAttributes.GENERATION_NAME.value in actual_keys
+            assert LangfuseSpanAttributes.OBSERVATION_INPUT.value not in actual_keys
 
     def test_responses_api_metadata_extraction(self):
         """Test that metadata is correctly extracted from ResponsesAPI kwargs."""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -499,6 +499,14 @@ class TestLangfuseOtelResponsesAPI:
                 ],
                 "tool_choice": "auto",
                 "reasoning": {"effort": "low"},
+                "previous_response_id": "resp_prev_123",
+                "prompt": {
+                    "id": "pmpt_123",
+                    "variables": {"tenant": "acme"},
+                },
+                "max_tool_calls": 3,
+                "functions": [{"name": "legacy_chat_only"}],
+                "metadata": {"request_id": "req_123"},
                 "stream": False,
             },
             "litellm_params": {"custom_llm_provider": "openai", "metadata": {}},
@@ -510,6 +518,12 @@ class TestLangfuseOtelResponsesAPI:
                     "tools": [{"type": "function", "name": "list_applications"}],
                     "tool_choice": "auto",
                     "reasoning": {"effort": "low"},
+                    "previous_response_id": "resp_prev_123",
+                    "prompt": {
+                        "id": "pmpt_123",
+                        "variables": {"tenant": "acme"},
+                    },
+                    "max_tool_calls": 3,
                     "stream": False,
                 },
             },
@@ -544,6 +558,15 @@ class TestLangfuseOtelResponsesAPI:
         assert observation_input["tool_choice"] == "auto"
         assert observation_input["reasoning"] == {"effort": "low"}
         assert observation_input["tools"][0]["name"] == "list_applications"
+        assert observation_input["previous_response_id"] == "resp_prev_123"
+        assert observation_input["prompt"] == {
+            "id": "pmpt_123",
+            "variables": {"tenant": "acme"},
+        }
+        assert observation_input["max_tool_calls"] == 3
+        assert "functions" not in observation_input
+        assert "metadata" not in observation_input
+        assert "stream" not in observation_input
         assert (
             "show me connected applications with high risk"
             in actual_attributes["langfuse.observation.input"]


### PR DESCRIPTION
## Relevant issues

Fixes a bug where `langfuse_otel` spans for LiteLLM Responses API calls expose request metadata like `instructions`, `tools`, `tool_choice`, and `reasoning`, but omit the actual model-visible `input` items from `langfuse.observation.input`.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Probe result before the fix for a Responses-style call with `input` and no `messages`:

- `langfuse.observation.input` contained `{"messages": null, "tools": [...]}`
- the actual user input text was absent
- `llm.invocation_parameters` still contained `instructions`, `tools`, `tool_choice`, and `reasoning`

After this fix:

- `langfuse.observation.input` includes the actual Responses API `input` items
- the same observation snapshot also preserves relevant request fields like `instructions`, `tools`, `tool_choice`, and `reasoning`
- chat-style logging behavior remains unchanged

## Type

🐛 Bug Fix
✅ Test

## Changes

- add a shared helper to build Langfuse OTEL observation input payloads for both chat and Responses API calls
- use Responses API `input` when `messages` is absent, while preserving the existing chat shape
- keep relevant model-visible request fields in the Responses observation snapshot for prompt debugging
- add a regression test that uses real Responses-style kwargs (`input`, no `messages`) and verifies the input items appear in `langfuse.observation.input`

## Validation

Ran locally:

```bash
uv run black --check litellm/integrations/langfuse/langfuse_otel.py litellm/integrations/langfuse/langfuse_otel_attributes.py tests/test_litellm/integrations/test_langfuse_otel.py
uv run pytest tests/test_litellm/integrations/test_langfuse_otel.py -x -vv
```

Note: `make lint` is currently red on this checkout due to pre-existing repo-wide Black drift on many untouched files, so this PR keeps formatting scoped to the touched files only.
