### PR TITLE
[Infra] Fix llm_translation worker OOMs at the root: proper test isolation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,7 +682,7 @@ jobs:
             for dir in "${IGNORE_DIRS[@]}"; do
               IGNORE_ARGS="$IGNORE_ARGS --ignore=$dir"
             done
-            uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5
+            uv run --no-sync python -m pytest -v tests/llm_translation $IGNORE_ARGS --junitxml=test-results/junit.xml --durations=20 -n 8 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5
           no_output_timeout: 15m
 
       # Store test results

--- a/litellm/caching/llm_caching_handler.py
+++ b/litellm/caching/llm_caching_handler.py
@@ -3,8 +3,49 @@ Add the event loop to the cache key, to prevent event loop closed errors.
 """
 
 import asyncio
+from typing import Any, Optional
 
 from .in_memory_cache import InMemoryCache
+
+
+def _client_is_closed(value: Any) -> bool:
+    """Return True if the cached HTTP client has already been closed.
+
+    A cached httpx / OpenAI SDK client becomes unusable once its underlying
+    httpx connection pool is closed — subsequent ``send()`` calls raise
+    ``RuntimeError: Cannot send a request, as the client has been closed``.
+    That state can be reached without the cache doing anything itself:
+
+      - a test or caller closes the client explicitly,
+      - the OpenAI SDK wraps httpx and one of its methods closes the pool,
+      - GC finalizes an AsyncHTTPHandler whose ``__del__`` schedules a close.
+
+    After that, handing the same cached instance back out of the cache
+    produces the "client has been closed" failure at request time.
+
+    Check a few common shapes because different callers cache different
+    wrappers:
+
+      - ``AsyncHTTPHandler`` / ``HTTPHandler``: wraps httpx on ``.client``.
+      - ``AsyncAzureOpenAI`` / ``AsyncOpenAI``: wraps httpx on ``._client``.
+      - raw ``httpx.AsyncClient`` / ``httpx.Client``: exposes ``.is_closed``.
+      - ``BaseLLMAIOHTTPHandler``: aiohttp-backed, so ``is_closed`` is not
+        defined; treat as open.
+    """
+    for candidate in (
+        value,
+        getattr(value, "_client", None),
+        getattr(value, "client", None),
+    ):
+        if candidate is None:
+            continue
+        try:
+            if getattr(candidate, "is_closed", False):
+                return True
+        except Exception:
+            # Defensive — an exotic wrapper shouldn't crash the cache read.
+            continue
+    return False
 
 
 class LLMClientCache(InMemoryCache):
@@ -17,6 +58,14 @@ class LLMClientCache(InMemoryCache):
 
     Clients that are no longer referenced will be garbage-collected normally.
     For explicit shutdown cleanup, use ``close_litellm_async_clients()``.
+
+    On READ, however, we do check whether the cached client is already closed
+    (``is_closed`` is True on the inner httpx client). If so we evict the
+    stale entry and return ``None`` — the caller will then build a fresh
+    client via its normal factory path. Without this, a closed client can
+    sit in the cache and be handed back to unrelated callers, producing
+    mysterious "Cannot send a request, as the client has been closed"
+    failures that are order-dependent and hard to reproduce.
     """
 
     def update_cache_key_with_event_loop(self, key):
@@ -31,6 +80,19 @@ class LLMClientCache(InMemoryCache):
         except RuntimeError:  # handle no current running event loop
             return key
 
+    def _get_and_drop_if_closed(self, key: str, value: Any) -> Optional[Any]:
+        """Return ``value`` unless its underlying HTTP client is closed.
+
+        When we detect a closed client we evict it so subsequent reads for
+        the same key don't keep hitting the same broken entry.
+        """
+        if value is None:
+            return value
+        if _client_is_closed(value):
+            self._remove_key(key)
+            return None
+        return value
+
     def set_cache(self, key, value, **kwargs):
         key = self.update_cache_key_with_event_loop(key)
         return super().set_cache(key, value, **kwargs)
@@ -40,11 +102,11 @@ class LLMClientCache(InMemoryCache):
         return await super().async_set_cache(key, value, **kwargs)
 
     def get_cache(self, key, **kwargs):
