### PR TITLE
fix: increase health check max_tokens from 1 to 16 (#23836)

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -304,7 +304,7 @@ def _update_litellm_params_for_health_check(
     elif "*" not in (
         model_info.get("health_check_model") or litellm_params.get("model") or ""
     ):
-        litellm_params["max_tokens"] = 1
+        litellm_params["max_tokens"] = 16
 
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -7,14 +7,14 @@ from unittest.mock import AsyncMock, patch, MagicMock
 @pytest.mark.asyncio
 async def test_update_litellm_params_max_tokens_default():
     """
-    Test that max_tokens defaults to 1 for non-wildcard models.
+    Test that max_tokens defaults to 16 for non-wildcard models.
     """
     model_info = {}
     litellm_params = {"model": "gpt-4"}
 
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
 
-    assert updated_params["max_tokens"] == 1
+    assert updated_params["max_tokens"] == 16
 
 
 @pytest.mark.asyncio
@@ -33,15 +33,15 @@ async def test_update_litellm_params_max_tokens_custom():
 @pytest.mark.asyncio
 async def test_update_litellm_params_max_tokens_wildcard():
     """
-    Test that max_tokens does NOT default to 1 for wildcard models.
+    Test that max_tokens is not set for wildcard models.
     """
     model_info = {}
     litellm_params = {"model": "openai/*"}
 
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
 
-    # Should not be set to 1
-    assert "max_tokens" not in updated_params or updated_params["max_tokens"] != 1
+    # Should not be set at all for wildcard models
+    assert "max_tokens" not in updated_params
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Fixes BerriAI/litellm#23836

## Pre-Submission checklist

- [x] I have added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem
Health checks set `max_tokens=1` for non-wildcard models, which causes failures with newer models like GPT-5 that have minimum token requirements. A single token is insufficient for these models to generate a valid response.

### Solution
Increased the default `max_tokens` from 1 to 16 for health check requests. This provides enough tokens for models to generate a meaningful response while keeping the health check lightweight.

Also tightened the wildcard test assertion from a weak disjunctive check (`not in or != 1`) to strict key-absence (`not in`), preventing false passes if a future bug sets `max_tokens` to an arbitrary value for wildcard models.

### Changes Made
- `litellm/proxy/health_check.py`: Changed `max_tokens` default from 1 to 16
- `tests/test_litellm/proxy/test_health_check_max_tokens.py`: Updated default assertion to expect 16, tightened wildcard assertion to strict key-absence check

Supersedes #24893 (closed due to branch contamination from upstream merge).