### PR TITLE
fix(mcp): resolve client-prefixed MCP tool names in semantic filter

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -3,9 +3,11 @@ Semantic MCP Tool Filtering using semantic-router
 
 Filters MCP tools semantically for /chat/completions and /responses endpoints.
 """
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
+from litellm.proxy._experimental.mcp_server.utils import get_tool_name_and_description
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
@@ -86,20 +88,13 @@ class SemanticMCPToolFilter:
             raise
 
     def _extract_tool_info(self, tool) -> tuple[str, str]:
-        """Extract name and description from MCP tool or OpenAI function dict."""
-        name: str
-        description: str
+        """Name + description used as the semantic-router embedding input.
 
-        if isinstance(tool, dict):
-            # OpenAI function format
-            name = tool.get("name", "")
-            description = tool.get("description", name)
-        else:
-            # MCPTool object
-            name = str(tool.name)
-            description = str(tool.description) if tool.description else str(tool.name)
-
-        return name, description
+        Description falls back to the name (handled inside
+        ``get_tool_name_and_description``) so the embedding text is never
+        empty for tools that omit a description.
+        """
+        return get_tool_name_and_description(tool)
 
     def _build_router(self, tools: List) -> None:
         """Build semantic router with tools (MCPTool objects or OpenAI function dicts)."""
@@ -216,16 +211,65 @@ class SemanticMCPToolFilter:
     def _get_tools_by_names(
         self, tool_names: List[str], available_tools: List[Any]
     ) -> List[Any]:
-        """Get tools from available_tools by their names, preserving order."""
-        # Match tools from available_tools (preserves format - dict or MCPTool)
-        matched_tools = []
-        for tool in available_tools:
-            tool_name, _ = self._extract_tool_info(tool)
-            if tool_name in tool_names:
-                matched_tools.append(tool)
+        """Get tools from ``available_tools`` by their names, preserving order.
 