-        key = self.update_cache_key_with_event_loop(key)
-
-        return super().get_cache(key, **kwargs)
+        resolved_key = self.update_cache_key_with_event_loop(key)
+        value = super().get_cache(resolved_key, **kwargs)
+        return self._get_and_drop_if_closed(resolved_key, value)
 
     async def async_get_cache(self, key, **kwargs):
-        key = self.update_cache_key_with_event_loop(key)
-
-        return await super().async_get_cache(key, **kwargs)
+        resolved_key = self.update_cache_key_with_event_loop(key)
+        value = await super().async_get_cache(resolved_key, **kwargs)
+        return self._get_and_drop_if_closed(resolved_key, value)

--- a/tests/llm_translation/conftest.py
+++ b/tests/llm_translation/conftest.py
@@ -1,110 +1,347 @@
-# conftest.py
-#
-# xdist-compatible test isolation for llm_translation tests.
-# Mirrors the pattern in tests/local_testing/conftest.py:
-#   - Function-scoped fixture resets litellm globals to true defaults
-#   - Module-scoped reload only in single-process mode
+"""Test isolation for tests/llm_translation/.
 
-import importlib
+Design goals
+------------
+1. Every test starts against a clean litellm state without relying on
+   ``importlib.reload(litellm)``. Reloading is expensive (hundreds of
+   submodules get rebuilt) and leaks memory because it rebinds module-level
+   singletons while their background tasks keep running on the shared event
+   loop. With ~2k tests × 8 xdist workers, that leak was driving CircleCI
+   workers past their memory limit.
+
+2. Per-test teardown explicitly stops the ``GLOBAL_LOGGING_WORKER`` background
+   task so its ``_worker_loop`` does not accumulate across tests. Cached HTTP
+   clients are released once at session end (not per-test) because tests and
+   SDKs hold references to those clients outside ``LLMClientCache``, and
+   closing them mid-run raises "Cannot send a request, as the client has been
+   closed." at the next call site.
+
+3. Anything that cannot be restored through a plain attribute assignment is
+   reset with a targeted helper (logger levels, asyncio tasks). If a future
+   test mutates a new module-level attribute, add it to the relevant baseline
+   rather than reaching for ``importlib.reload`` again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
 import os
 import sys
+from typing import Any, Dict, Iterable
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
-import litellm
+sys.path.insert(0, os.path.abspath("../.."))
+import litellm  # noqa: E402  (path manipulation must precede import)
 
-import asyncio
 
 # ---------------------------------------------------------------------------
-# Capture TRUE defaults at conftest import time (before test modules pollute).
+# Baseline snapshot of mutable module-level litellm state.
+# Captured once at conftest import time, before any test runs.
 # ---------------------------------------------------------------------------
-_SCALAR_DEFAULTS = {
-    "num_retries": getattr(litellm, "num_retries", None),
-    "set_verbose": getattr(litellm, "set_verbose", False),
-    "cache": getattr(litellm, "cache", None),
-    "allowed_fails": getattr(litellm, "allowed_fails", 3),
-    "disable_aiohttp_transport": getattr(litellm, "disable_aiohttp_transport", False),
-    "force_ipv4": getattr(litellm, "force_ipv4", False),
-    "drop_params": getattr(litellm, "drop_params", None),
-    "modify_params": getattr(litellm, "modify_params", False),
-    "api_base": getattr(litellm, "api_base", None),
-    "api_key": getattr(litellm, "api_key", None),
-    "cohere_key": getattr(litellm, "cohere_key", None),
-}
+
+# Attributes that are lists tests tend to append to. Reset to an empty list
+# every test so callback registration from one test does not leak into the
+# next one.
+_CALLBACK_LIST_ATTRS: tuple[str, ...] = (
+    "callbacks",
+    "success_callback",
+    "failure_callback",
+    "service_callback",
+    "input_callback",
+    "_async_success_callback",
+    "_async_failure_callback",
+)
+
+# Scalars / simple values tests frequently mutate. Snapshotted from the
+# current module state so we restore whatever the library considered the
+# default at import time.
+_SCALAR_ATTRS: tuple[str, ...] = (
+    "num_retries",
+    "set_verbose",
+    "cache",
+    "allowed_fails",
+    "disable_aiohttp_transport",
+    "force_ipv4",
+    "drop_params",
+    "modify_params",
+    "api_base",
+    "api_key",
+    "cohere_key",
+    "disable_stop_sequence_limit",
+    "enable_preview_features",
+)
+
+# Provider model collections tests mutate both in-place (``.add(...)``) and
+# by reassignment (e.g. ``litellm.vertex_mistral_models = [...]`` in
+# test_optional_params.py). Reassignment changes the type from ``set`` to
+# ``list``, which then breaks ``litellm.add_known_models()`` in any later
+# test that calls it. The old conftest's ``importlib.reload(litellm)`` hid
+# this by recreating the module attributes each time; we have to snapshot
+# and deep-copy them instead.
+_PROVIDER_MODEL_ATTRS: tuple[str, ...] = (
+    "open_ai_chat_completion_models",
+    "open_ai_text_completion_models",
+    "azure_text_models",
+    "cohere_models",
+    "cohere_chat_models",
+    "mistral_chat_models",
+    "anthropic_models",
+    "empower_models",
+    "openrouter_models",
+    "vercel_ai_gateway_models",
+    "datarobot_models",
+    "vertex_text_models",
+    "vertex_code_text_models",
+    "vertex_language_models",
+    "vertex_vision_models",
+    "vertex_chat_models",
+    "vertex_code_chat_models",
+    "vertex_embedding_models",
+    "vertex_anthropic_models",
+    "vertex_llama3_models",
+    "vertex_deepseek_models",
+    "vertex_mistral_models",
+)
+
+
+def _snapshot_scalar_baseline() -> Dict[str, Any]:
+    """Capture the clean-state value of every tracked attribute."""
+    baseline: Dict[str, Any] = {}
+    for attr in _CALLBACK_LIST_ATTRS:
+        if hasattr(litellm, attr):
+            # Store as an empty list; tests expect to start with nothing
+            # registered, and the library-side default is always [].
+            baseline[attr] = []
+    for attr in _SCALAR_ATTRS:
+        if hasattr(litellm, attr):
+            baseline[attr] = getattr(litellm, attr)
+    return baseline
+
+
+def _snapshot_provider_model_baseline() -> Dict[str, Any]:
+    """Deep-copy the original provider model collections.
+
+    Deep-copy so that in-place mutation of the snapshot itself is impossible
+    even if a test holds a reference and mutates it later. Restoration
+    always hands out a fresh deep-copy for the same reason.
+    """
+    return {
+        attr: copy.deepcopy(getattr(litellm, attr))
+        for attr in _PROVIDER_MODEL_ATTRS
+        if hasattr(litellm, attr)
+    }
+
+
+_BASELINE: Dict[str, Any] = _snapshot_scalar_baseline()
+_PROVIDER_MODEL_BASELINE: Dict[str, Any] = _snapshot_provider_model_baseline()
+
+# LiteLLM's three public loggers. Their level survives module reloads because
+# Python's ``logging`` module — not ``litellm`` — owns the Logger objects.
+_LITELLM_LOGGERS: tuple[str, ...] = (
+    "LiteLLM",
+    "LiteLLM Router",
+    "LiteLLM Proxy",
+)
+
+
+# ---------------------------------------------------------------------------
+# Event loop.
+# Session-scoped so long-running asyncio tasks spawned across tests can be
+# cancelled centrally. Each test gets its own isolation layer on top.
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="session")
 def event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+        yield loop
+    finally:
+        _drain_pending_tasks(loop)
+        loop.close()
 
 
-@pytest.fixture(scope="function", autouse=True)
-def setup_and_teardown(event_loop):  # Add event_loop as a dependency
-    curr_dir = os.getcwd()
-    sys.path.insert(0, os.path.abspath("../.."))
+def _drain_pending_tasks(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel and await every pending task on the loop. Safe to call repeatedly."""
+    pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+    if not pending:
+        return
+    for task in pending:
+        task.cancel()
+    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 
-    import litellm
 
