### PR TITLE
fix: coerce server_tool_use dict to ServerToolUse in stream_chunk_builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -587,7 +587,10 @@ class ChunkProcessor:
                     hasattr(usage_chunk, "server_tool_use")
                     and usage_chunk.server_tool_use is not None
                 ):
-                    server_tool_use = usage_chunk.server_tool_use
+                    _stu = usage_chunk.server_tool_use
+                    server_tool_use = (
+                        ServerToolUse(**_stu) if isinstance(_stu, dict) else _stu
+                    )
                 if (
                     usage_chunk_dict["prompt_tokens_details"] is not None
                     and getattr(


### PR DESCRIPTION
## Summary

Fixes #26153

When streaming Anthropic responses with `web_search_options`, `stream_chunk_builder` reconstructs `usage.server_tool_use` as a plain `dict` rather than a `ServerToolUse` pydantic object. In v1.83.10, a new check in `StandardBuiltInToolCostTracking.response_object_includes_web_search_call` (and `get_cost_for_anthropic_web_search`) accesses `.web_search_requests` as an attribute, causing:

```
AttributeError: 'dict' object has no attribute 'web_search_requests'
```

**Root cause**: In `_calculate_usage_per_chunk`, `server_tool_use` is assigned directly from `usage_chunk.server_tool_use` without checking whether it is already a `ServerToolUse` object or a raw dict.

**Fix**: Apply the same dict→object coercion pattern already used for `prompt_tokens_details` in the same method:

```python
# Before:
server_tool_use = usage_chunk.server_tool_use

# After:
_stu = usage_chunk.server_tool_use
server_tool_use = ServerToolUse(**_stu) if isinstance(_stu, dict) else _stu
```

## Reproduction

```python
from litellm import completion, stream_chunk_builder, completion_cost

chunks = list(completion(
    'claude-sonnet-4-6',
    [{'role': 'user', 'content': 'Search the web for otters and tell me one fact'}],
    stream=True,
    web_search_options={'search_context_size': 'low'},
    stream_options={'include_usage': True},
))
r = stream_chunk_builder(chunks)
print(type(r.usage.server_tool_use))  # was <class 'dict'>, now ServerToolUse
completion_cost(completion_response=r)  # was AttributeError, now works
```

## Test plan

- [ ] Verify `type(r.usage.server_tool_use)` returns `ServerToolUse` after streaming Anthropic web search response
- [ ] Verify `completion_cost()` no longer raises `AttributeError` for streaming Anthropic responses with `web_search_options`
- [ ] Existing streaming tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)