### PR TITLE
fix: url construction for trailing v1 base urls

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -721,14 +721,17 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         if api_key is None:
             api_key = get_secret_str("OPENAI_API_KEY")
 
-        # Strip api_base to just the base URL (scheme + host + port)
-        parsed_url = httpx.URL(api_base)
-        base_url = f"{parsed_url.scheme}://{parsed_url.host}"
-        if parsed_url.port:
-            base_url += f":{parsed_url.port}"
+        # Remove trailing slash from api_base if present
+        api_base = api_base.rstrip("/")
+
+        # If api_base already ends with /v1, just append /models
+        if api_base.endswith("/v1"):
+            url = f"{api_base}/models"
+        else:
+            url = f"{api_base}/v1/models"
 
         response = litellm.module_level_client.get(
-            url=f"{base_url}/v1/models",
+            url=url,
             headers={"Authorization": f"Bearer {api_key}"},
         )
 

--- a/tests/litellm/llms/test_openai_get_models_url.py
+++ b/tests/litellm/llms/test_openai_get_models_url.py
@@ -51,3 +51,37 @@ class TestGetModelsUrl:
     def test_localhost_without_v1(self):
         """Localhost with port but no /v1 should get /v1/models appended."""
         assert self._get_url_for_api_base("http://localhost:11434") == "http://localhost:11434/v1/models"
+
+    def test_default_api_base(self):
+        """If api_base is None, it should default to OpenAI and append /v1/models."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+
+        with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+            OpenAIGPTConfig().get_models(api_key="fake-key", api_base=None)
+            assert mock_get.call_args.kwargs["url"] == "https://api.openai.com/v1/models"
+
+    @patch("litellm.llms.openai.chat.gpt_transformation.get_secret_str", return_value="default-key")
+    def test_default_api_key(self, mock_get_secret):
+        """If api_key is None, it should fetch from secrets."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+
+        with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+            OpenAIGPTConfig().get_models(api_key=None, api_base="https://example.com")
+            assert mock_get.call_args.kwargs["url"] == "https://example.com/v1/models"
+            assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer default-key"
+
+    def test_get_models_error(self):
+        """If the API returns an error, get_models should raise an exception."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Error message"
+
+        import pytest
+        with patch("litellm.module_level_client.get", return_value=mock_response):
+            with pytest.raises(Exception) as exc:
+                OpenAIGPTConfig().get_models(api_key="fake-key", api_base="https://example.com")
+            assert "Failed to get models: Error message" in str(exc.value)

--- a/tests/litellm/llms/test_openai_get_models_url.py
+++ b/tests/litellm/llms/test_openai_get_models_url.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+
+
+class TestGetModelsUrl:
+    """Test that get_models() constructs the correct /v1/models URL from api_base."""
+
+    def _get_url_for_api_base(self, api_base: str) -> str:
+        """Call get_models() with a mocked HTTP client and return the URL it used."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+
+        with patch("litellm.module_level_client.get", return_value=mock_response) as mock_get:
+            OpenAIGPTConfig().get_models(api_key="fake-key", api_base=api_base)
+            return mock_get.call_args.kwargs["url"]
+
+    def test_plain_base_url(self):
+        """Standard OpenAI base URL without path should get /v1/models appended."""
+        assert self._get_url_for_api_base("https://api.openai.com") == "https://api.openai.com/v1/models"
+
+    def test_trailing_slash(self):
+        """Trailing slash should be stripped before appending /v1/models."""
+        assert self._get_url_for_api_base("https://api.openai.com/") == "https://api.openai.com/v1/models"
+
+    def test_v1_already_present(self):
+        """api_base ending in /v1 should only get /models appended, not /v1/models."""
+        assert self._get_url_for_api_base("https://api.openai.com/v1") == "https://api.openai.com/v1/models"
+
+    def test_v1_with_trailing_slash(self):
+        """api_base ending in /v1/ should be normalized and get /models appended."""
+        assert self._get_url_for_api_base("https://api.openai.com/v1/") == "https://api.openai.com/v1/models"
+
+    def test_subpath_with_v1(self):
+        """api_base with a sub-path ending in /v1 should preserve the full path."""
+        assert self._get_url_for_api_base("https://opencode.ai/zen/v1") == "https://opencode.ai/zen/v1/models"
+
+    def test_subpath_with_v1_trailing_slash(self):
+        """Sub-path with /v1/ should be normalized and get /models appended."""
+        assert self._get_url_for_api_base("https://opencode.ai/zen/v1/") == "https://opencode.ai/zen/v1/models"
+
+    def test_subpath_without_v1(self):
+        """Sub-path without /v1 should get /v1/models appended."""
+        assert self._get_url_for_api_base("https://opencode.ai/zen") == "https://opencode.ai/zen/v1/models"
+
+    def test_localhost_with_port_and_v1(self):
+        """Localhost with port and /v1 should only get /models appended."""
+        assert self._get_url_for_api_base("http://localhost:11434/v1") == "http://localhost:11434/v1/models"
+
+    def test_localhost_without_v1(self):
+        """Localhost with port but no /v1 should get /v1/models appended."""
+        assert self._get_url_for_api_base("http://localhost:11434") == "http://localhost:11434/v1/models"


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #26009 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

Before fix: test failing
```
PASS: https://api.openai.com                    -> https://api.openai.com/v1/models
PASS: https://api.openai.com/v1                 -> https://api.openai.com/v1/models
FAIL: https://opencode.ai/zen/v1                -> https://opencode.ai/v1/models
      expected                                   -> https://opencode.ai/zen/v1/models
FAIL: https://opencode.ai/zen                   -> https://opencode.ai/v1/models
      expected                                   -> https://opencode.ai/zen/v1/models
PASS: http://localhost:11434/v1                 -> http://localhost:11434/v1/models
```

After fix: tests passing
```
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_plain_base_url PASSED [ 11%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_trailing_slash PASSED [ 22%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_v1_already_present PASSED [ 33%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_v1_with_trailing_slash PASSED [ 44%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_subpath_with_v1 PASSED [ 55%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_subpath_with_v1_trailing_slash PASSED [ 66%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_subpath_without_v1 PASSED [ 77%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_localhost_with_port_and_v1 PASSED [ 88%]
tests/litellm/llms/test_openai_get_models_url.py::TestGetModelsUrl::test_localhost_without_v1 PASSED [100%]
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Fix: Preserves sub-paths in api_base and avoids duplicate /v1 segments when calling get_models() in OpenAIGPTConfig. Fixes #26009.
Tests: Adds unit tests for get_models() URL construction across multiple api_base formats.