### PR TITLE
docs(release_notes): fix Skills Marketplace 404 link in v1.83.3

### DIFF
--- a/docs/my-website/release_notes/v1.83.3/index.md
+++ b/docs/my-website/release_notes/v1.83.3/index.md
@@ -54,7 +54,7 @@ pip install litellm==1.83.3
 ## Key Highlights
 
 - **MCP Toolsets** — [Create curated tool subsets from one or more MCP servers with scoped permissions, and manage them from the UI or API](../../docs/mcp)
-- **Skills Marketplace** — [Browse, install, and publish Claude Code skills from a self-hosted marketplace — works across Anthropic, Vertex AI, Azure, and Bedrock](../../docs/proxy/skills)
+- **Skills Marketplace** — [Browse, install, and publish Claude Code skills from a self-hosted marketplace — works across Anthropic, Vertex AI, Azure, and Bedrock](../../docs/skills_gateway)
 - **Guardrail Fallbacks** — [Configure `on_error` behavior so guardrail failures degrade gracefully instead of blocking the request](../../docs/proxy/guardrails)
 - **Team Bring Your Own Guardrails** — [Teams can now attach and manage their own guardrails directly from team settings in the UI](../../docs/proxy/guardrails)
 
@@ -67,7 +67,7 @@ The Skills Marketplace gives teams a self-hosted catalog for discovering, instal
 
 ![Skills Marketplace](../../img/release_notes/skills_marketplace.png)
 
-[Get Started](../../docs/proxy/skills)
+[Get Started](../../docs/skills_gateway)
 
 ### Guardrail Fallbacks
 


### PR DESCRIPTION
Fixes #26035.

Reporter found that the v1.83.3 release notes link `../../docs/proxy/skills` resolves to a 404 — the actual page is `docs/skills_gateway.md` (lives at `/docs/skills_gateway`).

Both occurrences in `docs/my-website/release_notes/v1.83.3/index.md` updated:

```diff
- - **Skills Marketplace** — [Browse, install, and publish Claude Code skills...](../../docs/proxy/skills)
+ - **Skills Marketplace** — [Browse, install, and publish Claude Code skills...](../../docs/skills_gateway)

- [Get Started](../../docs/proxy/skills)
+ [Get Started](../../docs/skills_gateway)
```

Verified that `docs/my-website/docs/skills_gateway.md` exists in the repo (HTTP 200 on raw.githubusercontent.com) and `docs/proxy/skills` does not. Single file, docs-only.

The reporter also suggested auditing other release notes / sidebar entries for the same broken path. `grep -r 'docs/proxy/skills' docs/my-website/release_notes` shows the broken path is only in this one file, so a wider audit isn't needed for this fix; if the project wants a one-off sweep across non-release-note pages, happy to follow up.