### PR TITLE
fix: trigger eager fetch_stream for deferred streaming to enable fallbacks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2219,29 +2219,7 @@ class Router:
                     response.completion_stream is None
                     and response.make_call is not None
                 ):
-                    try:
-                        await response.fetch_stream()
-                    except Exception as fetch_err:
-                        # Strip Content-Length from upstream headers to prevent mismatch
-                        # when LiteLLM creates its own error response body
-                        _headers = getattr(fetch_err, "headers", None)
-                        if _headers:
-                            setattr(
-                                fetch_err,
-                                "headers",
-                                {
-                                    k: v
-                                    for k, v in _headers.items()
-                                    if k.lower()
-                                    not in (
-                                        "content-length",
-                                        "transfer-encoding",
-                                        "content-encoding",
-                                        "content-type",
-                                    )
-                                },
-                            )
-                        raise fetch_err
+                    await response.fetch_stream()
 
                 return await self._acompletion_streaming_iterator(
                     model_response=response,
@@ -5499,8 +5477,8 @@ class Router:
                     return response
 
                 else:
-                    error_message = "model={}. context_window_fallbacks={}.\n\nSet 'context_window_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
-                        model_group, context_window_fallbacks
+                    error_message = "model={}. context_window_fallbacks={}. fallbacks={}.\n\nSet 'context_window_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
+                        model_group, context_window_fallbacks, fallbacks
                     )
                     verbose_router_logger.info(
                         msg="Got 'ContextWindowExceededError'. No context_window_fallback set. Defaulting \
@@ -5534,8 +5512,8 @@ class Router:
                     )
                     return response
                 else:
-                    error_message = "model={}. content_policy_fallbacks={}.\n\nSet 'content_policy_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
-                        model_group, content_policy_fallbacks
+                    error_message = "model={}. content_policy_fallback={}. fallbacks={}.\n\nSet 'content_policy_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
+                        model_group, content_policy_fallbacks, fallbacks
                     )
                     verbose_router_logger.info(
                         msg="Got 'ContentPolicyViolationError'. No content_policy_fallback set. Defaulting \
@@ -5563,7 +5541,7 @@ class Router:
                         f"No fallback model group found for original model_group={model_group}. Fallbacks={fallbacks}"
                     )
                     if hasattr(original_exception, "message"):
-                        original_exception.message += f" No fallback model group found for original model_group={model_group}."  # type: ignore
+                        original_exception.message += f"No fallback model group found for original model_group={model_group}. Fallbacks={fallbacks}"  # type: ignore
                     raise original_exception
 
                 input_kwargs.update(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1800,6 +1800,9 @@ class Router:
                 async for item in model_response:
                     yield item
             except MidStreamFallbackError as e:
+                if not (e.is_pre_first_chunk or not e.generated_content):
+                    raise
+
                 from litellm.main import stream_chunk_builder
 
                 complete_response_object = stream_chunk_builder(
@@ -2210,6 +2213,36 @@ class Router:
             )
 
             if isinstance(response, CustomStreamWrapper):
+                # HTTP call is deferred until first iteration for streaming
+                # Trigger it now to catch errors early and enable normal fallback
+                if (
+                    response.completion_stream is None
+                    and response.make_call is not None
+                ):
+                    try:
+                        await response.fetch_stream()
+                    except Exception as fetch_err:
+                        # Strip Content-Length from upstream headers to prevent mismatch
+                        # when LiteLLM creates its own error response body
+                        _headers = getattr(fetch_err, "headers", None)
+                        if _headers:
+                            setattr(
+                                fetch_err,
+                                "headers",
+                                {
+                                    k: v
+                                    for k, v in _headers.items()
+                                    if k.lower()
+                                    not in (
+                                        "content-length",
+                                        "transfer-encoding",
+                                        "content-encoding",
+                                        "content-type",
+                                    )
+                                },
+                            )
+                        raise fetch_err
+
                 return await self._acompletion_streaming_iterator(
                     model_response=response,
                     messages=messages,
@@ -3864,7 +3897,7 @@ class Router:
             self._add_deployment_model_to_endpoint_for_llm_passthrough_route(
                 kwargs=kwargs, model=model, model_name=model_name
             )
-            
+
             # Get custom_llm_provider from deployment params
             try:
                 custom_llm_provider = data.get("custom_llm_provider")
@@ -3872,10 +3905,12 @@ class Router:
                     model=data["model"],
                     custom_llm_provider=custom_llm_provider,
                 )
-                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+                custom_llm_provider = (
+                    custom_llm_provider or inferred_custom_llm_provider
+                )
             except Exception:
                 custom_llm_provider = None
-            
+
             # Build response kwargs
             response_kwargs = {
                 **data,
@@ -3885,7 +3920,7 @@ class Router:
             # Only set custom_llm_provider if it's not None
             if custom_llm_provider is not None:
                 response_kwargs["custom_llm_provider"] = custom_llm_provider
-            
+
             response = original_generic_function(**response_kwargs)
 
             rpm_semaphore = self._get_client(
@@ -3981,7 +4016,9 @@ class Router:
                     model=data["model"],
                     custom_llm_provider=custom_llm_provider,
                 )
-                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+                custom_llm_provider = (
+                    custom_llm_provider or inferred_custom_llm_provider
+                )
             except Exception:
                 custom_llm_provider = None
 
@@ -4246,7 +4283,9 @@ class Router:
                     custom_llm_provider=custom_llm_provider,
                 )
                 # Preserve explicitly stored provider, fallback to inferred
-                custom_llm_provider = custom_llm_provider or inferred_custom_llm_provider
+                custom_llm_provider = (
+                    custom_llm_provider or inferred_custom_llm_provider
+                )
 
                 ## REPLACE MODEL IN FILE WITH SELECTED DEPLOYMENT ##
                 purpose = cast(Optional[OpenAIFilesPurpose], kwargs.get("purpose"))
@@ -5355,9 +5394,9 @@ class Router:
             e,
             (litellm.ContextWindowExceededError, litellm.ContentPolicyViolationError),
         )
