### PR TITLE
fix(anthropic): skip non-OpenAI file content blocks in file-id discovery helpers

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -452,7 +452,14 @@ def update_messages_with_model_file_ids(
                 for c in content:
                     if c["type"] == "file":
                         file_object = cast(ChatCompletionFileObject, c)
-                        file_object_file_field = file_object["file"]
+                        file_object_file_field = file_object.get("file")
+                        if not isinstance(file_object_file_field, dict):
+                            # Content block has `type: "file"` but not the
+                            # OpenAI Chat Completions shape (e.g. a LangChain
+                            # v1 standardized file block, or a provider-native
+                            # shape that also uses `type: "file"`). Nothing to
+                            # remap here, so skip instead of crashing.
+                            continue
                         file_id = file_object_file_field.get("file_id")
                         format = file_object_file_field.get(
                             "format", get_format_from_file_id(file_id)
@@ -1060,7 +1067,12 @@ def get_file_ids_from_messages(messages: List[AllMessageValues]) -> List[str]:
                 for c in content:
                     if c["type"] == "file":
                         file_object = cast(ChatCompletionFileObject, c)
-                        file_object_file_field = file_object["file"]
+                        file_object_file_field = file_object.get("file")
+                        if not isinstance(file_object_file_field, dict):
+                            # Content block has `type: "file"` but not the
+                            # OpenAI Chat Completions shape. No file_id to
+                            # extract, so skip instead of raising KeyError.
+                            continue
                         file_id = file_object_file_field.get("file_id")
                         if file_id:
                             file_ids.append(file_id)

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -11,6 +11,7 @@ sys.path.insert(
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     add_system_prompt_to_messages,
+    get_file_ids_from_messages,
     get_format_from_file_id,
     handle_any_messages_to_chat_completion_str_messages_conversion,
     split_concatenated_json_objects,
@@ -254,3 +255,115 @@ def test_split_concatenated_json_invalid_raises():
     """Completely invalid JSON raises JSONDecodeError."""
     with pytest.raises(json.JSONDecodeError):
         split_concatenated_json_objects("not json at all")
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for non-OpenAI file content blocks.
+#
+# `type: "file"` is a public content-block discriminator. Several producers
+# (LangChain v1, provider-native shapes, custom user code) emit blocks with
+# `type: "file"` but without the OpenAI Chat Completions `file` sub-dict.
+# The discovery helpers below are used unconditionally inside
+# `AnthropicConfig.validate_environment`, so any crash there surfaces as a
+# `500 InternalServerError` before the request is even dispatched.
+# ---------------------------------------------------------------------------
+
+
+def test_get_file_ids_from_messages_skips_langchain_v1_file_block():
+    """A LangChain v1 standardized file block must not crash file-id discovery."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "summarise this PDF"},
+                # LangChain v1 shape produced by `_normalize_messages`.
+                # No `file` sub-dict: the discriminator is `type: "file"` but
+                # the payload lives on `base64`/`mime_type` siblings.
+                {
+                    "type": "file",
+                    "id": "lc_1",
+                    "base64": "JVBERi0xLjQK",
+                    "mime_type": "application/pdf",
+                    "extras": {"file_format": "application/pdf"},
+                },
+            ],
+        }
+    ]
+
+    assert get_file_ids_from_messages(messages) == []
+
+
+def test_get_file_ids_from_messages_still_extracts_from_openai_shape():
+    """Well-formed OpenAI file blocks still yield their file_id."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "file", "file": {"file_id": "file-abc"}},
+            ],
+        }
+    ]
+
+    assert get_file_ids_from_messages(messages) == ["file-abc"]
+
+
+def test_get_file_ids_from_messages_mixed_shapes():
+    """Mixed OpenAI and non-OpenAI file blocks: extract from the former,
+    ignore the latter."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file": {"file_id": "file-keep"}},
+                {
+                    "type": "file",
+                    "id": "lc_2",
+                    "base64": "AAA",
+                    "mime_type": "application/pdf",
+                },
+            ],
+        }
+    ]
+
+    assert get_file_ids_from_messages(messages) == ["file-keep"]
+
+
+def test_get_file_ids_from_messages_file_field_not_dict():
+    """`file` set to a non-dict value (e.g. stringified payload) must not crash."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file": "unexpectedly-a-string"},
+            ],
+        }
+    ]
+
+    assert get_file_ids_from_messages(messages) == []
+
+
+def test_update_messages_with_model_file_ids_skips_non_openai_file_blocks():
+    """`update_messages_with_model_file_ids` is also called on user content
+    before provider dispatch. It must tolerate non-OpenAI file blocks the same
+    way."""
+    langchain_v1_block = {
+        "type": "file",
+        "id": "lc_3",
+        "base64": "AAA",
+        "mime_type": "application/pdf",
+    }
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                langchain_v1_block,
+            ],
+        }
+    ]
+
+    updated = update_messages_with_model_file_ids(messages, "model-1", {})
+
+    # Messages pass through unchanged when there is no `file` sub-dict to remap.
+    assert updated == messages


