### PR TITLE
Fix/streaming cost injection alias resolution test

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1764,7 +1764,11 @@ class ProxyBaseLLMRequestProcessing:
                 elif isinstance(chunk, dict):
                     str_so_far += str(chunk.get("content", ""))
 
-                model_name = request_data.get("model", "")
+                model_name = (
+                    ProxyBaseLLMRequestProcessing._resolve_cost_injection_model_name(
+                        request_data
+                    )
+                )
                 chunk = (
                     ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(
                         chunk, model_name
@@ -1915,6 +1919,26 @@ class ProxyBaseLLMRequestProcessing:
             return None
         except Exception:
             return None
+
+    @staticmethod
+    def _resolve_cost_injection_model_name(request_data: dict) -> str:
+        """
+        Pick the model name to use for streaming cost injection.
+
+        `request_data["model"]` is the public alias a client sends
+        (mirroring `model_name:` in the proxy YAML). For YAML aliases
+        this is not priceable by `litellm.completion_cost`. The router
+        has already resolved the alias to the deployment's
+        provider-prefixed model (e.g. `bedrock/us.anthropic.claude-opus-4-7`)
+        and stamped it on the `LiteLLMLoggingObj` via
+        `update_environment_variables(model=<deployment_model>)` inside
+        `litellm.completion()` — same instance that's on
+        `request_data["litellm_logging_obj"]`. Prefer that resolved name
+        and fall back to the raw request value only when it is missing.
+        """
+        logging_obj = request_data.get("litellm_logging_obj")
+        resolved = getattr(logging_obj, "model", None) if logging_obj else None
+        return resolved or request_data.get("model", "") or ""
 
     @staticmethod
     def _inject_cost_into_usage_dict(obj: dict, model_name: str) -> Optional[dict]:

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2035,23 +2035,20 @@ class TestInjectCostAliasResolution:
     Regression tests for the streaming cost-injection path introduced in
     #15102.
 
-    When a client sends a request using a user-defined alias (declared in
-    the proxy YAML as `model_name: opus-4.7`), `request_data["model"]` is
-    the alias string. `async_streaming_data_generator` reads it and hands
-    it straight to `_inject_cost_into_usage_dict`, which then calls
-    `litellm.completion_cost(model=<alias>)`. `completion_cost` cannot
-    price an unknown alias that has no provider prefix, so it raises
-    `BadRequestError: LLM Provider NOT provided`. The raise is swallowed
-    by `except Exception: cost_val = None` and cost is silently dropped
-    from the SSE `message_delta` event.
+    When a client sends a request using a proxy-level alias (declared in
+    the YAML as `model_name: opus-4.7`), `request_data["model"]` is the
+    alias string. Before this fix, `async_streaming_data_generator` handed
+    that alias straight to `litellm.completion_cost`, which cannot price
+    an unknown, unprefixed name and raised `LLM Provider NOT provided`.
+    The raise was swallowed by `except Exception: cost_val = None`,
+    silently dropping cost from the SSE `message_delta` event. Post-stream
+    logging was unaffected because it reads the resolved
+    `litellm_params.model` off the logging obj.
 
-    Post-stream logging (Prometheus/Braintrust/response headers) is
-    unaffected because it reads the resolved `litellm_params.model` off
-    the logging obj — only the in-stream injected cost is broken.
-
-    Fix: resolve the alias to the underlying deployment's
-    provider-prefixed model (e.g. `bedrock/us.anthropic.claude-opus-4-7`)
-    before pricing.
+    Fix: read the resolved deployment model the router already stamped on
+    `request_data["litellm_logging_obj"].model` (set inside
+    `litellm.completion()` via `update_environment_variables`) and use
+    that for pricing. No router lookup needed — the info is already there.
     """
 
     @staticmethod
@@ -2063,41 +2060,86 @@ class TestInjectCostAliasResolution:
 
     def test_cost_is_injected_when_model_is_provider_prefixed(self):
         """
-        Control: a provider-prefixed model name that exists in the
-        bundled model registry prices successfully and cost is injected.
+        Control: the leaf helper prices a provider-prefixed model directly.
+        Documents the contract callers must satisfy.
         """
         result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
             self._usage_event(), "bedrock/us.anthropic.claude-opus-4-7"
         )
-        assert result is not None, (
-            "control: provider-prefixed model should price successfully"
-        )
+        assert result is not None
         assert isinstance(result["usage"].get("cost"), float)
         assert result["usage"]["cost"] > 0
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: _inject_cost_into_usage_dict passes the raw "
-            "client-facing alias to litellm.completion_cost, which cannot "
-            "price an unprefixed, unknown alias and raises. The raise is "
-            "swallowed and cost is silently dropped. Fix: resolve the "
-            "alias to the underlying deployment model before pricing."
-        ),
-    )
-    def test_cost_is_injected_when_model_is_client_facing_alias(self):
+    def test_inject_cost_with_unresolved_alias_returns_none(self):
         """
-        A user-defined alias (`opus-4.7`) is not in litellm's registry
-        and has no provider prefix, so `completion_cost` raises.
-        Expected post-fix: the alias resolves to its deployment and cost
-        is injected just like the control test above.
+        Constraint documentation: `_inject_cost_into_usage_dict` does not
+        itself resolve aliases. Handed an unprefixed alias, pricing fails,
+        the exception is swallowed, and no cost is injected. Callers are
+        responsible for resolving first — that is what
+        `_resolve_cost_injection_model_name` is for.
         """
         result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
             self._usage_event(), "opus-4.7"
         )
-        assert result is not None, (
-            "expected cost injection, but completion_cost() raised on "
-            "the alias and the exception was swallowed"
+        assert result is None
+
+    def test_resolve_prefers_logging_obj_over_request_data(self):
+        """
+        Fix: when the router has stamped the deployment model on the
+        logging obj, use it instead of the client-facing alias.
+        """
+        logging_obj = MagicMock()
+        logging_obj.model = "bedrock/us.anthropic.claude-opus-4-7"
+        request_data = {"model": "opus-4.7", "litellm_logging_obj": logging_obj}
+
+        resolved = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model_name(
+            request_data
         )
+        assert resolved == "bedrock/us.anthropic.claude-opus-4-7"
+
+    def test_resolve_falls_back_when_logging_obj_has_no_model(self):
+        """
+        If the logging obj is present but `.model` is unset, the raw
+        request value is used. Keeps non-router / early-lifecycle paths
+        working.
+        """
+        logging_obj = MagicMock(spec=[])  # no .model attribute
+        request_data = {"model": "opus-4.7", "litellm_logging_obj": logging_obj}
+
+        resolved = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model_name(
+            request_data
+        )
+        assert resolved == "opus-4.7"
+
+    def test_resolve_falls_back_when_no_logging_obj(self):
+        """No logging obj on `request_data` → return the raw request model."""
+        resolved = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model_name(
+            {"model": "gpt-4o"}
+        )
+        assert resolved == "gpt-4o"
+
+    def test_resolve_returns_empty_string_when_nothing_available(self):
+        """Empty dict → empty string (matches pre-fix default)."""
+        resolved = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model_name({})
+        assert resolved == ""
+
+    def test_resolve_plus_inject_end_to_end(self):
+        """
+        End-to-end of the two pieces that compose the fix: resolver reads
+        the deployment model from the logging obj, and the leaf helper
+        prices that name successfully.
+        """
+        logging_obj = MagicMock()
+        logging_obj.model = "bedrock/us.anthropic.claude-opus-4-7"
+        request_data = {"model": "opus-4.7", "litellm_logging_obj": logging_obj}
+
+        model_name = ProxyBaseLLMRequestProcessing._resolve_cost_injection_model_name(
+            request_data
+        )
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
+            self._usage_event(), model_name
+        )
+
+        assert result is not None
         assert isinstance(result["usage"].get("cost"), float)
         assert result["usage"]["cost"] > 0

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2028,3 +2028,76 @@ class TestHandleLLMApiExceptionDictDetail:
         proxy_exc = await self._invoke(exc)
         assert proxy_exc.message == "Content blocked by guardrail"
         assert proxy_exc.provider_specific_fields is None
+
+
+class TestInjectCostAliasResolution:
+    """
+    Regression tests for the streaming cost-injection path introduced in
+    #15102.
+
+    When a client sends a request using a user-defined alias (declared in
+    the proxy YAML as `model_name: opus-4.7`), `request_data["model"]` is
+    the alias string. `async_streaming_data_generator` reads it and hands
+    it straight to `_inject_cost_into_usage_dict`, which then calls
+    `litellm.completion_cost(model=<alias>)`. `completion_cost` cannot
+    price an unknown alias that has no provider prefix, so it raises
+    `BadRequestError: LLM Provider NOT provided`. The raise is swallowed
+    by `except Exception: cost_val = None` and cost is silently dropped
+    from the SSE `message_delta` event.
+
+    Post-stream logging (Prometheus/Braintrust/response headers) is
+    unaffected because it reads the resolved `litellm_params.model` off
+    the logging obj — only the in-stream injected cost is broken.
+
+    Fix: resolve the alias to the underlying deployment's
+    provider-prefixed model (e.g. `bedrock/us.anthropic.claude-opus-4-7`)
+    before pricing.
+    """
+
+    @staticmethod
+    def _usage_event() -> dict:
+        return {
+            "type": "message_delta",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        }
+
+    def test_cost_is_injected_when_model_is_provider_prefixed(self):
+        """
+        Control: a provider-prefixed model name that exists in the
+        bundled model registry prices successfully and cost is injected.
+        """
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
+            self._usage_event(), "bedrock/us.anthropic.claude-opus-4-7"
+        )
+        assert result is not None, (
+            "control: provider-prefixed model should price successfully"
+        )
+        assert isinstance(result["usage"].get("cost"), float)
+        assert result["usage"]["cost"] > 0
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: _inject_cost_into_usage_dict passes the raw "
+            "client-facing alias to litellm.completion_cost, which cannot "
+            "price an unprefixed, unknown alias and raises. The raise is "
+            "swallowed and cost is silently dropped. Fix: resolve the "
+            "alias to the underlying deployment model before pricing."
+        ),
+    )
+    def test_cost_is_injected_when_model_is_client_facing_alias(self):
+        """
+        A user-defined alias (`opus-4.7`) is not in litellm's registry
+        and has no provider prefix, so `completion_cost` raises.
+        Expected post-fix: the alias resolves to its deployment and cost
+        is injected just like the control test above.
+        """
+        result = ProxyBaseLLMRequestProcessing._inject_cost_into_usage_dict(
+            self._usage_event(), "opus-4.7"
+        )
+        assert result is not None, (
+            "expected cost injection, but completion_cost() raised on "
+            "the alias and the exception was swallowed"
+        )
+        assert isinstance(result["usage"].get("cost"), float)
+        assert result["usage"]["cost"] > 0


### PR DESCRIPTION
## Relevant issues

https://github.com/BerriAI/litellm/pull/15102

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

First commit with a failing test, second commit with the fix and green test.

## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

Streaming cost injection (`include_cost_in_streaming_usage`) silently drops cost                                                                                                                                 
  from `message_delta` events when the client uses a proxy-level YAML alias.
                                                                                                                                                                                                                   
  `async_streaming_data_generator` passed `request_data["model"]` — the raw alias,                                                                                                                                 
  e.g. `opus-4.7` — to `litellm.completion_cost`. `completion_cost` can't price an                                                                                                                                 
  unknown, unprefixed name and raises `LLM Provider NOT provided`. The raise is                                                                                                                                    
  swallowed by `except Exception: cost_val = None` and no cost is injected.                                                                                                                                        
  Post-stream logging (Prometheus/Braintrust/`x-litellm-response-cost` header) is                                                                                                                                  
  unaffected because it reads the resolved `litellm_params.model` off the logging                                                                                                                                  
  obj — only the in-stream cost was broken.     
  


Read the resolved deployment model the router already stamped on                                                                                                                                                 
  `request_data["litellm_logging_obj"].model` (set inside `litellm.completion()`
  via `update_environment_variables`) and use that for pricing. Falls back to the                                                                                                                                  
  raw `request_data["model"]` when the logging obj isn't populated yet.                                                                                                                                            
   
  No new router lookup — the info is already there, same source post-stream cost                                                                                                                                   
  uses, so in-stream and post-stream cost can't disagree.