-        # Reorder to match semantic router's ordering
-        tool_map = {self._extract_tool_info(t)[0]: t for t in matched_tools}
+        The semantic router emits canonical MCP names (e.g. ``<server>-<tool>``
+        produced by ``add_server_prefix_to_name``). Clients, however, may
+        send tools with their own extra prefix — for example opencode wraps
+        every MCP tool as ``litellm_<server>-<tool>`` and Responses-API
+        callers sometimes mirror the same pattern. Strict equality then
+        drops every tool and the downstream request is shipped with
+        ``tools=[]``, which upstream vLLM rejects when ``tool_choice`` is
+        set.
+
+        Matching rules (applied in order for every available tool):
+
+        1. Exact canonical match wins.
+        2. Otherwise, the longest canonical that appears as a suffix of the
+           client name, preceded by ``-`` or ``_``, wins. The separator
+           boundary avoids cross-server false matches such as
+           ``server_b-a-search`` aliasing into canonical ``a-search``. The
+           longest-wins property is emergent: we scan separator positions in
+           the client name left-to-right, and the first matching tail is the
+           longest canonical suffix by construction. Canonicals produced by
+           ``add_server_prefix_to_name`` always carry a ``<server>-<tool>``
+           shape, so the suffix relation combined with the separator check
+           is specific enough in practice.
+
+        Ordering from ``tool_names`` is preserved; unmatched canonicals are
+        skipped rather than fabricated. When no canonical resolves at all we
+        log a warning so the empty-``tools`` failure mode stays observable
+        instead of silently degrading into an upstream HTTP 400.
+        """
+        if not tool_names or not available_tools:
+            return []
+
+        canonical_set = set(tool_names)
+
+        tool_map: Dict[str, Any] = {}
+        for tool in available_tools:
+            tool_name, _ = get_tool_name_and_description(tool)
+            if not tool_name:
+                continue
+
+            if tool_name in canonical_set:
+                tool_map.setdefault(tool_name, tool)
+                continue
+
+            for i, ch in enumerate(tool_name):
+                if ch in ("-", "_"):
+                    candidate = tool_name[i + 1 :]
+                    if candidate in canonical_set:
+                        tool_map.setdefault(candidate, tool)
+                        break
+
+        if not tool_map:
+            verbose_logger.warning(
+                "Semantic filter matched 0 tools for canonicals=%s; check "
+                "whether client-side tool names diverge from the registry.",
+                tool_names,
+            )
+
         return [tool_map[name] for name in tool_names if name in tool_map]
 
     def extract_user_query(self, messages: List[Dict[str, Any]]) -> str:

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -1,6 +1,7 @@
 """
 MCP Server Utilities
 """
+
 from typing import Any, Dict, Mapping, Optional, Tuple
 
 import os
@@ -98,6 +99,38 @@ def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:
         if len(parts) == 2:
             return parts[1], parts[0]
     return prefixed_name, ""
+
+
+def get_tool_name_and_description(tool: Any) -> Tuple[str, str]:
+    """Return ``(name, description)`` for any tool shape the proxy sees.
+
+    Callers throughout the proxy receive tool definitions in one of three
+    shapes, depending on whether a request came from the Responses API, the
+    Chat Completions API, or the internal MCP registry:
+
+    - OpenAI Chat Completions wrapper: ``{"type": "function", "function": {"name": ..., "description": ...}}``
+    - Flat dict (Responses API / expanded MCP tools): ``{"name": ..., "description": ...}``
+    - ``MCPTool`` (or any object with ``.name`` / ``.description`` attributes)
+
+    ``name`` defaults to the empty string when absent. ``description``
+    falls back to ``name`` when the tool payload omits it or leaves it
+    empty, which matches the historical ``_extract_tool_info`` behaviour
+    (the semantic router requires a non-empty embedding input). Callers
+    that only need the name can unpack ``[0]``.
+    """
+    if isinstance(tool, dict):
+        fn = tool.get("function") if isinstance(tool.get("function"), dict) else None
+        # Prefer the nested ``function`` block when it actually carries a
+        # name; otherwise fall through to the outer dict so malformed
+        # wrappers (``{"function": {...}, "name": "outer"}``) still resolve.
+        source = fn if fn and fn.get("name") else tool
+        name = source.get("name", "") or ""
+        description = source.get("description", "") or name
+        return name, description
+    name = getattr(tool, "name", "") or ""
+    raw_description = getattr(tool, "description", None)
+    description = str(raw_description) if raw_description else name
+    return name, description
 
 
 def is_tool_name_prefixed(

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -4,6 +4,7 @@ Semantic Tool Filter Hook
 Pre-call hook that filters MCP tools semantically before LLM inference.
 Reduces context window size and improves tool selection accuracy.
 """
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
@@ -13,6 +14,7 @@ from litellm.constants import (
     DEFAULT_MCP_SEMANTIC_FILTER_TOP_K,
 )
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._experimental.mcp_server.utils import get_tool_name_and_description
 
 if TYPE_CHECKING:
     from litellm.caching.caching import DualCache
@@ -287,20 +289,19 @@ class SemanticToolFilterHook(CustomLogger):
         return headers
 
     def _get_tool_names_csv(self, tools: List[Any]) -> str:
-        """Extract tool names and return as CSV string."""
+        """Extract tool names and return as CSV string.
+
+        Uses the shared ``get_tool_name_and_description`` helper so OpenAI
+        Chat Completions wrapper tools (``{"type": "function", "function":
+        {"name": ...}}``) and flat/MCP tool objects all resolve to their
+        display name.
+        """
         if not tools:
             return ""
 
