### PR TITLE
fix(deps): relax core runtime dependency pins from exact == to ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,18 @@ authors = [
     { name = "BerriAI" },
 ]
 dependencies = [
-    "fastuuid==0.14.0",
-    "httpx==0.28.1",
-    "openai==2.24.0",
-    "python-dotenv==1.0.1",
-    "tiktoken==0.12.0",
-    "importlib-metadata==8.5.0",
-    "tokenizers==0.22.2",
-    "click==8.1.8",
-    "jinja2==3.1.6",
-    "aiohttp==3.13.3",
-    "pydantic==2.12.5",
-    "jsonschema==4.23.0",
+    "fastuuid>=0.14.0",
+    "httpx>=0.28.0",
+    "openai>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "tiktoken>=0.7.0",
+    "importlib-metadata>=6.0.0",
+    "tokenizers>=0.19.0",
+    "click>=8.0.0",
+    "jinja2>=3.1.0",
+    "aiohttp>=3.10",
+    "pydantic>=2.5.0,<3.0.0",
+    "jsonschema>=4.0.0",
 ]
 
 [project.urls]
@@ -29,8 +29,9 @@ Homepage = "https://litellm.ai"
 Repository = "https://github.com/BerriAI/litellm"
 Documentation = "https://docs.litellm.ai"
 
-# Dependencies pinned from the published `litellm[proxy]==1.83.0` resolution.
-# Docker and CI should prefer `uv.lock` rather than maintaining parallel installers.
+# Optional extras retain exact pins because they are consumed by Docker images
+# where exact reproducibility matters. The core SDK uses ranges so downstream
+# consumers can coexist with other packages without forced downgrades.
 [project.optional-dependencies]
 proxy = [
     "gunicorn==23.0.0",
@@ -264,3 +265,4 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["litellm"]
 relative_files = true
+


### PR DESCRIPTION
## Summary

When litellm migrated from Poetry to uv in [PR #24905](https://github.com/BerriAI/litellm/pull/24905) (v1.83.1), a subtle semantic change broke library consumers:

- **Poetry**: bare version strings like `openai = "2.30.0"` are implicitly **caret ranges** — they resolve to `>=2.30.0,<3.0.0`
- **PEP 621**: `openai==2.24.0` is an **exact pin** — only that exact version is allowed

The migration converted Poetry's implicit ranges to PEP 621 exact pins, which forces every downstream package that lists `litellm` as a dependency to downgrade 12 common runtime libraries (aiohttp, pydantic, openai, click, tokenizers, jinja2, etc.) to specific old patch versions — even if newer compatible versions are already installed.

Fixes: #26154
Overlaps with: #25231 (which fixes only `python-dotenv`)

## Changes

Only the 12 core `[project.dependencies]` entries are changed — from exact `==` pins to lower-bounded ranges. The optional extras (`proxy`, `proxy-runtime`, etc.) keep their exact pins, since those are consumed by Docker images where reproducibility is important. The `uv.lock` file continues to provide exact pinning for Docker builds and CI.

**Before (exact pins — broken for downstream consumers):**
```toml
dependencies = [
    "fastuuid==0.14.0",
    "httpx==0.28.1",
    "openai==2.24.0",
    "python-dotenv==1.0.1",
    "tiktoken==0.12.0",
    "importlib-metadata==8.5.0",
    "tokenizers==0.22.2",
    "click==8.1.8",
    "jinja2==3.1.6",
    "aiohttp==3.13.3",
    "pydantic==2.12.5",
    "jsonschema==4.23.0",
]
```

**After (lower-bounded ranges — compatible with downstream):**
```toml
dependencies = [
    "fastuuid>=0.14.0",
    "httpx>=0.28.0",
    "openai>=2.0.0",
    "python-dotenv>=1.0.0",
    "tiktoken>=0.7.0",
    "importlib-metadata>=6.0.0",
    "tokenizers>=0.19.0",
    "click>=8.0.0",
    "jinja2>=3.1.0",
    "aiohttp>=3.10",
    "pydantic>=2.5.0,<3.0.0",
    "jsonschema>=4.0.0",
]
```

## Why pydantic has an upper bound

`pydantic>=2.5.0,<3.0.0` — pydantic v3 would be a breaking API change. All other ranges are open-ended upward since those packages follow semver and breaking changes would be a major version bump.

## Testing

This is a metadata-only change to `pyproject.toml`. The `uv.lock` file and CI continue to install the same exact versions for testing and Docker builds. No runtime behavior changes.