### PR TITLE
Add Anthropic task_budget support

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 else:
     AsyncIOScheduler = Any
 
+
 class PrometheusLogger(CustomLogger):
     # Class variables or attributes
 
@@ -991,9 +992,7 @@ class PrometheusLogger(CustomLogger):
         amount: float = 1.0,
     ) -> None:
         _labels = prometheus_label_factory(
-            supported_enum_labels=self.get_labels_for_metric(
-                metric_name=metric_name
-            ),
+            supported_enum_labels=self.get_labels_for_metric(metric_name=metric_name),
             enum_values=enum_values,
             label_context=label_context,
         )
@@ -1118,7 +1117,9 @@ class PrometheusLogger(CustomLogger):
 
             user_api_key = hash_token(user_api_key)
 
-        label_context = PrometheusLabelFactoryContext(enum_values) #amortized per request.
+        label_context = PrometheusLabelFactoryContext(
+            enum_values
+        )  # amortized per request.
 
         # increment total LLM requests and spend metric
         self._increment_top_level_request_and_spend_metrics(
@@ -3490,7 +3491,9 @@ def _prometheus_labels_from_context(
     }
 
     if UserAPIKeyLabelNames.END_USER.value in filtered_labels:
-        filtered_labels[UserAPIKeyLabelNames.END_USER.value] = ctx.get_resolved_end_user()
+        filtered_labels[UserAPIKeyLabelNames.END_USER.value] = (
+            ctx.get_resolved_end_user()
+        )
 
     for sk, val in ctx._custom_by_sanitized_key.items():
         if sk in supported_enum_labels:

--- a/litellm/integrations/prometheus_helpers.py
+++ b/litellm/integrations/prometheus_helpers.py
@@ -51,8 +51,7 @@ class PrometheusLabelFactoryContext:
         self.enum_values = enum_values
         enum_dict = enum_values.model_dump()
         self._sanitized_enum: Dict[str, Optional[str]] = {
-            k: _sanitize_prometheus_label_value(v)
-            for k, v in enum_dict.items()
+            k: _sanitize_prometheus_label_value(v) for k, v in enum_dict.items()
         }
         self._custom_by_sanitized_key: Dict[str, Optional[str]] = {}
         if enum_values.custom_metadata_labels is not None:

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -74,6 +74,7 @@ from litellm.utils import (
     has_tool_call_blocks,
     last_assistant_with_tool_calls_has_no_thinking_blocks,
     supports_reasoning,
+    supports_task_budget,
     token_counter,
 )
 
@@ -191,14 +192,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         )
 
     @staticmethod
