### PR TITLE
fix(proxy): paginate reset_budget_windows scans

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -28,6 +28,30 @@ class ResetBudgetJob:
 
     _RESET_BUDGET_WINDOWS_BATCH_SIZE = 500
 
+    async def _iter_budget_window_rows(self, table: Any, id_field: str):
+        cursor_value = None
+
+        while True:
+            query_kwargs = {
+                "take": self._RESET_BUDGET_WINDOWS_BATCH_SIZE,
+                "order": {id_field: "asc"},
+            }
+            if cursor_value is not None:
+                query_kwargs["cursor"] = {id_field: cursor_value}
+                query_kwargs["skip"] = 1
+
+            rows = await table.find_many(**query_kwargs)
+            if len(rows) == 0:
+                break
+
+            for row in rows:
+                yield row
+
+            if len(rows) < self._RESET_BUDGET_WINDOWS_BATCH_SIZE:
+                break
+
+            cursor_value = getattr(rows[-1], id_field)
+
     async def reset_budget(
         self,
     ):
@@ -636,37 +660,27 @@ class ResetBudgetJob:
 
         # --- Keys ---
         try:
-            skip = 0
-            while True:
-                all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                    skip=skip,
-                    take=self._RESET_BUDGET_WINDOWS_BATCH_SIZE,
-                    order={"token": "asc"},
-                )
-                if len(all_keys) == 0:
-                    break
-                for key in all_keys:
-                    raw = key.budget_limits  # type: ignore[attr-defined]
-                    if not raw:
-                        continue
-                    windows: list = raw if isinstance(raw, list) else json.loads(raw)
-                    changed = False
-                    for window in windows:
-                        counter_key = (
-                            f"spend:key:{key.token}:window:{window['budget_duration']}"
-                        )
-                        if await ResetBudgetJob._reset_expired_window(
-                            window, counter_key, spend_counter_cache, now
-                        ):
-                            changed = True
-                    if changed:
-                        await self.prisma_client.db.litellm_verificationtoken.update(
-                            where={"token": key.token},
-                            data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                        )
-                if len(all_keys) < self._RESET_BUDGET_WINDOWS_BATCH_SIZE:
-                    break
-                skip += self._RESET_BUDGET_WINDOWS_BATCH_SIZE
+            async for key in self._iter_budget_window_rows(
+                self.prisma_client.db.litellm_verificationtoken, "token"
+            ):
+                raw = key.budget_limits  # type: ignore[attr-defined]
+                if not raw:
+                    continue
+                windows: list = raw if isinstance(raw, list) else json.loads(raw)
+                changed = False
+                for window in windows:
+                    counter_key = (
+                        f"spend:key:{key.token}:window:{window['budget_duration']}"
+                    )
+                    if await ResetBudgetJob._reset_expired_window(
+                        window, counter_key, spend_counter_cache, now
+                    ):
+                        changed = True
+                if changed:
+                    await self.prisma_client.db.litellm_verificationtoken.update(
+                        where={"token": key.token},
+                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                    )
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Failed to reset budget windows for keys: %s", e
@@ -674,37 +688,27 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
-            skip = 0
-            while True:
-                all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
-                    skip=skip,
-                    take=self._RESET_BUDGET_WINDOWS_BATCH_SIZE,
-                    order={"team_id": "asc"},
-                )
-                if len(all_teams) == 0:
-                    break
-                for team in all_teams:
-                    raw = team.budget_limits  # type: ignore[attr-defined]
-                    if not raw:
-                        continue
-                    windows = raw if isinstance(raw, list) else json.loads(raw)
-                    changed = False
-                    for window in windows:
-                        counter_key = (
-                            f"spend:team:{team.team_id}:window:{window['budget_duration']}"
-                        )
-                        if await ResetBudgetJob._reset_expired_window(
-                            window, counter_key, spend_counter_cache, now
-                        ):
-                            changed = True
-                    if changed:
-                        await self.prisma_client.db.litellm_teamtable.update(
-                            where={"team_id": team.team_id},
-                            data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                        )
-                if len(all_teams) < self._RESET_BUDGET_WINDOWS_BATCH_SIZE:
-                    break
-                skip += self._RESET_BUDGET_WINDOWS_BATCH_SIZE
+            async for team in self._iter_budget_window_rows(
+                self.prisma_client.db.litellm_teamtable, "team_id"
+            ):
+                raw = team.budget_limits  # type: ignore[attr-defined]
+                if not raw:
+                    continue
+                windows = raw if isinstance(raw, list) else json.loads(raw)
+                changed = False
+                for window in windows:
+                    counter_key = (
+                        f"spend:team:{team.team_id}:window:{window['budget_duration']}"
+                    )
+                    if await ResetBudgetJob._reset_expired_window(
+                        window, counter_key, spend_counter_cache, now
+                    ):
+                        changed = True
+                if changed:
+                    await self.prisma_client.db.litellm_teamtable.update(
+                        where={"team_id": team.team_id},
+                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                    )
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Failed to reset budget windows for teams: %s", e

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -634,9 +634,7 @@ class ResetBudgetJob:
 
         # --- Keys ---
         try:
