### PR TITLE
[Fix] Remove unresolved merge conflict markers in bedrock test file

### DIFF
--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -34,13 +34,8 @@ def test_govcloud_cross_region_inference_prefix():
     base_model = bedrock_model_info.get_base_model(
         model="bedrock/us-gov.anthropic.claude-haiku-4-5-20251001-v1:0"
     )
-<<<<<<< worktree-rustling-wishing-kite
-    assert base_model == "anthropic.claude-3-5-sonnet-20240620-v1:0"
-
-=======
     assert base_model == "anthropic.claude-haiku-4-5-20251001-v1:0"
-    
->>>>>>> main
+
     # Test us-gov prefix is stripped correctly for different Claude versions
     base_model = bedrock_model_info.get_base_model(
         model="bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

`tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py` contains literal `<<<<<<<`, `=======`, `>>>>>>>` markers left over from a past merge. pytest fails to collect the file with `SyntaxError: invalid syntax`, which in turn fails the "All Other Providers" CI job on every PR targeting `litellm_internal_staging`.

### Fix

Remove the conflict markers. Keep the assertion that matches the model under test (`claude-haiku-4-5-20251001-v1:0`) — this matches the resolution already present on `main`.

## Testing

- `uv run pytest tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py -v` — all 3 tests pass.
- `python -c "import ast; ast.parse(open(...))"` — file parses cleanly.

## Type

🐛 Bug Fix
✅ Test

## Screenshots