-    def _is_opus_4_7_model(model: str) -> bool:
-        """Check if the model is specifically Claude Opus 4.7."""
-        model_lower = model.lower()
-        return any(
-            v in model_lower for v in ("opus-4-7", "opus_4_7", "opus-4.7", "opus_4.7")
-        )
-
-    @staticmethod
     def _supports_effort_level(model: str, level: str) -> bool:
         """Check ``supports_{level}_reasoning_effort`` in the model map.
 
@@ -234,7 +227,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "cache_control",
         ]
 
-        if AnthropicConfig._is_claude_4_7_model(model):
+        if supports_task_budget(
+            model=model,
+            custom_llm_provider=self.custom_llm_provider,
+        ):
             params.append("output_config")
 
         if (
@@ -1381,6 +1377,14 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             self._ensure_beta_header(
                 headers, ANTHROPIC_BETA_HEADER_VALUES.FAST_MODE_2026_02_01.value
             )
+        output_config = optional_params.get("output_config")
+        if (
+            isinstance(output_config, dict)
+            and output_config.get("task_budget") is not None
+        ):
+            self._ensure_beta_header(
+                headers, ANTHROPIC_BETA_HEADER_VALUES.TASK_BUDGETS_2026_03_13.value
+            )
         for tool in _tools:
             if tool.get("type") == ANTHROPIC_ADVISOR_TOOL_TYPE:
                 self._ensure_beta_header(
@@ -1563,9 +1567,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 f"effort='xhigh' is not supported by this model. Got model: {model}"
             )
         if task_budget is not None:
-            if not self._is_opus_4_7_model(model):
+            if not supports_task_budget(
+                model=model,
+                custom_llm_provider=self.custom_llm_provider,
+            ):
                 raise ValueError(
-                    f"output_config.task_budget is only supported by Claude Opus 4.7. "
+                    f"output_config.task_budget is not supported by this model. "
                     f"Got model: {model}"
                 )
             if not isinstance(task_budget, dict):

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1377,14 +1377,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             self._ensure_beta_header(
                 headers, ANTHROPIC_BETA_HEADER_VALUES.FAST_MODE_2026_02_01.value
             )
-        output_config = optional_params.get("output_config")
-        if (
-            isinstance(output_config, dict)
-            and output_config.get("task_budget") is not None
-        ):
-            self._ensure_beta_header(
-                headers, ANTHROPIC_BETA_HEADER_VALUES.TASK_BUDGETS_2026_03_13.value
-            )
         for tool in _tools:
             if tool.get("type") == ANTHROPIC_ADVISOR_TOOL_TYPE:
                 self._ensure_beta_header(
@@ -1533,6 +1525,14 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         self._apply_output_config(
             data=data, model=model, optional_params=optional_params
         )
+        output_config = optional_params.get("output_config")
+        if (
+            isinstance(output_config, dict)
+            and output_config.get("task_budget") is not None
+        ):
+            self._ensure_beta_header(
+                headers, ANTHROPIC_BETA_HEADER_VALUES.TASK_BUDGETS_2026_03_13.value
+            )
 
         return data
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -234,6 +234,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "cache_control",
         ]
 
+        if AnthropicConfig._is_claude_4_7_model(model):
+            params.append("output_config")
+
         if (
             "claude-3-7-sonnet" in model
             or AnthropicConfig._is_claude_4_6_model(model)
@@ -1105,7 +1108,18 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         "max": "max",
                     }
                     mapped_effort = effort_map.get(value, value)
-                    optional_params["output_config"] = {"effort": mapped_effort}
+                    output_config = optional_params.get("output_config")
+                    if not isinstance(output_config, dict):
+                        output_config = {}
+                    output_config["effort"] = mapped_effort
+                    optional_params["output_config"] = output_config
+            elif param == "output_config" and isinstance(value, dict):
+                output_config = optional_params.get("output_config")
+                if isinstance(output_config, dict):
+                    output_config.update(value)
+                    optional_params["output_config"] = output_config
+                else:
+                    optional_params["output_config"] = value
             elif param == "web_search_options" and isinstance(value, dict):
                 hosted_web_search_tool = self.map_web_search_tool(
                     cast(OpenAIWebSearchOptions, value)
@@ -1528,6 +1542,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if not output_config or not isinstance(output_config, dict):
             return
         effort = output_config.get("effort")
+        task_budget = output_config.get("task_budget")
         valid_efforts = ["high", "medium", "low", "xhigh", "max"]
         if effort and effort not in valid_efforts:
             raise ValueError(
@@ -1547,6 +1562,21 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             raise ValueError(
                 f"effort='xhigh' is not supported by this model. Got model: {model}"
             )
+        if task_budget is not None:
+            if not self._is_opus_4_7_model(model):
+                raise ValueError(
+                    f"output_config.task_budget is only supported by Claude Opus 4.7. "
+                    f"Got model: {model}"
+                )
+            if not isinstance(task_budget, dict):
+                raise ValueError("output_config.task_budget must be a dictionary")
+            if task_budget.get("type") != "tokens":
+                raise ValueError("output_config.task_budget.type must be 'tokens'")
+            total = task_budget.get("total")
+            if not isinstance(total, int) or total <= 0:
+                raise ValueError(
+                    "output_config.task_budget.total must be a positive integer"
+                )
         data["output_config"] = output_config
 
     def _transform_response_for_json_mode(

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -310,6 +310,20 @@ class AnthropicModelInfo(BaseLLMModelInfo):
 
         return False
 
+    def is_task_budget_used(self, optional_params: Optional[dict]) -> bool:
+        """
+        Check if output_config.task_budget is being used.
+        """
+        if not optional_params:
+            return False
+
+        output_config = optional_params.get("output_config")
+        if not output_config or not isinstance(output_config, dict):
+            return False
+
+        task_budget = output_config.get("task_budget")
+        return bool(task_budget and isinstance(task_budget, dict))
+
     def is_code_execution_tool_used(self, tools: Optional[List]) -> bool:
         """
         Check if code execution tool is being used.