-        _request_team_id: Optional[str] = (
-            kwargs.get("metadata", {}) or {}
-        ).get("user_api_key_team_id")
+        _request_team_id: Optional[str] = (kwargs.get("metadata", {}) or {}).get(
+            "user_api_key_team_id"
+        )
         all_deployments = self._get_all_deployments(
             model_name=original_model_group, team_id=_request_team_id
         )
@@ -5460,8 +5499,8 @@ class Router:
                     return response
 
                 else:
-                    error_message = "model={}. context_window_fallbacks={}. fallbacks={}.\n\nSet 'context_window_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
-                        model_group, context_window_fallbacks, fallbacks
+                    error_message = "model={}. context_window_fallbacks={}.\n\nSet 'context_window_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
+                        model_group, context_window_fallbacks
                     )
                     verbose_router_logger.info(
                         msg="Got 'ContextWindowExceededError'. No context_window_fallback set. Defaulting \
@@ -5495,8 +5534,8 @@ class Router:
                     )
                     return response
                 else:
-                    error_message = "model={}. content_policy_fallback={}. fallbacks={}.\n\nSet 'content_policy_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
-                        model_group, content_policy_fallbacks, fallbacks
+                    error_message = "model={}. content_policy_fallbacks={}.\n\nSet 'content_policy_fallback' - https://docs.litellm.ai/docs/routing#fallbacks".format(
+                        model_group, content_policy_fallbacks
                     )
                     verbose_router_logger.info(
                         msg="Got 'ContentPolicyViolationError'. No content_policy_fallback set. Defaulting \
@@ -5524,7 +5563,7 @@ class Router:
                         f"No fallback model group found for original model_group={model_group}. Fallbacks={fallbacks}"
                     )
                     if hasattr(original_exception, "message"):
-                        original_exception.message += f"No fallback model group found for original model_group={model_group}. Fallbacks={fallbacks}"  # type: ignore
+                        original_exception.message += f" No fallback model group found for original model_group={model_group}."  # type: ignore
                     raise original_exception
 
                 input_kwargs.update(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1825,24 +1825,7 @@ class Router:
                         "content_policy_fallbacks", self.content_policy_fallbacks
                     )
                     initial_kwargs["original_function"] = self._acompletion
