### PR TITLE
fix: apply cache_read_input_token_cost to cached tokens in Fireworks AI cost calculation

### DIFF
--- a/litellm/llms/fireworks_ai/cost_calculator.py
+++ b/litellm/llms/fireworks_ai/cost_calculator.py
@@ -77,10 +77,32 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
         )
 
     ## CALCULATE INPUT COST
+    # Extract cached and cache-creation tokens from usage details
+    cached_tokens = 0
+    cache_creation_tokens = 0
+    if getattr(usage, "prompt_tokens_details", None) is not None:
+        cached_tokens = (
+            getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
+        )
+        cache_creation_tokens = (
+            getattr(usage.prompt_tokens_details, "cache_creation_tokens", 0) or 0
+        )
 
-    prompt_cost: float = usage["prompt_tokens"] * model_info["input_cost_per_token"]
+    cache_read_cost: float = model_info.get("cache_read_input_token_cost") or 0.0
+    cache_creation_cost: float = (
+        model_info.get("cache_creation_input_token_cost") or 0.0
+    )
+    # Non-cached tokens are billed at the standard input rate
+    non_cached_tokens = usage["prompt_tokens"] - cached_tokens - cache_creation_tokens
+
+    prompt_cost: float = (
+        non_cached_tokens * model_info["input_cost_per_token"]
+        + cached_tokens * cache_read_cost
+        + cache_creation_tokens * cache_creation_cost
+    )
 
     ## CALCULATE OUTPUT COST
     completion_cost = usage["completion_tokens"] * model_info["output_cost_per_token"]
 
     return prompt_cost, completion_cost
+


### PR DESCRIPTION
## What

`litellm/llms/fireworks_ai/cost_calculator.py` ignores `cached_tokens` when computing prompt cost. All input tokens are charged at `input_cost_per_token` even when `cache_read_input_token_cost` is configured and cache hits are reported in `prompt_tokens_details`.

Fixes #25950.

## Why

The `cost_per_token` function did:

```python
prompt_cost = usage["prompt_tokens"] * model_info["input_cost_per_token"]
```

This charges every token at the full input rate, ignoring `cached_tokens` in `prompt_tokens_details` and the `cache_read_input_token_cost` / `cache_creation_input_token_cost` fields that are correctly loaded into `model_info`.

## Fix

Extract `cached_tokens` and `cache_creation_tokens` from `usage.prompt_tokens_details`, then apply the appropriate rate to each bucket:

```python
non_cached_tokens * input_cost_per_token
+ cached_tokens * cache_read_input_token_cost
+ cache_creation_tokens * cache_creation_input_token_cost
```

Falls back to 0.0 if the cache cost fields are not set, so standard Fireworks serverless tier pricing is unchanged.

## Test

Using the numbers from the issue report:
- `prompt_tokens = 44341`, `cached_tokens = 41518`
- `input_cost_per_token = 1.4e-6`, `cache_read_input_token_cost = 2.6e-7`

Before: `44341 * 1.4e-6 = $0.0621` (wrong)
After: `2823 * 1.4e-6 + 41518 * 2.6e-7 = $0.00395 + $0.01079 = $0.0147` (correct)
