### PR TITLE
fix(mcp): resolve client-prefixed MCP tool names in semantic filter

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -7,6 +7,10 @@ Filters MCP tools semantically for /chat/completions and /responses endpoints.
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
+from litellm.proxy._experimental.mcp_server.utils import (
+    MCP_TOOL_PREFIX_SEPARATOR,
+    get_tool_name,
+)
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
@@ -87,18 +91,23 @@ class SemanticMCPToolFilter:
             raise
 
     def _extract_tool_info(self, tool) -> tuple[str, str]:
-        """Extract name and description from MCP tool or OpenAI function dict."""
-        name: str
-        description: str
+        """Extract name and description from MCP tool or OpenAI function dict.
+
+        Description falls back to the name so the embedding input is never
+        empty, which matters when the same code path handles both MCP tool
+        objects and OpenAI-style function dicts.
+        """
+        name = get_tool_name(tool)
 
         if isinstance(tool, dict):
-            # OpenAI function format
-            name = tool.get("name", "")
-            description = tool.get("description", name)
+            # Prefer the nested ``function`` block if present (Chat
+            # Completions wrapper), otherwise read from the flat dict.
+            fn = tool.get("function") if isinstance(tool.get("function"), dict) else None
+            source: Dict[str, Any] = fn if fn is not None else tool
+            description = source.get("description", name) or name
         else:
-            # MCPTool object
-            name = str(tool.name)
-            description = str(tool.description) if tool.description else str(tool.name)
+            raw_description = getattr(tool, "description", None)
+            description = str(raw_description) if raw_description else name
 
         return name, description
 
@@ -217,16 +226,57 @@ class SemanticMCPToolFilter:
     def _get_tools_by_names(
         self, tool_names: List[str], available_tools: List[Any]
     ) -> List[Any]:
-        """Get tools from available_tools by their names, preserving order."""
-        # Match tools from available_tools (preserves format - dict or MCPTool)
-        matched_tools = []
-        for tool in available_tools:
-            tool_name, _ = self._extract_tool_info(tool)
-            if tool_name in tool_names:
-                matched_tools.append(tool)
+        """Get tools from ``available_tools`` by their names, preserving order.
 
-        # Reorder to match semantic router's ordering
-        tool_map = {self._extract_tool_info(t)[0]: t for t in matched_tools}
+        The semantic router emits canonical MCP names (e.g. ``<server>-<tool>``
+        produced by ``add_server_prefix_to_name``). Clients, however, may
+        send tools with their own extra prefix — for example opencode wraps
+        every MCP tool as ``litellm_<server>-<tool>`` and Responses-API
+        callers sometimes mirror the same pattern. Strict equality then
+        drops every tool and the downstream request is shipped with
+        ``tools=[]``, which upstream vLLM rejects when ``tool_choice`` is
+        set.
+
+        Matching rules (applied in order for every available tool):
+
+        1. Exact canonical match wins.
+        2. Otherwise, the longest canonical that appears as a suffix of the
+           client name, preceded by a separator (``MCP_TOOL_PREFIX_SEPARATOR``
+           or ``_``), is selected. Requiring a separator boundary prevents a
+           native client tool (e.g. ``read``) from aliasing into an MCP
+           canonical (e.g. ``fs-read``), and the longest-wins rule
+           disambiguates when several canonicals share a common tail
+           (e.g. ``search-scrape`` vs ``fc_web_search-scrape``).
+
+        Ordering from ``tool_names`` is preserved; unmatched canonicals are
+        skipped rather than fabricated.
+        """
+        if not tool_names or not available_tools:
+            return []
+
+        canonical_set = set(tool_names)
+        # Longer canonicals first so the suffix scan always picks the most
+        # specific match when several share a tail.
+        canonicals_desc_len = sorted(tool_names, key=len, reverse=True)
+        separators = (MCP_TOOL_PREFIX_SEPARATOR, "_")
+
+        tool_map: Dict[str, Any] = {}
+        for tool in available_tools:
+            tool_name = get_tool_name(tool)
+            if not tool_name:
+                continue
+
+            if tool_name in canonical_set:
+                tool_map.setdefault(tool_name, tool)
+                continue
+
+            for canonical in canonicals_desc_len:
+                if any(
+                    tool_name.endswith(sep + canonical) for sep in separators
+                ):
+                    tool_map.setdefault(canonical, tool)
+                    break
+
         return [tool_map[name] for name in tool_names if name in tool_map]
 
     def extract_user_query(self, messages: List[Dict[str, Any]]) -> str:

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -101,6 +101,29 @@ def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:
     return prefixed_name, ""
 
 
