### PR TITLE
docs: remove misleading Step 1 from Docker Compose quickstart

### DIFF
--- a/docs/my-website/docs/proxy/docker_quick_start.md
+++ b/docs/my-website/docs/proxy/docker_quick_start.md
@@ -104,23 +104,11 @@ $ uv tool install 'litellm[proxy]'
 
 Docker Compose bundles LiteLLM with a Postgres database. Follow the steps below — the proxy will be fully running by the end.
 
-### Step 1 — Pull the LiteLLM database image
-
-LiteLLM provides a dedicated `litellm-database` image for proxy deployments that connect to Postgres.
-
-```bash
-docker pull ghcr.io/berriai/litellm-database:main-latest
-```
-
-See all available tags on the [GitHub Container Registry](https://github.com/BerriAI/litellm/pkgs/container/litellm-database).
-
----
-
-### Step 2 — Set up a database
+### Step 1 — Set up a database
 
 Complete all three config files **before** running `docker compose up`. The proxy server will not start correctly if any of these are missing.
 
-#### 2.1 — Get `docker-compose.yml` and create `.env`
+#### 1.1 — Get `docker-compose.yml` and create `.env`
 
 ```bash
 # Get the docker compose file
@@ -139,7 +127,7 @@ echo 'AZURE_API_BASE="https://openai-***********/"' >> .env
 echo 'AZURE_API_KEY="your-azure-api-key"' >> .env
 ```
 
-#### 2.2 — Create `config.yaml`
+#### 1.2 — Create `config.yaml`
 
 The default `docker-compose.yml` starts a Postgres container at `db:5432`. Your `config.yaml` must include `database_url` pointing to it:
 
@@ -161,7 +149,7 @@ general_settings:
 `database_url` enables virtual keys, spend tracking, and the UI. Replace it with your [Supabase](https://supabase.com/) or [Neon](https://neon.tech/) connection string if you prefer a managed database.
 :::
 
-#### 2.3 — Create `prometheus.yml`
+#### 1.3 — Create `prometheus.yml`
 
 This file **must exist as a file** before `docker compose up`. If it is missing, Docker auto-creates it as an empty directory and the Prometheus container fails to start.
 
@@ -193,7 +181,7 @@ All three files (`.env`, `config.yaml`, `prometheus.yml`) must be present before
 
 ---
 
-### Step 3 — Start the proxy server and test it
+### Step 2 — Start the proxy server and test it
 
 After `config.yaml`, `prometheus.yml`, and `.env` are complete, start the proxy:
 
@@ -265,6 +253,9 @@ Navigate to **Virtual Keys** and click **+ Create New Key**:
 Virtual keys let you track spend, set rate limits, and control model access per user or team.
 
 </TabItem>
+
+
+
 
 </Tabs>
 


### PR DESCRIPTION
## Relevant issues

Fixes #26235

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai`

## Type

📖 Documentation

## Changes

The Getting Started tutorial told users to `docker pull ghcr.io/berriai/litellm-database:main-latest` as Step 1, but the `docker-compose.yml` downloaded in the next step uses `docker.litellm.ai/berriai/litellm:main-stable` and `postgres:16` — the `litellm-database` image is never referenced. This step was a no-op that confused users.

**Fix:** Remove the redundant step and renumber:
- Old Step 2 (config files setup) → Step 1
- Old Step 3 (`docker compose up`) → Step 2
