### PR TITLE
fix(ui): extra_headers not persisting on MCP server edit

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPPermissionManagement.tsx
@@ -27,10 +27,6 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
   // Set initial values when mcpServer changes
   useEffect(() => {
     if (mcpServer) {
-      // Set extra_headers if they exist
-      if (mcpServer.extra_headers) {
-        form.setFieldValue("extra_headers", mcpServer.extra_headers);
-      }
       if (mcpServer.static_headers) {
         const staticHeaders = Object.entries(mcpServer.static_headers).map(([header, value]) => ({
           header,

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -564,7 +564,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         mcp_access_groups: accessGroups,
         alias: restValues.alias,
         // Include permission management fields
-        extra_headers: restValues.extra_headers?.length ? restValues.extra_headers : undefined,
+        extra_headers: restValues.extra_headers || [],
         allowed_tools: allowedTools.length > 0 ? allowedTools : null,
         tool_name_to_display_name: Object.keys(toolNameToDisplayName).length > 0 ? toolNameToDisplayName : null,
         tool_name_to_description: Object.keys(toolNameToDescription).length > 0 ? toolNameToDescription : null,

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -189,6 +189,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       ...mcpServer,
       transport: effectiveTransport,
       static_headers: initialStaticHeaders,
+      extra_headers: mcpServer.extra_headers || [],
       oauth_flow_type: mcpServer.token_url ? OAUTH_FLOW.M2M : OAUTH_FLOW.INTERACTIVE,
       token_validation_json: mcpServer.token_validation
         ? JSON.stringify(mcpServer.token_validation, null, 2)
@@ -563,7 +564,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         mcp_access_groups: accessGroups,
         alias: restValues.alias,
         // Include permission management fields
-        extra_headers: restValues.extra_headers || [],
+        extra_headers: restValues.extra_headers?.length ? restValues.extra_headers : undefined,
         allowed_tools: allowedTools.length > 0 ? allowedTools : null,
         tool_name_to_display_name: Object.keys(toolNameToDisplayName).length > 0 ? toolNameToDisplayName : null,
         tool_name_to_description: Object.keys(toolNameToDescription).length > 0 ? toolNameToDescription : null,


### PR DESCRIPTION
## Summary
- Set `extra_headers` explicitly in `initialValues` memo in `mcp_server_edit.tsx` instead of relying on a `useEffect` → `form.setFieldValue` call in `MCPPermissionManagement.tsx` that races with Antd form initialization and silently fails
- Removed the broken `setFieldValue("extra_headers", ...)` from `MCPPermissionManagement.tsx`
- Changed submit payload to send `undefined` instead of `[]` when extra_headers is empty, so the backend's `exclude_none` drops it rather than overwriting stored values with an empty array

hard to repro because this initial bug is a race condition i think, but this should make it more defensive about keepign the correct values

## Test plan
- [x] Edit an MCP server that has extra_headers set — verify they appear in the form
- [x] Submit the edit without changing extra_headers — verify they are preserved in the DB
- [x] Clear extra_headers and submit — verify they are removed
- [x] Create a new MCP server with extra_headers — verify they persist