### PR TITLE
fix: cache list_all_params() to prevent RecursionError

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -97,6 +97,7 @@ from litellm.types.utils import (
     CostBreakdown,
     CostResponseTypes,
     CustomPricingLiteLLMParams,
+    DYNAMIC_PROMPT_MANAGEMENT_PARAMS,
     DynamicPromptManagementParamLiteral,
     EmbeddingResponse,
     GuardrailStatus,
@@ -684,7 +685,7 @@ class Logging(LiteLLMLoggingBaseClass):
         eg. AnthropicCacheControlHook and BedrockKnowledgeBaseHook both don't require a `prompt_id` to be passed in, they are triggered by dynamic params
         """
         for param in non_default_params:
-            if param in DynamicPromptManagementParamLiteral.list_all_params():
+            if param in DYNAMIC_PROMPT_MANAGEMENT_PARAMS:
                 return True
 
         #############################################################################

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3601,6 +3601,11 @@ class DynamicPromptManagementParamLiteral(str, Enum):
         return [param.value for param in cls]
 
 
+DYNAMIC_PROMPT_MANAGEMENT_PARAMS: frozenset[str] = frozenset(
+    param.value for param in DynamicPromptManagementParamLiteral
+)
+
+
 class CallbacksByType(TypedDict):
     success: List[str]
     failure: List[str]

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -36,6 +36,49 @@ def test_get_masked_api_base(logging_obj):
     assert type(masked_api_base) == str
 
 
+@pytest.mark.parametrize(
+    "non_default_params",
+    [
+        {"cache_control_injection_points": [{"location": "message", "index": -1}]},
+        {"knowledge_bases": ["kb-1"]},
+        {"vector_store_ids": ["vs-1"]},
+    ],
+)
+def test_should_run_prompt_management_hooks_without_prompt_id_for_dynamic_params(
+    logging_obj, non_default_params
+):
+    assert (
+        logging_obj.should_run_prompt_management_hooks(
+            non_default_params=non_default_params,
+            prompt_id=None,
+            tools=None,
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "non_default_params",
+    [
+        {"temperature": 0.5},
+        {"max_tokens": 100},
+        {"temperature": 0.7, "top_p": 0.9, "max_tokens": 256},
+        {},
+    ],
+)
+def test_should_run_prompt_management_hooks_false_for_non_dynamic_params(
+    logging_obj, non_default_params
+):
+    assert (
+        logging_obj.should_run_prompt_management_hooks(
+            non_default_params=non_default_params,
+            prompt_id=None,
+            tools=None,
+        )
+        is False
+    )
+
+
 def test_sentry_sample_rate():
     existing_sample_rate = os.getenv("SENTRY_API_SAMPLE_RATE")
     try:

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -19,6 +19,27 @@ def test_hidden_params_response_ms():
     assert hidden_params_dict.get("_response_ms") == 100
 
 
+def test_dynamic_prompt_management_list_all_params_preserves_enum_order():
+    from litellm.types.utils import DynamicPromptManagementParamLiteral
+
+    assert DynamicPromptManagementParamLiteral.list_all_params() == [
+        "cache_control_injection_points",
+        "knowledge_bases",
+        "vector_store_ids",
+    ]
+
+
+def test_dynamic_prompt_management_params_frozenset():
+    from litellm.types.utils import DYNAMIC_PROMPT_MANAGEMENT_PARAMS
+
+    assert "cache_control_injection_points" in DYNAMIC_PROMPT_MANAGEMENT_PARAMS
+    assert "knowledge_bases" in DYNAMIC_PROMPT_MANAGEMENT_PARAMS
+    assert "vector_store_ids" in DYNAMIC_PROMPT_MANAGEMENT_PARAMS
+    assert "temperature" not in DYNAMIC_PROMPT_MANAGEMENT_PARAMS
+    assert "max_tokens" not in DYNAMIC_PROMPT_MANAGEMENT_PARAMS
+    assert isinstance(DYNAMIC_PROMPT_MANAGEMENT_PARAMS, frozenset)
+
+
 def test_chat_completion_delta_tool_call():
     from litellm.types.utils import ChatCompletionDeltaToolCall, Function
 


### PR DESCRIPTION
## Relevant issues

Fixes #25859

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

Bug Fix

## Changes

### What's broken

`DynamicPromptManagementParamLiteral.list_all_params()` creates a new list on every call without caching. In deep async frameworks (Google ADK, LangGraph, CrewAI with 70+ sub-agents), the call stack is already near the recursion limit (~4000+ frames). Each `acompletion` call invokes `list_all_params()` once per kwarg key in `non_default_params`, and these extra frames push the stack over the limit, causing `RecursionError`.

### Root Cause

`_should_run_prompt_management_hooks_without_prompt_id` (litellm_logging.py:687) iterates over `non_default_params` and calls `list_all_params()` on every iteration, which rebuilds a list each time via `[param.value for param in cls]`. This is both wasteful (O(n) list creation per check) and dangerous (adds stack frames that can overflow in deep async stacks).

### Fix

Pre-compute the enum values as a **module-level `frozenset`** (`DYNAMIC_PROMPT_MANAGEMENT_PARAMS`) at import time. The call site now checks membership against this frozenset directly, giving:

- **Zero per-call allocation** — the frozenset is built once at module load
- **O(1) membership checks** — frozenset vs O(n) list scan
- **No extra stack frames** — eliminates the `list_all_params()` call from the hot path

This follows the established pattern used by `LIST_BATCHES_SUPPORTED_PROVIDERS` (types/utils.py line 3347) and `_LITELLM_ROUTES_MEMBER_NAMES` (route_checks.py).

`list_all_params()` is preserved unchanged for backward compatibility.

### Note on previous revert

The initial commit was reverted due to a suspected import cycle. Investigation confirmed this was a **false alarm** — `DYNAMIC_PROMPT_MANAGEMENT_PARAMS` is defined in `types/utils.py` which `litellm_logging.py` already imports from (line 100). Adding one symbol to an existing import block cannot create a circular dependency. The fix has been re-applied cleanly as a single commit.

## Testing

- Positive: each of the 3 dynamic params (`cache_control_injection_points`, `knowledge_bases`, `vector_store_ids`) correctly triggers prompt management hooks
- Negative: non-dynamic params (`temperature`, `max_tokens`, empty dict) do NOT trigger hooks
- Frozenset: membership checks work correctly, type is `frozenset`
- Backward compat: `list_all_params()` still returns original list with preserved enum order
- Both modified implementation files pass `py_compile` syntax verification
