### PR TITLE
fix(websearch_interception): dedupe follow-up kwargs against optional params

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -761,6 +761,16 @@ class WebSearchInterceptionLogger(CustomLogger):
 
             kwargs_for_followup = self._prepare_followup_kwargs(kwargs)
 
+            # Remove keys already present in optional_params to avoid
+            # duplicate keyword arguments in anthropic_messages.acreate().
+            # Claude Code sends params like context_management, output_config
+            # which end up in both dicts.
+            kwargs_for_followup = {
+                k: v
+                for k, v in kwargs_for_followup.items()
+                if k not in optional_params_without_max_tokens
+            }
+
             # Get model from logging_obj.model_call_details["agentic_loop_params"]
             # This preserves the full model name with provider prefix (e.g., "bedrock/invoke/...")
             if logging_obj is not None:


### PR DESCRIPTION
## Problem

When using Claude Code through LiteLLM's Anthropic `/v1/messages` endpoint with `websearch_interception` enabled, the follow-up Anthropic request crashes with:

```
TypeError: got multiple values for keyword argument 'context_management'
```

(and subsequently `output_config` after hotfixing the first one).

The web search itself succeeds, but the follow-up call fails silently, making web search appear broken to the end user.

## Root Cause

In `_execute_agentic_loop`, `anthropic_messages.acreate()` receives both:

```python
**optional_params_without_max_tokens,  # contains context_management, output_config
**kwargs_for_followup,                  # also contains context_management, output_config
```

`_prepare_followup_kwargs()` only strips `litellm_logging_obj` and internal `_websearch_interception*` keys. Claude Code-specific params like `context_management` and `output_config` pass through and collide with the same keys from the optional params dict.

## Fix

After building `kwargs_for_followup`, filter out any key already present in `optional_params_without_max_tokens` to prevent duplicate keyword arguments. This is generic — any future Claude Code params will also be handled correctly without hardcoding individual field names.

Fixes #26163