### PR TITLE
fix(proxy): replay consumed ASGI receive messages to downstream /metrics app

### DIFF
--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -39,8 +39,22 @@ class PrometheusAuthMiddleware:
 
         # Only run auth if configured to do so
         if litellm.require_auth_for_metrics_endpoint is True:
-            # Construct Request only when auth is actually needed
-            request = Request(scope, receive)
+            # user_api_key_auth calls _read_request_body internally, which
+            # drains the ASGI receive channel via Starlette's Request.body().
+            # If we then handed the already-drained `receive` straight to the
+            # downstream app (e.g. the prometheus_client ASGI app mounted at
+            # /metrics), it would block forever awaiting an http.request
+            # message that has already been consumed. Buffer whatever auth
+            # reads so we can replay it below when the request continues
+            # through to the inner application.
+            consumed_messages: list = []
+
+            async def buffering_receive():
+                message = await receive()
+                consumed_messages.append(message)
+                return message
+
+            request = Request(scope, buffering_receive)
             api_key = request.headers.get(_AUTHORIZATION_HEADER) or ""
 
             try:
@@ -68,6 +82,21 @@ class PrometheusAuthMiddleware:
                     }
                 )
                 return
+
+            # Auth succeeded; replay any messages it consumed so the
+            # downstream app sees the original request on its own `receive`.
+            replay_index = 0
+
+            async def replay_receive():
+                nonlocal replay_index
+                if replay_index < len(consumed_messages):
+                    message = consumed_messages[replay_index]
+                    replay_index += 1
+                    return message
+                return await receive()
+
+            await self.app(scope, replay_receive, send)
+            return
 
         # Pass through to the inner application
         await self.app(scope, receive, send)

--- a/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py
+++ b/tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py
@@ -170,3 +170,99 @@ def test_non_metrics_requests_dont_trigger_auth(app_with_middleware, monkeypatch
     response = client.get("/embeddings")
     assert response.status_code == 200, response.text
     assert response.json() == {"msg": "embeddings OK"}
+
+
+@pytest.mark.asyncio
+async def test_downstream_asgi_app_receives_http_request_after_auth_reads_body(
+    monkeypatch,
+):
+    """
+    Regression test: the real user_api_key_auth calls _read_request_body()
+    (user_api_key_auth.py, line ~1591), which drains the ASGI `receive`
+    channel. The middleware must not pass the already-drained `receive`
+    straight through to the downstream app, or a mounted ASGI sub-app at
+    /metrics (created by prometheus_client.make_asgi_app) blocks on
+    `await receive()` and the request hangs indefinitely.
+
+    Reproduction: patch user_api_key_auth with a stub that reads the body
+    (mirroring what the real function does for admin-role callers). Install
+    a pure ASGI inner app that records any message it receives. Drive the
+    middleware once with a minimal HTTP scope. With the bug present, the
+    inner app times out waiting on receive() because the http.request
+    message was already pulled by auth. With a fix in place (e.g. a
+    receive-replay wrapper in the middleware), the inner app observes the
+    http.request message and completes normally.
+    """
+    import asyncio
+
+    litellm.require_auth_for_metrics_endpoint = True
+
+    # Stub that mirrors real auth: it reads the request body, consuming the
+    # ASGI receive channel. The existing fake_valid_auth skips this step
+    # which is why the bug is not caught by the other tests in this file.
+    async def fake_auth_that_reads_body(request, api_key):
+        _ = await request.body()
+        return
+
+    monkeypatch.setattr(
+        "litellm.proxy.middleware.prometheus_auth_middleware.user_api_key_auth",
+        fake_auth_that_reads_body,
+    )
+
+    received_by_inner: list = []
+
+    async def inner_app(scope, receive, send):
+        # Pure ASGI inner app. Emulates what a mounted app like
+        # prometheus_client.make_asgi_app() does: try to receive, then
+        # respond. If receive() blocks, we abort after 2s so the test can
+        # fail cleanly rather than hanging.
+        try:
+            msg = await asyncio.wait_for(receive(), timeout=2.0)
+            received_by_inner.append(msg)
+        except asyncio.TimeoutError:
+            received_by_inner.append({"type": "<timeout>"})
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    middleware = PrometheusAuthMiddleware(inner_app)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/metrics",
+        "raw_path": b"/metrics",
+        "query_string": b"",
+        "headers": [(b"authorization", b"Bearer test-admin-key")],
+        "scheme": "http",
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "http_version": "1.1",
+    }
+
+    # Queue exactly one http.request message, as a real GET would deliver.
+    # After it is consumed, receive() would normally block.
+    queued = [{"type": "http.request", "body": b"", "more_body": False}]
+
+    async def receive():
+        if queued:
+            return queued.pop(0)
+        # Block indefinitely — same as real ASGI when no more messages.
+        await asyncio.Event().wait()
+
+    sent: list = []
+
+    async def send(message):
+        sent.append(message)
+
+    await asyncio.wait_for(middleware(scope, receive, send), timeout=5.0)
+
+    # Core assertion: the inner app must see the http.request message.
+    # With the current middleware, `received_by_inner` contains
+    # {"type": "<timeout>"} because `receive` was drained by the auth
+    # body-read.
+    assert received_by_inner, "inner app did not run"
+    assert received_by_inner[0].get("type") == "http.request", (
+        f"downstream app did not observe http.request; saw {received_by_inner[0]}. "
+        "Middleware must replay the consumed http.request message to downstream "
+        "when require_auth_for_metrics_endpoint is enabled."
+    )


