### PR TITLE
Refactor: extract shared PKCE helpers into utils/pkce.ts

### DIFF
--- a/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useMcpOAuthFlow.tsx
@@ -11,6 +11,7 @@ import {
   serverRootPath,
 } from "@/components/networking";
 import { extractErrorMessage } from "@/utils/errorUtils";
+import { generateCodeChallenge, generateCodeVerifier } from "@/utils/pkce";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
 
 export type McpOAuthStatus = "idle" | "authorizing" | "exchanging" | "success" | "error";
@@ -33,25 +34,6 @@ interface UseMcpOAuthFlowResult {
   error: string | null;
   tokenResponse: Record<string, any> | null;
 }
-
-const base64UrlEncode = (buffer: ArrayBuffer) => {
-  const bytes = new Uint8Array(buffer);
-  let binary = "";
-  bytes.forEach((b) => (binary += String.fromCharCode(b)));
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-};
-
-const generateCodeVerifier = () => {
-  const array = new Uint8Array(32);
-  window.crypto.getRandomValues(array);
-  return base64UrlEncode(array.buffer);
-};
-
-const generateCodeChallenge = async (verifier: string) => {
-  const data = new TextEncoder().encode(verifier);
-  const digest = await window.crypto.subtle.digest("SHA-256", data);
-  return base64UrlEncode(digest);
-};
 
 export const useMcpOAuthFlow = ({
   accessToken,

--- a/ui/litellm-dashboard/src/hooks/useUserMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useUserMcpOAuthFlow.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/networking";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { extractErrorMessage } from "@/utils/errorUtils";
+import { generateCodeChallenge, generateCodeVerifier } from "@/utils/pkce";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
 
 export type UserMcpOAuthStatus = "idle" | "authorizing" | "exchanging" | "success" | "error";
@@ -58,25 +59,6 @@ type StoredFlowState = {
   clientId?: string;
   clientSecret?: string;
   scopes?: string[];
-};
-
-const b64url = (buf: ArrayBuffer) => {
-  const bytes = new Uint8Array(buf);
-  let s = "";
-  bytes.forEach((b) => (s += String.fromCharCode(b)));
-  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-};
-
-const genVerifier = () => {
-  const arr = new Uint8Array(32);
-  window.crypto.getRandomValues(arr);
-  return b64url(arr.buffer);
-};
-
-const genChallenge = async (verifier: string) => {
-  const data = new TextEncoder().encode(verifier);
-  const digest = await window.crypto.subtle.digest("SHA-256", data);
-  return b64url(digest);
 };
 
 const setStorage = (key: string, value: string) => {
@@ -144,8 +126,8 @@ export const useUserMcpOAuthFlow = ({
         }
       }
 
-      const verifier = genVerifier();
-      const challenge = await genChallenge(verifier);
+      const verifier = generateCodeVerifier();
+      const challenge = await generateCodeChallenge(verifier);
       const state = crypto.randomUUID();
       const redirectUri = buildCallbackUrl();
       const scopeString = scopes?.filter((s) => s.trim()).join(" ");

--- a/ui/litellm-dashboard/src/utils/pkce.ts
+++ b/ui/litellm-dashboard/src/utils/pkce.ts
@@ -1,0 +1,18 @@
+const base64UrlEncode = (buffer: ArrayBuffer) => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+export const generateCodeVerifier = () => {
+  const array = new Uint8Array(32);
+  window.crypto.getRandomValues(array);
+  return base64UrlEncode(array.buffer);
+};
+
+export const generateCodeChallenge = async (verifier: string) => {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await window.crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(digest);
+};


### PR DESCRIPTION
## Summary
- Extracts `base64UrlEncode`, `generateCodeVerifier`, and `generateCodeChallenge` into a shared `src/utils/pkce.ts` module
- Updates `useMcpOAuthFlow` and `useUserMcpOAuthFlow` hooks to import from the shared module instead of defining their own copies
- No behavioral changes — pure deduplication

## Test plan
- [ ] Verify admin MCP OAuth flow (create-server form) still completes end-to-end
- [ ] Verify user MCP OAuth connect flow still completes end-to-end
- [ ] Confirm `npm run build` passes with no type errors