### PR TITLE
fix(vertex_ai): support multi-region endpoints (us/eu) with correct URL scheme

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -224,6 +224,12 @@ def get_vertex_base_model_name(model: str) -> str:
     return model
 
 
+_VERTEX_MULTI_REGION_URLS = {
+    "us": "https://aiplatform.us.rep.googleapis.com",
+    "eu": "https://aiplatform.eu.rep.googleapis.com",
+}
+
+
 def get_vertex_base_url(
     vertex_location: Optional[str],
 ) -> str:
@@ -232,8 +238,9 @@ def get_vertex_base_url(
     """
     if vertex_location == "global":
         return "https://aiplatform.googleapis.com"
-    else:
-        return f"https://{vertex_location}-aiplatform.googleapis.com"
+    if vertex_location in _VERTEX_MULTI_REGION_URLS:
+        return _VERTEX_MULTI_REGION_URLS[vertex_location]
+    return f"https://{vertex_location}-aiplatform.googleapis.com"
 
 
 def _get_embedding_url(


### PR DESCRIPTION
## Problem

Passing `vertex_location="us"` or `vertex_location="eu"` to use Google Vertex AI's multi-region endpoints generates an incorrect base URL:

| Input | Generated (wrong) | Expected (correct) |
|---|---|---|
| `"us"` | `https://us-aiplatform.googleapis.com` | `https://aiplatform.us.rep.googleapis.com` |
| `"eu"` | `https://eu-aiplatform.googleapis.com` | `https://aiplatform.eu.rep.googleapis.com` |

The wrong URLs don't exist and return errors.

## Root cause

`get_vertex_base_url` in `litellm/llms/vertex_ai/common_utils.py` only handled the `"global"` special case. Google's [multi-region endpoints](https://cloud.google.com/blog/products/ai-machine-learning/global-endpoint-for-claude-models-generally-available-on-vertex-ai) (announced April 2026) use the URL pattern `aiplatform.{region}.rep.googleapis.com` rather than `{region}-aiplatform.googleapis.com`.

## Fix

Added a `_VERTEX_MULTI_REGION_URLS` lookup for `"us"` and `"eu"` locations before falling back to the regional URL pattern:

```python
_VERTEX_MULTI_REGION_URLS = {
    "us": "https://aiplatform.us.rep.googleapis.com",
    "eu": "https://aiplatform.eu.rep.googleapis.com",
}

def get_vertex_base_url(vertex_location):
    if vertex_location == "global":
        return "https://aiplatform.googleapis.com"
    if vertex_location in _VERTEX_MULTI_REGION_URLS:
        return _VERTEX_MULTI_REGION_URLS[vertex_location]
    return f"https://{vertex_location}-aiplatform.googleapis.com"
```

Closes #25926