-                    if e.is_pre_first_chunk or not e.generated_content:
-                        # No content was generated before the error (e.g. a
-                        # rate-limit 429 on the very first chunk).  Retry with
-                        # the original messages — adding a continuation prompt
-                        # would waste tokens and confuse the model.
-                        initial_kwargs["messages"] = messages
-                    else:
-                        initial_kwargs["messages"] = messages + [
-                            {
-                                "role": "system",
-                                "content": "You are a helpful assistant. You are given a message and you need to respond to it. You are also given a generated content. You need to respond to the message in continuation of the generated content. Do not repeat the same content. Your response should be in continuation of this text: ",
-                            },
-                            {
-                                "role": "assistant",
-                                "content": e.generated_content,
-                                "prefix": True,
-                            },
-                        ]
+                    initial_kwargs["messages"] = messages
                     self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )
@@ -1949,6 +1932,9 @@ class Router:
                 for item in model_response:
                     yield item
             except MidStreamFallbackError as e:
+                if not (e.is_pre_first_chunk or not e.generated_content):
+                    raise
+
                 from litellm.main import stream_chunk_builder
 
                 complete_response_object = stream_chunk_builder(
@@ -1972,20 +1958,7 @@ class Router:
                         router_self.content_policy_fallbacks,
                     )
                     initial_kwargs["original_function"] = router_self._completion
-                    if e.is_pre_first_chunk or not e.generated_content:
-                        initial_kwargs["messages"] = messages
-                    else:
-                        initial_kwargs["messages"] = messages + [
-                            {
-                                "role": "system",
-                                "content": "You are a helpful assistant. You are given a message and you need to respond to it. You are also given a generated content. You need to respond to the message in continuation of the generated content. Do not repeat the same content. Your response should be in continuation of this text: ",
-                            },
-                            {
-                                "role": "assistant",
-                                "content": e.generated_content,
-                                "prefix": True,
-                            },
-                        ]
+                    initial_kwargs["messages"] = messages
                     router_self._update_kwargs_before_fallbacks(
                         model=model_group, kwargs=initial_kwargs
                     )

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -274,7 +274,7 @@ async def test_async_router_afile_content_uses_deployment_custom_llm_provider():
     """
     Regression test: Ensure afile_content preserves deployment custom_llm_provider
     when model name lacks provider prefix (e.g., "gpt-4.1-mini" instead of "azure/gpt-4.1-mini").
-    
+
     This prevents "None is not a valid LlmProviders" errors when calling file content operations.
     """
     from unittest.mock import AsyncMock, MagicMock, patch
@@ -297,9 +297,11 @@ async def test_async_router_afile_content_uses_deployment_custom_llm_provider():
     # Mock the Azure file handler's afile_content method
     mock_response = MagicMock(spec=HttpxBinaryResponseContent)
     mock_response.response = MagicMock()
-    
-    with patch("litellm.llms.azure.files.handler.AzureOpenAIFilesAPI.afile_content", 
-               return_value=mock_response) as mock_afile_content:
+
+    with patch(
+        "litellm.llms.azure.files.handler.AzureOpenAIFilesAPI.afile_content",
+        return_value=mock_response,
+    ) as mock_afile_content:
         result = await router.afile_content(
             model="team-azure-batch",
             file_id="file-123",
@@ -1277,15 +1279,18 @@ async def test_acompletion_streaming_iterator():
     assert all(chunk in mock_chunks for chunk in collected_chunks)
     print("✓ Successfully streamed all chunks")
 
-    # Test 2: MidStreamFallbackError with fallback
+    # Test 2: MidStreamFallbackError with fallback (pre-first-chunk, no content generated)
     print("\n=== Test 2: MidStreamFallbackError with fallback ===")
 
-    # Create error that should trigger after first chunk
+    # Create error that triggers before any content was generated (e.g. a 429 on
+    # the very first chunk).  In this case the fallback path should use the
+    # original messages without a continuation prompt.
     error = MidStreamFallbackError(
-        message="Connection lost",
+        message="429 Resource exhausted",
         model="gpt-4",
         llm_provider="openai",
-        generated_content="Hello",
+        generated_content="",
+        is_pre_first_chunk=True,
     )
 
     class AsyncIteratorWithError:
@@ -1308,8 +1313,8 @@ async def test_acompletion_streaming_iterator():
             return item
 
     mock_error_response = AsyncIteratorWithError(
-        mock_chunks, 1
-    )  # Error after first chunk
+        mock_chunks, 0
+    )  # Error on first chunk (pre-first-chunk)
 
     setattr(mock_error_response, "model", "gpt-4")
     setattr(mock_error_response, "custom_llm_provider", "openai")
