### PR TITLE
fix(otel): preserve Splunk Observability Cloud trace OTLP endpoint

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2282,9 +2282,7 @@ class OpenTelemetry(CustomLogger):
         endpoint = endpoint.rstrip("/")
 
         # Splunk Observability Cloud OTLP/HTTP uses /v2/trace/otlp (not /v1/traces). Do not rewrite.
-        if signal_type == "traces" and (
-            "/v2/trace/otlp" in endpoint or endpoint.endswith("/trace/otlp")
-        ):
+        if signal_type == "traces" and "/v2/trace/otlp" in endpoint:
             return endpoint
 
         # Check if endpoint already ends with the correct signal path

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2281,6 +2281,12 @@ class OpenTelemetry(CustomLogger):
         # Remove trailing slash
         endpoint = endpoint.rstrip("/")
 
+        # Splunk Observability Cloud OTLP/HTTP uses /v2/trace/otlp (not /v1/traces). Do not rewrite.
+        if signal_type == "traces" and (
+            "/v2/trace/otlp" in endpoint or endpoint.endswith("/trace/otlp")
+        ):
+            return endpoint
+
         # Check if endpoint already ends with the correct signal path
         target_path = f"/v1/{signal_type}"
         if endpoint.endswith(target_path):

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1390,6 +1390,60 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         self.assertIsInstance(processor, BatchSpanProcessor)
         self.assertIsInstance(processor.span_exporter, OTLPSpanExporterGRPC)
 
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_EXPORTER": "otlp_http",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4318",
+        },
+        clear=False,
+    )
+    def test_protocol_selection_from_otel_exporter_fallback_http(self):
+        """OTEL_EXPORTER drives protocol when OTEL_EXPORTER_OTLP_PROTOCOL is unset."""
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter as OTLPSpanExporterHTTP,
+        )
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        popped_protocol = os.environ.pop("OTEL_EXPORTER_OTLP_PROTOCOL", None)
+        try:
+            config = OpenTelemetryConfig.from_env()
+            self.assertEqual(config.exporter, "otlp_http")
+            otel = OpenTelemetry(config=config)
+            processor = otel._get_span_processor()
+            self.assertIsInstance(processor, BatchSpanProcessor)
+            self.assertIsInstance(processor.span_exporter, OTLPSpanExporterHTTP)
+        finally:
+            if popped_protocol is not None:
+                os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = popped_protocol
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_EXPORTER": "otlp_grpc",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4317",
+        },
+        clear=False,
+    )
+    def test_protocol_selection_from_otel_exporter_fallback_grpc(self):
+        """OTEL_EXPORTER drives protocol when OTEL_EXPORTER_OTLP_PROTOCOL is unset."""
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter as OTLPSpanExporterGRPC,
+        )
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        popped_protocol = os.environ.pop("OTEL_EXPORTER_OTLP_PROTOCOL", None)
+        try:
+            config = OpenTelemetryConfig.from_env()
+            self.assertEqual(config.exporter, "otlp_grpc")
+            otel = OpenTelemetry(config=config)
+            processor = otel._get_span_processor()
+            self.assertIsInstance(processor, BatchSpanProcessor)
+            self.assertIsInstance(processor.span_exporter, OTLPSpanExporterGRPC)
+        finally:
+            if popped_protocol is not None:
+                os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = popped_protocol
+
     def test_http_exporter_endpoint_normalization_for_traces(self):
         """Test that HTTP trace exporter gets properly normalized endpoint"""
         config = OpenTelemetryConfig(

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1047,6 +1047,34 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
         result = otel._normalize_otel_endpoint("http://collector:4318/", "traces")
         self.assertEqual(result, "http://collector:4318/v1/traces")
 
+    def test_normalize_traces_splunk_observability_cloud_otlp_url_unchanged(self):
+        """Splunk Observability Cloud trace OTLP ingest must not get /v1/traces appended."""
+        otel = OpenTelemetry()
+        url = "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
+        self.assertEqual(otel._normalize_otel_endpoint(url, "traces"), url)
+
+    def test_normalize_traces_splunk_observability_cloud_otlp_url_with_trailing_slash(
+        self,
+    ):
+        otel = OpenTelemetry()
+        self.assertEqual(
+            otel._normalize_otel_endpoint(
+                "https://ingest.us0.observability.splunkcloud.com/v2/trace/otlp/",
+                "traces",
+            ),
+            "https://ingest.us0.observability.splunkcloud.com/v2/trace/otlp",
+        )
+
+    def test_normalize_traces_legacy_signalfx_ingest_otlp_url_unchanged(self):
+        otel = OpenTelemetry()
+        url = "https://ingest.eu0.signalfx.com/v2/trace/otlp"
+        self.assertEqual(otel._normalize_otel_endpoint(url, "traces"), url)
+
+    def test_normalize_traces_custom_host_trace_otlp_suffix_unchanged(self):
+        otel = OpenTelemetry()
+        url = "https://example.com/prefix/v2/trace/otlp"
+        self.assertEqual(otel._normalize_otel_endpoint(url, "traces"), url)
+
     def test_normalize_endpoint_none(self):
         """Test that None endpoint returns None"""
         otel = OpenTelemetry()
@@ -1315,7 +1343,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "OTEL_EXPORTER": "otlp_http",
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
             "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4318",
         },
         clear=False,
