### PR TITLE
[Infra] Bump llm_translation_testing resource class to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -638,7 +638,7 @@ jobs:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
     working_directory: ~/project
-    resource_class: large
+    resource_class: xlarge
 
     steps:
       - checkout


### PR DESCRIPTION
## Summary

Bumps the CircleCI `llm_translation_testing` job's `resource_class` from `large` (4 vCPUs / 8GB RAM) to `xlarge` (8 vCPUs / 16GB RAM) to give the job more compute.

## Changes

- `.circleci/config.yml`: `resource_class: large` → `resource_class: xlarge` for the `llm_translation_testing` job.

## Testing

CI will exercise the new resource class when this PR runs.

## Type

🚄 Infrastructure