### PR TITLE
[Fix] Image edit endpoints: enforce multipart-only file inputs

### DIFF
--- a/litellm/llms/black_forest_labs/image_edit/transformation.py
+++ b/litellm/llms/black_forest_labs/image_edit/transformation.py
@@ -14,7 +14,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import httpx
 from httpx._types import RequestFiles
 
+import litellm
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+from litellm.litellm_core_utils.url_utils import safe_get
 from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.images.main import ImageEditOptionalRequestParams
@@ -206,14 +208,14 @@ class BlackForestLabsImageEditConfig(BaseImageEditConfig):
             )
         elif isinstance(image, str):
             if image.startswith(("http://", "https://")):
-                # Download image from URL
-                response = httpx.get(image, timeout=60.0)
+                response = safe_get(litellm.module_level_client, image, timeout=60.0)
                 response.raise_for_status()
                 return response.content
             else:
-                # Assume it's a file path
-                with open(image, "rb") as f:
-                    return f.read()
+                raise ValueError(
+                    f"Unsupported image input: plain string values that are not URLs are not accepted. "
+                    "Provide image bytes or a file-like object."
+                )
         elif hasattr(image, "read"):
             # File-like object
             pos = getattr(image, "tell", lambda: 0)()

--- a/litellm/llms/black_forest_labs/image_edit/transformation.py
+++ b/litellm/llms/black_forest_labs/image_edit/transformation.py
@@ -213,7 +213,7 @@ class BlackForestLabsImageEditConfig(BaseImageEditConfig):
                 return response.content
             else:
                 raise ValueError(
-                    f"Unsupported image input: plain string values that are not URLs are not accepted. "
+                    "Unsupported image input: plain string values that are not URLs are not accepted. "
                     "Provide image bytes or a file-like object."
                 )
         elif hasattr(image, "read"):

--- a/litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py
+++ b/litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py
@@ -348,13 +348,16 @@ class VertexAIImagenImageEditConfig(BaseImageEditConfig, VertexLLM):
             if stream_pos is not None:
                 image.seek(stream_pos)
             return data
-        if isinstance(image, (str, Path)):
-            path_obj = Path(image)
-            if not path_obj.exists():
-                raise ValueError(
-                    f"Mask/image path does not exist for Vertex AI Imagen image edit: {path_obj}"
-                )
-            return path_obj.read_bytes()
+        if isinstance(image, str):
+            raise ValueError(
+                "Unsupported image input: plain string values are not accepted for "
+                "Vertex AI Imagen image edit. Provide image bytes or a file-like object."
+            )
+        if isinstance(image, Path):
+            raise ValueError(
+                "Unsupported image input: filesystem paths are not accepted for "
+                "Vertex AI Imagen image edit. Provide image bytes or a file-like object."
+            )
         if hasattr(image, "read"):
             data = image.read()
             if isinstance(data, str):

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -285,6 +285,13 @@ async def image_edit_api(
     if mask_files:
         data["mask"] = mask_files
 
+    for _field in ("image", "mask"):
+        if _field in data and isinstance(data[_field], str):
+            raise HTTPException(
+                status_code=422,
+                detail=f"'{_field}' must be provided as a multipart file upload, not a string.",
+            )
+
     # Ensure prompt exists in data (default to None for models that don't require it)
     if "prompt" not in data:
         data["prompt"] = None


### PR DESCRIPTION
## Summary

- The `/v1/images/edits` endpoint now rejects `image` and `mask` parameters when they arrive as plain strings in a JSON body; these fields must be provided as multipart file uploads
- The Black Forest Labs image edit handler no longer reads from local filesystem paths for string inputs; URL strings are now fetched via the validated HTTP client (`safe_get`) instead of a raw `httpx.get`
- The Vertex AI Imagen image edit handler no longer accepts `str` or `Path` objects as image inputs; callers must provide bytes or a file-like object

## Testing

- `uv run pytest tests/test_litellm/llms/black_forest_labs/image_edit/test_bfl_image_edit_transformation.py tests/test_litellm/llms/vertex_ai/image_edit/test_vertex_ai_image_edit_transformation.py -v` — 37 passed
- Live proxy: confirmed string inputs return 422 before reaching any model handler; confirmed pre-fix behavior was 500 (strings passed through input validation)

## Type

🐛 Bug Fix
✅ Test