-        tool_names = []
-        for tool in tools:
-            name = (
-                tool.get("name", "")
-                if isinstance(tool, dict)
-                else getattr(tool, "name", "")
-            )
-            if name:
-                tool_names.append(name)
-
+        tool_names = [
+            name for name, _ in (get_tool_name_and_description(t) for t in tools) if name
+        ]
         return ",".join(tool_names)
 
     @staticmethod

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_utils.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for ``litellm/proxy/_experimental/mcp_server/utils.py`` helpers.
+
+Focuses on ``get_tool_name_and_description`` which normalises tool payloads
+across the three shapes the proxy sees in practice.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from mcp.types import Tool as MCPTool
+
+from litellm.proxy._experimental.mcp_server.utils import (
+    get_tool_name_and_description,
+)
+
+
+def test_pair_openai_wrapper_returns_function_block_fields():
+    tool = {
+        "type": "function",
+        "function": {"name": "foo", "description": "bar"},
+    }
+    assert get_tool_name_and_description(tool) == ("foo", "bar")
+
+
+def test_pair_flat_dict_returns_top_level_fields():
+    tool = {"name": "foo", "description": "bar"}
+    assert get_tool_name_and_description(tool) == ("foo", "bar")
+
+
+def test_pair_mcptool_object_returns_attributes():
+    tool = MCPTool(name="foo", description="bar", inputSchema={"type": "object"})
+    assert get_tool_name_and_description(tool) == ("foo", "bar")
+
+
+def test_pair_missing_fields_return_empty_strings():
+    assert get_tool_name_and_description({}) == ("", "")
+
+    class _Nameless:
+        pass
+
+    assert get_tool_name_and_description(_Nameless()) == ("", "")
+
+
+def test_pair_description_falls_back_to_name():
+    """Matches the historical ``_extract_tool_info`` fallback so the
+    semantic router never embeds an empty string."""
+    # Dict with no description.
+    assert get_tool_name_and_description({"name": "foo"}) == ("foo", "foo")
+    # Dict with empty description.
+    assert get_tool_name_and_description({"name": "foo", "description": ""}) == (
+        "foo",
+        "foo",
+    )
+    # MCPTool with no description.
+    tool = MCPTool(name="foo", description=None, inputSchema={"type": "object"})
+    assert get_tool_name_and_description(tool) == ("foo", "foo")
+
+
+def test_pair_openai_wrapper_missing_name_falls_back_to_outer_dict():
+    """Malformed wrapper where ``function`` block has no name - fall
+    through to the outer dict so both name and description are read
+    together from the same source."""
+    tool = {
+        "type": "function",
+        "function": {"description": "nope"},
+        "name": "outer",
+        "description": "outer-desc",
+    }
+    assert get_tool_name_and_description(tool) == ("outer", "outer-desc")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -4,6 +4,7 @@ Unit tests for MCP Semantic Tool Filtering
 Tests the core filtering logic that takes a long list of tools and returns
 an ordered set of top K tools based on semantic similarity.
 """
+
 import asyncio
 import os
 import sys
@@ -20,7 +21,7 @@ from mcp.types import Tool as MCPTool
 async def test_semantic_filter_basic_filtering():
     """
     Test that the semantic filter correctly filters tools based on query.
-    
+
     Given: 10 email/calendar tools
     When: Query is "send an email"
     Then: Email tools should rank higher than calendar tools
@@ -31,37 +32,77 @@ async def test_semantic_filter_basic_filtering():
 
     # Create mock tools - mix of email and calendar tools
     tools = [
-        MCPTool(name="gmail_send", description="Send an email via Gmail", inputSchema={"type": "object"}),
-        MCPTool(name="outlook_send", description="Send an email via Outlook", inputSchema={"type": "object"}),
-        MCPTool(name="calendar_create", description="Create a calendar event", inputSchema={"type": "object"}),
-        MCPTool(name="calendar_update", description="Update a calendar event", inputSchema={"type": "object"}),
-        MCPTool(name="email_read", description="Read emails from inbox", inputSchema={"type": "object"}),
-        MCPTool(name="email_delete", description="Delete an email", inputSchema={"type": "object"}),
-        MCPTool(name="calendar_delete", description="Delete a calendar event", inputSchema={"type": "object"}),
-        MCPTool(name="email_search", description="Search for emails", inputSchema={"type": "object"}),
-        MCPTool(name="calendar_list", description="List calendar events", inputSchema={"type": "object"}),
-        MCPTool(name="email_forward", description="Forward an email to someone", inputSchema={"type": "object"}),
+        MCPTool(
+            name="gmail_send",
+            description="Send an email via Gmail",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="outlook_send",
+            description="Send an email via Outlook",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="calendar_create",
+            description="Create a calendar event",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="calendar_update",
+            description="Update a calendar event",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="email_read",
+            description="Read emails from inbox",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="email_delete",
+            description="Delete an email",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="calendar_delete",
+            description="Delete a calendar event",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="email_search",
+            description="Search for emails",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="calendar_list",
+            description="List calendar events",
+            inputSchema={"type": "object"},
+        ),
+        MCPTool(
+            name="email_forward",
+            description="Forward an email to someone",
+            inputSchema={"type": "object"},
+        ),
     ]