@@ -382,14 +396,19 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             List of beta header strings
         """
         from litellm.types.llms.anthropic import ANTHROPIC_EFFORT_BETA_HEADER
+        from litellm.types.llms.anthropic import ANTHROPIC_TASK_BUDGETS_BETA_HEADER
 
         betas = []
 
         # Detect features
         effort_used = self.is_effort_used(optional_params, model)
+        task_budget_used = self.is_task_budget_used(optional_params)
 
         if effort_used:
             betas.append(ANTHROPIC_EFFORT_BETA_HEADER)  # effort-2025-11-24
+
+        if task_budget_used:
+            betas.append(ANTHROPIC_TASK_BUDGETS_BETA_HEADER)
 
         if computer_tool_used:
             beta_header = self.get_computer_tool_beta_header(computer_tool_used)
@@ -423,6 +442,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         programmatic_tool_calling_used: bool = False,
         input_examples_used: bool = False,
         effort_used: bool = False,
+        task_budget_used: bool = False,
         is_vertex_request: bool = False,
         user_anthropic_beta_headers: Optional[List[str]] = None,
         code_execution_tool_used: bool = False,
@@ -453,6 +473,13 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             from litellm.types.llms.anthropic import ANTHROPIC_EFFORT_BETA_HEADER
 
             betas.add(ANTHROPIC_EFFORT_BETA_HEADER)
+
+        if task_budget_used:
+            from litellm.types.llms.anthropic import (
+                ANTHROPIC_TASK_BUDGETS_BETA_HEADER,
+            )
+
+            betas.add(ANTHROPIC_TASK_BUDGETS_BETA_HEADER)
 
         # Code execution tool uses a separate beta header
         if code_execution_tool_used:
@@ -535,6 +562,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         )
         input_examples_used = self.is_input_examples_used(tools=tools)
         effort_used = self.is_effort_used(optional_params=optional_params, model=model)
+        task_budget_used = self.is_task_budget_used(optional_params=optional_params)
         code_execution_tool_used = self.is_code_execution_tool_used(tools=tools)
         container_with_skills_used = self.is_container_with_skills_used(
             optional_params=optional_params
@@ -557,6 +585,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             programmatic_tool_calling_used=programmatic_tool_calling_used,
             input_examples_used=input_examples_used,
             effort_used=effort_used,
+            task_budget_used=task_budget_used,
             code_execution_tool_used=code_execution_tool_used,
             container_with_skills_used=container_with_skills_used,
         )

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -372,6 +372,14 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if optional_params.get("speed") == "fast":
             beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.FAST_MODE_2026_02_01.value)
 
+        # Check for task budgets (Claude Opus 4.7+)
+        output_config = optional_params.get("output_config")
+        if (
+            isinstance(output_config, dict)
+            and output_config.get("task_budget") is not None
+        ):
+            beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.TASK_BUDGETS_2026_03_13.value)
+
         # Check for advisor tool
         tools = optional_params.get("tools")
         if tools:

--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -294,9 +294,7 @@ class Authenticator:
         access_token_url = os.getenv(
             "GITHUB_COPILOT_ACCESS_TOKEN_URL", DEFAULT_GITHUB_ACCESS_TOKEN_URL
         )
-        client_id = os.getenv(
-            "GITHUB_COPILOT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID
-        )
+        client_id = os.getenv("GITHUB_COPILOT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID)
 
         for attempt in range(max_attempts):
             try:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1173,6 +1173,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -1201,6 +1202,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -1229,6 +1231,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -1257,6 +1260,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1144,6 +1144,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -9162,6 +9163,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
@@ -9194,6 +9196,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {

--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -79,7 +79,9 @@ class BasePassthroughUtils:
         for header_name, header_value in request_headers.items():
             if header_name.lower().startswith(PASS_THROUGH_HEADER_PREFIX):
                 # Strip the 'x-pass-' prefix and normalize to lowercase
-                actual_header_name = header_name[len(PASS_THROUGH_HEADER_PREFIX) :].lower()
+                actual_header_name = header_name[
+                    len(PASS_THROUGH_HEADER_PREFIX) :
+                ].lower()
                 if actual_header_name in _PASS_THROUGH_PROTECTED_HEADERS or any(
                     actual_header_name.startswith(p)
                     for p in _PASS_THROUGH_PROTECTED_HEADER_PREFIXES

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -784,7 +784,7 @@ class UserAPIKeyLabelValues:
     org_id: Optional[str] = None
     org_alias: Optional[str] = None
 
-    #Added for test compatibility.
+    # Added for test compatibility.
     def __init__(self, **kwargs: Any) -> None:
         """
         Match former Pydantic behavior: unknown keys are ignored; ``api_key_hash`` maps to

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -36,10 +36,18 @@ class AnthropicOutputSchema(TypedDict, total=False):
     schema: Required[dict]
 
 
