### PR TITLE
Skills Marketplace: GitHub PAT import + agent registry discovery

### DIFF
--- a/litellm/llms/litellm_proxy/skills/handler.py
+++ b/litellm/llms/litellm_proxy/skills/handler.py
@@ -275,7 +275,12 @@ class LiteLLMSkillsHandler:
             take=limit,
             skip=offset,
             order={"created_at": "desc"},
-            include={},
+            select={
+                "skill_id": True,
+                "display_title": True,
+                "description": True,
+                "metadata": True,
+            },
         )
 
         result = []

--- a/litellm/llms/litellm_proxy/skills/handler.py
+++ b/litellm/llms/litellm_proxy/skills/handler.py
@@ -275,12 +275,6 @@ class LiteLLMSkillsHandler:
             take=limit,
             skip=offset,
             order={"created_at": "desc"},
-            select={
-                "skill_id": True,
-                "display_title": True,
-                "description": True,
-                "metadata": True,
-            },
         )
 
         result = []

--- a/litellm/llms/litellm_proxy/skills/handler.py
+++ b/litellm/llms/litellm_proxy/skills/handler.py
@@ -15,11 +15,20 @@ from litellm._logging import verbose_logger
 from litellm.proxy._types import LiteLLM_SkillsTable, NewSkillRequest
 
 
+def _redact_sensitive_metadata(
+    metadata: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Strip secrets that must never leave the server from a skill metadata dict."""
+    if not metadata:
+        return metadata
+    return {k: v for k, v in metadata.items() if k != "github_pat"}
+
+
 def _prisma_skill_to_litellm(prisma_skill) -> LiteLLM_SkillsTable:
     """
     Convert a Prisma skill record to LiteLLM_SkillsTable.
 
-    Handles Base64 decoding of file_content field.
+    Handles Base64 decoding of file_content and redacts the encrypted PAT.
     """
     import base64
 
@@ -31,8 +40,11 @@ def _prisma_skill_to_litellm(prisma_skill) -> LiteLLM_SkillsTable:
         if isinstance(data["file_content"], str):
             data["file_content"] = base64.b64decode(data["file_content"])
         elif isinstance(data["file_content"], bytes):
-            # Already bytes, no conversion needed
             pass
+
+    # Never expose the encrypted PAT ciphertext in API responses.
+    if data.get("metadata"):
+        data["metadata"] = _redact_sensitive_metadata(data["metadata"])
 
     return LiteLLM_SkillsTable(**data)
 

--- a/litellm/llms/litellm_proxy/skills/handler.py
+++ b/litellm/llms/litellm_proxy/skills/handler.py
@@ -5,8 +5,11 @@ This module contains the actual database operations for skills CRUD.
 Used by the transformation layer and skills injection hook.
 """
 
+import re
 import uuid
 from typing import Any, Dict, List, Optional
+
+import httpx
 
 from litellm._logging import verbose_logger
 from litellm.proxy._types import LiteLLM_SkillsTable, NewSkillRequest
@@ -34,6 +37,19 @@ def _prisma_skill_to_litellm(prisma_skill) -> LiteLLM_SkillsTable:
     return LiteLLM_SkillsTable(**data)
 
 
+def _parse_github_owner_repo(repo_url: str):
+    """Extract (owner, repo) from a GitHub URL."""
+    match = re.search(
+        r"github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$", repo_url.rstrip("/")
+    )
+    if not match:
+        raise ValueError(
+            f"Cannot parse GitHub owner/repo from URL: {repo_url}. "
+            "Expected format: https://github.com/owner/repo"
+        )
+    return match.group(1), match.group(2)
+
+
 class LiteLLMSkillsHandler:
     """
     Handler for LiteLLM database-backed skills operations.
@@ -55,6 +71,73 @@ class LiteLLMSkillsHandler:
         return prisma_client
 
     @staticmethod
+    async def _fetch_github_zip(repo_url: str, pat: str) -> tuple:
+        """
+        Fetch ZIP archive of a GitHub repo using a PAT.
+
+        Returns (zip_bytes, file_name, file_type).
+        Raises ValueError on auth failure or missing repo.
+        """
+        owner, repo = _parse_github_owner_repo(repo_url)
+        zip_url = f"https://api.github.com/repos/{owner}/{repo}/zipball"
+        headers = {
+            "Authorization": f"token {pat}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        async with httpx.AsyncClient(follow_redirects=True, timeout=30) as client:
+            response = await client.get(zip_url, headers=headers)
+
+        if response.status_code == 401:
+            raise ValueError("GitHub PAT authentication failed. Check the token.")
+        if response.status_code == 404:
+            raise ValueError(f"GitHub repo not found: {owner}/{repo}")
+        if response.status_code != 200:
+            raise ValueError(
+                f"GitHub API error {response.status_code}: {response.text[:200]}"
+            )
+
+        file_name = f"{owner}-{repo}.zip"
+        return response.content, file_name, "application/zip"
+
+    @staticmethod
+    async def test_github_connection(repo_url: str, pat: str) -> Dict[str, str]:
+        """
+        Verify a GitHub PAT can access the given repo without storing anything.
+
+        Returns {"status": "ok"} or {"status": "error", "message": "..."}.
+        """
+        try:
+            owner, repo = _parse_github_owner_repo(repo_url)
+            headers = {
+                "Authorization": f"token {pat}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.get(
+                    f"https://api.github.com/repos/{owner}/{repo}",
+                    headers=headers,
+                )
+            if response.status_code == 200:
+                return {"status": "ok"}
+            if response.status_code == 401:
+                return {
+                    "status": "error",
+                    "message": "PAT authentication failed. Check the token.",
+                }
+            if response.status_code == 404:
+                return {"status": "error", "message": f"Repo not found: {owner}/{repo}"}
+            return {
+                "status": "error",
+                "message": f"GitHub returned {response.status_code}",
+            }
+        except ValueError as e:
+            return {"status": "error", "message": str(e)}
+        except Exception as e:
+            return {"status": "error", "message": f"Connection failed: {e}"}
+
+    @staticmethod
     async def create_skill(
         data: NewSkillRequest,
         user_id: Optional[str] = None,
@@ -71,6 +154,29 @@ class LiteLLMSkillsHandler:
         """
         prisma_client = await LiteLLMSkillsHandler._get_prisma_client()
 
+        # GitHub import: fetch ZIP and encrypt PAT before building skill_data
+        file_content = data.file_content
+        file_name = data.file_name
+        file_type = data.file_type
+        metadata = dict(data.metadata) if data.metadata else {}
+
+        if data.github_repo_url:
+            if not data.github_pat:
+                raise ValueError(
+                    "github_pat is required when github_repo_url is provided"
+                )
+            file_content, file_name, file_type = (
+                await LiteLLMSkillsHandler._fetch_github_zip(
+                    data.github_repo_url, data.github_pat
+                )
+            )
+            from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+                encrypt_value_helper,
+            )
+
+            metadata["github_repo_url"] = data.github_repo_url
+            metadata["github_pat"] = encrypt_value_helper(data.github_pat)
+
         skill_id = f"litellm_skill_{uuid.uuid4()}"
 
         skill_data: Dict[str, Any] = {
@@ -84,20 +190,24 @@ class LiteLLMSkillsHandler:
         }
 
         # Handle metadata
