### PR TITLE
feat(prometheus): add exclude_labels support to PrometheusMetricsConfig

### DIFF
--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -523,10 +523,28 @@ litellm_settings:
         - "requested_model"
 ```
 
+### Exclude Specific Labels
+
+Use `exclude_labels` to strip specific labels from metrics — useful for privacy (e.g. removing `end_user`) or reducing cardinality. `exclude_labels` applies after `include_labels` when both are specified.
+
+```yaml
+litellm_settings:
+  callbacks: ["prometheus"]
+  prometheus_metrics_config:
+    - group: "privacy_filtered"
+      metrics:
+        - "litellm_proxy_total_requests_metric"
+        - "litellm_requests_metric"
+      exclude_labels:
+        - "end_user"
+        - "api_key_hash"
+```
+
 **Configuration Structure:**
 - `group`: A descriptive name for organizing related metrics
 - `metrics`: List of metric names to include in this group  
 - `include_labels`: (Optional) List of labels to include for these metrics
+- `exclude_labels`: (Optional) List of labels to strip from these metrics (applied after `include_labels`)
 
 **Default Behavior**: If no `prometheus_metrics_config` is specified, all metrics are enabled with their default labels (backward compatible).
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -84,6 +84,7 @@ class PrometheusLogger(CustomLogger):
             from prometheus_client import Counter, Gauge, Histogram
 
             # Always initialize label_filters, even for non-premium users
+            self.exclude_label_filters: Dict[str, List[str]] = {}
             self.label_filters = self._parse_prometheus_config()
 
             _custom_buckets = litellm.prometheus_latency_buckets
@@ -620,6 +621,13 @@ class PrometheusLogger(CustomLogger):
                     if label_error:
                         label_errors.append(label_error)
 
+                if config.exclude_labels:
+                    label_error = self._validate_single_metric_labels(
+                        metric_name, config.exclude_labels
+                    )
+                    if label_error:
+                        label_errors.append(label_error)
+
         return ValidationResults(metric_errors=metric_errors, label_errors=label_errors)
 
     def _validate_single_metric_name(
@@ -663,10 +671,12 @@ class PrometheusLogger(CustomLogger):
 
         for config in parsed_configs:
             for metric_name in config.metrics:
+                if self._validate_single_metric_name(metric_name) is not None:
+                    continue
                 if config.include_labels:
-                    # Only add if metric name is valid (validation already passed)
-                    if self._validate_single_metric_name(metric_name) is None:
-                        label_filters[metric_name] = config.include_labels
+                    label_filters[metric_name] = config.include_labels
+                if config.exclude_labels:
+                    self.exclude_label_filters[metric_name] = config.exclude_labels
 
         return label_filters
 
@@ -979,19 +989,21 @@ class PrometheusLogger(CustomLogger):
         # Get default labels for this metric from PrometheusMetricLabels
         default_labels = PrometheusMetricLabels.get_labels(metric_name)
 
-        # If no label filtering is configured for this metric, use default labels
-        if metric_name not in self.label_filters:
-            return default_labels
+        # Apply include_labels filter (allowlist)
+        if metric_name in self.label_filters:
+            configured_labels = self.label_filters[metric_name]
+            default_labels = [
+                label for label in default_labels if label in configured_labels
+            ]
 
-        # Get configured labels for this metric
-        configured_labels = self.label_filters[metric_name]
+        # Apply exclude_labels filter (blocklist)
+        if metric_name in self.exclude_label_filters:
+            excluded_labels = self.exclude_label_filters[metric_name]
+            default_labels = [
+                label for label in default_labels if label not in excluded_labels
+            ]
 
-        # Return intersection of configured and default labels to ensure we only use valid labels
-        filtered_labels = [
-            label for label in default_labels if label in configured_labels
-        ]
-
-        return filtered_labels
+        return default_labels
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         # Define prometheus client

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -853,7 +853,7 @@ class PrometheusSettings(BaseModel):
     prometheus_metrics_config: Optional[List[PrometheusMetricsConfig]] = Field(
         None,
         description="Configuration for filtering Prometheus metrics by groups and labels",
-    ) 6a34147f38 (feat(prometheus): add exclude_labels support to PrometheusMetricsConfig)
+    )
 
 
 class NoOpMetric:

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -841,6 +841,10 @@ class PrometheusMetricsConfig(BaseModel):
         None,
         description="List of labels to include for these metrics. If None, includes all default labels.",
     )
+    exclude_labels: Optional[List[str]] = Field(
+        None,
+        description="List of labels to exclude from these metrics. Applied after include_labels.",
+    )
 
 
 class PrometheusSettings(BaseModel):
@@ -849,7 +853,7 @@ class PrometheusSettings(BaseModel):
     prometheus_metrics_config: Optional[List[PrometheusMetricsConfig]] = Field(
         None,
         description="Configuration for filtering Prometheus metrics by groups and labels",
-    )
+    ) 6a34147f38 (feat(prometheus): add exclude_labels support to PrometheusMetricsConfig)
 
 
 class NoOpMetric:

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
@@ -1061,3 +1061,94 @@ async def test_langfuse_otel_callback_failure_metric(prometheus_logger):
 # ==============================================================================
 # END CALLBACK FAILURE METRICS TESTS
 # ==============================================================================
+
+
+# ==============================================================================
+# EXCLUDE LABELS TESTS
+# ==============================================================================
+
+
+def test_exclude_labels_removes_specified_labels():
+    """exclude_labels removes specified labels from a metric's label set"""
+    clear_prometheus_registry()
+
+    test_config = [
+        {
+            "group": "service_metrics",
+            "metrics": ["litellm_deployment_failure_responses"],
+            "exclude_labels": ["team", "api_provider"],
+        }
+    ]
+    litellm.prometheus_metrics_config = test_config
+
+    logger = PrometheusLogger()
+    labels = logger.get_labels_for_metric("litellm_deployment_failure_responses")
+
+    assert "team" not in labels
+    assert "api_provider" not in labels
+    # Other labels should still be present
+    assert len(labels) > 0
+
+    litellm.prometheus_metrics_config = None
+
+
+def test_exclude_labels_config_type():
+    """PrometheusMetricsConfig accepts exclude_labels field"""
+    config = PrometheusMetricsConfig(
+        group="service_metrics",
+        metrics=["litellm_deployment_failure_responses"],
+        exclude_labels=["team"],
+    )
+    assert config.exclude_labels == ["team"]
+    assert config.include_labels is None
+
+
+def test_exclude_labels_and_include_labels_together():
+    """include_labels applies first, then exclude_labels removes from the result"""
+    clear_prometheus_registry()
+
+    default_labels = PrometheusMetricLabels.get_labels(
+        "litellm_deployment_failure_responses"
+    )
+    # Pick two labels that are in the default set
+    include = default_labels[:3]
+    exclude = [include[0]]
+
+    test_config = [
+        {
+            "group": "service_metrics",
+            "metrics": ["litellm_deployment_failure_responses"],
+            "include_labels": include,
+            "exclude_labels": exclude,
+        }
+    ]
+    litellm.prometheus_metrics_config = test_config
+
+    logger = PrometheusLogger()
+    labels = logger.get_labels_for_metric("litellm_deployment_failure_responses")
+
+    assert exclude[0] not in labels
+    for label in include[1:]:
+        assert label in labels
+
+    litellm.prometheus_metrics_config = None
+
+
+def test_no_exclude_labels_returns_all_defaults():
+    """When exclude_labels is not set the full default label set is returned"""
+    clear_prometheus_registry()
+
+    litellm.prometheus_metrics_config = None
+    logger = PrometheusLogger()
+
+    default_labels = PrometheusMetricLabels.get_labels(
+        "litellm_deployment_failure_responses"
+    )
+    labels = logger.get_labels_for_metric("litellm_deployment_failure_responses")
+
+    assert labels == default_labels
+
+
+# ==============================================================================
+# END EXCLUDE LABELS TESTS
+# ==============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-13T16:35:18.496811Z"
+exclude-newer = "2026-04-15T20:50:13.172129Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3767,7 +3767,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.8"
+version = "1.83.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -4114,7 +4114,7 @@ source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.65"
+version = "0.4.66"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature
📖 Documentation

## Changes

Adds `exclude_labels` to `PrometheusMetricsConfig` so users can strip specific labels from metrics groups.

Use case: drop `end_user` or `api_key_hash` from high-cardinality metrics for privacy or to reduce Prometheus series count.

```yaml
litellm_settings:
  callbacks: ["prometheus"]
  prometheus_metrics_config:
    - group: "privacy_filtered"
      metrics:
        - "litellm_proxy_total_requests_metric"
      exclude_labels:
        - "end_user"
        - "api_key_hash"
```

`exclude_labels` is applied after `include_labels` when both are set.

Docs added to `docs/proxy/prometheus.md`.