### PR TITLE
fix(proxy): share temporary MCP OAuth sessions across instances via Redis

### DIFF
--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -396,10 +396,8 @@ if MCP_AVAILABLE:
             redis_server = await _get_temporary_mcp_server_from_redis(server_id)
             if redis_server is None:
                 return None
-            _cache_temporary_mcp_server(
-                server=redis_server,
-                ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS,
-            )
+            # Intentionally avoid repopulating local cache from Redis to prevent
+            # extending effective lifetime beyond the remaining Redis TTL.
             return redis_server
         return entry.server
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -379,6 +379,9 @@ if MCP_AVAILABLE:
     ) -> Optional[MCPServer]:
         """
         Best-effort read from Redis shared cache. Returns None on miss/errors.
+
+        Values must be encrypted strings (same contract as _cache_temporary_mcp_server_in_redis);
+        legacy plaintext dict payloads are rejected.
         """
         if litellm.cache is None or not hasattr(litellm.cache, "cache"):
             return None
@@ -396,28 +399,29 @@ if MCP_AVAILABLE:
             )
             return None
 
-        if isinstance(cached_server, dict):
-            payload_dict: Dict[str, Any] = cached_server
-        elif isinstance(cached_server, str):
-            decrypted_json = decrypt_value_helper(
-                value=cached_server,
-                key="temporary_mcp_server",
-                exception_type="debug",
+        if not isinstance(cached_server, str):
+            verbose_proxy_logger.debug(
+                "Temporary MCP Redis cache value must be an encrypted string; rejecting non-string payload"
             )
-            if decrypted_json is None:
-                return None
-            try:
-                loaded = json.loads(decrypted_json)
-            except Exception as e:
-                verbose_proxy_logger.debug(
-                    f"Invalid decrypted temporary MCP payload in Redis cache: {str(e)}"
-                )
-                return None
-            if not isinstance(loaded, dict):
-                return None
-            payload_dict = loaded
-        else:
             return None
+
+        decrypted_json = decrypt_value_helper(
+            value=cached_server,
+            key="temporary_mcp_server",
+            exception_type="debug",
+        )
+        if decrypted_json is None:
+            return None
+        try:
+            loaded = json.loads(decrypted_json)
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                f"Invalid decrypted temporary MCP payload in Redis cache: {str(e)}"
+            )
+            return None
+        if not isinstance(loaded, dict):
+            return None
+        payload_dict: Dict[str, Any] = loaded
 
         try:
             return MCPServer(**payload_dict)

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -58,6 +58,7 @@ router = APIRouter(prefix="/v1/mcp", tags=["mcp"])
 MCP_AVAILABLE: bool = True
 
 TEMPORARY_MCP_SERVER_TTL_SECONDS = 300
+TEMPORARY_MCP_SERVER_REDIS_KEY_PREFIX = "litellm:mcp:temporary_server"
 
 
 def does_mcp_server_exist(
@@ -329,13 +330,77 @@ if MCP_AVAILABLE:
         )
         return server
 
