### PR TITLE
fix: return None for routing_strategy_args when strategy is not latency-based

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8702,6 +8702,8 @@ class Router:
                 and self.routing_strategy == "latency-based-routing"
             ):
                 _settings_to_return[var] = self.lowestlatency_logger.routing_args.json()
+            elif var == "routing_strategy_args":
+                _settings_to_return[var] = None
         return _settings_to_return
 
     def update_settings(self, **kwargs):


### PR DESCRIPTION
## Summary
- `Router.get_settings()` returned `{}` for `routing_strategy_args` when the strategy was not `latency-based-routing`
- `{}` is truthy in JS, so the frontend `|| defaultArgs` fallback was skipped, causing the Latency-Based Configuration section to render with no inputs
- Now returns `None` instead, which the frontend handles correctly by falling back to default values (`ttl: 3600`, `lowest_latency_buffer: 0`)

## Screenshots 

before 

<img width="1302" height="722" alt="Screenshot 2026-04-16 at 11 49 38 AM" src="https://github.com/user-attachments/assets/4694c8eb-3fcd-4dfb-876a-548ca9b72696" />


after 
<img width="809" height="410" alt="Screenshot 2026-04-16 at 11 54 10 AM" src="https://github.com/user-attachments/assets/8a87509c-c830-40e1-bfa6-4d930d836123" />


## Test plan
- [x] Set routing strategy to `latency-based-routing` without custom args configured
- [x] Verify the Latency-Based Configuration section renders `ttl` and `lowest_latency_buffer` inputs with defaults
- [x] Set routing strategy to something else (e.g. `simple-shuffle`), verify no errors