### PR TITLE
Surface per-member budget cycle in Teams > Members tab

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3907,7 +3907,7 @@ class OrganizationMemberUpdateResponse(MemberUpdateResponse):
 
 
 class TeamInfoResponseObjectTeamTable(LiteLLM_TeamTable):
-    team_member_budget_table: Optional[LiteLLM_BudgetTable] = None
+    team_member_budget_table: Optional[LiteLLM_BudgetTableFull] = None
     # Resources inherited from access groups (separate from direct assignments)
     access_group_models: Optional[List[str]] = None
     access_group_mcp_server_ids: Optional[List[str]] = None

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, Request
 import litellm
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
+from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy._types import (  # key request types; user request types; team request types; customer request types
     BudgetNewRequest,
     DeleteCustomerRequest,
@@ -191,6 +192,13 @@ async def _clone_team_default_budget_for_member(
         if isinstance(value, list) and len(value) == 0:
             continue
         cloned_data[field] = value
+
+    # Start the member's budget window at clone time, not the pool's reset
+    # timestamp — otherwise a member joining mid-cycle inherits a stale reset.
+    if cloned_data.get("budget_duration"):
+        cloned_data["budget_reset_at"] = get_budget_reset_time(
+            cloned_data["budget_duration"]
+        )
 
     new_budget = await prisma_client.db.litellm_budgettable.create(data=cloned_data)
     return new_budget.budget_id

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -60,6 +60,7 @@ export interface TeamMembership {
   team_id: string;
   budget_id: string;
   spend: number;
+  total_spend: number | null;
   litellm_budget_table: {
     budget_id: string;
     soft_budget: number | null;

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -15,7 +15,6 @@ import {
   teamUpdateCall,
 } from "@/components/networking";
 import { useGuardrails } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
-import { formatBudgetReset } from "@/utils/budgetUtils";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
 import { isProxyAdminRole } from "@/utils/roles";
@@ -71,7 +70,6 @@ export interface TeamMembership {
     rpm_limit: number | null;
     model_max_budget: Record<string, number> | null;
     budget_duration: string | null;
-    budget_reset_at: string | null;
     allowed_models?: string[] | null;
   };
 }
@@ -122,7 +120,6 @@ export interface TeamData {
     team_member_budget_table: {
       max_budget: number;
       budget_duration: string;
-      budget_reset_at: string | null;
       tpm_limit: number | null;
       rpm_limit: number | null;
     } | null;
@@ -735,21 +732,12 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     <Text>
                       of {info.max_budget === null ? "Unlimited" : `$${formatNumberWithCommas(info.max_budget, 4)}`}
                     </Text>
-                    {formatBudgetReset(info.budget_reset_at) && (
-                      <Text className="text-gray-500">Resets {formatBudgetReset(info.budget_reset_at)}</Text>
-                    )}
+                    {info.budget_duration && <Text className="text-gray-500">Reset: {info.budget_duration}</Text>}
                     <br />
                     {info.team_member_budget_table && (
-                      <>
-                        <Text className="text-gray-500">
-                          Team Member Budget: ${formatNumberWithCommas(info.team_member_budget_table.max_budget, 4)}
-                        </Text>
-                        {formatBudgetReset(info.team_member_budget_table.budget_reset_at) && (
-                          <Text className="text-gray-500">
-                            Member budgets reset {formatBudgetReset(info.team_member_budget_table.budget_reset_at)}
-                          </Text>
-                        )}
-                      </>
+                      <Text className="text-gray-500">
+                        Team Member Budget: ${formatNumberWithCommas(info.team_member_budget_table.max_budget, 4)}
+                      </Text>
                     )}
                   </div>
                 </Card>

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -70,6 +70,7 @@ export interface TeamMembership {
     rpm_limit: number | null;
     model_max_budget: Record<string, number> | null;
     budget_duration: string | null;
+    budget_reset_at: string | null;
     allowed_models?: string[] | null;
   };
 }

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -15,6 +15,7 @@ import {
   teamUpdateCall,
 } from "@/components/networking";
 import { useGuardrails } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
+import { formatBudgetReset } from "@/utils/budgetUtils";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
 import { isProxyAdminRole } from "@/utils/roles";
@@ -70,6 +71,7 @@ export interface TeamMembership {
     rpm_limit: number | null;
     model_max_budget: Record<string, number> | null;
     budget_duration: string | null;
+    budget_reset_at: string | null;
     allowed_models?: string[] | null;
   };
 }
@@ -120,6 +122,7 @@ export interface TeamData {
     team_member_budget_table: {
       max_budget: number;
       budget_duration: string;
+      budget_reset_at: string | null;
       tpm_limit: number | null;
       rpm_limit: number | null;
     } | null;
@@ -732,12 +735,21 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     <Text>
                       of {info.max_budget === null ? "Unlimited" : `$${formatNumberWithCommas(info.max_budget, 4)}`}
                     </Text>
-                    {info.budget_duration && <Text className="text-gray-500">Reset: {info.budget_duration}</Text>}
+                    {formatBudgetReset(info.budget_reset_at) && (
+                      <Text className="text-gray-500">Resets {formatBudgetReset(info.budget_reset_at)}</Text>
+                    )}
                     <br />
                     {info.team_member_budget_table && (
-                      <Text className="text-gray-500">
-                        Team Member Budget: ${formatNumberWithCommas(info.team_member_budget_table.max_budget, 4)}
-                      </Text>
+                      <>
+                        <Text className="text-gray-500">
+                          Team Member Budget: ${formatNumberWithCommas(info.team_member_budget_table.max_budget, 4)}
+                        </Text>
+                        {formatBudgetReset(info.team_member_budget_table.budget_reset_at) && (
+                          <Text className="text-gray-500">
+                            Member budgets reset {formatBudgetReset(info.team_member_budget_table.budget_reset_at)}
+                          </Text>
+                        )}
+                      </>
                     )}
                   </div>
                 </Card>

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -45,11 +45,10 @@ export default function TeamMemberTab({
     return "0";
   };
 
-  // Helper function to get spend for a user
-  const getUserSpend = (userId: string | null): number | null => {
+  const getUserTotalSpend = (userId: string | null): number => {
     if (!userId) return 0;
     const membership = teamData.team_memberships.find((tm) => tm.user_id === userId);
-    return membership?.spend || 0;
+    return membership?.total_spend ?? 0;
   };
 
   const getUserBudget = (userId: string | null): string | null => {
@@ -124,15 +123,15 @@ export default function TeamMemberTab({
     {
       title: (
         <Space direction="horizontal">
-          Team Member Spend (USD)
-          <Tooltip title="This is the amount spent by a user in the team.">
+          Total Spend (USD)
+          <Tooltip title="Total spend by this member within this team. Tracking began 2026-04-21; spend from before that date is not included.">
             <InfoCircleOutlined />
           </Tooltip>
         </Space>
       ),
-      key: "spend",
+      key: "total_spend",
       render: (_: unknown, record: Member) => (
-        <Typography.Text>${formatNumberWithCommas(getUserSpend(record.user_id), 4)}</Typography.Text>
+        <Typography.Text>${formatNumberWithCommas(getUserTotalSpend(record.user_id), 4)}</Typography.Text>
       ),
     },
     {

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -1,6 +1,7 @@
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { Member } from "@/components/networking";
+import { formatBudgetReset } from "@/utils/budgetUtils";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { isProxyAdminRole, isUserTeamAdminForSingleTeam } from "@/utils/roles";
 import { InfoCircleOutlined } from "@ant-design/icons";
@@ -88,6 +89,12 @@ export default function TeamMemberTab({
     return models && models.length > 0 ? models : null;
   };
 
+  const getUserBudgetReset = (userId: string | null): string | null => {
+    if (!userId) return null;
+    const membership = teamData.team_memberships.find((tm) => tm.user_id === userId);
+    return formatBudgetReset(membership?.litellm_budget_table?.budget_reset_at);
+  };
+
   const extraColumns: ColumnsType<Member> = [
     {
       title: (
@@ -143,6 +150,18 @@ export default function TeamMemberTab({
           <Typography.Text>
             {budget ? `$${formatNumberWithCommas(Number(budget), 4)}` : "No Limit"}
           </Typography.Text>
+        );
+      },
+    },
+    {
+      title: "Budget Reset",
+      key: "budget_reset",
+      render: (_: unknown, record: Member) => {
+        const reset = getUserBudgetReset(record.user_id);
+        return reset ? (
+          <Typography.Text>{reset}</Typography.Text>
+        ) : (
+          <Typography.Text type="secondary">—</Typography.Text>
         );
       },
     },

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -46,6 +46,12 @@ export default function TeamMemberTab({
     return "0";
   };
 
+  const getUserCurrentCycleSpend = (userId: string | null): number => {
+    if (!userId) return 0;
+    const membership = teamData.team_memberships.find((tm) => tm.user_id === userId);
+    return membership?.spend ?? 0;
+  };
+
   const getUserTotalSpend = (userId: string | null): number => {
     if (!userId) return 0;
     const membership = teamData.team_memberships.find((tm) => tm.user_id === userId);
@@ -130,8 +136,22 @@ export default function TeamMemberTab({
     {
       title: (
         <Space direction="horizontal">
+          Current Cycle Spend (USD)
+          <Tooltip title="Spend for the current budget cycle. Resets to $0 when the member's budget window rolls over. This is the value checked against the member's budget.">
+            <InfoCircleOutlined />
+          </Tooltip>
+        </Space>
+      ),
+      key: "spend",
+      render: (_: unknown, record: Member) => (
+        <Typography.Text>${formatNumberWithCommas(getUserCurrentCycleSpend(record.user_id), 4)}</Typography.Text>
+      ),
+    },
+    {
+      title: (
+        <Space direction="horizontal">
           Total Spend (USD)
-          <Tooltip title="Total spend by this member within this team. Tracking began 2026-04-21; spend from before that date is not included.">
+          <Tooltip title="Cumulative spend by this member within this team, across all budget cycles. Tracking began 2026-04-21; spend from before that date is not included.">
             <InfoCircleOutlined />
           </Tooltip>
         </Space>

--- a/ui/litellm-dashboard/src/utils/budgetUtils.ts
+++ b/ui/litellm-dashboard/src/utils/budgetUtils.ts
@@ -1,0 +1,13 @@
+import dayjs from "dayjs";
+
+export function formatBudgetReset(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const resetDate = dayjs(iso);
+  if (!resetDate.isValid()) return null;
+
+  const days = resetDate.diff(dayjs(), "day");
+  if (days < 0) return `on ${resetDate.format("MMM D, YYYY")}`;
+  if (days === 0) return "today";
+  if (days < 7) return `in ${days} day${days === 1 ? "" : "s"}`;
+  return `on ${resetDate.format("MMM D, YYYY")}`;
+}

--- a/ui/litellm-dashboard/src/utils/budgetUtils.ts
+++ b/ui/litellm-dashboard/src/utils/budgetUtils.ts
@@ -4,10 +4,5 @@ export function formatBudgetReset(iso: string | null | undefined): string | null
   if (!iso) return null;
   const resetDate = dayjs(iso);
   if (!resetDate.isValid()) return null;
-
-  const days = resetDate.diff(dayjs(), "day");
-  if (days < 0) return `on ${resetDate.format("MMM D, YYYY")}`;
-  if (days === 0) return "today";
-  if (days < 7) return `in ${days} day${days === 1 ? "" : "s"}`;
-  return `on ${resetDate.format("MMM D, YYYY")}`;
+  return resetDate.format("MMM D, YYYY");
 }


### PR DESCRIPTION
## Summary

Frontend companion to #26195 — surfaces member spend and budget-cycle info on the Teams > Members tab.

- **Teams > Members tab**: adds three new columns.
  - **Current Cycle Spend (USD)** — spend in the member's current budget window (what's checked against their limit).
  - **Total Spend (USD)** — cumulative spend by this member within this team. Tooltip notes tracking began 2026-04-21; earlier spend is not included.
  - **Budget Reset** — date the member's budget next rolls over, or `—` if no budget/duration.
- **New helper** `src/utils/budgetUtils.ts` → `formatBudgetReset(iso)`: dayjs-based, returns `"MMM D, YYYY"` or `null` for missing/malformed input so callers skip rendering.

Requires backend PR #26195 to merge first — `total_spend` and `budget_reset_at` are populated by its `/team/info` changes.

## Screenshots

Issued a request with Alice's key under this team to verify per-member Current Cycle Spend / Total Spend increment and Budget Reset renders.

<img width="1401" height="500" alt="Screenshot 2026-04-23 at 3 39 31 PM" src="https://github.com/user-attachments/assets/afa80003-67f7-44a4-98eb-ae18bada1c80" />

## Test plan

- [ ] Teams > {team with members} > Members tab — Current Cycle Spend, Total Spend, and Budget Reset columns render
- [ ] Hover Total Spend header → tooltip mentions the 2026-04-21 tracking-start caveat
- [ ] Member with `budget_duration` + `budget_reset_at` set → Budget Reset shows `MMM D, YYYY`
- [ ] Member with no budget or no duration → Budget Reset shows `—`
- [ ] Typecheck: `cd ui/litellm-dashboard && npx tsc --noEmit -p tsconfig.json` — no new errors in edited files