### PR TITLE
fix(ollama): process both thinking and content in same streaming chunk

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -505,7 +505,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             if chunk["message"].get("thinking") is not None:
                 reasoning_content = chunk["message"].get("thinking")
                 self.started_reasoning_content = True
-            elif chunk["message"].get("content") is not None:
+            if chunk["message"].get("content") is not None:
                 if (
                     self.started_reasoning_content
                     and not self.finished_reasoning_content

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -694,6 +694,30 @@ class TestOllamaReasoningContentStreaming:
         # reasoning_content is not set when there's no thinking in the chunk
         assert getattr(result2.choices[0].delta, "reasoning_content", None) is None
 
+    def test_thinking_and_content_in_same_chunk(self):
+        """
+        Test that a chunk containing both thinking and content preserves both fields.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        chunk = {
+            "model": "deepseek-r1",
+            "message": {
+                "role": "assistant",
+                "thinking": "Let me reason first.",
+                "content": "Final answer.",
+            },
+            "done": False,
+        }
+
+        result = iterator.chunk_parser(chunk)
+
+        assert result.choices[0].delta.reasoning_content == "Let me reason first."
+        assert result.choices[0].delta.content == "Final answer."
+
     def test_think_tags_in_content(self):
         """
         Test that <think> tags embedded in content are properly parsed.


### PR DESCRIPTION
## Problem
Ollama's chat endpoint can include both `thinking` and `content` in a single streaming chunk. In the current implementation, when this occurs, `content` is ignored due to an elif branch, causing the content portion of that chunk to be dropped.

## Testing
New unit test:
- `test_thinking_and_content_in_same_chunk`

## Changes
- Changed `elif` to `if` in `OllamaChatCompletionResponseIterator.chunk_parser` so that `content` is processed independently of `thinking` in the same chunk.

## Type
🐛 Bug Fix