### PR TITLE
add moonshot/kimi-k2.6 to model registry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22872,6 +22872,20 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k2.6": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-06,
+        "source": "https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22872,6 +22872,20 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k2.6": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-06,
+        "source": "https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -653,3 +653,37 @@ class TestMoonshotConfig:
             result[1].get("reasoning_content")
             == "<thinking>Planning to call weather tool</thinking>"
         )
+
+
+class TestKimiK26ModelRegistry:
+    """Tests that kimi-k2.6 is correctly registered in the model registry."""
+
+    def test_kimi_k26_in_model_cost_map(self):
+        """kimi-k2.6 should be present in the model cost map."""
+        model_info = litellm.model_cost.get("moonshot/kimi-k2.6")
+        assert model_info is not None, "moonshot/kimi-k2.6 not found in model_cost"
+
+    def test_kimi_k26_pricing(self):
+        """kimi-k2.6 pricing should match official Kimi API rates."""
+        model_info = litellm.model_cost["moonshot/kimi-k2.6"]
+        assert model_info["input_cost_per_token"] == pytest.approx(6e-07)
+        assert model_info["output_cost_per_token"] == pytest.approx(2.8e-06)
+
+    def test_kimi_k26_context_window(self):
+        """kimi-k2.6 should have a 256K (262144 token) context window."""
+        model_info = litellm.model_cost["moonshot/kimi-k2.6"]
+        assert model_info["max_input_tokens"] == 262144
+        assert model_info["max_output_tokens"] == 262144
+        assert model_info["max_tokens"] == 262144
+
+    def test_kimi_k26_capabilities(self):
+        """kimi-k2.6 should support function calling, vision, and video input."""
+        model_info = litellm.model_cost["moonshot/kimi-k2.6"]
+        assert model_info.get("supports_function_calling") is True
+        assert model_info.get("supports_vision") is True
+        assert model_info.get("supports_video_input") is True
+
+    def test_kimi_k26_provider(self):
+        """kimi-k2.6 should be assigned to the moonshot provider."""
+        model_info = litellm.model_cost["moonshot/kimi-k2.6"]
+        assert model_info["litellm_provider"] == "moonshot"


### PR DESCRIPTION
## Relevant Issues / Related PRs

Adds Kimi K2.6 (released April 20, 2026) to the LiteLLM model registry.

## Pre-Submission Checklist

- [x] I have added tests in `tests/litellm/`
- [x] `make test-unit` passes for the modified tests

## Changes

- Added `moonshot/kimi-k2.6` to `model_prices_and_context_window.json` and backup
- Pricing: $0.60/M input, $2.80/M output (from https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart)
- 262K context window, supports function calling, vision, and video input
- Tests for model registry entry

## Usage

```python
import litellm

response = litellm.completion(
    model="moonshot/kimi-k2.6",
    messages=[{"role": "user", "content": "Hello!"}],
)
```