### PR TITLE
feat(messages): add web search response translation for /v1/messages → /v1/responses path

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -7,6 +7,11 @@ from typing import Any, AsyncIterator, Dict
 
 from litellm import verbose_logger
 from litellm._uuid import uuid
+from .utils import (
+    build_text_blocks_with_citations,
+    build_web_tool_use,
+    build_web_search_results_from_annotations,
+)
 
 
 class AnthropicResponsesStreamWrapper:
@@ -41,6 +46,8 @@ class AnthropicResponsesStreamWrapper:
         self._sent_message_start = False
         self._sent_message_stop = False
         self._chunk_queue: deque = deque()
+        # Web tools: defer text emission until output_item.done
+        self._web_tool_uses: list = []
 
     def _make_message_start(self) -> Dict[str, Any]:
         return {
@@ -96,6 +103,10 @@ class AnthropicResponsesStreamWrapper:
             )
 
             if item_type == "message":
+                if self._web_tool_uses:
+                    # Don't open text block here — deferred to
+                    # output_item.done where full annotations (citations) are available.
+                    return
                 block_idx = self._next_block_index()
                 if item_id:
                     self._item_id_to_block_index[item_id] = block_idx
@@ -133,6 +144,10 @@ class AnthropicResponsesStreamWrapper:
                         },
                     }
                 )
+            elif item_type == "web_search_call":
+                # Don't emit content_block_start here — search queries
+                # are only available in output_item.done.
+                pass
             elif item_type == "reasoning":
                 block_idx = self._next_block_index()
                 if item_id:
@@ -148,6 +163,10 @@ class AnthropicResponsesStreamWrapper:
 
         # ---- text delta ----
         if event_type == "response.output_text.delta":
+            if self._web_tool_uses:
+                # Don't stream text deltas here — full text with citation
+                # is emitted from output_item.done.
+                return
             item_id = getattr(event, "item_id", None) or (
                 event.get("item_id") if isinstance(event, dict) else None
             )
@@ -223,6 +242,29 @@ class AnthropicResponsesStreamWrapper:
                 if item
                 else None
             )
+            item_type = (
+                getattr(item, "type", None)
+                or (item.get("type") if isinstance(item, dict) else None)
+                if item
+                else None
+            )
+            if item_type == "reasoning":
+                # Reasoning items are closed by individual part.done events
+                return
+            if item_type == "web_search_call":
+                self._emit_web_tool_use(item)
+                return
+            if item_type == "message" and self._web_tool_uses:
+                if not isinstance(item, dict):
+                    item = item.model_dump()
+                for part in item.get("content") or []:
+                    if isinstance(part, dict) and part.get("type") == "output_text":
+                        text = part.get("text", "")
+                        annotations = part.get("annotations") or []
+                        citations = self._emit_web_search_results(annotations)
+                        self._emit_cited_text_blocks(text, citations)
+                        break
+                return
             block_idx = (
                 self._item_id_to_block_index.get(item_id, self._current_block_index)
                 if item_id
@@ -288,6 +330,11 @@ class AnthropicResponsesStreamWrapper:
                 usage_delta["cache_creation_input_tokens"] = cache_creation_tokens
             if cache_read_tokens:
                 usage_delta["cache_read_input_tokens"] = cache_read_tokens
+            if self._web_tool_uses:
+                usage_delta["server_tool_use"] = {
+                    "web_search_requests": sum(c["name"] == "web_search" for c in self._web_tool_uses),
+                    "web_fetch_requests": sum(c["name"] == "web_fetch" for c in self._web_tool_uses),
+                }
 
             self._chunk_queue.append(
                 {
@@ -299,6 +346,81 @@ class AnthropicResponsesStreamWrapper:
             self._chunk_queue.append({"type": "message_stop"})
             self._sent_message_stop = True
             return
+
+    def _emit_web_tool_use(self, item: Any) -> None:
+        """Emit server_tool_use block and collect web tool info."""
+        block, input_dict = build_web_tool_use(item)
+        block_idx = self._next_block_index()
+        self._web_tool_uses.append(block)
+        self._chunk_queue.append(
+            {
+                "type": "content_block_start",
+                "index": block_idx,
+                "content_block": block,
+            }
+        )
+        self._chunk_queue.append(
+            {
+                "type": "content_block_delta",
+                "index": block_idx,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": json.dumps(input_dict),
+                },
+            }
+        )
+        self._chunk_queue.append(
+            {"type": "content_block_stop", "index": block_idx}
+        )
+
+    def _emit_web_search_results(self, annotations: list) -> list:
+        """Emit web_search_tool_result blocks and return citations for text emission."""
+        blocks, citations = build_web_search_results_from_annotations(
+            self._web_tool_uses, annotations
+        )
+        for block in blocks:
+            block_idx = self._next_block_index()
+            self._chunk_queue.append(
+                {
+                    "type": "content_block_start",
+                    "index": block_idx,
+                    "content_block": block,
+                }
+            )
+            self._chunk_queue.append(
+            {"type": "content_block_stop", "index": block_idx}
+        )
+        return citations
+
+    def _emit_cited_text_blocks(self, text: str, citations: list) -> None:
+        """Emit text blocks with citation deltas."""
+        for block_data in build_text_blocks_with_citations(text, citations):
+            block_idx = self._next_block_index()
+            self._chunk_queue.append(
+                {
+                    "type": "content_block_start",
+                    "index": block_idx,
+                    "content_block": {"type": "text", "text": ""},
+                }
+            )
+            self._chunk_queue.append(
+                {
+                    "type": "content_block_delta",
+                    "index": block_idx,
+                    "delta": {"type": "text_delta", "text": block_data["text"]},
+                }
+            )
+            for cit in block_data.get("citations", []):
+                self._chunk_queue.append(
+                    {
+                        "type": "content_block_delta",
+                        "index": block_idx,
+                        "delta": {"type": "citations_delta", "citation": cit},
+                    }
+                )
+            self._chunk_queue.append(
+            {"type": "content_block_stop", "index": block_idx}
+        )
 
     def __aiter__(self) -> "AnthropicResponsesStreamWrapper":
         return self

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -332,8 +332,12 @@ class AnthropicResponsesStreamWrapper:
                 usage_delta["cache_read_input_tokens"] = cache_read_tokens
             if self._web_tool_uses:
                 usage_delta["server_tool_use"] = {
-                    "web_search_requests": sum(c["name"] == "web_search" for c in self._web_tool_uses),
-                    "web_fetch_requests": sum(c["name"] == "web_fetch" for c in self._web_tool_uses),
+                    "web_search_requests": sum(
+                        c["name"] == "web_search" for c in self._web_tool_uses
+                    ),
+                    "web_fetch_requests": sum(
+                        c["name"] == "web_fetch" for c in self._web_tool_uses
+                    ),
                 }
 
             self._chunk_queue.append(
@@ -369,9 +373,7 @@ class AnthropicResponsesStreamWrapper:
                 },
             }
         )