+class AnthropicTaskBudget(TypedDict, total=False):
+    """Soft token budget for an entire Claude agentic loop."""
+
+    type: Required[Literal["tokens"]]
+    total: Required[int]
+
+
 class AnthropicOutputConfig(TypedDict, total=False):
     """Configuration for controlling Claude's output behavior."""
 
-    effort: Literal["high", "medium", "low"]
+    effort: Literal["high", "medium", "low", "xhigh", "max"]
+    task_budget: AnthropicTaskBudget
 
 
 class AnthropicMessagesTool(TypedDict, total=False):
@@ -676,6 +684,9 @@ ANTHROPIC_TOOL_SEARCH_BETA_HEADER = "advanced-tool-use-2025-11-20"
 
 # Effort beta header constant
 ANTHROPIC_EFFORT_BETA_HEADER = "effort-2025-11-24"
+
+# Task budget beta header constant
+ANTHROPIC_TASK_BUDGETS_BETA_HEADER = "task-budgets-2026-03-13"
 
 # OAuth constants
 ANTHROPIC_OAUTH_TOKEN_PREFIX = "sk-ant-oat"

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -677,6 +677,7 @@ class ANTHROPIC_BETA_HEADER_VALUES(str, Enum):
     ADVANCED_TOOL_USE_2025_11_20 = "advanced-tool-use-2025-11-20"
     FAST_MODE_2026_02_01 = "fast-mode-2026-02-01"
     ADVISOR_TOOL_2026_03_01 = "advisor-tool-2026-03-01"
+    TASK_BUDGETS_2026_03_13 = "task-budgets-2026-03-13"
 
 
 # Tool search beta header constant (for Anthropic direct API and Microsoft Foundry)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -137,6 +137,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_parallel_function_calling: Optional[bool]
     supports_web_search: Optional[bool]
     supports_reasoning: Optional[bool]
+    supports_task_budget: Optional[bool]
     supports_url_context: Optional[bool]
     supports_none_reasoning_effort: Optional[bool]
     supports_xhigh_reasoning_effort: Optional[bool]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4804,6 +4804,14 @@ def add_provider_specific_params_to_optional_params(
                     k=k, additional_drop_params=additional_drop_params
                 ):
                     continue
+                if isinstance(optional_params.get(k), dict) and isinstance(
+                    passed_params[k], dict
+                ):
+                    optional_params[k] = {
+                        **optional_params[k],
+                        **passed_params[k],
+                    }
+                    continue
                 optional_params[k] = passed_params[k]
     return optional_params
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2738,6 +2738,15 @@ def supports_reasoning(model: str, custom_llm_provider: Optional[str] = None) ->
     )
 
 
+def supports_task_budget(model: str, custom_llm_provider: Optional[str] = None) -> bool:
+    """
+    Check if the given model supports Anthropic task budgets and return a boolean value.
+    """
+    return _supports_factory(
+        model=model, custom_llm_provider=custom_llm_provider, key="supports_task_budget"
+    )
+
+
 def supports_native_structured_output(
     model: str, custom_llm_provider: Optional[str] = None
 ) -> bool:
@@ -5898,6 +5907,7 @@ def _get_model_info_helper(  # noqa: PLR0915
                 supports_web_search=_model_info.get("supports_web_search", None),
                 supports_url_context=_model_info.get("supports_url_context", None),
                 supports_reasoning=_model_info.get("supports_reasoning", None),
+                supports_task_budget=_model_info.get("supports_task_budget", None),
                 supports_none_reasoning_effort=_model_info.get(
                     "supports_none_reasoning_effort", None
                 ),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1173,6 +1173,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -1201,6 +1202,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -1229,6 +1231,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -1257,6 +1260,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1144,6 +1144,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "supports_native_structured_output": true
@@ -9162,6 +9163,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {
@@ -9194,6 +9196,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
+        "supports_task_budget": true,
         "supports_xhigh_reasoning_effort": true,
         "tool_use_system_prompt_tokens": 346,
         "provider_specific_entry": {

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1696,6 +1696,31 @@ def test_task_budget_rejected_for_non_opus_47():
         )
 
 
+def test_task_budget_rejection_does_not_mutate_headers():
+    """Test that invalid task_budget requests do not leak beta headers."""
+    config = AnthropicConfig()
+    messages = [{"role": "user", "content": "Test"}]
+    headers = {"anthropic-beta": "existing-beta"}
+
+    with pytest.raises(
+        ValueError,
+        match="output_config.task_budget is not supported by this model",
+    ):
+        config.transform_request(
+            model="claude-opus-4-6-20260205",
+            messages=messages,
+            optional_params={
+                "output_config": {
+                    "task_budget": {"type": "tokens", "total": 64000},
+                }
+            },
+            litellm_params={},
+            headers=headers,
+        )
+
+    assert headers == {"anthropic-beta": "existing-beta"}
+
+
 def test_effort_beta_header_injection():
     """Test that effort beta header is automatically added when output_config is detected."""
     from litellm.llms.anthropic.common_utils import AnthropicModelInfo

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -8,12 +8,25 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
+import litellm
+from litellm import utils as litellm_utils
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
 )
 from litellm.types.llms.anthropic import ANTHROPIC_BETA_HEADER_VALUES
 from litellm.types.utils import ServerToolUse
+
+
+def _enable_task_budget_for_opus_47(monkeypatch):
+    model_info = dict(litellm.model_cost.get("claude-opus-4-7-20260416", {}))
+    model_info["supports_task_budget"] = True
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "claude-opus-4-7-20260416",
+        model_info,
+    )
+    litellm_utils._invalidate_model_cost_lowercase_map()
 
 
 def test_response_format_transformation_unit_test():
@@ -1559,8 +1572,9 @@ def test_effort_output_config_preservation():
     assert result["output_config"]["effort"] == "medium"
 
 
-def test_task_budget_output_config_preservation():
+def test_task_budget_output_config_preservation(monkeypatch):
     """Test that output_config with task_budget is preserved for Claude Opus 4.7."""
+    _enable_task_budget_for_opus_47(monkeypatch)
     config = AnthropicConfig()
 
     messages = [{"role": "user", "content": "Run this agentic task"}]
@@ -1607,8 +1621,9 @@ def test_task_budget_beta_header_injection():
     assert ANTHROPIC_TASK_BUDGETS_BETA_HEADER in headers["anthropic-beta"]
 
 
-def test_output_config_supported_for_claude_opus_47():
+def test_output_config_supported_for_claude_opus_47(monkeypatch):
     """Test that output_config is accepted as a direct param for Claude Opus 4.7."""
