### PR TITLE
[Infra] CircleCI config cleanup and consolidation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ commands:
       - setup_google_dns
       - restore_cache:
           keys:
-            - v3-litellm-uv-deps-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+            - v3-litellm-uv-deps-{{ checksum "uv.lock" }}
+            - v3-litellm-uv-deps-
       - install_uv
       - run:
           name: Install Dependencies
@@ -126,7 +127,7 @@ commands:
             - ~/.local/lib
             - ~/.local/bin
             - ~/.cache/uv
-          key: v3-litellm-uv-deps-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: v3-litellm-uv-deps-{{ checksum "uv.lock" }}
 
 jobs:
   # Add Windows testing job
@@ -176,9 +177,6 @@ jobs:
       - setup_google_dns
       - install_uv
       - run:
-          name: Install Semgrep
-          command: |
-      - run:
           name: Run Semgrep (custom rules only)
           command: |
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
@@ -203,7 +201,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+            - v2-dependencies-{{ checksum "uv.lock" }}
+            - v2-dependencies-
       - install_uv
       - run:
           name: Install Dependencies
@@ -213,7 +212,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: v2-dependencies-{{ checksum "uv.lock" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -283,7 +282,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+            - v2-dependencies-{{ checksum "uv.lock" }}
+            - v2-dependencies-
       - install_uv
       - run:
           name: Install Dependencies
@@ -293,7 +293,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: v2-dependencies-{{ checksum "uv.lock" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -364,7 +364,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+            - v2-dependencies-{{ checksum "uv.lock" }}
+            - v2-dependencies-
       - install_uv
       - run:
           name: Install Dependencies
@@ -374,7 +375,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: v2-dependencies-{{ checksum "uv.lock" }}
       - run:
           name: Run prisma ./docker/entrypoint.sh
           command: |
@@ -420,7 +421,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: v2-dependencies-{{ checksum "uv.lock" }}
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -461,6 +462,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-router-testing-deps-{{ checksum "uv.lock" }}
+            - v1-router-testing-deps-
       - install_uv
       - run:
           name: Install Dependencies
@@ -510,6 +512,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-router-unit-deps-{{ checksum "uv.lock" }}
+            - v1-router-unit-deps-
       - install_uv
       - run:
           name: Install Dependencies
@@ -576,6 +579,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-llm-translation-deps-{{ checksum "uv.lock" }}
+            - v1-llm-translation-deps-
       - install_uv
       - run:
           name: Install Dependencies
@@ -817,6 +821,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-llm-responses-deps-{{ checksum "uv.lock" }}
+            - v1-llm-responses-deps-
       - install_uv
       - run:
           name: Install Dependencies
@@ -1216,7 +1221,8 @@ jobs:
       - setup_google_dns
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+            - v2-dependencies-{{ checksum "uv.lock" }}
+            - v2-dependencies-
       - install_uv
       - run:
           name: Install Dependencies
@@ -1225,7 +1231,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: v2-dependencies-{{ checksum "uv.lock" }}
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -1335,7 +1341,7 @@ jobs:
             uv run --no-sync python -m pytest -v tests/local_testing/test_basic_python_version.py -k "not v2_resolver"
   helm_chart_testing:
     machine:
-      image: ubuntu-2204:2023.10.1 # Use machine executor instead of docker
+      image: ubuntu-2204:2024.04.1 # Use machine executor instead of docker
     resource_class: medium
     working_directory: ~/project
 
@@ -1461,7 +1467,7 @@ jobs:
 
   db_migration_disable_update_check:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: medium
     working_directory: ~/project
     steps:
@@ -1542,7 +1548,7 @@ jobs:
 
   build_and_test:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -1618,7 +1624,7 @@ jobs:
           path: test-results
   e2e_openai_endpoints:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -1699,7 +1705,7 @@ jobs:
           path: test-results
   proxy_logging_guardrails_model_info_tests:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -1817,7 +1823,7 @@ jobs:
           path: test-results
   proxy_spend_accuracy_tests:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -1890,7 +1896,7 @@ jobs:
 
   proxy_multi_instance_tests:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -1981,7 +1987,7 @@ jobs:
 
   proxy_store_model_in_db_tests:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -2051,7 +2057,7 @@ jobs:
   proxy_build_from_pip_tests:
     # Change from docker to machine executor
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -2121,7 +2127,7 @@ jobs:
           when: always
   proxy_pass_through_endpoint_tests:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -2241,7 +2247,7 @@ jobs:
 
   proxy_e2e_anthropic_messages_tests:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: large
     working_directory: ~/project
     steps:
@@ -2423,7 +2429,8 @@ jobs:
       - setup_google_dns
       - restore_cache:
           keys:
-            - ui-e2e-py-deps-v2-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+            - ui-e2e-py-deps-v2-{{ checksum "uv.lock" }}
+            - ui-e2e-py-deps-v2-
       - install_uv
       - run:
           name: Install Python dependencies
@@ -2431,7 +2438,7 @@ jobs:
             uv sync --frozen --all-groups --all-extras --python 3.12
             uv run --no-sync python -m prisma generate --schema litellm/proxy/schema.prisma
       - save_cache:
-          key: ui-e2e-py-deps-v2-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+          key: ui-e2e-py-deps-v2-{{ checksum "uv.lock" }}
           paths:
             - ./.venv
       - restore_cache:
@@ -2548,7 +2555,7 @@ jobs:
 
   test_bad_database_url:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.1
     resource_class: medium
     working_directory: ~/project
     steps:
@@ -2588,7 +2595,6 @@ jobs:
             fi
 
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - using_litellm_on_windows:
@@ -2817,16 +2823,6 @@ workflows:
           filters:
             branches:
               only:
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
                 - main
                 - /litellm_.*/
       - batches_testing:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
       - run:
           name: Install Dependencies
           command: |
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
@@ -208,12 +208,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
@@ -293,12 +288,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
@@ -357,7 +347,7 @@ jobs:
             - local_testing_part2_coverage
   langfuse_logging_unit_tests:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -379,12 +369,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - save_cache:
           paths:
@@ -411,7 +396,7 @@ jobs:
           path: test-results
   auth_ui_unit_tests:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -431,12 +416,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - save_cache:
           paths:
             - ./.venv
@@ -468,7 +448,7 @@ jobs:
 
   litellm_router_testing: # Runs all tests with the "router" keyword
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -485,12 +465,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - save_cache:
           paths:
             - /home/circleci/.pyenv
@@ -522,7 +497,7 @@ jobs:
 
   litellm_router_unit_testing: # Runs all tests with the "router" keyword
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -539,12 +514,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - save_cache:
           paths:
             - /home/circleci/.pyenv
@@ -564,7 +534,7 @@ jobs:
           path: test-results
   litellm_assistants_api_testing: # Runs all tests with the "assistants" keyword
     docker:
-      - image: cimg/python:3.13.1@sha256:87b243ae80d154db75ce5e58af16c72c5dd4b1e23e5c7264a816e85e0c440c13
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -578,12 +548,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
       - run:
@@ -598,7 +563,7 @@ jobs:
           path: test-results
   llm_translation_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -615,12 +580,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - save_cache:
           paths:
             - /home/circleci/.pyenv
@@ -650,7 +610,7 @@ jobs:
           path: test-results
   realtime_translation_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -663,12 +623,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run realtime tests
@@ -695,7 +650,7 @@ jobs:
             - realtime_translation_coverage
   mcp_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -708,12 +663,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -738,7 +688,7 @@ jobs:
             - mcp_coverage
   agent_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -751,12 +701,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -781,7 +726,7 @@ jobs:
             - agent_coverage
   guardrails_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -794,12 +739,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -825,7 +765,7 @@ jobs:
 
   google_generate_content_endpoint_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -838,12 +778,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -869,7 +804,7 @@ jobs:
 
   llm_responses_api_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -886,12 +821,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - save_cache:
           paths:
             - /home/circleci/.pyenv
@@ -911,7 +841,7 @@ jobs:
           path: test-results
   ocr_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -924,12 +854,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -954,7 +879,7 @@ jobs:
             - ocr_coverage
   search_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -967,12 +892,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -998,7 +918,7 @@ jobs:
   # Split litellm_mapped_tests into parallel jobs
   litellm_mapped_tests_proxy_part1:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1017,7 +937,7 @@ jobs:
           path: test-results
   litellm_mapped_tests_proxy_part2:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1036,7 +956,7 @@ jobs:
           path: test-results
   litellm_mapped_enterprise_tests:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1050,12 +970,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - run:
           name: Run enterprise tests
@@ -1070,7 +985,7 @@ jobs:
           path: test-results
   batches_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1083,12 +998,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -1113,7 +1023,7 @@ jobs:
             - batches_coverage
   litellm_utils_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1126,12 +1036,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -1157,7 +1062,7 @@ jobs:
 
   pass_through_unit_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1170,12 +1075,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -1200,7 +1100,7 @@ jobs:
             - pass_through_unit_tests_coverage
   image_gen_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1214,12 +1114,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -1233,7 +1128,7 @@ jobs:
           path: test-results
   logging_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1246,12 +1141,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - setup_litellm_enterprise_pip
       - run:
@@ -1277,7 +1167,7 @@ jobs:
             - logging_coverage
   audio_testing:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1290,12 +1180,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       # Run pytest and generate JUnit XML report
       - run:
           name: Run tests
@@ -1320,7 +1205,7 @@ jobs:
             - audio_coverage
   redis_caching_unit_tests:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1336,7 +1221,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - save_cache:
           paths:
             - ./.venv
@@ -1370,7 +1255,7 @@ jobs:
             - redis_caching_coverage
   installing_litellm_on_python:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1383,12 +1268,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - run:
           name: Run tests
@@ -1399,7 +1279,7 @@ jobs:
 
   installing_litellm_on_python_v2_migration_resolver:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1419,12 +1299,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - setup_litellm_enterprise_pip
       - wait_for_service:
           url: tcp://localhost:5432
@@ -1451,12 +1326,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.13
       - run:
           name: Run tests
           command: |
@@ -1545,7 +1415,7 @@ jobs:
 
   check_code_and_doc_quality:
     docker:
-      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1558,12 +1428,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - run: uv run --no-sync python -c "from litellm import *" || (echo '🚨 import failed, this means you introduced unprotected imports! 🚨'; exit 1)
       - run: uv run --no-sync ruff check ./litellm
       # - run: python ./tests/documentation_tests/test_general_setting_keys.py
@@ -1602,27 +1467,11 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
-      - run:
-          name: Install Python 3.9
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres:
           db_name: litellm_test
       - attach_workspace:
@@ -1701,27 +1550,11 @@ jobs:
       - attach_workspace:
           at: ~/project
       - setup_google_dns
-      - run:
-          name: Install Python 3.9
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - run:
           name: Load Docker Database Image
@@ -1795,27 +1628,11 @@ jobs:
           name: Verify Docker is available
           command: |
             docker version
-      - run:
-          name: Install Python 3.10
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -1892,27 +1709,11 @@ jobs:
           name: Verify Docker is available
           command: |
             docker version
-      - run:
-          name: Install Python 3.9
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -2026,27 +1827,11 @@ jobs:
           name: Verify Docker is available
           command: |
             docker version
-      - run:
-          name: Install Python 3.9
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -2115,27 +1900,11 @@ jobs:
           name: Verify Docker is available
           command: |
             docker version
-      - run:
-          name: Install Python 3.9
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -2223,27 +1992,11 @@ jobs:
           command: |
             docker version
             sudo systemctl restart docker
-      - run:
-          name: Install Python 3.9
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -2305,27 +2058,11 @@ jobs:
       - checkout
       - setup_google_dns
       # Remove Docker CLI installation since it's already available in machine executor
-      - run:
-          name: Install Python 3.13
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.13 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.13
       - run:
           name: Build Docker image
           command: |
@@ -2390,27 +2127,11 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
-      - run:
-          name: Install Python 3.10
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -2509,9 +2230,6 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export PATH="$HOME/miniconda/bin:$PATH"
-            source $HOME/miniconda/etc/profile.d/conda.sh
-            conda activate myenv
             pwd
             ls
             uv run --no-sync python -m pytest -v tests/pass_through_tests/ -x --junitxml=test-results/junit.xml --durations=5
@@ -2533,27 +2251,11 @@ jobs:
           name: Verify Docker is available
           command: |
             docker version
-      - run:
-          name: Install Python 3.10
-          command: |
-            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
-            bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
-            conda init bash
-            source ~/.bashrc
-            conda create -n myenv python=3.10 -y
-            conda activate myenv
-            python --version
       - install_uv
       - run:
           name: Install Dependencies
           command: |
-            if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
-              export PATH="$HOME/miniconda/bin:$PATH"
-              source "$HOME/miniconda/etc/profile.d/conda.sh"
-              conda activate myenv
-            fi
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
       - start_postgres
       - attach_workspace:
           at: ~/project
@@ -2591,9 +2293,6 @@ jobs:
       - run:
           name: Run Claude Agent SDK E2E Tests
           command: |
-            export PATH="$HOME/miniconda/bin:$PATH"
-            source $HOME/miniconda/etc/profile.d/conda.sh
-            conda activate myenv
             export LITELLM_PROXY_URL="http://localhost:4000"
             export LITELLM_API_KEY="sk-1234"
             pwd
@@ -2607,7 +2306,7 @@ jobs:
 
   upload-coverage:
     docker:
-      - image: cimg/python:3.9@sha256:32e85ea8c78a81b316a1ef956c11a591d0c47d2cc864ace824e4dc7cf87b34e0
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
     steps:
       - checkout
       - attach_workspace:
@@ -2729,7 +2428,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            uv sync --frozen --all-groups --all-extras --python "$(which python)"
+            uv sync --frozen --all-groups --all-extras --python 3.12
             uv run --no-sync python -m prisma generate --schema litellm/proxy/schema.prisma
       - save_cache:
           key: ui-e2e-py-deps-v2-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,40 +136,9 @@ jobs:
           command: |
             uv run --no-sync python -m pytest tests/windows_tests/test_litellm_on_windows.py -v
 
-  mypy_linting:
-    docker:
-      - image: cimg/python:3.12
-        auth:
-          username: ${DOCKERHUB_USERNAME}
-          password: ${DOCKERHUB_PASSWORD}
-    working_directory: ~/project
-    resource_class: medium
-
-    steps:
-      - checkout
-      - setup_google_dns
-      - run:
-          name: Install Dependencies
-          command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
-            uv sync --frozen --group dev --python "$(which python)" --no-install-package fastuuid
-      - run:
-          name: MyPy Type Checking
-          command: |
-            cd litellm
-            # Use the same approach as GitHub Actions, explicitly exclude fastuuid to avoid segfaults
-            uv run --no-sync python -m mypy .
-            cd ..
-          no_output_timeout: 10m
-
   semgrep:
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -196,7 +165,7 @@ jobs:
 
   local_testing_part1:
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -286,7 +255,7 @@ jobs:
             - local_testing_part1_coverage
   local_testing_part2:
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -376,7 +345,7 @@ jobs:
             - local_testing_part2_coverage
   langfuse_logging_unit_tests:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -435,11 +404,11 @@ jobs:
           path: test-results
   auth_ui_unit_tests:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
-      - image: cimg/postgres:16.0
+      - image: cimg/postgres:16.0@sha256:b125148bc76e8e8eee5eb3ad6020a3a14110a14e8192f1c645128afebe2e2f84
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -497,7 +466,7 @@ jobs:
 
   litellm_router_testing: # Runs all tests with the "router" keyword
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -556,7 +525,7 @@ jobs:
 
   litellm_router_unit_testing: # Runs all tests with the "router" keyword
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -603,7 +572,7 @@ jobs:
           path: test-results
   litellm_assistants_api_testing: # Runs all tests with the "assistants" keyword
     docker:
-      - image: cimg/python:3.13.1
+      - image: cimg/python:3.13.1@sha256:87b243ae80d154db75ce5e58af16c72c5dd4b1e23e5c7264a816e85e0c440c13
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -642,7 +611,7 @@ jobs:
           path: test-results
   llm_translation_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -699,7 +668,7 @@ jobs:
           path: test-results
   realtime_translation_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -749,7 +718,7 @@ jobs:
             - realtime_translation_coverage
   mcp_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -797,7 +766,7 @@ jobs:
             - mcp_coverage
   agent_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -845,7 +814,7 @@ jobs:
             - agent_coverage
   guardrails_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -894,7 +863,7 @@ jobs:
 
   google_generate_content_endpoint_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -943,7 +912,7 @@ jobs:
 
   llm_responses_api_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -990,7 +959,7 @@ jobs:
           path: test-results
   ocr_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1038,7 +1007,7 @@ jobs:
             - ocr_coverage
   search_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1087,7 +1056,7 @@ jobs:
   # Split litellm_mapped_tests into parallel jobs
   litellm_mapped_tests_proxy_part1:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1106,7 +1075,7 @@ jobs:
           path: test-results
   litellm_mapped_tests_proxy_part2:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1125,7 +1094,7 @@ jobs:
           path: test-results
   litellm_mapped_enterprise_tests:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1164,7 +1133,7 @@ jobs:
           path: test-results
   batches_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1212,7 +1181,7 @@ jobs:
             - batches_coverage
   litellm_utils_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1261,7 +1230,7 @@ jobs:
 
   pass_through_unit_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1309,7 +1278,7 @@ jobs:
             - pass_through_unit_tests_coverage
   image_gen_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1347,7 +1316,7 @@ jobs:
           path: test-results
   logging_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1396,7 +1365,7 @@ jobs:
             - logging_coverage
   audio_testing:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1444,7 +1413,7 @@ jobs:
             - audio_coverage
   redis_caching_unit_tests:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1499,7 +1468,7 @@ jobs:
             - redis_caching_coverage
   installing_litellm_on_python:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1533,11 +1502,11 @@ jobs:
 
   installing_litellm_on_python_v2_migration_resolver:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
-      - image: cimg/postgres:16.0
+      - image: cimg/postgres:16.0@sha256:b125148bc76e8e8eee5eb3ad6020a3a14110a14e8192f1c645128afebe2e2f84
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -1576,7 +1545,7 @@ jobs:
 
   installing_litellm_on_python_3_13:
     docker:
-      - image: cimg/python:3.13.1
+      - image: cimg/python:3.13.1@sha256:87b243ae80d154db75ce5e58af16c72c5dd4b1e23e5c7264a816e85e0c440c13
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1689,7 +1658,7 @@ jobs:
 
   check_code_and_doc_quality:
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.11@sha256:89910694a298ea0c861750804ddd100ac0ae8c6386055a8a68f7713dcdeb373d
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -1786,7 +1755,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=litellm_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -1901,7 +1870,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -1947,11 +1916,6 @@ jobs:
               --config /app/config.yaml \
               --port 4000 \
               --detailed_debug \
-      - run:
-          name: Install curl
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y curl
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2017,7 +1981,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2066,11 +2030,6 @@ jobs:
               --config /app/config.yaml \
               --port 4000 \
               --detailed_debug \
-      - run:
-          name: Install curl
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y curl
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2136,7 +2095,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2287,7 +2246,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2325,11 +2284,6 @@ jobs:
               --config /app/config.yaml \
               --port 4000 \
               --detailed_debug \
-      - run:
-          name: Install curl
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y curl
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2398,7 +2352,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2523,7 +2477,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2626,7 +2580,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - run:
           name: Wait for PostgreSQL to be ready
           command: |
@@ -2725,7 +2679,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2885,7 +2839,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -2941,7 +2895,7 @@ jobs:
 
   upload-coverage:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.9@sha256:32e85ea8c78a81b316a1ef956c11a591d0c47d2cc864ace824e4dc7cf87b34e0
     steps:
       - checkout
       - attach_workspace:
@@ -2970,7 +2924,7 @@ jobs:
 
   ui_build:
     docker:
-      - image: cimg/node:20.19
+      - image: cimg/node:20.19@sha256:35e64883e8d21bc345b0a7b04c35ee46442c127607ed1d8d7d37d8a1ed76db81
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -3012,7 +2966,7 @@ jobs:
 
   ui_unit_tests:
     docker:
-      - image: cimg/node:20.19
+      - image: cimg/node:20.19@sha256:35e64883e8d21bc345b0a7b04c35ee46442c127607ed1d8d7d37d8a1ed76db81
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
@@ -3044,11 +2998,11 @@ jobs:
 
   e2e_ui_testing:
     docker:
-      - image: cimg/python:3.12-browsers
+      - image: cimg/python:3.12-browsers@sha256:b432899af01c9a311bf74f4f22e9ada2e5306d4b1b4383f8d29e1228a5844ef2
         auth:
           username: ${DOCKERHUB_USERNAME}
           password: ${DOCKERHUB_PASSWORD}
-      - image: cimg/postgres:16.0
+      - image: cimg/postgres:16.0@sha256:b125148bc76e8e8eee5eb3ad6020a3a14110a14e8192f1c645128afebe2e2f84
         environment:
           POSTGRES_USER: e2euser
           POSTGRES_PASSWORD: e2epassword
@@ -3210,7 +3164,7 @@ jobs:
               -e POSTGRES_PASSWORD=postgres \
               -e POSTGRES_DB=circle_test \
               -p 5432:5432 \
-              postgres:14
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
       - wait_for_service:
           url: tcp://localhost:5432
           timeout: "60"
@@ -3254,12 +3208,6 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
-      - mypy_linting:
-          filters:
-            branches:
-              only:
-                - main
-                - /litellm_.*/
       - semgrep:
           filters:
             branches:
@@ -3282,16 +3230,6 @@ workflows:
           filters:
             branches:
               only:
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
-                - main
-                - /litellm_.*/
                 - main
                 - /litellm_.*/
       - litellm_assistants_api_testing:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,18 @@ commands:
             echo "513a7213d6d3332dd9ef27c24dab35e5ef10a04fa27274fe1c14d8a246493ded  /tmp/kind" | sha256sum -c -
             chmod +x /tmp/kind
             sudo mv /tmp/kind /usr/local/bin/kind
+  install_uv:
+    description: "Install pinned uv (0.10.9) with checksum verification. Adds ~/.local/bin to PATH."
+    steps:
+      - run:
+          name: Install uv (pinned 0.10.9)
+          command: |
+            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
+            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
+            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
+            rm -f /tmp/uv-install.sh
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+            export PATH="$HOME/.local/bin:$PATH"
   setup_litellm_enterprise_pip:
     steps:
       - run:
@@ -83,15 +95,10 @@ commands:
       - restore_cache:
           keys:
             - v3-litellm-uv-deps-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
       - setup_litellm_enterprise_pip
       - save_cache:
@@ -147,15 +154,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Semgrep
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
       - run:
           name: Run Semgrep (custom rules only)
           command: |
@@ -182,15 +184,10 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -272,15 +269,10 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -363,15 +355,10 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -420,15 +407,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -479,15 +461,10 @@ jobs:
       - restore_cache:
           keys:
             - v1-router-testing-deps-{{ checksum "uv.lock" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -538,15 +515,10 @@ jobs:
       - restore_cache:
           keys:
             - v1-router-unit-deps-{{ checksum "uv.lock" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -582,15 +554,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -624,15 +591,10 @@ jobs:
       - restore_cache:
           keys:
             - v1-llm-translation-deps-{{ checksum "uv.lock" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -677,15 +639,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -727,15 +684,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -775,15 +727,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -823,15 +770,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -872,15 +814,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -925,15 +862,10 @@ jobs:
       - restore_cache:
           keys:
             - v1-llm-responses-deps-{{ checksum "uv.lock" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -968,15 +900,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1016,15 +943,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1104,15 +1026,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1142,15 +1059,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1190,15 +1102,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1239,15 +1146,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1288,15 +1190,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1325,15 +1222,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1374,15 +1266,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1425,15 +1312,10 @@ jobs:
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
       - save_cache:
           paths:
@@ -1477,15 +1359,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1518,15 +1395,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1555,15 +1427,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1667,15 +1534,10 @@ jobs:
     steps:
       - checkout
       - setup_google_dns
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1731,15 +1593,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1846,15 +1703,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -1957,15 +1809,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2071,15 +1918,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2222,15 +2064,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2328,15 +2165,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2453,15 +2285,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2552,15 +2379,10 @@ jobs:
             conda create -n myenv python=3.13 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2655,15 +2477,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2815,15 +2632,10 @@ jobs:
             conda create -n myenv python=3.10 -y
             conda activate myenv
             python --version
+      - install_uv
       - run:
           name: Install Dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             if [ -f "$HOME/miniconda/etc/profile.d/conda.sh" ]; then
               export PATH="$HOME/miniconda/bin:$PATH"
               source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -2908,15 +2720,10 @@ jobs:
             ls -la
             echo "\nContents of tests/llm_translation:"
             ls -la tests/llm_translation
+      - install_uv
       - run:
           name: Combine Coverage
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             uv tool run --from 'coverage[toml]==7.10.6' coverage combine realtime_translation_coverage ocr_coverage search_coverage mcp_coverage logging_coverage audio_coverage local_testing_part1_coverage local_testing_part2_coverage pass_through_unit_tests_coverage batches_coverage guardrails_coverage redis_caching_coverage
             uv tool run --from 'coverage[toml]==7.10.6' coverage xml
       - codecov/upload:
@@ -3018,15 +2825,10 @@ jobs:
       - restore_cache:
           keys:
             - ui-e2e-py-deps-v2-{{ checksum "uv.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - install_uv
       - run:
           name: Install Python dependencies
           command: |
-            curl -LsSf -o /tmp/uv-install.sh https://astral.sh/uv/0.10.9/install.sh
-            echo "7fc46e39cb97290b57169c0c813a17970585ac519139f19006453c99b5f2f45f  /tmp/uv-install.sh" | sha256sum -c -
-            env UV_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh
-            rm -f /tmp/uv-install.sh
-            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-            export PATH="$HOME/.local/bin:$PATH"
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
             uv run --no-sync python -m prisma generate --schema litellm/proxy/schema.prisma
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,26 @@ commands:
             rm -f /tmp/uv-install.sh
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
+  start_postgres:
+    description: "Start a postgres-db container on port 5432 and wait until it accepts connections."
+    parameters:
+      db_name:
+        type: string
+        default: circle_test
+    steps:
+      - run:
+          name: Start PostgreSQL
+          command: |
+            docker run -d \
+              --name postgres-db \
+              -e POSTGRES_USER=postgres \
+              -e POSTGRES_PASSWORD=postgres \
+              -e POSTGRES_DB=<< parameters.db_name >> \
+              -p 5432:5432 \
+              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
+      - wait_for_service:
+          url: tcp://localhost:5432
+          timeout: "60"
   setup_litellm_enterprise_pip:
     steps:
       - run:
@@ -1603,19 +1623,8 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=litellm_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres:
+          db_name: litellm_test
       - attach_workspace:
           at: ~/project
       - run:
@@ -1713,19 +1722,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - run:
           name: Load Docker Database Image
           command: |
@@ -1819,19 +1816,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -1928,19 +1913,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -2074,19 +2047,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -2175,19 +2136,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -2295,19 +2244,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -2393,20 +2330,7 @@ jobs:
           name: Build Docker image
           command: |
             docker build -t my-app:latest -f docker/build_from_pip/Dockerfile.build_from_pip .
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - run:
-          name: Wait for PostgreSQL to be ready
-          command: |
-            timeout 60s bash -c 'until docker exec postgres-db pg_isready -U postgres -d circle_test; do sleep 2; done'
+      - start_postgres
       - run:
           name: Run Docker container
           # intentionally give bad redis credentials here
@@ -2487,19 +2411,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -2642,19 +2554,7 @@ jobs:
               conda activate myenv
             fi
             uv sync --frozen --all-groups --all-extras --python "$(which python)"
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - attach_workspace:
           at: ~/project
       - run:
@@ -2957,19 +2857,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - setup_google_dns
-      - run:
-          name: Start PostgreSQL Database
-          command: |
-            docker run -d \
-              --name postgres-db \
-              -e POSTGRES_USER=postgres \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=circle_test \
-              -p 5432:5432 \
-              postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
-      - wait_for_service:
-          url: tcp://localhost:5432
-          timeout: "60"
+      - start_postgres
       - run:
           name: Load Docker Database Image
           command: |


### PR DESCRIPTION
## Relevant issues

## Summary

### Problem

The CircleCI config had grown to 3,601 lines with significant duplication and drift:

- The `uv` installer block (`curl | sha256 | sh`, 6 lines) was copy-pasted in 43 places, with the version string and SHA256 hardcoded in every copy.
- The same `docker run ... postgres:14` + `wait_for_service` block was copy-pasted in 11 places.
- 8 machine-executor jobs downloaded Miniconda just to get a Python interpreter, then `uv sync`'d into that environment.
- Docker image references were unpinned (tagged only, e.g. `cimg/python:3.12`).
- The `mypy_linting` job duplicated a check that GitHub Actions' `test-linting.yml` already runs.
- Several jobs had redundant `Install curl` steps even though curl is already on the base image.
- Cache keys included `{{ checksum ".circleci/config.yml" }}`, which busts the cache on every unrelated config edit.
- Two copy-paste residues with 6× duplicated branch-filter entries.

### Fix

Five commits, one per change class, so review is navigable even though the PR is large:

1. **Clean up unused jobs and pin docker images by digest** — delete `mypy_linting` + 3× `Install curl` + dedup one filter block. Append `@sha256:<digest>` to every `cimg/*` and `postgres:14` reference so upstream tag moves can't silently change what runs.
2. **Add `install_uv` reusable command and migrate all call sites** — one command defines uv 0.10.9 + SHA256 in one place. All 43 inline install blocks replaced with `- install_uv`.
3. **Add `start_postgres` reusable command and migrate call sites** — parameterized on `db_name` (default `circle_test`, override to `litellm_test` for the helm job). All 11 inline `docker run` + `wait_for_service` pairs collapsed into `- start_postgres`.
4. **Standardize default Python to 3.12 and remove miniconda** — 26 jobs moved from `cimg/python:3.11` to `cimg/python:3.12`; one incidental 3.13.1 and one historical 3.9 image similarly consolidated. `installing_litellm_on_python_3_13` keeps 3.13.1 as its explicit compat matrix. Machine-executor jobs drop the miniconda install entirely and use `uv sync --python 3.12`, which auto-downloads a python-build-standalone interpreter when needed.
5. **Cleanup remaining inconsistencies** — fix a second 6× duplicated filter block, delete an empty `Install Semgrep` run step, bump the remaining `ubuntu-2204:2023.10.1` machine images to `2024.04.1` (already used by `build_docker_database_image`), remove the legacy `version: 2` inside `workflows:`, drop `config.yml` checksum from cache keys, and add partial-restore fallbacks for graceful cache degradation.

## Changes

Net **−677 lines** (3,601 → 2,934). Two new reusable commands, one uv install definition instead of 43, one postgres-start definition instead of 11, one Python default instead of five.

## Testing

Behavioral surface is unchanged: same jobs run the same tests on the same triggers. The mechanical changes are covered by running the full CCI pipeline on this PR.

First-run watchpoints:
- Machine-executor jobs that previously used miniconda for Python 3.10 now call `uv sync --python 3.12`, which downloads a python-build-standalone interpreter on first use. Expect a ~3–5s one-time download per cold cache.
- `proxy_build_from_pip_tests` retains Python 3.13 via `uv sync --python 3.13` (was `conda create python=3.13`).
- Cache keys changed — expect cold caches on the first run after merge.
- One site previously used a bespoke `pg_isready` loop instead of `wait_for_service`; now goes through the shared TCP probe path. Functionally equivalent for test ordering.

## Type

🚄 Infrastructure
🧹 Refactoring