-        self._chunk_queue.append(
-            {"type": "content_block_stop", "index": block_idx}
-        )
+        self._chunk_queue.append({"type": "content_block_stop", "index": block_idx})
 
     def _emit_web_search_results(self, annotations: list) -> list:
         """Emit web_search_tool_result blocks and return citations for text emission."""
@@ -387,9 +389,7 @@ class AnthropicResponsesStreamWrapper:
                     "content_block": block,
                 }
             )
-            self._chunk_queue.append(
-            {"type": "content_block_stop", "index": block_idx}
-        )
+            self._chunk_queue.append({"type": "content_block_stop", "index": block_idx})
         return citations
 
     def _emit_cited_text_blocks(self, text: str, citations: list) -> None:
@@ -418,9 +418,7 @@ class AnthropicResponsesStreamWrapper:
                         "delta": {"type": "citations_delta", "citation": cit},
                     }
                 )
-            self._chunk_queue.append(
-            {"type": "content_block_stop", "index": block_idx}
-        )
+            self._chunk_queue.append({"type": "content_block_stop", "index": block_idx})
 
     def __aiter__(self) -> "AnthropicResponsesStreamWrapper":
         return self

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -248,9 +248,6 @@ class AnthropicResponsesStreamWrapper:
                 if item
                 else None
             )
-            if item_type == "reasoning":
-                # Reasoning items are closed by individual part.done events
-                return
             if item_type == "web_search_call":
                 self._emit_web_tool_use(item)
                 return

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -444,7 +444,9 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         )
                         content.extend(blocks)
                         content.extend(
-                            build_text_blocks_with_citations(getattr(part, "text", ""), citations)
+                            build_text_blocks_with_citations(
+                                getattr(part, "text", ""), citations
+                            )
                         )
                         break
 
@@ -481,12 +483,16 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                 elif item_type == "message" and web_tool_uses:
                     for part in item.get("content", []):
                         if isinstance(part, dict) and part.get("type") == "output_text":
-                            blocks, citations = build_web_search_results_from_annotations(
-                                web_tool_uses, part.get("annotations") or []
+                            blocks, citations = (
+                                build_web_search_results_from_annotations(
+                                    web_tool_uses, part.get("annotations") or []
+                                )
                             )
                             content.extend(blocks)
                             content.extend(
-                                build_text_blocks_with_citations(part.get("text", ""), citations)
+                                build_text_blocks_with_citations(
+                                    part.get("text", ""), citations
+                                )
                             )
                             break
                 elif item_type == "message":
@@ -528,8 +534,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         if web_tool_uses:
             anthropic_usage["server_tool_use"] = {  # type: ignore[typeddict-unknown-key]
-                "web_search_requests": sum(c["name"] == "web_search" for c in web_tool_uses),
-                "web_fetch_requests": sum(c["name"] == "web_fetch" for c in web_tool_uses),
+                "web_search_requests": sum(
+                    c["name"] == "web_search" for c in web_tool_uses
+                ),
+                "web_fetch_requests": sum(
+                    c["name"] == "web_fetch" for c in web_tool_uses
+                ),
             }
 
         return AnthropicMessagesResponse(

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -11,6 +11,12 @@ from typing import Any, Dict, List, Optional, Union, cast
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
 )
+
+from .utils import (
+    build_text_blocks_with_citations,
+    build_web_tool_use,
+    build_web_search_results_from_annotations,
+)
 from litellm.types.llms.anthropic import (
     AllAnthropicToolsValues,
     AnthopicMessagesAssistantMessageParam,
@@ -401,6 +407,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         """
         from openai.types.responses import (
             ResponseFunctionToolCall,
+            ResponseFunctionWebSearch,
             ResponseOutputMessage,
             ResponseReasoningItem,
         )
@@ -409,6 +416,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         content: List[Dict[str, Any]] = []
         stop_reason: AnthropicFinishReason = "end_turn"
+        web_tool_uses: List[Dict[str, Any]] = []
 
         for item in response.output:
             if isinstance(item, ResponseReasoningItem):
@@ -422,6 +430,23 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 signature=None,
                             ).model_dump()
                         )
+
+            elif isinstance(item, ResponseFunctionWebSearch):
+                block, input_dict = build_web_tool_use(item)
+                web_tool_uses.append(block)
+                content.append({**block, "input": input_dict})
+
+            elif isinstance(item, ResponseOutputMessage) and web_tool_uses:
+                for part in item.content:
+                    if getattr(part, "type", None) == "output_text":
+                        blocks, citations = build_web_search_results_from_annotations(
+                            web_tool_uses, getattr(part, "annotations", []) or []
+                        )
+                        content.extend(blocks)
+                        content.extend(
+                            build_text_blocks_with_citations(getattr(part, "text", ""), citations)
+                        )
+                        break
 
             elif isinstance(item, ResponseOutputMessage):
                 for part in item.content:
@@ -449,7 +474,22 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
             elif isinstance(item, dict):
                 item_type = item.get("type")
-                if item_type == "message":
+                if item_type == "web_search_call":
+                    block, input_dict = build_web_tool_use(item)
+                    web_tool_uses.append(block)
+                    content.append({**block, "input": input_dict})
+                elif item_type == "message" and web_tool_uses:
+                    for part in item.get("content", []):
+                        if isinstance(part, dict) and part.get("type") == "output_text":
+                            blocks, citations = build_web_search_results_from_annotations(
+                                web_tool_uses, part.get("annotations") or []
+                            )
+                            content.extend(blocks)
+                            content.extend(
+                                build_text_blocks_with_citations(part.get("text", ""), citations)
+                            )
+                            break
+                elif item_type == "message":
                     for part in item.get("content", []):
                         if isinstance(part, dict) and part.get("type") == "output_text":
                             content.append(
@@ -485,6 +525,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
+
+        if web_tool_uses:
+            anthropic_usage["server_tool_use"] = {  # type: ignore[typeddict-unknown-key]
+                "web_search_requests": sum(c["name"] == "web_search" for c in web_tool_uses),
+                "web_fetch_requests": sum(c["name"] == "web_fetch" for c in web_tool_uses),
+            }
 
         return AnthropicMessagesResponse(
             id=response.id,

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -11,6 +11,12 @@ from typing import Any, Dict, List, Optional, Union, cast
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
 )
+
+from .utils import (
+    build_text_blocks_with_citations,
+    build_web_tool_use,
+    build_web_search_results_from_annotations,
+)
 from litellm.types.llms.anthropic import (
     AllAnthropicToolsValues,
     AnthopicMessagesAssistantMessageParam,
@@ -421,6 +427,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         """
         from openai.types.responses import (
             ResponseFunctionToolCall,
+            ResponseFunctionWebSearch,
             ResponseOutputMessage,
             ResponseReasoningItem,
         )
@@ -429,6 +436,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         content: List[Dict[str, Any]] = []
         stop_reason: AnthropicFinishReason = "end_turn"
+        web_tool_uses: List[Dict[str, Any]] = []
 
         for item in response.output:
             if isinstance(item, ResponseReasoningItem):
@@ -442,6 +450,23 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 signature=None,
                             ).model_dump()
                         )
