### PR TITLE
fix: coerce server_tool_use dict to ServerToolUse in stream_chunk_builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -587,7 +587,10 @@ class ChunkProcessor:
                     hasattr(usage_chunk, "server_tool_use")
                     and usage_chunk.server_tool_use is not None
                 ):
-                    server_tool_use = usage_chunk.server_tool_use
+                    stu = usage_chunk.server_tool_use
+                    server_tool_use = (
+                        ServerToolUse(**stu) if isinstance(stu, dict) else stu
+                    )
                 if (
                     usage_chunk_dict["prompt_tokens_details"] is not None
                     and getattr(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1652,6 +1652,8 @@ class Usage(SafeAttributeModel, CompletionUsage):
         )
 
         if server_tool_use is not None:
+            if isinstance(server_tool_use, dict):
+                server_tool_use = ServerToolUse(**server_tool_use)
             self.server_tool_use = server_tool_use
         else:  # maintain openai compatibility in usage object if possible
             del self.server_tool_use

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -603,3 +603,53 @@ def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
     response = stream_chunk_builder(chunks=[chunk_dict])
     assert response is not None
     assert response._hidden_params["provider_specific_fields"]["traffic_type"] == "default"
+
+
+def test_stream_chunk_builder_coerces_server_tool_use_dict_to_object():
+    """Regression test for https://github.com/BerriAI/litellm/issues/26153.
+
+    stream_chunk_builder must coerce usage.server_tool_use from dict to
+    ServerToolUse so that completion_cost() can access .web_search_requests
+    without AttributeError.
+    """
+    from litellm.litellm_core_utils.streaming_chunk_builder_utils import (
+        ChunkProcessor,
+    )
+    from litellm.types.utils import ServerToolUse, Usage
+
+    # Simulate a usage chunk where server_tool_use arrives as a plain dict
+    # (as happens during Anthropic streaming JSON deserialization).
+    usage_with_dict = Usage(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+    )
+    object.__setattr__(
+        usage_with_dict,
+        "server_tool_use",
+        {"web_search_requests": 2, "tool_search_requests": None},
+    )
+
+    chunks = [
+        {
+            "id": "msg_01",
+            "created": 1,
+            "model": "claude-sonnet-4-6",
+            "object": "chat.completion.chunk",
+            "choices": [{
+                "finish_reason": "stop",
+                "index": 0,
+                "delta": {"content": "The otter", "role": "assistant"},
+            }],
+            "usage": usage_with_dict,
+        }
+    ]
+
+    processor = ChunkProcessor(chunks)
+    result = processor.get_combined_usage(chunks)
+
+    assert result is not None
+    assert isinstance(result.server_tool_use, ServerToolUse), (
+        f"Expected ServerToolUse, got {type(result.server_tool_use)}"
+    )
+    assert result.server_tool_use.web_search_requests == 2

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -512,7 +512,7 @@ def test_stream_chunk_builder_anthropic_web_search():
     assert usage.prompt_tokens == 50
     assert usage.completion_tokens == 27
     assert usage.total_tokens == 77    
-    assert usage.server_tool_use['web_search_requests'] == 2
+    assert usage.server_tool_use.web_search_requests == 2
 
 
 def test_sort_chunks_handles_dict_hidden_params_created_at():
@@ -646,7 +646,11 @@ def test_stream_chunk_builder_coerces_server_tool_use_dict_to_object():
     ]
 
     processor = ChunkProcessor(chunks)
-    result = processor.get_combined_usage(chunks)
+    result = processor.calculate_usage(
+        chunks=chunks,
+        model="claude-sonnet-4-6",
+        completion_output="The otter",
+    )
 
     assert result is not None
     assert isinstance(result.server_tool_use, ServerToolUse), (


### PR DESCRIPTION
## What

Fixes `AttributeError: 'dict' object has no attribute 'web_search_requests'` raised by `completion_cost()` on streaming Anthropic responses that used `web_search_options`.

Closes #26153.

## Root cause

`stream_chunk_builder` accumulates `server_tool_use` from streaming chunks at:

```python
server_tool_use = usage_chunk.server_tool_use
```

When the Anthropic streaming JSON is deserialized, `usage_chunk.server_tool_use` may be a plain `dict` rather than a `ServerToolUse` pydantic object (pydantic does not auto-coerce nested model fields on a `SafeAttributeModel`). The reconstructed `Usage` object then carries a `dict` for `server_tool_use`.

In v1.83.10, `StandardBuiltInToolCostTracking.response_object_includes_web_search_call` added a direct attribute access:

```python
and usage.server_tool_use.web_search_requests is not None
```

This crashes when `server_tool_use` is a `dict`.

## Fix

Coerce the value to `ServerToolUse` at the point of accumulation in `streaming_chunk_builder_utils.py`:

```python
stu = usage_chunk.server_tool_use
server_tool_use = ServerToolUse(**stu) if isinstance(stu, dict) else stu
```

`ServerToolUse` is already imported in the file. The fix is one-liner and addresses the root cause rather than patching the two call sites that access `.web_search_requests`.

## Test

Added `test_stream_chunk_builder_coerces_server_tool_use_dict_to_object` in `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py`. The test injects a `dict`-typed `server_tool_use` into a usage chunk and asserts that the rebuilt `Usage` has a proper `ServerToolUse` instance with the correct `web_search_requests` value.