-        if data.metadata is not None:
+        if metadata:
+            from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
+            skill_data["metadata"] = safe_dumps(metadata)
+        elif data.metadata is not None:
             from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
             skill_data["metadata"] = safe_dumps(data.metadata)
 
         # Handle file content - wrap bytes in Base64 for Prisma
-        if data.file_content is not None:
+        if file_content is not None:
             from prisma.fields import Base64
 
-            skill_data["file_content"] = Base64.encode(data.file_content)
-        if data.file_name is not None:
-            skill_data["file_name"] = data.file_name
-        if data.file_type is not None:
-            skill_data["file_type"] = data.file_type
+            skill_data["file_content"] = Base64.encode(file_content)
+        if file_name is not None:
+            skill_data["file_name"] = file_name
+        if file_type is not None:
+            skill_data["file_type"] = file_type
 
         verbose_logger.debug(
             f"LiteLLMSkillsHandler: Creating skill {skill_id} with title={data.display_title}"
@@ -135,6 +245,43 @@ class LiteLLMSkillsHandler:
         )
 
         return [_prisma_skill_to_litellm(s) for s in skills]
+
+    @staticmethod
+    async def list_skills_for_registry(
+        limit: int = 20,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Return lightweight registry entries for agent discovery.
+
+        Each entry has: skill_id (litellm: prefixed), display_title,
+        description, examples, tags.
+        """
+        prisma_client = await LiteLLMSkillsHandler._get_prisma_client()
+
+        skills = await prisma_client.db.litellm_skillstable.find_many(
+            take=limit,
+            skip=offset,
+            order={"created_at": "desc"},
+            include={},
+        )
+
+        result = []
+        for s in skills:
+            meta: Dict[str, Any] = {}
+            if s.metadata:
+                meta = s.metadata if isinstance(s.metadata, dict) else {}
+
+            result.append(
+                {
+                    "skill_id": f"litellm:{s.skill_id}",
+                    "display_title": s.display_title,
+                    "description": s.description or meta.get("description"),
+                    "examples": meta.get("examples", []),
+                    "tags": meta.get("tags", []),
+                }
+            )
+        return result
 
     @staticmethod
     async def get_skill(skill_id: str) -> LiteLLM_SkillsTable:

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1403,6 +1403,8 @@ class NewSkillRequest(LiteLLMPydanticObjectBase):
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
+    github_repo_url: Optional[str] = None  # e.g. "https://github.com/org/my-skill"
+    github_pat: Optional[str] = None  # raw PAT, encrypted before storage
 
 
 class UpdateSkillRequest(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/anthropic_endpoints/skills_endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/skills_endpoints.py
@@ -236,6 +236,78 @@ async def list_skills(
         )
 
 
+# Static sub-paths must be registered before the /{skill_id} parameterized route
+# so FastAPI matches them correctly.
+
+
+@router.post(
+    "/v1/skills/test-github-connection",
+    tags=["[beta] Anthropic Skills API"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=TestGitHubConnectionResponse,
+)
+async def test_github_connection(
+    body: TestGitHubConnectionRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Verify a GitHub PAT can access the given repo without storing anything.
+
+    Returns {"status": "ok"} on success or {"status": "error", "message": "..."} on failure.
+
+    Example:
+    ```bash
+    curl -X POST "http://localhost:4000/v1/skills/test-github-connection" \\
+      -H "Authorization: Bearer your-key" \\
+      -H "Content-Type: application/json" \\
+      -d '{"repo_url": "https://github.com/org/my-skill", "github_pat": "ghp_xxx"}'
+    ```
+    """
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    result = await LiteLLMSkillsHandler.test_github_connection(
+        repo_url=body.repo_url,
+        pat=body.github_pat,
+    )
+    return TestGitHubConnectionResponse(**result)
+
+
+@router.get(
+    "/v1/skills/registry",
+    tags=["[beta] Anthropic Skills API"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=SkillRegistryResponse,
+)
+async def list_skills_registry(
+    limit: int = 20,
+    offset: int = 0,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Agent skill discovery endpoint. Returns lightweight skill metadata for agents
+    to browse available skills and decide which to use.
+
+    Each entry includes skill_id (prefixed with 'litellm:'), description, examples,
+    and tags. Use the skill_id in container.skills when making LLM requests.
+
+    Example:
+    ```bash
+    curl "http://localhost:4000/v1/skills/registry?limit=20" \\
+      -H "Authorization: Bearer your-key"
+    ```
+    """
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+    from litellm.types.llms.anthropic_skills import SkillRegistryItem
+
+    registry_items = await LiteLLMSkillsHandler.list_skills_for_registry(
+        limit=min(limit, 100),
+        offset=offset,
+    )
+    return SkillRegistryResponse(
+        data=[SkillRegistryItem(**item) for item in registry_items]
+    )
+
+
 @router.get(
     "/v1/skills/{skill_id}",
     tags=["[beta] Anthropic Skills API"],
@@ -438,71 +510,3 @@ async def delete_skill(
             proxy_logging_obj=proxy_logging_obj,
             version=version,
         )
-
-
-@router.post(
-    "/v1/skills/test-github-connection",
-    tags=["[beta] Anthropic Skills API"],
-    dependencies=[Depends(user_api_key_auth)],
-    response_model=TestGitHubConnectionResponse,
-)
-async def test_github_connection(
-    body: TestGitHubConnectionRequest,
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-):
-    """
-    Verify a GitHub PAT can access the given repo without storing anything.
-
-    Returns {"status": "ok"} on success or {"status": "error", "message": "..."} on failure.
-
-    Example:
-    ```bash
-    curl -X POST "http://localhost:4000/v1/skills/test-github-connection" \\
-      -H "Authorization: Bearer your-key" \\
-      -H "Content-Type: application/json" \\
-      -d '{"repo_url": "https://github.com/org/my-skill", "github_pat": "ghp_xxx"}'
-    ```
-    """
-    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
-
-    result = await LiteLLMSkillsHandler.test_github_connection(
-        repo_url=body.repo_url,
-        pat=body.github_pat,
-    )
-    return TestGitHubConnectionResponse(**result)
-
-
-@router.get(
-    "/v1/skills/registry",
-    tags=["[beta] Anthropic Skills API"],
-    dependencies=[Depends(user_api_key_auth)],
-    response_model=SkillRegistryResponse,
-)
-async def list_skills_registry(
-    limit: int = 20,
-    offset: int = 0,
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-):
-    """
-    Agent skill discovery endpoint. Returns lightweight skill metadata for agents
-    to browse available skills and decide which to use.
-
-    Each entry includes skill_id (prefixed with 'litellm:'), description, examples,
-    and tags. Use the skill_id in container.skills when making LLM requests.
-
-    Example:
-    ```bash
-    curl "http://localhost:4000/v1/skills/registry?limit=20" \\
-      -H "Authorization: Bearer your-key"
-    ```
-    """
-    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
-    from litellm.types.llms.anthropic_skills import SkillRegistryItem
-
-    registry_items = await LiteLLMSkillsHandler.list_skills_for_registry(
-        limit=min(limit, 100),
-        offset=offset,
-    )
-    return SkillRegistryResponse(
-        data=[SkillRegistryItem(**item) for item in registry_items]
-    )

--- a/litellm/proxy/anthropic_endpoints/skills_endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/skills_endpoints.py
@@ -14,10 +14,12 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     convert_upload_files_to_file_data,
     get_form_data,
 )
+from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
 from litellm.types.llms.anthropic_skills import (
     DeleteSkillResponse,
     ListSkillsResponse,
     Skill,
+    SkillRegistryItem,
     SkillRegistryResponse,
     TestGitHubConnectionRequest,
     TestGitHubConnectionResponse,
@@ -248,7 +250,6 @@ async def list_skills(
 )
 async def test_github_connection(
     body: TestGitHubConnectionRequest,
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
     Verify a GitHub PAT can access the given repo without storing anything.
@@ -263,8 +264,6 @@ async def test_github_connection(
       -d '{"repo_url": "https://github.com/org/my-skill", "github_pat": "ghp_xxx"}'
     ```
     """
-    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
-
     result = await LiteLLMSkillsHandler.test_github_connection(
         repo_url=body.repo_url,
         pat=body.github_pat,
@@ -281,7 +280,6 @@ async def test_github_connection(
 async def list_skills_registry(
     limit: int = 20,
     offset: int = 0,
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
     Agent skill discovery endpoint. Returns lightweight skill metadata for agents
@@ -296,9 +294,6 @@ async def list_skills_registry(
       -H "Authorization: Bearer your-key"
     ```
     """
-    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
-    from litellm.types.llms.anthropic_skills import SkillRegistryItem
-
     registry_items = await LiteLLMSkillsHandler.list_skills_for_registry(
         limit=min(limit, 100),
         offset=offset,

--- a/litellm/proxy/anthropic_endpoints/skills_endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/skills_endpoints.py
@@ -18,6 +18,9 @@ from litellm.types.llms.anthropic_skills import (
     DeleteSkillResponse,
     ListSkillsResponse,
     Skill,
+    SkillRegistryResponse,
+    TestGitHubConnectionRequest,
+    TestGitHubConnectionResponse,
 )
 
 router = APIRouter()
@@ -435,3 +438,71 @@ async def delete_skill(
             proxy_logging_obj=proxy_logging_obj,
             version=version,
         )
+
+
+@router.post(
+    "/v1/skills/test-github-connection",
+    tags=["[beta] Anthropic Skills API"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=TestGitHubConnectionResponse,
+)
+async def test_github_connection(
+    body: TestGitHubConnectionRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Verify a GitHub PAT can access the given repo without storing anything.
+
+    Returns {"status": "ok"} on success or {"status": "error", "message": "..."} on failure.
+
+    Example:
+    ```bash
+    curl -X POST "http://localhost:4000/v1/skills/test-github-connection" \\
+      -H "Authorization: Bearer your-key" \\
+      -H "Content-Type: application/json" \\
+      -d '{"repo_url": "https://github.com/org/my-skill", "github_pat": "ghp_xxx"}'
+    ```
+    """
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    result = await LiteLLMSkillsHandler.test_github_connection(
+        repo_url=body.repo_url,
+        pat=body.github_pat,
+    )
+    return TestGitHubConnectionResponse(**result)
+
+
+@router.get(
+    "/v1/skills/registry",
+    tags=["[beta] Anthropic Skills API"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=SkillRegistryResponse,
+)
+async def list_skills_registry(
+    limit: int = 20,
+    offset: int = 0,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Agent skill discovery endpoint. Returns lightweight skill metadata for agents
+    to browse available skills and decide which to use.
+
+    Each entry includes skill_id (prefixed with 'litellm:'), description, examples,
+    and tags. Use the skill_id in container.skills when making LLM requests.
+
+    Example:
+    ```bash
+    curl "http://localhost:4000/v1/skills/registry?limit=20" \\
+      -H "Authorization: Bearer your-key"
+    ```
+    """
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+    from litellm.types.llms.anthropic_skills import SkillRegistryItem
+
+    registry_items = await LiteLLMSkillsHandler.list_skills_for_registry(
+        limit=min(limit, 100),
+        offset=offset,
+    )
+    return SkillRegistryResponse(
+        data=[SkillRegistryItem(**item) for item in registry_items]
+    )

--- a/litellm/types/llms/anthropic_skills.py
+++ b/litellm/types/llms/anthropic_skills.py
@@ -2,10 +2,10 @@
 Type definitions for Anthropic Skills API
 """
 
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
-from typing_extensions import Required, TypedDict
+from typing_extensions import TypedDict
 
 
 # Skills API Request Types

--- a/litellm/types/llms/anthropic_skills.py
+++ b/litellm/types/llms/anthropic_skills.py
@@ -156,3 +156,52 @@ class DeleteSkillVersionResponse(BaseModel):
 
     deleted: bool
     """Whether the version was successfully deleted"""
+
+
+class SkillRegistryItem(BaseModel):
+    """Lightweight skill entry returned by the registry discovery endpoint"""
+
+    skill_id: str
+    """Skill ID prefixed with 'litellm:' for use in agent requests"""
+
+    display_title: Optional[str] = None
+    """Human-readable title"""
+
+    description: Optional[str] = None
+    """What the skill does"""
+
+    examples: List[str] = Field(default_factory=list)
+    """Example phrases that should trigger this skill"""
+
+    tags: List[str] = Field(default_factory=list)
+    """Broad category tags for filtering"""
+
+
+class SkillRegistryResponse(BaseModel):
+    """Response from GET /v1/skills/registry"""
+
+    data: List[SkillRegistryItem]
+    """List of skills available for agent discovery"""
+
+    has_more: bool = False
+    """Whether there are more skills available"""
+
+
+class TestGitHubConnectionRequest(BaseModel):
+    """Request body for POST /v1/skills/test-github-connection"""
+
+    repo_url: str
+    """GitHub repo URL, e.g. https://github.com/org/my-skill"""
+
+    github_pat: str
+    """Personal Access Token to authenticate with GitHub"""
+
+
+class TestGitHubConnectionResponse(BaseModel):
+    """Response from POST /v1/skills/test-github-connection"""
+
+    status: str
+    """'ok' on success, 'error' on failure"""
+
+    message: Optional[str] = None
+    """Error message if status is 'error'"""

--- a/ui/litellm-dashboard/src/components/agents/add_agent_form.tsx
+++ b/ui/litellm-dashboard/src/components/agents/add_agent_form.tsx
@@ -667,10 +667,10 @@ const AddAgentForm: React.FC<AddAgentFormProps> = ({
             </Form.Item>
           </div>
         ) : agentType === "a2a" ? (
-          <AgentFormFields showAgentName={true} />
+          <AgentFormFields showAgentName={true} accessToken={accessToken} />
         ) : selectedAgentTypeInfo?.use_a2a_form_fields ? (
           <>
-            <AgentFormFields showAgentName={true} />
+            <AgentFormFields showAgentName={true} accessToken={accessToken} />
             {selectedAgentTypeInfo.credential_fields.length > 0 && (
               <div className="mt-4 p-4 border border-gray-200 rounded-lg">
                 <h4 className="text-sm font-medium text-gray-700 mb-3">

--- a/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
+++ b/ui/litellm-dashboard/src/components/agents/agent_form_fields.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { Form, Input, Switch, Collapse, Select, Space, Tooltip } from "antd";
+import React, { useState } from "react";
+import { Form, Input, Switch, Collapse, Select, Space, Tooltip, Modal, List, Tag, message } from "antd";
 import { Button as AntButton } from "antd";
-import { PlusOutlined, MinusCircleOutlined, InfoCircleOutlined } from "@ant-design/icons";
+import { PlusOutlined, MinusCircleOutlined, InfoCircleOutlined, GithubOutlined, AppstoreOutlined, CheckCircleOutlined, CloseCircleOutlined, LoadingOutlined } from "@ant-design/icons";
 import { AGENT_FORM_CONFIG, SKILL_FIELD_CONFIG } from "./agent_config";
+import { fetchSkillsRegistry, testGitHubSkillConnection, createSkillFromGitHub, SkillRegistryItem } from "../networking";
 
 import CostConfigFields from "./cost_config_fields";
 
@@ -11,14 +12,72 @@ const { Panel } = Collapse;
 interface AgentFormFieldsProps {
   showAgentName?: boolean;
   visiblePanels?: string[];
+  accessToken?: string | null;
 }
 
-/**
- * Reusable form fields component for agent forms
- * Uses shared configuration from agent_config.ts
- */
-const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true, visiblePanels }) => {
+const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true, visiblePanels, accessToken }) => {
   const shouldShow = (key: string) => !visiblePanels || visiblePanels.includes(key);
+
+  // Registry modal state
+  const [registryOpen, setRegistryOpen] = useState(false);
+  const [registryItems, setRegistryItems] = useState<SkillRegistryItem[]>([]);
+  const [registryLoading, setRegistryLoading] = useState(false);
+
+  // GitHub import modal state
+  const [githubOpen, setGithubOpen] = useState(false);
+  const [githubRepoUrl, setGithubRepoUrl] = useState("");
+  const [githubPat, setGithubPat] = useState("");
+  const [testStatus, setTestStatus] = useState<"idle" | "loading" | "ok" | "error">("idle");
+  const [testMessage, setTestMessage] = useState("");
+  const [importLoading, setImportLoading] = useState(false);
+
+  const openRegistry = async () => {
+    if (!accessToken) return;
+    setRegistryOpen(true);
+    setRegistryLoading(true);
+    const items = await fetchSkillsRegistry(accessToken);
+    setRegistryItems(items);
+    setRegistryLoading(false);
+  };
+
+  const handleTestConnection = async () => {
+    if (!accessToken || !githubRepoUrl || !githubPat) return;
+    setTestStatus("loading");
+    const result = await testGitHubSkillConnection(accessToken, githubRepoUrl, githubPat);
+    if (result.status === "ok") {
+      setTestStatus("ok");
+      setTestMessage("");
+    } else {
+      setTestStatus("error");
+      setTestMessage(result.message ?? "Connection failed");
+    }
+  };
+
+  const handleGitHubImport = async () => {
+    if (!accessToken) return;
+    setImportLoading(true);
+    try {
+      await createSkillFromGitHub(accessToken, githubRepoUrl, githubPat);
+      message.success("Skill imported from GitHub successfully");
+      setGithubOpen(false);
+      setGithubRepoUrl("");
+      setGithubPat("");
+      setTestStatus("idle");
+    } catch (e: any) {
+      message.error(`Import failed: ${e.message}`);
+    } finally {
+      setImportLoading(false);
+    }
+  };
+
+  const resetGithubModal = () => {
+    setGithubOpen(false);
+    setGithubRepoUrl("");
+    setGithubPat("");
+    setTestStatus("idle");
+    setTestMessage("");
+  };
+
   return (
     <>
       {showAgentName && (
@@ -70,7 +129,7 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                     >
                       <Input placeholder={SKILL_FIELD_CONFIG.id.placeholder} />
                     </Form.Item>
-                    
+
                     <Form.Item
                       {...field}
                       label={SKILL_FIELD_CONFIG.name.label}
@@ -79,7 +138,7 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                     >
                       <Input placeholder={SKILL_FIELD_CONFIG.name.placeholder} />
                     </Form.Item>
-                    
+
                     <Form.Item
                       {...field}
                       label={SKILL_FIELD_CONFIG.description.label}
@@ -88,7 +147,7 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                     >
                       <Input.TextArea rows={SKILL_FIELD_CONFIG.description.rows} placeholder={SKILL_FIELD_CONFIG.description.placeholder} />
                     </Form.Item>
-                    
+
                     <Form.Item
                       {...field}
                       label={SKILL_FIELD_CONFIG.tags.label}
@@ -99,7 +158,7 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                     >
                       <Input placeholder={SKILL_FIELD_CONFIG.tags.placeholder} />
                     </Form.Item>
-                    
+
                     <Form.Item
                       {...field}
                       label={SKILL_FIELD_CONFIG.examples.label}
@@ -109,10 +168,10 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                     >
                       <Input placeholder={SKILL_FIELD_CONFIG.examples.placeholder} />
                     </Form.Item>
-                    
-                    <AntButton 
-                      type="link" 
-                      danger 
+
+                    <AntButton
+                      type="link"
+                      danger
                       onClick={() => remove(field.name)}
                       icon={<MinusCircleOutlined />}
                     >
@@ -120,14 +179,137 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
                     </AntButton>
                   </div>
                 ))}
-                <AntButton 
-                  type="dashed" 
-                  onClick={() => add()} 
-                  icon={<PlusOutlined />}
-                  style={{ width: '100%' }}
+
+                <Space style={{ width: '100%' }} direction="vertical">
+                  <AntButton
+                    type="dashed"
+                    onClick={() => add()}
+                    icon={<PlusOutlined />}
+                    style={{ width: '100%' }}
+                  >
+                    Add Skill Manually
+                  </AntButton>
+                  {accessToken && (
+                    <Space style={{ width: '100%' }}>
+                      <AntButton
+                        icon={<AppstoreOutlined />}
+                        style={{ flex: 1 }}
+                        onClick={openRegistry}
+                      >
+                        Browse Registry
+                      </AntButton>
+                      <AntButton
+                        icon={<GithubOutlined />}
+                        style={{ flex: 1 }}
+                        onClick={() => setGithubOpen(true)}
+                      >
+                        Import from GitHub
+                      </AntButton>
+                    </Space>
+                  )}
+                </Space>
+
+                {/* Registry browser modal */}
+                <Modal
+                  title="Skill Registry"
+                  open={registryOpen}
+                  onCancel={() => setRegistryOpen(false)}
+                  footer={null}
+                  width={600}
                 >
-                  Add Skill
-                </AntButton>
+                  <List
+                    loading={registryLoading}
+                    dataSource={registryItems}
+                    locale={{ emptyText: "No skills in registry" }}
+                    renderItem={(item) => (
+                      <List.Item
+                        actions={[
+                          <AntButton
+                            type="primary"
+                            size="small"
+                            key="add"
+                            onClick={() => {
+                              add({
+                                id: item.skill_id,
+                                name: item.display_title ?? item.skill_id,
+                                description: item.description ?? "",
+                                tags: item.tags,
+                                examples: item.examples,
+                              });
+                              setRegistryOpen(false);
+                              message.success(`Added "${item.display_title ?? item.skill_id}"`);
+                            }}
+                          >
+                            Add
+                          </AntButton>,
+                        ]}
+                      >
+                        <List.Item.Meta
+                          title={item.display_title ?? item.skill_id}
+                          description={
+                            <>
+                              <div style={{ marginBottom: 4 }}>{item.description}</div>
+                              {item.tags.map((t) => <Tag key={t}>{t}</Tag>)}
+                            </>
+                          }
+                        />
+                      </List.Item>
+                    )}
+                  />
+                </Modal>
+
+                {/* GitHub import modal */}
+                <Modal
+                  title="Import Skill from GitHub"
+                  open={githubOpen}
+                  onCancel={resetGithubModal}
+                  footer={[
+                    <AntButton key="cancel" onClick={resetGithubModal}>
+                      Cancel
+                    </AntButton>,
+                    <AntButton
+                      key="import"
+                      type="primary"
+                      disabled={testStatus !== "ok"}
+                      loading={importLoading}
+                      onClick={handleGitHubImport}
+                    >
+                      Import Skill
+                    </AntButton>,
+                  ]}
+                >
+                  <Space direction="vertical" style={{ width: '100%' }}>
+                    <Input
+                      placeholder="https://github.com/org/my-skill"
+                      value={githubRepoUrl}
+                      onChange={(e) => { setGithubRepoUrl(e.target.value); setTestStatus("idle"); }}
+                      addonBefore="Repo URL"
+                    />
+                    <Input.Password
+                      placeholder="ghp_xxxxxxxxxxxx"
+                      value={githubPat}
+                      onChange={(e) => { setGithubPat(e.target.value); setTestStatus("idle"); }}
+                      addonBefore="GitHub PAT"
+                    />
+                    <AntButton
+                      onClick={handleTestConnection}
+                      loading={testStatus === "loading"}
+                      disabled={!githubRepoUrl || !githubPat}
+                    >
+                      Test Connection
+                    </AntButton>
+                    {testStatus === "ok" && (
+                      <span style={{ color: "#52c41a" }}>
+                        <CheckCircleOutlined /> Connected successfully
+                      </span>
+                    )}
+                    {testStatus === "error" && (
+                      <span style={{ color: "#ff4d4f" }}>
+                        <CloseCircleOutlined /> {testMessage}
+                      </span>
+                    )}
+                  </Space>
+                </Modal>
               </>
             )}
           </Form.List>
@@ -260,4 +442,3 @@ const AgentFormFields: React.FC<AgentFormFieldsProps> = ({ showAgentName = true,
 };
 
 export default AgentFormFields;
-

--- a/ui/litellm-dashboard/src/components/agents/agent_info.tsx
+++ b/ui/litellm-dashboard/src/components/agents/agent_info.tsx
@@ -293,11 +293,11 @@ const AgentInfoView: React.FC<AgentInfoViewProps> = ({
                     </Form.Item>
 
                     {detectedAgentType === "a2a" ? (
-                      <AgentFormFields showAgentName={true} />
+                      <AgentFormFields showAgentName={true} accessToken={accessToken} />
                     ) : selectedAgentTypeInfo ? (
                       <DynamicAgentFormFields agentTypeInfo={selectedAgentTypeInfo} />
                     ) : (
-                    <AgentFormFields showAgentName={true} />
+                    <AgentFormFields showAgentName={true} accessToken={accessToken} />
                     )}
 
                     <Divider />

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -10014,15 +10014,24 @@ export const testGitHubSkillConnection = async (
   pat: string,
 ): Promise<{ status: string; message?: string }> => {
   const base = proxyBaseUrl ?? "";
-  const response = await fetch(`${base}/v1/skills/test-github-connection`, {
-    method: "POST",
-    headers: {
-      [globalLitellmHeaderName]: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ repo_url: repoUrl, github_pat: pat }),
-  });
-  return response.json();
+  try {
+    const response = await fetch(`${base}/v1/skills/test-github-connection`, {
+      method: "POST",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ repo_url: repoUrl, github_pat: pat }),
+    });
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { status: "error", message: text || `HTTP ${response.status}` };
+    }
+  } catch (e: any) {
+    return { status: "error", message: e?.message ?? "Network error" };
+  }
 };
 
 export const createSkillFromGitHub = async (
@@ -10045,9 +10054,18 @@ export const createSkillFromGitHub = async (
       display_title: displayTitle || undefined,
     }),
   });
+  const text = await response.text();
   if (!response.ok) {
-    const err = await response.text();
-    throw new Error(err);
+    let message = text;
+    try {
+      const parsed = JSON.parse(text);
+      message = parsed?.detail ?? parsed?.message ?? text;
+    } catch { /* use raw text */ }
+    throw new Error(message || `HTTP ${response.status}`);
   }
-  return response.json();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Unexpected response: ${text}`);
+  }
 };

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -9986,3 +9986,68 @@ export const listMCPUserCredentials = async (
   if (!response.ok) return [];
   return response.json();
 };
+
+export interface SkillRegistryItem {
+  skill_id: string;
+  display_title: string | null;
+  description: string | null;
+  examples: string[];
+  tags: string[];
+}
+
+export const fetchSkillsRegistry = async (
+  accessToken: string,
+  limit = 50,
+): Promise<SkillRegistryItem[]> => {
+  const base = proxyBaseUrl ?? "";
+  const response = await fetch(`${base}/v1/skills/registry?limit=${limit}`, {
+    headers: { [globalLitellmHeaderName]: `Bearer ${accessToken}` },
+  });
+  if (!response.ok) return [];
+  const data = await response.json();
+  return data.data ?? [];
+};
+
+export const testGitHubSkillConnection = async (
+  accessToken: string,
+  repoUrl: string,
+  pat: string,
+): Promise<{ status: string; message?: string }> => {
+  const base = proxyBaseUrl ?? "";
+  const response = await fetch(`${base}/v1/skills/test-github-connection`, {
+    method: "POST",
+    headers: {
+      [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ repo_url: repoUrl, github_pat: pat }),
+  });
+  return response.json();
+};
+
+export const createSkillFromGitHub = async (
+  accessToken: string,
+  repoUrl: string,
+  pat: string,
+  displayTitle?: string,
+): Promise<{ skill_id: string; display_title?: string }> => {
+  const base = proxyBaseUrl ?? "";
+  const response = await fetch(`${base}/v1/skills`, {
+    method: "POST",
+    headers: {
+      [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      custom_llm_provider: "litellm_proxy",
+      github_repo_url: repoUrl,
+      github_pat: pat,
+      display_title: displayTitle || undefined,
+    }),
+  });
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(err);
+  }
+  return response.json();
+};


### PR DESCRIPTION
## Relevant issues

Closes skills marketplace gaps for developer flow.

## Changes

**GitHub PAT skill import**
- `POST /v1/skills` now accepts `github_repo_url` + `github_pat` — fetches the repo ZIP via GitHub API and stores it
- PAT is encrypted at rest using `encrypt_value_helper()` (NaCl SecretBox, same as API key storage) in `metadata["github_pat"]`
- New `POST /v1/skills/test-github-connection` — verifies a PAT can reach the repo without storing anything, returns `{"status": "ok"}` or `{"status": "error", "message": "..."}`

**Agent skill registry discovery**
- New `GET /v1/skills/registry` — returns lightweight skill catalog for agents to browse (`skill_id`, `display_title`, `description`, `examples`, `tags`)
- `skill_id` is prefixed with `litellm:` so agents can drop it directly into `container.skills`
- Requires standard LiteLLM API key auth

## Pre-Submission checklist

- [ ] Added test in `tests/litellm/`
- [ ] `make test-unit` passes

## Type

- [ ] New feature

## Changes
- `litellm/types/llms/anthropic_skills.py` — new `SkillRegistryItem`, `SkillRegistryResponse`, `TestGitHubConnectionRequest/Response` types
- `litellm/proxy/_types.py` — `github_repo_url`, `github_pat` on `NewSkillRequest`
- `litellm/llms/litellm_proxy/skills/handler.py` — `_fetch_github_zip`, `test_github_connection`, `list_skills_for_registry`
- `litellm/proxy/anthropic_endpoints/skills_endpoints.py` — two new endpoints