+
+            elif isinstance(item, ResponseFunctionWebSearch):
+                block, input_dict = build_web_tool_use(item)
+                web_tool_uses.append(block)
+                content.append({**block, "input": input_dict})
+
+            elif isinstance(item, ResponseOutputMessage) and web_tool_uses:
+                for part in item.content:
+                    if getattr(part, "type", None) == "output_text":
+                        blocks, citations = build_web_search_results_from_annotations(
+                            web_tool_uses, getattr(part, "annotations", []) or []
+                        )
+                        content.extend(blocks)
+                        content.extend(
+                            build_text_blocks_with_citations(getattr(part, "text", ""), citations)
+                        )
+                        break
 
             elif isinstance(item, ResponseOutputMessage):
                 for part in item.content:
@@ -469,7 +494,22 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
             elif isinstance(item, dict):
                 item_type = item.get("type")
-                if item_type == "message":
+                if item_type == "web_search_call":
+                    block, input_dict = build_web_tool_use(item)
+                    web_tool_uses.append(block)
+                    content.append({**block, "input": input_dict})
+                elif item_type == "message" and web_tool_uses:
+                    for part in item.get("content", []):
+                        if isinstance(part, dict) and part.get("type") == "output_text":
+                            blocks, citations = build_web_search_results_from_annotations(
+                                web_tool_uses, part.get("annotations") or []
+                            )
+                            content.extend(blocks)
+                            content.extend(
+                                build_text_blocks_with_citations(part.get("text", ""), citations)
+                            )
+                            break
+                elif item_type == "message":
                     for part in item.get("content", []):
                         if isinstance(part, dict) and part.get("type") == "output_text":
                             content.append(
@@ -505,6 +545,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )
+
+        if web_tool_uses:
+            anthropic_usage["server_tool_use"] = {  # type: ignore[typeddict-unknown-key]
+                "web_search_requests": sum(c["name"] == "web_search" for c in web_tool_uses),
+                "web_fetch_requests": sum(c["name"] == "web_fetch" for c in web_tool_uses),
+            }
 
         return AnthropicMessagesResponse(
             id=response.id,

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -464,7 +464,9 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         )
                         content.extend(blocks)
                         content.extend(
-                            build_text_blocks_with_citations(getattr(part, "text", ""), citations)
+                            build_text_blocks_with_citations(
+                                getattr(part, "text", ""), citations
+                            )
                         )
                         break
 
@@ -501,12 +503,16 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                 elif item_type == "message" and web_tool_uses:
                     for part in item.get("content", []):
                         if isinstance(part, dict) and part.get("type") == "output_text":