### PR DESCRIPTION
## Summary

`/metrics` scrapes hang indefinitely when `require_auth_for_metrics_endpoint: true` is set and the caller is `proxy_admin`. `PrometheusAuthMiddleware` invokes `user_api_key_auth()`, which internally calls `_read_request_body()` at [user_api_key_auth.py:1591](https://github.com/BerriAI/litellm/blob/v1.83.7-stable/litellm/proxy/auth/user_api_key_auth.py#L1591) and drains the ASGI `receive` channel via Starlette's `Request.body()`. The middleware then forwarded the already-drained `receive` callable straight to the downstream app. `/metrics` is a mounted ASGI sub-app produced by `prometheus_client.make_asgi_app()` ([litellm/integrations/prometheus.py:3455](https://github.com/BerriAI/litellm/blob/v1.83.7-stable/litellm/integrations/prometheus.py#L3455) — `app.mount("/metrics", metrics_app)`), and that sub-app blocks forever on `await receive()` waiting for the `http.request` message that auth already consumed.

Non-admin roles (e.g. `proxy_admin_viewer`) raise during the admin-route check in `user_api_key_auth` *before* `_read_request_body` runs and return a fast 401, which is why the bug only manifests for admin callers — including the master key.

## Repro (pre-fix)

On `v1.83.7-stable` with the flag enabled:

```yaml
litellm_settings:
  callbacks: ["prometheus"]
  require_auth_for_metrics_endpoint: true
```

```
$ curl -H "Authorization: Bearer $MASTER_KEY" https://proxy.example.com/metrics/
# hangs forever; uvicorn logs no access-line for the request
```

Non-admin key on the same endpoint returns HTTP 401 in milliseconds, confirming the admin branch is the one reaching the bad code path.

## Fix

Buffer any messages that `user_api_key_auth` reads off `receive` through a buffering wrapper, then hand the downstream app a replay wrapper that yields the buffered messages before falling back to the original `receive`. The 401 path is untouched — if auth raises, the middleware responds 401 directly and never invokes the downstream app, so the replay machinery only runs when the request is actually being forwarded.

Scope is intentionally minimal: only `litellm/proxy/middleware/prometheus_auth_middleware.py` and its test module are touched.

## Test

New regression test `test_downstream_asgi_app_receives_http_request_after_auth_reads_body` in `tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py`:

- Installs a **stub auth** that mirrors the real one by calling `await request.body()` — the existing `fake_valid_auth` skips this step, which is why the module's other tests never exercised the drained-receive path.
- Installs a **pure-ASGI inner app** (rather than a FastAPI route) that times out after 2s if it does not observe its `http.request` message, matching the shape of the mounted `prometheus_client` sub-app.
- Drives the middleware once with a minimal HTTP scope and asserts the inner app receives the expected `http.request` message.

Before this change the assertion fails with `downstream app did not observe http.request; saw {'type': '<timeout>'}`. After this change the assertion passes.

All six tests in the middleware module pass post-fix.

## Relevant issues

<!-- Not tracked as a pre-existing issue upstream; the related /metrics-auth issues (#13644, #24530) are about the permissiveness or absence of auth, not the handler deadlock. Happy to file a standalone issue referencing this PR if preferred. -->

## Pre-Submission checklist

- [x] I have added testing in `tests/test_litellm/` — new regression test is part of this PR.
- [x] My PR passes all unit tests on the touched module (`make test-unit` scoped to `tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py` → 6/6 passing).
- [x] My PR's scope is isolated — fixes one specific problem (the receive drain) and adds one regression test for it.
- [ ] Greptile review — will request once the PR is open.

## Notes

- CLA signed.
- `make lint` on `main` itself fails on 15 unrelated enterprise-callback files that are already out of Black compliance on `origin/main`; this PR does not introduce new lint failures (confirmed with `black --check` scoped to the two touched files).