### PR TITLE
[Fix] Enforce format constraints on provider URL parameters

### DIFF
--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 
@@ -294,7 +295,8 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
             raise ValueError(f"Invalid ARN format: {batch_id}")
 
         region = arn_parts[3]
-        # arn_parts[5] contains "model-invocation-job/{jobId}"
+        if not re.match(r"^[a-z][a-z0-9-]*$", region):
+            raise ValueError(f"Invalid region in ARN: {batch_id}")
 
         # Build the endpoint URL for GetModelInvocationJob
         # AWS API format: GET /model-invocation-job/{jobIdentifier}

--- a/litellm/llms/s3_vectors/vector_stores/transformation.py
+++ b/litellm/llms/s3_vectors/vector_stores/transformation.py
@@ -1,3 +1,4 @@
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx
@@ -66,6 +67,8 @@ class S3VectorsVectorStoreConfig(BaseVectorStoreConfig, BaseAWSLLM):
         aws_region_name = litellm_params.get("aws_region_name")
         if not aws_region_name:
             raise ValueError("aws_region_name is required for S3 Vectors")
+        if not re.match(r"^[a-z][a-z0-9-]*$", aws_region_name):
+            raise ValueError("Invalid aws_region_name format")
         return f"https://s3vectors.{aws_region_name}.api.aws"
 
     def transform_search_vector_store_request(

--- a/litellm/llms/snowflake/utils.py
+++ b/litellm/llms/snowflake/utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from litellm.secret_managers.main import get_secret_str
@@ -61,6 +62,8 @@ class SnowflakeBaseConfig:
                 account_id = get_secret_str("SNOWFLAKE_ACCOUNT_ID")
             if account_id is None:
                 raise ValueError("Missing snowflake account_id")
+            if not re.match(r"^[a-zA-Z0-9_-]+$", account_id):
+                raise ValueError("Invalid account_id format")
             api_base = f"https://{account_id}.snowflakecomputing.com/api/v2"
 
         api_base = api_base.rstrip("/")

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -232,8 +232,11 @@ def get_vertex_base_url(
     """
     if vertex_location == "global":
         return "https://aiplatform.googleapis.com"
-    else:
-        return f"https://{vertex_location}-aiplatform.googleapis.com"
+    if vertex_location is not None and not re.match(
+        r"^[a-z][a-z0-9-]*$", vertex_location
+    ):
+        raise ValueError("Invalid vertex_location format")
+    return f"https://{vertex_location}-aiplatform.googleapis.com"
 
 
 def _get_embedding_url(

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -8,6 +8,7 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 
 import json
 import os
+import re
 from typing import Any, Optional, Tuple, Union, cast
 
 import httpx
@@ -1500,6 +1501,10 @@ def get_vertex_base_url(vertex_location: Optional[str]) -> str:
     """
     if vertex_location == "global":
         return "https://aiplatform.googleapis.com/"
+    if vertex_location is not None and not re.match(
+        r"^[a-z][a-z0-9-]*$", vertex_location
+    ):
+        raise ValueError("Invalid vertex_location format")
     return f"https://{vertex_location}-aiplatform.googleapis.com/"
 
 


### PR DESCRIPTION
## Summary

Provider integrations (Snowflake, S3 Vectors, Vertex AI, Bedrock) construct outbound request URLs by interpolating caller-supplied parameters such as `account_id`, `aws_region_name`, and `vertex_location` directly into URL strings. These parameters had no format constraints, so a caller could supply values containing URL metacharacters that alter the constructed hostname.

This PR adds regex format validation at each URL construction point before the parameter is interpolated. Invalid values raise `ValueError` immediately.

## Changes

- `litellm/llms/snowflake/utils.py` — validate `account_id` matches `^[a-zA-Z0-9_-]+$` before building the Snowflake endpoint URL
- `litellm/llms/s3_vectors/vector_stores/transformation.py` — validate `aws_region_name` matches `^[a-z][a-z0-9-]*$` before building the S3 Vectors endpoint URL
- `litellm/llms/vertex_ai/common_utils.py` — validate `vertex_location` matches `^[a-z][a-z0-9-]*$` (or equals `"global"`) in `get_vertex_base_url`
- `litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py` — same validation in the local `get_vertex_base_url` copy used by the pass-through handler
- `litellm/llms/bedrock/batches/transformation.py` — validate the region segment extracted from a Bedrock ARN matches `^[a-z][a-z0-9-]*$` before building the Bedrock endpoint URL

## Testing

- Verified that injected values (`attacker.com#`, `attacker.com?x=`, `attacker.com/evil`, etc.) now raise `ValueError` at construction time for all three integrations.
- Verified that valid values (`myorg-account123`, `us-east-1`, `us-central1`, `global`) continue to produce correct URLs.
- `pytest tests/test_litellm/llms/snowflake/ tests/test_litellm/llms/s3_vectors/ tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py` — 66 passed, 1 skipped
- `pytest tests/local_testing/test_auth_utils.py` — 39 passed

## Type

🐛 Bug Fix