-    # ---- Save current state (for teardown restore) ----
-    original_state = {}
-    for attr in (
-        "callbacks",
-        "success_callback",
-        "failure_callback",
-        "_async_success_callback",
-        "_async_failure_callback",
-    ):
-        if hasattr(litellm, attr):
-            val = getattr(litellm, attr)
-            original_state[attr] = val.copy() if val else []
+# ---------------------------------------------------------------------------
+# Reset helpers used by the per-test fixture.
+# ---------------------------------------------------------------------------
 
-    for attr in _SCALAR_DEFAULTS:
-        if hasattr(litellm, attr):
-            original_state[attr] = getattr(litellm, attr)
 
-    # ---- Reset to true defaults before the test ----
+def _reset_scalar_attributes() -> None:
+    """Restore tracked litellm.<attr> values to the captured baseline."""
+    for attr, value in _BASELINE.items():
+        if isinstance(value, list):
+            # Hand each test its own mutable list so mutations stay local.
+            setattr(litellm, attr, list(value))
+        else:
+            setattr(litellm, attr, value)
+
+
+def _reset_provider_model_collections() -> None:
+    """Restore provider model sets/collections to their original type and contents.
+
+    ``test_optional_params.py`` reassigns ``litellm.vertex_mistral_models`` from
+    a ``set`` to a ``list``, which then breaks ``litellm.add_known_models()``
+    (it calls ``.add(key)``). Restoring from a deep-copy of the original
+    snapshot fixes both reassignment and in-place mutation.
+    """
+    for attr, original in _PROVIDER_MODEL_BASELINE.items():
+        setattr(litellm, attr, copy.deepcopy(original))
+
+
+def _reset_logger_levels() -> None:
+    """Clamp the LiteLLM loggers back to WARNING.
+
+    Any test that called ``litellm._turn_on_debug()`` flipped these to DEBUG,
+    and that level survives module reloads because the Logger objects live in
+    the stdlib ``logging`` module. DEBUG-level logging allocates large debug
+    strings per live HTTP request, which is a per-request tax across every
+    subsequent test in the worker.
+    """
+    for name in _LITELLM_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+async def _stop_logging_worker() -> None:
+    """Cancel ``GLOBAL_LOGGING_WORKER._worker_task`` on the current loop.
+
+    ``start()`` is idempotent — the next test that enqueues a log message
+    will create a fresh worker task. Stopping here prevents the previous
+    test's ``_worker_loop`` coroutine from sitting on the session-scoped
+    event loop and holding references to old queues/semaphores.
+    """
     from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
