### PR TITLE
fix(openai): use ssl-aware http client in text completion streaming

### DIFF
--- a/litellm/llms/openai/completion/handler.py
+++ b/litellm/llms/openai/completion/handler.py
@@ -114,7 +114,7 @@ class OpenAITextCompletion(BaseLLM):
                     openai_client = OpenAI(
                         api_key=api_key,
                         base_url=api_base,
-                        http_client=litellm.client_session,
+                        http_client=BaseOpenAILLM._get_sync_http_client(),
                         timeout=timeout,
                         max_retries=max_retries,  # type: ignore
                         organization=organization,
@@ -224,7 +224,7 @@ class OpenAITextCompletion(BaseLLM):
             openai_client = OpenAI(
                 api_key=api_key,
                 base_url=api_base,
-                http_client=litellm.client_session,
+                http_client=BaseOpenAILLM._get_sync_http_client(),
                 timeout=timeout,
                 max_retries=max_retries,  # type: ignore
                 organization=organization,
@@ -285,7 +285,7 @@ class OpenAITextCompletion(BaseLLM):
             openai_client = AsyncOpenAI(
                 api_key=api_key,
                 base_url=api_base,
-                http_client=litellm.aclient_session,
+                http_client=BaseOpenAILLM._get_async_http_client(),
                 timeout=timeout,
                 max_retries=max_retries,
                 organization=organization,


### PR DESCRIPTION
## Root Cause

The `streaming()`, `async_streaming()`, and sync non-streaming `completion()` methods in `OpenAITextCompletion` (`litellm/llms/openai/completion/handler.py`) used `litellm.client_session` and `litellm.aclient_session` directly when creating OpenAI clients. These global sessions bypass SSL verification settings configured via `ssl_verify=False`.

Meanwhile, the `acompletion()` method already used `BaseOpenAILLM._get_async_http_client()` which correctly calls `get_ssl_configuration()` to respect the `ssl_verify` parameter.

## Fix

Changed all four code paths to consistently use `BaseOpenAILLM._get_sync_http_client()` and `BaseOpenAILLM._get_async_http_client()`, which call `get_ssl_configuration()` and properly respect the `ssl_verify` setting.

### Before
```python
# streaming() - line 227
http_client=litellm.client_session,        # ignores ssl_verify

# async_streaming() - line 288  
http_client=litellm.aclient_session,       # ignores ssl_verify

# completion() sync non-streaming - line 117
http_client=litellm.client_session,        # ignores ssl_verify
```

### After
```python
# streaming()
http_client=BaseOpenAILLM._get_sync_http_client(),    # respects ssl_verify

# async_streaming()
http_client=BaseOpenAILLM._get_async_http_client(),   # respects ssl_verify

# completion() sync non-streaming
http_client=BaseOpenAILLM._get_sync_http_client(),    # respects ssl_verify
```

## Testing

The fix is consistent with the existing `acompletion()` method (line 171) which already used `BaseOpenAILLM._get_async_http_client()`. The existing test `test_acompletion_uses_optimized_http_client` in `tests/llm_translation/test_text_completion_unit_tests.py` validates this pattern.

## Impact

- Changes 3 lines in a single file
- No API changes, no new dependencies
- Fixes #26053