### PR TITLE
Feat/prometheus exclude labels

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -73,6 +73,7 @@ class PrometheusLogger(CustomLogger):
             from prometheus_client import Counter, Gauge, Histogram
 
             # Always initialize label_filters, even for non-premium users
+            self.exclude_label_filters: Dict[str, List[str]] = {}
             self.label_filters = self._parse_prometheus_config()
 
             _custom_buckets = litellm.prometheus_latency_buckets
@@ -610,6 +611,13 @@ class PrometheusLogger(CustomLogger):
                     if label_error:
                         label_errors.append(label_error)
 
+                if config.exclude_labels:
+                    label_error = self._validate_single_metric_labels(
+                        metric_name, config.exclude_labels
+                    )
+                    if label_error:
+                        label_errors.append(label_error)
+
         return ValidationResults(metric_errors=metric_errors, label_errors=label_errors)
 
     def _validate_single_metric_name(
@@ -653,10 +661,12 @@ class PrometheusLogger(CustomLogger):
 
         for config in parsed_configs:
             for metric_name in config.metrics:
+                if self._validate_single_metric_name(metric_name) is not None:
+                    continue
                 if config.include_labels:
-                    # Only add if metric name is valid (validation already passed)
-                    if self._validate_single_metric_name(metric_name) is None:
-                        label_filters[metric_name] = config.include_labels
+                    label_filters[metric_name] = config.include_labels
+                if config.exclude_labels:
+                    self.exclude_label_filters[metric_name] = config.exclude_labels
 
         return label_filters
 
@@ -969,19 +979,21 @@ class PrometheusLogger(CustomLogger):
         # Get default labels for this metric from PrometheusMetricLabels
         default_labels = PrometheusMetricLabels.get_labels(metric_name)
 
-        # If no label filtering is configured for this metric, use default labels
-        if metric_name not in self.label_filters:
-            return default_labels
+        # Apply include_labels filter (allowlist)
+        if metric_name in self.label_filters:
+            configured_labels = self.label_filters[metric_name]
+            default_labels = [
+                label for label in default_labels if label in configured_labels
+            ]
 
-        # Get configured labels for this metric
-        configured_labels = self.label_filters[metric_name]
+        # Apply exclude_labels filter (blocklist)
+        if metric_name in self.exclude_label_filters:
+            excluded_labels = self.exclude_label_filters[metric_name]
+            default_labels = [
+                label for label in default_labels if label not in excluded_labels
+            ]
 
-        # Return intersection of configured and default labels to ensure we only use valid labels
-        filtered_labels = [
-            label for label in default_labels if label in configured_labels
-        ]
-
-        return filtered_labels
+        return default_labels
 
     def _inc_labeled_counter(
         self,

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -843,6 +843,7 @@ class PrometheusMetricsConfig:
     group: str
     metrics: List[str]
     include_labels: Optional[List[str]] = None
+    exclude_labels: Optional[List[str]] = None
 
 
 @dataclass

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
@@ -1061,3 +1061,94 @@ async def test_langfuse_otel_callback_failure_metric(prometheus_logger):
 # ==============================================================================
 # END CALLBACK FAILURE METRICS TESTS
 # ==============================================================================
+
+
+# ==============================================================================
+# EXCLUDE LABELS TESTS
+# ==============================================================================
+
+
+def test_exclude_labels_removes_specified_labels():
+    """exclude_labels removes specified labels from a metric's label set"""
+    clear_prometheus_registry()
+
+    test_config = [
+        {
+            "group": "service_metrics",
+            "metrics": ["litellm_deployment_failure_responses"],
+            "exclude_labels": ["team", "api_provider"],
+        }
+    ]
+    litellm.prometheus_metrics_config = test_config
+
+    logger = PrometheusLogger()
+    labels = logger.get_labels_for_metric("litellm_deployment_failure_responses")
+
+    assert "team" not in labels
+    assert "api_provider" not in labels
+    # Other labels should still be present
+    assert len(labels) > 0
+
+    litellm.prometheus_metrics_config = None
+
+
+def test_exclude_labels_config_type():
+    """PrometheusMetricsConfig accepts exclude_labels field"""
+    config = PrometheusMetricsConfig(
+        group="service_metrics",
+        metrics=["litellm_deployment_failure_responses"],
+        exclude_labels=["team"],
+    )
+    assert config.exclude_labels == ["team"]
+    assert config.include_labels is None
+
+
+def test_exclude_labels_and_include_labels_together():
+    """include_labels applies first, then exclude_labels removes from the result"""
+    clear_prometheus_registry()
+
+    default_labels = PrometheusMetricLabels.get_labels(
+        "litellm_deployment_failure_responses"
+    )
+    # Pick two labels that are in the default set
+    include = default_labels[:3]
+    exclude = [include[0]]
+
+    test_config = [
+        {
+            "group": "service_metrics",
+            "metrics": ["litellm_deployment_failure_responses"],
+            "include_labels": include,
+            "exclude_labels": exclude,
+        }
+    ]
+    litellm.prometheus_metrics_config = test_config
+
+    logger = PrometheusLogger()
+    labels = logger.get_labels_for_metric("litellm_deployment_failure_responses")
+
+    assert exclude[0] not in labels
+    for label in include[1:]:
+        assert label in labels
+
+    litellm.prometheus_metrics_config = None
+
+
+def test_no_exclude_labels_returns_all_defaults():
+    """When exclude_labels is not set the full default label set is returned"""
+    clear_prometheus_registry()
+
+    litellm.prometheus_metrics_config = None
+    logger = PrometheusLogger()
+
+    default_labels = PrometheusMetricLabels.get_labels(
+        "litellm_deployment_failure_responses"
+    )
+    labels = logger.get_labels_for_metric("litellm_deployment_failure_responses")
+
+    assert labels == default_labels
+
+
+# ==============================================================================
+# END EXCLUDE LABELS TESTS
+# ==============================================================================


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<img width="588" height="273" alt="Screenshot 2026-04-17 at 2 23 59 PM" src="https://github.com/user-attachments/assets/f1881515-a406-4926-921a-6be92ce5ff99" />


## Type

🆕 New Feature

## Changes

### Problem

Prometheus metrics exposed labels like `end_user` and `api_key_hash` with no way to opt out. Users needed a blocklist option to suppress specific labels across metric groups — e.g. for privacy or cardinality reasons.

### Fix

Add `exclude_labels` to `PrometheusMetricsConfig`, following the existing `include_labels` pattern. Labels listed under `exclude_labels` are stripped from the metric's label set at initialization time. Works standalone or combined with `include_labels` (include applies first, then exclude). Fully backwards compatible — omitting `exclude_labels` changes nothing.

Example config:
```yaml
litellm_settings:
  prometheus_metrics_config:
    - group: my-group
      metrics:
        - litellm_requests_metric
      exclude_labels:
        - end_user
        - api_key_hash
```
