### PR TITLE
Add capability to override default GitHub Copilot authentication endp…

### DIFF
--- a/docs/my-website/docs/providers/github_copilot.md
+++ b/docs/my-website/docs/providers/github_copilot.md
@@ -192,6 +192,13 @@ export GITHUB_COPILOT_ACCESS_TOKEN_FILE="access-token"
 
 # Optional: Custom API key file name
 export GITHUB_COPILOT_API_KEY_FILE="api-key.json"
+
+# Optional: Custom Copilot endpoints for authentication and usage
+# (needed when using GitHub Enterprise subscriptions with custom endpoints or self-hosted GitHub servers
+export GITHUB_COPILOT_API_BASE="https://copilot-api.my-company.ghe.com"
+export GITHUB_COPILOT_DEVICE_CODE_URL="https://my-company.ghe.com/login/device/code"
+export GITHUB_COPILOT_ACCESS_TOKEN_URL="https://my-company.ghe.com/login/oauth/access_token"
+export GITHUB_COPILOT_API_KEY_URL="https://my-company.ghe.com/api/v3/copilot_internal/v2/token"
 ```
 
 ### Headers

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -724,6 +724,7 @@ router_settings:
 | GITHUB_COPILOT_DEVICE_CODE_URL | URL for GitHub Copilot device code authentication. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/device/code. Default is https://github.com/login/device/code
 | GITHUB_COPILOT_ACCESS_TOKEN_URL | URL for GitHub Copilot access token retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/oauth/access_token. Default is https://github.com/login/oauth/access_token
 | GITHUB_COPILOT_API_KEY_URL | URL for GitHub Copilot API key retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/api/v3/copilot_internal/v2/token. Default is https://api.github.com/copilot_internal/v2/token
+| GITHUB_COPILOT_CLIENT_ID | Client ID for GitHub Copilot device flow authentication. This is used by the `github_copilot` provider for device code authentication. Default is "Iv1.9e819bb7cbd84c8b"
 | GREENSCALE_API_KEY | API key for Greenscale service
 | GREENSCALE_ENDPOINT | Endpoint URL for Greenscale service
 | GRAYSWAN_API_BASE | Base URL for GraySwan API. Default is https://api.grayswan.ai

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -720,6 +720,10 @@ router_settings:
 | GITHUB_COPILOT_TOKEN_DIR | Directory to store GitHub Copilot token for `github_copilot` llm provider
 | GITHUB_COPILOT_API_KEY_FILE | File to store GitHub Copilot API key for `github_copilot` llm provider
 | GITHUB_COPILOT_ACCESS_TOKEN_FILE | File to store GitHub Copilot access token for `github_copilot` llm provider
+| GITHUB_COPILOT_API_BASE | Base URL for GitHub Copilot API. For GitHub Enterprise subscriptions with custom host, it is similar to https://copilot-api.my-company.ghe.com. Default is https://api.githubcopilot.com
+| GITHUB_COPILOT_DEVICE_CODE_URL | URL for GitHub Copilot device code authentication. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/device/code. Default is https://github.com/login/device/code
+| GITHUB_COPILOT_ACCESS_TOKEN_URL | URL for GitHub Copilot access token retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/oauth/access_token. Default is https://github.com/login/oauth/access_token
+| GITHUB_COPILOT_API_KEY_URL | URL for GitHub Copilot API key retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/api/v3/copilot_internal/v2/token. Default is https://api.github.com/copilot_internal/v2/token
 | GREENSCALE_API_KEY | API key for Greenscale service
 | GREENSCALE_ENDPOINT | Endpoint URL for Greenscale service
 | GRAYSWAN_API_BASE | Base URL for GraySwan API. Default is https://api.grayswan.ai

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -724,7 +724,7 @@ router_settings:
 | GITHUB_COPILOT_DEVICE_CODE_URL | URL for GitHub Copilot device code authentication. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/device/code. Default is https://github.com/login/device/code
 | GITHUB_COPILOT_ACCESS_TOKEN_URL | URL for GitHub Copilot access token retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/login/oauth/access_token. Default is https://github.com/login/oauth/access_token
 | GITHUB_COPILOT_API_KEY_URL | URL for GitHub Copilot API key retrieval. For GitHub Enterprise subscriptions with custom host, it is similar to https://my-company.ghe.com/api/v3/copilot_internal/v2/token. Default is https://api.github.com/copilot_internal/v2/token
-| GITHUB_COPILOT_CLIENT_ID | Client ID for GitHub Copilot device flow authentication. This is used by the `github_copilot` provider for device code authentication. Default is "Iv1.9e819bb7cbd84c8b"
+| GITHUB_COPILOT_CLIENT_ID | Client ID for GitHub Copilot device flow authentication. This is used by the `github_copilot` provider for device code authentication. Default is "Iv1.b507a08c87ecfe98"
 | GREENSCALE_API_KEY | API key for Greenscale service
 | GREENSCALE_ENDPOINT | Endpoint URL for Greenscale service
 | GRAYSWAN_API_BASE | Base URL for GraySwan API. Default is https://api.grayswan.ai

--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -291,8 +291,6 @@ class Authenticator:
         sync_client = _get_httpx_client()
         max_attempts = 12  # 1 minute (12 * 5 seconds)
 
-        for attempt in range(max_attempts):
-            try:
         access_token_url = os.getenv(
             "GITHUB_COPILOT_ACCESS_TOKEN_URL", DEFAULT_GITHUB_ACCESS_TOKEN_URL
         )

--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -17,11 +17,11 @@ from .common_utils import (
     RefreshAPIKeyError,
 )
 
-# Constants
-GITHUB_CLIENT_ID = "Iv1.b507a08c87ecfe98"
-GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
-GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
-GITHUB_API_KEY_URL = "https://api.github.com/copilot_internal/v2/token"
+# Constants (default values — overridable via environment variables at call time)
+DEFAULT_GITHUB_CLIENT_ID = "Iv1.b507a08c87ecfe98"
+DEFAULT_GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+DEFAULT_GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+DEFAULT_GITHUB_API_KEY_URL = "https://api.github.com/copilot_internal/v2/token"
 
 
 class Authenticator:
@@ -161,12 +161,15 @@ class Authenticator:
         """
         access_token = self.get_access_token()
         headers = self._get_github_headers(access_token)
+        api_key_url = os.getenv(
+            "GITHUB_COPILOT_API_KEY_URL", DEFAULT_GITHUB_API_KEY_URL
+        )
 
         max_retries = 3
         for attempt in range(max_retries):
             try:
                 sync_client = _get_httpx_client()
-                response = sync_client.get(GITHUB_API_KEY_URL, headers=headers)
+                response = sync_client.get(api_key_url, headers=headers)
                 response.raise_for_status()
 
                 response_json = response.json()
@@ -232,10 +235,14 @@ class Authenticator:
         """
         try:
             sync_client = _get_httpx_client()
+            device_code_url = os.getenv(
+                "GITHUB_COPILOT_DEVICE_CODE_URL", DEFAULT_GITHUB_DEVICE_CODE_URL
+            )
+            client_id = os.getenv("GITHUB_COPILOT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID)
             resp = sync_client.post(
-                GITHUB_DEVICE_CODE_URL,
+                device_code_url,
                 headers=self._get_github_headers(),
-                json={"client_id": GITHUB_CLIENT_ID, "scope": "read:user"},
+                json={"client_id": client_id, "scope": "read:user"},
             )
             resp.raise_for_status()
             resp_json = resp.json()
@@ -286,11 +293,17 @@ class Authenticator:
 
         for attempt in range(max_attempts):
             try:
+                access_token_url = os.getenv(
+                    "GITHUB_COPILOT_ACCESS_TOKEN_URL", DEFAULT_GITHUB_ACCESS_TOKEN_URL
+                )
+                client_id = os.getenv(
+                    "GITHUB_COPILOT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID
+                )
                 resp = sync_client.post(
-                    GITHUB_ACCESS_TOKEN_URL,
+                    access_token_url,
                     headers=self._get_github_headers(),
                     json={
-                        "client_id": GITHUB_CLIENT_ID,
+                        "client_id": client_id,
                         "device_code": device_code,
                         "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
                     },

--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -293,12 +293,15 @@ class Authenticator:
 
         for attempt in range(max_attempts):
             try:
-                access_token_url = os.getenv(
-                    "GITHUB_COPILOT_ACCESS_TOKEN_URL", DEFAULT_GITHUB_ACCESS_TOKEN_URL
-                )
-                client_id = os.getenv(
-                    "GITHUB_COPILOT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID
-                )
+        access_token_url = os.getenv(
+            "GITHUB_COPILOT_ACCESS_TOKEN_URL", DEFAULT_GITHUB_ACCESS_TOKEN_URL
+        )
+        client_id = os.getenv(
+            "GITHUB_COPILOT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID
+        )
+
+        for attempt in range(max_attempts):
+            try:
                 resp = sync_client.post(
                     access_token_url,
                     headers=self._get_github_headers(),

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Tuple
 
+import os
 
 from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
@@ -7,7 +8,7 @@ from litellm.types.llms.openai import AllMessageValues
 
 from ..authenticator import Authenticator
 from ..common_utils import (
-    GITHUB_COPILOT_API_BASE,
+    DEFAULT_GITHUB_COPILOT_API_BASE,
     GetAPIKeyError,
     get_copilot_default_headers,
 )
@@ -30,7 +31,9 @@ class GithubCopilotConfig(OpenAIConfig):
         api_key: Optional[str],
         custom_llm_provider: str,
     ) -> Tuple[Optional[str], Optional[str], str]:
-        dynamic_api_base = self.authenticator.get_api_base() or GITHUB_COPILOT_API_BASE
+        dynamic_api_base = self.authenticator.get_api_base() or os.getenv(
+            "GITHUB_COPILOT_API_BASE", DEFAULT_GITHUB_COPILOT_API_BASE
+        )
         try:
             dynamic_api_key = self.authenticator.get_api_key()
         except GetAPIKeyError as e:

--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -31,8 +31,11 @@ class GithubCopilotConfig(OpenAIConfig):
         api_key: Optional[str],
         custom_llm_provider: str,
     ) -> Tuple[Optional[str], Optional[str], str]:
-        dynamic_api_base = self.authenticator.get_api_base() or os.getenv(
-            "GITHUB_COPILOT_API_BASE", DEFAULT_GITHUB_COPILOT_API_BASE
+        dynamic_api_base = (
+            api_base
+            or self.authenticator.get_api_base()
+            or os.getenv("GITHUB_COPILOT_API_BASE")
+            or DEFAULT_GITHUB_COPILOT_API_BASE
         )
         try:
             dynamic_api_key = self.authenticator.get_api_key()

--- a/litellm/llms/github_copilot/common_utils.py
+++ b/litellm/llms/github_copilot/common_utils.py
@@ -1,6 +1,7 @@
 """
 Constants for Copilot integration
 """
+
 from typing import Optional, Union
 from uuid import uuid4
 
@@ -13,7 +14,7 @@ COPILOT_VERSION = "0.26.7"
 EDITOR_PLUGIN_VERSION = f"copilot-chat/{COPILOT_VERSION}"
 USER_AGENT = f"GitHubCopilotChat/{COPILOT_VERSION}"
 API_VERSION = "2025-04-01"
-GITHUB_COPILOT_API_BASE = "https://api.githubcopilot.com"
+DEFAULT_GITHUB_COPILOT_API_BASE = "https://api.githubcopilot.com"
 
 
 class GithubCopilotError(BaseLLMException):

--- a/litellm/llms/github_copilot/embedding/transformation.py
+++ b/litellm/llms/github_copilot/embedding/transformation.py
@@ -103,8 +103,8 @@ class GithubCopilotEmbeddingConfig(BaseEmbeddingConfig):
         """
         # Use provided api_base or fall back to authenticator's base or default
         effective_api_base = (
-            self.authenticator.get_api_base()
-            or api_base
+            api_base
+            or self.authenticator.get_api_base()
             or os.getenv("GITHUB_COPILOT_API_BASE")
             or DEFAULT_GITHUB_COPILOT_API_BASE
         )

--- a/litellm/llms/github_copilot/embedding/transformation.py
+++ b/litellm/llms/github_copilot/embedding/transformation.py
@@ -6,7 +6,10 @@ This module provides the configuration for GitHub Copilot's Embedding API.
 Implementation based on analysis of the copilot-api project by caozhiyuan:
 https://github.com/caozhiyuan/copilot-api
 """
+
 from typing import TYPE_CHECKING, Any, Optional
+
+import os
 
 import httpx
 
@@ -20,7 +23,7 @@ from litellm.utils import convert_to_model_response_object
 from ..authenticator import Authenticator
 from ..common_utils import (
     GetAPIKeyError,
-    GITHUB_COPILOT_API_BASE,
+    DEFAULT_GITHUB_COPILOT_API_BASE,
     get_copilot_default_headers,
 )
 
@@ -99,15 +102,18 @@ class GithubCopilotEmbeddingConfig(BaseEmbeddingConfig):
         Get the complete URL for GitHub Copilot Embedding API endpoint.
         """
         # Use provided api_base or fall back to authenticator's base or default
-        api_base = (
-            self.authenticator.get_api_base() or api_base or GITHUB_COPILOT_API_BASE
+        effective_api_base = (
+            self.authenticator.get_api_base()
+            or api_base
+            or os.getenv("GITHUB_COPILOT_API_BASE")
+            or DEFAULT_GITHUB_COPILOT_API_BASE
         )
 
         # Remove trailing slashes
-        api_base = api_base.rstrip("/")
+        effective_api_base = effective_api_base.rstrip("/")
 
         # Return the embeddings endpoint
-        return f"{api_base}/embeddings"
+        return f"{effective_api_base}/embeddings"
 
     def transform_embedding_request(
         self,

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -7,7 +7,10 @@ which is required for models like gpt-5.1-codex that only support the /responses
 Implementation based on analysis of the copilot-api project by caozhiyuan:
 https://github.com/caozhiyuan/copilot-api
 """
+
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+import os
 
 from litellm._logging import verbose_logger
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
@@ -22,7 +25,7 @@ from litellm.types.utils import LlmProviders
 
 from ..authenticator import Authenticator
 from ..common_utils import (
-    GITHUB_COPILOT_API_BASE,
+    DEFAULT_GITHUB_COPILOT_API_BASE,
     GetAPIKeyError,
     get_copilot_default_headers,
 )
@@ -157,23 +160,20 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
     ) -> str:
         """
         Get the complete URL for GitHub Copilot Responses API endpoint.
-
-        Returns: https://api.githubcopilot.com/responses
-
-        Note: Currently only supports individual accounts.
-        Business/enterprise accounts (api.business.githubcopilot.com) can be
-        added in the future by detecting account type.
         """
         # Use provided api_base or fall back to authenticator's base or default
-        api_base = (
-            api_base or self.authenticator.get_api_base() or GITHUB_COPILOT_API_BASE
+        effective_api_base = (
+            api_base
+            or self.authenticator.get_api_base()
+            or os.getenv("GITHUB_COPILOT_API_BASE")
+            or DEFAULT_GITHUB_COPILOT_API_BASE
         )
 
         # Remove trailing slashes
-        api_base = api_base.rstrip("/")
+        effective_api_base = effective_api_base.rstrip("/")
 
         # Return the responses endpoint
-        return f"{api_base}/responses"
+        return f"{effective_api_base}/responses"
 
     def _handle_reasoning_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py
@@ -189,3 +189,65 @@ class TestGitHubCopilotAuthenticator:
         with patch("builtins.open", mock_open(read_data=mock_api_key_data)):
             api_base = authenticator.get_api_base()
             assert api_base == "https://api.enterprise.githubcopilot.com"
+
+    def test_get_device_code_with_custom_url(self, authenticator, mock_http_client):
+        """GITHUB_COPILOT_DEVICE_CODE_URL env var must be used by _get_device_code at call time."""
+        mock_client, mock_response = mock_http_client
+        custom_url = "https://custom.example.com/device"
+        mock_response.json.return_value = {
+            "device_code": "dc",
+            "user_code": "UC",
+            "verification_uri": "https://example.com",
+        }
+        with patch.dict(os.environ, {"GITHUB_COPILOT_DEVICE_CODE_URL": custom_url}), \
+             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client):
+            authenticator._get_device_code()
+            assert mock_client.post.call_args[0][0] == custom_url
+
+    def test_get_device_code_with_custom_client_id(self, authenticator, mock_http_client):
+        """GITHUB_COPILOT_CLIENT_ID env var must appear as client_id in the device-code request body."""
+        mock_client, mock_response = mock_http_client
+        custom_id = "custom_client_id"
+        mock_response.json.return_value = {
+            "device_code": "dc",
+            "user_code": "UC",
+            "verification_uri": "https://example.com",
+        }
+        with patch.dict(os.environ, {"GITHUB_COPILOT_CLIENT_ID": custom_id}), \
+             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client):
+            authenticator._get_device_code()
+            assert mock_client.post.call_args[1]["json"]["client_id"] == custom_id
+
+    def test_poll_for_access_token_with_custom_url(self, authenticator, mock_http_client):
+        """GITHUB_COPILOT_ACCESS_TOKEN_URL env var must be used by _poll_for_access_token at call time."""
+        mock_client, mock_response = mock_http_client
+        custom_url = "https://custom.example.com/token"
+        mock_response.json.return_value = {"access_token": "tok"}
+        with patch.dict(os.environ, {"GITHUB_COPILOT_ACCESS_TOKEN_URL": custom_url}), \
+             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client), \
+             patch("time.sleep"):
+            authenticator._poll_for_access_token("dc")
+            assert mock_client.post.call_args[0][0] == custom_url
+
+    def test_poll_for_access_token_with_custom_client_id(self, authenticator, mock_http_client):
+        """GITHUB_COPILOT_CLIENT_ID env var must appear as client_id in the polling request body."""
+        mock_client, mock_response = mock_http_client
+        custom_id = "custom_client_id"
+        mock_response.json.return_value = {"access_token": "tok"}
+        with patch.dict(os.environ, {"GITHUB_COPILOT_CLIENT_ID": custom_id}), \
+             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client), \
+             patch("time.sleep"):
+            authenticator._poll_for_access_token("dc")
+            assert mock_client.post.call_args[1]["json"]["client_id"] == custom_id
+
+    def test_refresh_api_key_with_custom_url(self, authenticator, mock_http_client):
+        """GITHUB_COPILOT_API_KEY_URL env var must be used by _refresh_api_key at call time."""
+        mock_client, mock_response = mock_http_client
+        custom_url = "https://custom.example.com/api-key"
+        mock_response.json.return_value = {"token": "api-tok", "expires_at": 9999999999}
+        with patch.dict(os.environ, {"GITHUB_COPILOT_API_KEY_URL": custom_url}), \
+             patch("litellm.llms.github_copilot.authenticator._get_httpx_client", return_value=mock_client), \
+             patch.object(authenticator, "get_access_token", return_value="access-tok"):
+            authenticator._refresh_api_key()
+            assert mock_client.get.call_args[0][0] == custom_url
+


### PR DESCRIPTION
## Relevant issues

Fixes #25914

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [X] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
- Add support for configurable GitHub Copilot endpoints (via environment variables) to allow usage with GitHub Enterprise subscriptions with custom host (e.g. mycompany.ghe.com) or with self-hosted GitHub instances