### PR TITLE
Fix "occured" typo in log messages

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -354,7 +354,7 @@ class LangFuseLogger:
             return {"trace_id": trace_id, "generation_id": generation_id}
         except Exception as e:
             verbose_logger.exception(
-                "Langfuse Layer Error(): Exception occured - {}".format(str(e))
+                "Langfuse Layer Error(): Exception occurred - {}".format(str(e))
             )
             return {"trace_id": None, "generation_id": None}
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1578,7 +1578,7 @@ class PrometheusLogger(CustomLogger):
             )
         except Exception as e:
             verbose_logger.exception(
-                "prometheus Layer Error(): Exception occured - {}".format(str(e))
+                "prometheus Layer Error(): Exception occurred - {}".format(str(e))
             )
             pass
         pass
@@ -1809,7 +1809,7 @@ class PrometheusLogger(CustomLogger):
 
         except Exception as e:
             verbose_logger.exception(
-                "prometheus Layer Error(): Exception occured - {}".format(str(e))
+                "prometheus Layer Error(): Exception occurred - {}".format(str(e))
             )
             pass
 
@@ -2056,7 +2056,7 @@ class PrometheusLogger(CustomLogger):
             pass
         except Exception as e:
             verbose_logger.debug(
-                "Prometheus Error: set_llm_deployment_failure_metrics. Exception occured - {}".format(
+                "Prometheus Error: set_llm_deployment_failure_metrics. Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -2267,7 +2267,7 @@ class PrometheusLogger(CustomLogger):
 
         except Exception as e:
             verbose_logger.exception(
-                "Prometheus Error: set_llm_deployment_success_metrics. Exception occured - {}".format(
+                "Prometheus Error: set_llm_deployment_success_metrics. Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -870,7 +870,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         and isinstance(error_str, str)
                         and "bearer" in error_str.lower()
                     ):
-                        # only keep the first 10 chars after the occurnence of "bearer"
+                        # only keep the first 10 chars after the occurrence of "bearer"
                         _bearer_token_start_index = error_str.lower().find("bearer")
                         error_str = error_str[: _bearer_token_start_index + 14]
                         error_str += "XXXXXXX" + '"'

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1095,7 +1095,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                 except Exception as e:
                     verbose_logger.exception(
-                        "litellm.Logging.pre_call(): Exception occured - {}".format(
+                        "litellm.Logging.pre_call(): Exception occurred - {}".format(
                             str(e)
                         )
                     )

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -107,7 +107,7 @@ def _generic_cost_per_character(
         prompt_cost = prompt_characters * custom_prompt_cost
     except Exception as e:
         verbose_logger.exception(
-            "litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
+            "litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occurred - {}\nDefaulting to None".format(
                 str(e)
             )
         )
@@ -127,7 +127,7 @@ def _generic_cost_per_character(
         completion_cost = completion_characters * custom_completion_cost
     except Exception as e:
         verbose_logger.exception(
-            "litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
+            "litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occurred - {}\nDefaulting to None".format(
                 str(e)
             )
         )
@@ -360,7 +360,7 @@ def _get_cost_per_unit(
             return float(cost_per_unit)
         except ValueError:
             verbose_logger.exception(
-                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::calculate_cost_per_component(): Exception occured - {cost_per_unit}\nDefaulting to 0.0"
+                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::calculate_cost_per_component(): Exception occurred - {cost_per_unit}\nDefaulting to 0.0"
             )
 
     # If the service tier key doesn't exist or is None, try to fall back to the standard key
@@ -381,7 +381,7 @@ def _get_cost_per_unit(
                         return float(fallback_cost)
                     except ValueError:
                         verbose_logger.exception(
-                            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_cost_per_unit(): Exception occured - {fallback_cost}\nDefaulting to 0.0"
+                            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_cost_per_unit(): Exception occurred - {fallback_cost}\nDefaulting to 0.0"
                         )
                 break  # Only try the first matching suffix
 

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -633,7 +633,7 @@ class CustomStreamWrapper:
                 return ""
         except Exception as e:
             verbose_logger.exception(
-                "litellm.CustomStreamWrapper.handle_baseten_chunk(): Exception occured - {}".format(
+                "litellm.CustomStreamWrapper.handle_baseten_chunk(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -1542,7 +1542,7 @@ class CustomStreamWrapper:
                             model_response.choices[0].delta = Delta(**_json_delta)
                         except Exception as e:
                             verbose_logger.exception(
-                                "litellm.CustomStreamWrapper.chunk_creator(): Exception occured - {}".format(
+                                "litellm.CustomStreamWrapper.chunk_creator(): Exception occurred - {}".format(
                                     str(e)
                                 )
                             )

--- a/litellm/llms/vertex_ai/cost_calculator.py
+++ b/litellm/llms/vertex_ai/cost_calculator.py
@@ -122,7 +122,7 @@ def cost_per_character(
                 prompt_cost = prompt_characters * model_info["input_cost_per_character"]
         except Exception as e:
             verbose_logger.debug(
-                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
+                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occurred - {}\nDefaulting to None".format(
                     str(e)
                 )
             )
@@ -169,7 +169,7 @@ def cost_per_character(
                 )
         except Exception as e:
             verbose_logger.debug(
-                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
+                "litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occurred - {}\nDefaulting to None".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -119,7 +119,7 @@ async def anthropic_response(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.anthropic_response(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.anthropic_response(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -76,7 +76,7 @@ class UserAPIKeyAuthExceptionHandler:
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for", False),
             )
             verbose_proxy_logger.exception(
-                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - {}\nRequester IP Address:{}".format(
+                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occurred - {}\nRequester IP Address:{}".format(
                     str(e),
                     requester_ip,
                 ),

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -318,7 +318,7 @@ async def create_batch(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.create_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -573,7 +573,7 @@ async def retrieve_batch(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -758,7 +758,7 @@ async def list_batches(
             request_data={"after": after, "limit": limit},
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -963,7 +963,7 @@ async def cancel_batch(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.create_batch(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_batch(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1571,7 +1571,7 @@ class ProxyBaseLLMRequestProcessing:
     ):
         """Raises ProxyException (OpenAI API compatible) if an exception is raised"""
         verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {str(e)}"
+            f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occurred - {str(e)}"
         )
         # Allow callbacks to transform the error response
         transformed_exception = await proxy_logging_obj.post_call_failure_hook(
@@ -1773,7 +1773,7 @@ class ProxyBaseLLMRequestProcessing:
                 yield serialize_chunk(chunk)
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.proxy_server.async_data_generator(): Exception occured - {}".format(
+                "litellm.proxy.proxy_server.async_data_generator(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -427,7 +427,7 @@ async def health_services_endpoint(  # noqa: PLR0915
 
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.health_services_endpoint(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.health_services_endpoint(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -879,7 +879,7 @@ async def health_endpoint(
             )
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.py::health_endpoint(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.py::health_endpoint(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/hooks/azure_content_safety.py
+++ b/litellm/proxy/hooks/azure_content_safety.py
@@ -127,7 +127,7 @@ class _PROXY_AzureContentSafety(
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                "litellm.proxy.hooks.azure_content_safety.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.azure_content_safety.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/batch_redis_get.py
+++ b/litellm/proxy/hooks/batch_redis_get.py
@@ -98,7 +98,7 @@ class _PROXY_BatchRedisRequests(CustomLogger):
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                "litellm.proxy.hooks.batch_redis_get.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.batch_redis_get.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/cache_control_check.py
+++ b/litellm/proxy/hooks/cache_control_check.py
@@ -52,7 +52,7 @@ class _PROXY_CacheControlCheck(CustomLogger):
             raise e
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.cache_control_check.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.cache_control_check.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -66,7 +66,7 @@ class DynamicRateLimiterCache:
             )
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_set_cache_sadd(): Exception occured - {}".format(
+                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_set_cache_sadd(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -296,7 +296,7 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
             )
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_post_call_success_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.dynamic_rate_limiter.py::async_post_call_success_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -43,7 +43,7 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             raise e
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.max_budget_limiter.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.max_budget_limiter.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -211,7 +211,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             raise e
         except Exception as e:
             verbose_proxy_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -179,7 +179,7 @@ async def image_generation(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.image_generation(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.image_generation(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -394,7 +394,7 @@ async def new_end_user(
         return response_dict
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.customer_endpoints.new_end_user(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.customer_endpoints.new_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -476,7 +476,7 @@ async def end_user_info(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.customer_endpoints.end_user_info(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.customer_endpoints.end_user_info(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -684,7 +684,7 @@ async def update_end_user(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.update_end_user(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -773,7 +773,7 @@ async def delete_end_user(
         # update based on remaining passed in values
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.delete_end_user(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -850,7 +850,7 @@ async def list_end_user(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.customer_endpoints.list_end_user(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.customer_endpoints.list_end_user(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -264,7 +264,7 @@ async def _add_user_to_team(
             )
         else:
             verbose_proxy_logger.debug(
-                "litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): Exception occured - {}".format(
+                "litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -523,7 +523,7 @@ async def new_user(
         return new_user_response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/user/new: Exception occured - {}".format(str(e))
+            "/user/new: Exception occurred - {}".format(str(e))
         )
         raise handle_exception_on_proxy(e)
 
@@ -783,7 +783,7 @@ async def user_info(  # noqa: PLR0915
         return response_data
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.user_info(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.user_info(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -943,7 +943,7 @@ async def user_info_v2(
         )
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.user_info_v2(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.user_info_v2(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1377,7 +1377,7 @@ async def user_update(
         return response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.user_update(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.user_update(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -2616,7 +2616,7 @@ async def get_user_daily_activity(
         raise
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/spend/daily/analytics: Exception occured - {}".format(str(e))
+            "/spend/daily/analytics: Exception occurred - {}".format(str(e))
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -2711,7 +2711,7 @@ async def get_user_daily_activity_aggregated(
         raise
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/user/daily/activity/aggregated: Exception occured - {}".format(str(e))
+            "/user/daily/activity/aggregated: Exception occurred - {}".format(str(e))
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1355,7 +1355,7 @@ async def generate_key_fn(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.generate_key_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.generate_key_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1535,7 +1535,7 @@ def prepare_metadata_fields(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.prepare_metadata_fields(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.prepare_metadata_fields(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -2312,7 +2312,7 @@ async def update_key_fn(  # noqa: PLR0915
         # update based on remaining passed in values
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.update_key_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_key_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -2679,7 +2679,7 @@ async def delete_key_fn(
         return {"deleted_keys": deleted_keys}
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.delete_key_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_key_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -3170,7 +3170,7 @@ async def generate_key_helper_fn(  # noqa: PLR0915
                     key_data["router_settings"] = {}
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.generate_key_helper_fn(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.generate_key_helper_fn(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -3401,7 +3401,7 @@ async def delete_verification_tokens(
             raise Exception("DB not connected. prisma_client is None")
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.delete_verification_tokens(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_verification_tokens(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -1057,7 +1057,7 @@ async def add_new_model(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.add_new_model(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.add_new_model(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1215,7 +1215,7 @@ async def update_model(
             return model_response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.update_model(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_model(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/project_endpoints.py
+++ b/litellm/proxy/management_endpoints/project_endpoints.py
@@ -469,7 +469,7 @@ async def new_project(
         return response
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.project_endpoints.new_project(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.project_endpoints.new_project(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -688,7 +688,7 @@ async def update_project(  # noqa: PLR0915
         return updated_project
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.project_endpoints.update_project(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.project_endpoints.update_project(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -796,7 +796,7 @@ async def delete_project(
         return deleted_projects
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.project_endpoints.delete_project(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.project_endpoints.delete_project(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -871,7 +871,7 @@ async def project_info(
         return project
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.project_endpoints.project_info(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.project_endpoints.project_info(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -931,7 +931,7 @@ async def list_projects(
         return projects
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.management_endpoints.project_endpoints.list_projects(): Exception occured - {}".format(
+            "litellm.proxy.management_endpoints.project_endpoints.list_projects(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -143,7 +143,7 @@ async def add_team_callbacks(
         raise e
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.add_team_callbacks(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.add_team_callbacks(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -546,7 +546,7 @@ async def create_file(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.create_file(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_file(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -838,7 +838,7 @@ async def get_file_content(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.retrieve_file_content(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_file_content(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1027,7 +1027,7 @@ async def get_file(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.retrieve_file(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.retrieve_file(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1230,7 +1230,7 @@ async def delete_file(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.delete_file(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_file(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -1407,7 +1407,7 @@ async def list_files(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.list_files(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.list_files(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -300,7 +300,7 @@ async def chat_completion_pass_through_endpoint(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.completion(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.completion(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -961,7 +961,7 @@ async def pass_through_request(  # noqa: PLR0915
             api_base=str(url._uri_reference) if url else None,
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.pass_through_endpoint(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5826,7 +5826,7 @@ async def async_assistants_data_generator(
         yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.async_assistants_data_generator(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.async_assistants_data_generator(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -5983,7 +5983,7 @@ async def async_data_generator(
         yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.async_data_generator(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.async_data_generator(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7531,7 +7531,7 @@ async def completion(  # noqa: PLR0915
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.completion(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.completion(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7797,7 +7797,7 @@ async def moderations(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.moderations(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.moderations(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -7941,7 +7941,7 @@ async def audio_speech(
             request_data=data,
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.audio_speech(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.audio_speech(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8089,7 +8089,7 @@ async def audio_transcriptions(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.audio_transcription(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.audio_transcription(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8369,7 +8369,7 @@ async def get_assistants(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.get_assistants(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_assistants(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8468,7 +8468,7 @@ async def create_assistant(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.create_assistant(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_assistant(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8565,7 +8565,7 @@ async def delete_assistant(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.delete_assistant(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.delete_assistant(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8662,7 +8662,7 @@ async def create_threads(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.create_threads(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.create_threads(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8757,7 +8757,7 @@ async def get_thread(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.get_thread(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_thread(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8856,7 +8856,7 @@ async def add_messages(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.add_messages(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.add_messages(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -8951,7 +8951,7 @@ async def get_messages(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.get_messages(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_messages(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -9061,7 +9061,7 @@ async def run_thread(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.run_thread(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.run_thread(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -9247,7 +9247,7 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
             )
         except Exception:
             verbose_proxy_logger.exception(
-                "litellm.proxy.proxy_server.token_counter(): Exception occured while getting deployment"
+                "litellm.proxy.proxy_server.token_counter(): Exception occurred while getting deployment"
             )
             pass
     if deployment is not None:
@@ -12599,7 +12599,7 @@ async def update_config(  # noqa: PLR0915
         return {"message": "Config updated successfully"}
     except Exception as e:
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.update_config(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.update_config(): Exception occurred - {}".format(
                 str(e)
             )
         )
@@ -13235,7 +13235,7 @@ async def get_config():  # noqa: PLR0915
         }
     except Exception as e:
         verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.get_config(): Exception occured - {}".format(
+            "litellm.proxy.proxy_server.get_config(): Exception occurred - {}".format(
                 str(e)
             )
         )

--- a/litellm/proxy/rerank_endpoints/endpoints.py
+++ b/litellm/proxy/rerank_endpoints/endpoints.py
@@ -108,7 +108,7 @@ async def rerank(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.rerank(): Exception occured - {}".format(str(e))
+            "litellm.proxy.proxy_server.rerank(): Exception occurred - {}".format(str(e))
         )
         if isinstance(e, HTTPException):
             raise ProxyException(

--- a/litellm/proxy/rerank_endpoints/endpoints.py
+++ b/litellm/proxy/rerank_endpoints/endpoints.py
@@ -108,7 +108,9 @@ async def rerank(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.error(
-            "litellm.proxy.proxy_server.rerank(): Exception occurred - {}".format(str(e))
+            "litellm.proxy.proxy_server.rerank(): Exception occurred - {}".format(
+                str(e)
+            )
         )
         if isinstance(e, HTTPException):
             raise ProxyException(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3157,7 +3157,7 @@ async def provider_budgets() -> ProviderBudgetResponse:
         return ProviderBudgetResponse(providers=provider_budget_response_dict)
     except Exception as e:
         verbose_proxy_logger.exception(
-            "/provider/budgets: Exception occured - {}".format(str(e))
+            "/provider/budgets: Exception occurred - {}".format(str(e))
         )
         raise handle_exception_on_proxy(e)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6217,7 +6217,7 @@ class Router:
 
         except Exception as e:
             verbose_router_logger.debug(
-                "litellm.router.Router::deployment_callback_on_success(): Exception occured - {}".format(
+                "litellm.router.Router::deployment_callback_on_success(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -96,7 +96,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.router_strategy.lowest_cost.py::log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_cost.py::log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -184,7 +184,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -182,7 +182,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -253,7 +253,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 return
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {}".format(
+                "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -407,7 +407,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.router_strategy.lowest_latency.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_latency.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -80,7 +80,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.error(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -151,7 +151,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.exception(
-                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -267,7 +267,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occured - {}".format(
+                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )
@@ -318,7 +318,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occured - {}".format(
+                "litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occurred - {}".format(
                     str(e)
                 )
             )

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -33,7 +33,7 @@ def test_split_embedding_by_shape_passes():
         )
         assert split_output_data == [[1, 2, 3], [4, 5, 6]]
     except Exception as e:
-        pytest.fail(f"An exception occured: {e}")
+        pytest.fail(f"An exception occurred: {e}")
 
 
 def test_split_embedding_by_shape_fails_with_shape_value_error():

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -736,7 +736,7 @@ def test_vertex_ai_embedding_completion_cost(caplog):
     for item in captured_logs:
         print("\nitem:{}\n".format(item))
         if (
-            "litellm.litellm_core_utils.llm_cost_calc.google.cost_per_character(): Exception occured "
+            "litellm.litellm_core_utils.llm_cost_calc.google.cost_per_character(): Exception occurred "
             in item
         ):
             raise Exception("Error log raised for calculating embedding cost")

--- a/tests/local_testing/test_exceptions.py
+++ b/tests/local_testing/test_exceptions.py
@@ -1047,7 +1047,7 @@ async def test_exception_with_headers(sync_mode, provider, model, call_type, str
     but Azure says to retry in at most 9s
 
     ```
-    {"message": "litellm.proxy.proxy_server.embeddings(): Exception occured - No deployments available for selected model, Try again in 60 seconds. Passed model=text-embedding-ada-002. pre-call-checks=False, allowed_model_region=n/a, cooldown_list=[('b49cbc9314273db7181fe69b1b19993f04efb88f2c1819947c538bac08097e4c', {'Exception Received': 'litellm.RateLimitError: AzureException RateLimitError - Requests to the Embeddings_Create Operation under Azure OpenAI API version 2023-09-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 9 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit.', 'Status Code': '429'})]", "level": "ERROR", "timestamp": "2024-08-22T03:25:36.900476"}
+    {"message": "litellm.proxy.proxy_server.embeddings(): Exception occurred - No deployments available for selected model, Try again in 60 seconds. Passed model=text-embedding-ada-002. pre-call-checks=False, allowed_model_region=n/a, cooldown_list=[('b49cbc9314273db7181fe69b1b19993f04efb88f2c1819947c538bac08097e4c', {'Exception Received': 'litellm.RateLimitError: AzureException RateLimitError - Requests to the Embeddings_Create Operation under Azure OpenAI API version 2023-09-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 9 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit.', 'Status Code': '429'})]", "level": "ERROR", "timestamp": "2024-08-22T03:25:36.900476"}
     ```
     """
     print(f"Received args: {locals()}")
@@ -1224,7 +1224,7 @@ async def test_exception_with_headers_httpx(
     but Azure says to retry in at most 9s
 
     ```
-    {"message": "litellm.proxy.proxy_server.embeddings(): Exception occured - No deployments available for selected model, Try again in 60 seconds. Passed model=text-embedding-ada-002. pre-call-checks=False, allowed_model_region=n/a, cooldown_list=[('b49cbc9314273db7181fe69b1b19993f04efb88f2c1819947c538bac08097e4c', {'Exception Received': 'litellm.RateLimitError: AzureException RateLimitError - Requests to the Embeddings_Create Operation under Azure OpenAI API version 2023-09-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 9 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit.', 'Status Code': '429'})]", "level": "ERROR", "timestamp": "2024-08-22T03:25:36.900476"}
+    {"message": "litellm.proxy.proxy_server.embeddings(): Exception occurred - No deployments available for selected model, Try again in 60 seconds. Passed model=text-embedding-ada-002. pre-call-checks=False, allowed_model_region=n/a, cooldown_list=[('b49cbc9314273db7181fe69b1b19993f04efb88f2c1819947c538bac08097e4c', {'Exception Received': 'litellm.RateLimitError: AzureException RateLimitError - Requests to the Embeddings_Create Operation under Azure OpenAI API version 2023-09-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 9 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit.', 'Status Code': '429'})]", "level": "ERROR", "timestamp": "2024-08-22T03:25:36.900476"}
     ```
     """
     print(f"Received args: {locals()}")

--- a/tests/local_testing/test_litellm_max_budget.py
+++ b/tests/local_testing/test_litellm_max_budget.py
@@ -26,4 +26,4 @@
 #     except BudgetExceededError as e:
 #         pass
 #     except Exception as e:
-#         pytest.fail(f"An error occured: {str(e)}")
+#         pytest.fail(f"An error occurred: {str(e)}")

--- a/tests/local_testing/test_prometheus_service.py
+++ b/tests/local_testing/test_prometheus_service.py
@@ -139,7 +139,7 @@ async def test_router_with_caching():
         assert sl.prometheusServicesLogger.mock_testing_success_calls > 0
 
     except Exception as e:
-        pytest.fail(f"An exception occured - {str(e)}")
+        pytest.fail(f"An exception occurred - {str(e)}")
 
 
 @pytest.mark.asyncio

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -1984,7 +1984,7 @@ def test_router_dynamic_cooldown_correct_retry_after_time():
     but Azure says to retry in at most 9s
 
     ```
-    {"message": "litellm.proxy.proxy_server.embeddings(): Exception occured - No deployments available for selected model, Try again in 60 seconds. Passed model=text-embedding-ada-002. pre-call-checks=False, allowed_model_region=n/a, cooldown_list=[('b49cbc9314273db7181fe69b1b19993f04efb88f2c1819947c538bac08097e4c', {'Exception Received': 'litellm.RateLimitError: AzureException RateLimitError - Requests to the Embeddings_Create Operation under Azure OpenAI API version 2023-09-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 9 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit.', 'Status Code': '429'})]", "level": "ERROR", "timestamp": "2024-08-22T03:25:36.900476"}
+    {"message": "litellm.proxy.proxy_server.embeddings(): Exception occurred - No deployments available for selected model, Try again in 60 seconds. Passed model=text-embedding-ada-002. pre-call-checks=False, allowed_model_region=n/a, cooldown_list=[('b49cbc9314273db7181fe69b1b19993f04efb88f2c1819947c538bac08097e4c', {'Exception Received': 'litellm.RateLimitError: AzureException RateLimitError - Requests to the Embeddings_Create Operation under Azure OpenAI API version 2023-09-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 9 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit.', 'Status Code': '429'})]", "level": "ERROR", "timestamp": "2024-08-22T03:25:36.900476"}
     ```
     """
     router = Router(

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -225,7 +225,7 @@ def test_tokenizers():
 
         print("test tokenizer: It worked!")
     except Exception as e:
-        pytest.fail(f"An exception occured: {e}")
+        pytest.fail(f"An exception occurred: {e}")
 
 
 # test_tokenizers()
@@ -259,7 +259,7 @@ def test_encoding_and_decoding():
 
         assert llama2_text == sample_text
     except Exception as e:
-        pytest.fail(f"An exception occured: {e}\n{traceback.format_exc()}")
+        pytest.fail(f"An exception occurred: {e}\n{traceback.format_exc()}")
 
 
 # test_encoding_and_decoding()


### PR DESCRIPTION
Mechanical typo fix (`occured` → `occurred`) across 42 files, 104 occurrences — mostly log format strings, plus a few `pytest.fail` messages and one stale comment in `exception_mapping_utils.py`.

The test assertion in `tests/local_testing/test_completion_cost.py` that checks for the exact log substring is updated to match the corrected source string.

No behavior change. `litellm/litellm_core_utils/tokenizers/anthropic_tokenizer.json` is intentionally not touched — `occured` is a trained BPE token in that vocab file.

## Note on the Black lint failure

The Lint workflow flags 13 files, but only 1 is caused by this PR:

- `litellm/proxy/rerank_endpoints/endpoints.py` — the one-character typo fix pushed a log format string past Black's 88-char line limit. Reformatted in the follow-up commit.

The other 12 files are **pre-existing Black violations** on the `litellm_internal_staging` base branch, unrelated to this PR (trailing whitespace, missing blank lines, multi-line calls Black would collapse — none of them on lines this PR touched). They went unnoticed because the Lint workflow only runs on PRs, not on pushes to the base branch. Happy to fold a separate formatting-only PR if it would help, but kept them out of this one to preserve the "mechanical typo" scope.