### PR TITLE
fix(azure/responses): strip non-'ctc' id from custom_tool_call input items

### DIFF
--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -33,18 +33,10 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         Azure Responses API does not support context_management (compaction).
         """
         base_supported_params = super().get_supported_openai_params(model)
-        return [
-            param
-            for param in base_supported_params
-            if param not in self.AZURE_UNSUPPORTED_PARAMS
-        ]
+        return [param for param in base_supported_params if param not in self.AZURE_UNSUPPORTED_PARAMS]
 
-    def validate_environment(
-        self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]
-    ) -> dict:
-        return BaseAzureLLM._base_validate_azure_environment(
-            headers=headers, litellm_params=litellm_params
-        )
+    def validate_environment(self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]) -> dict:
+        return BaseAzureLLM._base_validate_azure_environment(headers=headers, litellm_params=litellm_params)
 
     def get_stripped_model_name(self, model: str) -> str:
         # if "responses/" is in the model name, remove it
@@ -81,32 +73,57 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
                 return dict_reasoning_item
             except Exception as e:
-                verbose_logger.debug(
-                    f"Failed to create ResponseReasoningItem, falling back to manual filtering: {e}"
-                )
+                verbose_logger.debug(f"Failed to create ResponseReasoningItem, falling back to manual filtering: {e}")
                 # Fallback: manually filter out known None fields
                 filtered_item = {
                     k: v
                     for k, v in item.items()
-                    if v is not None
-                    or k not in {"status", "content", "encrypted_content"}
+                    if v is not None or k not in {"status", "content", "encrypted_content"}
                 }
                 return filtered_item
         return item
 
-    def _validate_input_param(
-        self, input: Union[str, ResponseInputParam]
-    ) -> Union[str, ResponseInputParam]:
+    def _handle_custom_tool_call_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Override parent method to also filter out 'status' field from message items.
-        Azure OpenAI API does not accept 'status' field in input messages.
+        Handle custom_tool_call items to strip an 'id' that does not start with 'ctc'.
+
+        Azure OpenAI Responses API requires that the 'id' of a custom_tool_call
+        input item begins with 'ctc' (e.g. 'ctc_...'). When a conversation is
+        continued across providers (e.g. an OpenAI-generated response whose
+        custom_tool_call id starts with 'fc_' is replayed against Azure), Azure
+        rejects the request with:
+
+            Invalid 'input[N].id': '<id>'. Expected an ID that begins with 'ctc'.
+
+        Azure generates its own id when the field is omitted, so we strip the
+        offending id rather than attempt to rewrite it. ids that already begin
+        with 'ctc' are preserved untouched.
+        """
+        if item.get("type") != "custom_tool_call":
+            return item
+        item_id = item.get("id")
+        if isinstance(item_id, str) and not item_id.startswith("ctc"):
+            verbose_logger.debug(
+                "Stripping non-'ctc' id %r from custom_tool_call input item for Azure.",
+                item_id,
+            )
+            filtered_item = {k: v for k, v in item.items() if k != "id"}
+            return filtered_item
+        return item
+
+    def _validate_input_param(self, input: Union[str, ResponseInputParam]) -> Union[str, ResponseInputParam]:
+        """
+        Override parent method to also filter Azure-specific input constraints:
+        - 'status' field is removed from 'message' items.
+        - 'id' is removed from 'custom_tool_call' items whose id does not
+          start with 'ctc' (Azure-required prefix).
         """
         from typing import cast
 
         # First call parent's validation
         validated_input = super()._validate_input_param(input)
 
-        # Then filter out status from message items
+        # Apply Azure-specific per-item filters
         if isinstance(validated_input, list):
             filtered_input: List[Any] = []
             for item in validated_input:
@@ -114,6 +131,8 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
                     # Filter out status field from message items
                     filtered_item = {k: v for k, v in item.items() if k != "status"}
                     filtered_input.append(filtered_item)
+                elif isinstance(item, dict) and item.get("type") == "custom_tool_call":
+                    filtered_input.append(self._handle_custom_tool_call_item(cast(Dict[str, Any], item)))
                 else:
                     filtered_input.append(item)
             return cast(ResponseInputParam, filtered_input)
@@ -187,9 +206,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
     #########################################################
     ########## DELETE RESPONSE API TRANSFORMATION ##############
     #########################################################
