### PR TITLE
fix(anthropic): preserve reasoning content and add think-tag regression coverage

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1663,6 +1663,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 if thinking_content is not None:
                     reasoning_content += thinking_content
 
+        if "</think>" in text_content:
+            text_content = text_content.split("</think>", 1)[1].lstrip()
+
         return (
             text_content,
             citations,

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1249,10 +1249,14 @@ class LiteLLMAnthropicMessagesAdapter:
                 )
 
             # Handle text content
-            if choice.message.content is not None:
+            text_content = choice.message.content
+            if isinstance(text_content, str) and "</think>" in text_content:
+                text_content = text_content.split("</think>", 1)[1].lstrip()
+
+            if text_content:
                 new_content.append(
                     AnthropicResponseContentBlockText(
-                        type="text", text=choice.message.content
+                        type="text", text=text_content
                     ).model_dump()
                 )
             # Handle tool calls (in parallel to text content)

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -555,6 +555,7 @@ class LiteLLMAnthropicMessagesAdapter:
             )  # For content blocks with cache_control
             has_cache_control_in_text = False
             tool_calls: List[ChatCompletionAssistantToolCall] = []
+            reasoning_content_parts: List[str] = []
             thinking_blocks: List[
                 Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
             ] = []
@@ -612,12 +613,15 @@ class LiteLLMAnthropicMessagesAdapter:
                                 )
                                 tool_calls.append(tool_call)
                             elif content.get("type") == "thinking":
+                                thinking_text = content.get("thinking") or ""
                                 thinking_block = ChatCompletionThinkingBlock(
                                     type="thinking",
-                                    thinking=content.get("thinking") or "",
+                                    thinking=thinking_text,
                                     signature=content.get("signature") or "",
                                     cache_control=content.get("cache_control", {}),
                                 )
+                                if thinking_text:
+                                    reasoning_content_parts.append(thinking_text)
                                 thinking_blocks.append(thinking_block)
                             elif content.get("type") == "redacted_thinking":
                                 redacted_thinking_block = (
@@ -655,6 +659,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 )
                 if len(tool_calls) > 0:
                     assistant_message["tool_calls"] = tool_calls  # type: ignore
+                    assistant_message["reasoning_content"] = (
+                        "".join(reasoning_content_parts) if len(reasoning_content_parts) > 0 else " "
+                    )  # type: ignore
                 if len(thinking_blocks) > 0:
                     assistant_message["thinking_blocks"] = thinking_blocks  # type: ignore
                 new_messages.append(assistant_message)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -45,6 +45,41 @@ def _should_route_to_responses_api(custom_llm_provider: Optional[str]) -> bool:
     return custom_llm_provider in _RESPONSES_API_PROVIDERS
 
 