@@ -1343,26 +1348,18 @@ async def test_acompletion_streaming_iterator():
         assert mock_fallback_utils.called
         call_args = mock_fallback_utils.call_args
 
-        # Check that generated content was added to messages
+        # Pre-first-chunk: should use original messages, no continuation prompt
         fallback_kwargs = call_args.kwargs["kwargs"]
         modified_messages = fallback_kwargs["messages"]
-
-        # Should have original message + system message + assistant message with prefix
-        assert len(modified_messages) == 3
-        assert modified_messages[0] == {"role": "user", "content": "Hello"}
-        assert modified_messages[1]["role"] == "system"
-        assert "continuation" in modified_messages[1]["content"]
-        assert modified_messages[2]["role"] == "assistant"
-        assert modified_messages[2]["content"] == "Hello"
-        assert modified_messages[2]["prefix"] == True
+        assert modified_messages == messages
 
         # Verify fallback parameters
         assert call_args.kwargs["disable_fallbacks"] == False
         assert call_args.kwargs["model_group"] == "gpt-4"
 
-        # Should get original chunk + fallback chunks
-        assert len(collected_chunks) == 3  # 1 original + 2 fallback
-        print("✓ Fallback system called correctly with proper message modification")
+        # Should get fallback chunks only (no original chunks were yielded)
+        assert len(collected_chunks) == 2
+        print("✓ Fallback system called correctly with original messages")
 
     print("\n=== All tests passed! ===")
 
@@ -3132,7 +3129,9 @@ def test_multiregion_team_deployments_unique_model_names():
 
     # Each deployment has a unique ID (critical for cooldown/retry to work)
     deployment_ids = {d["model_info"]["id"] for d in deployments}