-    def _construct_url_for_response_id_in_path(
-        self, api_base: str, response_id: str
-    ) -> str:
+    def _construct_url_for_response_id_in_path(self, api_base: str, response_id: str) -> str:
         """
         Constructs a URL for the API request with the response_id in the path.
         """
@@ -232,9 +249,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         This function handles URLs with query parameters by inserting the response_id
         at the correct location (before any query parameters).
         """
-        delete_url = self._construct_url_for_response_id_in_path(
-            api_base=api_base, response_id=response_id
-        )
+        delete_url = self._construct_url_for_response_id_in_path(api_base=api_base, response_id=response_id)
 
         data: Dict = {}
         verbose_logger.debug(f"delete response url={delete_url}")
@@ -256,9 +271,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         OpenAI API expects the following request
         - GET /v1/responses/{response_id}
         """
-        get_url = self._construct_url_for_response_id_in_path(
-            api_base=api_base, response_id=response_id
-        )
+        get_url = self._construct_url_for_response_id_in_path(api_base=api_base, response_id=response_id)
         data: Dict = {}
         verbose_logger.debug(f"get response url={get_url}")
         return get_url, data
@@ -275,12 +288,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         limit: int = 20,
         order: Literal["asc", "desc"] = "desc",
     ) -> Tuple[str, Dict]:
-        url = (
-            self._construct_url_for_response_id_in_path(
-                api_base=api_base, response_id=response_id
-            )
-            + "/input_items"
-        )
+        url = self._construct_url_for_response_id_in_path(api_base=api_base, response_id=response_id) + "/input_items"
         params: Dict[str, Any] = {}
         if after is not None:
             params["after"] = after
@@ -353,7 +361,5 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         except Exception:
             from litellm.llms.azure.chat.gpt_transformation import AzureOpenAIError
 
-            raise AzureOpenAIError(
-                message=raw_response.text, status_code=raw_response.status_code
-            )
+            raise AzureOpenAIError(message=raw_response.text, status_code=raw_response.status_code)
         return ResponsesAPIResponse(**raw_response_json)

--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -5,9 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 from unittest.mock import MagicMock
 
@@ -24,9 +22,7 @@ def test_validate_environment_api_key_within_litellm_params():
     azure_openai_responses_apiconfig = AzureOpenAIResponsesAPIConfig()
     litellm_params = GenericLiteLLMParams(api_key="test-api-key")
 
-    result = azure_openai_responses_apiconfig.validate_environment(
-        headers={}, model="", litellm_params=litellm_params
-    )
+    result = azure_openai_responses_apiconfig.validate_environment(headers={}, model="", litellm_params=litellm_params)
 
     expected = {"api-key": "test-api-key"}
 
@@ -87,9 +83,7 @@ def test_get_complete_url():
     api_base = "https://litellm8397336933.openai.azure.com"
     litellm_params = {"api_version": "2024-05-01-preview"}
 
-    result = azure_openai_responses_apiconfig.get_complete_url(
-        api_base=api_base, litellm_params=litellm_params
-    )
+    result = azure_openai_responses_apiconfig.get_complete_url(api_base=api_base, litellm_params=litellm_params)
 
     expected = "https://litellm8397336933.openai.azure.com/openai/responses?api-version=2024-05-01-preview"
 
@@ -118,9 +112,7 @@ def test_azure_o_series_responses_api_drop_temperature_param():
     config = AzureOpenAIOSeriesResponsesAPIConfig()
 
     # Create request params with temperature
