### PR TITLE
fix(cost): do not bill url_context as web_search grounding

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -314,13 +314,23 @@ class StandardBuiltInToolCostTracking:
         from litellm.types.utils import PromptTokensDetailsWrapper
 
         if isinstance(response_object, ModelResponse):
-            # chat completions only include url_citation annotations when a web search call is made
             has_url_citations = (
                 StandardBuiltInToolCostTracking.response_includes_annotation_type(
                     response_object=response_object, annotation_type="url_citation"
                 )
             )
-            if has_url_citations:
+            # Gemini's url_context tool also emits url_citation annotations for
+            # per-claim grounding against user-specified URLs. url_context is
+            # token-billed only, not a grounded-search request, so annotation
+            # presence alone is not a valid signal here. When url_context
+            # metadata is attached, fall through to usage-based detection which
+            # distinguishes actual web_search calls via web_search_requests.
+            if (
+                has_url_citations
+                and not StandardBuiltInToolCostTracking.response_object_includes_url_context_call(
+                    response_object
+                )
+            ):
                 return True
             if usage is not None:
                 # Vertex AI Gemini uses usage.prompt_tokens_details.web_search_requests
@@ -366,6 +376,25 @@ class StandardBuiltInToolCostTracking:
                 return True
 
         return False
+
+    @staticmethod
+    def response_object_includes_url_context_call(response_object: Any) -> bool:
+        """
+        Check if Gemini's url_context tool populated metadata on the response.
+
+        url_context is distinct from Grounding with Google Search: it fetches
+        user-specified URLs and is billed as input tokens per model pricing
+        (no per-request surcharge). It emits the same `url_citation` annotation
+        type as web_search, so annotation presence alone cannot distinguish the
+        two tools — the `vertex_ai_url_context_metadata` field is the reliable
+        signal (attached by the Gemini adapter).
+        """
+        if not isinstance(response_object, ModelResponse):
+            return False
+        if getattr(response_object, "vertex_ai_url_context_metadata", None):
+            return True
+        hidden = getattr(response_object, "_hidden_params", None) or {}
+        return bool(hidden.get("vertex_ai_url_context_metadata"))
 
     @staticmethod
     def response_object_includes_file_search_call(

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -311,3 +311,157 @@ def test_completion_cost_includes_web_search_without_standard_built_in_tools_par
 
 # Note: File search integration test removed due to complex annotation detection logic
 # The unit tests in test_azure_assistant_cost_tracking.py provide comprehensive coverage
+
+
+def _make_model_response_with_url_citation(model: str, url_context_metadata=None):
+    """Build a Gemini-style ModelResponse with a url_citation annotation.
+
+    Optionally attaches vertex_ai_url_context_metadata (set by the Gemini adapter
+    when the url_context tool is invoked).
+    """
+    from litellm.types.utils import Choices, Message
+
+    message = Message(content="Study summary with citation.", role="assistant")
+    # url_citation annotations are emitted by both web_search AND url_context.
+    # Attach one on the message to exercise the annotation-based detection path.
+    message.annotations = [
+        {
+            "type": "url_citation",
+            "url_citation": {
+                "start_index": 0,
+                "end_index": 10,
+                "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10018306/",
+                "title": "Spleen Length Study",
+            },
+        }
+    ]
+    response = ModelResponse(
+        id="test-id",
+        choices=[Choices(finish_reason="stop", index=0, message=message)],
+        created=1234567890,
+        model=model,
+        object="chat.completion",
+        system_fingerprint=None,
+    )
+    if url_context_metadata is not None:
+        response.vertex_ai_url_context_metadata = url_context_metadata  # type: ignore[attr-defined]
+    return response
+
+
+def test_url_context_does_not_trigger_web_search_cost():
+    """
+    Regression test: Gemini's url_context tool emits url_citation annotations
+    for per-claim grounding against user-specified URLs, but is NOT a
+    Grounding-with-Google-Search request and is billed as input tokens only.
+
+    Detection must return False when vertex_ai_url_context_metadata is present
+    and web_search_requests is not reported in usage.
+    """
+    response = _make_model_response_with_url_citation(
+        model="gemini-3-flash-preview",
+        url_context_metadata=[
+            {
+                "urlMetadata": [
+                    {
+                        "retrievedUrl": "https://pmc.ncbi.nlm.nih.gov/articles/PMC10018306/",
+                        "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS",
+                    }
+                ]
+            }
+        ],
+    )
+
+    includes = StandardBuiltInToolCostTracking.response_object_includes_web_search_call(
+        response_object=response, usage=None
+    )
+    assert includes is False, (
+        "url_context with url_citation annotation should not be classified "
+        "as a web_search call"
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model="gemini-3-flash-preview",
+        usage=None,
+        response_object=response,
+        custom_llm_provider="vertex_ai",
+        standard_built_in_tools_params=None,
+    )
+    assert cost == 0.0, f"Expected no grounding surcharge for url_context, got ${cost}"
+
+
+def test_url_citation_without_url_context_still_triggers_web_search_cost():
+    """
+    Regression test for #15858: Anthropic-style url_citation-only responses
+    (no url_context metadata) must still be detected as web_search calls.
+    Guards against the fix over-broadly suppressing web_search detection.
+    """
+    response = _make_model_response_with_url_citation(
+        model="claude-3-5-sonnet-20241022",
+        url_context_metadata=None,  # no url_context, just plain annotation
+    )
+
+    includes = StandardBuiltInToolCostTracking.response_object_includes_web_search_call(
+        response_object=response, usage=None
+    )
+    assert includes is True, (
+        "url_citation annotation without url_context metadata should still be "
+        "detected as a web_search call (regression for #15858)"
+    )
+
+
+def test_response_object_includes_url_context_call():
+    """Direct test of the new helper."""
+    # ModelResponse with url_context metadata as a top-level attribute
+    response_with_ctx = _make_model_response_with_url_citation(
+        model="gemini-3-flash-preview",
+        url_context_metadata=[
+            {
+                "urlMetadata": [
+                    {
+                        "retrievedUrl": "https://example.com",
+                        "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS",
+                    }
+                ]
+            }
+        ],
+    )
+    assert (
+        StandardBuiltInToolCostTracking.response_object_includes_url_context_call(
+            response_with_ctx
+        )
+        is True
+    )
+
+    # Same metadata attached via _hidden_params (alternate storage path in the
+    # Gemini adapter).
+    response_with_hidden = _make_model_response_with_url_citation(
+        model="gemini-3-flash-preview"
+    )
+    response_with_hidden._hidden_params = {
+        "vertex_ai_url_context_metadata": [{"urlMetadata": [{"retrievedUrl": "x"}]}]
+    }
+    assert (
+        StandardBuiltInToolCostTracking.response_object_includes_url_context_call(
+            response_with_hidden
+        )
+        is True
+    )
+
+    # No metadata → False
+    response_without = _make_model_response_with_url_citation(
+        model="gemini-3-flash-preview"
+    )
+    assert (
+        StandardBuiltInToolCostTracking.response_object_includes_url_context_call(
+            response_without
+        )
+        is False
+    )
+
+    # Non-ModelResponse → False
+    assert (
+        StandardBuiltInToolCostTracking.response_object_includes_url_context_call(
+            {"foo": "bar"}
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary

Fixes url_context being falsely billed as web_search grounding.

Gemini's `url_context` tool emits `url_citation` annotations for per-claim grounding, but the detection logic in `response_object_includes_web_search_call` treated any `url_citation` annotation as evidence of a web_search call. This caused url_context requests to be charged the $0.035 grounding surcharge when Google's actual pricing for url_context is **token-cost only** (no per-request fee).

Per [Google's url_context docs](https://ai.google.dev/gemini-api/docs/url-context): "Charged as input tokens per model pricing." Neither the [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing) nor the [Vertex AI pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing) list a url_context surcharge; only Grounding with Google Search is billed per-request.

Fixes #26253

## Changes

- **`litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py`**:
  - New helper `response_object_includes_url_context_call()` that inspects the `vertex_ai_url_context_metadata` field already attached to `ModelResponse` by the Gemini adapter (`vertex_and_google_ai_studio_gemini.py:2475-2479`).
  - In `response_object_includes_web_search_call`, the annotation-based shortcut now skips when url_context metadata is present. Detection falls through to the structured `usage.prompt_tokens_details.web_search_requests` check, which correctly distinguishes actual web_search calls from url_context calls.

- **`tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py`**:
  - `test_url_context_does_not_trigger_web_search_cost` — url_context + `url_citation` annotation + no `web_search_requests` → no grounding surcharge.
  - `test_url_citation_without_url_context_still_triggers_web_search_cost` — regression guard for #15858: pure-annotation responses (Anthropic-style) are still correctly detected.
  - `test_response_object_includes_url_context_call` — covers both storage paths (top-level attribute and `_hidden_params`).

## Behavior table

| Scenario | `url_citation` annotation | `vertex_ai_url_context_metadata` | `web_search_requests` | Before | After |
|---|---|---|---|---|---|
| web_search only | ✓ | — | > 0 | True ✓ | True ✓ |
| url_context only | ✓ | ✓ | None | True ❌ | **False ✓** |
| both | ✓ | ✓ | > 0 | True ✓ | True ✓ (via structured check) |
| neither | — | — | None | False ✓ | False ✓ |

## Test plan

- [x] Added 3 unit tests (see `test_tool_call_cost_tracking.py`)
- [x] Full file: `uv run pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py -v` → 17/17 passing (3 new + 14 existing regression)
- [x] `uv run black .` — no changes required
- [x] Verified existing `test_get_cost_for_vertex_ai_gemini_web_search` continues to pass (no regression to #15858 fix)

## Related

- Depends on / complements #24369 — the hardcoded `$0.035` rate is also incorrect for Gemini 3.x (should be `$0.014` per [current Gemini 3 pricing](https://ai.google.dev/gemini-api/docs/pricing)). That fix is being handled by PR #24448. This PR fixes the **trigger** (should not fire for url_context); #24448 fixes the **rate** (should be $0.014 not $0.035). Both are needed to correctly bill Gemini 3 grounded requests.
- #15858 — earlier bug (grounding fee was missing entirely) which introduced the annotation-based shortcut this PR refines.
