### PR TITLE
[Test] Skip provider env/account failures to reduce CCI flakiness (3 flaky tests)

### DIFF
--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -26,7 +26,8 @@ _ENV_ERROR_SUBSTRINGS = (
     "insufficient_quota",
     "credit balance is too low",
     "exceeded your current quota",
-    "billing",
+    "billing_hard_limit_reached",
+    "does not have billing enabled",
 )
 
 

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -15,6 +15,34 @@ import asyncio
 import litellm
 
 
+# Substrings that indicate the failure is caused by the CI provider account
+# (billing, quota, missing scope) rather than a LiteLLM regression. When any of
+# these appear in a provider error message, the test should `pytest.skip` rather
+# than fail, so CircleCI flakiness from upstream account state stops bleeding
+# into the pipeline signal. Keep this list narrow and allow-listed.
+_ENV_ERROR_SUBSTRINGS = (
+    "missing scopes",
+    "insufficient permissions",
+    "insufficient_quota",
+    "credit balance is too low",
+    "exceeded your current quota",
+    "billing",
+)
+
+
+def _is_env_error(message: str) -> bool:
+    """Return True when `message` matches a known provider env/account condition.
+
+    Matches are case-insensitive substring checks against the allow-list above.
+    Used to distinguish "CI credentials are temporarily unhealthy" from a real
+    LiteLLM regression.
+    """
+    if not message:
+        return False
+    lowered = message.lower()
+    return any(needle in lowered for needle in _ENV_ERROR_SUBSTRINGS)
+
+
 @pytest.mark.asyncio
 async def test_azure_health_check():
     response = await litellm.ahealth_check(
@@ -206,6 +234,11 @@ async def test_audio_speech_health_check():
         prompt="Hey",
     )
 
+    if "error" in response and _is_env_error(str(response.get("error", ""))):
+        pytest.skip(
+            f"Skipping due to provider env/account condition: {response.get('error')}"
+        )
+
     assert "error" not in response
 
     print(response)
@@ -222,6 +255,11 @@ async def test_audio_speech_health_check_with_another_voice():
         mode="audio_speech",
         prompt="Hey",
     )
+
+    if "error" in response and _is_env_error(str(response.get("error", ""))):
+        pytest.skip(
+            f"Skipping due to provider env/account condition: {response.get('error')}"
+        )
 
     assert "error" not in response
 

--- a/tests/llm_translation/base_llm_unit_tests.py
+++ b/tests/llm_translation/base_llm_unit_tests.py
@@ -43,7 +43,8 @@ _ENV_PROVIDER_ERROR_SUBSTRINGS = (
     "insufficient_quota",
     "credit balance is too low",
     "exceeded your current quota",
-    "billing",
+    "billing_hard_limit_reached",
+    "does not have billing enabled",
 )
 
 

--- a/tests/llm_translation/base_llm_unit_tests.py
+++ b/tests/llm_translation/base_llm_unit_tests.py
@@ -31,6 +31,36 @@ from abc import ABC, abstractmethod
 from openai import OpenAI
 
 
+# Substrings that indicate the failure is caused by the CI provider account
+# (billing, quota, missing scope) rather than a LiteLLM regression. When a
+# provider raises `BadRequestError`/`AuthenticationError`/`RateLimitError` with
+# one of these messages, the test should `pytest.skip` rather than fail: the
+# underlying LiteLLM code path is not broken, the CI credential is just
+# temporarily unhealthy. Keep this list narrow and allow-listed.
+_ENV_PROVIDER_ERROR_SUBSTRINGS = (
+    "missing scopes",
+    "insufficient permissions",
+    "insufficient_quota",
+    "credit balance is too low",
+    "exceeded your current quota",
+    "billing",
+)
+
+
+def _is_env_provider_error(exc: Exception) -> bool:
+    """Return True when `exc` was raised by a provider for an env/account reason.
+
+    Case-insensitive substring match against the allow-list above. Used to
+    distinguish "CI credentials are temporarily unhealthy" from a real LiteLLM
+    regression.
+    """
+    message = str(exc) if exc else ""
+    if not message:
+        return False
+    lowered = message.lower()
+    return any(needle in lowered for needle in _ENV_PROVIDER_ERROR_SUBSTRINGS)
+
+
 def _usage_format_tests(usage: litellm.Usage):
     """
     OpenAI prompt caching
@@ -1416,6 +1446,19 @@ class BaseLLMChatTest(ABC):
             print(response)
         except litellm.ServiceUnavailableError:
             pass
+        except (
+            litellm.BadRequestError,
+            litellm.AuthenticationError,
+            litellm.RateLimitError,
+        ) as e:
+            # Some providers return billing/quota/permission errors as 400/401/429.
+            # These are CI account-state conditions, not LiteLLM regressions -- skip
+            # the test rather than fail the pipeline. Any other BadRequestError /
+            # AuthenticationError will still propagate and fail normally (e.g. a
+            # genuine transformation regression).
+            if _is_env_provider_error(e):
+                pytest.skip(f"Skipping due to provider env/account condition: {e}")
+            raise
 
     def test_reasoning_effort(self):
         """Test that reasoning_effort is passed correctly to the model"""

--- a/tests/search_tests/test_perplexity_search.py
+++ b/tests/search_tests/test_perplexity_search.py
@@ -33,7 +33,8 @@ _ENV_PROVIDER_ERROR_SUBSTRINGS = (
     "insufficient_quota",
     "credit balance is too low",
     "exceeded your current quota",
-    "billing",
+    "billing_hard_limit_reached",
+    "does not have billing enabled",
 )
 
 

--- a/tests/search_tests/test_perplexity_search.py
+++ b/tests/search_tests/test_perplexity_search.py
@@ -23,6 +23,29 @@ class TestPerplexitySearch(BaseSearchTest):
         return "perplexity"
 
 
+# Substrings that indicate the failure is caused by the CI provider account
+# (billing, quota, missing scope) rather than a LiteLLM regression. Perplexity
+# in particular returns quota exhaustion as a 401 AuthenticationError, which
+# would otherwise fail this test.
+_ENV_PROVIDER_ERROR_SUBSTRINGS = (
+    "missing scopes",
+    "insufficient permissions",
+    "insufficient_quota",
+    "credit balance is too low",
+    "exceeded your current quota",
+    "billing",
+)
+
+
+def _is_env_provider_error(exc: Exception) -> bool:
+    """Return True when `exc` was raised by a provider for an env/account reason."""
+    message = str(exc) if exc else ""
+    if not message:
+        return False
+    lowered = message.lower()
+    return any(needle in lowered for needle in _ENV_PROVIDER_ERROR_SUBSTRINGS)
+
+
 class TestRouterSearch:
     """
     Tests for Router Search functionality.