-    request_params = ResponsesAPIOptionalRequestParams(
-        temperature=0.7, max_output_tokens=1000, stream=False, top_p=0.9
-    )
+    request_params = ResponsesAPIOptionalRequestParams(temperature=0.7, max_output_tokens=1000, stream=False, top_p=0.9)
 
     # Test with drop_params=True
     mapped_params_with_drop = config.map_openai_params(
@@ -154,9 +146,7 @@ def test_azure_o_series_responses_api_drop_params_no_temperature():
     config = AzureOpenAIOSeriesResponsesAPIConfig()
 
     # Create request params without temperature
-    request_params = ResponsesAPIOptionalRequestParams(
-        max_output_tokens=1000, stream=False, top_p=0.9
-    )
+    request_params = ResponsesAPIOptionalRequestParams(max_output_tokens=1000, stream=False, top_p=0.9)
 
     # Should work fine even with drop_params=True
     mapped_params = config.map_openai_params(
@@ -242,30 +232,21 @@ class TestAzureResponsesAPIConfig:
             api_base=base_url,
             litellm_params={"api_version": "preview"},
         )
-        assert (
-            result_preview
-            == "https://litellm8397336933.openai.azure.com/openai/v1/responses?api-version=preview"
-        )
+        assert result_preview == "https://litellm8397336933.openai.azure.com/openai/v1/responses?api-version=preview"
 
         # Test with latest version - should use openai/v1/responses
         result_latest = self.config.get_complete_url(
             api_base=base_url,
             litellm_params={"api_version": "latest"},
         )
-        assert (
-            result_latest
-            == "https://litellm8397336933.openai.azure.com/openai/v1/responses?api-version=latest"
-        )
+        assert result_latest == "https://litellm8397336933.openai.azure.com/openai/v1/responses?api-version=latest"
 
         # Test with date-based version - should use openai/responses
         result_date = self.config.get_complete_url(
             api_base=base_url,
             litellm_params={"api_version": "2025-01-01"},
         )
-        assert (
-            result_date
-            == "https://litellm8397336933.openai.azure.com/openai/responses?api-version=2025-01-01"
-        )
+        assert result_date == "https://litellm8397336933.openai.azure.com/openai/responses?api-version=2025-01-01"
 
     def test_azure_get_complete_url_with_default_api_version(self):
         """Test Azure get_complete_url uses default API version when none is provided"""
@@ -311,7 +292,9 @@ class TestAzureResponsesAPIConfig:
             headers=headers,
         )
 
-        expected_url = "https://test.openai.azure.com/openai/responses/resp_test123/cancel?api-version=2024-05-01-preview"
+        expected_url = (
+            "https://test.openai.azure.com/openai/responses/resp_test123/cancel?api-version=2024-05-01-preview"
+        )
         assert url == expected_url
         assert data == {}
 
