### PR TITLE
fix(proxy): skip redundant tiktoken recount when provider supplies reasoning_tokens

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5058,12 +5058,25 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
     return valid_string
 
 
-def add_cache_point_tool_block(tool: dict) -> Optional[BedrockToolBlock]:
+def add_cache_point_tool_block(
+    tool: dict, model: Optional[str] = None
+) -> Optional[BedrockToolBlock]:
+    from litellm.llms.bedrock.common_utils import is_claude_4_5_on_bedrock
+
     cache_control = tool.get("cache_control", None)
     if cache_control is not None:
         cache_point = cache_control.get("type", "ephemeral")
         if cache_point == "ephemeral":
-            return {"cachePoint": {"type": "default"}}
+            cache_point_block: CachePointBlock = {"type": "default"}
+            if isinstance(cache_control, dict) and "ttl" in cache_control:
+                ttl = cache_control["ttl"]
+                if (
+                    ttl in ["5m", "1h"]
+                    and model is not None
+                    and is_claude_4_5_on_bedrock(model)
+                ):
+                    cache_point_block["ttl"] = ttl
+            return {"cachePoint": cache_point_block}
     return None
 
 
@@ -5093,7 +5106,9 @@ def _is_bedrock_tool_block(tool: dict) -> bool:
     )
 
 
-def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
+def _bedrock_tools_pt(
+    tools: List, model: Optional[str] = None
+) -> List[BedrockToolBlock]:
     """
     OpenAI tools looks like:
     tools = [
@@ -5209,7 +5224,7 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
         tool_block_list.append(tool_block)
 
         ## ADD CACHE POINT TOOL BLOCK ##
-        cache_point_tool_block = add_cache_point_tool_block(tool)
+        cache_point_tool_block = add_cache_point_tool_block(tool, model=model)
         if cache_point_tool_block is not None:
             tool_block_list.append(cache_point_tool_block)
 
@@ -5276,9 +5291,7 @@ def default_response_schema_prompt(response_schema: dict) -> str:
     prompt_str = """Use this JSON schema: 
     ```json 
     {}
-    ```""".format(
-        response_schema
-    )
+    ```""".format(response_schema)
     return prompt_str
 
 

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -508,6 +508,52 @@ class ChunkProcessor:
             "prompt_tokens_details": prompt_tokens_details,
         }
 
+    def chunks_have_reasoning_tokens(
+        self,
+        chunks: List[Union[Dict[str, Any], ModelResponse]],
+    ) -> bool:
+        """
+        Return True if any streaming usage chunk already reports
+        completion_tokens_details.reasoning_tokens.
+
+        When the provider supplies this value, calculate_usage uses it
+        directly and discards any locally recomputed value (see
+        calculate_usage: reasoning_tokens is only applied when
+        completion_tokens_details.reasoning_tokens is None). The local
+        recount via count_reasoning_tokens calls tiktoken.encode() which
+        holds the GIL and blocks the asyncio event loop on large reasoning
+        responses, so skipping it in this common case avoids liveness-probe
+        timeouts without changing any observable output.
+        """
+        for chunk in chunks:
+            usage: Any = None
+            if isinstance(chunk, dict):
+                usage = chunk.get("usage")
+            else:
+                usage = getattr(chunk, "usage", None)
+                if usage is None and hasattr(chunk, "_hidden_params"):
+                    hidden = chunk._hidden_params
+                    if isinstance(hidden, dict):
+                        usage = hidden.get("usage")
+            if usage is None:
+                continue
+
+            details: Any = None
+            if isinstance(usage, dict):
+                details = usage.get("completion_tokens_details")
+            elif hasattr(usage, "completion_tokens_details"):
+                details = usage.completion_tokens_details
+            if details is None:
+                continue
+
+            if isinstance(details, dict):
+                reasoning_tokens = details.get("reasoning_tokens")
+            else:
+                reasoning_tokens = getattr(details, "reasoning_tokens", None)
+            if reasoning_tokens is not None:
+                return True
+        return False
+
     def count_reasoning_tokens(self, response: ModelResponse) -> Optional[int]:
         reasoning_tokens: Optional[int] = None
         for choice in response.choices:

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1299,7 +1299,7 @@ class AmazonConverseConfig(BaseConfig):
             )
 
             # Process regular function tools using existing logic
