### PR TITLE
fix(proxy): restore deprecated key auth cache lookups

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2400,10 +2400,25 @@ async def _lookup_deprecated_key(
 
     # Check cache first
     cached = _deprecated_key_cache.get(hashed_token)
-    cached = _deprecated_key_cache.get(hashed_token)
     if cached is not None:
-        active_token_id, cache_expires_at_ts, revoke_at_ts = cached
-        if now_ts < cache_expires_at_ts and now_ts < revoke_at_ts:
+        if len(cached) == 3:
+            active_token_id, cache_expires_at_ts, revoke_at_ts = cached
+        elif len(cached) == 2:
+            # Backward compatibility for cache entries written before
+            # revoke_at_ts was added to the in-memory tuple.
+            active_token_id, cache_expires_at_ts = cached
+            revoke_at_ts = float("inf")
+        else:
+            _deprecated_key_cache.pop(hashed_token, None)
+            active_token_id = None
+            cache_expires_at_ts = 0.0
+            revoke_at_ts = 0.0
+
+        if (
+            active_token_id is not None
+            and now_ts < cache_expires_at_ts
+            and now_ts < revoke_at_ts
+        ):
             return active_token_id
         else:
             _deprecated_key_cache.pop(hashed_token, None)
@@ -2414,12 +2429,17 @@ async def _lookup_deprecated_key(
                 "token": hashed_token,
                 "revoke_at": {"gt": now},
             },
-            select={"active_token_id": True},
+            select={"active_token_id": True, "revoke_at": True},
         )
-        if deprecated_row and deprecated_row.active_token_id:
+        if (
+            deprecated_row
+            and deprecated_row.active_token_id
+            and deprecated_row.revoke_at is not None
+        ):
             _deprecated_key_cache[hashed_token] = (
                 deprecated_row.active_token_id,
                 now_ts + _DEPRECATED_KEY_CACHE_TTL_SECONDS,
+                deprecated_row.revoke_at.timestamp(),
             )
             return deprecated_row.active_token_id
         # Only cache positive results; negative lookups are fast on indexed columns

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from datetime import datetime, timedelta, timezone
 from typing import Tuple
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -901,6 +902,43 @@ def test_proxy_admin_jwt_auth_handles_no_team_object():
     assert result.team_metadata is None
     assert result.org_id is None
     assert result.end_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_deprecated_key_uses_cache_on_subsequent_requests():
+    """
+    Regression test for deprecated key auth during grace period.
+
+    The in-memory cache entry must be readable on the second lookup; otherwise
+    rotated keys intermittently fail auth with token_not_found_in_db.
+    """
+    from types import SimpleNamespace
+
+    from litellm.proxy.utils import _deprecated_key_cache, _lookup_deprecated_key
+
+    hashed_old_key = "old-key-hash"
+    hashed_new_key = "new-key-hash"
+    revoke_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+
+    _deprecated_key_cache.clear()
+
+    mock_db = MagicMock()
+    mock_db.litellm_deprecatedverificationtoken.find_first = AsyncMock(
+        return_value=SimpleNamespace(
+            active_token_id=hashed_new_key,
+            revoke_at=revoke_at,
+        )
+    )
+
+    try:
+        first_lookup = await _lookup_deprecated_key(mock_db, hashed_old_key)
+        second_lookup = await _lookup_deprecated_key(mock_db, hashed_old_key)
+    finally:
+        _deprecated_key_cache.clear()
+
+    assert first_lookup == hashed_new_key
+    assert second_lookup == hashed_new_key
+    mock_db.litellm_deprecatedverificationtoken.find_first.assert_awaited_once()
 
 
 class TestJWTOAuth2Coexistence:


### PR DESCRIPTION
## Relevant issues

  Fixes #24680

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/
  litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/
  extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a
  **Confidence Score of at least 4/5** before requesting a maintainer review

  ## Delays in PR merge?

  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-
  review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-
  p_kbNJj8taRfXGgQI1~YyA).

  ## CI (LiteLLM team)

  > **CI status guideline:**
  >
  > - 50-55 passing tests: main is stable with minor issues.
  > - 45-49 passing tests: acceptable but needs attention
  > - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

  - [ ] **Branch creation CI run**
         Link:

  - [ ] **CI run for the last commit**
         Link:

  - [ ] **Merge / cherry-pick CI run**
         Links:

  ## Type

  🐛 Bug Fix

  ## Changes

  ### Problem
  After upgrading to v1.82.3, some previously valid LiteLLM virtual keys started failing
  auth with:

  `Authentication Error, Invalid proxy server token passed ... Unable to find token in
  cache or LiteLLM_VerificationTokenTable`

  This affects keys that are still expected to work during the deprecated-key grace
  period after regeneration / rotation.

  ### Root cause
  LiteLLM supports grace-period auth for rotated keys via `_lookup_deprecated_key()`,
  which checks `LiteLLM_DeprecatedVerificationToken` and caches old-key -> active-key
  mappings in memory.

  The bug was in the in-memory cache tuple handling:

  - cache reads expected 3 values:
    - `active_token_id`
    - `cache_expires_at_ts`
    - `revoke_at_ts`
  - cache writes only stored 2 values:
    - `active_token_id`
    - `cache_expires_at_ts`

  That means the first deprecated-key lookup could succeed from DB, but the next lookup
  could fail when reading the malformed cache entry. In practice this breaks auth for
  keys relying on the deprecated-key grace-period fallback and surfaces as
  `token_not_found_in_db`.

  ### Fix
  This PR updates `litellm/proxy/utils.py` to make deprecated-key cache reads and writes
  consistent:

  - store `revoke_at.timestamp()` in the cache tuple
  - support both the new 3-field tuple and legacy 2-field tuples when reading
  - evict malformed cache entries safely
  - remove the duplicate cache read in `_lookup_deprecated_key()`

  ### Test
  Added a regression test in `tests/test_litellm/proxy/auth/test_user_api_key_auth.py` to
  verify:

  - the first deprecated-key lookup resolves via DB
  - the second lookup resolves from the in-memory cache
  - the cached path no longer breaks auth

  Local verification completed:
  - `tests/test_litellm/proxy/auth/test_user_api_key_auth.py -k
  deprecated_key_uses_cache_on_subsequent_requests`