### PR TITLE
fix(bedrock/cohere): wrap embedding_types as list when encoding_format is string

### DIFF
--- a/litellm/llms/bedrock/embed/cohere_transformation.py
+++ b/litellm/llms/bedrock/embed/cohere_transformation.py
@@ -22,7 +22,7 @@ class BedrockCohereEmbeddingConfig:
     ) -> dict:
         for k, v in non_default_params.items():
             if k == "encoding_format":
-                optional_params["embedding_types"] = v
+                optional_params["embedding_types"] = v if isinstance(v, list) else [v]
             elif k == "dimensions":
                 optional_params["output_dimension"] = v
         return optional_params
@@ -45,3 +45,4 @@ class BedrockCohereEmbeddingConfig:
                 new_transformed_request[k] = transformed_request[k]  # type: ignore
 
         return new_transformed_request
+


### PR DESCRIPTION
## Problem

Calling `cohere-embed-v4` via Bedrock (e.g. `bedrock/eu.cohere.embed-v4:0`) with `encoding_format: "float"` causes a 400 Bad Request:

```
BedrockException - {"message":"Malformed request. Please check your parameter/values and try again."}
```

The Bedrock Cohere embedding API requires `embedding_types` to be an **array** of strings (`["float"]`), but `BedrockCohereEmbeddingConfig.map_openai_params` was passing it as a raw string (`"float"`).

## Root cause

In `litellm/llms/bedrock/embed/cohere_transformation.py`:

```python
# Before (bug):
if k == "encoding_format":
    optional_params["embedding_types"] = v  # v is "float" (string)
```

The parent class `CohereEmbeddingConfig` already has the correct behaviour (wrapping `v` in a list), but the Bedrock subclass did not.

## Fix

```python
# After:
if k == "encoding_format":
    optional_params["embedding_types"] = v if isinstance(v, list) else [v]
```

Closes #25925