### PR TITLE
fix(langfuse): guard against None standard_callback_dynamic_params

### DIFF
--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -86,9 +86,7 @@ class LangFuseHandler:
         if globalLangfuseLogger is not None:
             return globalLangfuseLogger
 
-        credentials_dict: Dict[
-            str, Any
-        ] = (
+        credentials_dict: Dict[str, Any] = (
             {}
         )  # the global langfuse logger uses Environment Variables, there are no dynamic credentials
         globalLangfuseLogger = in_memory_dynamic_logger_cache.get_cache(
@@ -159,6 +157,9 @@ class LangFuseHandler:
         Returns:
             bool: True if the dynamic langfuse credentials are passed, False otherwise
         """
+
+        if standard_callback_dynamic_params is None:
+            return False
 
         if (
             standard_callback_dynamic_params.get("langfuse_host") is not None

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_handler.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_handler.py
@@ -1,0 +1,39 @@
+from litellm.integrations.langfuse.langfuse_handler import LangFuseHandler
+
+
+class TestLangFuseHandlerDynamicCredentials:
+    def test_dynamic_credentials_none_returns_false(self):
+        """_dynamic_langfuse_credentials_are_passed should return False when
+        standard_callback_dynamic_params is None (env-var-only config)."""
+        result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(None)
+        assert result is False
+
+    def test_dynamic_credentials_empty_dict_returns_false(self):
+        """_dynamic_langfuse_credentials_are_passed should return False when
+        standard_callback_dynamic_params is an empty dict."""
+        result = LangFuseHandler._dynamic_langfuse_credentials_are_passed({})
+        assert result is False
+
+    def test_dynamic_credentials_with_langfuse_host_returns_true(self):
+        result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(
+            {"langfuse_host": "http://localhost:3000"}
+        )
+        assert result is True
+
+    def test_dynamic_credentials_with_public_key_returns_true(self):
+        result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(
+            {"langfuse_public_key": "pk-lf-test"}
+        )
+        assert result is True
+
+    def test_dynamic_credentials_with_secret_key_returns_true(self):
+        result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(
+            {"langfuse_secret_key": "sk-lf-test"}
+        )
+        assert result is True
+
+    def test_dynamic_credentials_with_secret_returns_true(self):
+        result = LangFuseHandler._dynamic_langfuse_credentials_are_passed(
+            {"langfuse_secret": "sk-lf-test"}
+        )
+        assert result is True


### PR DESCRIPTION
## Summary

`_dynamic_langfuse_credentials_are_passed()` now returns `False` immediately
when `standard_callback_dynamic_params` is `None`, preventing the
`AttributeError` that caused all Langfuse success callbacks to silently fail
when credentials were supplied via environment variables.

Closes #25940

## Relevant issues

Fixes #25940

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before (v1.83.x)** — every LLM call logs this error and no traces reach Langfuse:
```
{"message": "Langfuse Layer Error - Exception occurred while logging success event: 'NoneType' object has no attribute 'get'",
 "level": "ERROR", ...}
```

**After** — `_dynamic_langfuse_credentials_are_passed(None)` returns `False`,
the global env-var logger is used, and traces are sent normally.

## Type

🐛 Bug Fix

## Changes

- `litellm/integrations/langfuse/langfuse_handler.py` — added early `None`
  guard in `_dynamic_langfuse_credentials_are_passed()` so it returns `False`
  instead of raising `AttributeError` when called without per-request dynamic
  params.
- `tests/test_litellm/integrations/langfuse/test_langfuse_handler.py` — 6 new
  unit tests covering `None`, empty dict, and all four credential keys.