-    
+
     # Mock router that returns mock embeddings
     from litellm.types.utils import Embedding, EmbeddingResponse
-    
+
     mock_router = Mock()
-    
+
     def mock_embedding_sync(*args, **kwargs):
         return EmbeddingResponse(
             data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
             model="text-embedding-3-small",
             object="list",
-            usage={"prompt_tokens": 10, "total_tokens": 10}
+            usage={"prompt_tokens": 10, "total_tokens": 10},
         )
-    
+
     async def mock_embedding_async(*args, **kwargs):
         return mock_embedding_sync()
-    
+
     mock_router.embedding = mock_embedding_sync
     mock_router.aembedding = mock_embedding_async
-    
+
     # Create filter
     filter_instance = SemanticMCPToolFilter(
         embedding_model="text-embedding-3-small",
@@ -70,28 +111,36 @@ async def test_semantic_filter_basic_filtering():
         similarity_threshold=0.3,
         enabled=True,
     )
-    
+
     # Build router with the tools before filtering
     filter_instance._build_router(tools)
-    
+
     # Filter tools with email-related query
     filtered = await filter_instance.filter_tools(
         query="send an email to john@example.com",
         available_tools=tools,
     )
-    
+
     # Assertions - validate filtering mechanics work
-    assert len(filtered) <= 3, f"Should return at most 3 tools (top_k), got {len(filtered)}"
+    assert (
+        len(filtered) <= 3
+    ), f"Should return at most 3 tools (top_k), got {len(filtered)}"
     assert len(filtered) > 0, "Should return at least some tools"
-    assert len(filtered) < len(tools), f"Should filter down from {len(tools)} tools, got {len(filtered)}"
-    
+    assert len(filtered) < len(
+        tools
+    ), f"Should filter down from {len(tools)} tools, got {len(filtered)}"
+
     # Validate tools are actual MCPTool objects
     for tool in filtered:
-        assert hasattr(tool, 'name'), "Filtered result should be MCPTool with name"
-        assert hasattr(tool, 'description'), "Filtered result should be MCPTool with description"
-    
+        assert hasattr(tool, "name"), "Filtered result should be MCPTool with name"
+        assert hasattr(
+            tool, "description"
+        ), "Filtered result should be MCPTool with description"
+
     filtered_names = [t.name for t in filtered]
-    print(f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}")
+    print(
+        f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}"
+    )
     print(f"   Filter respects top_k parameter correctly")
 
 