-    asyncio.run(GLOBAL_LOGGING_WORKER.clear_queue())
-    importlib.reload(litellm)
 
-    # Set the event loop from the fixture
+    try:
+        await GLOBAL_LOGGING_WORKER.stop()
+    except Exception:
+        # Best-effort; a broken stop() must not break the test suite.
+        pass
+
+
+def _restore_env_vars(initial_env: Dict[str, str], current_env: Iterable[str]) -> None:
+    """Restore os.environ to its pre-test state.
+
+    Tests that set env vars without using ``monkeypatch`` would otherwise leak
+    API keys, model-cost overrides, and region settings into subsequent tests.
+    """
+    current_keys = set(current_env)
+    for key in current_keys - set(initial_env):
+        os.environ.pop(key, None)
+    for key, value in initial_env.items():
+        if os.environ.get(key) != value:
+            os.environ[key] = value
+
+
+# ---------------------------------------------------------------------------
+# Per-test fixture.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolate_litellm_state(event_loop):
+    """Snapshot state, run the test, restore state.
+
+    HTTP client cleanup is deliberately NOT done here:
+      - ``close_litellm_async_clients()`` closes clients the OpenAI / Azure
+        SDKs and a few passthrough handlers hold references to outside
+        ``LLMClientCache``. Closing them mid-run makes subsequent tests
+        fail with ``"Cannot send a request, as the client has been closed"``.
+      - Instead, client cleanup runs once at session end in
+        ``cleanup_http_clients_at_session_end``. Within a single worker the
+        client pool is bounded by the number of distinct ``cache_key``
+        tuples, not by the test count.
+    """
+    # ---- Setup ----
+    _reset_scalar_attributes()
+    _reset_provider_model_collections()
+    _reset_logger_levels()
+    initial_env = dict(os.environ)
     asyncio.set_event_loop(event_loop)
 
     yield
 
     # ---- Teardown ----
