### PR TITLE
fix(bedrock): remove remove_custom_field_from_tools — Bedrock now supports custom.defer_loading natively

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -17,7 +17,6 @@ from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation
 from litellm.llms.bedrock.common_utils import (
     get_anthropic_beta_from_headers,
     normalize_tool_input_schema_types_for_bedrock_invoke,
-    remove_custom_field_from_tools,
 )
 from litellm.types.llms.anthropic import ANTHROPIC_TOOL_SEARCH_BETA_HEADER
 from litellm.types.llms.openai import AllMessageValues
@@ -173,8 +172,6 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
         if "anthropic_version" not in anthropic_request:
             anthropic_request["anthropic_version"] = self.anthropic_version
 
-        # Remove `custom` field from tools (Bedrock doesn't support it)
-        remove_custom_field_from_tools(anthropic_request)
         normalize_tool_input_schema_types_for_bedrock_invoke(anthropic_request)
         return anthropic_request
 

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -49,27 +49,6 @@ def get_cached_model_info():
     return _get_model_info
 
 
-def remove_custom_field_from_tools(request_body: dict) -> None:
-    """
-    Remove ``custom`` field from each tool in the request body.
-
-    Claude Code (v2.1.69+) sends ``custom: {defer_loading: true}`` on tool
-    definitions, which Anthropic's API accepts but Bedrock rejects with
-    ``"Extra inputs are not permitted"``.
-
-    Args:
-        request_body: The request dictionary to modify in-place.
-
-    Ref: https://github.com/BerriAI/litellm/issues/22847
-    """
-    tools = request_body.get("tools")
-    if not tools or not isinstance(tools, list):
-        return
-    for tool in tools:
-        if isinstance(tool, dict):
-            tool.pop("custom", None)
-
-
 def normalize_json_schema_custom_types_to_object(schema: dict) -> None:
     """
     In-place: replace JSON Schema ``type: \"custom\"`` with ``\"object\"`` (iterative walk).

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -31,7 +31,6 @@ from litellm.llms.bedrock.common_utils import (
     get_anthropic_beta_from_headers,
     is_claude_4_5_on_bedrock,
     normalize_tool_input_schema_types_for_bedrock_invoke,
-    remove_custom_field_from_tools,
 )
 from litellm.types.llms.anthropic import ANTHROPIC_TOOL_SEARCH_BETA_HEADER
 from litellm.types.llms.openai import AllMessageValues
@@ -504,11 +503,6 @@ class AmazonAnthropicClaudeMessagesConfig(
         # Fixes: https://github.com/BerriAI/litellm/issues/22797
         anthropic_messages_request.pop("output_config", None)
 
-        # 5a. Remove `custom` field from tools (Bedrock doesn't support it)
-        # Claude Code sends `custom: {defer_loading: true}` on tool definitions,
-        # which causes Bedrock to reject the request with "Extra inputs are not permitted"
-        # Ref: https://github.com/BerriAI/litellm/issues/22847
-        remove_custom_field_from_tools(anthropic_messages_request)
         normalize_tool_input_schema_types_for_bedrock_invoke(anthropic_messages_request)
         ensure_bedrock_anthropic_messages_tool_names(anthropic_messages_request)
 

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -16,7 +16,6 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.llms.bedrock.common_utils import (
     ensure_bedrock_anthropic_messages_tool_names,
     normalize_tool_input_schema_types_for_bedrock_invoke,
-    remove_custom_field_from_tools,
 )
 from litellm.constants import BEDROCK_MIN_THINKING_BUDGET_TOKENS
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
@@ -246,60 +245,6 @@ def test_remove_ttl_from_cache_control():
     request5 = {}
     cfg._remove_ttl_from_cache_control(request5)
     assert request5 == {}
-
-
-def test_remove_custom_field_from_tools():
-    """
-    Ensure the `custom` field is stripped from every tool definition.
-
-    Claude Code v2.1.69+ sends `custom: {defer_loading: true}` on tool
-    objects.  Bedrock does not accept this extra field and returns
-    "Extra inputs are not permitted".
-
-    Ref: https://github.com/BerriAI/litellm/issues/22847
-    """
-
-    # Case 1: tool with `custom` field should have it removed
-    request = {
-        "tools": [
-            {
-                "name": "Read",
-                "description": "Read a file",
-                "input_schema": {"type": "object", "properties": {}},
-                "custom": {"defer_loading": True},
-            },
-            {
-                "name": "Write",
-                "description": "Write a file",
-                "input_schema": {"type": "object", "properties": {}},
-            },
-        ]
-    }
-
-    remove_custom_field_from_tools(request)
-
-    for tool in request["tools"]:
-        assert "custom" not in tool, f"Tool {tool['name']} still has 'custom' field"
-    # Other fields should be preserved
-    assert request["tools"][0]["name"] == "Read"
-    assert request["tools"][1]["name"] == "Write"
-
-    # Case 2: request without tools key (should not raise error)
-    request2 = {"messages": [{"role": "user", "content": "hi"}]}
-    remove_custom_field_from_tools(request2)
-    assert "tools" not in request2
-
-    # Case 3: empty tools list (should not raise error)
-    request3 = {"tools": []}
-    remove_custom_field_from_tools(request3)
-    assert request3["tools"] == []
-
-    # Case 4: tools with None value (should not raise error)
-    request4 = {"tools": None}
-    remove_custom_field_from_tools(request4)
-    assert request4["tools"] is None
-
-
 def test_normalize_tool_input_schema_types_for_bedrock_invoke():
     """
     Claude Code sends ``input_schema.type: \"custom\"`` for custom tools.


### PR DESCRIPTION
## Summary

Removes `remove_custom_field_from_tools()` and all its call sites.

This function was added in #22861 (fixing #22847) to strip the `custom: {defer_loading: true}` field from tool definitions before forwarding to Bedrock, because Bedrock was rejecting it with `"Extra inputs are not permitted"`.

**Bedrock has since been updated** and now accepts `custom.defer_loading` natively. When using Claude Code directly against Bedrock (without LiteLLM), Tool Search works correctly. But routing through LiteLLM → Bedrock caused the field to be stripped, defeating the feature and loading every tool definition into context — adding **~20k+ extra input tokens per request** for a typical MCP setup.

## Changes

- `litellm/llms/bedrock/common_utils.py`: Remove `remove_custom_field_from_tools()` function
- `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py`: Remove import + call
- `litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py`: Remove import + call
- `tests/…/test_anthropic_claude3_transformation.py`: Remove `test_remove_custom_field_from_tools` test

Note: `normalize_json_schema_custom_types_to_object()` and `normalize_tool_input_schema_types_for_bedrock_invoke()` are **intentionally kept** — they handle `type: "custom"` in JSON schemas, which is a separate issue that Bedrock still does not accept.

## Test plan

- [ ] Verify existing Bedrock invoke tests pass
- [ ] Manually test with Claude Code + LiteLLM → Bedrock: confirm `defer_loading` is preserved in tool definitions
- [ ] Confirm token usage drops to match direct Bedrock path

Fixes #26113

🤖 Generated with [Claude Code](https://claude.com/claude-code)