### PR TITLE
fix: count image tokens in Titan embed response

### DIFF
--- a/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py
+++ b/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py
@@ -93,9 +93,9 @@ class AmazonTitanMultimodalEmbeddingG1Config:
             )
 
         usage = Usage(
-            prompt_tokens=total_prompt_tokens,
+            prompt_tokens=total_prompt_tokens + image_count,
             completion_tokens=0,
-            total_tokens=total_prompt_tokens,
+            total_tokens=total_prompt_tokens + image_count,
             prompt_tokens_details=prompt_tokens_details,
         )
         return EmbeddingResponse(model=model, usage=usage, data=transformed_responses)

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -863,6 +863,8 @@ def test_titan_multimodal_embedding_image_cost_tracking():
     )
 
     assert result.usage is not None
+    assert result.usage.prompt_tokens == 1  # image_count included in prompt_tokens
+    assert result.usage.total_tokens == 1
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.image_count == 1
 


### PR DESCRIPTION
## What's broken?

When using `amazon.titan-embed-image-v1` with image inputs, `EmbeddingResponse.usage.prompt_tokens` is always 0, even though the model successfully processed the image and returned an embedding.

## Who is affected?

Any downstream consumer (quota/billing system, logging layer, monitoring tool) reading `response.usage.prompt_tokens` directly — rather than going through LiteLLM's cost calculator — gets `0` and cannot detect that work was performed.

Text-only embedding calls are **not** affected (they correctly report `inputTextTokenCount`).

## Root Cause

In `_transform_response()` of `amazon_titan_multimodal_transformation.py`, `prompt_tokens` is set solely from `inputTextTokenCount`, which AWS intentionally returns as `0` for image inputs (Titan charges per-image at a flat rate, not per-token).

PR #21646 previously fixed the **cost calculator** path by reading `image_count` from `prompt_tokens_details`, but the `usage.prompt_tokens` field on the `EmbeddingResponse` was never updated.

## Fix

Added `image_count` to both `prompt_tokens` and `total_tokens` in the `Usage` object:

```python
usage = Usage(
    prompt_tokens=total_prompt_tokens + image_count,   # was: total_prompt_tokens
    total_tokens=total_prompt_tokens + image_count,     # was: total_prompt_tokens
    ...
)
```

This is backward-compatible: text-only paths are unaffected since `image_count=0`.

## Testing

Updated existing unit test `test_titan_multimodal_embedding_image_cost_tracking` to assert `prompt_tokens == 1` and `total_tokens == 1` for image inputs. All 3 related tests pass:

- `test_titan_multimodal_embedding_image_cost_tracking` ✅
- `test_titan_multimodal_embedding_text_no_image_count` ✅
- `test_titan_multimodal_embedding_backward_compat_no_batch_data` ✅

Fixes #25857
