### PR TITLE
fix(databricks): respect custom User-Agent set via extra_headers

### DIFF
--- a/litellm/llms/databricks/common_utils.py
+++ b/litellm/llms/databricks/common_utils.py
@@ -387,8 +387,10 @@ class DatabricksBase:
         if api_key is not None:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        # Set User-Agent with optional custom prefix
-        headers["User-Agent"] = self._build_user_agent(custom_user_agent)
+        # Set User-Agent with optional custom prefix, but don't overwrite
+        # if the caller explicitly set one (e.g. via extra_headers)
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = self._build_user_agent(custom_user_agent)
 
         # Debug logging with redaction (never log actual tokens)
         verbose_logger.debug(

--- a/tests/test_litellm/llms/databricks/test_databricks_partner_integration.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_partner_integration.py
@@ -334,6 +334,40 @@ class TestValidateEnvironmentUserAgent:
 
         assert headers["User-Agent"].startswith("mycompany_litellm/")
 
+    def test_extra_headers_user_agent_preserved(self, monkeypatch):
+        """User-Agent set via headers dict (extra_headers) is not overwritten."""
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_CLIENT_SECRET", raising=False)
+
+        databricks_base = DatabricksBase()
+
+        api_base, headers = databricks_base.databricks_validate_environment(
+            api_key="test-key",
+            api_base="https://adb-123.net/serving-endpoints",
+            endpoint_type="chat_completions",
+            custom_endpoint=False,
+            headers={"User-Agent": "My-Custom-Agent/1.0"},
+        )
+
+        assert headers["User-Agent"] == "My-Custom-Agent/1.0"
+
+    def test_default_user_agent_when_not_in_headers(self, monkeypatch):
+        """Default User-Agent is set when headers dict has no User-Agent."""
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_CLIENT_SECRET", raising=False)
+
+        databricks_base = DatabricksBase()
+
+        api_base, headers = databricks_base.databricks_validate_environment(
+            api_key="test-key",
+            api_base="https://adb-123.net/serving-endpoints",
+            endpoint_type="chat_completions",
+            custom_endpoint=False,
+            headers={},
+        )
+
+        assert headers["User-Agent"].startswith("litellm/")
+
 
 class TestSDKPartnerTelemetry:
     """Test that SDK partner telemetry is registered."""


### PR DESCRIPTION
## Relevant issues

Databricks `validate_environment` unconditionally overwrites `User-Agent` header, making `extra_headers={"User-Agent": "..."}` ineffective for Databricks endpoints.

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before:** `extra_headers={"User-Agent": "My-Custom-Agent/1.0"}` is silently overwritten by `_build_user_agent()` at line 391 of `common_utils.py`.

**After:** The caller-provided User-Agent is preserved. When no User-Agent is in headers, the default is still built as before.

Test output (46/46 pass):
```
tests/test_litellm/llms/databricks/test_databricks_partner_integration.py::TestValidateEnvironmentUserAgent::test_extra_headers_user_agent_preserved PASSED
tests/test_litellm/llms/databricks/test_databricks_partner_integration.py::TestValidateEnvironmentUserAgent::test_default_user_agent_when_not_in_headers PASSED
```

## Type

🐛 Bug Fix

## Changes

**1 line change** in `litellm/llms/databricks/common_utils.py` (line 391):

```python
# Before:
headers["User-Agent"] = self._build_user_agent(custom_user_agent)

# After:
if "User-Agent" not in headers:
    headers["User-Agent"] = self._build_user_agent(custom_user_agent)
```

If a `User-Agent` is already present in the headers dict (e.g. set via `extra_headers`), it is preserved. Otherwise, the default user agent is built exactly as before.

Databricks is the only provider whose `validate_environment` actively sets `User-Agent`. Other providers only add `Authorization` and `Content-Type`, leaving `User-Agent` untouched when set by the caller. This fix aligns Databricks with that pattern.

**2 new tests** in `tests/test_litellm/llms/databricks/test_databricks_partner_integration.py`:
- `test_extra_headers_user_agent_preserved` — User-Agent in headers survives validation
- `test_default_user_agent_when_not_in_headers` — default is still set when absent (regression guard)