-    for attr, original_value in original_state.items():
-        if hasattr(litellm, attr):
-            setattr(litellm, attr, original_value)
+    _reset_scalar_attributes()
+    _reset_provider_model_collections()
+    _reset_logger_levels()
+    try:
+        event_loop.run_until_complete(_stop_logging_worker())
+    except RuntimeError:
+        # The test may have closed or replaced the loop; ignore and let the
+        # session-scoped cleanup catch anything we missed.
+        pass
+    _drain_pending_tasks(event_loop)
+    _restore_env_vars(initial_env, list(os.environ))
 
-    # Clean up any pending tasks
-    pending = asyncio.all_tasks(event_loop)
-    for task in pending:
-        task.cancel()
 
-    # Run the event loop until all tasks are cancelled
-    if pending:
-        event_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+# ---------------------------------------------------------------------------
+# Session-scoped HTTP client cleanup.
+# Runs once after all tests in the worker finish. Releases the aiohttp
+# sessions / TCP connectors cached in ``LLMClientCache`` plus the global
+# ``base_llm_aiohttp_handler`` session. The library also registers an
+# atexit hook, but atexit does not fire on SIGKILL (OOM), so doing it
+# explicitly here guarantees cleanup under normal exit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_http_clients_at_session_end(event_loop):
+    yield
+
+    async def _close_all() -> None:
+        try:
+            from litellm.llms.custom_httpx.async_client_cleanup import (
+                close_litellm_async_clients,
+            )
+
+            await close_litellm_async_clients()
+        except Exception:
+            pass
+
+    try:
+        event_loop.run_until_complete(_close_all())
+    except RuntimeError:
+        pass
+
+    # Drop Python references so GC can reclaim anything the close routine
+    # released. Safe because no more tests will run.
+    cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+    cache_dict = getattr(cache, "cache_dict", None)
+    if isinstance(cache_dict, dict):
+        cache_dict.clear()
+
+
+# ---------------------------------------------------------------------------
+# Collection ordering.
+# custom_logger tests install global logging callbacks; grouping them first
+# avoids interleaving them with unrelated tests that would then see leftover
+# callbacks from a partially-completed custom_logger test run.
+# ---------------------------------------------------------------------------
 
 
 def pytest_collection_modifyitems(config, items):
-    # Separate tests in 'test_amazing_proxy_custom_logger.py' and other tests
     custom_logger_tests = [
         item for item in items if "custom_logger" in item.parent.name
     ]
-    other_tests = [item for item in items if "custom_logger" not in item.parent.name]
+    other_tests = [
+        item for item in items if "custom_logger" not in item.parent.name
+    ]
 
-    # Sort tests based on their names
     custom_logger_tests.sort(key=lambda x: x.name)
     other_tests.sort(key=lambda x: x.name)
 
-    # Reorder the items list
     items[:] = custom_logger_tests + other_tests