@@ -99,7 +148,7 @@ async def test_semantic_filter_basic_filtering():
 async def test_semantic_filter_top_k_limiting():
     """
     Test that the filter respects top_k parameter.
-    
+
     Given: 20 tools
     When: top_k=5
     Then: Should return at most 5 tools
@@ -110,29 +159,33 @@ async def test_semantic_filter_top_k_limiting():
 
     # Create 20 tools
     tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool number {i} for testing", inputSchema={"type": "object"})
+        MCPTool(
+            name=f"tool_{i}",
+            description=f"Tool number {i} for testing",
+            inputSchema={"type": "object"},
+        )
         for i in range(20)
     ]
-    
+
     # Mock router
     from litellm.types.utils import Embedding, EmbeddingResponse
-    
+
     mock_router = Mock()
-    
+
     def mock_embedding_sync(*args, **kwargs):
         return EmbeddingResponse(
             data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
             model="text-embedding-3-small",
             object="list",
-            usage={"prompt_tokens": 10, "total_tokens": 10}
+            usage={"prompt_tokens": 10, "total_tokens": 10},
         )
-    
+
     async def mock_embedding_async(*args, **kwargs):
         return mock_embedding_sync()
-    
+
     mock_router.embedding = mock_embedding_sync
     mock_router.aembedding = mock_embedding_async
-    
+
     # Create filter with top_k=5
     filter_instance = SemanticMCPToolFilter(
         embedding_model="text-embedding-3-small",
@@ -141,16 +194,16 @@ async def test_semantic_filter_top_k_limiting():
         similarity_threshold=0.3,
         enabled=True,
     )
-    
+
     # Build router with the tools before filtering
     filter_instance._build_router(tools)
-    
+
     # Filter tools
     filtered = await filter_instance.filter_tools(
         query="test query",
         available_tools=tools,
     )
-    
+
     # Should return at most 5 tools
     assert len(filtered) <= 5, f"Expected at most 5 tools, got {len(filtered)}"
     print(f"Returned {len(filtered)} tools out of {len(tools)} (top_k=5)")
@@ -164,14 +217,16 @@ async def test_semantic_filter_disabled():
     from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
         SemanticMCPToolFilter,
     )
-    
+
     tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
+        MCPTool(
+            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
+        )
         for i in range(10)
     ]
-    
+
     mock_router = Mock()
-    
+
     # Create disabled filter
     filter_instance = SemanticMCPToolFilter(
         embedding_model="text-embedding-3-small",
@@ -180,15 +235,17 @@ async def test_semantic_filter_disabled():
         similarity_threshold=0.3,
         enabled=False,  # Disabled
     )
-    
+
     # Filter tools
     filtered = await filter_instance.filter_tools(
         query="test query",
         available_tools=tools,
     )
-    
+
     # Should return all tools when disabled
-    assert len(filtered) == len(tools), f"Expected all {len(tools)} tools, got {len(filtered)}"
+    assert len(filtered) == len(
+        tools
+    ), f"Expected all {len(tools)} tools, got {len(filtered)}"
 
 
 @pytest.mark.asyncio
@@ -199,9 +256,9 @@ async def test_semantic_filter_empty_tools():
     from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
         SemanticMCPToolFilter,
     )
-    
+
     mock_router = Mock()
-    
+
     filter_instance = SemanticMCPToolFilter(
         embedding_model="text-embedding-3-small",
         litellm_router_instance=mock_router,
@@ -209,13 +266,13 @@ async def test_semantic_filter_empty_tools():
         similarity_threshold=0.3,
         enabled=True,
     )
-    
+
     # Filter empty list
     filtered = await filter_instance.filter_tools(
         query="test query",
         available_tools=[],
     )
-    
+
     assert len(filtered) == 0, "Should return empty list for empty input"
 
 
@@ -227,9 +284,9 @@ async def test_semantic_filter_extract_user_query():
     from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
         SemanticMCPToolFilter,
     )
-    
+
     mock_router = Mock()
-    
+
     filter_instance = SemanticMCPToolFilter(
         embedding_model="text-embedding-3-small",
         litellm_router_instance=mock_router,
@@ -237,32 +294,35 @@ async def test_semantic_filter_extract_user_query():
         similarity_threshold=0.3,
         enabled=True,
     )
-    
+
     # Test string content
     messages = [
         {"role": "system", "content": "You are a helpful assistant"},
         {"role": "user", "content": "Send an email to john@example.com"},
     ]
-    
+
     query = filter_instance.extract_user_query(messages)
     assert query == "Send an email to john@example.com"
-    
+
     # Test list content blocks
     messages_with_blocks = [
-        {"role": "user", "content": [
-            {"type": "text", "text": "Hello, "},
-            {"type": "text", "text": "send email please"},
-        ]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello, "},
+                {"type": "text", "text": "send email please"},
+            ],
+        },
     ]
-    
+
     query2 = filter_instance.extract_user_query(messages_with_blocks)
     assert "Hello" in query2 and "send email" in query2
-    
+
     # Test no user messages
     messages_no_user = [
         {"role": "system", "content": "System message only"},
     ]
-    
+
     query3 = filter_instance.extract_user_query(messages_no_user)
     assert query3 == ""
 
@@ -280,21 +340,21 @@ async def test_semantic_filter_hook_triggers_on_completion():
 
     # Create mock filter
     mock_router = Mock()
-    
+
     def mock_embedding_sync(*args, **kwargs):
         return EmbeddingResponse(
             data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
             model="text-embedding-3-small",
             object="list",
-            usage={"prompt_tokens": 10, "total_tokens": 10}
+            usage={"prompt_tokens": 10, "total_tokens": 10},
         )
-    
+
     async def mock_embedding_async(*args, **kwargs):
         return mock_embedding_sync()
-    
+
     mock_router.embedding = mock_embedding_sync
     mock_router.aembedding = mock_embedding_async
-    
+
     filter_instance = SemanticMCPToolFilter(
         embedding_model="text-embedding-3-small",
         litellm_router_instance=mock_router,
@@ -302,32 +362,32 @@ async def test_semantic_filter_hook_triggers_on_completion():
         similarity_threshold=0.3,
         enabled=True,
     )
-    
+
     # Prepare data - completion request with tools
     tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
+        MCPTool(
+            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
+        )
         for i in range(10)
     ]
-    
+
     # Build router with the tools before filtering
     filter_instance._build_router(tools)
-    
+
     # Create hook
     hook = SemanticToolFilterHook(filter_instance)
-    
+
     data = {
         "model": "gpt-4",
-        "messages": [
-            {"role": "user", "content": "Send an email"}
-        ],
+        "messages": [{"role": "user", "content": "Send an email"}],
         "tools": tools,
         "metadata": {},  # Hook needs metadata field to store filter stats
     }
-    
+
     # Mock user API key dict and cache
     mock_user_api_key_dict = Mock()
     mock_cache = Mock()
-    
+
     # Call hook
     result = await hook.async_pre_call_hook(
         user_api_key_dict=mock_user_api_key_dict,
@@ -335,14 +395,218 @@ async def test_semantic_filter_hook_triggers_on_completion():
         data=data,
         call_type="completion",
     )
-    
+
     # Assertions
     assert result is not None, "Hook should return modified data"
     assert "tools" in result, "Result should contain tools"
-    assert len(result["tools"]) < len(tools), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
-    
+    assert len(result["tools"]) < len(
+        tools
+    ), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
+
     print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
 
+
+def _make_filter():
+    """Build a ``SemanticMCPToolFilter`` without exercising the embedding
+    router. These tests only poke pure-Python methods (``_extract_tool_info``
+    and ``_get_tools_by_names``)."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    return SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=10,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+
+def test_extract_tool_info_openai_chat_wrapper():
+    """Chat Completions wrapper: name and description come from .function."""
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        {"type": "function", "function": {"name": "foo", "description": "bar"}}
+    )
+    assert (name, description) == ("foo", "bar")
+
+
+def test_extract_tool_info_flat_dict():
+    """Responses API / expanded MCP tool: flat dict with name+description."""
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        {"name": "foo", "description": "bar"}
+    )
+    assert (name, description) == ("foo", "bar")
+
+
+def test_extract_tool_info_mcptool_object():
+    """MCPTool objects keep working unchanged."""
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        MCPTool(name="foo", description="bar", inputSchema={"type": "object"})
+    )
+    assert (name, description) == ("foo", "bar")
+
+
+def test_extract_tool_info_falls_back_to_name_when_description_missing():
+    f = _make_filter()
+    name, description = f._extract_tool_info(
+        {"type": "function", "function": {"name": "foo"}}
+    )
+    assert (name, description) == ("foo", "foo")
+
+
+def test_get_tools_by_names_exact_match_preserves_router_order():
+    f = _make_filter()
+    tools = [
+        MCPTool(name="b", description="", inputSchema={}),
+        MCPTool(name="a", description="", inputSchema={}),
+        MCPTool(name="c", description="", inputSchema={}),
+    ]
+    matched = f._get_tools_by_names(["a", "c", "b"], tools)
+    assert [t.name for t in matched] == ["a", "c", "b"]
+
+
+def test_get_tools_by_names_client_prefix_is_resolved():
+    """Client wraps an MCP canonical tool with its own alias prefix
+    (``litellm_<server>-<tool>``). Canonical from the router is
+    ``fc_web_search-firecrawl_scrape``; the wrapped client name still
+    resolves to it."""
+    f = _make_filter()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "litellm_fc_web_search-firecrawl_scrape",
+                "description": "scrape",
+            },
+        }
+    ]
+    matched = f._get_tools_by_names(["fc_web_search-firecrawl_scrape"], tools)
+    assert len(matched) == 1
+    assert matched[0] is tools[0]
+
+
+def test_get_tools_by_names_longest_canonical_wins():
+    """Two canonicals share a tail; client-prefixed name must bind to the
+    longer (more specific) canonical only."""
+    f = _make_filter()
+    tool = MCPTool(
+        name="litellm_fc_web_search-scrape", description="", inputSchema={}
+    )
+    canonicals = ["search-scrape", "fc_web_search-scrape"]
+    matched = f._get_tools_by_names(canonicals, [tool])
+    # The tool resolves exactly once, against the longer canonical, so
+    # ``search-scrape`` must drop out of the result.
+    assert len(matched) == 1
+    assert matched[0] is tool
+
+
+def test_get_tools_by_names_multi_server_no_cross_match():
+    """Two MCP servers register a same-named tool. A client-prefixed name
+    referencing server_a must not be bound to server_b's canonical."""
+    f = _make_filter()
+    tools = [
+        MCPTool(
+            name="litellm_server_a-search", description="", inputSchema={}
+        )
+    ]
+    canonicals = ["server_a-search", "server_b-search"]
+    matched = f._get_tools_by_names(canonicals, tools)
+    assert len(matched) == 1
+    assert matched[0] is tools[0]
+
+
+def test_get_tools_by_names_native_tool_no_false_match():
+    """A native client tool shorter than the canonical (``read`` vs
+    ``fs-read``) cannot alias into it: ``endswith`` requires the canonical
+    to fit inside the tool name, which naturally excludes shorter native
+    tools."""
+    f = _make_filter()
+    tools = [MCPTool(name="read", description="", inputSchema={})]
+    matched = f._get_tools_by_names(["fs-read"], tools)
+    assert matched == []
+
+
+def test_get_tools_by_names_requires_boundary_before_canonical():
+    """No hyphen/underscore immediately before the canonical - no match.
+
+    Pure ``endswith`` would alias client ``foo123a-search`` into canonical
+    ``a-search``; the separator-boundary guard (``-`` or ``_`` preceding
+    the canonical suffix) rejects that aliasing, addressing Greptile's
+    cross-server false-match concern.
+    """
+    f = _make_filter()
+    tools = [MCPTool(name="foo123a-search", description="", inputSchema={})]
+    matched = f._get_tools_by_names(["a-search"], tools)
+    assert matched == []
+
+
+def test_get_tools_by_names_warns_when_no_matches(caplog):
+    """When every canonical fails to resolve we surface a warn log so the
+    pathological empty-``tools`` request doesn't silently degrade into an
+    upstream HTTP 400."""
+    f = _make_filter()
+    tools = [{"type": "function", "function": {"name": "unrelated_native_tool"}}]
+    with caplog.at_level("WARNING", logger="LiteLLM"):
+        matched = f._get_tools_by_names(["server-foo", "server-bar"], tools)
+    assert matched == []
+    assert any("matched 0 tools" in r.getMessage() for r in caplog.records)
+
+
+def test_get_tools_by_names_ordering_follows_router_with_mixed_inputs():
+    f = _make_filter()
+    tools = [
+        # Exact match for "a".
+        MCPTool(name="a", description="", inputSchema={}),
+        # Client-prefixed name for canonical "c".
+        {"type": "function", "function": {"name": "litellm_c"}},
+        # Wrapped flat dict for canonical "b".
+        {"name": "ext-b"},
+    ]
+    matched = f._get_tools_by_names(["b", "a", "c"], tools)
+    matched_names = [get_tool_name_for_test(t) for t in matched]
+    assert matched_names == ["ext-b", "a", "litellm_c"]
+
+
+def get_tool_name_for_test(tool):
+    """Local mirror of ``get_tool_name_and_description`` (first element) so
+    assertions don't couple to the helper module import order in other
+    tests."""
+    from litellm.proxy._experimental.mcp_server.utils import (
+        get_tool_name_and_description,
+    )
+
+    return get_tool_name_and_description(tool)[0]
+
+
+def test_get_tool_names_csv_handles_all_shapes():
+    """``_get_tool_names_csv`` used to read only flat-dict ``name`` or
+    ``.name``; wrapped Chat Completions tools therefore surfaced as empty
+    strings in the ``x-litellm-semantic-filter-tools`` response header."""
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    hook = SemanticToolFilterHook(filter_instance)
+
+    tools = [
+        {"type": "function", "function": {"name": "foo"}},
+        {"name": "bar"},
+        MCPTool(name="baz", description="", inputSchema={}),
+    ]
+
+    assert hook._get_tool_names_csv(tools) == "foo,bar,baz"
 
 
 @pytest.mark.asyncio
