### PR TITLE
fix: web_search tool translation fixes for `/v1/messages` → `/v1/chat/completions` → `/v1/responses` path

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1008,6 +1008,9 @@ class LiteLLMAnthropicMessagesAdapter:
             new_kwargs["web_search_options"] = {}  # type: ignore
 
         if not regular_tools:
+            # No regular tools left — drop tool_choice to avoid
+            # "tools are required when tool choice is specified" errors.
+            new_kwargs.pop("tool_choice", None)
             return {}
 
         translated_tools, tool_name_mapping = self.translate_anthropic_tools_to_openai(

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1010,7 +1010,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 wst_dict = cast(Dict[str, Any], wst)
                 allowed = wst_dict.get("allowed_domains")
                 if allowed:
-                    web_search_options.setdefault("filters", {})["allowed_domains"] = allowed
+                    web_search_options.setdefault("filters", {})[
+                        "allowed_domains"
+                    ] = allowed
             new_kwargs["web_search_options"] = web_search_options  # type: ignore
 
         if not regular_tools:

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1005,7 +1005,13 @@ class LiteLLMAnthropicMessagesAdapter:
                 regular_tools.append(cast(AllAnthropicToolsValues, tool))
 
         if web_search_tools:
-            new_kwargs["web_search_options"] = {}  # type: ignore
+            web_search_options: Dict[str, Any] = {}
+            for wst in web_search_tools:
+                wst_dict = cast(Dict[str, Any], wst)
+                allowed = wst_dict.get("allowed_domains")
+                if allowed:
+                    web_search_options.setdefault("filters", {})["allowed_domains"] = allowed
+            new_kwargs["web_search_options"] = web_search_options  # type: ignore
 
         if not regular_tools:
             # No regular tools left — drop tool_choice to avoid

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1049,7 +1049,13 @@ class LiteLLMAnthropicMessagesAdapter:
                 regular_tools.append(cast(AllAnthropicToolsValues, tool))
 
         if web_search_tools:
-            new_kwargs["web_search_options"] = {}  # type: ignore
+            web_search_options: Dict[str, Any] = {}
+            for wst in web_search_tools:
+                wst_dict = cast(Dict[str, Any], wst)
+                allowed = wst_dict.get("allowed_domains")
+                if allowed:
+                    web_search_options.setdefault("filters", {})["allowed_domains"] = allowed
+            new_kwargs["web_search_options"] = web_search_options  # type: ignore
 
         if not regular_tools:
             # No regular tools left — drop tool_choice to avoid

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1052,6 +1052,9 @@ class LiteLLMAnthropicMessagesAdapter:
             new_kwargs["web_search_options"] = {}  # type: ignore
 
         if not regular_tools:
+            # No regular tools left — drop tool_choice to avoid
+            # "tools are required when tool choice is specified" errors.
+            new_kwargs.pop("tool_choice", None)
             return {}
 
         translated_tools, tool_name_mapping = self.translate_anthropic_tools_to_openai(

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1054,7 +1054,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 wst_dict = cast(Dict[str, Any], wst)
                 allowed = wst_dict.get("allowed_domains")
                 if allowed:
-                    web_search_options.setdefault("filters", {})["allowed_domains"] = allowed
+                    web_search_options.setdefault("filters", {})[
+                        "allowed_domains"
+                    ] = allowed
             new_kwargs["web_search_options"] = web_search_options  # type: ignore
 
         if not regular_tools:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1531,15 +1531,14 @@ def completion(  # type: ignore # noqa: PLR0915
         # If the model will be bridged to the Responses API, allow params
         # that the bridge can handle (e.g. web_search_options) even if the
         # provider's chat/completions config doesn't list them.
-        if responses_api_model_info.get("mode") == "responses":
-            _bridge_params = []
-            if web_search_options is not None:
-                _bridge_params.append("web_search_options")
-            if _bridge_params:
-                existing = optional_param_args.get("allowed_openai_params") or []
-                optional_param_args["allowed_openai_params"] = list(
-                    set(existing + _bridge_params)
-                )
+        if (
+            responses_api_model_info.get("mode") == "responses"
+            and web_search_options is not None
+        ):
+            existing = optional_param_args.get("allowed_openai_params") or []
+            optional_param_args["allowed_openai_params"] = list(
+                set(existing + ["web_search_options"])
+            )
 
         optional_params = get_optional_params(
             **optional_param_args, **non_default_params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -957,6 +957,19 @@ def responses_api_bridge_check(
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
 
+        # Auto-bridge to Responses API when web_search_options is requested
+        # and the model supports web search and the /v1/responses endpoint,
+        # but its current mode is not already "responses". The bridge
+        # converts web_search_options into a web_search_preview tool.
+        if (
+            web_search_options is not None
+            and model_info.get("mode") != "responses"
+            and model_info.get("supports_web_search") is True
+            and "/v1/responses"
+            in (model_info.get("supported_endpoints") or [])
+        ):
+            model_info["mode"] = "responses"
+
     except Exception as e:
         verbose_logger.debug("Error getting model info: {}".format(e))
 
@@ -1514,6 +1527,20 @@ def completion(  # type: ignore # noqa: PLR0915
             "service_tier": service_tier,
             "allowed_openai_params": kwargs.get("allowed_openai_params"),
         }
+
+        # If the model will be bridged to the Responses API, allow params
+        # that the bridge can handle (e.g. web_search_options) even if the
+        # provider's chat/completions config doesn't list them.
+        if responses_api_model_info.get("mode") == "responses":
+            _bridge_params = []
+            if web_search_options is not None:
+                _bridge_params.append("web_search_options")
+            if _bridge_params:
+                existing = optional_param_args.get("allowed_openai_params") or []
+                optional_param_args["allowed_openai_params"] = list(
+                    set(existing + _bridge_params)
+                )
+
         optional_params = get_optional_params(
             **optional_param_args, **non_default_params
         )

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -965,8 +965,7 @@ def responses_api_bridge_check(
             web_search_options is not None
             and model_info.get("mode") != "responses"
             and model_info.get("supports_web_search") is True
-            and "/v1/responses"
-            in (model_info.get("supported_endpoints") or [])
+            and "/v1/responses" in (model_info.get("supported_endpoints") or [])
         ):
             model_info["mode"] = "responses"
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1571,15 +1571,14 @@ def completion(  # type: ignore # noqa: PLR0915
         # If the model will be bridged to the Responses API, allow params
         # that the bridge can handle (e.g. web_search_options) even if the
         # provider's chat/completions config doesn't list them.
-        if responses_api_model_info.get("mode") == "responses":
-            _bridge_params = []
-            if web_search_options is not None:
-                _bridge_params.append("web_search_options")
-            if _bridge_params:
-                existing = optional_param_args.get("allowed_openai_params") or []
-                optional_param_args["allowed_openai_params"] = list(
-                    set(existing + _bridge_params)
-                )
+        if (
+            responses_api_model_info.get("mode") == "responses"
+            and web_search_options is not None
+        ):
+            existing = optional_param_args.get("allowed_openai_params") or []
+            optional_param_args["allowed_openai_params"] = list(
+                set(existing + ["web_search_options"])
+            )
 
         optional_params = get_optional_params(
             **optional_param_args, **non_default_params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -981,6 +981,19 @@ def responses_api_bridge_check(
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
 
+        # Auto-bridge to Responses API when web_search_options is requested
+        # and the model supports web search and the /v1/responses endpoint,
+        # but its current mode is not already "responses". The bridge
+        # converts web_search_options into a web_search_preview tool.
+        if (
+            web_search_options is not None
+            and model_info.get("mode") != "responses"
+            and model_info.get("supports_web_search") is True
+            and "/v1/responses"
+            in (model_info.get("supported_endpoints") or [])
+        ):
+            model_info["mode"] = "responses"
+
     except Exception as e:
         verbose_logger.debug("Error getting model info: {}".format(e))
 
@@ -1554,6 +1567,20 @@ def completion(  # type: ignore # noqa: PLR0915
             "allowed_openai_params": kwargs.get("allowed_openai_params"),
             "base_model": base_model,
         }
+
+        # If the model will be bridged to the Responses API, allow params
+        # that the bridge can handle (e.g. web_search_options) even if the
+        # provider's chat/completions config doesn't list them.
+        if responses_api_model_info.get("mode") == "responses":
+            _bridge_params = []
+            if web_search_options is not None:
+                _bridge_params.append("web_search_options")
+            if _bridge_params:
+                existing = optional_param_args.get("allowed_openai_params") or []
+                optional_param_args["allowed_openai_params"] = list(
+                    set(existing + _bridge_params)
+                )
+
         optional_params = get_optional_params(
             **optional_param_args, **non_default_params
         )

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -989,8 +989,7 @@ def responses_api_bridge_check(
             web_search_options is not None
             and model_info.get("mode") != "responses"
             and model_info.get("supports_web_search") is True
-            and "/v1/responses"
-            in (model_info.get("supported_endpoints") or [])
+            and "/v1/responses" in (model_info.get("supported_endpoints") or [])
         ):
             model_info["mode"] = "responses"
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -140,6 +140,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_url_context: Optional[bool]
     supports_none_reasoning_effort: Optional[bool]
     supports_xhigh_reasoning_effort: Optional[bool]
+    supported_endpoints: Optional[list]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -140,7 +140,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_url_context: Optional[bool]
     supports_none_reasoning_effort: Optional[bool]
     supports_xhigh_reasoning_effort: Optional[bool]
-    supported_endpoints: Optional[list]
+    supported_endpoints: Optional[List[str]]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -151,7 +151,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     bedrock_output_config_effort_ceiling: Optional[
         Literal["low", "medium", "high", "max", "xhigh"]
     ]
-    supported_endpoints: Optional[list]
+    supported_endpoints: Optional[List[str]]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -151,6 +151,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     bedrock_output_config_effort_ceiling: Optional[
         Literal["low", "medium", "high", "max", "xhigh"]
     ]
+    supported_endpoints: Optional[list]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5896,6 +5896,7 @@ def _get_model_info_helper(  # noqa: PLR0915
                 supports_xhigh_reasoning_effort=_model_info.get(
                     "supports_xhigh_reasoning_effort", None
                 ),
+                supported_endpoints=_model_info.get("supported_endpoints", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),
                 search_context_cost_per_query=_model_info.get(
                     "search_context_cost_per_query", None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6063,6 +6063,7 @@ def _get_model_info_helper(  # noqa: PLR0915
                 bedrock_output_config_effort_ceiling=_model_info.get(
                     "bedrock_output_config_effort_ceiling", None
                 ),
+                supported_endpoints=_model_info.get("supported_endpoints", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),
                 search_context_cost_per_query=_model_info.get(
                     "search_context_cost_per_query", None

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2175,3 +2175,62 @@ class TestTranslateAnthropicOutputFormatToOpenAI:
             )
             is None
         )
+
+
+class TestTranslateToolsDropsToolChoice:
+    """Test that tool_choice is dropped when only web_search tools remain."""
+
+    def setup_method(self):
+        self.adapter = LiteLLMAnthropicMessagesAdapter()
+
+    def test_tool_choice_removed_when_only_web_search_tools(self):
+        """When all tools are web_search-type, tool_choice should be popped."""
+        new_kwargs: dict = {"tool_choice": "auto", "model": "gpt-4o"}
+        anthropic_request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "search the web"}],
+            "tools": [
+                {"type": "web_search_20260209", "name": "web_search"},
+            ],
+            "tool_choice": {"type": "auto"},
+        }
+
+        self.adapter._translate_tools_to_openai(
+            anthropic_message_request=anthropic_request,
+            new_kwargs=new_kwargs,
+        )
+
+        assert "tool_choice" not in new_kwargs
+        assert new_kwargs.get("web_search_options") == {}
+
+    def test_tool_choice_preserved_when_regular_tools_exist(self):
+        """When regular tools exist alongside web_search, tool_choice stays."""
+        new_kwargs: dict = {"tool_choice": "auto", "model": "gpt-4o"}
+        anthropic_request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "search and compute"}],
+            "tools": [
+                {"type": "web_search_20260209", "name": "web_search"},
+                {
+                    "type": "custom",
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                },
+            ],
+            "tool_choice": {"type": "auto"},
+        }
+
+        self.adapter._translate_tools_to_openai(
+            anthropic_message_request=anthropic_request,
+            new_kwargs=new_kwargs,
+        )
+
+        assert "tool_choice" in new_kwargs
+        assert new_kwargs.get("web_search_options") == {}
+        assert "tools" in new_kwargs

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2641,3 +2641,62 @@ def test_translate_openai_response_to_anthropic_with_polyfill_both_compaction_an
     cm = result.get("context_management")
     assert cm is not None
     assert cm["applied_edits"][0]["type"] == "compact_20260112"
+
+
+class TestTranslateToolsDropsToolChoice:
+    """Test that tool_choice is dropped when only web_search tools remain."""
+
+    def setup_method(self):
+        self.adapter = LiteLLMAnthropicMessagesAdapter()
+
+    def test_tool_choice_removed_when_only_web_search_tools(self):
+        """When all tools are web_search-type, tool_choice should be popped."""
+        new_kwargs: dict = {"tool_choice": "auto", "model": "gpt-4o"}
+        anthropic_request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "search the web"}],
+            "tools": [
+                {"type": "web_search_20260209", "name": "web_search"},
+            ],
+            "tool_choice": {"type": "auto"},
+        }
+
+        self.adapter._translate_tools_to_openai(
+            anthropic_message_request=anthropic_request,
+            new_kwargs=new_kwargs,
+        )
+
+        assert "tool_choice" not in new_kwargs
+        assert new_kwargs.get("web_search_options") == {}
+
+    def test_tool_choice_preserved_when_regular_tools_exist(self):
+        """When regular tools exist alongside web_search, tool_choice stays."""
+        new_kwargs: dict = {"tool_choice": "auto", "model": "gpt-4o"}
+        anthropic_request = {
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "search and compute"}],
+            "tools": [
+                {"type": "web_search_20260209", "name": "web_search"},
+                {
+                    "type": "custom",
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                },
+            ],
+            "tool_choice": {"type": "auto"},
+        }
+
+        self.adapter._translate_tools_to_openai(
+            anthropic_message_request=anthropic_request,
+            new_kwargs=new_kwargs,
+        )
+
+        assert "tool_choice" in new_kwargs
+        assert new_kwargs.get("web_search_options") == {}
+        assert "tools" in new_kwargs

