### PR TITLE
Add docs announcement bar for Trivy compromise resolution

### DIFF
--- a/docs/my-website/docs/index.md
+++ b/docs/my-website/docs/index.md
@@ -12,7 +12,7 @@ import Image from '@theme/IdealImage';
 <Image style={{padding: '10px', margin: '0 0 2.5rem'}} img={require('../img/hero.png')} />
 
 :::note Security Update
-The Trivy supply-chain compromise has been fully mitigated and resolved. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
+The Trivy supply-chain compromise has been contained :tada:. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
 :::
 
 **LiteLLM** is an open-source library that gives you a single, unified interface to call 100+ LLMs — OpenAI, Anthropic, Vertex AI, Bedrock, and more — using the OpenAI format.

--- a/docs/my-website/docs/index.md
+++ b/docs/my-website/docs/index.md
@@ -10,7 +10,7 @@ import NavigationCards from '@site/src/components/NavigationCards';
 import Image from '@theme/IdealImage';
 
 :::note Security Update
-The Trivy supply-chain compromise has been contained :tada:. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
+The Trivy supply-chain compromise has been contained :tada: . All affected packages have been deleted and current releases are free of the compromised code/component. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
 :::
 
 <Image style={{padding: '10px', margin: '0 0 2.5rem'}} img={require('../img/hero.png')} />

--- a/docs/my-website/docs/index.md
+++ b/docs/my-website/docs/index.md
@@ -11,6 +11,10 @@ import Image from '@theme/IdealImage';
 
 <Image style={{padding: '10px', margin: '0 0 2.5rem'}} img={require('../img/hero.png')} />
 
+:::note Security Update
+The Trivy supply-chain compromise has been fully mitigated and resolved. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
+:::
+
 **LiteLLM** is an open-source library that gives you a single, unified interface to call 100+ LLMs — OpenAI, Anthropic, Vertex AI, Bedrock, and more — using the OpenAI format.
 
 - Call any provider using the same `completion()` interface — no re-learning the API for each one

--- a/docs/my-website/docs/index.md
+++ b/docs/my-website/docs/index.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 import NavigationCards from '@site/src/components/NavigationCards';
 import Image from '@theme/IdealImage';
 
-<Image style={{padding: '10px', margin: '0 0 2.5rem'}} img={require('../img/hero.png')} />
-
 :::note Security Update
 The Trivy supply-chain compromise has been contained :tada:. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
 :::
+
+<Image style={{padding: '10px', margin: '0 0 2.5rem'}} img={require('../img/hero.png')} />
 
 **LiteLLM** is an open-source library that gives you a single, unified interface to call 100+ LLMs — OpenAI, Anthropic, Vertex AI, Bedrock, and more — using the OpenAI format.
 

--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -256,6 +256,14 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: 'trivy_compromise_resolved',
+        content:
+          '🔒 The Trivy supply-chain compromise has been fully mitigated and resolved. All affected packages have been deleted and current releases are safe to use. Please refer to our <a href="/blog/security-townhall-updates">Security Townhall</a> for a deeper understanding of the problem, and <a href="/blog/ci-cd-v2-improvements">CI/CD v2</a> for how we\'re improving moving forward.',
+        backgroundColor: '#e6f4ea',
+        textColor: '#1e4620',
+        isCloseable: true,
+      },
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.png',
       navbar: {

--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -256,14 +256,6 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      announcementBar: {
-        id: 'trivy_compromise_resolved',
-        content:
-          '🔒 The Trivy supply-chain compromise has been fully mitigated and resolved. All affected packages have been deleted and current releases are safe to use. Please refer to our <a href="/blog/security-townhall-updates">Security Townhall</a> for a deeper understanding of the problem, and <a href="/blog/ci-cd-v2-improvements">CI/CD v2</a> for how we\'re improving moving forward.',
-        backgroundColor: '#e6f4ea',
-        textColor: '#1e4620',
-        isCloseable: true,
-      },
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.png',
       navbar: {

--- a/docs/my-website/src/pages/index.md
+++ b/docs/my-website/src/pages/index.md
@@ -1,6 +1,10 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::note Security Update
+The Trivy supply-chain compromise has been contained :tada:. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
+:::
+
 # LiteLLM - Getting Started
 
 https://github.com/BerriAI/litellm

--- a/docs/my-website/src/pages/index.md
+++ b/docs/my-website/src/pages/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 :::note Security Update
-The Trivy supply-chain compromise has been contained :tada:. All affected packages have been deleted and current releases are safe to use. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
+The Trivy supply-chain compromise has been contained :tada: . All affected packages have been deleted and current releases are free of the compromised code/component. Please refer to our [Security Townhall](/blog/security-townhall-updates) for a deeper understanding of the problem, and [CI/CD v2](/blog/ci-cd-v2-improvements) for how we're improving moving forward.
 :::
 
 # LiteLLM - Getting Started


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Adds a security notice to the top of the docs landing page and root page informing users the Trivy supply-chain compromise has been contained.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

> Note: This is a docs-only change (Markdown admonition), no code tests needed.

## Screenshots / Proof of Fix

Root page (`/`):

[Security Update note on root page](https://cursor.com/agents/bc-f268a27c-2a2d-5b0d-8ff1-d02d00912a80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froot_page_note.webp)

Docs page (`/docs`), note appears above the hero image:

[Security Update note on docs page](https://cursor.com/agents/bc-f268a27c-2a2d-5b0d-8ff1-d02d00912a80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_page_note.webp)

[security_note_both_pages.mp4](https://cursor.com/agents/bc-f268a27c-2a2d-5b0d-8ff1-d02d00912a80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecurity_note_both_pages.mp4)

## Type

📖 Documentation

## Changes

- Added a `:::note Security Update` admonition to `docs/my-website/docs/index.md` above the hero image
- Added the same admonition to `docs/my-website/src/pages/index.md` (root page) above the heading
- The note states the Trivy compromise has been contained, all affected packages deleted, and current releases are safe
- Links to the [Security Townhall](/blog/security-townhall-updates) and [CI/CD v2](/blog/ci-cd-v2-improvements) blog posts

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/D092E9K4EMP/p1773108831937859?thread_ts=1773108831.937859&cid=D092E9K4EMP)

<div><a href="https://cursor.com/agents/bc-f268a27c-2a2d-5b0d-8ff1-d02d00912a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f268a27c-2a2d-5b0d-8ff1-d02d00912a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