+def _sanitize_think_tag_text_blocks(
+    response: Union[AnthropicMessagesResponse, AsyncIterator]
+) -> Union[AnthropicMessagesResponse, AsyncIterator]:
+    if not isinstance(response, dict):
+        return response
+
+    content = response.get("content")
+    if not isinstance(content, list):
+        return response
+
+    sanitized_content: List[Dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            sanitized_content.append(block)
+            continue
+
+        if block.get("type") != "text":
+            sanitized_content.append(block)
+            continue
+
+        text = block.get("text")
+        if not isinstance(text, str) or "</think>" not in text:
+            sanitized_content.append(block)
+            continue
+
+        cleaned_text = text.split("</think>", 1)[1].lstrip()
+        if cleaned_text:
+            sanitized_block = dict(block)
+            sanitized_block["text"] = cleaned_text
+            sanitized_content.append(sanitized_block)
+
+    response["content"] = sanitized_content
+    return response
+
+
 ####### ENVIRONMENT VARIABLES ###################
 # Initialize any necessary instances or variables here
 base_llm_http_handler = BaseLLMHTTPHandler()
@@ -286,7 +321,7 @@ async def anthropic_messages(
         response = await init_response
     else:
         response = init_response
-    return response
+    return _sanitize_think_tag_text_blocks(response)
 
 
 def validate_anthropic_api_metadata(metadata: Optional[Dict] = None) -> Optional[Dict]:
@@ -421,10 +456,12 @@ def anthropic_messages_handler(
             **kwargs,
         )
         if _should_route_to_responses_api(custom_llm_provider):
-            return LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(
-                **_shared_kwargs
+            return _sanitize_think_tag_text_blocks(
+                LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(
+                    **_shared_kwargs
+                )
             )
-        return (
+        return _sanitize_think_tag_text_blocks(
             LiteLLMMessagesToCompletionTransformationHandler.anthropic_messages_handler(
                 **_shared_kwargs
             )
@@ -441,20 +478,22 @@ def anthropic_messages_handler(
             params=local_vars
         )
     )
-    return base_llm_http_handler.anthropic_messages_handler(
-        model=model,
-        messages=messages,
-        anthropic_messages_provider_config=anthropic_messages_provider_config,
-        anthropic_messages_optional_request_params=dict(
-            anthropic_messages_optional_request_params
-        ),
-        _is_async=is_async,
-        client=client,
-        custom_llm_provider=custom_llm_provider,
-        litellm_params=litellm_params,
-        logging_obj=litellm_logging_obj,
-        api_key=api_key,
-        api_base=api_base,
-        stream=stream,
-        kwargs=kwargs,
+    return _sanitize_think_tag_text_blocks(
+        base_llm_http_handler.anthropic_messages_handler(
+            model=model,
+            messages=messages,
+            anthropic_messages_provider_config=anthropic_messages_provider_config,
+            anthropic_messages_optional_request_params=dict(
+                anthropic_messages_optional_request_params
+            ),
+            _is_async=is_async,
+            client=client,
+            custom_llm_provider=custom_llm_provider,
+            litellm_params=litellm_params,
+            logging_obj=litellm_logging_obj,
+            api_key=api_key,
+            api_base=api_base,
+            stream=stream,
+            kwargs=kwargs,
+        )
     )

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -511,6 +511,41 @@ def test_multiple_web_search_tool_results():
     assert web_search_results[1]["tool_use_id"] == "srvtoolu_search2"
 
 
+def test_extract_response_content_strips_leaked_think_tags_from_text_blocks():
+    config = AnthropicConfig()
+
+    completion_response = {
+        "content": [
+            {
+                "type": "text",
+                "text": "I need to call the tool first.\n</think>\n\ntool-loop-ok",
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu_01XYZ789",
+                "name": "echo_status",
+                "input": {"status": "ok"},
+            },
+        ]
+    }
+
+    (
+        text,
+        citations,
+        thinking_blocks,
+        reasoning_content,
+        tool_calls,
+        web_search_results,
+        tool_results,
+        compaction_blocks,
+    ) = config.extract_response_content(completion_response)
+
+    assert text == "tool-loop-ok"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "echo_status"
+
+
 def test_add_code_execution_tool():
     config = AnthropicConfig()
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -424,6 +424,45 @@ def test_translate_openai_response_to_anthropic_text_and_tool_calls():
     assert anthropic_response.get("stop_reason") == "tool_use"
 
 
+def test_translate_openai_response_to_anthropic_strips_leaked_think_tags():
+    openai_response = ModelResponse(
+        id="resp_text_tool_sanitized",
+        model="gpt-4o-mini",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                message=Message(
+                    role="assistant",
+                    content="I need to call the tool first.\n</think>\n\ntool-loop-ok",
+                    tool_calls=[
+                        ChatCompletionAssistantToolCall(
+                            id="call_tool_combo",
+                            type="function",
+                            function=Function(
+                                name="echo_status", arguments='{"status": "ok"}'
+                            ),
+                        )
+                    ],
+                ),
+            )
+        ],
+        usage=Usage(prompt_tokens=5, completion_tokens=2),
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_response = adapter.translate_openai_response_to_anthropic(
+        response=openai_response
+    )
+
+    anthropic_content = anthropic_response.get("content")
+    assert anthropic_content is not None
+    assert len(anthropic_content) == 2
+    assert anthropic_content[0]["type"] == "text"
+    assert anthropic_content[0]["text"] == "tool-loop-ok"
+    assert anthropic_content[1]["type"] == "tool_use"
+    assert anthropic_content[1]["name"] == "echo_status"
+
+
 def test_translate_streaming_openai_chunk_to_anthropic_with_partial_json():
     """Test that partial tool arguments are correctly handled as input_json_delta."""
     choices = [

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -499,3 +499,51 @@ class TestThinkingSummaryPreservation:
         assert result == {
             "reasoning_effort": {"effort": "medium", "summary": "concise"}
         }
+
+
+def test_anthropic_messages_handler_strips_leaked_think_tags_from_completion_path():
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+    from litellm.types.llms.anthropic_messages.anthropic_response import (
+        AnthropicMessagesResponse,
+    )
+
+    leaked_response = AnthropicMessagesResponse(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        content=[
+            {
+                "type": "text",
+                "text": "I need to call the tool first.\n</think>\n\ntool-loop-ok",
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu_01XYZ789",
+                "name": "echo_status",
+                "input": {"status": "ok"},
+            },
+        ],
+        model="custom-provider/test-model",
+        stop_reason="tool_use",
+        usage={"input_tokens": 10, "output_tokens": 20},
+    )
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.handler.LiteLLMMessagesToCompletionTransformationHandler.anthropic_messages_handler",
+        return_value=leaked_response,
+    ) as mock_completion_handler:
+        result = anthropic_messages_handler(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "Hello"}],
+            model="my-custom-model",
+            custom_llm_provider="my-custom-llm",
+            api_key="test-api-key",
+        )
+
+    mock_completion_handler.assert_called_once()
+    assert result["content"][0]["type"] == "text"
+    assert result["content"][0]["text"] == "tool-loop-ok"
+    assert result["content"][1]["type"] == "tool_use"
+    assert result["content"][1]["name"] == "echo_status"


### PR DESCRIPTION
## Relevant issues

<!-- none -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This PR fixes an Anthropic `/v1/messages` regression where leaked reasoning text could remain visible in non-streaming text blocks as `</think> ...`, while also preserving `reasoning_content` in the Anthropic-compatible tool-call pass-through path.

Proof included in this branch:

- repo-local regression tests were added for the affected Anthropic boundaries
- focused local regression runs passed for:
  - Anthropic chat transformation sanitization
  - Anthropic experimental pass-through adapter sanitization
  - Anthropic experimental `/messages` handler sanitization

Local validation covered the bug shape directly: mixed reasoning + tool-use responses and leaked `</think>` content in client-visible text.

## Type

🐛 Bug Fix
✅ Test

## Changes

- preserve `reasoning_content` in the Anthropic experimental pass-through adapter when tool calls and reasoning appear together
- strip leaked `</think>` prefixes from Anthropic-visible non-streaming text content
- add a final sanitization step at the Anthropic experimental `/messages` handler boundary so the returned response is cleaned regardless of the internal path used
- add repo-local regression coverage for the affected Anthropic transformation and handler boundaries
