### PR TITLE
fix(router): propagate `custom cost_per_token` from db `model_info` in fallback path

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7852,14 +7852,16 @@ class Router:
                 # Get mode from database model_info if available, otherwise default to "chat"
                 db_model_info = model.get("model_info", {})
                 mode = db_model_info.get("mode", "chat")
+                input_cost_per_token = db_model_info.get("input_cost_per_token")
+                output_cost_per_token = db_model_info.get("output_cost_per_token")
 
                 model_info = ModelMapInfo(
                     key=model_group,
                     max_tokens=None,
                     max_input_tokens=None,
                     max_output_tokens=None,
-                    input_cost_per_token=None,
-                    output_cost_per_token=None,
+                    input_cost_per_token=input_cost_per_token,
+                    output_cost_per_token=output_cost_per_token,
                     litellm_provider=llm_provider,
                     mode=mode,
                     supported_openai_params=supported_openai_params,

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1076,6 +1076,69 @@ def test_cached_get_model_group_info():
     assert result5 is result6
 
 
+def test_model_group_info_cost_from_db_model_info():
+    """
+    When get_deployment_model_info fails (model_info is None fallback),
+    input_cost_per_token and output_cost_per_token should be read from db model_info.
+    """
+    from unittest.mock import patch
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-custom-model",
+                "litellm_params": {
+                    "model": "openai/my-custom-model",
+                    "api_key": "fake",
+                    "api_base": "https://my-custom-endpoint.com",
+                },
+                "model_info": {
+                    "input_cost_per_token": 0.0001,
+                    "output_cost_per_token": 0.0002,
+                },
+            },
+        ]
+    )
+
+    with patch.object(
+        router, "get_deployment_model_info", side_effect=Exception("not found")
+    ):
+        result = router._cached_get_model_group_info("my-custom-model")
+        assert result is not None
+        assert result.input_cost_per_token == 0.0001
+        assert result.output_cost_per_token == 0.0002
+
+
+def test_model_group_info_cost_none_when_db_model_info_has_no_cost():
+    """
+    When get_deployment_model_info fails and db model_info has no cost fields,
+    input/output_cost_per_token should be None.
+    """
+    from unittest.mock import patch
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-custom-model-no-cost",
+                "litellm_params": {
+                    "model": "openai/my-custom-model-no-cost",
+                    "api_key": "fake",
+                    "api_base": "https://my-custom-endpoint.com",
+                },
+                "model_info": {},
+            },
+        ]
+    )
+
+    with patch.object(
+        router, "get_deployment_model_info", side_effect=Exception("not found")
+    ):
+        result = router._cached_get_model_group_info("my-custom-model-no-cost")
+        assert result is not None
+        assert result.input_cost_per_token is None
+        assert result.output_cost_per_token is None
+
+
 def test_get_model_access_groups_caching():
     """
     Test that get_model_access_groups caches the no-args result


### PR DESCRIPTION
## Relevant issues

Fixes #25874
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="800" alt="Before fix - cost_per_token is None" src="https://github.com/user-attachments/assets/162771f0-f124-4f71-8797-c7e1fa4ec64f" /></td>
<td><img width="800" alt="After fix - cost_per_token propagated from db model_info" src="https://github.com/user-attachments/assets/68f6cf44-90c9-42f1-a923-5c7efef49799" /></td>
</tr>
</table>

**Unit tests** — 2 new tests added and passing:

- `test_model_group_info_cost_from_db_model_info` — verifies `input_cost_per_token` / `output_cost_per_token` are read from `db_model_info` when `get_deployment_model_info` fails
- `test_model_group_info_cost_none_when_db_model_info_has_no_cost` — verifies values remain `None` when `db_model_info` has no cost fields

```
tests/test_litellm/test_router.py::test_model_group_info_cost_from_db_model_info PASSED
tests/test_litellm/test_router.py::test_model_group_info_cost_none_when_db_model_info_has_no_cost PASSED
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

When a model is not found in LiteLLM's built-in model cost map (`model_info is None` in `get_model_group_info()`), the fallback `ModelMapInfo` was hardcoding `input_cost_per_token` and `output_cost_per_token` to `None`, ignoring any custom cost values the user had configured in the database's `model_info`.

This fix reads `input_cost_per_token` and `output_cost_per_token` from `db_model_info` (the user's database/config model_info), consistent with how `mode` is already read from the same source. If the keys are not present, `.get()` returns `None`, preserving backward compatibility.

### Before
```python
model_info = ModelMapInfo(
    ...
    input_cost_per_token=None,
    output_cost_per_token=None,
    ...
)
```

### After
```python
input_cost_per_token = db_model_info.get("input_cost_per_token")
output_cost_per_token = db_model_info.get("output_cost_per_token")

model_info = ModelMapInfo(
    ...
    input_cost_per_token=input_cost_per_token,
    output_cost_per_token=output_cost_per_token,
    ...
)
```