@@ -51,12 +74,26 @@ class TestRouterSearch:
             ]
         )
 
-        # Test the search
-        response = await router.asearch(
-            query="latest AI developments",
-            search_tool_name="litellm-search",
-            max_results=3,
-        )
+        # Test the search. Perplexity can return transient upstream conditions
+        # (rate-limit, overloaded, quota-as-401) that are CI account-state
+        # issues rather than LiteLLM regressions. Mirror the behavior of
+        # BaseSearchTest._handle_rate_limits (which this class does not inherit)
+        # and `pytest.skip` in those narrow cases. Any other exception still
+        # propagates normally.
+        try:
+            response = await router.asearch(
+                query="latest AI developments",
+                search_tool_name="litellm-search",
+                max_results=3,
+            )
+        except litellm.RateLimitError:
+            pytest.skip("Rate limit exceeded")
+        except litellm.InternalServerError:
+            pytest.skip("Model is overloaded")
+        except litellm.AuthenticationError as e:
+            if _is_env_provider_error(e):
+                pytest.skip(f"Skipping due to provider env/account condition: {e}")
+            raise
 
         print(f"\n{'='*80}")
         print(f"Router Search Test Results:")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Reduce CircleCI flakiness by targeting the heaviest hitters from the last 2 weeks of runs.

## Summary

CircleCI's `find_flaky_tests` API returned **3 flaky tests** on `gh/BerriAI/litellm` over the past 2-week window. All three fail for the same category of reason: an external provider (OpenAI / Anthropic / Perplexity) intermittently returns an **environmental** error (billing, quota, or missing-scope) that is not a LiteLLM regression.

| # | Test | Observed failure signal |
| --- | --- | --- |
| 1 | `tests/litellm_utils_tests/test_health_check.py::test_audio_speech_health_check` (and the `..._with_another_voice` variant) | OpenAI 400: `Missing scopes: api.model.audio.request` |
| 2 | `tests/llm_translation/test_anthropic_completion.py::TestAnthropicCompletion::test_function_calling_with_tool_response` (defined on `BaseLLMChatTest` in `base_llm_unit_tests.py`) | Anthropic 400: `Your credit balance is too low` |
| 3 | `tests/search_tests/test_perplexity_search.py::TestRouterSearch::test_router_search_with_search_tools` | Perplexity 401: `You exceeded your current quota ... insufficient_quota` |

## Fix

Test-only. Add a **narrow, allow-listed** classifier of provider env-error substrings and convert matching upstream failures into `pytest.skip(...)`. This mirrors the existing `_handle_rate_limits` fixture in `tests/search_tests/base_search_unit_tests.py` and the pre-existing `except litellm.ServiceUnavailableError: pass` in the base function-calling test.

**Allow-list (case-insensitive substring match):**
- `missing scopes`
- `insufficient permissions`
- `insufficient_quota`
- `credit balance is too low`
- `exceeded your current quota`
- `billing_hard_limit_reached` (OpenAI)
- `does not have billing enabled` (Anthropic/Google phrase)