+    _enable_task_budget_for_opus_47(monkeypatch)
     config = AnthropicConfig()
 
     supported_params = config.get_supported_openai_params(
@@ -1665,7 +1680,7 @@ def test_task_budget_rejected_for_non_opus_47():
 
     with pytest.raises(
         ValueError,
-        match="output_config.task_budget is only supported by Claude Opus 4.7",
+        match="output_config.task_budget is not supported by this model",
     ):
         config.transform_request(
             model="claude-opus-4-6-20260205",
@@ -3668,6 +3683,17 @@ def test_messages_path_advisor_beta_header_preserved_when_user_sends_it():
     optional_params: dict = {"tools": []}
     result = config._update_headers_with_anthropic_beta(headers, optional_params)
     assert "advisor-tool-2026-03-01" in result.get("anthropic-beta", "")
+
+
+def test_messages_path_task_budget_beta_header_injected():
+    """task-budgets beta header is auto-injected in /messages path."""
+    config = AnthropicMessagesConfig()
+    headers: dict = {}
+    optional_params = {
+        "output_config": {"task_budget": {"type": "tokens", "total": 64000}}
+    }
+    result = config._update_headers_with_anthropic_beta(headers, optional_params)
+    assert "task-budgets-2026-03-13" in result.get("anthropic-beta", "")
 
 
 def test_strip_advisor_blocks_when_no_advisor_tool():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1559,6 +1559,128 @@ def test_effort_output_config_preservation():
     assert result["output_config"]["effort"] == "medium"
 
 
+def test_task_budget_output_config_preservation():
+    """Test that output_config with task_budget is preserved for Claude Opus 4.7."""
+    config = AnthropicConfig()
+
+    messages = [{"role": "user", "content": "Run this agentic task"}]
+    optional_params = {
+        "output_config": {
+            "effort": "high",
+            "task_budget": {"type": "tokens", "total": 64000},
+        }
+    }
+
+    result = config.transform_request(
+        model="claude-opus-4-7-20260416",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["output_config"]["effort"] == "high"
+    assert result["output_config"]["task_budget"] == {
+        "type": "tokens",
+        "total": 64000,
+    }
+
+
+def test_task_budget_beta_header_injection():
+    """Test that task budget beta header is added when task_budget is detected."""
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+    from litellm.types.llms.anthropic import ANTHROPIC_TASK_BUDGETS_BETA_HEADER
+
+    model_info = AnthropicModelInfo()
+    optional_params = {
+        "output_config": {"task_budget": {"type": "tokens", "total": 64000}}
+    }
+
+    task_budget_used = model_info.is_task_budget_used(optional_params=optional_params)
+    assert task_budget_used is True
+
+    headers = model_info.get_anthropic_headers(
+        api_key="test-key", task_budget_used=task_budget_used
+    )
+
+    assert "anthropic-beta" in headers
+    assert ANTHROPIC_TASK_BUDGETS_BETA_HEADER in headers["anthropic-beta"]
+
+
+def test_output_config_supported_for_claude_opus_47():
+    """Test that output_config is accepted as a direct param for Claude Opus 4.7."""
+    config = AnthropicConfig()
+
+    supported_params = config.get_supported_openai_params(
+        model="claude-opus-4-7-20260416"
+    )
+
+    assert "output_config" in supported_params
+
+
+def test_output_config_maps_direct_param():
+    """Test that output_config maps from non-default params."""
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={
+            "reasoning_effort": "high",
+            "output_config": {"task_budget": {"type": "tokens", "total": 64000}},
+        },
+        optional_params={},
+        model="claude-opus-4-7-20260416",
+        drop_params=False,
+    )
+
+    assert result["output_config"]["effort"] == "high"
+    assert result["output_config"]["task_budget"] == {
+        "type": "tokens",
+        "total": 64000,
+    }
+
+
+def test_output_config_maps_from_completion_optional_params():
+    """Test that output_config is accepted through the public optional params path."""
+    from litellm.utils import get_optional_params
+
+    result = get_optional_params(
+        model="claude-opus-4-7-20260416",
+        custom_llm_provider="anthropic",
+        messages=[{"role": "user", "content": "Run this agentic task"}],
+        reasoning_effort="high",
+        output_config={"task_budget": {"type": "tokens", "total": 64000}},
+    )
+
+    assert result["output_config"]["effort"] == "high"
+    assert result["output_config"]["task_budget"] == {
+        "type": "tokens",
+        "total": 64000,
+    }
+
+
+def test_task_budget_rejected_for_non_opus_47():
+    """Test that task_budget is rejected for models other than Claude Opus 4.7."""
+    config = AnthropicConfig()
+    messages = [{"role": "user", "content": "Test"}]
+
+    with pytest.raises(
+        ValueError,
+        match="output_config.task_budget is only supported by Claude Opus 4.7",
+    ):
+        config.transform_request(
+            model="claude-opus-4-6-20260205",
+            messages=messages,
+            optional_params={
+                "output_config": {
+                    "effort": "high",
+                    "task_budget": {"type": "tokens", "total": 64000},
+                }
+            },
+            litellm_params={},
+            headers={},
+        )
+
+
 def test_effort_beta_header_injection():
     """Test that effort beta header is automatically added when output_config is detected."""
     from litellm.llms.anthropic.common_utils import AnthropicModelInfo

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -34,13 +34,8 @@ def test_govcloud_cross_region_inference_prefix():
     base_model = bedrock_model_info.get_base_model(
         model="bedrock/us-gov.anthropic.claude-haiku-4-5-20251001-v1:0"
     )
-<<<<<<< worktree-rustling-wishing-kite
-    assert base_model == "anthropic.claude-3-5-sonnet-20240620-v1:0"
-
-=======
     assert base_model == "anthropic.claude-haiku-4-5-20251001-v1:0"
-    
->>>>>>> main
+
     # Test us-gov prefix is stripped correctly for different Claude versions
     base_model = bedrock_model_info.get_base_model(
         model="bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -768,6 +768,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_multimodal": {"type": "boolean"},
                 "uses_embed_content": {"type": "boolean"},
                 "supports_reasoning": {"type": "boolean"},
+                "supports_task_budget": {"type": "boolean"},
                 "supports_minimal_reasoning_effort": {"type": "boolean"},
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},


### PR DESCRIPTION
## Summary
- add typed Anthropic output_config.task_budget support and validation
- add task-budgets beta header injection for chat and messages pass-through paths
- add supports_task_budget model metadata for Claude Opus 4.7 and focused tests

Fixes #25971

## Tests
- uv run pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py -q

Note: formatting commands were not run per request.