### PR TITLE
[Fix] UI - Keys: strip empty premium fields from key update payload

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -757,5 +757,24 @@ describe("KeyInfoView", () => {
         expect.objectContaining({ policies: [] }),
       );
     });
+
+    it("should keep an empty policies field when the previous value lives only at the top level of keyData", async () => {
+      // Defensive: some premium fields may be present at the top level but not
+      // mirrored into metadata. A genuine clear must still be forwarded.
+      const keyData: KeyResponse = {
+        ...MOCK_KEY_DATA,
+        user_id: "proxy-admin-user",
+        metadata: {},
+        policies: ["existing-policy"],
+      } as KeyResponse;
+
+      await enterEditMode(keyData);
+      await editViewMocks.onSubmit!({ key: keyData.token, token: keyData.token, policies: [] });
+
+      expect(keyUpdateCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ policies: [] }),
+      );
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -7,7 +7,19 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useResetKeySpend } from "@/app/(dashboard)/hooks/keys/useResetKeySpend";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
+import { keyUpdateCall } from "../networking";
 import KeyInfoView from "./key_info_view";
+
+const editViewMocks = vi.hoisted(() => ({
+  onSubmit: undefined as ((v: Record<string, any>) => Promise<void>) | undefined,
+}));
+
+vi.mock("./key_edit_view", () => ({
+  KeyEditView: ({ onSubmit }: { onSubmit: (v: Record<string, any>) => Promise<void> }) => {
+    editViewMocks.onSubmit = onSubmit;
+    return <div data-testid="key-edit-view-stub" />;
+  },
+}));
 
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
   default: vi.fn(),
@@ -678,6 +690,72 @@ describe("KeyInfoView", () => {
           expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
         );
       });
