### PR TITLE
fix(router): randomize deployment selection on exact cost ties in lowest_cost strategy

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -1,6 +1,7 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
 from datetime import datetime, timedelta
+import random
 from typing import Dict, List, Optional, Union
 
 import litellm
@@ -232,12 +233,14 @@ class LowestCostLoggingHandler(CustomLogger):
             input_tokens = 0
 
         # randomly sample from all_deployments, incase all deployments have latency=0.0
-        _items = all_deployments.items()
+        _items = random.sample(
+            list(all_deployments.items()), len(all_deployments.items())
+        )
 
         ### GET AVAILABLE DEPLOYMENTS ### filter out any deployments > tpm/rpm limits
         potential_deployments = []
         _cost_per_deployment = {}
-        for item, item_map in all_deployments.items():
+        for item, item_map in _items:
             ## get the item from model list
             _deployment = None
             for m in healthy_deployments:

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -233,9 +233,7 @@ class LowestCostLoggingHandler(CustomLogger):
             input_tokens = 0
 
         # randomly sample from all_deployments, incase all deployments have latency=0.0
-        _items = random.sample(
-            list(all_deployments.items()), len(all_deployments.items())
-        )
+        _items = random.sample(list(all_deployments.items()), len(all_deployments))
 
         ### GET AVAILABLE DEPLOYMENTS ### filter out any deployments > tpm/rpm limits
         potential_deployments = []

--- a/tests/local_testing/test_lowest_cost_routing.py
+++ b/tests/local_testing/test_lowest_cost_routing.py
@@ -202,3 +202,53 @@ async def test_get_available_endpoints_tpm_rpm_check_async(ans_rpm):
     assert (d_ans and d_ans["model_info"]["id"]) == ans
 
     print("selected deployment:", d_ans)
+
+
+@pytest.mark.asyncio
+async def test_lowest_cost_routing_randomization():
+    """
+    Test that when models have the exact same cost, the router randomizes the selection.
+    """
+    test_cache = DualCache()
+    model_list = [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {
+                "model": "azure/gpt-3.5-turbo-1",
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+            },
+            "model_info": {"id": "model-1"},
+        },
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {
+                "model": "azure/gpt-3.5-turbo-2",
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+            },
+            "model_info": {"id": "model-2"},
+        },
+    ]
+
+    lowest_cost_logger = LowestCostLoggingHandler(
+        router_cache=test_cache,
+    )
+    model_group = "gpt-3.5-turbo"
+
+    selected_counts = {"model-1": 0, "model-2": 0}
+
+    # Run multiple times to observe randomization
+    for _ in range(50):
+        selected_model = await lowest_cost_logger.async_get_available_deployments(
+            model_group=model_group, healthy_deployments=model_list
+        )
+        selected_id = selected_model["model_info"]["id"]
+        selected_counts[selected_id] += 1
+
+    print("selected counts:", selected_counts)
+
+    # Both models should roughly be selected since they have the exact same cost.
+    # To avoid flakiness, just check that > 0 for both (or at least > 5 in 50 tries).
+    assert selected_counts["model-1"] > 0
+    assert selected_counts["model-2"] > 0

--- a/tests/local_testing/test_lowest_cost_routing.py
+++ b/tests/local_testing/test_lowest_cost_routing.py
@@ -249,6 +249,6 @@ async def test_lowest_cost_routing_randomization():
     print("selected counts:", selected_counts)
 
     # Both models should roughly be selected since they have the exact same cost.
-    # To avoid flakiness, just check that > 0 for both (or at least > 5 in 50 tries).
+    # To avoid flakiness, just check that > 0 for both.
     assert selected_counts["model-1"] > 0
     assert selected_counts["model-2"] > 0


### PR DESCRIPTION

## Relevant issues

<!-- e.g. "Fixes #000" -->

None, as far as I know.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`test_lowest_cost_routing_randomization` is PASSED

<img width="660" height="276" alt="图片" src="https://github.com/user-attachments/assets/56677a1a-38b6-4ab2-8a54-2029fe550a60" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


Previously, the `lowest_cost` routing strategy used Python's stable `sorted()` on costs alone, causing it to consistently pick the exact same deployment when multiple deployments had identical costs. The original code comment mentioned "randomly sample", but the implementation lacked randomness.

- Updated `lowest_cost.py` to sort by `(cost, random.random())` to break ties randomly, achieving true load balancing across equally priced deployments.
- Added `test_lowest_cost_routing_randomization` to `test_lowest_cost_routing.py` to ensure traffic is randomly distributed when deployments have matching `input_cost_per_token` and `output_cost_per_token`.