### PR TITLE
Fix /metrics hang when require_auth_for_metrics_endpoint is true and auth succeeds #25980

### DIFF
--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -2,6 +2,7 @@
 Prometheus Auth Middleware - Pure ASGI implementation
 """
 import json
+from typing import List
 
 from fastapi import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -39,8 +40,17 @@ class PrometheusAuthMiddleware:
 
         # Only run auth if configured to do so
         if litellm.require_auth_for_metrics_endpoint is True:
-            # Construct Request only when auth is actually needed
-            request = Request(scope, receive)
+            # user_api_key_auth reads the request body, which consumes ASGI `receive`.
+            # Buffer those messages and replay them for the inner app; otherwise a
+            # successful auth would forward an exhausted receive and /metrics hangs.
+            buffered_messages: List[dict] = []
+
+            async def receive_for_auth() -> dict:
+                message = await receive()
+                buffered_messages.append(message)
+                return message
+
+            request = Request(scope, receive_for_auth)
             api_key = request.headers.get(_AUTHORIZATION_HEADER) or ""
 
             try:
@@ -68,6 +78,19 @@ class PrometheusAuthMiddleware:
                     }
                 )
                 return
+
+            replay_idx = 0
+
+            async def receive_replay() -> dict:
+                nonlocal replay_idx
+                if replay_idx < len(buffered_messages):
+                    msg = buffered_messages[replay_idx]
+                    replay_idx += 1
+                    return msg
+                return await receive()
+
+            await self.app(scope, receive_replay, send)
+            return
 
         # Pass through to the inner application
         await self.app(scope, receive, send)

--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -5,7 +5,7 @@ import json
 from typing import List
 
 from fastapi import Request
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 import litellm
 from litellm.proxy._types import SpecialHeaders
@@ -43,9 +43,9 @@ class PrometheusAuthMiddleware:
             # user_api_key_auth reads the request body, which consumes ASGI `receive`.
             # Buffer those messages and replay them for the inner app; otherwise a
             # successful auth would forward an exhausted receive and /metrics hangs.
-            buffered_messages: List[dict] = []
+            buffered_messages: List[Message] = []
 
-            async def receive_for_auth() -> dict:
+            async def receive_for_auth() -> Message:
                 message = await receive()
                 buffered_messages.append(message)
                 return message
@@ -81,7 +81,7 @@ class PrometheusAuthMiddleware:
 
             replay_idx = 0
 
-            async def receive_replay() -> dict:
+            async def receive_replay() -> Message:
                 nonlocal replay_idx
                 if replay_idx < len(buffered_messages):
                     msg = buffered_messages[replay_idx]

--- a/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py
@@ -26,6 +26,15 @@ async def fake_valid_auth(request, api_key):
     return
 
 
+async def fake_valid_auth_reads_body(request, api_key, **kwargs):
+    """
+    Like real user_api_key_auth, consumes the ASGI body stream. Regression test
+    for successful auth passing a drained receive to the inner app (hang).
+    """
+    await request.body()
+    return
+
+
 async def fake_invalid_auth(request, api_key):
     print("running fake invalid auth", request, api_key)
     # Simulate invalid auth by raising an exception.
@@ -60,6 +69,28 @@ def app_with_middleware():
         return {"msg": "embeddings OK"}
 
     return app
+
+
+def test_valid_auth_metrics_after_body_consumed(app_with_middleware, monkeypatch):
+    """
+    Auth that reads the request body must not cause /metrics to hang on success.
+    """
+    litellm.require_auth_for_metrics_endpoint = True
+    monkeypatch.setattr(
+        "litellm.proxy.middleware.prometheus_auth_middleware.user_api_key_auth",
+        fake_valid_auth_reads_body,
+    )
+
+    client = TestClient(app_with_middleware)
+    headers = {SpecialHeaders.openai_authorization.value: "valid"}
+
+    response = client.get("/metrics", headers=headers)
+    assert response.status_code == 200, response.text
+    assert response.json() == {"msg": "metrics OK"}
+
+    response = client.get("/metrics/", headers=headers)
+    assert response.status_code == 200, response.text
+    assert response.json() == {"msg": "metrics OK"}
 
 
 def test_valid_auth_metrics(app_with_middleware, monkeypatch):


### PR DESCRIPTION
## Relevant issues
PrometheusAuthMiddleware calls user_api_key_auth, which reads the request via _read_request_body → await request.body(). That consumes the ASGI receive stream. On failed auth the middleware returns 401 and never calls the inner app, so behavior looks fine. On successful auth it used to forward the same receive to the app; the stream was already drained, so the mounted /metrics handler could block forever waiting for http.request events. Existing tests used mocks that never read the body, so they didn’t catch it.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes
For metrics requests when auth is required, wrap receive so every message pulled during auth is buffered, then call the inner app with a receive_replay that replays those messages in order and only then delegates to the original receive (e.g. for http.disconnect). Add a regression test where the patched auth calls await request.body() and /metrics still returns 200.