-    assert len(deployment_ids) == 2, "Each deployment must have a unique ID for cooldown tracking"
+    assert (
+        len(deployment_ids) == 2
+    ), "Each deployment must have a unique ID for cooldown tracking"
 
     # Wrong team: returns nothing
     deployments = router._get_all_deployments(
@@ -3185,9 +3184,9 @@ async def test_multiregion_team_failover_between_regions():
     deployments = router._get_all_deployments(
         model_name="claude-sonnet", team_id="metis-team"
     )
-    assert len(deployments) == 2, (
-        "Router must find both regional deployments by team_public_model_name"
-    )
+    assert (
+        len(deployments) == 2
+    ), "Router must find both regional deployments by team_public_model_name"
 
     # Make a normal request — should succeed from one of the regions
     response = await router.acompletion(
@@ -3200,3 +3199,197 @@ async def test_multiregion_team_failover_between_regions():
         "response from us-east-1",
         "response from us-west-2",
     ]
+
+
+@pytest.mark.asyncio
+async def test_eager_fetch_stream_raises_to_enable_fallback():
+    """When fetch_stream() fails the error must propagate so the retry/fallback
+    machinery in async_function_with_retries can handle it.
+
+    Providers like Vertex AI defer the real HTTP call until the first
+    iteration of the stream.  The eager fetch_stream() call in _acompletion
+    surfaces the error *before* entering the streaming iterator, which keeps
+    it inside the normal exception-handling path.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "vertex-model",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-2.0-flash",
+                    "api_key": "fake-key",
+                },
+            },
+        ],
+    )
+
+    # Build a CustomStreamWrapper with a deferred make_call (completion_stream=None)
+    mock_stream_wrapper = MagicMock(spec=CustomStreamWrapper)
+    mock_stream_wrapper.completion_stream = None
+
+    fetch_error = litellm.RateLimitError(
+        message="429 Resource exhausted",
+        model="vertex_ai/gemini-2.0-flash",
+        llm_provider="vertex_ai",
+    )
+    fetch_error.headers = {
+        "Content-Length": "123",
+        "Transfer-Encoding": "chunked",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json",
+        "X-Custom-Header": "keep-me",
+    }
+    mock_stream_wrapper.make_call = AsyncMock()
+    mock_stream_wrapper.fetch_stream = AsyncMock(side_effect=fetch_error)
+
+    # Patch litellm.acompletion to return our mock streaming wrapper
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value = mock_stream_wrapper
+
+        with pytest.raises(litellm.RateLimitError) as exc_info:
+            await router._acompletion(
+                model="vertex-model",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+            )
+
+        # fetch_stream should have been called
+        mock_stream_wrapper.fetch_stream.assert_called_once()
+
+        # Verify problematic headers were stripped
+        raised = exc_info.value
+        assert "Content-Length" not in raised.headers
+        assert "Transfer-Encoding" not in raised.headers
+        assert "Content-Encoding" not in raised.headers
+        assert "Content-Type" not in raised.headers
+        assert raised.headers["X-Custom-Header"] == "keep-me"
+
+
+@pytest.mark.asyncio
+async def test_eager_fetch_stream_skipped_when_stream_already_set():
+    """If completion_stream is already set (non-deferred provider), fetch_stream
+    must not be called and the response passes through to the streaming iterator.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai-model",
+                "litellm_params": {
+                    "model": "gpt-4",
+                    "api_key": "fake-key",
+                },
+            },
+        ],
+    )
+
+    mock_stream_wrapper = MagicMock(spec=CustomStreamWrapper)
+    mock_stream_wrapper.completion_stream = MagicMock()  # already set
+    mock_stream_wrapper.make_call = None
+    mock_stream_wrapper.fetch_stream = AsyncMock()
+
+    # Patch _acompletion_streaming_iterator to avoid full iteration
+    mock_iterator_result = MagicMock()
+    with (
+        patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion,
+        patch.object(
+            router,
+            "_acompletion_streaming_iterator",
+            new_callable=AsyncMock,
+            return_value=mock_iterator_result,
+        ),
+    ):
+        mock_acompletion.return_value = mock_stream_wrapper
+
+        result = await router._acompletion(
+            model="openai-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+        )
+
+        # fetch_stream should NOT have been called
+        mock_stream_wrapper.fetch_stream.assert_not_called()
+        assert result == mock_iterator_result
+
+
+@pytest.mark.asyncio
+async def test_midstream_fallback_reraises_when_content_generated():
+    """When a MidStreamFallbackError occurs after content has already been
+    streamed (is_pre_first_chunk=False, generated_content is non-empty),
+    it must be re-raised instead of triggering the continuation-fallback path.
+
+    Once content has been sent to the client, switching to a fallback model
+    mid-stream could produce incoherent output.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            },
+        ],
+        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "gpt-4", "stream": True}
+
+    # Error with generated_content AND is_pre_first_chunk=False
+    midstream_error = MidStreamFallbackError(
+        message="Connection reset",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="Hello, I am a helpful assistant",
+        is_pre_first_chunk=False,
+    )
+
+    mock_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content="Hello"))]),
+    ]
+
+    class AsyncIteratorMidStreamError:
+        def __init__(self):
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = mock_chunks
+            self._index = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._index >= 1:
+                raise midstream_error
+            self._index += 1
+            return mock_chunks[0]
+
+    mock_response = AsyncIteratorMidStreamError()
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+    ) as mock_fallback_utils:
+        iterator = await router._acompletion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        with pytest.raises(MidStreamFallbackError):
+            async for _ in iterator:
+                pass
+
+        # Fallback should NOT have been attempted
+        mock_fallback_utils.assert_not_called()

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -3236,13 +3236,6 @@ async def test_eager_fetch_stream_raises_to_enable_fallback():
         model="vertex_ai/gemini-2.0-flash",
         llm_provider="vertex_ai",
     )
-    fetch_error.headers = {
-        "Content-Length": "123",
-        "Transfer-Encoding": "chunked",
-        "Content-Encoding": "gzip",
-        "Content-Type": "application/json",
-        "X-Custom-Header": "keep-me",
-    }
     mock_stream_wrapper.make_call = AsyncMock()
     mock_stream_wrapper.fetch_stream = AsyncMock(side_effect=fetch_error)
 
@@ -3250,7 +3243,7 @@ async def test_eager_fetch_stream_raises_to_enable_fallback():
     with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acompletion:
         mock_acompletion.return_value = mock_stream_wrapper
 
-        with pytest.raises(litellm.RateLimitError) as exc_info:
+        with pytest.raises(litellm.RateLimitError):
             await router._acompletion(
                 model="vertex-model",
                 messages=[{"role": "user", "content": "Hello"}],
@@ -3259,14 +3252,6 @@ async def test_eager_fetch_stream_raises_to_enable_fallback():
 
         # fetch_stream should have been called
         mock_stream_wrapper.fetch_stream.assert_called_once()
-
-        # Verify problematic headers were stripped
-        raised = exc_info.value
-        assert "Content-Length" not in raised.headers
-        assert "Transfer-Encoding" not in raised.headers
-        assert "Content-Encoding" not in raised.headers
-        assert "Content-Type" not in raised.headers
-        assert raised.headers["X-Custom-Header"] == "keep-me"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -3378,3 +3378,71 @@ async def test_midstream_fallback_reraises_when_content_generated():
 
         # Fallback should NOT have been attempted
         mock_fallback_utils.assert_not_called()
+
+
+def test_sync_midstream_fallback_reraises_when_content_generated():
+    """Sync counterpart: MidStreamFallbackError with generated content must
+    re-raise instead of attempting continuation-fallback."""
+    from unittest.mock import MagicMock
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            },
+        ],
+        fallbacks=[{"gpt-4": ["gpt-3.5-turbo"]}],
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    initial_kwargs = {"model": "gpt-4", "stream": True}
+
+    midstream_error = MidStreamFallbackError(
+        message="Connection reset",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="Hello, I am a helpful assistant",
+        is_pre_first_chunk=False,
+    )
+
+    mock_chunks = [
+        MagicMock(choices=[MagicMock(delta=MagicMock(content="Hello"))]),
+    ]
+
+    class SyncIteratorMidStreamError:
+        def __init__(self):
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = mock_chunks
+            self._index = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._index >= 1:
+                raise midstream_error
+            self._index += 1
+            return mock_chunks[0]
+
+    mock_response = SyncIteratorMidStreamError()
+
+    with patch.object(
+        router,
+        "function_with_fallbacks",
+    ) as mock_fallback:
+        result = router._completion_streaming_iterator(
+            model_response=mock_response,
+            messages=messages,
+            initial_kwargs=initial_kwargs,
+        )
+
+        with pytest.raises(MidStreamFallbackError):
+            list(result)
+
+        # Fallback should NOT have been attempted
+        mock_fallback.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Fixes streaming fallback failures for providers using deferred HTTP calls (Vertex AI, Bedrock, Predibase, Codestral).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Several providers (Vertex AI, Bedrock, Predibase, Codestral) create `CustomStreamWrapper` with `completion_stream=None` and a deferred `make_call`. The actual HTTP call only happens on first iteration via `fetch_stream()`. This means initialization errors (auth failures, rate limits, 429s) are raised inside the streaming iterator — outside the normal retry/fallback exception handling in `async_function_with_retries`.

### Root cause
When streaming with these providers, errors surface inside `_acompletion_streaming_iterator` instead of in `_acompletion` where the Router's retry and fallback machinery can catch them.

### Fix
1. **Eager `fetch_stream()`**: Call `fetch_stream()` in `_acompletion` *before* entering the streaming iterator. Initialization errors now propagate through the normal fallback path.
2. **Mid-stream re-raise guard** (async + sync): When `MidStreamFallbackError` fires after content has already been generated (`is_pre_first_chunk=False` and `generated_content` is non-empty), re-raise instead of attempting continuation-fallback — partial content has already been sent to the client, so switching models mid-stream produces incoherent output.

### Behavioral change: continuation prompt injection removed

Previously, when a `MidStreamFallbackError` occurred after content had already been streamed, the router would silently rewrite the user's messages — injecting a system prompt and an assistant prefix with `"prefix": True` — and send them to a fallback model to "continue" the partial response. This has been removed because:

- It silently mutated the caller's messages with prompts they never requested
- A different model continuing another model's partial output with a generic "continue from here" instruction produces unreliable, potentially incoherent results
- The client has already received chunks from the original model, so there is no way to produce a clean response

Now, mid-stream errors with generated content re-raise to the caller. Pre-first-chunk errors (no content sent yet) still fall back cleanly with the original messages.

### Tests added
- `test_eager_fetch_stream_raises_to_enable_fallback` — verifies deferred stream errors propagate for fallback handling
- `test_eager_fetch_stream_skipped_when_stream_already_set` — verifies non-deferred providers skip the eager fetch
- `test_midstream_fallback_reraises_when_content_generated` — async: mid-stream errors with generated content re-raise
- `test_sync_midstream_fallback_reraises_when_content_generated` — sync: same behavior
- Updated `test_acompletion_streaming_iterator` to reflect the new pre-first-chunk-only fallback behavior