### PR TITLE
[Fix] Docker: restore pre-uv Prisma cache path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,8 @@ RUN apk add --no-cache \
     npm \
     libsndfile
 
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    UV_PROJECT_ENVIRONMENT=/app/.venv \
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
-    XDG_CACHE_HOME=/app/.cache \
     PATH="/app/.venv/bin:${PATH}"
 
 # Copy dependency metadata first for layer caching
@@ -97,17 +95,14 @@ WORKDIR /app
 ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY --from=builder /app /app
+# Prisma binaries live in $HOME/.cache (default prisma-python location),
+# which is /root/.cache here. Copy them from the builder so they survive
+# deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem
+# + emptyDir) — otherwise the mount would shadow the baked-in query engine.
+COPY --from=builder /root/.cache /root/.cache
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete
-
-# Regenerate the Prisma client in the runtime stage so the baked-in
-# BINARY_PATHS resolve to a location outside /app. Users with volume mounts
-# that shadow /app/.cache (e.g. readOnlyRootFilesystem + emptyDir) would
-# otherwise lose access to the pre-downloaded query engine at runtime.
-# Drop the builder's /app/.cache afterwards — it's stale and adds ~800 MB
-# the runtime doesn't use.
-RUN rm -rf /app/.cache && prisma generate --schema=./schema.prisma
 
 EXPOSE 4000/tcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,14 +94,20 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile supervi
     { apk del --no-cache npm 2>/dev/null || true; }
 
 WORKDIR /app
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    XDG_CACHE_HOME=/app/.cache \
-    PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY --from=builder /app /app
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete
+
+# Regenerate the Prisma client in the runtime stage so the baked-in
+# BINARY_PATHS resolve to a location outside /app. Users with volume mounts
+# that shadow /app/.cache (e.g. readOnlyRootFilesystem + emptyDir) would
+# otherwise lose access to the pre-downloaded query engine at runtime.
+# Drop the builder's /app/.cache afterwards — it's stale and adds ~800 MB
+# the runtime doesn't use.
+RUN rm -rf /app/.cache && prisma generate --schema=./schema.prisma
 
 EXPOSE 4000/tcp
 

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -26,10 +26,8 @@ RUN apk add --no-cache \
     npm \
     libsndfile
 
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    UV_PROJECT_ENVIRONMENT=/app/.venv \
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
-    XDG_CACHE_HOME=/app/.cache \
     PATH="/app/.venv/bin:${PATH}"
 
 # Copy dependency metadata first for layer caching
@@ -95,17 +93,14 @@ WORKDIR /app
 ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY --from=builder /app /app
+# Prisma binaries live in $HOME/.cache (default prisma-python location),
+# which is /root/.cache here. Copy them from the builder so they survive
+# deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem
+# + emptyDir) — otherwise the mount would shadow the baked-in query engine.
+COPY --from=builder /root/.cache /root/.cache
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete
-
-# Regenerate the Prisma client in the runtime stage so the baked-in
-# BINARY_PATHS resolve to a location outside /app. Users with volume mounts
-# that shadow /app/.cache (e.g. readOnlyRootFilesystem + emptyDir) would
-# otherwise lose access to the pre-downloaded query engine at runtime.
-# Drop the builder's /app/.cache afterwards — it's stale and adds ~800 MB
-# the runtime doesn't use.
-RUN rm -rf /app/.cache && prisma generate --schema=./schema.prisma
 
 EXPOSE 4000/tcp
 

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -92,14 +92,20 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile supervi
     { apk del --no-cache npm 2>/dev/null || true; }
 
 WORKDIR /app
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    XDG_CACHE_HOME=/app/.cache \
-    PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY --from=builder /app /app
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete
+
+# Regenerate the Prisma client in the runtime stage so the baked-in
+# BINARY_PATHS resolve to a location outside /app. Users with volume mounts
+# that shadow /app/.cache (e.g. readOnlyRootFilesystem + emptyDir) would
+# otherwise lose access to the pre-downloaded query engine at runtime.
+# Drop the builder's /app/.cache afterwards — it's stale and adds ~800 MB
+# the runtime doesn't use.
+RUN rm -rf /app/.cache && prisma generate --schema=./schema.prisma
 
 EXPOSE 4000/tcp
 


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

When a deployment mounts a volume at `/app/.cache` (common with `securityContext.readOnlyRootFilesystem: true` plus an emptyDir for a writable cache), the proxy fails at startup:

```
prisma.engine.errors.BinaryNotFoundError: Expected /app/prisma-query-engine-debian-openssl-3.6.x
or /app/.cache/prisma-python/binaries/prisma-query-engine-debian-openssl-3.6.x to exist but
neither were found or could not be executed.
```

The uv migration (#25007) added `PRISMA_BINARY_CACHE_DIR=/app/.cache/...` and `XDG_CACHE_HOME=/app/.cache` to the runtime stages of `Dockerfile` and `Dockerfile.database`. The generated prisma client's `BINARY_PATHS` was baked to point into `/app/.cache`. Any volume mount shadowing that directory removes the pre-downloaded query engine at pod startup.

Before the uv migration the binaries lived in `/root/.cache` (prisma-python's default under `HOME=/root`) and were unaffected by `/app/*` mounts.

### Fix

Drop the two env vars from the runtime stage, then re-run `prisma generate` there. With no override, prisma-python defaults to `$HOME/.cache` = `/root/.cache`, so both the downloaded query engine and the baked `BINARY_PATHS` land outside `/app`. Remove the stale builder-stage `/app/.cache` afterwards (~800 MB it would otherwise carry unused).

`Dockerfile.non_root` is intentionally unchanged — its `/app/.cache` location is by design for the hardened offline-install flow.

## Testing

Built both fixed images and ran a three-scenario matrix against a local Postgres:

| Scenario | Result |
|---|---|
| No volume mount | CONNECTED |
| `docker run --tmpfs /app/.cache` (reproduces pre-fix failure exactly) | CONNECTED |
| `docker run --read-only --tmpfs /tmp --tmpfs /app/.cache --tmpfs /app/.npm` | CONNECTED |

Verified `BINARY_PATHS` in the generated client resolves to `/root/.cache/prisma-python/binaries/5.4.2/<engine-hash>/node_modules/prisma/query-engine-*` on both `Dockerfile` and `Dockerfile.database` outputs.

## Type

🐛 Bug Fix
🚄 Infrastructure