### PR TITLE
fix(vertex_ai): fix API error when setting `budget_tokens=0` on Gemini 2.5 Pro

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -929,13 +929,17 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 # Thinking disabled
                 params["includeThoughts"] = False
         else:
-            # For older Gemini models, use thinkingBudget
-            if thinking_enabled and not VertexGeminiConfig._is_thinking_budget_zero(
-                thinking_budget
-            ):
-                params["includeThoughts"] = True
-            if thinking_budget is not None and isinstance(thinking_budget, int):
-                params["thinkingBudget"] = thinking_budget
+            # For older Gemini models, use thinkingBudget instead of thinkingLevel
+            if thinking_enabled:
+                if VertexGeminiConfig._is_thinking_budget_zero(thinking_budget):
+                    # thinkingBudget: 0 is rejected by models with a minimum budget (e.g. gemini-2.5-pro).
+                    params["includeThoughts"] = False
+                else:
+                    params["includeThoughts"] = True
+                    if thinking_budget is not None and isinstance(thinking_budget, int):
+                        params["thinkingBudget"] = thinking_budget
+            else:
+                params["includeThoughts"] = False
 
         return params
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -898,19 +898,35 @@ def test_vertex_ai_usage_metadata_accumulates_duplicate_modalities():
 
 def test_vertex_ai_map_thinking_param_with_budget_tokens_0():
     """
-    If budget_tokens is 0, do not set includeThoughts to True
+    budget_tokens=0 must produce includeThoughts: False with no thinkingBudget field.
+    Models with a minimum budget requirement (e.g. gemini-2.5-pro) reject thinkingBudget: 0.
     """
     from litellm.types.llms.anthropic import AnthropicThinkingParam
 
     v = VertexGeminiConfig()
     thinking_param: AnthropicThinkingParam = {"type": "enabled", "budget_tokens": 0}
-    assert "includeThoughts" not in v._map_thinking_param(thinking_param=thinking_param)
+    result = v._map_thinking_param(thinking_param=thinking_param)
+    assert result == {"includeThoughts": False}
+    assert "thinkingBudget" not in result
 
     thinking_param: AnthropicThinkingParam = {"type": "enabled", "budget_tokens": 100}
     assert v._map_thinking_param(thinking_param=thinking_param) == {
         "includeThoughts": True,
         "thinkingBudget": 100,
     }
+
+
+def test_vertex_ai_map_thinking_param_disabled():
+    """
+    type="adaptive" (non-enabled) must produce includeThoughts: False with no thinkingBudget field.
+    """
+    from litellm.types.llms.anthropic import AnthropicThinkingParam
+
+    v = VertexGeminiConfig()
+    thinking_param: AnthropicThinkingParam = {"type": "adaptive"}
+    result = v._map_thinking_param(thinking_param=thinking_param)
+    assert result == {"includeThoughts": False}
+    assert "thinkingBudget" not in result
 
 
 def test_vertex_ai_map_tools():


### PR DESCRIPTION
## Relevant issues

Fixes [11557](https://github.com/BerriAI/litellm/issues/11557)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix


### Before `litellm==1.83.0`

**Request:**
```python
import litellm

response = litellm.completion(
    model="gemini/gemini-2.5-pro",
    messages=[{"role": "user", "content": "What is 2+2?"}],
    thinking={"type": "enabled", "budget_tokens": 0},
)
print(response.choices[0].message.content)
```

**Response:** ❌ 

```json
litellm.llms.vertex_ai.common_utils.VertexAIError: {
  "error": {
    "code": 400,
    "message": "Unable to submit request because The model does not support setting thinking_budget to 0.. Learn more: [https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini)",
    "status": "INVALID_ARGUMENT"
  }
}
```


### After 

**Request:**
```  python                                                                                                                                                                                                              
import litellm                                                                                                                                                                                                 

# Works after fix — sends {"includeThoughts": false} instead of {"thinkingBudget": 0}                                                                                                                            
 
response = litellm.completion(                                                                                                                                                                                   
    model="gemini/gemini-2.5-pro",                                                                                                                                                                             
    messages=[{"role": "user", "content": "What is 2+2?"}],
    thinking={"type": "enabled", "budget_tokens": 0},
)                                                                                                                                                                                                                
print(response.choices[0].message.content)
```
**Response:** ✅
```json
4
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes


In `_map_thinking_param`, the `else` branch (non-Gemini-3 models) forwarded `thinkingBudget: 0` to the API when `budget_tokens=0`. Models with a minimum budget requirement (e.g. gemini-2.5-pro) reject this at the API 
  level.
                                                                                                                                                                                                                   
  Fix: when `budget_tokens=0`, send `{"includeThoughts": false}` with no `thinkingBudget` field. When `type: "disabled"`, the same applies for consistency with the Gemini 3+ branch.                                      
   
  Two unit tests updated/added in `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py.` 