### PR TITLE
docs(proxy): document enable_post_custom_auth_checks for custom auth

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -185,6 +185,7 @@ router_settings:
 | langfuse_default_tags | array of strings | Default tags for Langfuse Logging. Use this if you want to control which LiteLLM-specific fields are logged as tags by the LiteLLM proxy. By default LiteLLM Proxy logs no LiteLLM-specific fields as tags. [Further docs](./logging#litellm-specific-tags-on-langfuse---cache_hit-cache_key) |
 | set_verbose | boolean | [DEPRECATED - see debugging docs](./debugging) Use `--debug` or `--detailed_debug` CLI flags, or set `LITELLM_LOG` env var to "INFO", "DEBUG", or "ERROR" instead. |
 | json_logs | boolean | If true, logs will be in json format. If you need to store the logs as JSON, just set the `litellm.json_logs = True`. We currently just log the raw POST request from litellm as a JSON [Further docs](./debugging) |
+| enable_post_custom_auth_checks | boolean | If true, runs LiteLLM post-custom-auth checks (for example expiry, end-user budget, and model budget checks) on `UserAPIKeyAuth` objects returned by custom auth handlers. Default is false for performance. |
 | default_fallbacks | array of strings | List of fallback models to use if a specific model group is misconfigured / bad. [Further docs](./reliability#default-fallbacks) |
 | request_timeout | integer | The timeout for requests in seconds. If not set, the default value is `6000 seconds`. [For reference OpenAI Python SDK defaults to `600 seconds`.](https://github.com/openai/openai-python/blob/main/src/openai/_constants.py) |
 | force_ipv4 | boolean | If true, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6 + Anthropic API |
@@ -285,7 +286,6 @@ router_settings:
 | always_include_stream_usage | boolean | If true, includes usage metrics in every streaming response chunk |
 | auto_redirect_ui_login_to_sso | boolean | If true, automatically redirects UI login page to SSO provider |
 | control_plane_url | string | URL of the control plane for cross-instance state sharing |
-| enable_post_custom_auth_checks | boolean | If true, runs LiteLLM post-custom-auth checks (for example expiry, end-user budget, and model budget checks) on `UserAPIKeyAuth` objects returned by custom auth handlers. Default is false for performance. |
 | custom_auth_run_common_checks | boolean | If true, runs standard auth validation checks alongside custom auth handlers |
 | custom_ui_sso_sign_in_handler | string | Custom handler for SSO sign-in logic in the UI |
 | database_connection_pool_timeout | integer | Database connection pool timeout in seconds |

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -285,6 +285,7 @@ router_settings:
 | always_include_stream_usage | boolean | If true, includes usage metrics in every streaming response chunk |
 | auto_redirect_ui_login_to_sso | boolean | If true, automatically redirects UI login page to SSO provider |
 | control_plane_url | string | URL of the control plane for cross-instance state sharing |
+| enable_post_custom_auth_checks | boolean | If true, runs LiteLLM post-custom-auth checks (for example expiry, end-user budget, and model budget checks) on `UserAPIKeyAuth` objects returned by custom auth handlers. Default is false for performance. |
 | custom_auth_run_common_checks | boolean | If true, runs standard auth validation checks alongside custom auth handlers |
 | custom_ui_sso_sign_in_handler | string | Custom handler for SSO sign-in logic in the UI |
 | database_connection_pool_timeout | integer | Database connection pool timeout in seconds |

--- a/docs/my-website/docs/proxy/custom_auth.md
+++ b/docs/my-website/docs/proxy/custom_auth.md
@@ -232,12 +232,14 @@ general_settings:
 
 ### Optional: run LiteLLM's post-custom-auth checks
 
-If your custom auth function returns a `UserAPIKeyAuth` object and you want LiteLLM to run the built-in checks on that object, enable the following flags in `general_settings`:
+If your custom auth function returns a `UserAPIKeyAuth` object and you want LiteLLM to run the built-in checks on that object, enable the following flags in `litellm_settings` and `general_settings`:
 
 ```yaml
+litellm_settings:
+  enable_post_custom_auth_checks: true   # opt in to LiteLLM post-auth checks
+
 general_settings:
   custom_auth: custom_auth.user_api_key_auth
-  enable_post_custom_auth_checks: true   # opt in to LiteLLM post-auth checks
   custom_auth_run_common_checks: true    # optional: also run standard model access checks
 ```
 

--- a/docs/my-website/docs/proxy/custom_auth.md
+++ b/docs/my-website/docs/proxy/custom_auth.md
@@ -230,6 +230,28 @@ general_settings:
 
 [**Implementation Code**](https://github.com/BerriAI/litellm/blob/caf2a6b279ddbe89ebd1d8f4499f65715d684851/litellm/proxy/utils.py#L122)
 
+### Optional: run LiteLLM's post-custom-auth checks
+
+If your custom auth function returns a `UserAPIKeyAuth` object and you want LiteLLM to run the built-in checks on that object, enable the following flags in `general_settings`:
+
+```yaml
+general_settings:
+  custom_auth: custom_auth.user_api_key_auth
+  enable_post_custom_auth_checks: true   # opt in to LiteLLM post-auth checks
+  custom_auth_run_common_checks: true    # optional: also run standard model access checks
+```
+
+What each flag does:
+
+- `enable_post_custom_auth_checks: true`
+  - Runs LiteLLM's post-custom-auth validation on the returned `UserAPIKeyAuth`
+  - This includes checks such as key expiry, end-user budget enforcement, and per-model budget enforcement
+- `custom_auth_run_common_checks: true`
+  - Runs the common model-access / fallback checks inside the post-custom-auth flow
+  - This flag only has an effect when `enable_post_custom_auth_checks` is also enabled
+
+By default, `enable_post_custom_auth_checks` is `false`. This keeps trusted custom-auth deployments on the fast path and avoids extra DB-backed checks unless you explicitly opt in.
+
 #### 3. Start the proxy
 ```shell
 $ litellm --config /path/to/config.yaml 


### PR DESCRIPTION
## Relevant issues

- Closes #25862

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the `tests/test_litellm/` directory
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

Notes:
- This is a docs-only PR. It does not change runtime behavior.
- I did not mark the testing items complete because I only updated proxy documentation.

## Summary

The current proxy docs mention `custom_auth_run_common_checks`, but they do not document the outer `enable_post_custom_auth_checks` gate that actually enables LiteLLM's post-custom-auth validation flow.

That creates a docs gap for operators using custom auth:
- the code and tests make the opt-in behavior explicit
- the published docs only mention the inner `custom_auth_run_common_checks` flag
- readers can incorrectly assume the inner flag is sufficient on its own

## Type

📖 Documentation

## Changes

1. Add `enable_post_custom_auth_checks` to `docs/my-website/docs/proxy/config_settings.md`
   - documents the flag
   - documents the default (`false`)
   - explains that the default is performance-oriented

2. Add a short explanation to `docs/my-website/docs/proxy/custom_auth.md`
   - shows how `enable_post_custom_auth_checks` interacts with `custom_auth_run_common_checks`
   - explains which built-in checks run when post-custom-auth checks are enabled
   - makes it explicit that `custom_auth_run_common_checks` only has an effect inside the post-custom-auth flow

## Screenshots / Proof of Fix

Docs-only change.

Proof from current code/docs state before this PR:
- `litellm/proxy/auth/user_api_key_auth.py` gates `_run_post_custom_auth_checks(...)` behind `enable_post_custom_auth_checks`
- `docs/my-website/docs/proxy/config_settings.md` documented `custom_auth_run_common_checks` but not `enable_post_custom_auth_checks`

After this PR:
- both docs pages describe the opt-in flag and its interaction with the common-check flag
- no runtime behavior changes
