### PR TITLE
bump litellm-proxy-extras to 0.4.67

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.36"
+version = "0.1.38"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -25,7 +25,7 @@ required-version = "==0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.36"
+version = "0.1.38"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.66"
+version = "0.4.67"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -25,7 +25,7 @@ required-version = "==0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.66"
+version = "0.4.67"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ proxy = [
     "azure-identity==1.25.2",
     "azure-storage-blob==12.28.0",
     "mcp==1.26.0",
-    "litellm-proxy-extras==0.4.66",
+    "litellm-proxy-extras==0.4.67",
     "litellm-enterprise==0.1.37",
     "RestrictedPython==8.1",
     "rich==13.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ proxy = [
     "azure-storage-blob==12.28.0",
     "mcp==1.26.0",
     "litellm-proxy-extras==0.4.67",
-    "litellm-enterprise==0.1.37",
+    "litellm-enterprise==0.1.38",
     "RestrictedPython==8.1",
     "rich==13.9.4",
     "polars==1.38.1",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-16T01:58:08.296393Z"
+exclude-newer = "2026-04-16T02:00:05.930008Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3413,7 +3413,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.36"
+version = "0.1.38"
 source = { editable = "enterprise" }
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-16T01:42:55.429233Z"
+exclude-newer = "2026-04-16T01:58:08.296393Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3418,7 +3418,7 @@ source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.66"
+version = "0.4.67"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

🚄 Infrastructure

## Changes

- Bumped `litellm-proxy-extras` from `0.4.66` → `0.4.67` in `litellm-proxy-extras/pyproject.toml`
- Updated the pin in `pyproject.toml` `[project.optional-dependencies.proxy]` to match
- Regenerated `uv.lock`