-                            blocks, citations = build_web_search_results_from_annotations(
-                                web_tool_uses, part.get("annotations") or []
+                            blocks, citations = (
+                                build_web_search_results_from_annotations(
+                                    web_tool_uses, part.get("annotations") or []
+                                )
                             )
                             content.extend(blocks)
                             content.extend(
-                                build_text_blocks_with_citations(part.get("text", ""), citations)
+                                build_text_blocks_with_citations(
+                                    part.get("text", ""), citations
+                                )
                             )
                             break
                 elif item_type == "message":
@@ -548,8 +554,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         if web_tool_uses:
             anthropic_usage["server_tool_use"] = {  # type: ignore[typeddict-unknown-key]
-                "web_search_requests": sum(c["name"] == "web_search" for c in web_tool_uses),
-                "web_fetch_requests": sum(c["name"] == "web_fetch" for c in web_tool_uses),
+                "web_search_requests": sum(
+                    c["name"] == "web_search" for c in web_tool_uses
+                ),
+                "web_fetch_requests": sum(
+                    c["name"] == "web_fetch" for c in web_tool_uses
+                ),
             }
 
         return AnthropicMessagesResponse(

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -418,12 +418,15 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
     # Response translation: Responses API -> Anthropic                    #
     # ------------------------------------------------------------------ #
 
-    def translate_response(
+    def _translate_output_item(
         self,
-        response: ResponsesAPIResponse,
-    ) -> AnthropicMessagesResponse:
-        """
-        Translate an OpenAI ResponsesAPIResponse to AnthropicMessagesResponse.
+        item: Any,
+        content: List[Dict[str, Any]],
+        web_tool_uses: List[Dict[str, Any]],
+    ) -> Optional[AnthropicFinishReason]:
+        """Translate a single output item, appending blocks to *content*.
+
+        Returns a stop_reason override if the item implies one, else None.
         """
         from openai.types.responses import (
             ResponseFunctionToolCall,
@@ -432,6 +435,122 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             ResponseReasoningItem,
         )
 
+        if isinstance(item, ResponseReasoningItem):
+            for summary in item.summary:
+                text = getattr(summary, "text", "")
+                if text:
+                    content.append(
+                        AnthropicResponseContentBlockThinking(
+                            type="thinking",
+                            thinking=text,
+                            signature=None,
+                        ).model_dump()
+                    )
+
+        elif isinstance(item, ResponseFunctionWebSearch):
+            block, input_dict = build_web_tool_use(item)
+            web_tool_uses.append(block)
+            content.append({**block, "input": input_dict})
+
+        elif isinstance(item, ResponseOutputMessage) and web_tool_uses:
+            for part in item.content:
+                if getattr(part, "type", None) == "output_text":
+                    blocks, citations = build_web_search_results_from_annotations(
+                        web_tool_uses, getattr(part, "annotations", []) or []
+                    )
+                    content.extend(blocks)
+                    content.extend(
+                        build_text_blocks_with_citations(
+                            getattr(part, "text", ""), citations
+                        )
+                    )
+                    break
+
+        elif isinstance(item, ResponseOutputMessage):
+            for part in item.content:
+                if getattr(part, "type", None) == "output_text":
+                    content.append(
+                        AnthropicResponseContentBlockText(
+                            type="text", text=getattr(part, "text", "")
+                        ).model_dump()
+                    )
+
+        elif isinstance(item, ResponseFunctionToolCall):
+            try:
+                input_data = json.loads(item.arguments) if item.arguments else {}
+            except (json.JSONDecodeError, TypeError):
+                input_data = {}
+            content.append(
+                AnthropicResponseContentBlockToolUse(
+                    type="tool_use",
+                    id=item.call_id or item.id or "",
+                    name=item.name,
+                    input=input_data,
+                ).model_dump()
+            )
+            return "tool_use"
+
+        elif isinstance(item, dict):
+            return self._translate_dict_output_item(item, content, web_tool_uses)
+
+        return None
+
+    def _translate_dict_output_item(
+        self,
+        item: Dict[str, Any],
+        content: List[Dict[str, Any]],
+        web_tool_uses: List[Dict[str, Any]],
+    ) -> Optional[AnthropicFinishReason]:
+        """Handle dict-typed output items (untyped SDK responses)."""
+        item_type = item.get("type")
+        if item_type == "web_search_call":
+            block, input_dict = build_web_tool_use(item)
+            web_tool_uses.append(block)
+            content.append({**block, "input": input_dict})
+        elif item_type == "message" and web_tool_uses:
+            for part in item.get("content", []):
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    blocks, citations = build_web_search_results_from_annotations(
+                        web_tool_uses, part.get("annotations") or []
+                    )
+                    content.extend(blocks)
+                    content.extend(
+                        build_text_blocks_with_citations(
+                            part.get("text", ""), citations
+                        )
+                    )
+                    break
+        elif item_type == "message":
+            for part in item.get("content", []):
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    content.append(
+                        AnthropicResponseContentBlockText(
+                            type="text", text=part.get("text", "")
+                        ).model_dump()
+                    )
+        elif item_type == "function_call":
+            try:
+                input_data = json.loads(item.get("arguments", "{}"))
+            except (json.JSONDecodeError, TypeError):
+                input_data = {}
+            content.append(
+                AnthropicResponseContentBlockToolUse(
+                    type="tool_use",
+                    id=item.get("call_id") or item.get("id", ""),
+                    name=item.get("name", ""),
+                    input=input_data,
+                ).model_dump()
+            )
+            return "tool_use"
+        return None
+
+    def translate_response(
+        self,
+        response: ResponsesAPIResponse,
+    ) -> AnthropicMessagesResponse:
+        """
+        Translate an OpenAI ResponsesAPIResponse to AnthropicMessagesResponse.
+        """
         from litellm.types.llms.openai import ResponseAPIUsage
 
         content: List[Dict[str, Any]] = []
@@ -439,104 +558,9 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         web_tool_uses: List[Dict[str, Any]] = []
 
         for item in response.output:
-            if isinstance(item, ResponseReasoningItem):
-                for summary in item.summary:
-                    text = getattr(summary, "text", "")
-                    if text:
-                        content.append(
-                            AnthropicResponseContentBlockThinking(
-                                type="thinking",
-                                thinking=text,
-                                signature=None,
-                            ).model_dump()
-                        )
-
-            elif isinstance(item, ResponseFunctionWebSearch):
-                block, input_dict = build_web_tool_use(item)
-                web_tool_uses.append(block)
-                content.append({**block, "input": input_dict})
-
-            elif isinstance(item, ResponseOutputMessage) and web_tool_uses:
-                for part in item.content:
-                    if getattr(part, "type", None) == "output_text":
-                        blocks, citations = build_web_search_results_from_annotations(
-                            web_tool_uses, getattr(part, "annotations", []) or []
-                        )
-                        content.extend(blocks)
-                        content.extend(
-                            build_text_blocks_with_citations(
-                                getattr(part, "text", ""), citations
-                            )
-                        )
-                        break
-
-            elif isinstance(item, ResponseOutputMessage):
-                for part in item.content:
-                    if getattr(part, "type", None) == "output_text":
-                        content.append(
-                            AnthropicResponseContentBlockText(
-                                type="text", text=getattr(part, "text", "")
-                            ).model_dump()
-                        )
-
-            elif isinstance(item, ResponseFunctionToolCall):
-                try:
-                    input_data = json.loads(item.arguments) if item.arguments else {}
-                except (json.JSONDecodeError, TypeError):
-                    input_data = {}
-                content.append(
-                    AnthropicResponseContentBlockToolUse(
-                        type="tool_use",
-                        id=item.call_id or item.id or "",
-                        name=item.name,
-                        input=input_data,
-                    ).model_dump()
-                )
-                stop_reason = "tool_use"
-
-            elif isinstance(item, dict):
-                item_type = item.get("type")
-                if item_type == "web_search_call":
-                    block, input_dict = build_web_tool_use(item)
-                    web_tool_uses.append(block)
-                    content.append({**block, "input": input_dict})
-                elif item_type == "message" and web_tool_uses:
-                    for part in item.get("content", []):
-                        if isinstance(part, dict) and part.get("type") == "output_text":
-                            blocks, citations = (
-                                build_web_search_results_from_annotations(
-                                    web_tool_uses, part.get("annotations") or []
-                                )
-                            )
-                            content.extend(blocks)
-                            content.extend(
-                                build_text_blocks_with_citations(
-                                    part.get("text", ""), citations
-                                )
-                            )
-                            break
-                elif item_type == "message":
-                    for part in item.get("content", []):
-                        if isinstance(part, dict) and part.get("type") == "output_text":
-                            content.append(
-                                AnthropicResponseContentBlockText(
-                                    type="text", text=part.get("text", "")
-                                ).model_dump()
-                            )
-                elif item_type == "function_call":
-                    try:
-                        input_data = json.loads(item.get("arguments", "{}"))
-                    except (json.JSONDecodeError, TypeError):
-                        input_data = {}
-                    content.append(
-                        AnthropicResponseContentBlockToolUse(
-                            type="tool_use",
-                            id=item.get("call_id") or item.get("id", ""),
-                            name=item.get("name", ""),
-                            input=input_data,
-                        ).model_dump()
-                    )
-                    stop_reason = "tool_use"
+            override = self._translate_output_item(item, content, web_tool_uses)
+            if override is not None:
+                stop_reason = override
 
         # status -> stop_reason override
         if response.status == "incomplete":

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/utils.py
@@ -64,12 +64,18 @@ def build_web_search_results_from_annotations(
         start = ann.get("start_index", 0) or 0
         end = ann.get("end_index", 0) or 0
 
-        citations.append((start, end, {
-            "type": "web_search_result_location",
-            "url": url,
-            "title": title,
-            "cited_text": title,
-        }))
+        citations.append(
+            (
+                start,
+                end,
+                {
+                    "type": "web_search_result_location",
+                    "url": url,
+                    "title": title,
+                    "cited_text": title,
+                },
+            )
+        )
 
         if url and url not in seen_urls:
             seen_urls[url] = {
@@ -105,9 +111,7 @@ def build_text_blocks_with_citations(
     text[start:end] is the cited range; everything else is uncited.
     """
     if not citations:
-        return [
-            AnthropicResponseContentBlockText(type="text", text=text).model_dump()
-        ]
+        return [AnthropicResponseContentBlockText(type="text", text=text).model_dump()]
 
     blocks: List[Dict[str, Any]] = []
     pos = 0
@@ -129,9 +133,7 @@ def build_text_blocks_with_citations(
 
     if pos < len(text):
         blocks.append(
-            AnthropicResponseContentBlockText(
-                type="text", text=text[pos:]
-            ).model_dump()
+            AnthropicResponseContentBlockText(type="text", text=text[pos:]).model_dump()
         )
 
     return blocks

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/utils.py
@@ -26,7 +26,7 @@ def build_web_tool_use(item: Any) -> Tuple[Dict[str, Any], Dict[str, str]]:
         input_dict = {"url": action.get("url", "")}
     else:
         name = "web_search"
-        queries = action.get("queries", {})
+        queries = action.get("queries") or []
         if queries:
             query = "\n".join(queries)
         else:

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/utils.py
@@ -1,0 +1,137 @@
+"""
+Shared utilities for Anthropic <-> OpenAI Responses API web search translation.
+
+Used by both the streaming (streaming_iterator.py) and non-streaming
+(transformation.py) response paths.
+"""
+
+from typing import Any, Dict, List, Tuple
+
+from litellm.types.llms.anthropic import AnthropicResponseContentBlockText
+
+
+def build_web_tool_use(item: Any) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    """Build server_tool_use content block from a response web_search_call item.
+
+    Returns (server_tool_use_block, input_dict) where:
+    - server_tool_use_block: {"type": "server_tool_use", "id": ..., "name": "web_search"|"web_fetch"}
+    - input_dict: {"query": "..."} for search, {"url": "..."} for open_page/find_in_page
+    """
+    if not isinstance(item, dict):
+        item = item.model_dump()
+    action = item.get("action", {})
+    action_type = action.get("type", "search")
+    if action_type in ("open_page", "find_in_page"):
+        name = "web_fetch"
+        input_dict = {"url": action.get("url", "")}
+    else:
+        name = "web_search"
+        queries = action.get("queries", {})
+        if queries:
+            query = "\n".join(queries)
+        else:
+            query = action.get("query", "")
+        input_dict = {"query": query}
+    block = {
+        "type": "server_tool_use",
+        "name": name,
+        "id": item.get("id", ""),
+    }
+    return block, input_dict
+
+
+def build_web_search_results_from_annotations(
+    web_tool_uses: List[Dict[str, Any]],
+    annotations: list,
+) -> Tuple[List[Dict[str, Any]], List[tuple]]:
+    """Build web search content blocks and citations from search calls and annotations.
+
+    Returns (content_blocks, citations) where:
+    - content_blocks: web_search_tool_result blocks
+    - citations: list of (start_index, end_index, citation_dict) tuples sorted by position
+    """
+    citations: List[tuple] = []
+    seen_urls: Dict[str, Dict[str, Any]] = {}
+
+    for ann in annotations:
+        if not isinstance(ann, dict):
+            ann = ann.model_dump()
+        if ann.get("type") != "url_citation":
+            continue
+
+        url = ann.get("url", "")
+        title = ann.get("title", "")
+        start = ann.get("start_index", 0) or 0
+        end = ann.get("end_index", 0) or 0
+
+        citations.append((start, end, {
+            "type": "web_search_result_location",
+            "url": url,
+            "title": title,
+            "cited_text": title,
+        }))
+
+        if url and url not in seen_urls:
+            seen_urls[url] = {
+                "type": "web_search_result",
+                "url": url,
+                "title": title,
+            }
+
+    citations.sort(key=lambda x: x[0])
+    search_results = list(seen_urls.values())
+    search_calls = [c for c in web_tool_uses if c["name"] == "web_search"]
+
+    content_blocks: List[Dict[str, Any]] = []
+    if search_calls:
+        content_blocks.append(
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": search_calls[0]["id"],
+                "content": search_results,
+            }
+        )
+
+    return content_blocks, citations
+
+
+def build_text_blocks_with_citations(
+    text: str,
+    citations: List[tuple],
+) -> List[Dict[str, Any]]:
+    """Split text into alternating uncited / cited Anthropic text blocks.
+
+    Each citation tuple is (start_index, end_index, citation_dict).
+    text[start:end] is the cited range; everything else is uncited.
+    """
+    if not citations:
+        return [
+            AnthropicResponseContentBlockText(type="text", text=text).model_dump()
+        ]
+
+    blocks: List[Dict[str, Any]] = []
+    pos = 0
+
+    for start, end, citation in citations:
+        if pos < start:
+            blocks.append(
+                AnthropicResponseContentBlockText(
+                    type="text", text=text[pos:start]
+                ).model_dump()
+            )
+        if start < end:
+            block = AnthropicResponseContentBlockText(
+                type="text", text=text[start:end]
+            ).model_dump()
+            block["citations"] = [citation]
+            blocks.append(block)
+        pos = end
+
+    if pos < len(text):
+        blocks.append(
+            AnthropicResponseContentBlockText(
+                type="text", text=text[pos:]
+            ).model_dump()
+        )
+
+    return blocks

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_web_search_translation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_web_search_translation.py
@@ -1,0 +1,338 @@
+"""
+Tests for web search response translation utilities and integration.
+
+Tests for responses_adapters/utils.py functions:
+- build_web_tool_use
+- build_web_search_results_from_annotations
+- build_text_blocks_with_citations
+
+Tests for non-streaming response translation (transformation.py):
+- translate_response with web_search_call items
+
+Tests for streaming response translation (streaming_iterator.py):
+- web_search_call deferred emission
+- text delta suppression during web search
+- cited text block emission on output_item.done
+"""
+
+import json
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../../../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.utils import (
+    build_text_blocks_with_citations,
+    build_web_search_results_from_annotations,
+    build_web_tool_use,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_web_tool_use
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWebToolUse:
+    def test_search_action(self):
+        item = {
+            "id": "ws_123",
+            "type": "web_search_call",
+            "action": {"type": "search", "query": "React 19 features"},
+        }
+        block, input_dict = build_web_tool_use(item)
+        assert block["type"] == "server_tool_use"
+        assert block["name"] == "web_search"
+        assert block["id"] == "ws_123"
+        assert input_dict == {"query": "React 19 features"}
+
+    def test_search_action_with_queries_list(self):
+        item = {
+            "id": "ws_456",
+            "type": "web_search_call",
+            "action": {"type": "search", "queries": ["React 19", "Vue 4"]},
+        }
+        block, input_dict = build_web_tool_use(item)
+        assert block["name"] == "web_search"
+        assert input_dict == {"query": "React 19\nVue 4"}
+
+    def test_open_page_action(self):
+        item = {
+            "id": "ws_789",
+            "type": "web_search_call",
+            "action": {"type": "open_page", "url": "https://react.dev"},
+        }
+        block, input_dict = build_web_tool_use(item)
+        assert block["name"] == "web_fetch"
+        assert input_dict == {"url": "https://react.dev"}
+
+    def test_find_in_page_action(self):
+        item = {
+            "id": "ws_abc",
+            "type": "web_search_call",
+            "action": {"type": "find_in_page", "url": "https://react.dev/blog"},
+        }
+        block, input_dict = build_web_tool_use(item)
+        assert block["name"] == "web_fetch"
+        assert input_dict == {"url": "https://react.dev/blog"}
+
+    def test_model_dump_object(self):
+        """Non-dict item with model_dump() is handled."""
+        item = MagicMock()
+        item.model_dump.return_value = {
+            "id": "ws_obj",
+            "action": {"type": "search", "query": "test"},
+        }
+        block, input_dict = build_web_tool_use(item)
+        assert block["id"] == "ws_obj"
+        assert block["name"] == "web_search"
+
+
+# ---------------------------------------------------------------------------
+# build_web_search_results_from_annotations
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWebSearchResultsFromAnnotations:
+    def test_basic_annotations(self):
+        web_tool_uses = [
+            {"type": "server_tool_use", "name": "web_search", "id": "ws_1"}
+        ]
+        annotations = [
+            {
+                "type": "url_citation",
+                "url": "https://react.dev/blog",
+                "title": "React Blog",
+                "start_index": 0,
+                "end_index": 10,
+            },
+            {
+                "type": "url_citation",
+                "url": "https://vue.org",
+                "title": "Vue.js",
+                "start_index": 20,
+                "end_index": 30,
+            },
+        ]
+        blocks, citations = build_web_search_results_from_annotations(
+            web_tool_uses, annotations
+        )
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "web_search_tool_result"
+        assert blocks[0]["tool_use_id"] == "ws_1"
+        assert len(blocks[0]["content"]) == 2
+        assert len(citations) == 2
+        assert citations[0][0] < citations[1][0]  # sorted by start_index
+
+    def test_deduplicates_urls(self):
+        web_tool_uses = [
+            {"type": "server_tool_use", "name": "web_search", "id": "ws_1"}
+        ]
+        annotations = [
+            {
+                "type": "url_citation",
+                "url": "https://react.dev",
+                "title": "React",
+                "start_index": 0,
+                "end_index": 5,
+            },
+            {
+                "type": "url_citation",
+                "url": "https://react.dev",
+                "title": "React",
+                "start_index": 10,
+                "end_index": 15,
+            },
+        ]
+        blocks, citations = build_web_search_results_from_annotations(
+            web_tool_uses, annotations
+        )
+        assert len(blocks[0]["content"]) == 1  # deduplicated
+        assert len(citations) == 2  # both citations kept
+
+    def test_empty_annotations(self):
+        web_tool_uses = [
+            {"type": "server_tool_use", "name": "web_search", "id": "ws_1"}
+        ]
+        blocks, citations = build_web_search_results_from_annotations(
+            web_tool_uses, []
+        )
+        assert len(blocks) == 1
+        assert blocks[0]["content"] == []
+        assert citations == []
+
+    def test_no_web_search_calls(self):
+        """Only web_fetch calls — no web_search_tool_result emitted."""
+        web_tool_uses = [
+            {"type": "server_tool_use", "name": "web_fetch", "id": "wf_1"}
+        ]
+        annotations = [
+            {
+                "type": "url_citation",
+                "url": "https://example.com",
+                "title": "Example",
+                "start_index": 0,
+                "end_index": 5,
+            },
+        ]
+        blocks, citations = build_web_search_results_from_annotations(
+            web_tool_uses, annotations
+        )
+        assert len(blocks) == 0
+        assert len(citations) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_text_blocks_with_citations
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTextBlocksWithCitations:
+    def test_no_citations(self):
+        blocks = build_text_blocks_with_citations("Hello world", [])
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert blocks[0]["text"] == "Hello world"
+        assert "citations" not in blocks[0]
+
+    def test_single_citation_middle(self):
+        text = "Before cited text after"
+        citations = [
+            (7, 18, {"type": "web_search_result_location", "url": "https://example.com"}),
+        ]
+        blocks = build_text_blocks_with_citations(text, citations)
+        assert len(blocks) == 3
+        assert blocks[0]["text"] == "Before "
+        assert "citations" not in blocks[0]
+        assert blocks[1]["text"] == "cited text "
+        assert len(blocks[1]["citations"]) == 1
+        assert blocks[2]["text"] == "after"
+
+    def test_citation_at_start(self):
+        text = "cited rest"
+        citations = [
+            (0, 5, {"type": "web_search_result_location", "url": "https://example.com"}),
+        ]
+        blocks = build_text_blocks_with_citations(text, citations)
+        assert len(blocks) == 2
+        assert blocks[0]["text"] == "cited"
+        assert "citations" in blocks[0]
+        assert blocks[1]["text"] == " rest"
+
+    def test_multiple_citations(self):
+        text = "aaa bbb ccc ddd"
+        citations = [
+            (0, 3, {"type": "web_search_result_location", "url": "https://a.com"}),
+            (8, 11, {"type": "web_search_result_location", "url": "https://c.com"}),
+        ]
+        blocks = build_text_blocks_with_citations(text, citations)
+        assert len(blocks) == 4  # cited, uncited, cited, uncited
+        assert blocks[0]["text"] == "aaa"
+        assert "citations" in blocks[0]
+        assert blocks[1]["text"] == " bbb "
+        assert "citations" not in blocks[1]
+        assert blocks[2]["text"] == "ccc"
+        assert "citations" in blocks[2]
+        assert blocks[3]["text"] == " ddd"
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming: translate_response with web search
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateResponseWebSearch:
+    """Test the non-streaming translate_response path with web_search_call items."""
+
+    def test_web_search_response_has_server_tool_use(self):
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
+            LiteLLMAnthropicToResponsesAPIAdapter,
+        )
+
+        adapter = LiteLLMAnthropicToResponsesAPIAdapter()
+
+        # Simulate a Responses API response with web_search_call + message
+        response = MagicMock()
+        response.id = "resp_123"
+        response.model = "gpt-5.4"
+        response.status = "completed"
+        response.usage = MagicMock()
+        response.usage.input_tokens = 100
+        response.usage.output_tokens = 50
+
+        search_item = {
+            "type": "web_search_call",
+            "id": "ws_1",
+            "action": {"type": "search", "query": "React 19"},
+        }
+        message_item = {
+            "type": "message",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "React 19 is great.",
+                    "annotations": [
+                        {
+                            "type": "url_citation",
+                            "url": "https://react.dev",
+                            "title": "React",
+                            "start_index": 0,
+                            "end_index": 8,
+                        },
+                    ],
+                }
+            ],
+        }
+        response.output = [search_item, message_item]
+
+        result = adapter.translate_response(response)
+
+        content_types = [b["type"] for b in result["content"]]
+        assert "server_tool_use" in content_types
+        assert "web_search_tool_result" in content_types
+        assert "text" in content_types
+
+        # server_tool_use should come first
+        server_tool = [b for b in result["content"] if b["type"] == "server_tool_use"][0]
+        assert server_tool["name"] == "web_search"
+        assert server_tool["input"] == {"query": "React 19"}
+
+        # usage should include server_tool_use counts
+        assert result["usage"]["server_tool_use"]["web_search_requests"] == 1
+
+    def test_no_web_search_response_unchanged(self):
+        """Response without web_search_call should not add server_tool_use."""
+        from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
+            LiteLLMAnthropicToResponsesAPIAdapter,
+        )
+        from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+        adapter = LiteLLMAnthropicToResponsesAPIAdapter()
+
+        response = MagicMock()
+        response.id = "resp_456"
+        response.model = "gpt-5.4"
+        response.status = "completed"
+        response.usage = MagicMock()
+        response.usage.input_tokens = 100
+        response.usage.output_tokens = 50
+
+        msg = ResponseOutputMessage(
+            id="msg_1",
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[
+                ResponseOutputText(type="output_text", text="Hello world", annotations=[])
+            ],
+        )
+        response.output = [msg]
+
+        result = adapter.translate_response(response)
+
+        content_types = [b["type"] for b in result["content"]]
+        assert "server_tool_use" not in content_types
+        assert "web_search_tool_result" not in content_types
+        assert "server_tool_use" not in result.get("usage", {})


