### PR TITLE
fix: merge server_side_tool_invocations by id in stream_chunk_builder

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7604,6 +7604,19 @@ def stream_chunk_builder(  # noqa: PLR0915
                     for key, value in fields.items():
                         if key not in combined_provider_fields:
                             combined_provider_fields[key] = value
+                        elif key == "server_side_tool_invocations" and isinstance(value, list):
+                            existing = {e.get("id", ""): e for e in combined_provider_fields[key]}
+                            for inv in value:
+                                inv_id = inv.get("id", "")
+                                if inv_id in existing:
+                                    for k, v in inv.items():
+                                        if v is not None and (k not in existing[inv_id] or existing[inv_id][k] is None):
+                                            existing[inv_id][k] = v
+                                else:
+                                    existing[inv_id] = dict(inv)
+                            combined_provider_fields[key] = list(existing.values())
+                        elif key == "thought_signatures" and isinstance(value, list):
+                            combined_provider_fields[key] = combined_provider_fields[key] + value
                         elif isinstance(value, list) and isinstance(
                             combined_provider_fields[key], list
                         ):


### PR DESCRIPTION
## Problem

When using Gemini models with streaming + web search + tool calls, follow-up turns fail with `400 Bad Request: "Corrupted tool call context"`. The bug is in `stream_chunk_builder` — it uses a naive last-wins merge for list-type `provider_specific_fields`, overwriting correct `server_side_tool_invocations` entries (with `args` + correct `thought_signature`) with later chunks that have bloated/missing data.

## Fix

Replace the naive last-wins logic with:

1. **`server_side_tool_invocations`**: merge by `id`, first-wins per key (also fills `None`-valued keys from later chunks) — matching `_extract_server_side_tool_invocations` behavior
2. **`thought_signatures`**: accumulate across chunks instead of overwriting
3. All other lists: keep existing last-wins behavior

Fixes #25869