+def get_tool_name(tool: Any) -> str:
+    """Extract the tool name from an MCP tool or an OpenAI tool dict.
+
+    Callers throughout the proxy receive tool definitions in one of three
+    shapes, depending on whether a request came from the Responses API, the
+    Chat Completions API, or the internal MCP registry. This helper
+    normalises them to a single string:
+
+    - OpenAI Chat Completions wrapper: ``{"type": "function", "function": {"name": ...}}``
+    - Flat dict (Responses API / expanded MCP tools): ``{"name": ...}``
+    - ``MCPTool`` (or any object with a ``.name`` attribute)
+
+    Returns ``""`` when the name cannot be determined, so callers can still
+    filter out unnamed entries without raising.
+    """
+    if isinstance(tool, dict):
+        fn = tool.get("function")
+        if isinstance(fn, dict) and fn.get("name"):
+            return fn["name"]
+        return tool.get("name", "") or ""
+    return getattr(tool, "name", "") or ""
+
+
 def is_tool_name_prefixed(
     tool_name: str,
     known_server_prefixes: Optional[set] = None,

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -14,6 +14,7 @@ from litellm.constants import (
     DEFAULT_MCP_SEMANTIC_FILTER_TOP_K,
 )
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._experimental.mcp_server.utils import get_tool_name
 
 if TYPE_CHECKING:
     from litellm.caching.caching import DualCache
@@ -288,20 +289,16 @@ class SemanticToolFilterHook(CustomLogger):
         return headers
 
     def _get_tool_names_csv(self, tools: List[Any]) -> str:
-        """Extract tool names and return as CSV string."""
+        """Extract tool names and return as CSV string.
+
+        Uses the shared ``get_tool_name`` helper so OpenAI Chat Completions
+        wrapper tools (``{"type": "function", "function": {"name": ...}}``)
+        and flat/MCP tool objects all resolve to their display name.
+        """
         if not tools:
             return ""
 
-        tool_names = []
-        for tool in tools:
-            name = (
-                tool.get("name", "")
-                if isinstance(tool, dict)
-                else getattr(tool, "name", "")
-            )
-            if name:
-                tool_names.append(name)
-
+        tool_names = [name for name in (get_tool_name(t) for t in tools) if name]
         return ",".join(tool_names)
 
     @staticmethod

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_utils.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for ``litellm/proxy/_experimental/mcp_server/utils.py`` helpers.
+
+Focuses on ``get_tool_name`` which normalises tool payloads across the three
+shapes the proxy sees in practice.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from mcp.types import Tool as MCPTool
+
+from litellm.proxy._experimental.mcp_server.utils import get_tool_name
+
+
+def test_get_tool_name_openai_wrapper():
+    tool = {
+        "type": "function",
+        "function": {"name": "foo", "description": "bar"},
+    }
+    assert get_tool_name(tool) == "foo"
+
+
+def test_get_tool_name_flat_dict():
+    tool = {"name": "foo", "description": "bar"}
+    assert get_tool_name(tool) == "foo"
+
+
+def test_get_tool_name_mcptool_object():
+    tool = MCPTool(name="foo", description="bar", inputSchema={"type": "object"})
+    assert get_tool_name(tool) == "foo"
+
+
+def test_get_tool_name_missing_returns_empty_string():
+    assert get_tool_name({}) == ""
+    assert get_tool_name({"function": {"description": "no name"}}) == ""
+
+    class _Nameless:
+        pass
+
+    assert get_tool_name(_Nameless()) == ""
+
+
+def test_get_tool_name_openai_wrapper_missing_name_falls_back_to_flat():
+    # Wrapper present but no name -> fall through to flat-dict lookup.
+    tool = {
+        "type": "function",
+        "function": {"description": "nope"},
+        "name": "outer",
+    }
+    assert get_tool_name(tool) == "outer"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -406,6 +406,180 @@ async def test_semantic_filter_hook_triggers_on_completion():
     print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
 
 
+def _make_filter():
+    """Build a ``SemanticMCPToolFilter`` without exercising the embedding
+    router. These tests only poke pure-Python methods (``_extract_tool_info``
+    and ``_get_tools_by_names``)."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    return SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=10,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+
+def test_extract_tool_info_openai_chat_wrapper():
+    """Chat Completions wrapper: name and description come from .function."""
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        {"type": "function", "function": {"name": "foo", "description": "bar"}}
+    )
+    assert (name, description) == ("foo", "bar")
+
+
+def test_extract_tool_info_flat_dict():
+    """Responses API / expanded MCP tool: flat dict with name+description."""
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        {"name": "foo", "description": "bar"}
+    )
+    assert (name, description) == ("foo", "bar")
+
+
+def test_extract_tool_info_mcptool_object():
+    """MCPTool objects keep working unchanged."""
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        MCPTool(name="foo", description="bar", inputSchema={"type": "object"})
+    )
+    assert (name, description) == ("foo", "bar")
+
+
+def test_extract_tool_info_falls_back_to_name_when_description_missing():
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        {"type": "function", "function": {"name": "foo"}}
+    )
+    assert (name, description) == ("foo", "foo")
+
+
+def test_get_tools_by_names_exact_match_preserves_router_order():
+    f = _make_filter()
+    tools = [
+        MCPTool(name="b", description="", inputSchema={}),
+        MCPTool(name="a", description="", inputSchema={}),
+        MCPTool(name="c", description="", inputSchema={}),
+    ]
+    matched = f._get_tools_by_names(["a", "c", "b"], tools)
+    assert [t.name for t in matched] == ["a", "c", "b"]
+
+
+def test_get_tools_by_names_client_prefix_is_resolved():
+    """Client wraps an MCP canonical tool with its own alias prefix
+    (``litellm_<server>-<tool>``). Canonical from the router is
+    ``fc_web_search-firecrawl_scrape``; the wrapped client name still
+    resolves to it."""
+    f = _make_filter()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "litellm_fc_web_search-firecrawl_scrape",
+                "description": "scrape",
+            },
+        }
+    ]
+    matched = f._get_tools_by_names(["fc_web_search-firecrawl_scrape"], tools)
+    assert len(matched) == 1
+    assert matched[0] is tools[0]
+
+
+def test_get_tools_by_names_longest_canonical_wins():
+    """Two canonicals share a tail; client-prefixed name must bind to the
+    longer (more specific) canonical only."""
+    f = _make_filter()
+    tool = MCPTool(
+        name="litellm_fc_web_search-scrape", description="", inputSchema={}
+    )
+    canonicals = ["search-scrape", "fc_web_search-scrape"]
+    matched = f._get_tools_by_names(canonicals, [tool])
+    # The tool resolves exactly once, against the longer canonical, so
+    # ``search-scrape`` must drop out of the result.
+    assert len(matched) == 1
+    assert matched[0] is tool
+
+
+def test_get_tools_by_names_multi_server_no_cross_match():
+    """Two MCP servers register a same-named tool. A client-prefixed name
+    referencing server_a must not be bound to server_b's canonical."""
+    f = _make_filter()
+    tools = [
+        MCPTool(
+            name="litellm_server_a-search", description="", inputSchema={}
+        )
+    ]
+    canonicals = ["server_a-search", "server_b-search"]
+    matched = f._get_tools_by_names(canonicals, tools)
+    assert len(matched) == 1
+    assert matched[0] is tools[0]
+
+
+def test_get_tools_by_names_native_tool_no_false_match():
+    """A native client tool that happens to share the trailing portion of
+    a canonical name (``read`` vs ``fs-read``) must not alias into it:
+    the match requires a separator boundary immediately before the full
+    canonical."""
+    f = _make_filter()
+    tools = [MCPTool(name="read", description="", inputSchema={})]
+    matched = f._get_tools_by_names(["fs-read"], tools)
+    assert matched == []
+
+
+def test_get_tools_by_names_ordering_follows_router_with_mixed_inputs():
+    f = _make_filter()
+    tools = [
+        # Exact match for "a".
+        MCPTool(name="a", description="", inputSchema={}),
+        # Client-prefixed name for canonical "c".
+        {"type": "function", "function": {"name": "litellm_c"}},
+        # Wrapped flat dict for canonical "b".
+        {"name": "ext-b"},
+    ]
+    matched = f._get_tools_by_names(["b", "a", "c"], tools)
+    matched_names = [get_tool_name_for_test(t) for t in matched]
+    assert matched_names == ["ext-b", "a", "litellm_c"]
+
+
+def get_tool_name_for_test(tool):
+    """Local mirror of ``get_tool_name`` so assertions don't couple to the
+    helper module import order in other tests."""
+    from litellm.proxy._experimental.mcp_server.utils import get_tool_name
+
+    return get_tool_name(tool)
+
+
+def test_get_tool_names_csv_handles_all_shapes():
+    """``_get_tool_names_csv`` used to read only flat-dict ``name`` or
+    ``.name``; wrapped Chat Completions tools therefore surfaced as empty
+    strings in the ``x-litellm-semantic-filter-tools`` response header."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    hook = SemanticToolFilterHook(filter_instance)
+
+    tools = [
+        {"type": "function", "function": {"name": "foo"}},
+        {"name": "bar"},
+        MCPTool(name="baz", description="", inputSchema={}),
+    ]
+
+    assert hook._get_tool_names_csv(tools) == "foo,bar,baz"
+
+
 @pytest.mark.asyncio
 async def test_semantic_filter_hook_skips_no_tools():
     """


### PR DESCRIPTION
## Relevant issues

Fixes #26078

## Pre-Submission checklist

- I have added unit tests for the bug fix and shared helper in `tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py` and `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_utils.py`.
- I have run the affected tests locally and they pass.
- Scope is isolated to the semantic tool filter matching logic and its shared tool-name helper.

## Type

Bug Fix

## Changes

**Background.** Issue #26078 reports that when a client such as opencode wraps MCP tool names with its own alias prefix (e.g. `litellm_fc_web_search-firecrawl_scrape`) and/or sends them in the OpenAI Chat Completions wrapper shape (`{\"type\":\"function\",\"function\":{\"name\":...}}`), the `mcp_semantic_tool_filter` callback drops every tool. The hook still overwrites `data[\"tools\"]` with `[]` while leaving `tool_choice: auto`, which upstream vLLM rejects with HTTP 400: `'tool_choice' is only allowed when 'tools' are specified`.

**Root cause.** Two small bugs combined:
1. `SemanticMCPToolFilter._extract_tool_info` only recognised flat-dict `name`/`description`, so Chat-Completions-wrapped tools returned `(\"\", \"\")` and never matched anything in the semantic router's registry.
2. `SemanticMCPToolFilter._get_tools_by_names` used strict equality against the router's canonical names (`<server>-<tool>`), so any client-added prefix caused the lookup to miss.

**Fix.**

- New shared helper `get_tool_name(tool)` in `litellm/proxy/_experimental/mcp_server/utils.py` normalises the three tool shapes the proxy handles today: OpenAI Chat Completions wrapper, flat dict (Responses API / expanded MCP tool), and `MCPTool` objects.
- `SemanticMCPToolFilter._extract_tool_info` delegates to the helper for the name; description fallback stays local (filter-specific embedding-text concern).
- `SemanticToolFilterHook._get_tool_names_csv` delegates to the helper so the `x-litellm-semantic-filter-tools` response header reflects wrapped tool names as well.
- `SemanticMCPToolFilter._get_tools_by_names` now performs a registry-grounded longest-endswith canonical match with a separator boundary:
  - Exact canonical match wins first.
  - Otherwise the longest canonical that appears as a suffix of the client name, preceded by `MCP_TOOL_PREFIX_SEPARATOR` (`-` by default) or `_`, is selected.
  - This disambiguates sibling canonicals that share a tail (e.g. `search-scrape` vs `fc_web_search-scrape`) and prevents a native client tool (e.g. `read`) from aliasing into an MCP canonical (e.g. `fs-read`).
  - Ordering from the router is preserved; unmatched canonicals are skipped.

**Tests added (all passing locally).**

- `test_mcp_server_utils.py` — 5 tests for `get_tool_name` across wrapper, flat dict, MCPTool object, missing-name, and wrapper-without-name-falls-back-to-outer cases.
- `test_semantic_tool_filter.py` — 9 new tests covering the extractor across all three shapes, exact/prefixed matching, longest-wins disambiguation, multi-server sibling isolation, native-tool non-match, router-order preservation, and the hook CSV across all three shapes.

Made with Cursor.

Made with [Cursor](https://cursor.com)