### PR TITLE
fix(proxy): honor client-supplied x-litellm-call-id in spend log request_id

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -783,9 +783,12 @@ class ProxyBaseLLMRequestProcessing:
         ):
             self.data["model"] = user_api_key_dict.aliases[self.data["model"]]
 
-        self.data["litellm_call_id"] = request.headers.get(
-            "x-litellm-call-id", str(uuid.uuid4())
-        )
+        client_supplied_call_id = request.headers.get("x-litellm-call-id")
+        if client_supplied_call_id:
+            self.data["litellm_call_id"] = client_supplied_call_id
+            self.data["litellm_call_id_from_client"] = True
+        else:
+            self.data["litellm_call_id"] = str(uuid.uuid4())
         DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
         DDSpanTagger.tag_request(
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -789,6 +789,10 @@ class ProxyBaseLLMRequestProcessing:
             self.data["litellm_call_id_from_client"] = True
         else:
             self.data["litellm_call_id"] = str(uuid.uuid4())
+            # Defensive: explicitly clear the flag so a body-injected
+            # `litellm_call_id_from_client: true` cannot flip precedence
+            # in get_spend_logs_id when no header was actually supplied.
+            self.data["litellm_call_id_from_client"] = False
         DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
         DDSpanTagger.tag_request(
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -58,9 +58,12 @@ async def google_generate_content(
     )
 
     # Create logging object with full request metadata so callbacks (e.g. S3) get user/trace_id
-    data["litellm_call_id"] = request.headers.get(
-        "x-litellm-call-id", str(uuid.uuid4())
-    )
+    client_supplied_call_id = request.headers.get("x-litellm-call-id")
+    if client_supplied_call_id:
+        data["litellm_call_id"] = client_supplied_call_id
+        data["litellm_call_id_from_client"] = True
+    else:
+        data["litellm_call_id"] = str(uuid.uuid4())
     logging_obj, data = litellm.utils.function_setup(
         original_function="agenerate_content",
         rules_obj=litellm.utils.Rules(),
@@ -121,9 +124,12 @@ async def google_stream_generate_content(
     )
 
     # Create logging object with full request metadata so streaming END callbacks (e.g. S3) get user/trace_id
-    data["litellm_call_id"] = request.headers.get(
-        "x-litellm-call-id", str(uuid.uuid4())
-    )
+    client_supplied_call_id = request.headers.get("x-litellm-call-id")
+    if client_supplied_call_id:
+        data["litellm_call_id"] = client_supplied_call_id
+        data["litellm_call_id_from_client"] = True
+    else:
+        data["litellm_call_id"] = str(uuid.uuid4())
     logging_obj, data = litellm.utils.function_setup(
         original_function="agenerate_content_stream",
         rules_obj=litellm.utils.Rules(),

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -64,6 +64,10 @@ async def google_generate_content(
         data["litellm_call_id_from_client"] = True
     else:
         data["litellm_call_id"] = str(uuid.uuid4())
+        # Defensive: explicitly clear the flag so a body-injected
+        # `litellm_call_id_from_client: true` cannot flip precedence
+        # in get_spend_logs_id when no header was actually supplied.
+        data["litellm_call_id_from_client"] = False
     logging_obj, data = litellm.utils.function_setup(
         original_function="agenerate_content",
         rules_obj=litellm.utils.Rules(),
@@ -130,6 +134,10 @@ async def google_stream_generate_content(
         data["litellm_call_id_from_client"] = True
     else:
         data["litellm_call_id"] = str(uuid.uuid4())
+        # Defensive: explicitly clear the flag so a body-injected
+        # `litellm_call_id_from_client: true` cannot flip precedence
+        # in get_spend_logs_id when no header was actually supplied.
+        data["litellm_call_id_from_client"] = False
     logging_obj, data = litellm.utils.function_setup(
         original_function="agenerate_content_stream",
         rules_obj=litellm.utils.Rules(),

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -169,6 +169,12 @@ def get_spend_logs_id(
     if call_type == "aretrieve_batch" or call_type == "acreate_file":
         # Generate a hash from the response object
         id: Optional[str] = generate_hash_from_response(response_obj)
+    elif kwargs.get("litellm_call_id_from_client"):
+        # Client explicitly supplied x-litellm-call-id; honor it so callers
+        # can correlate spend log records with their own request id.
+        id = cast(Optional[str], kwargs.get("litellm_call_id")) or cast(
+            Optional[str], response_obj.get("id")
+        )
     else:
         id = cast(Optional[str], response_obj.get("id")) or cast(
             Optional[str], kwargs.get("litellm_call_id")

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1469,3 +1469,82 @@ class TestIsMasterKey:
         master = "sk-master-key-123"
         hashed = hash_token(master)
         assert _is_master_key(api_key=hashed, _master_key=master) is True
+
+
+class TestGetSpendLogsId:
+    """Tests for get_spend_logs_id precedence between response.id and litellm_call_id."""
+
+    def setup_method(self):
+        from litellm.proxy.spend_tracking.spend_tracking_utils import (
+            get_spend_logs_id,
+        )
+
+        self.fn = get_spend_logs_id
+
+    def test_default_prefers_response_id(self):
+        """Without the client-supplied flag, response.id wins (existing behavior)."""
+        result = self.fn(
+            call_type="acompletion",
+            response_obj={"id": "chatcmpl-provider-id"},
+            kwargs={"litellm_call_id": "auto-generated-uuid"},
+        )
+        assert result == "chatcmpl-provider-id"
+
+    def test_default_falls_back_to_litellm_call_id(self):
+        """Without the client-supplied flag, falls back to litellm_call_id when response.id missing."""
+        result = self.fn(
+            call_type="acompletion",
+            response_obj={},
+            kwargs={"litellm_call_id": "auto-generated-uuid"},
+        )
+        assert result == "auto-generated-uuid"
+
+    def test_client_supplied_flag_prefers_litellm_call_id(self):
+        """With client-supplied flag, litellm_call_id wins over response.id."""
+        result = self.fn(
+            call_type="acompletion",
+            response_obj={"id": "chatcmpl-provider-id"},
+            kwargs={
+                "litellm_call_id": "client-correlation-uuid",
+                "litellm_call_id_from_client": True,
+            },
+        )
+        assert result == "client-correlation-uuid"
+
+    def test_client_supplied_flag_falls_back_to_response_id(self):
+        """With client-supplied flag but missing litellm_call_id, falls back to response.id."""
+        result = self.fn(
+            call_type="acompletion",
+            response_obj={"id": "chatcmpl-provider-id"},
+            kwargs={
+                "litellm_call_id": None,
+                "litellm_call_id_from_client": True,
+            },
+        )
+        assert result == "chatcmpl-provider-id"
+
+    def test_client_supplied_flag_false_uses_default_precedence(self):
+        """Explicit False on flag uses default (response.id wins)."""
+        result = self.fn(
+            call_type="acompletion",
+            response_obj={"id": "chatcmpl-provider-id"},
+            kwargs={
+                "litellm_call_id": "auto-uuid",
+                "litellm_call_id_from_client": False,
+            },
+        )
+        assert result == "chatcmpl-provider-id"
+
+    def test_aretrieve_batch_unchanged(self):
+        """The batch hash path is independent of the flag."""
+        result = self.fn(
+            call_type="aretrieve_batch",
+            response_obj={"id": "batch-id", "data": "x"},
+            kwargs={
+                "litellm_call_id": "client-uuid",
+                "litellm_call_id_from_client": True,
+            },
+        )
+        # Hash-based id, not the client uuid
+        assert result is not None
+        assert result != "client-uuid"

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1548,3 +1548,17 @@ class TestGetSpendLogsId:
         # Hash-based id, not the client uuid
         assert result is not None
         assert result != "client-uuid"
+
+    def test_acreate_file_unchanged(self):
+        """The acreate_file hash path is also independent of the flag."""
+        result = self.fn(
+            call_type="acreate_file",
+            response_obj={"id": "file-id", "data": "y"},
+            kwargs={
+                "litellm_call_id": "client-uuid",
+                "litellm_call_id_from_client": True,
+            },
+        )
+        # Hash-based id, not the client uuid
+        assert result is not None
+        assert result != "client-uuid"


### PR DESCRIPTION
## Summary

When a client sends `x-litellm-call-id: <my-uuid>` explicitly, today the proxy silently discards it from the spend log: the spend record exists, but with an unrelated provider response id as `request_id`, so `/spend/logs/v2?request_id=<my-uuid>` returns empty.

## Root cause

`get_spend_logs_id` (`litellm/proxy/spend_tracking/spend_tracking_utils.py:166`) does:

```python
id = response_obj.get("id") or kwargs.get("litellm_call_id")
```

`response_obj.id` is the provider's own response id (e.g. Gemini's `"QanhadapC_val7oP15PyuQM"`, OpenAI's `"chatcmpl-..."`, Anthropic's `"msg_..."`). It's always present, so it always wins — `litellm_call_id` is never used to populate `request_id` in the spend log.

This is most painful on the Google-native `:generateContent` route, where the response also lacks `x-litellm-*` headers (see #25500), so clients can't even read back the resolved id from the response. But the underlying defect is cross-route.

## Fix

Track whether `litellm_call_id` was supplied by the client via `x-litellm-call-id` (vs. an auto-generated UUID). When the client supplied it, prefer it over `response.id` for the spend log `request_id`. When the call_id is auto-generated, fall back to existing behavior (`response.id` first, then the auto-uuid).

This preserves backward compatibility for callers that don't set the header (existing tests at `tests/test_keys.py:519`, `tests/test_spend_logs.py:115/181`, etc., still assert `request_id == response["id"]`).

## Files changed

- `litellm/proxy/common_request_processing.py` — set `data["litellm_call_id_from_client"] = True` when the header is present (covers `/v1/chat/completions`, `/v1/messages`, etc.)
- `litellm/proxy/google_endpoints/endpoints.py` — same flag for both `:generateContent` and `:streamGenerateContent`
- `litellm/proxy/spend_tracking/spend_tracking_utils.py` — `get_spend_logs_id` honors the new flag
- `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py` — 6 new tests (`TestGetSpendLogsId`) covering both default and flagged precedence, plus the `aretrieve_batch` carve-out

## Manual testing

```bash
# Without the fix
curl -X POST "https://<proxy>/v1beta/models/gemini-2.5-pro:generateContent" \
  -H "x-goog-api-key: sk-..." \
  -H "x-litellm-call-id: my-uuid-123" \
  -d '{"contents": [{"parts": [{"text": "hi"}], "role": "user"}]}'

curl "https://<proxy>/spend/logs/v2?request_id=my-uuid-123"
# → data: []  (BAD)

# With the fix
# → data: [{"request_id": "my-uuid-123", ...}]  (GOOD)
```

## Tests

```
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py::TestGetSpendLogsId::test_default_prefers_response_id PASSED
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py::TestGetSpendLogsId::test_default_falls_back_to_litellm_call_id PASSED
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py::TestGetSpendLogsId::test_client_supplied_flag_prefers_litellm_call_id PASSED
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py::TestGetSpendLogsId::test_client_supplied_flag_falls_back_to_response_id PASSED
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py::TestGetSpendLogsId::test_client_supplied_flag_false_uses_default_precedence PASSED
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py::TestGetSpendLogsId::test_aretrieve_batch_unchanged PASSED
```

Test plan:

- [x] Add unit tests for new behavior
- [x] Verify existing tests asserting `request_id == response["id"]` are unaffected (default path unchanged)
- [ ] Manual end-to-end on Google-native `:generateContent` route

## Related

Part of a larger cluster of bugs in the Google-native `/v1beta/...` route (separate detailed issue forthcoming). Companion fixes:

- #25500 (in flight) — outbound `x-litellm-*` response headers on Google-native routes
- #24097 — streaming success_callback silently skipped on Google-native streaming
- Forthcoming PR — `metadata` / `user` propagation into spend logs on Google-native non-streaming

## Tracking issue

#25956 — full root-cause writeup for the Google-native correlation cluster (this PR is Fix #1 of 4 defects)