### PR TITLE
[Infra] Reduce llm_translation_testing parallelism and tolerate worker restarts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
             for dir in "${IGNORE_DIRS[@]}"; do
               IGNORE_ARGS="$IGNORE_ARGS --ignore=$dir"
             done
-            uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 8 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5
+            uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5
           no_output_timeout: 15m
 
       # Store test results


### PR DESCRIPTION
## Relevant issues

## Summary

### Problem

Workers in the \`llm_translation_testing\` CircleCI job have been crashing mid-run with \`[gw*] node down: Not properly terminated\`, failing the job and blocking the pipeline. The crashes are OOM kills: multiple workers go down near the end of the run (97–99% through), and the log shows accumulating \`Unclosed client session\` / \`Unclosed connector\` messages before the final crash. Bumping \`resource_class\` from \`large\` to \`xlarge\` did not resolve it.

### Fix

Two small, independent mitigations on the pytest invocation:

- Drop xdist workers from \`-n 8\` to \`-n 4\`. Memory pressure per worker is the dominant failure mode, not CPU throughput; these tests are I/O-bound.
- Add \`--max-worker-restart=5\` so a crashed worker is replaced and its remaining tests are redistributed, instead of failing the entire job on the first OOM.

Staging counterpart of #25897.

## Testing

CI will exercise the new configuration when this PR runs.

## Type

🚄 Infrastructure