### PR TITLE
fix(google_genai): propagate user from kwargs to logging obj in agenerate_content

### DIFF
--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -188,6 +188,7 @@ class GenerateContentHelper:
         litellm_logging_obj.update_from_kwargs(
             kwargs=kwargs,
             model=model,
+            user=kwargs.get("user"),
             optional_params=dict(generate_content_config_dict),
             litellm_params={
                 "litellm_call_id": litellm_call_id,

--- a/tests/test_litellm/google_genai/test_google_genai_main.py
+++ b/tests/test_litellm/google_genai/test_google_genai_main.py
@@ -43,3 +43,68 @@ async def test_agenerate_content_stream():
         )
         mock_post.assert_called_once()
         mock_post.call_args.kwargs["stream"] == True
+
+
+def test_setup_generate_content_call_propagates_user_to_logging_obj():
+    """
+    Regression test for Google-native /v1beta/.../:generateContent route
+    dropping the `user` field from the spend log.
+
+    `setup_generate_content_call` must pass `user` from kwargs to
+    `litellm_logging_obj.update_from_kwargs` so that `logging_obj.user` and
+    `model_call_details["user"]` reflect what the client sent (via header or
+    body) instead of defaulting to None / "".
+    """
+    from unittest.mock import MagicMock, patch
+
+    from litellm.google_genai.main import GenerateContentHelper
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    # Use a real Logging instance (required by Pydantic model validation),
+    # but stub out update_from_kwargs so we can assert what it was called with.
+    real_logging_obj = Logging(
+        model="gemini-2.5-pro",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="agenerate_content",
+        start_time=__import__("datetime").datetime.now(),
+        litellm_call_id="call-id-123",
+        function_id="",
+    )
+    mock_update = MagicMock()
+    real_logging_obj.update_from_kwargs = mock_update  # type: ignore[method-assign]
+
+    # Mock the provider config so we hit the update_from_kwargs path (not the
+    # adapter early-return path). Use spec= on a real subclass so Pydantic's
+    # is_instance_of check passes.
+    from litellm.llms.gemini.google_genai.transformation import (
+        GoogleGenAIConfig,
+    )
+
+    mock_provider_config = MagicMock(spec=GoogleGenAIConfig())
+    mock_provider_config.map_generate_content_optional_params.return_value = {}
+    mock_provider_config.transform_generate_content_request.return_value = {}
+
+    with patch(
+        "litellm.get_llm_provider",
+        return_value=("gemini-2.5-pro", "gemini", None, None),
+    ), patch(
+        "litellm.utils.ProviderConfigManager.get_provider_google_genai_generate_content_config",
+        return_value=mock_provider_config,
+    ):
+        GenerateContentHelper.setup_generate_content_call(
+            model="gemini-2.5-pro",
+            contents=[{"parts": [{"text": "hi"}], "role": "user"}],
+            config={},
+            custom_llm_provider="gemini",
+            litellm_logging_obj=real_logging_obj,
+            litellm_call_id="call-id-123",
+            user="my-end-user-uuid-456",
+            metadata={"tags": ["scan_id=abc"]},
+        )
+
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args.kwargs
+    assert (
+        call_kwargs.get("user") == "my-end-user-uuid-456"
+    ), f"Expected user to be propagated, got: {call_kwargs.get('user')!r}"

--- a/tests/test_litellm/google_genai/test_google_genai_main.py
+++ b/tests/test_litellm/google_genai/test_google_genai_main.py
@@ -2,9 +2,11 @@
 """
 Test to verify the Google GenAI generate_content adapter functionality
 """
-import json
+
+import datetime
 import os
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,13 +14,9 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-import json
-import os
-import sys
-
-import pytest
-
-import litellm
+from litellm.google_genai.main import GenerateContentHelper
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.gemini.google_genai.transformation import GoogleGenAIConfig
 
 
 @pytest.mark.asyncio
@@ -55,11 +53,6 @@ def test_setup_generate_content_call_propagates_user_to_logging_obj():
     `model_call_details["user"]` reflect what the client sent (via header or
     body) instead of defaulting to None / "".
     """
-    from unittest.mock import MagicMock, patch
-
-    from litellm.google_genai.main import GenerateContentHelper
-    from litellm.litellm_core_utils.litellm_logging import Logging
-
     # Use a real Logging instance (required by Pydantic model validation),
     # but stub out update_from_kwargs so we can assert what it was called with.
     real_logging_obj = Logging(
@@ -67,7 +60,7 @@ def test_setup_generate_content_call_propagates_user_to_logging_obj():
         messages=[{"role": "user", "content": "hi"}],
         stream=False,
         call_type="agenerate_content",
-        start_time=__import__("datetime").datetime.now(),
+        start_time=datetime.datetime.now(),
         litellm_call_id="call-id-123",
         function_id="",
     )
@@ -77,20 +70,19 @@ def test_setup_generate_content_call_propagates_user_to_logging_obj():
     # Mock the provider config so we hit the update_from_kwargs path (not the
     # adapter early-return path). Use spec= on a real subclass so Pydantic's
     # is_instance_of check passes.
-    from litellm.llms.gemini.google_genai.transformation import (
-        GoogleGenAIConfig,
-    )
-
     mock_provider_config = MagicMock(spec=GoogleGenAIConfig())
     mock_provider_config.map_generate_content_optional_params.return_value = {}
     mock_provider_config.transform_generate_content_request.return_value = {}
 
-    with patch(
-        "litellm.get_llm_provider",
-        return_value=("gemini-2.5-pro", "gemini", None, None),
-    ), patch(
-        "litellm.utils.ProviderConfigManager.get_provider_google_genai_generate_content_config",
-        return_value=mock_provider_config,
+    with (
+        patch(
+            "litellm.get_llm_provider",
+            return_value=("gemini-2.5-pro", "gemini", None, None),
+        ),
+        patch(
+            "litellm.utils.ProviderConfigManager.get_provider_google_genai_generate_content_config",
+            return_value=mock_provider_config,
+        ),
     ):
         GenerateContentHelper.setup_generate_content_call(
             model="gemini-2.5-pro",


### PR DESCRIPTION
## Summary

The Google-native `/v1beta/models/{model}:generateContent` and `/v1beta/models/{model}:streamGenerateContent` routes silently drop the `user` field from the spend log. Spend records are written with the correct cost and tokens, but `user: ""` and `end_user: ""`, blocking per-end-user attribution on this route.

## Root cause

The Google-native handler in `litellm/proxy/google_endpoints/endpoints.py` reads `user` from the request body via `add_litellm_data_to_request`, which correctly populates `data["user"]`. That value flows through `function_setup` and then through `llm_router.agenerate_content(**data)` into `litellm.agenerate_content`, where `kwargs["user"]` is set.

But in `setup_generate_content_call` (`litellm/google_genai/main.py:185`), the call to `litellm_logging_obj.update_from_kwargs` doesn't pass `user`:

```python
litellm_logging_obj.update_from_kwargs(
    kwargs=kwargs,
    model=model,
    optional_params=dict(generate_content_config_dict),
    litellm_params={
        "litellm_call_id": litellm_call_id,
    },
    custom_llm_provider=custom_llm_provider,
)
```

Without `user=...`, `update_from_kwargs` defers to its default `user=None`, so `logging_obj.user` and `model_call_details["user"]` are `None`, and the spend log row shows an empty `user` field.

OpenAI-compat `/v1/chat/completions` works because `litellm.completion` calls `logging.update_environment_variables(user=user, ...)` with the resolved user value (`litellm/main.py:1597, 4806, 6325, 6496, 6746`).

## Fix

Pass `user=kwargs.get("user")` to `update_from_kwargs` so the logging object reflects what the client sent.

## Files changed

- `litellm/google_genai/main.py` — pass `user` through (one-line change)
- `tests/test_litellm/google_genai/test_google_genai_main.py` — regression test using a real `Logging` instance with stubbed `update_from_kwargs` to verify `user` is propagated

## Tests

Added `test_setup_generate_content_call_propagates_user_to_logging_obj` which:
1. Constructs a real `Logging` instance (required by Pydantic on `GenerateContentSetupResult`)
2. Stubs `update_from_kwargs`
3. Calls `setup_generate_content_call` with `user="my-end-user-uuid-456"`
4. Asserts `update_from_kwargs.call_args.kwargs["user"] == "my-end-user-uuid-456"`

Verified the test fails on `main` and passes with this commit.

```
tests/test_litellm/google_genai/test_google_genai_main.py::test_setup_generate_content_call_propagates_user_to_logging_obj PASSED
```

## Manual testing

```bash
# Without the fix
curl -X POST "https://<proxy>/v1beta/models/gemini-2.5-pro:generateContent" \
  -H "x-goog-api-key: sk-..." \
  -H "Content-Type: application/json" \
  -d '{
    "contents": [{"parts": [{"text": "hi"}], "role": "user"}],
    "user": "my-end-user-uuid-456"
  }'

curl "https://<proxy>/spend/logs/v2?api_key=<hashed>"
# → {... "user": "", "end_user": ""}  (BAD)

# With the fix
# → {... "user": "my-end-user-uuid-456", "end_user": "my-end-user-uuid-456"}  (GOOD)
```

## Related

Part of a larger cluster of bugs in the Google-native `/v1beta/...` route (separate detailed issue forthcoming). Companion fixes:

- #25500 (in flight) — outbound `x-litellm-*` response headers on Google-native routes
- #25952 — `x-litellm-call-id` precedence in spend log `request_id`
- #24097 — streaming success_callback silently skipped on Google-native streaming

## Note: tags propagation

The developer's repro report also noted `request_tags: []` (empty) when sending `x-litellm-tags`. From code inspection, `add_litellm_data_to_request` and `update_from_kwargs` should propagate `metadata["tags"]` correctly through the `agenerate_content` path, so tags may already work — or there may be a separate downstream gap in how `StandardLoggingPayload._get_request_tags` reads from `litellm_params.metadata` for the `agenerate_content` call_type. That investigation is out of scope for this PR. The user fix here is independent and unblocks per-end-user attribution today; tags can be addressed in a follow-up.

## Tracking issue

#25956 — full root-cause writeup for the Google-native correlation cluster (this PR is Fix #3 of 4 defects)