-            bedrock_tools = _bedrock_tools_pt(regular_tools)
+            bedrock_tools = _bedrock_tools_pt(regular_tools, model=model)
 
             # Add computer use tools and anthropic_beta if needed (only when computer use tools are present)
             if computer_use_tools:
@@ -1367,7 +1367,7 @@ class AmazonConverseConfig(BaseConfig):
                 additional_request_params["tools"] = transformed_computer_tools
         else:
             # No computer use tools, process all tools as regular tools
-            bedrock_tools = _bedrock_tools_pt(filtered_tools)
+            bedrock_tools = _bedrock_tools_pt(filtered_tools, model=model)
 
         # Append pre-formatted tools (systemTool etc.) after transformation
         bedrock_tools.extend(pre_formatted_tools)

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -132,7 +132,7 @@ class AmazonAnthropicClaudeMessagesConfig(
         - `scope` (e.g., "global") - always removed
         - `ttl` - removed for older models; Claude 4.5+ supports "5m" and "1h"
 
-        Processes both `system` and `messages` content blocks.
+        Processes `tools`, `system`, and `messages` content blocks.
 
         Args:
             anthropic_messages_request: The request dictionary to modify in-place
@@ -158,6 +158,12 @@ class AmazonAnthropicClaudeMessagesConfig(
             for item in content:
                 if isinstance(item, dict) and "cache_control" in item:
                     _sanitize_cache_control(item["cache_control"])
+
+        # Process tools
+        if "tools" in anthropic_messages_request:
+            for tool in anthropic_messages_request["tools"]:
+                if isinstance(tool, dict) and "cache_control" in tool:
+                    _sanitize_cache_control(tool["cache_control"])
 
         # Process system (list of content blocks)
         if "system" in anthropic_messages_request:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7619,7 +7619,15 @@ def stream_chunk_builder(  # noqa: PLR0915
 
         completion_output = get_content_from_model_response(response)
 
-        reasoning_tokens = processor.count_reasoning_tokens(response)
+        # Skip the local tiktoken recount when the provider already reports
+        # reasoning_tokens in a streaming usage chunk. calculate_usage would
+        # discard the recomputed value anyway, and tiktoken.encode() holds
+        # the GIL for tens of seconds on large reasoning responses — long
+        # enough to fail liveness probes and get pods killed.
+        if processor.chunks_have_reasoning_tokens(chunks):
+            reasoning_tokens = None
+        else:
+            reasoning_tokens = processor.count_reasoning_tokens(response)
 
         usage = processor.calculate_usage(
             chunks=chunks,

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2367,3 +2367,112 @@ def test_anthropic_messages_pt_file_block_preserves_cache_control():
     assert text_block["type"] == "text"
     assert "cache_control" in text_block
     assert text_block["cache_control"]["type"] == "ephemeral"
+
+
+def test_add_cache_point_tool_block_passes_ttl_for_claude_4_5():
+    """
+    Tools with cache_control ttl should preserve the ttl in the cachePoint
+    block for Claude 4.5+ models on Bedrock, matching the behavior of system
+    block cache_control.
+
+    Without this fix, tool cachePoint is always {"type": "default"} (5m),
+    while system blocks can have ttl="1h", violating Bedrock's non-increasing
+    TTL ordering constraint (tools -> system -> messages).
+
+    Ref: https://github.com/BerriAI/litellm/issues/XXXXX
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        add_cache_point_tool_block,
+    )
+
+    tool_with_1h = {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+    }
+
+    # Claude 4.5 model: ttl should be preserved
+    result = add_cache_point_tool_block(
+        tool_with_1h, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    assert result is not None
+    assert result["cachePoint"]["type"] == "default"
+    assert result["cachePoint"]["ttl"] == "1h"
+
+    # Claude 4.5 model with 5m ttl: also preserved
+    tool_with_5m = {
+        "cache_control": {"type": "ephemeral", "ttl": "5m"},
+    }
+    result_5m = add_cache_point_tool_block(
+        tool_with_5m, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    assert result_5m is not None
+    assert result_5m["cachePoint"]["ttl"] == "5m"
+
+    # Older model: ttl should be stripped
+    result_old = add_cache_point_tool_block(
+        tool_with_1h, model="anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+    assert result_old is not None
+    assert result_old["cachePoint"]["type"] == "default"
+    assert "ttl" not in result_old["cachePoint"]
+
+    # No model provided: ttl should be stripped (safe default)
+    result_no_model = add_cache_point_tool_block(tool_with_1h, model=None)
+    assert result_no_model is not None
+    assert "ttl" not in result_no_model["cachePoint"]
+
+    # No cache_control: returns None (unchanged behavior)
+    tool_no_cache = {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+    assert add_cache_point_tool_block(tool_no_cache) is None
+
+    # cache_control without ttl: returns default cachePoint (unchanged behavior)
+    tool_no_ttl = {"cache_control": {"type": "ephemeral"}}
+    result_no_ttl = add_cache_point_tool_block(
+        tool_no_ttl, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    assert result_no_ttl is not None
+    assert result_no_ttl["cachePoint"]["type"] == "default"
+    assert "ttl" not in result_no_ttl["cachePoint"]
+
+
+def test_bedrock_tools_pt_passes_ttl_for_claude_4_5():
+    """
+    End-to-end: _bedrock_tools_pt should produce cachePoint blocks with ttl
+    for Claude 4.5+ models when tools have cache_control with ttl.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+        }
+    ]
+
+    # Claude 4.5: cachePoint should have ttl
+    result = _bedrock_tools_pt(
+        tools, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    cache_blocks = [b for b in result if "cachePoint" in b]
+    assert len(cache_blocks) == 1
+    assert cache_blocks[0]["cachePoint"]["ttl"] == "1h"
+
+    # Older model: cachePoint should not have ttl
+    result_old = _bedrock_tools_pt(
+        tools, model="anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+    cache_blocks_old = [b for b in result_old if "cachePoint" in b]
+    assert len(cache_blocks_old) == 1
+    assert "ttl" not in cache_blocks_old[0]["cachePoint"]

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProces
 from litellm.types.utils import (
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
+    CompletionTokensDetailsWrapper,
     Delta,
     Function,
     ModelResponseStream,
@@ -613,3 +614,109 @@ def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
     assert (
         response._hidden_params["provider_specific_fields"]["traffic_type"] == "default"
     )
+
+
+def _make_reasoning_chunk(
+    reasoning_tokens,
+    completion_tokens=10,
+    prompt_tokens=5,
+    reasoning_content="some reasoning content",
+):
+    """Build a minimal ModelResponseStream with optional reasoning_tokens usage."""
+    completion_details = (
+        CompletionTokensDetailsWrapper(reasoning_tokens=reasoning_tokens)
+        if reasoning_tokens is not None
+        else None
+    )
+    chunk = ModelResponseStream(
+        id="chatcmpl-reasoning-1",
+        created=1,
+        model="o1-mini",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="final answer", role="assistant"),
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=completion_tokens,
+            prompt_tokens=prompt_tokens,
+            total_tokens=completion_tokens + prompt_tokens,
+            completion_tokens_details=completion_details,
+            prompt_tokens_details=None,
+        ),
+    )
+    # Attach reasoning_content at the message level (how stream_chunk_builder
+    # sees the assembled response).
+    chunk.choices[0].delta.provider_specific_fields = {
+        "reasoning_content": reasoning_content
+    }
+    return chunk
+
+
+def test_chunks_have_reasoning_tokens_true_when_provider_supplies():
+    """Regression test for https://github.com/BerriAI/litellm/issues/26193.
+
+    When any streaming usage chunk already reports reasoning_tokens,
+    chunks_have_reasoning_tokens must return True so callers can skip the
+    expensive local tiktoken recount (which would be discarded downstream
+    by calculate_usage and which holds the GIL long enough to fail K8s
+    liveness probes on large reasoning responses).
+    """
+    chunks = [_make_reasoning_chunk(reasoning_tokens=12345)]
+    processor = ChunkProcessor(chunks=chunks)
+    assert processor.chunks_have_reasoning_tokens(chunks) is True
+
+
+def test_chunks_have_reasoning_tokens_false_when_provider_omits():
+    """When no streaming usage chunk reports reasoning_tokens, the caller
+    must still fall back to count_reasoning_tokens (the existing slow path)
+    so providers that don't supply usage are unaffected by the short-circuit.
+    """
+    chunks = [_make_reasoning_chunk(reasoning_tokens=None)]
+    processor = ChunkProcessor(chunks=chunks)
+    assert processor.chunks_have_reasoning_tokens(chunks) is False
+
+
+def test_chunks_have_reasoning_tokens_handles_dict_chunks():
+    """stream_chunk_builder accepts plain-dict chunks (e.g. from proxies).
+    The presence check must handle both ModelResponseStream objects and
+    dicts without raising."""
+    chunks = [
+        {
+            "id": "chatcmpl-reasoning-dict",
+            "choices": [{"finish_reason": "stop", "index": 0, "delta": {}}],
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 10,
+                "total_tokens": 15,
+                "completion_tokens_details": {"reasoning_tokens": 999},
+            },
+        }
+    ]
+    processor = ChunkProcessor(chunks=chunks)
+    assert processor.chunks_have_reasoning_tokens(chunks) is True
+
+
+def test_stream_chunk_builder_skips_count_reasoning_tokens_when_usage_present():
+    """End-to-end: stream_chunk_builder must not invoke the expensive
+    count_reasoning_tokens path when the provider already supplied
+    reasoning_tokens in a streaming usage chunk."""
+    from unittest.mock import patch
+
+    chunks = [_make_reasoning_chunk(reasoning_tokens=42)]
+
+    with patch.object(
+        ChunkProcessor,
+        "count_reasoning_tokens",
+        autospec=True,
+    ) as mock_count:
+        response = stream_chunk_builder(chunks=chunks)
+
+    assert response is not None
+    mock_count.assert_not_called()
+    # Provider-supplied reasoning_tokens is preserved on the final response.
+    assert response.usage.completion_tokens_details.reasoning_tokens == 42

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -467,6 +467,86 @@ def test_bedrock_invoke_messages_transform_converts_custom_tool_schema_type_to_o
     assert result["tools"][0]["type"] == "custom"
 
 
+def test_remove_ttl_from_cache_control_processes_tools():
+    """
+    Ensure _remove_ttl_from_cache_control also sanitizes cache_control on tools.
+
+    Without this, tools keep unsupported ttl values while system/messages have
+    them stripped, causing TTL ordering violations on Bedrock.
+    """
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    # Tools with ttl should have it stripped for non-Claude-4.5 models
+    request = {
+        "tools": [
+            {
+                "name": "get_weather",
+                "input_schema": {"type": "object"},
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            },
+            {
+                "name": "get_time",
+                "input_schema": {"type": "object"},
+            },
+        ],
+        "system": [
+            {
+                "type": "text",
+                "text": "You are helpful.",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            }
+        ],
+        "messages": [],
+    }
+
+    cfg._remove_ttl_from_cache_control(
+        request, model="anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+    # Tool ttl should be stripped
+    assert "ttl" not in request["tools"][0]["cache_control"]
+    assert request["tools"][0]["cache_control"]["type"] == "ephemeral"
+    # Tool without cache_control should be unchanged
+    assert "cache_control" not in request["tools"][1]
+    # System ttl should also be stripped
+    assert "ttl" not in request["system"][0]["cache_control"]
+
+
+def test_remove_ttl_from_cache_control_preserves_tools_ttl_for_claude_4_5():
+    """
+    For Claude 4.5+ models, ttl in ["5m", "1h"] should be preserved on tools,
+    just like it is for system and messages.
+    """
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    request = {
+        "tools": [
+            {
+                "name": "get_weather",
+                "input_schema": {"type": "object"},
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            },
+        ],
+        "system": [
+            {
+                "type": "text",
+                "text": "You are helpful.",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            }
+        ],
+    }
+
+    cfg._remove_ttl_from_cache_control(
+        request, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+
+    # Both tools and system should preserve ttl for Claude 4.5
+    assert request["tools"][0]["cache_control"]["ttl"] == "1h"
+    assert request["system"][0]["cache_control"]["ttl"] == "1h"
+
+
 def test_remove_scope_from_cache_control():
     """Ensure scope field is removed from cache_control for Bedrock (not supported)."""
 


### PR DESCRIPTION
## Relevant issues

Fixes #26193

## Type

Bug Fix

## Changes

### Problem

`stream_chunk_builder` unconditionally calls `ChunkProcessor.count_reasoning_tokens`, which recomputes `reasoning_tokens` via `tiktoken.encode()` — a C extension that holds the GIL for tens of seconds on large reasoning responses (Claude extended thinking, OpenAI o1/o3, Gemini thinking, 100k+ tokens).

The computed value is already discarded by `calculate_usage` when the provider supplied `reasoning_tokens` in a streaming usage chunk. Specifically, `calculate_usage` only applies the recomputed value when `completion_tokens_details.reasoning_tokens is None`:

```python
if reasoning_tokens is not None:
    if returned_usage.completion_tokens_details is None:
        returned_usage.completion_tokens_details = (
            CompletionTokensDetailsWrapper(reasoning_tokens=reasoning_tokens)
        )
    elif (
        returned_usage.completion_tokens_details is not None
        and returned_usage.completion_tokens_details.reasoning_tokens is None
    ):
        returned_usage.completion_tokens_details.reasoning_tokens = (
            reasoning_tokens
        )
```

All major reasoning providers (Anthropic extended thinking, OpenAI o1/o3, Gemini thinking) supply `reasoning_tokens` in streaming usage chunks, so in the common case the expensive recount runs purely to be thrown away.

The bug report (#26193) includes py-spy thread dumps showing a single `tiktoken.encode()` call monopolizing the event loop for the full liveness-probe window, resulting in pods being SIGKILLed by Kubernetes.

### Fix

Inspect the already-parsed streaming chunks for any `completion_tokens_details.reasoning_tokens` entry. If one exists, skip the local tiktoken recount entirely — `calculate_usage` will pick up the provider-supplied value as before. If none exists (rare), fall through to `count_reasoning_tokens` so providers that emit `reasoning_content` without reporting usage are unaffected.

New helper `ChunkProcessor.chunks_have_reasoning_tokens(chunks)` handles both `ModelResponseStream` objects and plain-dict chunks, matching the existing chunk-parsing patterns in `_calculate_usage_per_chunk`.

Call-site change in `litellm/main.py`:

```python
if processor.chunks_have_reasoning_tokens(chunks):
    reasoning_tokens = None
else:
    reasoning_tokens = processor.count_reasoning_tokens(response)
```

### Tests

Four new tests in `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py`:

1. `test_chunks_have_reasoning_tokens_true_when_provider_supplies` — regression test for the reported bug.
2. `test_chunks_have_reasoning_tokens_false_when_provider_omits` — ensures the slow fallback is still exercised when providers omit usage.
3. `test_chunks_have_reasoning_tokens_handles_dict_chunks` — dict-chunk path (proxy-style chunks) is covered.
4. `test_stream_chunk_builder_skips_count_reasoning_tokens_when_usage_present` — end-to-end: `stream_chunk_builder` does not invoke `count_reasoning_tokens` when the provider already supplied the value, and the final response carries the provider-supplied number.

All four tests fail on `litellm_oss_branch` without the fix and pass with it.

### Scope

- No API changes: existing public method signatures untouched.
- No new config flags or defaults.
- No changes to `count_reasoning_tokens` itself (it remains the correct fallback).
- Does not address the separate case where a misbehaving provider emits `reasoning_content` without any usage chunk. That path still blocks the event loop and could be fixed in a follow-up (e.g. `asyncio.to_thread` at the async caller), but is orthogonal to this issue's reported reproduction.

## Pre-Submission checklist

- [x] Added testing in `tests/test_litellm/`
- [x] PR passes the touched test file (13/13 in `test_streaming_chunk_builder_utils.py`)
- [x] Scope isolated to a single bug
- [ ] Greptile review (auto-triggered)