--- a/tests/llm_translation/test_bedrock_moonshot.py
+++ b/tests/llm_translation/test_bedrock_moonshot.py
@@ -29,7 +29,6 @@ class TestBedrockMoonshotInvoke(BaseLLMChatTest):
     """
     
     def get_base_completion_call_args(self) -> dict:
-        litellm._turn_on_debug()
         return {
             "model": "bedrock/invoke/moonshot.kimi-k2-thinking",
         }

--- a/tests/test_litellm/caching/test_llm_caching_handler.py
+++ b/tests/test_litellm/caching/test_llm_caching_handler.py
@@ -172,3 +172,120 @@ def test_remove_key_removes_plain_values():
 
     assert "str-key" not in cache.cache_dict
     assert "dict-key" not in cache.cache_dict
+
+
+class _ClosableClient:
+    """Mock httpx-like client that exposes ``is_closed``."""
+
+    def __init__(self, closed: bool = False):
+        self.is_closed = closed
+
+
+class _WrappedClient:
+    """Mock SDK wrapper (AsyncAzureOpenAI-style) whose httpx is on ``_client``."""
+
+    def __init__(self, inner):
+        self._client = inner
+
+
+def test_get_cache_returns_value_when_client_is_open():
+    """Baseline: an open cached client comes back unchanged."""
+    cache = LLMClientCache(max_size_in_memory=2)
+    inner = _ClosableClient(closed=False)
+    cache.set_cache("k", _WrappedClient(inner))
+
+    assert cache.get_cache("k") is not None
+    assert "k-" + str(id(None)) not in cache.cache_dict  # sanity: no loop id yet
+    # Key lives under the resolved (no-loop) key because this test is sync.
+    assert "k" in cache.cache_dict
+
+
+def test_get_cache_drops_wrapped_closed_client():
+    """If the inner httpx on ``_client`` reports is_closed=True, the cached
+    wrapper is evicted and None is returned so the caller builds a fresh one.
+    """
+    cache = LLMClientCache(max_size_in_memory=2)
+    inner = _ClosableClient(closed=True)
+    wrapped = _WrappedClient(inner)
+    cache.set_cache("k", wrapped)
+    # Pre-condition: the entry is there.
+    assert "k" in cache.cache_dict
+
+    result = cache.get_cache("k")
+
+    assert result is None
+    assert "k" not in cache.cache_dict  # evicted
+
+
+def test_get_cache_drops_handler_closed_client():
+    """AsyncHTTPHandler-style wrapper stores httpx on ``.client`` (no underscore).
+    That shape should also be detected.
+    """
+    cache = LLMClientCache(max_size_in_memory=2)
+
+    class _Handler:
+        def __init__(self, inner):
+            self.client = inner
+
+    inner = _ClosableClient(closed=True)
+    cache.set_cache("k", _Handler(inner))
+
+    assert cache.get_cache("k") is None
+    assert "k" not in cache.cache_dict
+
+
+def test_get_cache_drops_bare_closed_httpx_client():
+    """A bare ``httpx.AsyncClient`` with ``is_closed=True`` is also evicted."""
+    cache = LLMClientCache(max_size_in_memory=2)
+    cache.set_cache("k", _ClosableClient(closed=True))
+
+    assert cache.get_cache("k") is None
+    assert "k" not in cache.cache_dict
+
+
+def test_get_cache_leaves_value_without_is_closed_attr_alone():
+    """Non-httpx values (e.g. aiohttp handlers) don't expose is_closed — we
+    must not false-positive on them and evict otherwise-fine entries.
+    """
+    cache = LLMClientCache(max_size_in_memory=2)
+
+    class _AiohttpLike:
+        """Deliberately no is_closed attribute."""
+
+        pass
+
+    value = _AiohttpLike()
+    cache.set_cache("k", value)
+
+    assert cache.get_cache("k") is value
+    assert "k" in cache.cache_dict
+
+
+@pytest.mark.asyncio
+async def test_async_get_cache_drops_closed_client():
+    """Same eviction-on-closed behaviour from the async read path."""
+    cache = LLMClientCache(max_size_in_memory=2)
+    wrapped = _WrappedClient(_ClosableClient(closed=True))
+    await cache.async_set_cache("k", wrapped)
+
+    assert await cache.async_get_cache("k") is None
+    # Under a running loop the resolved key includes the loop id; check that
+    # no stale "k..." key remains in the underlying dict.
+    assert not any(str(key).startswith("k-") for key in cache.cache_dict)
+
+
+def test_get_cache_survives_weird_is_closed_raising():
+    """A cached object whose is_closed access raises should be treated as open,
+    not crash the cache read.
+    """
+    cache = LLMClientCache(max_size_in_memory=2)
+
+    class _Hostile:
+        @property
+        def is_closed(self):
+            raise RuntimeError("boom")
+
+    value = _Hostile()
+    cache.set_cache("k", value)
+    # Should not raise, and should return the value.
+    assert cache.get_cache("k") is value


### PR DESCRIPTION
## Relevant issues

Follow-up to #25898 and the resource_class bump. Workers in \`llm_translation_testing\` kept OOM-killing mid-run even at \`resource_class: xlarge\` with \`-n 4\` and \`--max-worker-restart=5\`.

## Summary

### Problem 1: Test-harness leaks caused worker OOMs

Three leaks in the test harness compounded linearly over the ~200 tests per xdist worker and OOM-killed the process near the end of the run:

1. **\`GLOBAL_LOGGING_WORKER\` zombie tasks.** The conftest called \`clear_queue()\` but never \`stop()\`. Every \`importlib.reload(litellm)\` rebound the singleton but left the old instance's \`asyncio.Task\` running on the session-scoped loop.
2. **\`LLMClientCache\` never closed HTTP clients.** By design, the cache does not close on eviction (to avoid tearing down clients mid-request). The library relies on an \`atexit\` handler to close cached clients, but \`atexit\` does not run when a worker is OOM-killed.
3. **Global \`base_llm_aiohttp_handler\` session never closed.** Same pattern — singleton opens a \`ClientSession\`, reload rebinds the reference but does not release the underlying aiohttp resources.

### Problem 2: Stale closed clients poisoning the cache (latent prod bug)

Removing \`importlib.reload(litellm)\` from the conftest (needed to fix Problem 1) exposed a real, prod-facing bug: the reload was masking it. \`LLMClientCache\` keys are \`(hashed_api_key, is_async, api_base, ...)\`. Once a cached client's underlying httpx pool gets closed — by an explicit \`close()\`, by GC running an \`AsyncHTTPHandler.__del__\`, or by a test fixture — the next caller for the same key would receive the stale closed client and fail with:

> RuntimeError: Cannot send a request, as the client has been closed.

Diagnostic instrumentation on a throwaway branch confirmed this: the same hashed-api-key entry flipped closed repeatedly across ~6 tests in one worker, and those exact keys were the failing tests' keys.

In prod this affects any caller whose cached client is closed (by user code, shutdown logic, or GC) — the cache silently keeps serving the closed client for up to the TTL (1 hour).

### Fix

\`tests/llm_translation/conftest.py\` — proper per-test isolation without module reload:

- Snapshot ~20 scalar litellm module attributes + 22 provider model collections at conftest import time; restore them via plain attribute assignment before and after every test.
- Reset \`LiteLLM\` / \`LiteLLM Router\` / \`LiteLLM Proxy\` logger levels to \`WARNING\` every test (loggers live in \`logging\`, not \`litellm\`, so reload never reset them).
- Per-test teardown calls \`GLOBAL_LOGGING_WORKER.stop()\` and cancels pending asyncio tasks. HTTP client cleanup runs once at session end (per-test \`close_litellm_async_clients()\` breaks tests that hold references outside the cache).
- Restore \`os.environ\` to its pre-test snapshot.
- Drop \`importlib.reload(litellm)\` entirely.

\`litellm/caching/llm_caching_handler.py\` — make \`LLMClientCache\` self-healing:

- On every \`get_cache\` / \`async_get_cache\`, check whether the returned value's underlying httpx client (inspect \`value.is_closed\`, \`value._client.is_closed\`, or \`value.client.is_closed\` — covers httpx bare clients, OpenAI SDK wrappers, and AsyncHTTPHandler) is closed. If so, evict the entry and return \`None\` so the caller builds a fresh client.
- Preserves the "never close on eviction" invariant (the problem is reading a client that's already closed by someone else, not closing on behalf of anyone).

\`tests/test_litellm/caching/test_llm_caching_handler.py\` — 7 new tests covering the wrapped (\`_client\`), handler (\`client\`), and bare client shapes, the async path, a non-httpx cached value (must NOT be evicted), and a hostile \`is_closed\` property that raises.

\`test_bedrock_moonshot.py\` — drop the stray \`litellm._turn_on_debug()\`; the logger reset in the conftest now covers anything similar across the suite.

\`.circleci/config.yml\` — restores \`-n 8\` parallelism; drops the \`--max-worker-restart=5\` safety net.

## Testing

- \`pytest tests/test_litellm/caching/\` — 117 tests pass, including the 7 new ones.
- Smoke test locally: \`pytest tests/llm_translation/test_bedrock_moonshot.py tests/llm_translation/test_bedrock_common_utils.py tests/llm_translation/test_optional_params.py -n 4\` runs to completion with no worker crashes and no "client closed" errors. (Bedrock tests fail with 403 without AWS creds — expected.)
- CI will exercise the full suite at \`-n 8\` when this PR runs.

## Type

🚄 Infrastructure
🐛 Bug Fix
✅ Test