@@ -502,3 +485,98 @@ class TestAzureResponsesAPIConfig:
         """
         supported = self.config.get_supported_openai_params(self.model)
         assert "context_management" not in supported
+
+    # ------------------------------------------------------------------
+    # custom_tool_call id sanitization
+    # ------------------------------------------------------------------
+
+    def test_handle_custom_tool_call_item_strips_non_ctc_id(self):
+        """Azure rejects custom_tool_call ids that don't start with 'ctc'.
+
+        Cross-provider continuations (e.g. OpenAI -> Azure) replay items whose
+        id begins with 'fc_'. We strip the id so Azure can assign its own.
+        """
+        item = {
+            "type": "custom_tool_call",
+            "id": "fc_0faf4ac39d04a3c60069e79b9d30348197b37bae4e42072a2c",
+            "name": "get_weather",
+            "input": '{"city": "Seattle"}',
+            "call_id": "call_abc",
+        }
+        result = self.config._handle_custom_tool_call_item(item)
+        assert "id" not in result
+        # Other fields must be preserved verbatim.
+        assert result["type"] == "custom_tool_call"
+        assert result["name"] == "get_weather"
+        assert result["input"] == '{"city": "Seattle"}'
+        assert result["call_id"] == "call_abc"
+        # Original item must not be mutated in place.
+        assert item["id"] == "fc_0faf4ac39d04a3c60069e79b9d30348197b37bae4e42072a2c"
+
+    def test_handle_custom_tool_call_item_preserves_ctc_id(self):
+        """Ids that already start with 'ctc' are Azure-valid and untouched."""
+        item = {
+            "type": "custom_tool_call",
+            "id": "ctc_123abc",
+            "name": "get_weather",
+            "input": "{}",
+            "call_id": "call_xyz",
+        }
+        result = self.config._handle_custom_tool_call_item(item)
+        assert result == item
+        assert result["id"] == "ctc_123abc"
+
+    def test_handle_custom_tool_call_item_ignores_other_types(self):
+        """Non custom_tool_call items are returned unchanged, even with fc_ id."""
+        for other_type in ("function_call", "reasoning", "message"):
+            item = {"type": other_type, "id": "fc_should_not_be_stripped"}
+            assert self.config._handle_custom_tool_call_item(item) == item
+
+    def test_handle_custom_tool_call_item_no_id(self):
+        """Items without an id are returned unchanged."""
+        item = {"type": "custom_tool_call", "name": "get_weather", "input": "{}"}
+        assert self.config._handle_custom_tool_call_item(item) == item
+
+    def test_handle_custom_tool_call_item_non_string_id(self):
+        """Non-string ids (unexpected shape) are left alone rather than stripped."""
+        item = {"type": "custom_tool_call", "id": 123}
+        assert self.config._handle_custom_tool_call_item(item) == item
+
+    def test_validate_input_param_strips_non_ctc_custom_tool_call_id(self):
+        """End-to-end: _validate_input_param dispatches custom_tool_call items."""
+        input_items = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": "what's the weather in Seattle?",
+                "status": "completed",
+            },
+            {
+                "type": "custom_tool_call",
+                "id": "fc_abc",
+                "name": "get_weather",
+                "input": '{"city": "Seattle"}',
+                "call_id": "call_1",
+            },
+            {
+                "type": "custom_tool_call",
+                "id": "ctc_keep_me",
+                "name": "get_weather",
+                "input": "{}",
+                "call_id": "call_2",
+            },
+        ]
+        result = self.config._validate_input_param(input_items)
+        assert isinstance(result, list)
+        # message: status removed
+        assert "status" not in result[0]
+        assert result[0]["role"] == "user"
+        # non-ctc custom_tool_call: id removed
+        assert "id" not in result[1]
+        assert result[1]["name"] == "get_weather"
+        # ctc-prefixed custom_tool_call: id preserved
+        assert result[2]["id"] == "ctc_keep_me"
+
+    def test_validate_input_param_string_input_untouched(self):
+        """String inputs should pass through without modification."""
+        assert self.config._validate_input_param("hello") == "hello"


### PR DESCRIPTION
## Title
fix(azure/responses): strip non-'ctc' id from `custom_tool_call` input items

## Relevant issues
Companion to #26221, which correctly stripped `namespace` from `custom_tool_call` items. This PR addresses a second, independent Azure-specific issue that surfaces once `namespace` is fixed.

## Pre-Submission checklist
- [x] I have added a new test for my fix
- [x] I have run the new tests locally (`pytest tests/test_litellm/llms/azure/response/test_azure_transformation.py` → 28 passed)

## Type
🐛 Bug Fix

## Problem

Azure OpenAI's Responses API requires the `id` of a `custom_tool_call` input item to begin with `ctc` (e.g. `ctc_...`). When a conversation is replayed across providers — for example, an OpenAI-generated `custom_tool_call` whose id begins with `fc_` is fed back to an Azure-deployed model — Azure rejects the request with:

```
Error code: 400 - Invalid 'input[1].id': 'fc_0faf4ac39d04a3c60069e79b9d30348197b37bae4e42072a2c'. Expected an ID that begins with 'ctc'.
```

Reproduction (after #26221 is in place, so `namespace` is no longer the problem): POST `/v1/responses` to an Azure-backed deployment with input containing a prior `custom_tool_call` item whose `id` is `fc_...`.

This is orthogonal to the `namespace` stripping done in #26221 — that PR handles parameters LiteLLM itself injects; this PR handles ids that originate from a different upstream provider and flow back into an Azure request.

## Changes

- Add `_handle_custom_tool_call_item` to `AzureOpenAIResponsesAPIConfig`, mirroring the existing `_handle_reasoning_item` precedent.
- If the item is a `custom_tool_call` with a string `id` that does not start with `'ctc'`, drop the `id` (Azure assigns its own when omitted). Ids already prefixed with `ctc` are preserved untouched. Other fields and other item types are unchanged.
- Dispatch from `_validate_input_param` alongside the existing `message` handler. Stripping is intentionally scoped to `custom_tool_call` only, so nothing else is altered.

## Tests

Added 7 focused unit tests in `tests/test_litellm/llms/azure/response/test_azure_transformation.py::TestAzureResponsesAPIConfig`:

1. `test_handle_custom_tool_call_item_strips_non_ctc_id` — non-`ctc` id removed; other fields preserved; original item not mutated.
2. `test_handle_custom_tool_call_item_preserves_ctc_id` — `ctc_`-prefixed id kept as-is.
3. `test_handle_custom_tool_call_item_ignores_other_types` — `function_call` / `reasoning` / `message` items not touched.
4. `test_handle_custom_tool_call_item_no_id` — items without `id` unchanged.
5. `test_handle_custom_tool_call_item_non_string_id` — non-string ids left alone.
6. `test_validate_input_param_strips_non_ctc_custom_tool_call_id` — end-to-end dispatch through `_validate_input_param` (mixed message + non-ctc + ctc ids).
7. `test_validate_input_param_string_input_untouched` — string `input` passes through unchanged.

Full file runs clean: `28 passed, 11 warnings in 0.47s`.