--- a/tests/test_litellm/test_web_search_auto_bridge.py
+++ b/tests/test_litellm/test_web_search_auto_bridge.py
@@ -1,0 +1,132 @@
+"""
+Test automatic bridging of web_search_options to Responses API
+when a model only supports /v1/responses.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import pytest
+
+from litellm.main import responses_api_bridge_check
+
+
+def _make_model_info(
+    mode="chat",
+    supports_web_search=False,
+    supported_endpoints=None,
+):
+    """Return a minimal model_info dict for mocking."""
+    return {
+        "key": "openai/gpt-5.4",
+        "max_tokens": 100000,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 100000,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "litellm_provider": "openai",
+        "mode": mode,
+        "supports_web_search": supports_web_search,
+        "supported_endpoints": supported_endpoints,
+    }
+
+
+class TestWebSearchAutoBridge:
+    """Test that web_search_options triggers auto-bridge to Responses API
+    when the model supports web search only via /v1/responses."""
+
+    @patch("litellm.main._get_model_info_helper")
+    def test_auto_bridge_when_model_only_supports_responses(self, mock_get_model_info):
+        """Model supports web search + /v1/responses but mode is chat.
+        web_search_options should trigger bridge to responses mode."""
+        mock_get_model_info.return_value = _make_model_info(
+            mode="chat",
+            supports_web_search=True,
+            supported_endpoints=["/v1/chat/completions", "/v1/responses"],
+        )
+
+        model_info, updated_model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            web_search_options={},
+        )
+
+        assert model_info.get("mode") == "responses"
+        assert updated_model == "gpt-5.4"
+
+    @patch("litellm.main._get_model_info_helper")
+    def test_no_bridge_without_web_search_options(self, mock_get_model_info):
+        """Without web_search_options, no auto-bridge even if model supports it."""
+        mock_get_model_info.return_value = _make_model_info(
+            mode="chat",
+            supports_web_search=True,
+            supported_endpoints=["/v1/chat/completions", "/v1/responses"],
+        )
+
+        model_info, updated_model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            web_search_options=None,
+        )
+
+        assert model_info.get("mode") == "chat"
+        assert updated_model == "gpt-5.4"
+
+    @patch("litellm.main._get_model_info_helper")
+    def test_no_bridge_when_no_responses_endpoint(self, mock_get_model_info):
+        """Model supports web search but NOT /v1/responses -- no bridge."""
+        mock_get_model_info.return_value = _make_model_info(
+            mode="chat",
+            supports_web_search=True,
+            supported_endpoints=["/v1/chat/completions"],
+        )
+
+        model_info, updated_model = responses_api_bridge_check(
+            model="gpt-4o",
+            custom_llm_provider="openai",
+            web_search_options={},
+        )
+
+        assert model_info.get("mode") == "chat"
+
+    @patch("litellm.main._get_model_info_helper")
+    def test_no_bridge_when_supports_web_search_false(self, mock_get_model_info):
+        """Model has /v1/responses but supports_web_search is False -- no bridge."""
+        mock_get_model_info.return_value = _make_model_info(
+            mode="chat",
+            supports_web_search=False,
+            supported_endpoints=["/v1/chat/completions", "/v1/responses"],
+        )
+
+        model_info, updated_model = responses_api_bridge_check(
+            model="some-model",
+            custom_llm_provider="openai",
+            web_search_options={},
+        )
+
+        assert model_info.get("mode") == "chat"
+
+    @patch("litellm.main._get_model_info_helper")
+    def test_no_bridge_when_already_responses_mode(self, mock_get_model_info):
+        """Model is already in responses mode -- no double-bridge."""
+        mock_get_model_info.return_value = _make_model_info(
+            mode="responses",
+            supports_web_search=True,
+            supported_endpoints=["/v1/responses"],
+        )
+
+        model_info, updated_model = responses_api_bridge_check(
+            model="gpt-5.4",
+            custom_llm_provider="openai",
+            web_search_options={},
+        )
+
+        # Still responses, but did not change -- already was responses
+        assert model_info.get("mode") == "responses"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Relevant issues

- Fixes #25477
- Competing: #25515

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

🐛 Bug Fix

## Changes

Three fixes for web search on the `/v1/messages` → `/v1/chat/completions` → `/v1/responses` adapter path:

### 1. Drop orphan `tool_choice` after web_search conversion

When all tools are web_search-type and get converted to `web_search_options`, `tool_choice` wasn't cleaned up — the empty tools array + leftover `tool_choice` triggers `"tools are required when tool choice is specified"` from the provider.

**Fix:** Drop `tool_choice` when the tools array is empty after web_search conversion.

### 2. Auto-bridge `web_search_options` to Responses API

Some models (e.g. GPT 5.4) only support web search on `/v1/responses`, not `/v1/chat/completions`. When `web_search_options` is present, auto-switch to the Responses API bridge for models with `supports_web_search=True` and `/v1/responses` in `supported_endpoints`.

### 3. Pass `allowed_domains` through `web_search_options`

Anthropic's `allowed_domains` on web_search tools was silently dropped — `web_search_options` was always set to `{}`. Now extracts `allowed_domains` and passes it as `filters.allowed_domains`, which the Responses API bridge forwards to the `web_search` tool.

**Files changed:**

| File | Change |
|------|--------|
| `.../adapters/transformation.py` | Drop `tool_choice` when tools empty; pass `allowed_domains` via `web_search_options` |
| `litellm/main.py` | Auto-bridge logic in `responses_api_bridge_check` + allow `web_search_options` param |
| `litellm/types/utils.py` | Add `supported_endpoints` to `ModelInfoBase` |
| `litellm/utils.py` | Read `supported_endpoints` in `_get_model_info_helper` |

## Test plan

7 tests across 2 test files:

**TestTranslateToolsDropsToolChoice (2 tests):**
- `tool_choice` removed when tools array is empty after web_search → `web_search_options` conversion
- `tool_choice` preserved when regular tools exist alongside web_search

**TestWebSearchAutoBridge (5 tests):**
- Auto-bridge triggers when `web_search_options` present + model has `supports_web_search` + `/v1/responses` endpoint
- No bridge when `web_search_options` is None
- No bridge when model lacks `/v1/responses` endpoint
- No bridge when `supports_web_search` is False
- No bridge when already in responses mode