### PR TITLE
fix(ollama): prefer explicit api_base

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3969,8 +3969,8 @@ def completion(  # type: ignore # noqa: PLR0915
             response = model_response
         elif custom_llm_provider == "ollama":
             api_base = (
-                litellm.api_base
-                or api_base
+                api_base
+                or litellm.api_base
                 or get_secret("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )
@@ -3998,8 +3998,8 @@ def completion(  # type: ignore # noqa: PLR0915
 
         elif custom_llm_provider == "ollama_chat":
             api_base = (
-                litellm.api_base
-                or api_base
+                api_base
+                or litellm.api_base
                 or get_secret("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )
@@ -5317,8 +5317,8 @@ def embedding(  # noqa: PLR0915
             )
         elif custom_llm_provider == "ollama":
             api_base = (
-                litellm.api_base
-                or api_base
+                api_base
+                or litellm.api_base
                 or get_secret_str("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )  # type: ignore

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -1323,6 +1323,37 @@ def test_lm_studio_completion(monkeypatch):
         print(e)
 
 
+@pytest.mark.parametrize("model", ["ollama/phi", "ollama_chat/phi"])
+def test_ollama_completion_explicit_api_base_takes_precedence(monkeypatch, model):
+    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
+
+    with patch("litellm.main.base_llm_http_handler.completion") as mock_completion:
+        mock_completion.return_value = MagicMock()
+
+        litellm.completion(
+            model=model,
+            messages=[{"role": "user", "content": "Hello"}],
+            api_base="http://localhost:11434",
+        )
+
+        assert mock_completion.call_args.kwargs["api_base"] == "http://localhost:11434"
+
+
+def test_ollama_embedding_explicit_api_base_takes_precedence(monkeypatch):
+    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
+
+    with patch("litellm.main.ollama.ollama_embeddings") as mock_embeddings:
+        mock_embeddings.return_value = MagicMock()
+
+        litellm.embedding(
+            model="ollama/qwen3-embedding:0.6b",
+            input="hello",
+            api_base="http://localhost:11434",
+        )
+
+        assert mock_embeddings.call_args.kwargs["api_base"] == "http://localhost:11434"
+
+
 # ################### Hugging Face Conversational models ########################
 # def hf_test_completion_conv():
 #     try:

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -1354,6 +1354,22 @@ def test_ollama_embedding_explicit_api_base_takes_precedence(monkeypatch):
         assert mock_embeddings.call_args.kwargs["api_base"] == "http://localhost:11434"
 
 
+@pytest.mark.asyncio
+async def test_ollama_aembedding_explicit_api_base_takes_precedence(monkeypatch):
+    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
+
+    with patch("litellm.main.ollama.ollama_aembeddings") as mock_aembeddings:
+        mock_aembeddings.return_value = MagicMock()
+
+        await litellm.aembedding(
+            model="ollama/qwen3-embedding:0.6b",
+            input="hello",
+            api_base="http://localhost:11434",
+        )
+
+        assert mock_aembeddings.call_args.kwargs["api_base"] == "http://localhost:11434"
+
+
 # ################### Hugging Face Conversational models ########################
 # def hf_test_completion_conv():
 #     try:

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -1323,52 +1323,6 @@ def test_lm_studio_completion(monkeypatch):
         print(e)
 
 
-@pytest.mark.parametrize("model", ["ollama/phi", "ollama_chat/phi"])
-def test_ollama_completion_explicit_api_base_takes_precedence(monkeypatch, model):
-    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
-
-    with patch("litellm.main.base_llm_http_handler.completion") as mock_completion:
-        mock_completion.return_value = MagicMock()
-
-        litellm.completion(
-            model=model,
-            messages=[{"role": "user", "content": "Hello"}],
-            api_base="http://localhost:11434",
-        )
-
-        assert mock_completion.call_args.kwargs["api_base"] == "http://localhost:11434"
-
-
-def test_ollama_embedding_explicit_api_base_takes_precedence(monkeypatch):
-    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
-
-    with patch("litellm.main.ollama.ollama_embeddings") as mock_embeddings:
-        mock_embeddings.return_value = MagicMock()
-
-        litellm.embedding(
-            model="ollama/qwen3-embedding:0.6b",
-            input="hello",
-            api_base="http://localhost:11434",
-        )
-
-        assert mock_embeddings.call_args.kwargs["api_base"] == "http://localhost:11434"
-
-
-@pytest.mark.asyncio
-async def test_ollama_aembedding_explicit_api_base_takes_precedence(monkeypatch):
-    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
-
-    with patch("litellm.main.ollama.ollama_aembeddings") as mock_aembeddings:
-        mock_aembeddings.return_value = MagicMock()
-
-        await litellm.aembedding(
-            model="ollama/qwen3-embedding:0.6b",
-            input="hello",
-            api_base="http://localhost:11434",
-        )
-
-        assert mock_aembeddings.call_args.kwargs["api_base"] == "http://localhost:11434"
-
 
 # ################### Hugging Face Conversational models ########################
 # def hf_test_completion_conv():

--- a/tests/test_litellm/llms/ollama/test_ollama_api_base_precedence.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_api_base_precedence.py
@@ -1,0 +1,62 @@
+"""Regression tests for ollama `api_base` precedence.
+
+Explicit `api_base` kwargs must override `litellm.api_base` global, across:
+  - ollama / ollama_chat completion
+  - ollama embedding (sync)
+  - ollama aembedding (async)
+
+Fixes the precedence bug in `litellm.main` where `litellm.api_base or api_base`
+swallowed explicit kwargs whenever the global was set.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+
+
+@pytest.mark.parametrize("model", ["ollama/phi", "ollama_chat/phi"])
+def test_ollama_completion_explicit_api_base_takes_precedence(monkeypatch, model):
+    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
+
+    with patch("litellm.main.base_llm_http_handler.completion") as mock_completion:
+        mock_completion.return_value = MagicMock()
+
+        litellm.completion(
+            model=model,
+            messages=[{"role": "user", "content": "Hello"}],
+            api_base="http://localhost:11434",
+        )
+
+        assert mock_completion.call_args.kwargs["api_base"] == "http://localhost:11434"
+
+
+def test_ollama_embedding_explicit_api_base_takes_precedence(monkeypatch):
+    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
+
+    with patch("litellm.main.ollama.ollama_embeddings") as mock_embeddings:
+        mock_embeddings.return_value = MagicMock()
+
+        litellm.embedding(
+            model="ollama/qwen3-embedding:0.6b",
+            input="hello",
+            api_base="http://localhost:11434",
+        )
+
+        assert mock_embeddings.call_args.kwargs["api_base"] == "http://localhost:11434"
+
+
+@pytest.mark.asyncio
+async def test_ollama_aembedding_explicit_api_base_takes_precedence(monkeypatch):
+    monkeypatch.setattr(litellm, "api_base", "https://api.deepseek.com")
+
+    with patch("litellm.main.ollama.ollama_aembeddings") as mock_aembeddings:
+        mock_aembeddings.return_value = MagicMock()
+
+        await litellm.aembedding(
+            model="ollama/qwen3-embedding:0.6b",
+            input="hello",
+            api_base="http://localhost:11434",
+        )
+
+        assert mock_aembeddings.call_args.kwargs["api_base"] == "http://localhost:11434"


### PR DESCRIPTION
Summary
- make the explicit api_base kwarg win over the global litellm.api_base for ollama completion
- apply the same precedence fix to ollama_chat completion and ollama embeddings
- add regression tests for completion and embedding paths

Closes #26170.

Testing
- attempted: python3 -m pytest tests/local_testing/test_completion.py -q -k "ollama_completion_explicit_api_base_takes_precedence or ollama_embedding_explicit_api_base_takes_precedence"
- blocked locally because litellm imports tiktoken during test setup and tiktoken is not installed in the current environment
