### PR TITLE
docs(readme): preserve hero image aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
     </a>
 </h4>
 
-<img width="2688" height="1600" alt="Group 7154 (1)" src="https://github.com/user-attachments/assets/c5ee0412-6fb5-4fb6-ab5b-bafae4209ca6" />
+<img alt="LiteLLM" src="https://github.com/user-attachments/assets/c5ee0412-6fb5-4fb6-ab5b-bafae4209ca6" />
 
 ---
 


### PR DESCRIPTION
## Relevant issues

N/A

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] N/A — README-only change, no code logic affected (no tests required)

## Screenshots / Proof of Fix
<img width="1413" height="803" alt="Screenshot 2026-04-17 at 11 32 43" src="https://github.com/user-attachments/assets/1d6cb8eb-4b97-4a0e-809f-2e610de984fb" />

**Fixed:**
<img width="1424" height="743" alt="Screenshot 2026-04-17 at 11 33 43" src="https://github.com/user-attachments/assets/1f208f9d-fe2a-4771-a5f0-74b6158d5687" />

The hero image in `README.md` had hardcoded `width="2688" height="1600"` attributes that didn't match the asset's actual aspect ratio. GitHub respects those attributes when rendering the README, which forced the image into a taller box and produced visible vertical stretching.

## Type

📖 Documentation