### PR TITLE
fix(cloudflare): handle API errors and missing response keys gracefully

### DIFF
--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -147,9 +147,29 @@ class CloudflareChatConfig(BaseConfig):
     ) -> ModelResponse:
         completion_response = raw_response.json()
 
-        model_response.choices[0].message.content = completion_response["result"][  # type: ignore
-            "response"
-        ]
+        if not completion_response.get("success", True):
+            errors = completion_response.get("errors", [])
+            raise CloudflareError(
+                status_code=raw_response.status_code,
+                message=f"Cloudflare Error: {errors}",
+            )
+
+        result = completion_response.get("result", {})
+        if result is None:
+            raise CloudflareError(
+                status_code=raw_response.status_code,
+                message=f"Cloudflare Error: result is None. Response: {completion_response}",
+            )
+
+        if "response" in result:
+            model_response.choices[0].message.content = result["response"]
+        elif isinstance(result, str):
+            model_response.choices[0].message.content = result
+        else:
+            raise CloudflareError(
+                status_code=raw_response.status_code,
+                message=f"Cloudflare Error: 'response' key missing from result. Response: {completion_response}",
+            )
 
         prompt_tokens = litellm.utils.get_token_count(messages=messages, model=model)
         completion_tokens = len(

--- a/tests/llm_translation/test_cloudflare.py
+++ b/tests/llm_translation/test_cloudflare.py
@@ -35,6 +35,15 @@ def _chat_response() -> Dict[str, Any]:
     }
 
 
+def _error_response() -> Dict[str, Any]:
+    return {
+        "result": None,
+        "success": False,
+        "errors": [{"code": 7003, "message": "Could not route"}],
+        "messages": [],
+    }
+
+
 def _streaming_chunks() -> list[str]:
     return [
         json.dumps({"response": "I am"}),
@@ -145,3 +154,25 @@ def test_completion_cloudflare_stream(sync_mode):
         if c.choices[0].delta.content
     )
     assert "language" in content.lower()
+
+
+def test_completion_cloudflare_api_error():
+    messages = [{"role": "user", "content": "what llm are you"}]
+    mock_resp = _make_mock_response(_error_response())
+    # Setting to a 200 HTTP code because Cloudflare returns standard HTTP OK even when it wraps error JSONs.
+    mock_resp.status_code = 200
+
+    import litellm
+
+    with patch.object(HTTPHandler, "post", return_value=mock_resp) as mock_post:
+        with pytest.raises(litellm.exceptions.APIConnectionError) as exc_info:
+            completion(
+                model="cloudflare/@cf/meta/llama-2-7b-chat-int8",
+                messages=messages,
+                max_tokens=15,
+                api_base=FAKE_API_BASE,
+                api_key=FAKE_API_KEY,
+            )
+        
+        mock_post.assert_called_once()
+        assert "7003" in str(exc_info.value)

--- a/tests/llm_translation/test_cloudflare.py
+++ b/tests/llm_translation/test_cloudflare.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from litellm import acompletion, completion
+from litellm.exceptions import APIConnectionError
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 
 FAKE_API_BASE = (
@@ -162,10 +163,8 @@ def test_completion_cloudflare_api_error():
     # Setting to a 200 HTTP code because Cloudflare returns standard HTTP OK even when it wraps error JSONs.
     mock_resp.status_code = 200
 
-    import litellm
-
     with patch.object(HTTPHandler, "post", return_value=mock_resp) as mock_post:
-        with pytest.raises(litellm.exceptions.APIConnectionError) as exc_info:
+        with pytest.raises(APIConnectionError) as exc_info:
             completion(
                 model="cloudflare/@cf/meta/llama-2-7b-chat-int8",
                 messages=messages,
@@ -173,6 +172,6 @@ def test_completion_cloudflare_api_error():
                 api_base=FAKE_API_BASE,
                 api_key=FAKE_API_KEY,
             )
-        
+
         mock_post.assert_called_once()
         assert "7003" in str(exc_info.value)


### PR DESCRIPTION
Fixes - 
Prevents an unhandled `KeyError: 'response'` during Cloudflare Worker AI API failures (e.g. invalid models, authentication issues) by properly reading the `success` field and extracting the provider `errors` payload into a standard `CloudflareError`.

#25999 