-            all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
-            )
+            all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many()
             for key in all_keys:
                 raw = key.budget_limits  # type: ignore[attr-defined]
                 if not raw:
@@ -663,9 +661,7 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
-            all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
-            )
+            all_teams = await self.prisma_client.db.litellm_teamtable.find_many()
             for team in all_teams:
                 raw = team.budget_limits  # type: ignore[attr-defined]
                 if not raw:

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -26,6 +26,8 @@ class ResetBudgetJob:
         self.proxy_logging_obj: ProxyLogging = proxy_logging_obj
         self.prisma_client: PrismaClient = prisma_client
 
+    _RESET_BUDGET_WINDOWS_BATCH_SIZE = 500
+
     async def reset_budget(
         self,
     ):
@@ -634,26 +636,37 @@ class ResetBudgetJob:
 
         # --- Keys ---
         try:
-            all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many()
-            for key in all_keys:
-                raw = key.budget_limits  # type: ignore[attr-defined]
-                if not raw:
-                    continue
-                windows: list = raw if isinstance(raw, list) else json.loads(raw)
-                changed = False
-                for window in windows:
-                    counter_key = (
-                        f"spend:key:{key.token}:window:{window['budget_duration']}"
-                    )
-                    if await ResetBudgetJob._reset_expired_window(
-                        window, counter_key, spend_counter_cache, now
-                    ):
-                        changed = True
-                if changed:
-                    await self.prisma_client.db.litellm_verificationtoken.update(
-                        where={"token": key.token},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                    )
+            skip = 0
+            while True:
+                all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
+                    skip=skip,
+                    take=self._RESET_BUDGET_WINDOWS_BATCH_SIZE,
+                    order={"token": "asc"},
+                )
+                if len(all_keys) == 0:
+                    break
+                for key in all_keys:
+                    raw = key.budget_limits  # type: ignore[attr-defined]
+                    if not raw:
+                        continue
+                    windows: list = raw if isinstance(raw, list) else json.loads(raw)
+                    changed = False
+                    for window in windows:
+                        counter_key = (
+                            f"spend:key:{key.token}:window:{window['budget_duration']}"
+                        )
+                        if await ResetBudgetJob._reset_expired_window(
+                            window, counter_key, spend_counter_cache, now
+                        ):
+                            changed = True
+                    if changed:
+                        await self.prisma_client.db.litellm_verificationtoken.update(
+                            where={"token": key.token},
+                            data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                        )
+                if len(all_keys) < self._RESET_BUDGET_WINDOWS_BATCH_SIZE:
+                    break
+                skip += self._RESET_BUDGET_WINDOWS_BATCH_SIZE
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Failed to reset budget windows for keys: %s", e
@@ -661,26 +674,37 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
-            all_teams = await self.prisma_client.db.litellm_teamtable.find_many()
-            for team in all_teams:
-                raw = team.budget_limits  # type: ignore[attr-defined]
-                if not raw:
-                    continue
-                windows = raw if isinstance(raw, list) else json.loads(raw)
-                changed = False
-                for window in windows:
-                    counter_key = (
-                        f"spend:team:{team.team_id}:window:{window['budget_duration']}"
-                    )
-                    if await ResetBudgetJob._reset_expired_window(
-                        window, counter_key, spend_counter_cache, now
-                    ):
-                        changed = True
-                if changed:
-                    await self.prisma_client.db.litellm_teamtable.update(
-                        where={"team_id": team.team_id},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                    )
+            skip = 0
+            while True:
+                all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
+                    skip=skip,
+                    take=self._RESET_BUDGET_WINDOWS_BATCH_SIZE,
+                    order={"team_id": "asc"},
+                )
+                if len(all_teams) == 0:
+                    break
+                for team in all_teams:
+                    raw = team.budget_limits  # type: ignore[attr-defined]
+                    if not raw:
+                        continue
+                    windows = raw if isinstance(raw, list) else json.loads(raw)
+                    changed = False
+                    for window in windows:
+                        counter_key = (
+                            f"spend:team:{team.team_id}:window:{window['budget_duration']}"
+                        )
+                        if await ResetBudgetJob._reset_expired_window(
+                            window, counter_key, spend_counter_cache, now
+                        ):
+                            changed = True
+                    if changed:
+                        await self.prisma_client.db.litellm_teamtable.update(
+                            where={"team_id": team.team_id},
+                            data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                        )
+                if len(all_teams) < self._RESET_BUDGET_WINDOWS_BATCH_SIZE:
+                    break
+                skip += self._RESET_BUDGET_WINDOWS_BATCH_SIZE
         except Exception as e:
             verbose_proxy_logger.exception(
                 "Failed to reset budget windows for teams: %s", e

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -4,6 +4,7 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,12 +28,44 @@ class MockLiteLLMTeamMembership:
 
 class MockLiteLLMVerificationToken:
     def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_calls: List[Dict[str, Any]] = []
         self.update_many_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        self.update_calls.append({"where": where, "data": data})
+        return {"count": 1}
 
     async def update_many(
         self, where: Dict[str, Any], data: Dict[str, Any]
     ) -> Dict[str, Any]:
         self.update_many_calls.append({"where": where, "data": data})
+        return {"count": 1}
+
+
+class MockLiteLLMTeamTable:
+    def __init__(self):
+        self.find_many_calls: List[Dict[str, Any]] = []
+        self.update_calls: List[Dict[str, Any]] = []
+        self._find_many_results: List[Any] = []
+
+    def set_find_many_results(self, results: List[Any]):
+        self._find_many_results = results
+
+    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Any]:
+        self.find_many_calls.append({"where": where})
+        return self._find_many_results
+
+    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+        self.update_calls.append({"where": where, "data": data})
         return {"count": 1}
 
 