### PR DESCRIPTION
## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

✨ New Feature

## Changes

When `/v1/messages` routes to a model via the Responses API adapter (e.g. `gpt-5.4` with `mode: responses`), web search results from the Responses API were not translated back to Anthropic format. Clients like Claude Code expect `server_tool_use` + `web_search_tool_result` + cited text blocks with `citations`, but received raw `output_text` with no search metadata.

This PR adds full web search response translation for both streaming and non-streaming paths:

### Response mapping

| Responses API | Anthropic `/v1/messages` |
|---|---|
| `web_search_call` (with action queries) | `server_tool_use` (name=`web_search`, input=`{query}`) |
| `output_text.annotations` (url_citation) | `web_search_tool_result` entries (unique URLs) |
| Text ranges matching annotations | Separate `text` blocks with `citations` array |
| Uncited text between annotations | Plain `text` blocks (no citations) |

### Streaming behavior

- `response.output_item.added` with `web_search_call`: defers text block opening (no `content_block_start` for text yet)
- `response.output_text.delta`: suppressed when web search is active (text accumulated server-side)
- `response.output_item.done` with `web_search_call`: emits `server_tool_use` content block
- `response.output_item.done` with `message`: emits `web_search_tool_result` + cited text blocks from accumulated annotations
- Handles `search`, `open_page`, and `find_in_page` action types