@@ -1339,7 +1367,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "OTEL_EXPORTER": "otlp_grpc",
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
             "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4317",
         },
         clear=False,

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1047,33 +1047,35 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
         result = otel._normalize_otel_endpoint("http://collector:4318/", "traces")
         self.assertEqual(result, "http://collector:4318/v1/traces")
 
-    def test_normalize_traces_splunk_observability_cloud_otlp_url_unchanged(self):
-        """Splunk Observability Cloud trace OTLP ingest must not get /v1/traces appended."""
-        otel = OpenTelemetry()
-        url = "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp"
-        self.assertEqual(otel._normalize_otel_endpoint(url, "traces"), url)
-
-    def test_normalize_traces_splunk_observability_cloud_otlp_url_with_trailing_slash(
-        self,
-    ):
+    @parameterized.expand(
+        [
+            (
+                "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp",
+                "https://ingest.eu1.observability.splunkcloud.com/v2/trace/otlp",
+            ),
+            (
+                "https://ingest.us0.observability.splunkcloud.com/v2/trace/otlp/",
+                "https://ingest.us0.observability.splunkcloud.com/v2/trace/otlp",
+            ),
+            (
+                "https://ingest.eu0.signalfx.com/v2/trace/otlp",
+                "https://ingest.eu0.signalfx.com/v2/trace/otlp",
+            ),
+            (
+                "https://example.com/prefix/v2/trace/otlp",
+                "https://example.com/prefix/v2/trace/otlp",
+            ),
+        ]
+    )
+    def test_normalize_traces_nonstandard_otlp_ingest_urls_unchanged(
+        self, input_url: str, expected: str
+    ) -> None:
+        """Splunk-style /v2/trace/otlp endpoints must not get /v1/traces appended."""
         otel = OpenTelemetry()
         self.assertEqual(
-            otel._normalize_otel_endpoint(
-                "https://ingest.us0.observability.splunkcloud.com/v2/trace/otlp/",
-                "traces",
-            ),
-            "https://ingest.us0.observability.splunkcloud.com/v2/trace/otlp",
+            otel._normalize_otel_endpoint(input_url, "traces"),
+            expected,
         )
-
-    def test_normalize_traces_legacy_signalfx_ingest_otlp_url_unchanged(self):
-        otel = OpenTelemetry()
-        url = "https://ingest.eu0.signalfx.com/v2/trace/otlp"
-        self.assertEqual(otel._normalize_otel_endpoint(url, "traces"), url)
-
-    def test_normalize_traces_custom_host_trace_otlp_suffix_unchanged(self):
-        otel = OpenTelemetry()
-        url = "https://example.com/prefix/v2/trace/otlp"
-        self.assertEqual(otel._normalize_otel_endpoint(url, "traces"), url)
 
     def test_normalize_endpoint_none(self):
         """Test that None endpoint returns None"""


### PR DESCRIPTION
Splunk ingest uses /v2/trace/otlp; _normalize_otel_endpoint must not append /v1/traces.

- Return trace endpoints unchanged when they match Splunk OTLP path patterns
- Add unit tests for observability.splunkcloud.com, signalfx.com, and /trace/otlp suffix
- Set OTEL_EXPORTER_OTLP_PROTOCOL in protocol selection tests (from_env precedence over OTEL_EXPORTER)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review


## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix
<img width="975" height="594" alt="image" src="https://github.com/user-attachments/assets/4b334da2-91d4-46b6-b4ea-1df1c72fa7e5" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Changes
- OTLP traces URL: Skip appending /v1/traces when the endpoint is Splunk-style …/v2/trace/otlp (fixes broken …/v2/trace/otlp/v1/traces URLs).
- Tests: Cover Splunk/SignalFx-style ingest URLs; collapse duplicate cases with parameterized.expand. Set OTEL_EXPORTER_OTLP_PROTOCOL in protocol-selection tests so from_env() stays deterministic.