### PR TITLE
Fix: ollama provider respects explicit api_base kwarg over global

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3969,8 +3969,8 @@ def completion(  # type: ignore # noqa: PLR0915
             response = model_response
         elif custom_llm_provider == "ollama":
             api_base = (
-                litellm.api_base
-                or api_base
+                api_base
+                or litellm.api_base
                 or get_secret("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )
@@ -3998,8 +3998,8 @@ def completion(  # type: ignore # noqa: PLR0915
 
         elif custom_llm_provider == "ollama_chat":
             api_base = (
-                litellm.api_base
-                or api_base
+                api_base
+                or litellm.api_base
                 or get_secret("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )
@@ -5317,8 +5317,8 @@ def embedding(  # noqa: PLR0915
             )
         elif custom_llm_provider == "ollama":
             api_base = (
-                litellm.api_base
-                or api_base
+                api_base
+                or litellm.api_base
                 or get_secret_str("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )  # type: ignore


### PR DESCRIPTION
Fixes #26170.

## What

The ollama, ollama_chat, and ollama embedding provider blocks in `litellm/main.py` resolved `api_base` as `litellm.api_base or api_base or ...` — global first, explicit kwarg second. This contradicts the openai provider (line 2038) and every other major provider block in the same file, which resolve kwarg first.

Swap the first two operands in each of the three blocks so the explicit kwarg wins. Behavior is now consistent with the openai provider.

## Impact

Client code that explicitly passes `api_base="http://my-ollama:11434"` to `litellm.completion()` or `litellm.embedding()` had the value silently overridden if `litellm.api_base` happened to be set globally by unrelated code. This happens in practice whenever an application routes multiple providers through LiteLLM — e.g. an openai-compat provider like DeepSeek sets `litellm.api_base = "https://api.deepseek.com"` during its own init, and subsequent ollama calls inherit the wrong URL.

Real-world repro and symptom are in #26170.

## Change

Three two-line swaps. No new logic, no semantic change to the other resolution fallbacks (`get_secret("OLLAMA_API_BASE")` and the localhost default remain the final fallbacks).

| Line | Provider |
|---|---|
| 3970 | ollama (completion path) |
| 3999 | ollama_chat (completion path) |
| 5318 | ollama (embedding path) |

## Manual verification

With the patch applied locally:

```python
import litellm
litellm.api_base = "https://api.deepseek.com"   # simulate leaked global

r = litellm.embedding(
    model="ollama/qwen3-embedding:0.6b",
    input="hello",
    api_base="http://ollama:11434",
)
# ✓ hits http://ollama:11434/api/embed, returns embedding
```

Before the patch, the same call 401s at `api.deepseek.com`.