### PR TITLE
fix(docker.non_root): use numeric UID 65534 for K8s runAsNonRoot

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -138,7 +138,7 @@ RUN mkdir -p /nonexistent /var/lib/litellm/assets /var/lib/litellm/ui && \
     [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g+w "$LITELLM_PROXY_EXTRAS_PATH" || true && \
     chmod -R g+rX "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets /app/.cache
 
-USER nobody
+USER 65534
 
 RUN prisma generate --schema=./schema.prisma
 

--- a/docker/tests/nonroot.yaml
+++ b/docker/tests/nonroot.yaml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 
 metadataTest:
   entrypoint: ["docker/prod_entrypoint.sh"]
-  user: "nobody"
+  user: "65534"
   workdir: "/app"
 
 fileExistenceTests:

--- a/tests/test_litellm/test_dockerfile_non_root.py
+++ b/tests/test_litellm/test_dockerfile_non_root.py
@@ -1,0 +1,54 @@
+"""
+Static checks on docker/Dockerfile.non_root.
+
+The non_root image is intended for deployment into hardened Kubernetes
+clusters where `securityContext.runAsNonRoot: true` is enforced. The
+kubelet validates non-root status by parsing the image's USER field as
+an integer — a string name like "nobody" is rejected with
+CreateContainerConfigError because the kubelet cannot resolve
+/etc/passwd inside the image at admission time.
+"""
+
+import os
+import re
+
+import pytest
+
+DOCKERFILE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "docker",
+    "Dockerfile.non_root",
+)
+
+
+def _final_user_directive(dockerfile_text: str) -> str:
+    """Return the value of the last `USER` directive in the file."""
+    matches = re.findall(r"^USER\s+(\S+)\s*$", dockerfile_text, re.MULTILINE)
+    assert matches, "Dockerfile.non_root has no USER directive"
+    return matches[-1]
+
+
+@pytest.mark.skipif(
+    not os.path.exists(DOCKERFILE_PATH),
+    reason="Dockerfile.non_root not present in this checkout",
+)
+def test_final_user_directive_is_numeric():
+    """The runtime USER must be a numeric UID so kubelet's runAsNonRoot
+    admission check (strconv.Atoi) succeeds."""
+    with open(DOCKERFILE_PATH, "r", encoding="utf-8") as f:
+        contents = f.read()
+
+    final_user = _final_user_directive(contents)
+
+    assert final_user.isdigit(), (
+        f"Dockerfile.non_root final USER is {final_user!r}; must be a numeric UID "
+        "so Kubernetes' runAsNonRoot admission check can verify non-root status. "
+        "See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+    )
+
+    assert int(final_user) != 0, (
+        f"Dockerfile.non_root final USER is {final_user} (root); the non_root image "
+        "must run as a non-zero UID."
+    )


### PR DESCRIPTION
## Relevant issues

Related to #11866 (broader request for non-root UID/GID configurability in the base image

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Image OCI config — before:

```
$ docker inspect ghcr.io/berriai/litellm-non_root:main-stable --format '{{.Config.User}}'
nobody
```

Kubelet rejection observed by the reporter:

```
CreateContainerConfigError (container has runAsNonRoot and image has non-numeric user (nobody),
cannot verify user is non-root ...)
```

Image OCI config — after this PR:

```
$ docker inspect <patched-image> --format '{{.Config.User}}'
65534
```

Kubelet's `runAsNonRoot` admission can now `strconv.Atoi("65534") → 65534`, non-zero → admit.

## Type

🐛 Bug Fix

## Changes

### `docker/Dockerfile.non_root`

Change `USER nobody` to `USER 65534`.

Kubernetes' `runAsNonRoot` admission check requires a numeric UID in the OCI image config — the kubelet does not resolve `/etc/passwd` inside the image at admission time, so a string name like `nobody` cannot be verified as non-root and the pod is rejected with `CreateContainerConfigError`. This is especially impactful because the `non_root` image variant exists specifically for hardened Kubernetes deployments where `runAsNonRoot: true` is enforced — i.e. the bug breaks the image at the use case it was built for.

`65534` is the numeric UID `nobody` already resolves to in the Wolfi base image, so runtime behavior is unchanged: same UID, same file ownership, same group memberships. Only the OCI manifest's `Config.User` field flips from a name to a number the kubelet can validate. The build-time `chown -R nobody:nogroup ...` calls earlier in the Dockerfile are unaffected — they run as root and resolve names from `/etc/passwd`/`/etc/group` while the build is happening, and the underlying numeric IDs they produce are unchanged.

### `docker/tests/nonroot.yaml`

Update the `container-structure-test` `metadataTest.user` assertion from `"nobody"` to `"65534"` so the assertion matches the new image config.

### `tests/test_litellm/test_dockerfile_non_root.py` (new)

Static-text guard that reads `docker/Dockerfile.non_root` and asserts the final `USER` directive is numeric and non-zero. Catches any future regression that would re-break Kubernetes admission by reverting to a named user.

### Workaround for affected users (until merged)

Add `securityContext.runAsUser: 65534` to the container spec — gives the kubelet the number explicitly and satisfies `runAsNonRoot` regardless of the image's `USER` field.
