### PR TITLE
fix: add None guard for num_retries comparison in router

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5768,7 +5768,7 @@ class Router:
             _metadata["max_retries"] = num_retries
 
             ## LOGGING
-            if num_retries > 0:
+            if num_retries is not None and num_retries > 0:
                 kwargs = self.log_retry(kwargs=kwargs, e=original_exception)
             else:
                 raise


### PR DESCRIPTION
## What's broken?

When Ollama returns a rate limit / session usage limit error, litellm crashes with:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

instead of properly propagating the original error.

## Who is affected?

Any user hitting a rate limit through Ollama (or any provider path where `num_retries` is not explicitly set), especially when `optional_pre_call_checks: enforce_model_rate_limits` is configured.

## Root Cause

In `router.py`, `async_function_with_retries` pops `num_retries` from kwargs (line 5688):

```python
num_retries = kwargs.pop("num_retries")
```

This can be `None` when the caller doesn't set it. Later, the comparison on line 5771:

```python
if num_retries > 0:
```

raises a `TypeError` because Python cannot compare `None > int`.

## Fix

Added a `None` guard before the comparison:

```python
if num_retries is not None and num_retries > 0:
```

This matches the defensive pattern already used elsewhere in the same file (e.g., line 516: `if num_retries is not None:`). When `num_retries` is `None`, the code falls through to `raise`, correctly propagating the original exception to the caller.

## Testing

Verified the fix handles the `None` case: when `num_retries` is `None`, the condition evaluates to `False` and the original exception is re-raised as expected.

Fixes #25889
