### PR TITLE
fix(proxy): avoid invalid Prisma JsonFilter in reset_budget_windows

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -634,9 +634,7 @@ class ResetBudgetJob:
 
         # --- Keys ---
         try:
-            all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
-            )
+            all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many()
             for key in all_keys:
                 raw = key.budget_limits  # type: ignore[attr-defined]
                 if not raw:
@@ -663,9 +661,7 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
-            all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
-            )
+            all_teams = await self.prisma_client.db.litellm_teamtable.find_many()
             for team in all_teams:
                 raw = team.budget_limits  # type: ignore[attr-defined]
                 if not raw:

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -40,7 +40,9 @@ class MockLiteLLMVerificationToken:
         self.find_many_calls.append({"where": where})
         return self._find_many_results
 
-    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+    async def update(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
         return {"count": 1}
 
@@ -64,7 +66,9 @@ class MockLiteLLMTeamTable:
         self.find_many_calls.append({"where": where})
         return self._find_many_results
 
-    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+    async def update(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
         return {"count": 1}
 
@@ -690,21 +694,20 @@ def test_reset_budget_windows_filters_null_budget_limits_in_python(
         [team_with_windows, team_without_windows]
     )
 
-    with patch(
-        "litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()
-    ), patch.object(
-        ResetBudgetJob,
-        "_reset_expired_window",
-        new=AsyncMock(return_value=True),
+    with (
+        patch("litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()),
+        patch.object(
+            ResetBudgetJob,
+            "_reset_expired_window",
+            new=AsyncMock(return_value=True),
+        ),
     ):
         asyncio.run(reset_budget_job.reset_budget_windows())
 
     assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
         {"where": None}
     ]
-    assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
-        {"where": None}
-    ]
+    assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [{"where": None}]
 
     key_updates = mock_prisma_client.db.litellm_verificationtoken.update_calls
     assert len(key_updates) == 1
@@ -795,9 +798,9 @@ def test_reset_budget_resets_endusers_with_null_budget_id(
 
     # Both end users should have been reset
     updated = mock_prisma_client.updated_data["enduser"]
-    assert len(updated) == 2, (
-        f"Expected 2 endusers reset (1 explicit + 1 implicit), got {len(updated)}"
-    )
+    assert (
+        len(updated) == 2
+    ), f"Expected 2 endusers reset (1 explicit + 1 implicit), got {len(updated)}"
 
     user_ids = {u.user_id for u in updated}
     assert "enduser-explicit" in user_ids

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -4,6 +4,7 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,12 +28,44 @@ class MockLiteLLMTeamMembership:
 
 class MockLiteLLMVerificationToken:
     def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_calls: List[Dict[str, Any]] = []
         self.update_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        self.update_calls.append({"where": where, "data": data})
+        return {"count": 1}
 
     async def update_many(
         self, where: Dict[str, Any], data: Dict[str, Any]
     ) -> Dict[str, Any]:
         self.update_many_calls.append({"where": where, "data": data})
+        return {"count": 1}
+
+
+class MockLiteLLMTeamTable:
+    def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        self.update_calls.append({"where": where, "data": data})
         return {"count": 1}
 
 
@@ -53,6 +86,7 @@ class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
+        self.litellm_teamtable = MockLiteLLMTeamTable()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
 
 
@@ -613,6 +647,72 @@ def test_budget_table_reset_also_resets_linked_keys(
     )
     assert calls[0]["where"]["budget_id"] == {"in": ["7d-budget-tier"]}
     assert calls[0]["data"]["spend"] == 0
+
+
+def test_reset_budget_windows_filters_null_budget_limits_in_python(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    reset_budget_windows() should fetch keys and teams without Prisma JSON null
+    filters and skip empty budget_limits records in Python.
+    """
+    key_with_windows = type(
+        "LiteLLM_VerificationToken",
+        (),
+        {
+            "token": "sk-key-with-windows",
+            "budget_limits": '[{"budget_duration": "24h", "reset_at": null}]',
+        },
+    )
+    key_without_windows = type(
+        "LiteLLM_VerificationToken",
+        (),
+        {"token": "sk-key-without-windows", "budget_limits": None},
+    )
+    team_with_windows = type(
+        "LiteLLM_TeamTable",
+        (),
+        {
+            "team_id": "team-with-windows",
+            "budget_limits": [{"budget_duration": "7d", "reset_at": None}],
+        },
+    )
+    team_without_windows = type(
+        "LiteLLM_TeamTable",
+        (),
+        {"team_id": "team-without-windows", "budget_limits": None},
+    )
+
+    mock_prisma_client.db.litellm_verificationtoken.set_find_many_results(
+        [key_with_windows, key_without_windows]
+    )
+    mock_prisma_client.db.litellm_teamtable.set_find_many_results(
+        [team_with_windows, team_without_windows]
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()
+    ), patch.object(
+        ResetBudgetJob,
+        "_reset_expired_window",
+        new=AsyncMock(return_value=True),
+    ):
+        asyncio.run(reset_budget_job.reset_budget_windows())
+
+    assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
+        {"where": None}
+    ]
+    assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
+        {"where": None}
+    ]
+
+    key_updates = mock_prisma_client.db.litellm_verificationtoken.update_calls
+    assert len(key_updates) == 1
+    assert key_updates[0]["where"] == {"token": "sk-key-with-windows"}
+
+    team_updates = mock_prisma_client.db.litellm_teamtable.update_calls
+    assert len(team_updates) == 1
+    assert team_updates[0]["where"] == {"team_id": "team-with-windows"}
 
 
 def test_reset_budget_resets_endusers_with_null_budget_id(


### PR DESCRIPTION
## Summary
- stop using `where={"budget_limits": {"not": None}}` in `reset_budget_windows()` for keys and teams
- keep filtering in Python with the existing `if not raw: continue` guard and add a regression test for that behavior
- avoid periodic `prisma.errors.MissingRequiredValueError` noise from the background budget reset scheduler

## Reproduction
This reproduces on the current LiteLLM codepath even when the database contains **zero** rows with `budget_limits` set.

Environment used while debugging:
- LiteLLM `1.83.10`
- `prisma==0.11.0`
- `budget_limits` columns present as nullable `jsonb`
- `0` rows in both `LiteLLM_VerificationToken` and `LiteLLM_TeamTable` with non-null `budget_limits`

Direct reproduction from the running LiteLLM container:

```python
rows = await table.find_many(where={"budget_limits": {"not": None}})
```

This raises:

```text
prisma.errors.MissingRequiredValueError: Unable to match input value to any allowed input type for the field.
Parse errors: [`where.budget_limits.not`: A value is required but not set, ...]
```

The failure happens before any matching rows are read from Postgres. In this setup, Prisma's generated `JsonFilter.not` expects a JSON value, not Python `None`, so the query itself is invalid.

## Why this change
`reset_budget_windows()` already skips empty values in Python:

```python
raw = key.budget_limits
if not raw:
    continue
```

So the safest fix is to fetch keys/teams without the invalid Prisma JSON-null filter and preserve the existing Python-side guard. This keeps behavior the same for rows with real window data while avoiding the scheduler log noise for installations that do not use `budget_limits` at all.

## Validation
- confirmed the bug against a live LiteLLM container backed by Postgres with no `budget_limits` rows
- rebuilt and redeployed the patched image locally
- ran `ResetBudgetJob.reset_budget_windows()` successfully in the deployed container with no `MissingRequiredValueError`
- verified recent LiteLLM logs no longer contain `MissingRequiredValueError`, `where.budget_limits.not`, or `Failed to reset budget windows`

## Notes
I also added a regression test covering the intended behavior: fetch records without a Prisma JSON null filter and only update rows that actually contain `budget_limits`.
