### PR TITLE
fix: add fallback for Azure deployment names in _supports_reasoning_effort_level

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -31,7 +31,20 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
             model = "azure/" + model[len(cls.GPT5_SERIES_ROUTE) :]
         elif not model.startswith("azure/"):
             model = "azure/" + model
-        return super()._supports_reasoning_effort_level(model, level)
+
+        if super()._supports_reasoning_effort_level(model, level):
+            return True
+
+        # Fallback: registry lookup fails for Azure deployment names
+        # (e.g. "gpt-5.1-DataZoneStandard") that are not in
+        # model_prices_and_context_window.json. Use string matching as a
+        # safe fallback, consistent with the behaviour in litellm 1.81.x.
+        model_name = model.split("/")[-1]
+        if level == "none":
+            return model_name.startswith("gpt-5.1") or model_name.startswith(
+                "gpt-5.2"
+            )
+        return False
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:


### PR DESCRIPTION
## What's broken?

`AzureOpenAIGPT5Config._supports_reasoning_effort_level` fails for Azure deployment names that don't match entries in the `model_prices` map (e.g. `azure/gpt-5.1-DataZoneStandard`), incorrectly rejecting `reasoning_effort='none'` with `UnsupportedParamsError`.

## Who is affected?

Anyone using Azure OpenAI with custom deployment names for gpt-5.1 or gpt-5.2 models and passing `reasoning_effort='none'`. Standard canonical model names (e.g. `azure/gpt-5.1`) are not affected.

## Root Cause

The method normalises the model string and does a registry lookup via `_supports_factory`. Azure deployment names are user-defined (e.g. `gpt-5.1-DataZoneStandard`) and won't exist in `model_prices_and_context_window.json`, so the lookup always returns `False`. This is a regression from 1.81.x which used a simple `startswith("gpt-5.1")` check.

## Fix

Added a string-based fallback in `AzureOpenAIGPT5Config._supports_reasoning_effort_level`: when the registry lookup returns `False`, check if the model name starts with a known prefix (`gpt-5.1` or `gpt-5.2`) for `level == "none"`. This restores the 1.81.x behaviour for custom deployment names while preserving the registry-first approach for canonical names.

## Testing

- All 24 existing tests in `test_azure_gpt5_transformation.py` pass
- Verified deployment names like `azure/gpt-5.1-DataZoneStandard`, `gpt-5.1-DataZoneStandard`, `gpt5_series/gpt-5.1-mydeployment`, and `azure/gpt-5.2-custom` correctly return `True` for `level="none"`
- Verified non-matching models (`azure/gpt-5`, `azure/gpt-5-DataZone`) still correctly return `False`

Fixes #25850