Any other `BadRequestError` / `AuthenticationError` / `RateLimitError` still propagates and fails the test — so a genuine LiteLLM regression (e.g. a transformation bug producing a 400 with a different message) will still turn CI red.

### Why not retries?
`.circleci/config.yml` already passes `--retries=2` to the main `pytest` command. Retries do **not** help for deterministic 401 / billing / missing-scope errors — the account state does not clear in a minute. `pytest.skip` surfaces a clear CI message without wasting CI time or falsely going red.

### Why not delete the tests?
Under a healthy CI credential the three tests exercise real LiteLLM code paths (`ahealth_check` routing, streaming tool-call accumulation on the base chat test, `Router.asearch` wiring). Skipping is the right policy **only** when the provider message matches the narrow allow-list.

## Files changed

| File | Change |
| --- | --- |
| `tests/litellm_utils_tests/test_health_check.py` | Add `_is_env_error` helper + skip branch in 2 audio-speech tests |
| `tests/llm_translation/base_llm_unit_tests.py` | Add `_is_env_provider_error` helper + widen the existing `try/except` in `test_function_calling_with_tool_response` |
| `tests/search_tests/test_perplexity_search.py` | Add helper + wrap `test_router_search_with_search_tools` body with a tight `try/except/skip` (RateLimit / InternalServerError / env-Auth) |

3 files changed, 127 insertions, 6 deletions. No production code changes. No new dependencies.

## Precedents followed

- `c8a94ff1ec` — `[Test] stub flaky bedrock gpt-oss function-calling stream test`
- `5445297da9` — `[Fix] Stabilize flaky spend accuracy tests with local ground truth`
- `tests/search_tests/base_search_unit_tests.py::_handle_rate_limits` — the exact "skip-on-upstream-env-condition" fixture pattern this PR extends to three sibling tests.

## Review

An independent reviewer (subagent) audited the diff end-to-end and returned `APPROVE`. Their feedback recommended tightening a broader `"billing"` substring to two concrete provider phrases (`billing_hard_limit_reached`, `does not have billing enabled`) — applied in commit `8767a72dc9`.

## CCI result on this PR (pipeline #74527)

**Jobs containing the 3 targeted tests — all PASSED:**

| Targeted flaky test | CCI job | Status |
| --- | --- | --- |
| `test_audio_speech_health_check` (+ voice variant) | `litellm_utils_testing` | ✅ pass |
| `test_function_calling_with_tool_response` (Anthropic) | `llm_translation_testing` | ✅ pass |
| `test_router_search_with_search_tools` | `search_testing` | ✅ pass |

**Jobs that failed on this PR — NOT caused by this change (unrelated pre-existing flakes in files this PR does not touch):**

| CCI job | Failing test | In a file touched by this PR? |
| --- | --- | --- |
| `litellm_mapped_tests_proxy_part2` | `test_spend_management_endpoints.py::test_ui_view_session_spend_logs_pagination`, `test_ui_view_spend_logs_date_range_filter` (`assert 401 == 200`) | No |
| `litellm_router_testing` | `test_tpm_rpm_routing_v2.py::test_router_caching_ttl` (`AttributeError: 'NoneType' object has no attribute 'kwargs'`) | No |
| `logging_testing` | `test_built_in_tools_cost_tracking.py::test_openai_responses_api_web_search_cost_tracking` (OpenAI `InternalServerError` / `AttributeError`) | No |

All three failures are in files with no recent commits and in areas this PR does not modify. They represent a separate (broader) flakiness surface that is out of scope for this PR — I've confirmed by inspecting diffs that this PR changes exactly three test files and adds no production code.

## Pre-Submission checklist

- [x] Tests changed are the flaky tests themselves; helper behavior was exercised locally with positive/negative inputs (including a `billing_address is wrong` false-positive probe that correctly does **not** match).
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem (reduce CCI flakiness for the 3 env-flaky tests).
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [x] **Branch creation CI run**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/74527

- [x] **CI run for the last commit**  
       Link: https://app.circleci.com/pipelines/github/BerriAI/litellm/74527

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Type

✅ Test

## Changes

- Add narrow allow-list of provider env-error substrings.
- `test_audio_speech_health_check` + its voice variant: `pytest.skip` when `response["error"]` matches the allow-list; otherwise the original `assert "error" not in response` runs.
- `BaseLLMChatTest.test_function_calling_with_tool_response`: widen existing `except ServiceUnavailableError: pass` to also `pytest.skip` on matching `BadRequestError` / `AuthenticationError` / `RateLimitError`; re-raise otherwise.
- `TestRouterSearch.test_router_search_with_search_tools`: wrap the `router.asearch` call with a tight `try/except` that skips on `RateLimitError`, `InternalServerError`, and env-matched `AuthenticationError`; re-raises all other exceptions so response-structure assertions still trip on real regressions.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5a39139-80b7-47a0-ae56-5ddfa5e370ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5a39139-80b7-47a0-ae56-5ddfa5e370ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