-    def get_cached_temporary_mcp_server(
+    async def _cache_temporary_mcp_server_in_redis(
+        server: MCPServer, ttl_seconds: int
+    ) -> None:
+        """
+        Best-effort write-through to Redis so temporary MCP OAuth sessions are
+        shared across proxy instances. Keep local in-memory cache as fallback.
+        """
+        if litellm.cache is None or not hasattr(litellm.cache, "cache"):
+            return
+        cache_backend = getattr(litellm.cache, "cache", None)
+        if cache_backend is None or not hasattr(cache_backend, "async_set_cache"):
+            return
+
+        payload: Dict[str, Any] = server.model_dump(mode="json")
+
+        try:
+            await cache_backend.async_set_cache(
+                key=f"{TEMPORARY_MCP_SERVER_REDIS_KEY_PREFIX}:{server.server_id}",
+                value=payload,
+                ttl=max(1, ttl_seconds),
+            )
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                f"Failed to write temporary MCP server to Redis cache: {str(e)}"
+            )
+
+    async def _get_temporary_mcp_server_from_redis(server_id: str) -> Optional[MCPServer]:
+        """
+        Best-effort read from Redis shared cache. Returns None on miss/errors.
+        """
+        if litellm.cache is None or not hasattr(litellm.cache, "cache"):
+            return None
+        cache_backend = getattr(litellm.cache, "cache", None)
+        if cache_backend is None or not hasattr(cache_backend, "async_get_cache"):
+            return None
+
+        try:
+            cached_server = await cache_backend.async_get_cache(
+                key=f"{TEMPORARY_MCP_SERVER_REDIS_KEY_PREFIX}:{server_id}"
+            )
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                f"Failed reading temporary MCP server from Redis cache: {str(e)}"
+            )
+            return None
+
+        if not isinstance(cached_server, dict):
+            return None
+
+        try:
+            return MCPServer(**cached_server)
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                f"Invalid temporary MCP server payload in Redis cache: {str(e)}"
+            )
+            return None
+
+    async def get_cached_temporary_mcp_server(
         server_id: str,
     ) -> Optional[MCPServer]:
         _prune_expired_temporary_mcp_servers()
         entry = _temporary_mcp_servers.get(server_id)
         if entry is None:
-            return None
+            redis_server = await _get_temporary_mcp_server_from_redis(server_id)
+            if redis_server is None:
+                return None
+            _cache_temporary_mcp_server(
+                server=redis_server,
+                ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS,
+            )
+            return redis_server
         return entry.server
 
     def _redact_mcp_credentials(
@@ -1325,6 +1390,10 @@ if MCP_AVAILABLE:
                 temporary_server,
                 ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS,
             )
+            await _cache_temporary_mcp_server_in_redis(
+                temporary_server,
+                ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS,
+            )
         except Exception as e:
             verbose_proxy_logger.exception(
                 f"Error caching temporary mcp server: {str(e)}"
@@ -1336,8 +1405,8 @@ if MCP_AVAILABLE:
 
         return _redact_mcp_credentials(temp_record)
 
-    def _get_cached_temporary_mcp_server_or_404(server_id: str) -> MCPServer:
-        server = get_cached_temporary_mcp_server(server_id)
+    async def _get_cached_temporary_mcp_server_or_404(server_id: str) -> MCPServer:
+        server = await get_cached_temporary_mcp_server(server_id)
         if server is None:
             # Fall back to real DB/config server (e.g. for the user-side OAuth flow
             # which calls these endpoints with a real server_id, not a temp session id).
@@ -1370,7 +1439,7 @@ if MCP_AVAILABLE:
         response_type: Optional[str] = None,
         scope: Optional[str] = None,
     ):
-        mcp_server = _get_cached_temporary_mcp_server_or_404(server_id)
+        mcp_server = await _get_cached_temporary_mcp_server_or_404(server_id)
         # Use the server's stored client_id when the caller doesn't supply one
         resolved_client_id = mcp_server.client_id or client_id or ""
         if not resolved_client_id:
@@ -1412,7 +1481,7 @@ if MCP_AVAILABLE:
         refresh_token: Optional[str] = Form(None),
         scope: Optional[str] = Form(None),
     ):
-        mcp_server = _get_cached_temporary_mcp_server_or_404(server_id)
+        mcp_server = await _get_cached_temporary_mcp_server_or_404(server_id)
         resolved_client_id = mcp_server.client_id or client_id or ""
         if not resolved_client_id:
             raise HTTPException(
@@ -1443,7 +1512,7 @@ if MCP_AVAILABLE:
         include_in_schema=False,
     )
     async def mcp_register(request: Request, server_id: str):