### Usage

Adds `server_tool_use` counts to the usage object:
```json
"usage": {
  "server_tool_use": {
    "web_search_requests": 3,
    "web_fetch_requests": 1
  }
}
```

### New file

`responses_adapters/utils.py` — shared utilities for web search translation:
- `build_web_tool_use()`: creates `server_tool_use` content block
- `build_web_search_results_from_annotations()`: deduplicates URLs from annotations into `web_search_tool_result` entries, returns citation mapping
- `build_text_blocks_with_citations()`: splits text by annotation ranges into alternating cited/uncited text blocks

### Design decisions

**`cited_text` uses page title as fallback:** Anthropic's `web_search_result_location.cited_text` is the verbatim text from the **source web page**. OpenAI's `url_citation` annotations only provide `url`, `title`, `start_index`, and `end_index` — the web page source text is not available. `title` is used as the best available approximation.

**Single aggregated `web_search_tool_result`:** When a response contains multiple `web_search_call` items, all URL citations are collected into a single `web_search_tool_result` block. OpenAI's `url_citation` annotations are aggregated across all searches with no indication of which search call produced each citation — splitting them per call is not possible with the available data. Emitting empty `web_search_tool_result` blocks for the remaining calls would also degrade the client experience: Claude Code renders each empty result as a separate "No links found" notice, cluttering the output. A single result block with all discovered URLs provides the complete search context.

