### PR TITLE
docs: add per-page copy markdown action in Docusaurus

### DIFF
--- a/docs/my-website/.gitignore
+++ b/docs/my-website/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+.generated
 
 # Misc
 .DS_Store

--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -1,10 +1,60 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+const fs = require('fs');
+const path = require('path');
 // @ts-ignore
 const lightCodeTheme = require('prism-react-renderer/themes/vsLight');
 // @ts-ignore
 const darkCodeTheme = require('prism-react-renderer/themes/nightOwl');
+
+const COPY_MARKDOWN_STATIC_DIR = '.generated/copy-markdown-static';
+const COPY_MARKDOWN_SOURCE_PREFIX = '__source_markdown';
+
+function copyMarkdownSourcesForClient(siteDir) {
+  const sourceRoots = ['docs', 'release_notes'];
+  const generatedRoot = path.join(siteDir, COPY_MARKDOWN_STATIC_DIR);
+  const outputRoot = path.join(generatedRoot, COPY_MARKDOWN_SOURCE_PREFIX);
+
+  fs.rmSync(generatedRoot, {recursive: true, force: true});
+  fs.mkdirSync(outputRoot, {recursive: true});
+
+  const shouldCopyFile = (filename) =>
+    filename.endsWith('.md') || filename.endsWith('.mdx');
+
+  const copyDirectory = (absoluteDirPath, relativeDirPath) => {
+    const entries = fs.readdirSync(absoluteDirPath, {withFileTypes: true});
+    for (const entry of entries) {
+      const relativePath = path
+        .join(relativeDirPath, entry.name)
+        .replaceAll(path.sep, '/');
+      const absoluteEntryPath = path.join(absoluteDirPath, entry.name);
+
+      if (entry.isDirectory()) {
+        copyDirectory(absoluteEntryPath, relativePath);
+        continue;
+      }
+
+      if (!entry.isFile() || !shouldCopyFile(entry.name)) {
+        continue;
+      }
+
+      const outputFilePath = path.join(outputRoot, relativePath);
+      fs.mkdirSync(path.dirname(outputFilePath), {recursive: true});
+      fs.copyFileSync(absoluteEntryPath, outputFilePath);
+    }
+  };
+
+  for (const sourceRoot of sourceRoots) {
+    const sourceRootAbsolutePath = path.join(siteDir, sourceRoot);
+    if (!fs.existsSync(sourceRootAbsolutePath)) {
+      continue;
+    }
+    copyDirectory(sourceRootAbsolutePath, sourceRoot);
+  }
+}
+
+copyMarkdownSourcesForClient(__dirname);
 
 const inkeepConfig = {
   baseSettings: {
@@ -53,6 +103,7 @@ const config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
+  staticDirectories: ['static', COPY_MARKDOWN_STATIC_DIR],
 
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',

--- a/docs/my-website/src/theme/DocItem/index.js
+++ b/docs/my-website/src/theme/DocItem/index.js
@@ -13,17 +13,26 @@ function normalizeSourcePath(source) {
 }
 
 async function copyTextToClipboard(text) {
+  let clipboardWriteError = null;
   if (
     typeof navigator !== 'undefined' &&
     navigator.clipboard &&
     typeof navigator.clipboard.writeText === 'function'
   ) {
-    await navigator.clipboard.writeText(text);
-    return;
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch (error) {
+      clipboardWriteError = error;
+    }
   }
 
   if (typeof document === 'undefined') {
-    throw new Error('Clipboard API unavailable');
+    throw new Error(
+      clipboardWriteError instanceof Error
+        ? `Clipboard API unavailable: ${clipboardWriteError.message}`
+        : 'Clipboard API unavailable',
+    );
   }
 
   const textarea = document.createElement('textarea');
@@ -38,7 +47,11 @@ async function copyTextToClipboard(text) {
   document.body.removeChild(textarea);
 
   if (!success) {
-    throw new Error('Fallback copy command failed');
+    throw new Error(
+      clipboardWriteError instanceof Error
+        ? `Fallback copy command failed after writeText error: ${clipboardWriteError.message}`
+        : 'Fallback copy command failed',
+    );
   }
 }
 

--- a/docs/my-website/src/theme/DocItem/index.js
+++ b/docs/my-website/src/theme/DocItem/index.js
@@ -1,0 +1,136 @@
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+import OriginalDocItem from '@theme-original/DocItem';
+import styles from './styles.module.css';
+
+function normalizeSourcePath(source) {
+  if (!source || typeof source !== 'string') {
+    return null;
+  }
+  if (source.startsWith('@site/')) {
+    return source.slice('@site/'.length);
+  }
+  return null;
+}
+
+async function copyTextToClipboard(text) {
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === 'function'
+  ) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  if (typeof document === 'undefined') {
+    throw new Error('Clipboard API unavailable');
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  const success = document.execCommand('copy');
+  document.body.removeChild(textarea);
+
+  if (!success) {
+    throw new Error('Fallback copy command failed');
+  }
+}
+
+function CopyMarkdownButton({metadata}) {
+  const timeoutRef = useRef(null);
+  const [status, setStatus] = useState('idle');
+
+  const rawMarkdownUrl = useMemo(() => {
+    const sourcePath = normalizeSourcePath(metadata?.source);
+    if (!sourcePath) {
+      return null;
+    }
+
+    return `/__source_markdown/${sourcePath}`;
+  }, [metadata?.source]);
+
+  const hasSource = Boolean(rawMarkdownUrl);
+
+  const buttonLabel = (() => {
+    if (status === 'loading') {
+      return 'Copying...';
+    }
+    if (status === 'copied') {
+      return 'Copied markdown';
+    }
+    if (status === 'error') {
+      return 'Retry copy markdown';
+    }
+    return 'Copy markdown';
+  })();
+
+  const onCopyMarkdown = async () => {
+    if (!rawMarkdownUrl || status === 'loading') {
+      return;
+    }
+
+    setStatus('loading');
+    try {
+      const response = await fetch(rawMarkdownUrl, {
+        headers: {'Accept': 'text/plain'},
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to load markdown: ${response.status}`);
+      }
+      const markdown = await response.text();
+      await copyTextToClipboard(markdown);
+      setStatus('copied');
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        setStatus('idle');
+      }, 2000);
+    } catch (_error) {
+      setStatus('error');
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className={styles.copyMarkdownToolbar}>
+      <button
+        type="button"
+        className={styles.copyMarkdownButton}
+        onClick={onCopyMarkdown}
+        disabled={!hasSource || status === 'loading'}
+        title={
+          hasSource
+            ? 'Copy this page markdown to your clipboard'
+            : 'Markdown source path unavailable for this page'
+        }>
+        {buttonLabel}
+      </button>
+    </div>
+  );
+}
+
+export default function DocItem(props) {
+  const metadata = props?.content?.metadata;
+
+  return (
+    <>
+      <CopyMarkdownButton metadata={metadata} />
+      <OriginalDocItem {...props} />
+    </>
+  );
+}

--- a/docs/my-website/src/theme/DocItem/styles.module.css
+++ b/docs/my-website/src/theme/DocItem/styles.module.css
@@ -1,0 +1,27 @@
+.copyMarkdownToolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 0.75rem 0;
+}
+
+.copyMarkdownButton {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1;
+  padding: 0.45rem 0.65rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.copyMarkdownButton:hover:not(:disabled) {
+  border-color: var(--ifm-color-primary);
+}
+
+.copyMarkdownButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a global docs-page `Copy markdown` action by swizzling `DocItem`.
- Copy markdown from local static source files (`/__source_markdown/...`) generated from `docs/` + `release_notes/`.
- Add clipboard fallback behavior so copy succeeds when `navigator.clipboard.writeText()` is unavailable or rejects.
- Ignore generated local source directory in docs `.gitignore`.

## Walkthrough Artifacts
[docs_copy_markdown_fix_demo.mp4](https://cursor.com/agents/bc-f7bf5cc1-9456-4cc9-9043-f3d25e202ab5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_copy_markdown_fix_demo.mp4)
[copied-markdown-button-state](https://cursor.com/agents/bc-f7bf5cc1-9456-4cc9-9043-f3d25e202ab5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocusaurus_copy_markdown_copied_state.png)
[copy_markdown_assertion.log](https://cursor.com/agents/bc-f7bf5cc1-9456-4cc9-9043-f3d25e202ab5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcopy_markdown_assertion.log)

## Validation
- `npm run build`
- `curl -s -o /tmp/local_source_reliability.md -w "%{http_code}" http://localhost:3000/__source_markdown/docs/proxy/reliability.md`
- `node -e "... playwright clipboard-fallback assertion ..."`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7bf5cc1-9456-4cc9-9043-f3d25e202ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7bf5cc1-9456-4cc9-9043-f3d25e202ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