-        mcp_server = _get_cached_temporary_mcp_server_or_404(server_id)
+        mcp_server = await _get_cached_temporary_mcp_server_or_404(server_id)
         request_data = await _read_request_body(request=request)
         data: dict = {**request_data}
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -52,6 +52,10 @@ from litellm.proxy._experimental.mcp_server.utils import (
 from litellm.proxy._experimental.mcp_server.utils import (
     validate_and_normalize_mcp_server_payload as _base_validate_and_normalize_mcp_server_payload,
 )
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_value_helper,
+    encrypt_value_helper,
+)
 
 router = APIRouter(prefix="/v1/mcp", tags=["mcp"])
 
@@ -344,11 +348,25 @@ if MCP_AVAILABLE:
             return
 
         payload: Dict[str, Any] = server.model_dump(mode="json")
+        payload_json = json.dumps(payload)
+        try:
+            encrypted_payload = encrypt_value_helper(payload_json)
+        except Exception as e:
+            verbose_proxy_logger.debug(
+                f"Failed to encrypt temporary MCP server payload for Redis cache: {str(e)}"
+            )
+            return
+
+        if not isinstance(encrypted_payload, str):
+            verbose_proxy_logger.debug(
+                "Encrypted temporary MCP payload is not a string; skipping Redis cache write"
+            )
+            return
 
         try:
             await cache_backend.async_set_cache(
                 key=f"{TEMPORARY_MCP_SERVER_REDIS_KEY_PREFIX}:{server.server_id}",
-                value=payload,
+                value=encrypted_payload,
                 ttl=max(1, ttl_seconds),
             )
         except Exception as e:
@@ -376,11 +394,31 @@ if MCP_AVAILABLE:
             )
             return None
 
-        if not isinstance(cached_server, dict):
+        if isinstance(cached_server, dict):
+            payload_dict: Dict[str, Any] = cached_server
+        elif isinstance(cached_server, str):
+            decrypted_json = decrypt_value_helper(
+                value=cached_server,
+                key="temporary_mcp_server",
+                exception_type="debug",
+            )
+            if decrypted_json is None:
+                return None
+            try:
+                loaded = json.loads(decrypted_json)
+            except Exception as e:
+                verbose_proxy_logger.debug(
+                    f"Invalid decrypted temporary MCP payload in Redis cache: {str(e)}"
+                )
+                return None
+            if not isinstance(loaded, dict):
+                return None
+            payload_dict = loaded
+        else:
             return None
 
         try:
-            return MCPServer(**cached_server)
+            return MCPServer(**payload_dict)
         except Exception as e:
             verbose_proxy_logger.debug(
                 f"Invalid temporary MCP server payload in Redis cache: {str(e)}"

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -374,7 +374,9 @@ if MCP_AVAILABLE:
                 f"Failed to write temporary MCP server to Redis cache: {str(e)}"
             )
 
-    async def _get_temporary_mcp_server_from_redis(server_id: str) -> Optional[MCPServer]:
+    async def _get_temporary_mcp_server_from_redis(
+        server_id: str,
+    ) -> Optional[MCPServer]:
         """
         Best-effort read from Redis shared cache. Returns None on miss/errors.
         """

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1348,7 +1348,7 @@ class TestTemporaryMCPSessionEndpoints:
             result = await _get_cached_temporary_mcp_server_or_404("cached")
 
         assert result is server
-        get_cached.assert_called_once_with("cached")
+        get_cached.assert_awaited_once_with("cached")
 
         with patch(
             "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1311,7 +1311,8 @@ class TestTemporaryMCPSessionEndpoints:
         assert cache["temp-cache"].server is server
         assert cache["temp-cache"].expires_at > datetime.utcnow()
 
-    def test_get_cached_temporary_mcp_server_prunes_expired_entries(self):
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_prunes_expired_entries(self):
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (
             _TemporaryMCPServerEntry,
             get_cached_temporary_mcp_server,
@@ -1327,12 +1328,13 @@ class TestTemporaryMCPSessionEndpoints:
             "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
             cache,
         ):
-            result = get_cached_temporary_mcp_server("expired")
+            result = await get_cached_temporary_mcp_server("expired")
 
         assert result is None
         assert "expired" not in cache
 
-    def test_get_cached_temporary_mcp_server_or_404(self):
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_or_404(self):
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (
             _get_cached_temporary_mcp_server_or_404,
         )
@@ -1343,7 +1345,7 @@ class TestTemporaryMCPSessionEndpoints:
             "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
             return_value=server,
         ) as get_cached:
