### PR TITLE
fix(anthropic): detect invalid thinking signatures from Vertex AI error format

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -763,8 +763,9 @@ def is_anthropic_invalid_thinking_signature_error(error_text: str) -> bool:
     Detect Anthropic 400 when encrypted thinking signatures in history do not match
     the current deployment (e.g. user rotated API key or switched model endpoint).
 
-    Example API message:
-    messages.N.content.M: Invalid `signature` in `thinking` block
+    Example API messages:
+    - messages.N.content.M: Invalid `signature` in `thinking` block
+    - messages.N.content.M.thinking.signature.str: Input should be a valid string
     """
     if not error_text:
         return False
@@ -773,7 +774,6 @@ def is_anthropic_invalid_thinking_signature_error(error_text: str) -> bool:
         "invalid" in lower
         and "signature" in lower
         and "thinking" in lower
-        and "block" in lower
     )
 
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1153,6 +1153,20 @@ class TestAnthropicThinkingSignatureSelfHeal:
         )
         assert is_anthropic_invalid_thinking_signature_error(raw) is True
 
+    def test_is_anthropic_invalid_thinking_signature_error_vertex_ai(self):
+        """Vertex AI returns a different error format for invalid thinking signatures."""
+        from litellm.llms.anthropic.common_utils import (
+            is_anthropic_invalid_thinking_signature_error,
+        )
+
+        raw = (
+            '{"type":"error","error":{"type":"invalid_request_error",'
+            '"message":"messages.1.content.0.thinking.signature.str: '
+            'Input should be a valid string"},'
+            '"request_id":"req_vrtx_011CaB4qJPWdYMoM8yyQUQ5C"}'
+        )
+        assert is_anthropic_invalid_thinking_signature_error(raw) is True
+
     def test_is_anthropic_invalid_thinking_signature_error_negative(self):
         from litellm.llms.anthropic.common_utils import (
             is_anthropic_invalid_thinking_signature_error,


### PR DESCRIPTION
## Summary
- Remove the `"block"` keyword requirement from `is_anthropic_invalid_thinking_signature_error`
- The Vertex AI error format uses `"messages.N.content.M.thinking.signature.str: Input should be a valid string"` which contains `"invalid"`, `"signature"`, and `"thinking"` but not `"block"`
- The triple combination is already specific enough to avoid false positives

## Test Plan
- Added new test `test_is_anthropic_invalid_thinking_signature_error_vertex_ai` with the Vertex AI error format
- All 3 related tests pass (positive, vertex_ai, negative)

Fixes #26005