### PR TITLE
[Fix] Agent endpoint and routing permission checks

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -3,7 +3,25 @@ from urllib.parse import parse_qs
 
 import httpx
 
+from litellm._logging import verbose_logger
 from litellm.constants import PASS_THROUGH_HEADER_PREFIX
+
+# Headers that must not be overwritten via the x-pass- forwarding mechanism.
+# Includes standard credential/auth headers and protocol-level headers that
+# affect routing or message framing.
+_PASS_THROUGH_PROTECTED_HEADERS: frozenset = frozenset(
+    {
+        "authorization",
+        "api-key",
+        "x-api-key",
+        "x-goog-api-key",
+        "host",
+        "content-length",
+    }
+)
+
+# Header name prefix used to block AWS SigV4 signing headers from being overridden.
+_PASS_THROUGH_PROTECTED_HEADER_PREFIXES: tuple = ("x-amz-",)
 
 
 class BasePassthroughUtils:
@@ -57,13 +75,19 @@ class BasePassthroughUtils:
             headers = {**request_headers, **headers}
 
         # Process x-pass- prefixed headers (strip prefix and forward)
-        # Certain protocol-level and credential headers are excluded from this mechanism.
-        _PROTECTED_HEADERS = {"authorization", "api-key", "host", "content-length"}
+        # Credential and protocol-level headers are excluded from this mechanism.
         for header_name, header_value in request_headers.items():
             if header_name.lower().startswith(PASS_THROUGH_HEADER_PREFIX):
-                # Strip the 'x-pass-' prefix to get the actual header name
-                actual_header_name = header_name[len(PASS_THROUGH_HEADER_PREFIX) :]
-                if actual_header_name.lower() in _PROTECTED_HEADERS:
+                # Strip the 'x-pass-' prefix and normalize to lowercase
+                actual_header_name = header_name[len(PASS_THROUGH_HEADER_PREFIX) :].lower()
+                if actual_header_name in _PASS_THROUGH_PROTECTED_HEADERS or any(
+                    actual_header_name.startswith(p)
+                    for p in _PASS_THROUGH_PROTECTED_HEADER_PREFIXES
+                ):
+                    verbose_logger.debug(
+                        "x-pass- header %s maps to a protected header name; skipping",
+                        header_name,
+                    )
                     continue
                 headers[actual_header_name] = header_value
 

--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -56,11 +56,15 @@ class BasePassthroughUtils:
             # Combine request headers with custom headers
             headers = {**request_headers, **headers}
 
-        # Always process x-pass- prefixed headers (strip prefix and forward)
+        # Process x-pass- prefixed headers (strip prefix and forward)
+        # Certain protocol-level and credential headers are excluded from this mechanism.
+        _PROTECTED_HEADERS = {"authorization", "api-key", "host", "content-length"}
         for header_name, header_value in request_headers.items():
             if header_name.lower().startswith(PASS_THROUGH_HEADER_PREFIX):
                 # Strip the 'x-pass-' prefix to get the actual header name
                 actual_header_name = header_name[len(PASS_THROUGH_HEADER_PREFIX) :]
+                if actual_header_name.lower() in _PROTECTED_HEADERS:
+                    continue
                 headers[actual_header_name] = header_value
 
         return headers