-            result = _get_cached_temporary_mcp_server_or_404("cached")
+            result = await _get_cached_temporary_mcp_server_or_404("cached")
 
         assert result is server
         get_cached.assert_called_once_with("cached")
@@ -1353,7 +1355,7 @@ class TestTemporaryMCPSessionEndpoints:
             return_value=None,
         ):
             with pytest.raises(HTTPException) as exc_info:
-                _get_cached_temporary_mcp_server_or_404("missing")
+                await _get_cached_temporary_mcp_server_or_404("missing")
 
         assert exc_info.value.status_code == 404
 
@@ -1403,6 +1405,10 @@ class TestTemporaryMCPSessionEndpoints:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints._cache_temporary_mcp_server",
                 MagicMock(),
             ) as cache_mock,
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._cache_temporary_mcp_server_in_redis",
+                AsyncMock(),
+            ) as redis_cache_mock,
         ):
             response = await add_session_mcp_server(
                 payload=payload,
@@ -1412,6 +1418,9 @@ class TestTemporaryMCPSessionEndpoints:
         validate_mock.assert_called_once_with(payload)
         mock_manager.build_mcp_server_from_table.assert_awaited_once()
         cache_mock.assert_called_once_with(
+            built_server, ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS
+        )
+        redis_cache_mock.assert_awaited_once_with(
             built_server, ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS
         )
 
@@ -1486,7 +1495,7 @@ class TestTemporaryMCPSessionEndpoints:
             )
 
         assert result is authorize_response
-        get_server.assert_called_once_with("server-1")
+        get_server.assert_awaited_once_with("server-1")
         authorize_mock.assert_awaited_once_with(
             request=request,
             mcp_server=server,
@@ -1533,7 +1542,7 @@ class TestTemporaryMCPSessionEndpoints:
             )
 
         assert result is exchange_response
-        get_server.assert_called_once_with("server-1")
+        get_server.assert_awaited_once_with("server-1")
         exchange_mock.assert_awaited_once_with(
             request=request,
             mcp_server=server,
@@ -1581,7 +1590,7 @@ class TestTemporaryMCPSessionEndpoints:
             )
 
         assert result is exchange_response
-        get_server.assert_called_once_with("server-1")
+        get_server.assert_awaited_once_with("server-1")
         exchange_mock.assert_awaited_once_with(
             request=request,
             mcp_server=server,
@@ -1628,7 +1637,7 @@ class TestTemporaryMCPSessionEndpoints:
             result = await mcp_register(request=request, server_id="server-1")
 
         assert result is register_response
-        get_server.assert_called_once_with("server-1")
+        get_server.assert_awaited_once_with("server-1")
         read_body.assert_awaited_once_with(request=request)
         register_mock.assert_awaited_once_with(
             request=request,
@@ -1639,6 +1648,53 @@ class TestTemporaryMCPSessionEndpoints:
             token_endpoint_auth_method="client_secret_basic",
             fallback_client_id="server-1",
         )
+
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_falls_back_to_redis(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            get_cached_temporary_mcp_server,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="from-redis")
+        mock_cache_backend = SimpleNamespace(
+            async_get_cache=AsyncMock(return_value=server.model_dump(mode="json"))
+        )
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
+                {},
+            ):
+                result = await get_cached_temporary_mcp_server("from-redis")
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        assert result is not None
+        assert result.server_id == "from-redis"
+        mock_cache_backend.async_get_cache.assert_awaited_once_with(
+            key="litellm:mcp:temporary_server:from-redis"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_temporary_mcp_server_in_redis_uses_ttl_and_key(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _cache_temporary_mcp_server_in_redis,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="to-redis")
+        mock_cache_backend = SimpleNamespace(async_set_cache=AsyncMock())
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            await _cache_temporary_mcp_server_in_redis(server, ttl_seconds=123)
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        mock_cache_backend.async_set_cache.assert_awaited_once()
+        call_kwargs = mock_cache_backend.async_set_cache.await_args.kwargs
+        assert call_kwargs["key"] == "litellm:mcp:temporary_server:to-redis"
+        assert call_kwargs["ttl"] == 123
 
 
 class TestUpdateMCPServer:

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1657,8 +1657,9 @@ class TestTemporaryMCPSessionEndpoints:
         )
 
         server = generate_mock_mcp_server_config_record(server_id="from-redis")
