### PR TITLE
[Fix] CI: e2e_ui_testing tests stale bundle on Ubuntu (cp -r merge semantics)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3051,10 +3051,19 @@ jobs:
             - ui/litellm-dashboard/node_modules
       - run:
           name: Build UI from source
+          # Prior version used `cp -r out/ ../../litellm/proxy/_experimental/out/`.
+          # GNU cp (used on CircleCI's Ubuntu image) interprets that as "copy the
+          # source directory as a child of the destination" when the destination
+          # already exists — silently creating `_experimental/out/out/` instead of
+          # replacing the served bundle. The proxy continued serving whatever was
+          # checked into `_experimental/out/*`, so this job was effectively testing
+          # the pre-build bundle on every run. Replace-and-move guarantees the
+          # freshly built bundle is what the proxy actually serves.
           command: |
             cd ui/litellm-dashboard
             npm run build
-            cp -r out/ ../../litellm/proxy/_experimental/out/
+            rm -rf ../../litellm/proxy/_experimental/out
+            mv out ../../litellm/proxy/_experimental/out
             # Restructure HTML so extensionless routes work (login.html -> login/index.html)
             find ../../litellm/proxy/_experimental/out -name '*.html' ! -name 'index.html' | while read -r f; do
               d="${f%.html}"; mkdir -p "$d"; mv "$f" "$d/index.html"


### PR DESCRIPTION
## Summary

### The problem

Every `e2e_ui_testing` run between the job's introduction on 2026-04-08 (commit `d09d98a70a`, adding the `Build UI from source` step) and the bundle-rebuild commit on 2026-04-18 (`de790fd273`) was testing a stale UI bundle — not the one produced from the branch's source.

The bundle that ended up in production had the double-prefix bug (`NEXT_PUBLIC_BASE_URL="ui/"` in `.env.production` combined with `networking.tsx` reading that env var, inlined by Next.js into a minified `proxyBaseUrl = "/ui/"` in the compiled JS). The trigger was in source from PR #25109 on 2026-04-06 — roughly 12 days before the broken bundle landed in `_experimental/out/`. During that window, `e2e_ui_testing` ran many times, built the broken bundle from source each time, and passed anyway.

### Failure path (before fix)

The `Build UI from source` step ran:

```sh
cd ui/litellm-dashboard
npm run build
cp -r out/ ../../litellm/proxy/_experimental/out/
```

GNU `cp` (coreutils 8.32, which is what CircleCI's Ubuntu image ships) interprets `cp -r src/ dest/` as "copy the source directory as a **child** of the destination" when the destination already exists. The command silently created `litellm/proxy/_experimental/out/out/` — a nested dir the proxy does not serve — and left the served root `litellm/proxy/_experimental/out/*` untouched.

The proxy continued serving whatever bundle was checked into the repo. Playwright's `globalSetup` logged in against the stale (pre-PR) bundle, which worked fine. The freshly built bundle — the one that actually carried the bug — never reached the HTTP layer.

### Fix

Replace the ambiguous `cp -r` with an unambiguous `rm -rf` + `mv`:

```sh
rm -rf ../../litellm/proxy/_experimental/out
mv out ../../litellm/proxy/_experimental/out
```

This cleanly swaps the destination for the freshly built bundle with no merging, no nested subdirectory, and no dependence on the quirks of whichever `cp` implementation the CI image ships.

## Testing

Reproduced and verified end-to-end on Ubuntu 22.04 / GNU coreutils 8.32 (matching CircleCI):

| State | `ui/` literal occurrences in served bundle | Local e2e outcome |
|---|---|---|
| Bug source + current `cp -r` command | 0 (stale bundle still served) | passes (stale bundle works) |
| Bug source + `rm -rf` / `mv` fix | 9 (fresh broken bundle reaches proxy) | `globalSetup` times out at login — suite fully blocked, which is the intended signal |
| Bug removed + `rm -rf` / `mv` fix | 0 (fresh clean bundle reaches proxy) | 18 passed (2 pre-existing flakes unrelated to routing, 2 `test.skip`'d) |

Local repro was done with the same stack CI uses: postgres 16, mock LLM server on 8090, `python -m litellm.proxy.proxy_cli` on 4000, `cimg/python:3.12-browsers`-equivalent build.

## Why no new test infrastructure

The existing Playwright `globalSetup` already exercises what the user sees — it logs in as each role and waits for the post-login redirect. If the UI bundle can't reach the API, login POST 404s, the redirect never happens, `waitForURL` times out, and every downstream spec is blocked. That's the canonical catch for this class of bug; it just needed CI to actually hand it the freshly built bundle.

An earlier draft of this PR added a `guardedPage` fixture with request/response listeners. It was removed: status-based 4xx detection produced false positives on legitimate Next.js internals like `/__next._tree.txt?_rsc=…`, and the URL-pattern alternative required maintaining a ~50-entry API-verb list in parallel with `networking.tsx`. Once the CI rebuild-step bug is fixed, the existing `globalSetup` is sufficient.

## Type

🐛 Bug Fix
🚄 Infrastructure

## Follow-ups not in this PR

- **Branch-filter gap.** The `e2e_ui_testing` workflow filter runs on `main` and `/litellm_.*/`. Bundle-rebuild commits pushed to branches that don't match that pattern (e.g. `yj_ui_build_apr18`, which is how the broken bundle actually reached `litellm_internal_staging` on 2026-04-18) skip the UI suite entirely. Worth broadening the filter or path-triggering on `_experimental/out/**` changes.
- **Branch protection.** Mark the CircleCI `e2e_ui_testing` status as a required check on `litellm_internal_staging` / `main` in the repo settings UI.