### PR DESCRIPTION
## Relevant issues

Closes #26227. Related to #24503 (different approach, see below).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) for the affected module
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

Bug Fix

## Problem

`AnthropicConfig.validate_environment` (run on every Anthropic + Anthropic-via-Vertex request) calls:

- `is_file_id_used` -> `get_file_ids_from_messages` (`common_utils.py:1049`)
- downstream also `update_messages_with_model_file_ids` (`common_utils.py:431`)

Both helpers short-circuit on `c[\"type\"] == \"file\"` and then do a bare `c[\"file\"]` access. Any content block that uses `\"file\"` as its `type` discriminator but does not match the OpenAI Chat Completions sub-shape (nested `file` dict) raises `KeyError: 'file'`. The Vertex partner layer wraps this as `VertexAIError(500)` -> `litellm.InternalServerError`, before the LLM is contacted.

Real-world trigger: LangChain v1's `_normalize_messages` rewrites OpenAI file blocks into `{\"type\":\"file\",\"id\":...,\"base64\":...,\"mime_type\":...,\"extras\":{}}` on the way into every chat model. Hits every `vertex_ai/claude-*` and `anthropic/claude-*` request that carries an attachment.

See #26227 for full RCA, traceback, and minimal repro.

## Fix

`type: \"file\"` is a public content-block discriminator. The two helpers above are *discovery* passes:

- `get_file_ids_from_messages` returns a list of file IDs.
- `update_messages_with_model_file_ids` rewrites provider-scoped file IDs in-place.

A block with no `file` sub-dict has no file_id to extract or remap, so the correct behavior is to skip the block, not raise. This patch switches both from `c[\"file\"]` to `c.get(\"file\")` + `isinstance(..., dict)` check, and continues past non-OpenAI blocks.

### Why skip and not raise `BadRequestError` (as in #24503)

PR #24503 raises `BadRequestError` in these two spots. For the stricter sites it also touches (Gemini/Bedrock/Anthropic transformers, `migrate_file_to_image_url`), that is the right behavior: a block that has reached the provider transformer is expected to be fully-formed OpenAI shape, and a missing `file` sub-dict really is a malformed request.

These two *discovery* helpers are different. They run unconditionally inside `validate_environment`, ahead of any provider-specific transformer. Raising `BadRequestError` here fails the whole request for any legitimate non-OpenAI block (LangChain v1, provider-native, custom user shapes) even when the downstream transformer would handle it correctly. Skip is strictly more permissive: well-formed OpenAI blocks still yield their file_id, and non-OpenAI blocks stop crashing `validate_environment`.

Happy to coordinate with @krisxia0506 if this should land as a delta on top of #24503, or get rolled in there directly.

## Changes

| File | Change |
|---|---|
| `litellm/litellm_core_utils/prompt_templates/common_utils.py` | Defensive `.get(\"file\")` + `isinstance(..., dict)` check in `get_file_ids_from_messages` and `update_messages_with_model_file_ids`; skip the block if the sub-dict is missing or malformed. |
| `tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py` | 5 new regression tests (LangChain v1 shape, OpenAI happy path, mixed shapes, `file` set to a non-dict value, remap path for non-OpenAI blocks). |

## Tests

All 25 tests in `test_litellm_core_utils_prompt_templates_common_utils.py` pass locally:

```text
======================== 25 passed, 2 warnings in 0.40s ========================
```

New tests cover:

- `test_get_file_ids_from_messages_skips_langchain_v1_file_block`
- `test_get_file_ids_from_messages_still_extracts_from_openai_shape`
- `test_get_file_ids_from_messages_mixed_shapes`
- `test_get_file_ids_from_messages_file_field_not_dict`
- `test_update_messages_with_model_file_ids_skips_non_openai_file_blocks`