+    });
+  });
+
+  describe("premium metadata payload normalization", () => {
+    const enterEditMode = async (keyData: KeyResponse) => {
+      vi.mocked(useAuthorized).mockReturnValue({
+        ...baseUseAuthorizedMock,
+        userId: "proxy-admin-user",
+        userRole: "proxy_admin",
+      });
+      renderWithProviders(
+        <KeyInfoView
+          keyData={keyData}
+          onClose={() => {}}
+          keyId="test-key-id"
+          onKeyDataUpdate={() => {}}
+          teams={[]}
+        />,
+      );
+      await userEvent.click(screen.getByRole("tab", { name: /settings/i }));
+      await userEvent.click(screen.getByRole("button", { name: /edit settings/i }));
+      await waitFor(() => expect(editViewMocks.onSubmit).toBeDefined());
+    };
+
+    beforeEach(() => {
+      editViewMocks.onSubmit = undefined;
+      vi.mocked(keyUpdateCall).mockClear();
+      vi.mocked(keyUpdateCall).mockResolvedValue({});
+    });
+
+    it("should drop an empty policies field when the key previously had no policies", async () => {
+      // Reproduces the real bug: after a successful /key/update, the response echoes
+      // top-level `policies: []` into client state. Without stripping, the next save
+      // resends `[]` and trips the premium gate in prepare_metadata_fields.
+      const keyData: KeyResponse = {
+        ...MOCK_KEY_DATA,
+        user_id: "proxy-admin-user",
+        metadata: {},
+        policies: [],
+      } as KeyResponse;
+
+      await enterEditMode(keyData);
+      await editViewMocks.onSubmit!({ key: keyData.token, token: keyData.token, policies: [] });
+
+      expect(keyUpdateCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.not.objectContaining({ policies: expect.anything() }),
+      );
+    });
+
+    it("should keep an empty policies field when the key previously had policies set", async () => {
+      // Premium users must still be able to clear existing policies by sending `[]`.
+      const keyData: KeyResponse = {
+        ...MOCK_KEY_DATA,
+        user_id: "proxy-admin-user",
+        metadata: { policies: ["existing-policy"] },
+        policies: ["existing-policy"],
+      } as KeyResponse;
+
+      await enterEditMode(keyData);
+      await editViewMocks.onSubmit!({ key: keyData.token, token: keyData.token, policies: [] });
+
+      expect(keyUpdateCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ policies: [] }),
+      );
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -166,7 +166,9 @@ export default function KeyInfoView({
       // state; without this, the next save resends `[]` and trips the premium
       // gate in prepare_metadata_fields for non-premium users.
       for (const field of PREMIUM_METADATA_FIELDS) {
-        const previousValue = (currentKeyData.metadata as Record<string, unknown> | undefined)?.[field];
+        const previousValue =
+          (currentKeyData.metadata as Record<string, unknown> | undefined)?.[field] ??
+          (currentKeyData as unknown as Record<string, unknown>)[field];
         if (isEmptyValue(formValues[field]) && isEmptyValue(previousValue)) {
           delete formValues[field];
         }

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -34,6 +34,21 @@ interface KeyInfoViewProps {
   backButtonText?: string;
 }
 
+// Must stay in sync with LiteLLM_ManagementEndpoint_MetadataFields_Premium
+// in litellm/proxy/_types.py — limited to fields the key-edit form submits.
+const PREMIUM_METADATA_FIELDS = [
+  "policies",
+  "guardrails",
+  "prompts",
+  "tags",
+  "allowed_passthrough_routes",
+] as const;
+
+const isEmptyValue = (v: unknown): boolean =>
+  v == null ||
+  (Array.isArray(v) && v.length === 0) ||
+  (typeof v === "string" && v.trim() === "");
+
 /**
  * ─────────────────────────────────────────────────────────────────────────
  * @deprecated
@@ -144,6 +159,17 @@ export default function KeyInfoView({
       if (!canEditGuardrails) {
         delete formValues.guardrails;
         delete formValues.prompts;
+      }
+
+      // Drop premium metadata fields that are empty AND were empty before.
+      // The /key/update response echoes defaults like `policies: []` back into
+      // state; without this, the next save resends `[]` and trips the premium
+      // gate in prepare_metadata_fields for non-premium users.
+      for (const field of PREMIUM_METADATA_FIELDS) {
+        const previousValue = (currentKeyData.metadata as Record<string, unknown> | undefined)?.[field];
+        if (isEmptyValue(formValues[field]) && isEmptyValue(previousValue)) {
+          delete formValues[field];
+        }
       }
 
       // Handle max budget empty string


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

On the Key Settings page, the second save of a key fails with an enterprise license error — even when the only change is to the model list — as long as the user is not a premium user.

Reproduction:
1. Open Key Settings for any key, change the model list, Save — succeeds.
2. Open the same key again, change the model list again, Save — fails with `"This feature is only available for LiteLLM Enterprise users: policies."`

Root cause: the `/key/update` response includes `policies: []` at the top level (a Pydantic default). The UI merges the response into `currentKeyData`, so the form's `policies` field is populated with `[]` on the next edit via a blanket `...keyData` spread in `key_edit_view.tsx`. On submit, the form sends `policies: []`, and the backend's `prepare_metadata_fields` runs the premium check on any premium field present in the request body regardless of value.

### Fix

In `key_info_view.tsx` `handleKeyUpdate`, drop premium metadata fields from the payload when both the current form value and the previously persisted value in `currentKeyData.metadata` are empty. Genuine clears (non-empty → empty) still pass through so premium users can clear policies/guardrails/etc. as intended. Non-premium users setting a non-empty value still correctly hit the 403. Applied to `policies`, `guardrails`, `prompts`, `tags`, `allowed_passthrough_routes`.

## Testing

Added two unit tests in `key_info_view.test.tsx`:
- Drops `policies` from the update payload when the previously persisted value was empty.
- Keeps `policies: []` in the payload when the previously persisted value was non-empty (so clears still work).

Also manually verified with curl against a local proxy:
- `POST /key/update` with `{"policies":[]}` → **403** (before fix reproduces the bug)
- Same payload with `policies` omitted → **200**
- `{"policies":["x"]}` as a non-premium user → still **403** (security intact)

## Type

🐛 Bug Fix
✅ Test