### PR TITLE
feat(vertex_ai): multi-region Vertex hosts (aiplatform.*.rep.googleapis.com)

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -229,11 +229,16 @@ def get_vertex_base_url(
 ) -> str:
     """
     Get the base URL for Vertex AI API calls.
+
+    - ``global`` uses the global control plane host.
+    - Multi-region geographies (e.g. ``us``, ``eu``) use ``aiplatform.{geo}.rep.googleapis.com``.
+    - Regional locations (e.g. ``us-central1``) use ``{region}-aiplatform.googleapis.com``.
     """
     if vertex_location == "global":
         return "https://aiplatform.googleapis.com"
-    else:
-        return f"https://{vertex_location}-aiplatform.googleapis.com"
+    if vertex_location and "-" not in vertex_location:
+        return f"https://aiplatform.{vertex_location}.rep.googleapis.com"
+    return f"https://{vertex_location}-aiplatform.googleapis.com"
 
 
 def _get_embedding_url(

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1496,10 +1496,14 @@ class VertexAIPassThroughHandler(BaseVertexAIPassThroughHandler):
 
 def get_vertex_base_url(vertex_location: Optional[str]) -> str:
     """
-    Returns the base URL for Vertex AI based on the provided location.
+    Base URL for Vertex AI pass-through (trailing slash for URL joining).
+
+    Keep location rules aligned with ``litellm.llms.vertex_ai.common_utils.get_vertex_base_url``.
     """
     if vertex_location == "global":
         return "https://aiplatform.googleapis.com/"
+    if vertex_location and "-" not in vertex_location:
+        return f"https://aiplatform.{vertex_location}.rep.googleapis.com/"
     return f"https://{vertex_location}-aiplatform.googleapis.com/"
 
 
@@ -1703,7 +1707,8 @@ async def _base_vertex_proxy_route(
     Base function for Vertex AI passthrough routes.
     Handles common logic for all Vertex AI services.
 
-    Default base_target_url is `https://{vertex_location}-aiplatform.googleapis.com/`
+    Default base_target_url is derived from ``get_vertex_base_url`` in this module
+    (regional, ``global``, or multi-region ``.rep.`` hosts), with a trailing slash.
 
     Args:
         endpoint: The endpoint path
@@ -2275,11 +2280,7 @@ async def vertex_ai_live_websocket_passthrough(
         return
 
     host_location = resolved_location or vertex_llm_base.get_default_vertex_location()
-    host = (
-        "aiplatform.googleapis.com"
-        if host_location == "global"
-        else f"{host_location}-aiplatform.googleapis.com"
-    )
+    host = get_vertex_base_url(host_location).removeprefix("https://").rstrip("/")
     service_url = (
         f"wss://{host}/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
     )

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_global_url_support.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_global_url_support.py
@@ -5,6 +5,7 @@ This test suite ensures that all Vertex AI endpoints properly handle the 'global
 which uses a different URL format than regional endpoints.
 
 Regional: https://{region}-aiplatform.googleapis.com/...
+Multi-region: https://aiplatform.{geo}.rep.googleapis.com/...
 Global: https://aiplatform.googleapis.com/...
 """
 
@@ -30,6 +31,8 @@ class TestVertexBaseURL:
             ("europe-west1", "https://europe-west1-aiplatform.googleapis.com"),
             ("asia-northeast1", "https://asia-northeast1-aiplatform.googleapis.com"),
             ("global", "https://aiplatform.googleapis.com"),
+            ("us", "https://aiplatform.us.rep.googleapis.com"),
+            ("eu", "https://aiplatform.eu.rep.googleapis.com"),
         ],
     )
     def test_get_vertex_base_url(self, vertex_location, expected_base_url):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -21,6 +21,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     bedrock_llm_proxy_route,
     create_pass_through_route,
     cursor_proxy_route,
+    get_vertex_base_url,
     llm_passthrough_factory_proxy_route,
     milvus_proxy_route,
     openai_proxy_route,
@@ -29,6 +30,35 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     vllm_proxy_route,
 )
 from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
+
+
+class TestVertexPassthroughGetVertexBaseUrl:
+    """Module-local get_vertex_base_url (trailing slash); rules match common_utils."""
+
+    @pytest.mark.parametrize(
+        "vertex_location, expected",
+        [
+            ("global", "https://aiplatform.googleapis.com/"),
+            ("us-central1", "https://us-central1-aiplatform.googleapis.com/"),
+            ("us", "https://aiplatform.us.rep.googleapis.com/"),
+            ("eu", "https://aiplatform.eu.rep.googleapis.com/"),
+        ],
+    )
+    def test_returns_base_with_trailing_slash(self, vertex_location, expected):
+        assert get_vertex_base_url(vertex_location) == expected
+
+    @pytest.mark.parametrize(
+        "vertex_location, expected_host",
+        [
+            ("global", "aiplatform.googleapis.com"),
+            ("us-central1", "us-central1-aiplatform.googleapis.com"),
+            ("us", "aiplatform.us.rep.googleapis.com"),
+            ("eu", "aiplatform.eu.rep.googleapis.com"),
+        ],
+    )
+    def test_websocket_host_strips_scheme(self, vertex_location, expected_host):
+        host = get_vertex_base_url(vertex_location).removeprefix("https://").rstrip("/")
+        assert host == expected_host
 
 
 class TestBaseOpenAIPassThroughHandler:


### PR DESCRIPTION
## Relevant issues

Fixes #25926

**Reference:** [Multi-region endpoints for Claude on Vertex AI (Google Cloud Blog)](https://cloud.google.com/blog/products/ai-machine-learning/multi-region-endpoints-for-claude-available-on-vertex-ai)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:


## Type

🆕 New Feature  
✅ Test

## Changes

- **`litellm/llms/vertex_ai/common_utils.py` — `get_vertex_base_url`:** After `global`, treat locations that are truthy and contain no `-` as Vertex **multi-region** hosts (`https://aiplatform.{geo}.rep.googleapis.com`). Otherwise keep the regional pattern `https://{region}-aiplatform.googleapis.com` (preserves prior behavior for `None` / empty via the final branch).
- **`litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py`:** Local `get_vertex_base_url` duplicates the same rules with trailing slashes for URL joining (no import from `common_utils`). WebSocket upstream host for Vertex live passthrough uses the same multi-region vs regional logic so `us` / `eu` work for `wss://`.
- **`tests/test_litellm/llms/vertex_ai/test_vertex_global_url_support.py`:** Parametrize `us` and `eu` expected base URLs for `get_vertex_base_url`.