### PR TITLE
fix(responses): emit per-summary thinking blocks and deduplicate message_start

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -485,7 +485,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     encrypted_content=getattr(item, "encrypted_content", None),
                     summary_raw=item.summary,
                 )
-                reasoning_content = " ".join(
+                reasoning_content = "\n\n".join(
                     s["text"]
                     for s in pending_reasoning_item["summary"]
                     if s.get("text")

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -86,8 +86,9 @@ class AnthropicResponsesStreamWrapper:
 
         # ---- message_start ----
         if event_type == "response.created":
-            self._sent_message_start = True
-            self._chunk_queue.append(self._make_message_start())
+            if not self._sent_message_start:
+                self._sent_message_start = True
+                self._chunk_queue.append(self._make_message_start())
             return
 
         # ---- content_block_start for a new output message item ----

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -14,13 +14,22 @@ class AnthropicResponsesStreamWrapper:
     Wraps a Responses API streaming iterator and re-emits events in Anthropic SSE format.
 
     Responses API event flow (relevant subset):
-      response.created                   -> message_start
-      response.output_item.added         -> content_block_start (if message/function_call)
-      response.output_text.delta         -> content_block_delta (text_delta)
-      response.reasoning_summary_text.delta -> content_block_delta (thinking_delta)
-      response.function_call_arguments.delta -> content_block_delta (input_json_delta)
-      response.output_item.done          -> content_block_stop
-      response.completed                 -> message_delta + message_stop
+      response.created                        -> message_start
+      response.output_item.added (message)    -> content_block_start (text)
+      response.output_item.added (fn_call)    -> content_block_start (tool_use)
+      response.output_item.added (reasoning)  -> (deferred to part.added)
+      response.reasoning_summary_part.added   -> content_block_start (thinking)
+      response.reasoning_summary_text.delta   -> content_block_delta (thinking_delta)
+      response.reasoning_summary_part.done    -> content_block_stop
+      response.output_text.delta              -> content_block_delta (text_delta)
+      response.function_call_arguments.delta  -> content_block_delta (input_json_delta)
+      response.output_item.done              -> content_block_stop (non-reasoning only)
+      response.completed                     -> message_delta + message_stop
+
+    Each reasoning summary part becomes its own thinking content block.
+    This causes clients (e.g. Claude Code) to display each summary segment
+    immediately upon its content_block_stop, rather than buffering all
+    thinking until the entire reasoning phase completes.
     """
 
     def __init__(
@@ -134,16 +143,9 @@ class AnthropicResponsesStreamWrapper:
                     }
                 )
             elif item_type == "reasoning":
-                block_idx = self._next_block_index()
-                if item_id:
-                    self._item_id_to_block_index[item_id] = block_idx
-                self._chunk_queue.append(
-                    {
-                        "type": "content_block_start",
-                        "index": block_idx,
-                        "content_block": {"type": "thinking", "thinking": ""},
-                    }
-                )
+                # Don't emit content_block_start here — each summary part
+                # will open its own thinking block via part.added.
+                pass
             return
 
         # ---- text delta ----
@@ -168,23 +170,31 @@ class AnthropicResponsesStreamWrapper:
             )
             return
 
+        # ---- reasoning summary part start -> new thinking content block ----
+        # Each summary part becomes its own thinking block so that clients
+        # display each segment immediately on content_block_stop.
+        # Event flow per summary part:
+        #   part.added (once)  ->  text.delta (many)  ->  part.done (once)
+        if event_type == "response.reasoning_summary_part.added":
+            block_idx = self._next_block_index()
+            self._chunk_queue.append(
+                {
+                    "type": "content_block_start",
+                    "index": block_idx,
+                    "content_block": {"type": "thinking", "thinking": ""},
+                }
+            )
+            return
+
         # ---- reasoning summary text delta ----
         if event_type == "response.reasoning_summary_text.delta":
-            item_id = getattr(event, "item_id", None) or (
-                event.get("item_id") if isinstance(event, dict) else None
-            )
             delta = getattr(event, "delta", "") or (
                 event.get("delta", "") if isinstance(event, dict) else ""
-            )
-            block_idx = (
-                self._item_id_to_block_index.get(item_id, self._current_block_index)
-                if item_id
-                else self._current_block_index
             )
             self._chunk_queue.append(
                 {
                     "type": "content_block_delta",
-                    "index": block_idx,
+                    "index": self._current_block_index,
                     "delta": {"type": "thinking_delta", "thinking": delta},
                 }
             )
@@ -212,11 +222,30 @@ class AnthropicResponsesStreamWrapper:
             )
             return
 
+        # ---- reasoning summary part done -> content_block_stop ----
+        if event_type == "response.reasoning_summary_part.done":
+            self._chunk_queue.append(
+                {
+                    "type": "content_block_stop",
+                    "index": self._current_block_index,
+                }
+            )
+            return
+
         # ---- output item done -> content_block_stop ----
         if event_type == "response.output_item.done":
             item = getattr(event, "item", None) or (
                 event.get("item") if isinstance(event, dict) else None
             )
+            # Reasoning items are closed by individual part.done events
+            item_type = (
+                getattr(item, "type", None)
+                or (item.get("type") if isinstance(item, dict) else None)
+                if item
+                else None
+            )
+            if item_type == "reasoning":
+                return
             item_id = (
                 getattr(item, "id", None)
                 or (item.get("id") if isinstance(item, dict) else None)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator.py
@@ -1,0 +1,404 @@
+"""
+Tests for AnthropicResponsesStreamWrapper
+(litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py)
+"""
+
+import asyncio
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
+    AnthropicResponsesStreamWrapper,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockSSEStream:
+    """Async iterator that yields mock SSE events in order."""
+
+    def __init__(self, events: List[Any]) -> None:
+        self._events = events
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._index >= len(self._events):
+            raise StopAsyncIteration
+        event = self._events[self._index]
+        self._index += 1
+        return event
+
+
+def _event(event_type: str, **kwargs) -> Dict[str, Any]:
+    """Build a dict-based SSE event."""
+    return {"type": event_type, **kwargs}
+
+
+def _reasoning_item(item_id: str = "rs_001") -> Dict[str, Any]:
+    """Build a minimal reasoning output_item.added event."""
+    return _event(
+        "response.output_item.added",
+        item={"type": "reasoning", "id": item_id},
+    )
+
+
+def _summary_part_added() -> Dict[str, Any]:
+    return _event("response.reasoning_summary_part.added")
+
+
+def _summary_text_delta(delta: str) -> Dict[str, Any]:
+    return _event("response.reasoning_summary_text.delta", delta=delta)
+
+
+def _summary_part_done() -> Dict[str, Any]:
+    return _event("response.reasoning_summary_part.done")
+
+
+def _response_created() -> Dict[str, Any]:
+    return _event("response.created")
+
+
+def _response_completed(
+    status: str = "completed",
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+) -> Dict[str, Any]:
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    usage.cache_creation_input_tokens = 0
+    usage.cache_read_input_tokens = 0
+    usage.input_tokens_details = None
+    usage.output_tokens_details = None
+
+    response_obj = MagicMock()
+    response_obj.status = status
+    response_obj.usage = usage
+    response_obj.output = []
+    return _event("response.completed", response=response_obj)
+
+
+async def _collect_all(wrapper: AnthropicResponsesStreamWrapper) -> List[Dict[str, Any]]:
+    """Drain all chunks from the wrapper."""
+    chunks: List[Dict[str, Any]] = []
+    async for chunk in wrapper:
+        chunks.append(chunk)
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Test: each reasoning summary part produces its own content block cycle
+# ---------------------------------------------------------------------------
+
+
+class TestPerSummaryThinkingBlocks:
+    """Commit cf2024f: each reasoning summary part gets its own
+    content_block_start / content_block_delta / content_block_stop cycle."""
+
+    @pytest.mark.asyncio
+    async def test_two_summaries_produce_two_thinking_blocks(self):
+        """Two summary parts yield two independent thinking block cycles."""
+        events = [
+            _response_created(),
+            # reasoning item added (no content_block_start emitted here)
+            _reasoning_item(),
+            # First summary part
+            _summary_part_added(),
+            _summary_text_delta("**Step 1**"),
+            _summary_text_delta("\nAnalyze the problem."),
+            _summary_part_done(),
+            # Second summary part
+            _summary_part_added(),
+            _summary_text_delta("**Step 2**"),
+            _summary_text_delta("\nFormulate answer."),
+            _summary_part_done(),
+            _response_completed(),
+        ]
+
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        # Extract thinking-related chunks
+        block_starts = [c for c in chunks if c["type"] == "content_block_start"]
+        block_deltas = [c for c in chunks if c["type"] == "content_block_delta"]
+        block_stops = [c for c in chunks if c["type"] == "content_block_stop"]
+
+        # Two thinking block starts
+        assert len(block_starts) == 2
+        for bs in block_starts:
+            assert bs["content_block"]["type"] == "thinking"
+
+        # Each start has a different index
+        assert block_starts[0]["index"] != block_starts[1]["index"]
+
+        # Two block stops, matching the start indices
+        assert len(block_stops) == 2
+        assert block_stops[0]["index"] == block_starts[0]["index"]
+        assert block_stops[1]["index"] == block_starts[1]["index"]
+
+        # Four thinking deltas total (2 per summary)
+        thinking_deltas = [
+            d for d in block_deltas if d["delta"]["type"] == "thinking_delta"
+        ]
+        assert len(thinking_deltas) == 4
+
+    @pytest.mark.asyncio
+    async def test_single_summary_one_block_cycle(self):
+        """A single summary part produces exactly one thinking block cycle."""
+        events = [
+            _response_created(),
+            _reasoning_item(),
+            _summary_part_added(),
+            _summary_text_delta("Reasoning content."),
+            _summary_part_done(),
+            _response_completed(),
+        ]
+
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        block_starts = [c for c in chunks if c["type"] == "content_block_start"]
+        block_stops = [c for c in chunks if c["type"] == "content_block_stop"]
+
+        assert len(block_starts) == 1
+        assert block_starts[0]["content_block"]["type"] == "thinking"
+        assert len(block_stops) == 1
+        assert block_stops[0]["index"] == block_starts[0]["index"]
+
+    @pytest.mark.asyncio
+    async def test_reasoning_item_added_does_not_emit_block_start(self):
+        """response.output_item.added with type=reasoning must NOT emit
+        content_block_start -- that is deferred to part.added."""
+        events = [
+            _response_created(),
+            _reasoning_item(),
+            _response_completed(),
+        ]
+
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        block_starts = [c for c in chunks if c["type"] == "content_block_start"]
+        assert len(block_starts) == 0
+
+    @pytest.mark.asyncio
+    async def test_reasoning_item_done_does_not_emit_block_stop(self):
+        """response.output_item.done with type=reasoning must NOT emit
+        content_block_stop -- individual part.done events handle that."""
+        events = [
+            _response_created(),
+            _reasoning_item("rs_002"),
+            _summary_part_added(),
+            _summary_text_delta("Thinking..."),
+            _summary_part_done(),
+            # reasoning output_item.done
+            _event(
+                "response.output_item.done",
+                item={"type": "reasoning", "id": "rs_002"},
+            ),
+            _response_completed(),
+        ]
+
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        block_stops = [c for c in chunks if c["type"] == "content_block_stop"]
+        # Only 1 stop from part.done, not a second from item.done
+        assert len(block_stops) == 1
+
+    @pytest.mark.asyncio
+    async def test_three_summaries_indices_increment(self):
+        """Block indices increase monotonically across multiple summary parts."""
+        events = [
+            _response_created(),
+            _reasoning_item(),
+        ]
+        # Add 3 summary parts
+        for i in range(3):
+            events.extend([
+                _summary_part_added(),
+                _summary_text_delta(f"Summary {i}"),
+                _summary_part_done(),
+            ])
+        events.append(_response_completed())
+
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        block_starts = [c for c in chunks if c["type"] == "content_block_start"]
+        indices = [bs["index"] for bs in block_starts]
+        assert indices == [0, 1, 2]
+        assert all(bs["content_block"]["type"] == "thinking" for bs in block_starts)
+
+    @pytest.mark.asyncio
+    async def test_reasoning_then_text_output_indices_correct(self):
+        """After reasoning summary blocks, a text output message gets the next index."""
+        events = [
+            _response_created(),
+            _reasoning_item(),
+            _summary_part_added(),
+            _summary_text_delta("Thought."),
+            _summary_part_done(),
+            _summary_part_added(),
+            _summary_text_delta("More thought."),
+            _summary_part_done(),
+            # Now a text message output item
+            _event(
+                "response.output_item.added",
+                item={"type": "message", "id": "msg_001"},
+            ),
+            _event(
+                "response.output_text.delta",
+                item_id="msg_001",
+                delta="Hello!",
+            ),
+            _event(
+                "response.output_item.done",
+                item={"type": "message", "id": "msg_001"},
+            ),
+            _response_completed(),
+        ]
+
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        block_starts = [c for c in chunks if c["type"] == "content_block_start"]
+        # 2 thinking + 1 text = 3 block starts
+        assert len(block_starts) == 3
+        assert block_starts[0]["content_block"]["type"] == "thinking"
+        assert block_starts[0]["index"] == 0
+        assert block_starts[1]["content_block"]["type"] == "thinking"
+        assert block_starts[1]["index"] == 1
+        assert block_starts[2]["content_block"]["type"] == "text"
+        assert block_starts[2]["index"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: deduplicate message_start
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicateMessageStart:
+    """Commit f4bcf05: when response.created fires and _sent_message_start
+    is already True, skip the duplicate message_start."""
+
+    @pytest.mark.asyncio
+    async def test_single_response_created_emits_one_message_start(self):
+        """Normal case: one response.created -> one message_start."""
+        events = [
+            _response_created(),
+            _response_completed(),
+        ]
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        message_starts = [c for c in chunks if c["type"] == "message_start"]
+        assert len(message_starts) == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_response_created_emits_one_message_start(self):
+        """Two response.created events -> still only one message_start emitted."""
+        events = [
+            _response_created(),
+            _response_created(),  # duplicate
+            _response_completed(),
+        ]
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        message_starts = [c for c in chunks if c["type"] == "message_start"]
+        assert len(message_starts) == 1
+
+    @pytest.mark.asyncio
+    async def test_fallback_message_start_then_response_created(self):
+        """Fallback message_start (from __anext__) followed by response.created
+        should not produce a second message_start."""
+        # If response.created never fires first, __anext__ fallback emits it.
+        # Then if response.created arrives later, it should be skipped.
+        events = [
+            # First event is NOT response.created, so __anext__ emits fallback
+            _reasoning_item(),
+            _summary_part_added(),
+            _summary_text_delta("think"),
+            _summary_part_done(),
+            # Now response.created arrives late
+            _response_created(),
+            _response_completed(),
+        ]
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        message_starts = [c for c in chunks if c["type"] == "message_start"]
+        assert len(message_starts) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_response_created_fallback_still_works(self):
+        """If response.created never fires, __anext__ fallback emits message_start."""
+        events = [
+            # Skip response.created entirely
+            _event(
+                "response.output_item.added",
+                item={"type": "message", "id": "msg_001"},
+            ),
+            _event(
+                "response.output_text.delta",
+                item_id="msg_001",
+                delta="Hello",
+            ),
+            _event(
+                "response.output_item.done",
+                item={"type": "message", "id": "msg_001"},
+            ),
+            _response_completed(),
+        ]
+        wrapper = AnthropicResponsesStreamWrapper(
+            responses_stream=MockSSEStream(events),
+            model="test-model",
+        )
+        chunks = await _collect_all(wrapper)
+
+        message_starts = [c for c in chunks if c["type"] == "message_start"]
+        assert len(message_starts) == 1
+        # Verify it has the expected structure
+        msg = message_starts[0]["message"]
+        assert msg["role"] == "assistant"
+        assert msg["type"] == "message"


### PR DESCRIPTION
## Relevant issues

- Relates to #21345

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

🐛 Bug Fix

## Changes

### 1. Per-summary thinking blocks

Previously all reasoning summaries were concatenated into a single thinking block. This caused:
- Bold summary titles running into the previous paragraph without separation
- Under high reasoning effort (e.g. gpt-5.4 at `xhigh`), clients like Claude Code buffered all thinking content until the block closed — the UI felt stuck for 30+ seconds with no visible output

Each summary part now emits its own `content_block_start` / `content_block_delta` / `content_block_stop` cycle, so streaming clients can render each segment as soon as it completes.

### 2. Deduplicate message_start

When `response.created` fires after `message_start` has already been sent (either by an earlier `response.created` or by the `__anext__` fallback), the duplicate is now skipped. Previously this could produce two `message_start` events in a single stream.

**Files changed (2):**

| File | Change |
|------|--------|
| `.../responses_adapters/streaming_iterator.py` | Per-summary block emission + message_start dedup guard |
| `.../transformation.py` | 1-line tweak to support per-summary block indexing |

## Test plan

10 tests in `tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_streaming_iterator.py`:

**TestPerSummaryThinkingBlocks (6 tests):**
- Two summary parts → two independent thinking block cycles
- Single summary → exactly one cycle
- `reasoning` item.added does NOT emit content_block_start
- `reasoning` item.done does NOT emit content_block_stop
- Three summaries get monotonically increasing block indices
- Text output after reasoning gets the next sequential index

**TestDeduplicateMessageStart (4 tests):**
- Single `response.created` → one message_start
- Duplicate `response.created` → still only one
- Fallback message_start followed by `response.created` → only one
- Missing `response.created` → fallback triggers correctly