### PR TITLE
[Fix] Align image URL fetch with validated HTTP client in Bedrock and token counter paths

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -15,6 +15,7 @@ import litellm.types
 import litellm.types.llms
 from litellm import verbose_logger
 from litellm._uuid import uuid
+from litellm.litellm_core_utils.url_utils import async_safe_get, safe_get
 from litellm.llms.custom_httpx.http_handler import HTTPHandler, get_async_httpx_client
 from litellm.types.files import get_file_extension_from_mime_type
 from litellm.types.llms.anthropic import *
@@ -3324,7 +3325,7 @@ def _load_image_from_url(image_url):
     try:
         # Send a GET request to the image URL
         client = HTTPHandler(concurrent_limit=1)
-        response = client.get(image_url)
+        response = safe_get(client, image_url)
         response.raise_for_status()  # Raise an exception for HTTP errors
 
         # Check the response's content type to ensure it is an image
@@ -3562,7 +3563,7 @@ class BedrockImageProcessor:
                 params={"concurrent_limit": 1},
             )
             # Send a GET request to the image URL
-            response = await client.get(image_url, follow_redirects=True)
+            response = await async_safe_get(client, image_url)
             response.raise_for_status()  # Raise an exception for HTTP errors
 
             return BedrockImageProcessor._post_call_image_processing(
@@ -3577,7 +3578,7 @@ class BedrockImageProcessor:
         try:
             client = HTTPHandler(concurrent_limit=1)
             # Send a GET request to the image URL
-            response = client.get(image_url, follow_redirects=True)
+            response = safe_get(client, image_url)
             response.raise_for_status()  # Raise an exception for HTTP errors
 
             return BedrockImageProcessor._post_call_image_processing(

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -23,6 +23,7 @@ from litellm.constants import (
     DEFAULT_IMAGE_HEIGHT,
     DEFAULT_IMAGE_TOKEN_COUNT,
     DEFAULT_IMAGE_WIDTH,
+    MAX_IMAGE_URL_DOWNLOAD_SIZE_MB,
     MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES,
     MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES,
     MAX_TILE_HEIGHT,
@@ -215,7 +216,13 @@ def get_image_dimensions(
         try:
             client = _get_httpx_client()
             response = safe_get(client, data)
+            max_bytes = int(MAX_IMAGE_URL_DOWNLOAD_SIZE_MB * 1024 * 1024)
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None and int(content_length) > max_bytes:
+                raise ValueError("Image response exceeds size limit")
             img_data = response.read()
+            if len(img_data) > max_bytes:
+                raise ValueError("Image response exceeds size limit")
         except Exception:
             pass
     if img_data is None:


### PR DESCRIPTION
## Summary

- `BedrockImageProcessor.get_image_details` and `get_image_details_async` in `factory.py` were fetching image URLs via raw `client.get()` calls with `follow_redirects=True`. These are now routed through `safe_get`/`async_safe_get`, which validates the destination before connecting and handles redirects with per-hop validation.
- `_load_image_from_url` in `factory.py` had the same pattern and is updated to use `safe_get`.
- `get_image_dimensions` in `token_counter.py` used `safe_get` (address validation already present) but then called `response.read()` without a size bound. Added a Content-Length pre-check and a post-read size check using the existing `MAX_IMAGE_URL_DOWNLOAD_SIZE_MB` constant.

The `safe_get`/`async_safe_get` helpers and `validate_url` already existed in `litellm_core_utils/url_utils.py` and were already used by `image_handling.py` and `base_ingestion.py`; these changes bring the remaining image-fetch sites in line with that pattern.

## Testing

- Verified Bedrock image URL fetch paths now reject loopback, link-local, and RFC-1918 targets via live proxy on `:4000`.
- Adjacent OpenAI text chat and public image URL handling unaffected.
- `pytest tests/test_litellm/litellm_core_utils/test_token_counter.py tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py` — 232 passed, 1 skipped.

## Type

🐛 Bug Fix
✅ Test