### PR TITLE
fix: guard against None thinking param for reasoning_effort=none

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1088,9 +1088,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "thinking":
                 optional_params["thinking"] = value
             elif param == "reasoning_effort" and isinstance(value, str):
-                optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
+                thinking = AnthropicConfig._map_reasoning_effort(
                     reasoning_effort=value, model=model
                 )
+                if thinking is not None:
+                    optional_params["thinking"] = thinking
                 # For Claude 4.6+ models, effort is controlled via output_config,
                 # not thinking budget_tokens. Map reasoning_effort to output_config.
                 if AnthropicConfig._is_claude_4_6_model(

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -449,9 +449,11 @@ class AmazonConverseConfig(BaseConfig):
             optional_params.update(reasoning_config)
         else:
             # Anthropic and other models: convert to thinking parameter
-            optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
+            thinking = AnthropicConfig._map_reasoning_effort(
                 reasoning_effort=reasoning_effort, model=model
             )
+            if thinking is not None:
+                optional_params["thinking"] = thinking
 
     @staticmethod
     def _clamp_thinking_budget_tokens(optional_params: dict) -> None:

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -330,9 +330,11 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
             )  # unsupported for claude models - if json_schema -> convert to tool call
 
         if "reasoning_effort" in non_default_params and "claude" in model:
-            optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
+            thinking = AnthropicConfig._map_reasoning_effort(
                 reasoning_effort=non_default_params.get("reasoning_effort"), model=model
             )
+            if thinking is not None:
+                optional_params["thinking"] = thinking
             optional_params.pop("reasoning_effort", None)
         ## handle thinking tokens
         self.update_optional_params_with_thinking_tokens(


### PR DESCRIPTION
## What's broken?

Bedrock Anthropic models crash with `AttributeError: 'NoneType' object has no attribute 'get'` when `reasoning_effort="none"` is passed. The crash happens during request transformation, before any HTTP call.

## Root Cause

`AnthropicConfig._map_reasoning_effort("none", model)` correctly returns `None` (to disable thinking). But the callers unconditionally assign that `None` to `optional_params["thinking"]`. Downstream, `is_thinking_enabled` does:

```python
non_default_params.get("thinking", {}).get("type")
```

Because `"thinking"` exists with value `None`, `.get("thinking", {})` returns `None` (not `{}`), and `.get("type")` on `None` raises `AttributeError`.

## Fix

Added a `None` check in all three callers of `_map_reasoning_effort` so that when it returns `None`, we skip assigning to `optional_params["thinking"]`. This effectively disables thinking as intended.

**Files changed:**
- `litellm/llms/bedrock/chat/converse_transformation.py` — primary fix (Bedrock path)
- `litellm/llms/anthropic/chat/transformation.py` — same pattern (Anthropic direct path)
- `litellm/llms/databricks/chat/transformation.py` — same pattern (Databricks/Claude path)

Fixes #25792