--- a/litellm/proxy/agent_endpoints/a2a_routing.py
+++ b/litellm/proxy/agent_endpoints/a2a_routing.py
@@ -11,7 +11,7 @@ import litellm
 from fastapi import HTTPException
 
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 
 
 async def route_a2a_agent_request(
@@ -50,16 +50,21 @@ async def route_a2a_agent_request(
         route_name = ROUTE_ENDPOINT_MAPPING.get(route_type, route_type)
         raise ProxyModelNotFoundError(route=route_name, model_name=model_name)
 
-    # Verify the caller is permitted to use this agent
-    is_allowed = await AgentRequestHandler.is_agent_allowed(
-        agent_id=agent.agent_id,
-        user_api_key_auth=user_api_key_dict,
+    # Verify the caller is permitted to use this agent (admins bypass the check)
+    is_admin = user_api_key_dict is not None and (
+        user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+        or user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
     )
-    if not is_allowed:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Agent '{agent_name}' is not allowed for your key/team. Contact proxy admin for access.",
+    if not is_admin:
+        is_allowed = await AgentRequestHandler.is_agent_allowed(
+            agent_id=agent.agent_id,
+            user_api_key_auth=user_api_key_dict,
         )
+        if not is_allowed:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Agent '{agent_name}' is not allowed for your key/team. Contact proxy admin for access.",
+            )
 
     # Get API base URL from agent config
     if not agent.agent_card_params or "url" not in agent.agent_card_params:

--- a/litellm/proxy/agent_endpoints/a2a_routing.py
+++ b/litellm/proxy/agent_endpoints/a2a_routing.py
@@ -8,10 +8,17 @@ Looks up agents in the registry and injects their API base URL.
 from typing import Any, Optional
 
 import litellm
+from fastapi import HTTPException
+
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import UserAPIKeyAuth
 
 
-def route_a2a_agent_request(data: dict, route_type: str) -> Optional[Any]:
+async def route_a2a_agent_request(
+    data: dict,
+    route_type: str,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+) -> Optional[Any]:
     """
     Route A2A agent requests directly to litellm with injected API base.
 
@@ -19,6 +26,9 @@ def route_a2a_agent_request(data: dict, route_type: str) -> Optional[Any]:
     """
     # Import here to avoid circular imports
     from litellm.proxy.agent_endpoints.agent_registry import global_agent_registry
+    from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
+        AgentRequestHandler,
+    )
     from litellm.proxy.route_llm_request import (
         ROUTE_ENDPOINT_MAPPING,
         ProxyModelNotFoundError,
@@ -39,6 +49,17 @@ def route_a2a_agent_request(data: dict, route_type: str) -> Optional[Any]:
         verbose_proxy_logger.error(f"[A2A] Agent '{agent_name}' not found in registry")
         route_name = ROUTE_ENDPOINT_MAPPING.get(route_type, route_type)
         raise ProxyModelNotFoundError(route=route_name, model_name=model_name)
+
+    # Verify the caller is permitted to use this agent
+    is_allowed = await AgentRequestHandler.is_agent_allowed(
+        agent_id=agent.agent_id,
+        user_api_key_auth=user_api_key_dict,
+    )
+    if not is_allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{agent_name}' is not allowed for your key/team. Contact proxy admin for access.",
+        )
 
     # Get API base URL from agent config
     if not agent.agent_card_params or "url" not in agent.agent_card_params:

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -200,10 +200,9 @@ async def get_agents(
         for agent in returned_agents:
             if agent.litellm_params is None:
                 agent.litellm_params = {}
-            agent.litellm_params[
-                "is_public"
-            ] = litellm.public_agent_groups is not None and (
-                agent.agent_id in litellm.public_agent_groups
+            agent.litellm_params["is_public"] = (
+                litellm.public_agent_groups is not None
+                and (agent.agent_id in litellm.public_agent_groups)
             )
 
         # Redact sensitive fields for non-admin users
@@ -393,6 +392,19 @@ async def get_agent_by_id(
     """
     await check_feature_access_for_user(user_api_key_dict, "agents")
 
+    from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
+        AgentRequestHandler,
+    )
+
+    is_allowed = await AgentRequestHandler.is_agent_allowed(
+        agent_id=agent_id, user_api_key_auth=user_api_key_dict
+    )
+    if not is_allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{agent_id}' is not allowed for your key/team. Contact proxy admin for access.",
+        )
+
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
@@ -409,13 +421,13 @@ async def get_agent_by_id(
                 agent_dict = agent_row.model_dump()
                 if agent_row.object_permission is not None:
                     try:
-                        agent_dict[
-                            "object_permission"
-                        ] = agent_row.object_permission.model_dump()
+                        agent_dict["object_permission"] = (
+                            agent_row.object_permission.model_dump()
+                        )
                     except Exception:
-                        agent_dict[
-                            "object_permission"
-                        ] = agent_row.object_permission.dict()
+                        agent_dict["object_permission"] = (
+                            agent_row.object_permission.dict()
+                        )
                 agent = AgentResponse(**agent_dict)  # type: ignore
         else:
             # Agent found in memory — refresh spend from DB

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -392,18 +392,23 @@ async def get_agent_by_id(
     """
     await check_feature_access_for_user(user_api_key_dict, "agents")
 
-    from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
-        AgentRequestHandler,
+    is_admin = (
+        user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+        or user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
     )
-
-    is_allowed = await AgentRequestHandler.is_agent_allowed(
-        agent_id=agent_id, user_api_key_auth=user_api_key_dict
-    )
-    if not is_allowed:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Agent '{agent_id}' is not allowed for your key/team. Contact proxy admin for access.",
+    if not is_admin:
+        from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
+            AgentRequestHandler,
         )
+
+        is_allowed = await AgentRequestHandler.is_agent_allowed(
+            agent_id=agent_id, user_api_key_auth=user_api_key_dict
+        )
+        if not is_allowed:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Agent '{agent_id}' is not allowed for your key/team. Contact proxy admin for access.",
+            )
 
     from litellm.proxy.proxy_server import prisma_client
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -69,7 +69,8 @@ def check_complete_credentials(request_body: dict) -> bool:
         # complex credentials - easier to make a malicious request
         return False
 
-    if "api_key" in request_body:
+    api_key_value = request_body.get("api_key")
+    if api_key_value and isinstance(api_key_value, str) and api_key_value.strip():
         return True
 
     return False

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -866,9 +866,11 @@ class ProxyBaseLLMRequestProcessing:
                 "Request received by LiteLLM: payload too large to log (%d bytes, limit %d). Keys: %s",
                 len(_payload_str),
                 MAX_PAYLOAD_SIZE_FOR_DEBUG_LOG,
-                list(self.data.keys())
-                if isinstance(self.data, dict)
-                else type(self.data).__name__,
+                (
+                    list(self.data.keys())
+                    if isinstance(self.data, dict)
+                    else type(self.data).__name__
+                ),
             )
         else:
             verbose_proxy_logger.debug(
@@ -1054,6 +1056,7 @@ class ProxyBaseLLMRequestProcessing:
             route_type=route_type,
             llm_router=llm_router,
             user_model=user_model,
+            user_api_key_dict=user_api_key_dict,
         )
         tasks.append(llm_call)
 
@@ -1128,9 +1131,9 @@ class ProxyBaseLLMRequestProcessing:
                 # aliasing/routing, but the OpenAI-compatible response `model` field should reflect
                 # what the client sent.
                 if requested_model_from_client:
-                    self.data[
-                        "_litellm_client_requested_model"
-                    ] = requested_model_from_client
+                    self.data["_litellm_client_requested_model"] = (
+                        requested_model_from_client
+                    )
 
                 # Streaming: attach a closure that fires after all guardrail
                 # end-of-stream blocks complete.  CSW.__anext__ stores the
@@ -1731,7 +1734,9 @@ class ProxyBaseLLMRequestProcessing:
         verbose_proxy_logger.debug("inside generator")
         try:
             str_so_far = ""
-            async for chunk in proxy_logging_obj.async_post_call_streaming_iterator_hook(
+            async for (
+                chunk
+            ) in proxy_logging_obj.async_post_call_streaming_iterator_hook(
                 user_api_key_dict=user_api_key_dict,
                 response=response,
                 request_data=request_data,
@@ -1959,9 +1964,9 @@ class ProxyBaseLLMRequestProcessing:
 
             # Add cache-related fields to **params (handled by Usage.__init__)
             if cache_creation_input_tokens is not None:
-                usage_kwargs[
-                    "cache_creation_input_tokens"
-                ] = cache_creation_input_tokens
+                usage_kwargs["cache_creation_input_tokens"] = (
+                    cache_creation_input_tokens
+                )
             if cache_read_input_tokens is not None:
                 usage_kwargs["cache_read_input_tokens"] = cache_read_input_tokens
 

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 from fastapi import HTTPException, status
 
 import litellm
+from litellm.proxy._types import UserAPIKeyAuth
 
 if TYPE_CHECKING:
     from litellm.router import Router as _Router
@@ -314,6 +315,7 @@ async def route_request(  # noqa: PLR0915 - Complex routing function, refactorin
         "acancel_run",
         "adelete_run",
     ],
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
 ):
     """
     Common helper to route the request
@@ -548,7 +550,9 @@ async def route_request(  # noqa: PLR0915 - Complex routing function, refactorin
                     route_a2a_agent_request,
                 )
 
-                result = route_a2a_agent_request(data, route_type)
+                result = await route_a2a_agent_request(
+                    data, route_type, user_api_key_dict=user_api_key_dict
+                )
                 if result is not None:
                     return result
                 # Fall through to raise exception below if result is None

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -19,7 +19,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import litellm
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
-from litellm.proxy.auth.auth_utils import is_request_body_safe
+from litellm.proxy.auth.auth_utils import (
+    check_complete_credentials,
+    is_request_body_safe,
+)
 from litellm.proxy.litellm_pre_call_utils import (
     _get_dynamic_logging_metadata,
     add_litellm_data_to_request,
@@ -33,7 +36,9 @@ def mock_request(monkeypatch):
     mock_request = Mock(spec=Request)
     mock_request.query_params = {}  # Set mock query_params to an empty dictionary
     mock_request.headers = {"traceparent": "test_traceparent"}
-    mock_request.state = State()  # Real State so _safe_get_request_headers caching works
+    mock_request.state = (
+        State()
+    )  # Real State so _safe_get_request_headers caching works
     monkeypatch.setattr(
         "litellm.proxy.litellm_pre_call_utils.add_litellm_data_to_request", mock_request
     )
@@ -465,6 +470,21 @@ def test_is_request_body_safe_model_enabled(
     assert expect_error == error_raised
 
 
+@pytest.mark.parametrize(
+    "api_key_value, expect_complete",
+    [
+        ("sk-real-key", True),
+        ("", False),
+        (None, False),
+        ("   ", False),
+    ],
+)
+def test_check_complete_credentials_api_key_values(api_key_value, expect_complete):
+    request_body = {"model": "gpt-3.5-turbo", "api_key": api_key_value}
+    result = check_complete_credentials(request_body=request_body)
+    assert result == expect_complete
+
+
 def test_reading_openai_org_id_from_headers():
     from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
@@ -734,6 +754,7 @@ def test_get_docs_url(env_vars, expected_url):
 
     result = _get_docs_url()
     assert result == expected_url
+
 
 @pytest.mark.parametrize(
     "env_vars, expected_url",
@@ -1516,7 +1537,7 @@ class MockPrismaClientDB:
         mock_key_data,
     ):
         self.db = MockDb(mock_team_data, mock_key_data)
-    
+
     async def get_data(
         self,
         token: Optional[Union[str, list]] = None,
@@ -1534,7 +1555,7 @@ class MockPrismaClientDB:
     ):
         """Mock get_data method to return user info for admin"""
         from litellm.proxy._types import LiteLLM_UserTable
-        
+
         # Return a proper LiteLLM_UserTable object when querying by user_id
         if user_id:
             return LiteLLM_UserTable(
@@ -2072,7 +2093,7 @@ def test_team_alias_stale_bypass_disabled_by_default(monkeypatch):
     monkeypatch.delenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", raising=False)
     import litellm.proxy.litellm_pre_call_utils as pre_call_utils
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
-    
+
     # Reset module-level cache to ensure test isolation
     pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
 
@@ -2097,7 +2118,7 @@ def test_team_alias_stale_bypass_disabled_by_default(monkeypatch):
 def test_team_alias_stale_bypass_enabled_by_flag(monkeypatch):
     import litellm.proxy.litellm_pre_call_utils as pre_call_utils
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
-    
+
     # Reset module-level cache to ensure test isolation
     pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
 
@@ -2394,16 +2415,17 @@ async def test_handle_logging_proxy_only_error_syncs_normalized_call_type(
         captured_logging_obj["logging_obj"] = logging_obj
         return logging_obj, data
 
-    with patch(
-        "litellm.proxy.utils.litellm.utils.function_setup",
-        side_effect=_capture_function_setup,
-    ), patch.object(
-        Logging, "async_failure_handler", new=AsyncMock(return_value=None)
-    ), patch.object(
-        Logging, "failure_handler", return_value=None
-    ), patch(
-        "litellm.proxy.utils.threading.Thread"
-    ) as mock_thread:
+    with (
+        patch(
+            "litellm.proxy.utils.litellm.utils.function_setup",
+            side_effect=_capture_function_setup,
+        ),
+        patch.object(
+            Logging, "async_failure_handler", new=AsyncMock(return_value=None)
+        ),
+        patch.object(Logging, "failure_handler", return_value=None),
+        patch("litellm.proxy.utils.threading.Thread") as mock_thread,
+    ):
         mock_thread.return_value.start = Mock()
 
         await proxy_logging._handle_logging_proxy_only_error(
@@ -2647,7 +2669,9 @@ async def test_handle_logging_proxy_only_error_skips_handlers_for_pass_through()
         "model": "claude-3-5-sonnet",
     }
 
-    with patch.object(logging_obj, "async_failure_handler", new_callable=AsyncMock) as mock_async:
+    with patch.object(
+        logging_obj, "async_failure_handler", new_callable=AsyncMock
+    ) as mock_async:
         with patch.object(logging_obj, "failure_handler") as mock_sync:
             await proxy_logging._handle_logging_proxy_only_error(
                 request_data=request_data,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -451,6 +451,60 @@ def test_forward_headers_from_request_x_pass_prefix():
     assert "x-pass-custom-header" not in result
 
 
+def test_forward_headers_from_request_protected_headers_not_overwritten():
+    """
+    Test that x-pass- headers whose stripped names resolve to credential or
+    protocol-level header names are silently dropped and do not overwrite
+    values already present in the outbound headers dict.
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+
+    proxy_headers = {
+        "authorization": "Bearer proxy-upstream-key",
+        "api-key": "proxy-azure-key",
+        "x-api-key": "proxy-anthropic-key",
+        "x-goog-api-key": "proxy-google-key",
+    }
+
+    request_headers = {
+        "x-pass-authorization": "Bearer attacker-key",
+        "x-pass-api-key": "attacker-azure-key",
+        "x-pass-x-api-key": "attacker-anthropic-key",
+        "x-pass-x-goog-api-key": "attacker-google-key",
+        "x-pass-host": "evil.example.com",
+        "x-pass-content-length": "0",
+        "x-pass-x-amz-security-token": "attacker-aws-token",
+        # Legitimate x-pass- header that should still be forwarded
+        "x-pass-anthropic-beta": "context-1m-2025-08-07",
+        "content-type": "application/json",
+    }
+
+    result = BasePassthroughUtils.forward_headers_from_request(
+        request_headers=request_headers,
+        headers=proxy_headers.copy(),
+        forward_headers=False,
+    )
+
+    # Protected headers must retain the proxy-configured values
+    assert result["authorization"] == "Bearer proxy-upstream-key"
+    assert result["api-key"] == "proxy-azure-key"
+    assert result["x-api-key"] == "proxy-anthropic-key"
+    assert result["x-goog-api-key"] == "proxy-google-key"
+
+    # Protocol headers must not be injected
+    assert "host" not in result
+    assert "content-length" not in result
+
+    # AWS SigV4 headers must not be injected
+    assert "x-amz-security-token" not in result
+
+    # Legitimate non-protected x-pass- header still forwarded
+    assert result["anthropic-beta"] == "context-1m-2025-08-07"
+
+    # Header name must be normalized to lowercase in output
+    assert "Anthropic-Beta" not in result
+
+
 @pytest.mark.asyncio
 async def test_vertex_passthrough_custom_model_name_replaced_in_url():
     """


### PR DESCRIPTION
## Summary

- The `GET /v1/agents/{agent_id}` endpoint verified feature access but did not enforce per-agent ACLs. Any authenticated user with the agents feature enabled could fetch the full configuration of any agent.
- The `route_a2a_agent_request` helper, used when routing `a2a/<name>` model strings through `/v1/chat/completions`, had no permission check before forwarding to the backend.

## Changes

`get_agent_by_id` now calls `AgentRequestHandler.is_agent_allowed` after the feature-flag check, returning 403 if the caller's key/team does not include the requested agent in its allowed list.

`route_a2a_agent_request` is now async and accepts an optional `user_api_key_dict`. It calls `AgentRequestHandler.is_agent_allowed` before injecting `api_base` and forwarding the request. `route_request` in `route_llm_request.py` now accepts and passes through `user_api_key_dict`, and `base_process_llm_request` forwards it from the handler. Both changes follow the pattern already used in `invoke_agent_a2a` and `get_agent_card`.

## Testing

- Verified `GET /v1/agents/{id}` returns 403 for a key whose `object_permission.agents` does not include the requested agent (was 200 before).
- Verified admin key still gets 200 with full `static_headers`.
- Verified key with the agent in its allowed list still gets 200.
- Verified unrestricted keys (no `object_permission`) still get 200 on any agent.
- `uv run pytest tests/test_litellm/proxy/agent_endpoints/ tests/test_litellm/proxy/test_route_a2a_models.py -v` — 65 passed.

## Type

🐛 Bug Fix
✅ Test