@@ -364,22 +628,20 @@ async def test_semantic_filter_hook_skips_no_tools():
         similarity_threshold=0.3,
         enabled=True,
     )
-    
+
     # Create hook
     hook = SemanticToolFilterHook(filter_instance)
-    
+
     # Prepare data - completion without tools
     data = {
         "model": "gpt-4",
-        "messages": [
-            {"role": "user", "content": "Hello"}
-        ],
+        "messages": [{"role": "user", "content": "Hello"}],
     }
-    
+
     # Mock user API key dict and cache
     mock_user_api_key_dict = Mock()
     mock_cache = Mock()
-    
+
     # Call hook
     result = await hook.async_pre_call_hook(
         user_api_key_dict=mock_user_api_key_dict,
@@ -387,8 +649,7 @@ async def test_semantic_filter_hook_skips_no_tools():
         data=data,
         call_type="completion",
     )
-    
+
     # Should return None (no modification)
     assert result is None, "Hook should skip requests without tools"
     print("✅ Hook correctly skips requests without tools")
-


### PR DESCRIPTION
## Relevant issues

Fixes #26078

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
      Link:

- [x] **CI run for the last commit**
      Link: https://github.com/BerriAI/litellm/actions/runs/24660644292/job/72105438983

- [ ] **Merge / cherry-pick CI run**
      Links:

## Screenshots / Proof of Fix

**Before** - the MCP semantic filter silently emitted `tools=[]` whenever a chat client wrapped MCP tool names with its own prefix (e.g. opencode `litellm_<server>-<tool>`) or sent them in the OpenAI Chat Completions wrapper shape. Upstream vLLM then rejected the request:

```
litellm.BadRequestError: Invalid value for 'tool_choice': 'tool_choice'
is only allowed when 'tools' are specified.
```

Two bugs combined:

1. `_extract_tool_info` only recognised flat-dict `name`/`description`, so wrapped tools `{"type":"function","function":{"name":"..."}}` returned `("", "")` and never matched anything.
2. `_get_tools_by_names` used strict equality against canonical router names (`<server>-<tool>`), so any client prefix defeated the lookup.

**After** - all 24 affected unit tests pass locally:

```
tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_utils.py      5 passed
tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py 19 passed
======================= 24 passed, 40 warnings in 5.59s ========================
```

The new coverage exercises OpenAI Chat wrapper extraction, client-prefixed canonical resolution (opencode case), longest-wins disambiguation across shared-tail canonicals, multi-server sibling isolation, native-tool non-match, router-order preservation, and the warn-log emission when zero canonicals resolve.

## Type

🐛 Bug Fix

## Changes

- New shared `get_tool_name` helper in `litellm/proxy/_experimental/mcp_server/utils.py` normalising the three tool shapes the proxy actually receives: OpenAI Chat Completions wrapper `{"type":"function","function":{"name":...}}`, flat dict `{"name":...}`, and `MCPTool` objects.
- `SemanticMCPToolFilter._extract_tool_info` and `SemanticToolFilterHook._get_tool_names_csv` delegate to the helper, so the CSV header `x-litellm-semantic-filter-tools` now reflects wrapped tool names too.
- `SemanticMCPToolFilter._get_tools_by_names` now performs a **registry-grounded longest-endswith canonical match** (no hardcoded boundary character). Canonicals from `add_server_prefix_to_name` always carry the `<server>-<tool>` shape, so the suffix relation alone is specific enough:
  - a shorter native tool cannot alias into a longer canonical (`"read".endswith("fs-read")` is `False`);
  - the longest-wins rule binds to the more specific canonical when several share a tail (e.g. `fc_web_search-scrape` is preferred over `search-scrape`).
- When no canonical resolves at all we now emit `verbose_logger.warning`, so the pathological empty-`tools` case stays observable instead of silently degrading into an upstream HTTP 400.

Made with Cursor