**No `input: {}` on streaming `server_tool_use`:** Unlike `tool_use` (user-defined tools), `server_tool_use` in Anthropic's native streaming format does not include `input` in `content_block_start`. The input is delivered via `input_json_delta` in the subsequent `content_block_delta`. This matches Anthropic's native API behavior.

**First `output_text` only:** The `break` after processing the first `output_text` part is intentional. The Responses API currently returns a single `output_text` per message. If multi-part messages are introduced in the future, this can be extended.

**Files changed (3 + 1 test):**

| File | Change |
|------|--------|
| `.../responses_adapters/utils.py` | **New** — shared web search translation utilities |
| `.../responses_adapters/transformation.py` | Non-streaming: translate `web_search_call` + annotations to Anthropic format |
| `.../responses_adapters/streaming_iterator.py` | Streaming: defer text, emit `server_tool_use` + cited text on item done |
| `tests/.../test_web_search_translation.py` | **New** — 15 unit tests |

## Test plan

15 tests in `test_web_search_translation.py`:

**TestBuildWebToolUse (5 tests):**
- `search` action → `web_search` name with query
- `search` with queries list → joined query string
- `open_page` action → `web_fetch` name with url
- `find_in_page` action → `web_fetch` name with url
- Non-dict item with `model_dump()` handled

**TestBuildWebSearchResultsFromAnnotations (4 tests):**
- Basic annotations → `web_search_tool_result` with deduplicated URLs + sorted citations
- Duplicate URLs deduplicated in results, all citations preserved
- Empty annotations → empty content
- Only `web_fetch` calls → no `web_search_tool_result` emitted

**TestBuildTextBlocksWithCitations (3 tests):**
- No citations → single text block
- Citation in middle → 3 blocks (uncited + cited + uncited)
- Multiple citations → alternating cited/uncited blocks

**TestTranslateResponseWebSearch (2 tests):**
- Response with `web_search_call` → `server_tool_use` + `web_search_tool_result` + cited text + usage counts
- Response without `web_search_call` → no `server_tool_use` added

**Integration (manual):**
- [ ] Non-streaming: `curl /v1/messages` with `web_search` tool → verify full Anthropic web search format
- [ ] Streaming: same with `"stream": true` → verify SSE events