### PR TITLE
fix(router): keep timedelta out of redis-backed latency cache

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -55,6 +55,20 @@ else:
     Span = Any
 
 
+def _json_default(obj: Any) -> Any:
+    """`json.dumps(default=)` callback used by Redis writers.
+
+    Maps `timedelta -> total_seconds()` (not `str(timedelta)`) so latency values
+    written by `LowestLatencyLoggingHandler` round-trip as `float` and survive
+    `_get_available_deployments`' `isinstance(_, float)` filter. Falls back to
+    `str(obj)` for any other non-JSON-native type, matching the `default=str`
+    pattern used elsewhere in litellm.
+    """
+    if isinstance(obj, timedelta):
+        return obj.total_seconds()
+    return str(obj)
+
+
 def _get_call_stack_info(num_frames: int = 2) -> str:
     """
     Get the function names from the previous 1-2 functions in the call stack.
@@ -585,7 +599,7 @@ class RedisCache(BaseCache):
                 raise Exception("Redis client cannot set cache. Attribute not found.")
             result = await _redis_client.set(
                 name=key,
-                value=json.dumps(value),
+                value=json.dumps(value, default=_json_default),
                 nx=nx,
                 ex=ttl,
             )
@@ -643,7 +657,7 @@ class RedisCache(BaseCache):
             print_verbose(
                 f"Set ASYNC Redis Cache PIPELINE: key: {cache_key}\nValue {cache_value}\nttl={ttl}"
             )
-            json_cache_value = json.dumps(cache_value)
+            json_cache_value = json.dumps(cache_value, default=_json_default)
             # Set the value with a TTL if it's provided.
             _td: Optional[timedelta] = None
             if ttl is not None:

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -77,6 +77,11 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 precise_minute = f"{current_date}-{current_hour}-{current_minute}"
 
                 response_ms = end_time - start_time
+                response_seconds: float = (
+                    response_ms.total_seconds()
+                    if isinstance(response_ms, timedelta)
+                    else float(response_ms)
+                )
                 time_to_first_token_response_time = None
 
                 if kwargs.get("stream", None) is not None and kwargs["stream"] is True:
@@ -85,7 +90,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         kwargs.get("completion_start_time", end_time) - start_time
                     )
 
-                final_value: Union[float, timedelta] = response_ms
+                final_value: float = response_seconds
                 time_to_first_token: Optional[float] = None
                 total_tokens = 0
 
@@ -302,6 +307,11 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 precise_minute = f"{current_date}-{current_hour}-{current_minute}"
 
                 response_ms = end_time - start_time
+                response_seconds: float = (
+                    response_ms.total_seconds()
+                    if isinstance(response_ms, timedelta)
+                    else float(response_ms)
+                )
                 time_to_first_token_response_time = None
                 if kwargs.get("stream", None) is not None and kwargs["stream"] is True:
                     # only log ttft for streaming request
@@ -309,7 +319,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         kwargs.get("completion_start_time", end_time) - start_time
                     )
 
-                final_value: Union[float, timedelta] = response_ms
+                final_value: float = response_seconds
                 total_tokens = 0
                 time_to_first_token: Optional[float] = None
 
@@ -331,7 +341,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         if final_value is not None:
                             final_value = float(final_value)
                         else:
-                            final_value = response_ms
+                            final_value = response_seconds
 
                         if time_to_first_token_response_time is not None:
                             if isinstance(time_to_first_token_response_time, timedelta):

--- a/tests/test_litellm/caching/test_redis_cache_timedelta.py
+++ b/tests/test_litellm/caching/test_redis_cache_timedelta.py
@@ -1,0 +1,89 @@
+"""
+Tests that RedisCache writers tolerate `datetime.timedelta` values in the payload,
+serializing them as `float` seconds (not stringified). Defence-in-depth against
+the latency-cache regression class — keeps the cache numeric for the
+`_get_available_deployments` read path.
+"""
+
+import json
+import os
+import sys
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.caching.redis_cache import RedisCache
+
+
+@pytest.fixture
+def redis_no_ping():
+    """Patch RedisCache initialization to prevent async ping tasks from being created."""
+    with patch("asyncio.get_running_loop") as mock_get_loop:
+        mock_get_loop.side_effect = RuntimeError("No running event loop")
+        yield
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_serializes_timedelta_as_float(
+    monkeypatch, redis_no_ping
+):
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.__aenter__.return_value = mock_redis_instance
+    mock_redis_instance.__aexit__.return_value = None
+
+    payload = {"latency": [timedelta(seconds=1.5), 2.0]}
+
+    with patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_set_cache(key="embed-group_map", value=payload)
+
+    mock_redis_instance.set.assert_called_once()
+    call_kwargs = mock_redis_instance.set.call_args.kwargs
+    assert call_kwargs["name"] == "embed-group_map"
+    decoded = json.loads(call_kwargs["value"])
+    assert decoded == {
+        "latency": [1.5, 2.0]
+    }, f"timedelta did not round-trip as float: {decoded!r}"
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_pipeline_serializes_timedelta_as_float(
+    monkeypatch, redis_no_ping
+):
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.__aenter__.return_value = mock_redis_instance
+    mock_redis_instance.__aexit__.return_value = None
+
+    mock_pipe = MagicMock()
+    mock_pipe.set = MagicMock()
+    mock_pipe.execute = AsyncMock(return_value=[True])
+
+    pipe_ctx = MagicMock()
+    pipe_ctx.__aenter__ = AsyncMock(return_value=mock_pipe)
+    pipe_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_redis_instance.pipeline = MagicMock(return_value=pipe_ctx)
+
+    payload = {"latency": [timedelta(seconds=0.25)]}
+
+    with patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_set_cache_pipeline(
+            cache_list=[("embed-group_map", payload)]
+        )
+
+    mock_pipe.set.assert_called_once()
+    call_kwargs = mock_pipe.set.call_args.kwargs
+    decoded = json.loads(call_kwargs["value"])
+    assert decoded == {
+        "latency": [0.25]
+    }, f"pipeline timedelta did not round-trip as float: {decoded!r}"

--- a/tests/test_litellm/test_lowest_latency_timedelta_serialization.py
+++ b/tests/test_litellm/test_lowest_latency_timedelta_serialization.py
@@ -1,0 +1,133 @@
+"""
+Tests that LowestLatencyLoggingHandler stores latency values as floats
+(not raw datetime.timedelta) in the cache, across all success-callback branches.
+
+Regression test for: timedelta values in the {model_group}_map cache breaking
+RedisCache.async_set_cache JSON serialization. Earlier partial fix in PR #14040
+covered only the sync ModelResponse-with-usage branch.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler
+from litellm.types.utils import EmbeddingResponse
+
+
+def _make_kwargs(deployment_id: str = "1234", model_group: str = "embed-group") -> dict:
+    return {
+        "litellm_params": {
+            "metadata": {
+                "model_group": model_group,
+                "deployment": "openai/text-embedding-3-small",
+            },
+            "model_info": {"id": deployment_id},
+        }
+    }
+
+
+def _latency_list(cache: DualCache, model_group: str, deployment_id: str) -> list:
+    cached = cache.get_cache(key=f"{model_group}_map")
+    assert cached is not None
+    assert deployment_id in cached
+    return cached[deployment_id].get("latency", [])
+
+
+def test_log_success_event_embedding_response_stores_float():
+    """EmbeddingResponse hits the non-ModelResponse branch — final_value must be float."""
+    cache = DualCache()
+    handler = LowestLatencyLoggingHandler(router_cache=cache)
+    kwargs = _make_kwargs()
+    response_obj = EmbeddingResponse(
+        model="text-embedding-3-small",
+        usage=litellm.Usage(prompt_tokens=4, completion_tokens=0, total_tokens=4),
+    )
+    start_time = datetime.now()
+    end_time = start_time + timedelta(seconds=1.5)
+
+    handler.log_success_event(
+        kwargs=kwargs,
+        response_obj=response_obj,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    latencies = _latency_list(cache, "embed-group", "1234")
+    assert latencies, "expected one latency entry"
+    assert all(isinstance(v, float) for v in latencies), f"non-float in {latencies!r}"
+
+
+def test_log_success_event_model_response_no_usage_stores_float():
+    """ModelResponse with usage=None hits a sub-branch that skips conversion — must still produce float."""
+    cache = DualCache()
+    handler = LowestLatencyLoggingHandler(router_cache=cache)
+    kwargs = _make_kwargs(model_group="chat-group")
+    response_obj = litellm.ModelResponse()
+    response_obj.usage = None  # type: ignore[attr-defined]
+    start_time = datetime.now()
+    end_time = start_time + timedelta(seconds=0.75)
+
+    handler.log_success_event(
+        kwargs=kwargs,
+        response_obj=response_obj,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    latencies = _latency_list(cache, "chat-group", "1234")
+    assert latencies and all(isinstance(v, float) for v in latencies)
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_embedding_response_stores_float():
+    """Async mirror of the embedding test."""
+    cache = DualCache()
+    handler = LowestLatencyLoggingHandler(router_cache=cache)
+    kwargs = _make_kwargs()
+    response_obj = EmbeddingResponse(
+        model="text-embedding-3-small",
+        usage=litellm.Usage(prompt_tokens=4, completion_tokens=0, total_tokens=4),
+    )
+    start_time = datetime.now()
+    end_time = start_time + timedelta(seconds=2.0)
+
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=response_obj,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    latencies = _latency_list(cache, "embed-group", "1234")
+    assert latencies and all(isinstance(v, float) for v in latencies)
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_zero_completion_tokens_stores_float():
+    """Async ModelResponse with completion_tokens=0 takes the safe_divide_seconds → None
+    fallback at lowest_latency.py:344, which PR #14040 only fixed in the sync mirror."""
+    cache = DualCache()
+    handler = LowestLatencyLoggingHandler(router_cache=cache)
+    kwargs = _make_kwargs(model_group="chat-group")
+    response_obj = litellm.ModelResponse(
+        usage=litellm.Usage(prompt_tokens=100, completion_tokens=0, total_tokens=100),
+    )
+    start_time = datetime.now()
+    end_time = start_time + timedelta(seconds=0.5)
+
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=response_obj,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    latencies = _latency_list(cache, "chat-group", "1234")
+    assert latencies and all(isinstance(v, float) for v in latencies)


### PR DESCRIPTION
## Relevant issues

Refs #14383 (closed-stale; same `Object of type timedelta is not JSON serializable`, customer comment 2026-04-16 confirms still broken on v1.83.0). Related: #8025, #9391 (same surface symptom, embeddings + `lowest_latency`). Builds on #14040, which fixed one of three leak points back in August.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

**Before fix** — Pi `v1.83.6`, `latency-based-routing` + Redis, one `POST /v1/embeddings`:

```
21:45:39 - LiteLLM:ERROR: redis_cache.py:624 - LiteLLM Redis Caching: async set() - Got exception from REDIS Object of type timedelta is not JSON serializable, Writing value={'ad2c057d12dfd06bc54038ee8304785f66c196b756bad2aa6990dc13aae2f781': {'latency': [datetime.timedelta(seconds=2, microseconds=732275)], '2026-04-16-21-45': {'tpm': 0, 'rpm': 1}}}
```

`docker exec ... redis-cli KEYS '*embed-group*'` → empty (write was lost).

**After fix** — same setup with this PR applied:

```
22:22:59 - LiteLLM Router:INFO: router.py:4177 - litellm.aembedding(model=openai/text-embedding-3-small) 200 OK
INFO:     127.0.0.1:47588 - "POST /v1/embeddings HTTP/1.1" 200 OK
```

No `Object of type timedelta` line anywhere in the log. Redis state:

```
$ docker exec litellm-repro-redis redis-cli KEYS '*embed-group*'
embed-group_map

$ docker exec litellm-repro-redis redis-cli GET 'embed-group_map'
{"ad2c057d12dfd06bc54038ee8304785f66c196b756bad2aa6990dc13aae2f781": {"latency": [2.37388], "2026-04-16-22-22": {"tpm": 0, "rpm": 1}}}
```

Latency value persists as a plain `float` (`2.37388`), not a stringified timedelta.

## Type

🐛 Bug Fix

## Changes

`LowestLatencyLoggingHandler.log_success_event` (and its async sibling) compute `response_ms = end_time - start_time` (a `timedelta`) but only convert to `float` inside the `isinstance(response_obj, ModelResponse) and usage is not None` branch. Any callback taking another path — `EmbeddingResponse`, `ModelResponse` without `usage`, the async `safe_divide_seconds → None` fallback — appended a raw `timedelta` to the cache dict. `RedisCache.async_set_cache` then called `json.dumps(value)` with no `default=`, raising `TypeError: Object of type timedelta is not JSON serializable`. The error was caught and logged but the write was lost — multi-replica deployments using `latency-based-routing + Redis` lose cross-instance latency state.

#14040 patched the sync `safe_divide_seconds → None` branch back in August; this PR closes the remaining two leak points (async mirror + non-`ModelResponse` callbacks) and adds a sink-side defence so the same regression class can't quietly recur.

**Source side** (`litellm/router_strategy/lowest_latency.py`):

- Hoists `response_seconds: float = response_ms.total_seconds() if isinstance(response_ms, timedelta) else float(response_ms)` above the `ModelResponse` branch in both sync and async handlers.
- Narrows the `final_value` annotation from `Union[float, timedelta]` to `float`, so a future regression in this same shape becomes a type error.
- Mirrors #14040's `response_ms → response_seconds` fix in the async fallback (`final_value = response_ms` → `final_value = response_seconds`).

**Sink side** (`litellm/caching/redis_cache.py`):

- Adds a small `_json_default` helper used at `async_set_cache` and `_pipeline_helper`. Maps `timedelta → total_seconds()` (deliberately not `default=str`, which would stringify to `"0:00:00.256..."` and silently break the read-path `isinstance(_, float)` filter at `_get_available_deployments`, biasing routing decisions). Falls back to `str(obj)` for any other non-JSON-native type, matching the `default=str` pattern used in `in_memory_cache.py`.

The combined change keeps the cache numeric end-to-end so `_get_available_deployments` continues to sum and average correctly, and the sink-side default acts as defence-in-depth against future callbacks that miss the same conversion.

**New tests:**

- `tests/test_litellm/test_lowest_latency_timedelta_serialization.py` — 4 tests covering sync/async × `EmbeddingResponse` / `ModelResponse(usage=None)`, plus async `completion_tokens=0` (the fallback branch #14040 missed).
- `tests/test_litellm/caching/test_redis_cache_timedelta.py` — 2 tests covering `async_set_cache` and `async_set_cache_pipeline` with a `{"latency": [timedelta(...)]}` payload, asserting timedeltas round-trip as floats (`{"latency": [1.5]}`).