@@ -53,6 +86,7 @@ class MockDB:
     def __init__(self):
         self.litellm_teammembership = MockLiteLLMTeamMembership()
         self.litellm_verificationtoken = MockLiteLLMVerificationToken()
+        self.litellm_teamtable = MockLiteLLMTeamTable()
         self.litellm_endusertable = MockLiteLLMEndUserTable()
 
 
@@ -613,6 +647,72 @@ def test_budget_table_reset_also_resets_linked_keys(
     )
     assert calls[0]["where"]["budget_id"] == {"in": ["7d-budget-tier"]}
     assert calls[0]["data"]["spend"] == 0
+
+
+def test_reset_budget_windows_filters_null_budget_limits_in_python(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    reset_budget_windows() should fetch keys and teams without Prisma JSON null
+    filters and skip empty budget_limits records in Python.
+    """
+    key_with_windows = type(
+        "LiteLLM_VerificationToken",
+        (),
+        {
+            "token": "sk-key-with-windows",
+            "budget_limits": '[{"budget_duration": "24h", "reset_at": null}]',
+        },
+    )
+    key_without_windows = type(
+        "LiteLLM_VerificationToken",
+        (),
+        {"token": "sk-key-without-windows", "budget_limits": None},
+    )
+    team_with_windows = type(
+        "LiteLLM_TeamTable",
+        (),
+        {
+            "team_id": "team-with-windows",
+            "budget_limits": [{"budget_duration": "7d", "reset_at": None}],
+        },
+    )
+    team_without_windows = type(
+        "LiteLLM_TeamTable",
+        (),
+        {"team_id": "team-without-windows", "budget_limits": None},
+    )
+
+    mock_prisma_client.db.litellm_verificationtoken.set_find_many_results(
+        [key_with_windows, key_without_windows]
+    )
+    mock_prisma_client.db.litellm_teamtable.set_find_many_results(
+        [team_with_windows, team_without_windows]
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()
+    ), patch.object(
+        ResetBudgetJob,
+        "_reset_expired_window",
+        new=AsyncMock(return_value=True),
+    ):
+        asyncio.run(reset_budget_job.reset_budget_windows())
+
+    assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
+        {"where": None}
+    ]
+    assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
+        {"where": None}
+    ]
+
+    key_updates = mock_prisma_client.db.litellm_verificationtoken.update_calls
+    assert len(key_updates) == 1
+    assert key_updates[0]["where"] == {"token": "sk-key-with-windows"}
+
+    team_updates = mock_prisma_client.db.litellm_teamtable.update_calls
+    assert len(team_updates) == 1
+    assert team_updates[0]["where"] == {"team_id": "team-with-windows"}
 
 
 def test_reset_budget_resets_endusers_with_null_budget_id(

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -36,9 +36,13 @@ class MockLiteLLMVerificationToken:
     def set_find_many_results(self, results: List[Any]):
         self._find_many_results = results
 
-    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Any]:
-        self.find_many_calls.append({"where": where})
-        return self._find_many_results
+    async def find_many(self, **kwargs) -> List[Any]:
+        self.find_many_calls.append(kwargs)
+        skip = kwargs.get("skip", 0)
+        take = kwargs.get("take")
+        if take is None:
+            return self._find_many_results[skip:]
+        return self._find_many_results[skip : skip + take]
 
     async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
@@ -60,9 +64,13 @@ class MockLiteLLMTeamTable:
     def set_find_many_results(self, results: List[Any]):
         self._find_many_results = results
 
-    async def find_many(self, where: Dict[str, Any] | None = None) -> List[Any]:
-        self.find_many_calls.append({"where": where})
-        return self._find_many_results
+    async def find_many(self, **kwargs) -> List[Any]:
+        self.find_many_calls.append(kwargs)
+        skip = kwargs.get("skip", 0)
+        take = kwargs.get("take")
+        if take is None:
+            return self._find_many_results[skip:]
+        return self._find_many_results[skip : skip + take]
 
     async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
@@ -700,10 +708,10 @@ def test_reset_budget_windows_filters_null_budget_limits_in_python(
         asyncio.run(reset_budget_job.reset_budget_windows())
 
     assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
-        {"where": None}
+        {"skip": 0, "take": 500, "order": {"token": "asc"}}
     ]
     assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
-        {"where": None}
+        {"skip": 0, "take": 500, "order": {"team_id": "asc"}}
     ]
 
     key_updates = mock_prisma_client.db.litellm_verificationtoken.update_calls
@@ -713,6 +721,46 @@ def test_reset_budget_windows_filters_null_budget_limits_in_python(
     team_updates = mock_prisma_client.db.litellm_teamtable.update_calls
     assert len(team_updates) == 1
     assert team_updates[0]["where"] == {"team_id": "team-with-windows"}
+
+
+def test_reset_budget_windows_paginates_large_tables(
+    reset_budget_job, mock_prisma_client
+):
+    reset_budget_job._RESET_BUDGET_WINDOWS_BATCH_SIZE = 2
+
+    keys = [
+        type(
+            "LiteLLM_VerificationToken",
+            (),
+            {"token": f"sk-{i}", "budget_limits": None},
+        )
+        for i in range(5)
+    ]
+    teams = [
+        type(
+            "LiteLLM_TeamTable",
+            (),
+            {"team_id": f"team-{i}", "budget_limits": None},
+        )
+        for i in range(5)
+    ]
+
+    mock_prisma_client.db.litellm_verificationtoken.set_find_many_results(keys)
+    mock_prisma_client.db.litellm_teamtable.set_find_many_results(teams)
+
+    with patch("litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()):
+        asyncio.run(reset_budget_job.reset_budget_windows())
+
+    assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
+        {"skip": 0, "take": 2, "order": {"token": "asc"}},
+        {"skip": 2, "take": 2, "order": {"token": "asc"}},
+        {"skip": 4, "take": 2, "order": {"token": "asc"}},
+    ]
+    assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
+        {"skip": 0, "take": 2, "order": {"team_id": "asc"}},
+        {"skip": 2, "take": 2, "order": {"team_id": "asc"}},
+        {"skip": 4, "take": 2, "order": {"team_id": "asc"}},
+    ]
 
 
 def test_reset_budget_resets_endusers_with_null_budget_id(

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -38,11 +38,21 @@ class MockLiteLLMVerificationToken:
 
     async def find_many(self, **kwargs) -> List[Any]:
         self.find_many_calls.append(kwargs)
-        skip = kwargs.get("skip", 0)
         take = kwargs.get("take")
+        cursor = kwargs.get("cursor")
+        skip = kwargs.get("skip", 0)
+        results = self._find_many_results
+        if cursor is not None:
+            token = cursor.get("token")
+            start = next(
+                index for index, item in enumerate(results) if item.token == token
+            )
+            results = results[start + skip :]
+        elif skip:
+            results = results[skip:]
         if take is None:
-            return self._find_many_results[skip:]
-        return self._find_many_results[skip : skip + take]
+            return results
+        return results[:take]
 
     async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
@@ -66,11 +76,21 @@ class MockLiteLLMTeamTable:
 
     async def find_many(self, **kwargs) -> List[Any]:
         self.find_many_calls.append(kwargs)
-        skip = kwargs.get("skip", 0)
         take = kwargs.get("take")
+        cursor = kwargs.get("cursor")
+        skip = kwargs.get("skip", 0)
+        results = self._find_many_results
+        if cursor is not None:
+            team_id = cursor.get("team_id")
+            start = next(
+                index for index, item in enumerate(results) if item.team_id == team_id
+            )
+            results = results[start + skip :]
+        elif skip:
+            results = results[skip:]
         if take is None:
-            return self._find_many_results[skip:]
-        return self._find_many_results[skip : skip + take]
+            return results
+        return results[:take]
 
     async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
@@ -188,6 +208,10 @@ def reset_budget_job(mock_prisma_client, mock_proxy_logging):
 # Helper function to run async tests
 async def run_async_test(coro):
     return await coro
+
+
+async def _collect_async_iter(async_iterable):
+    return [item async for item in async_iterable]
 
 
 # Tests
@@ -708,10 +732,10 @@ def test_reset_budget_windows_filters_null_budget_limits_in_python(
         asyncio.run(reset_budget_job.reset_budget_windows())
 
     assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
-        {"skip": 0, "take": 500, "order": {"token": "asc"}}
+        {"take": 500, "order": {"token": "asc"}}
     ]
     assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
-        {"skip": 0, "take": 500, "order": {"team_id": "asc"}}
+        {"take": 500, "order": {"team_id": "asc"}}
     ]
 
     key_updates = mock_prisma_client.db.litellm_verificationtoken.update_calls
@@ -752,15 +776,102 @@ def test_reset_budget_windows_paginates_large_tables(
         asyncio.run(reset_budget_job.reset_budget_windows())
 
     assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
-        {"skip": 0, "take": 2, "order": {"token": "asc"}},
-        {"skip": 2, "take": 2, "order": {"token": "asc"}},
-        {"skip": 4, "take": 2, "order": {"token": "asc"}},
+        {"take": 2, "order": {"token": "asc"}},
+        {"take": 2, "order": {"token": "asc"}, "cursor": {"token": "sk-1"}, "skip": 1},
+        {"take": 2, "order": {"token": "asc"}, "cursor": {"token": "sk-3"}, "skip": 1},
     ]
     assert mock_prisma_client.db.litellm_teamtable.find_many_calls == [
-        {"skip": 0, "take": 2, "order": {"team_id": "asc"}},
-        {"skip": 2, "take": 2, "order": {"team_id": "asc"}},
-        {"skip": 4, "take": 2, "order": {"team_id": "asc"}},
+        {"take": 2, "order": {"team_id": "asc"}},
+        {
+            "take": 2,
+            "order": {"team_id": "asc"},
+            "cursor": {"team_id": "team-1"},
+            "skip": 1,
+        },
+        {
+            "take": 2,
+            "order": {"team_id": "asc"},
+            "cursor": {"team_id": "team-3"},
+            "skip": 1,
+        },
     ]
+
+
+def test_iter_budget_window_rows_uses_cursor_pagination(reset_budget_job, mock_prisma_client):
+    reset_budget_job._RESET_BUDGET_WINDOWS_BATCH_SIZE = 2
+
+    keys = [
+        type(
+            "LiteLLM_VerificationToken",
+            (),
+            {"token": f"sk-{i}", "budget_limits": None},
+        )
+        for i in range(5)
+    ]
+    mock_prisma_client.db.litellm_verificationtoken.set_find_many_results(keys)
+
+    rows = asyncio.run(
+        _collect_async_iter(
+            reset_budget_job._iter_budget_window_rows(
+                mock_prisma_client.db.litellm_verificationtoken, "token"
+            )
+        )
+    )
+
+    assert [row.token for row in rows] == [f"sk-{i}" for i in range(5)]
+    assert mock_prisma_client.db.litellm_verificationtoken.find_many_calls == [
+        {"take": 2, "order": {"token": "asc"}},
+        {"take": 2, "order": {"token": "asc"}, "cursor": {"token": "sk-1"}, "skip": 1},
+        {"take": 2, "order": {"token": "asc"}, "cursor": {"token": "sk-3"}, "skip": 1},
+    ]
+
+
+def test_reset_budget_windows_updates_items_across_cursor_pages(
+    reset_budget_job, mock_prisma_client
+):
+    reset_budget_job._RESET_BUDGET_WINDOWS_BATCH_SIZE = 1
+
+    keys = [
+        type(
+            "LiteLLM_VerificationToken",
+            (),
+            {
+                "token": f"sk-{i}",
+                "budget_limits": '[{"budget_duration": "24h", "reset_at": null}]',
+            },
+        )
+        for i in range(2)
+    ]
+    teams = [
+        type(
+            "LiteLLM_TeamTable",
+            (),
+            {
+                "team_id": f"team-{i}",
+                "budget_limits": [{"budget_duration": "7d", "reset_at": None}],
+            },
+        )
+        for i in range(2)
+    ]
+
+    mock_prisma_client.db.litellm_verificationtoken.set_find_many_results(keys)
+    mock_prisma_client.db.litellm_teamtable.set_find_many_results(teams)
+
+    with patch(
+        "litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()
+    ), patch.object(
+        ResetBudgetJob,
+        "_reset_expired_window",
+        new=AsyncMock(return_value=True),
+    ):
+        asyncio.run(reset_budget_job.reset_budget_windows())
+
+    assert [
+        call["where"] for call in mock_prisma_client.db.litellm_verificationtoken.update_calls
+    ] == [{"token": "sk-0"}, {"token": "sk-1"}]
+    assert [
+        call["where"] for call in mock_prisma_client.db.litellm_teamtable.update_calls
+    ] == [{"team_id": "team-0"}, {"team_id": "team-1"}]
 
 
 def test_reset_budget_resets_endusers_with_null_budget_id(

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -54,7 +54,9 @@ class MockLiteLLMVerificationToken:
             return results
         return results[:take]
 
-    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+    async def update(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
         return {"count": 1}
 
@@ -92,7 +94,9 @@ class MockLiteLLMTeamTable:
             return results
         return results[:take]
 
-    async def update(self, where: Dict[str, Any], data: Dict[str, Any]) -> Dict[str, Any]:
+    async def update(
+        self, where: Dict[str, Any], data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         self.update_calls.append({"where": where, "data": data})
         return {"count": 1}
 
@@ -722,12 +726,13 @@ def test_reset_budget_windows_filters_null_budget_limits_in_python(
         [team_with_windows, team_without_windows]
     )
 
-    with patch(
-        "litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()
-    ), patch.object(
-        ResetBudgetJob,
-        "_reset_expired_window",
-        new=AsyncMock(return_value=True),
+    with (
+        patch("litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()),
+        patch.object(
+            ResetBudgetJob,
+            "_reset_expired_window",
+            new=AsyncMock(return_value=True),
+        ),
     ):
         asyncio.run(reset_budget_job.reset_budget_windows())
 
@@ -797,7 +802,9 @@ def test_reset_budget_windows_paginates_large_tables(
     ]
 
 
-def test_iter_budget_window_rows_uses_cursor_pagination(reset_budget_job, mock_prisma_client):
+def test_iter_budget_window_rows_uses_cursor_pagination(
+    reset_budget_job, mock_prisma_client
+):
     reset_budget_job._RESET_BUDGET_WINDOWS_BATCH_SIZE = 2
 
     keys = [
@@ -857,17 +864,19 @@ def test_reset_budget_windows_updates_items_across_cursor_pages(
     mock_prisma_client.db.litellm_verificationtoken.set_find_many_results(keys)
     mock_prisma_client.db.litellm_teamtable.set_find_many_results(teams)
 
-    with patch(
-        "litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()
-    ), patch.object(
-        ResetBudgetJob,
-        "_reset_expired_window",
-        new=AsyncMock(return_value=True),
+    with (
+        patch("litellm.proxy.proxy_server.spend_counter_cache", new=MagicMock()),
+        patch.object(
+            ResetBudgetJob,
+            "_reset_expired_window",
+            new=AsyncMock(return_value=True),
+        ),
     ):
         asyncio.run(reset_budget_job.reset_budget_windows())
 
     assert [
-        call["where"] for call in mock_prisma_client.db.litellm_verificationtoken.update_calls
+        call["where"]
+        for call in mock_prisma_client.db.litellm_verificationtoken.update_calls
     ] == [{"token": "sk-0"}, {"token": "sk-1"}]
     assert [
         call["where"] for call in mock_prisma_client.db.litellm_teamtable.update_calls
@@ -954,9 +963,9 @@ def test_reset_budget_resets_endusers_with_null_budget_id(
 
     # Both end users should have been reset
     updated = mock_prisma_client.updated_data["enduser"]
-    assert len(updated) == 2, (
-        f"Expected 2 endusers reset (1 explicit + 1 implicit), got {len(updated)}"
-    )
+    assert (
+        len(updated) == 2
+    ), f"Expected 2 endusers reset (1 explicit + 1 implicit), got {len(updated)}"
 
     user_ids = {u.user_id for u in updated}
     assert "enduser-explicit" in user_ids


### PR DESCRIPTION
## Summary
- paginate the background `reset_budget_windows()` scans for keys and teams
- add a fixed safety batch size plus deterministic ordering for each page
- extend the regression tests to cover the paginated behavior

## Why
PR #26085 fixes a correctness issue where Prisma rejects `{"budget_limits": {"not": None}}` for nullable JSON fields.

That correctness fix intentionally removed the invalid DB filter and relied on the existing Python-side `if not raw: continue` guard. This follow-up addresses the separate scalability concern noted in review by avoiding unbounded `find_many()` scans on every scheduler tick.

## What changed
- keys are now fetched in batches with:
  - `take=500`
  - `skip=<page offset>`
  - `order={"token": "asc"}`
- teams are now fetched in batches with:
  - `take=500`
  - `skip=<page offset>`
  - `order={"team_id": "asc"}`
- existing semantics are preserved: rows without `budget_limits` are still skipped in Python, and rows with changed windows are still updated individually.

## Validation
```bash
/home/staticduo/.local/bin/uv run --group dev --extra proxy --extra extra_proxy --extra proxy-runtime python -m pytest tests/test_litellm/proxy/common_utils/test_reset_budget_job.py -q
```

Result: `20 passed`