+        serialized = json.dumps(server.model_dump(mode="json"))
         mock_cache_backend = SimpleNamespace(
-            async_get_cache=AsyncMock(return_value=server.model_dump(mode="json"))
+            async_get_cache=AsyncMock(return_value="encrypted-payload")
         )
         original_cache = mgmt_endpoints.litellm.cache
         mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
@@ -1666,6 +1667,9 @@ class TestTemporaryMCPSessionEndpoints:
             with patch(
                 "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
                 {},
+            ), patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
+                return_value=serialized,
             ):
                 result = await get_cached_temporary_mcp_server("from-redis")
         finally:
@@ -1833,6 +1837,26 @@ class TestTemporaryMCPSessionEndpoints:
                 return_value=None,
             ):
                 result = await _get_temporary_mcp_server_from_redis("decrypt-none")
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_temporary_mcp_server_from_redis_rejects_plain_dict_payload(self):
+        """Plain dict values in Redis are not accepted (write path is encrypted-only)."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_temporary_mcp_server_from_redis,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="legacy-dict")
+        mock_cache_backend = SimpleNamespace(
+            async_get_cache=AsyncMock(return_value=server.model_dump(mode="json"))
+        )
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            result = await _get_temporary_mcp_server_from_redis("legacy-dict")
         finally:
             mgmt_endpoints.litellm.cache = original_cache
 

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1752,6 +1752,92 @@ class TestTemporaryMCPSessionEndpoints:
         assert result.server_id == "from-redis-encrypted"
         decrypt_mock.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_cache_temporary_mcp_server_in_redis_skips_on_encrypt_failure(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _cache_temporary_mcp_server_in_redis,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="encrypt-fail")
+        mock_cache_backend = SimpleNamespace(async_set_cache=AsyncMock())
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.encrypt_value_helper",
+                side_effect=Exception("boom"),
+            ):
+                await _cache_temporary_mcp_server_in_redis(server, ttl_seconds=60)
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        mock_cache_backend.async_set_cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cache_temporary_mcp_server_in_redis_skips_non_string_encryption_result(
+        self,
+    ):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _cache_temporary_mcp_server_in_redis,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="encrypt-non-string")
+        mock_cache_backend = SimpleNamespace(async_set_cache=AsyncMock())
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.encrypt_value_helper",
+                return_value={"not": "a-string"},
+            ):
+                await _cache_temporary_mcp_server_in_redis(server, ttl_seconds=60)
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        mock_cache_backend.async_set_cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_temporary_mcp_server_from_redis_returns_none_on_invalid_decrypt_json(
+        self,
+    ):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_temporary_mcp_server_from_redis,
+        )
+
+        mock_cache_backend = SimpleNamespace(async_get_cache=AsyncMock(return_value="enc"))
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
+                return_value="{not json}",
+            ):
+                result = await _get_temporary_mcp_server_from_redis("bad-json")
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_temporary_mcp_server_from_redis_returns_none_on_decrypt_none(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_temporary_mcp_server_from_redis,
+        )
+
+        mock_cache_backend = SimpleNamespace(async_get_cache=AsyncMock(return_value="enc"))
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
+                return_value=None,
+            ):
+                result = await _get_temporary_mcp_server_from_redis("decrypt-none")
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        assert result is None
+
 
 class TestUpdateMCPServer:
     """Test suite for update MCP server functionality"""

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import json
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import List, Optional
@@ -1687,7 +1688,11 @@ class TestTemporaryMCPSessionEndpoints:
         original_cache = mgmt_endpoints.litellm.cache
         mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
         try:
-            await _cache_temporary_mcp_server_in_redis(server, ttl_seconds=123)
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.encrypt_value_helper",
+                return_value="encrypted-payload",
+            ):
+                await _cache_temporary_mcp_server_in_redis(server, ttl_seconds=123)
         finally:
             mgmt_endpoints.litellm.cache = original_cache
 
@@ -1695,6 +1700,57 @@ class TestTemporaryMCPSessionEndpoints:
         call_kwargs = mock_cache_backend.async_set_cache.await_args.kwargs
         assert call_kwargs["key"] == "litellm:mcp:temporary_server:to-redis"
         assert call_kwargs["ttl"] == 123
+
+    @pytest.mark.asyncio
+    async def test_cache_temporary_mcp_server_in_redis_encrypts_payload(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _cache_temporary_mcp_server_in_redis,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="to-redis-encrypted")
+        mock_cache_backend = SimpleNamespace(async_set_cache=AsyncMock())
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.encrypt_value_helper",
+                return_value="encrypted-payload",
+            ) as encrypt_mock:
+                await _cache_temporary_mcp_server_in_redis(server, ttl_seconds=60)
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        encrypt_mock.assert_called_once()
+        call_kwargs = mock_cache_backend.async_set_cache.await_args.kwargs
+        assert call_kwargs["value"] == "encrypted-payload"
+
+    @pytest.mark.asyncio
+    async def test_get_temporary_mcp_server_from_redis_decrypts_payload(self):
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_temporary_mcp_server_from_redis,
+        )
+
+        server = generate_mock_mcp_server_config_record(server_id="from-redis-encrypted")
+        serialized = json.dumps(server.model_dump(mode="json"))
+        mock_cache_backend = SimpleNamespace(
+            async_get_cache=AsyncMock(return_value="encrypted-payload")
+        )
+        original_cache = mgmt_endpoints.litellm.cache
+        mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
+        try:
+            with patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
+                return_value=serialized,
+            ) as decrypt_mock:
+                result = await _get_temporary_mcp_server_from_redis(
+                    "from-redis-encrypted"
+                )
+        finally:
+            mgmt_endpoints.litellm.cache = original_cache
+
+        assert result is not None
+        assert result.server_id == "from-redis-encrypted"
+        decrypt_mock.assert_called_once()
 
 
 class TestUpdateMCPServer:


### PR DESCRIPTION
## Relevant issues
Fixes temporary MCP OAuth session lookup failures in multi-instance/LB proxy deployments where `/v1/mcp/server/oauth/session` is created on one instance and subsequent `/server/oauth/{server_id}/...` requests may land on another.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Targeted local test runs:

- `poetry run python -m pytest tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py -v`
  - Result: `56 passed`

Focused path validation also covered temporary MCP OAuth handlers, Redis fallback logic, and encrypted Redis payload read/write paths in:
- `TestTemporaryMCPSessionEndpoints`

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Fixes multi-instance/LB temporary MCP OAuth flow by sharing temporary MCP session servers in Redis (instead of process-only memory).
- Keeps current in-memory cache as fallback/L1; Redis is best-effort shared backing store.
- Encrypts temporary MCP session payloads before Redis write and decrypts on Redis read using existing proxy encryption/decryption helpers.
- Converts temporary MCP cache lookup helpers to async and updates OAuth endpoints (`authorize`, `token`, `register`) to await them.
- Adds/updates unit tests for:
  - Redis fallback lookup on local-cache miss
  - Redis write key + TTL behavior
  - encrypted payload write/decrypt read paths
  - async lookup call path assertions