### PR TITLE
[Fix] Image edit: reject string values for file parameters

### DIFF
--- a/litellm/llms/black_forest_labs/image_edit/transformation.py
+++ b/litellm/llms/black_forest_labs/image_edit/transformation.py
@@ -15,6 +15,7 @@ import httpx
 from httpx._types import RequestFiles
 
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+from litellm.litellm_core_utils.url_utils import safe_get
 from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.images.main import ImageEditOptionalRequestParams
@@ -206,14 +207,14 @@ class BlackForestLabsImageEditConfig(BaseImageEditConfig):
             )
         elif isinstance(image, str):
             if image.startswith(("http://", "https://")):
-                # Download image from URL
-                response = httpx.get(image, timeout=60.0)
+                with httpx.Client() as client:
+                    response = safe_get(client, image, timeout=60.0)
                 response.raise_for_status()
                 return response.content
             else:
-                # Assume it's a file path
-                with open(image, "rb") as f:
-                    return f.read()
+                raise ValueError(
+                    f"Unsupported string input for image: expected a URL starting with http:// or https://"
+                )
         elif hasattr(image, "read"):
             # File-like object
             pos = getattr(image, "tell", lambda: 0)()

--- a/litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py
+++ b/litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py
@@ -349,12 +349,10 @@ class VertexAIImagenImageEditConfig(BaseImageEditConfig, VertexLLM):
                 image.seek(stream_pos)
             return data
         if isinstance(image, (str, Path)):
-            path_obj = Path(image)
-            if not path_obj.exists():
-                raise ValueError(
-                    f"Mask/image path does not exist for Vertex AI Imagen image edit: {path_obj}"
-                )
-            return path_obj.read_bytes()
+            raise ValueError(
+                "String file paths are not accepted for Vertex AI Imagen image edit. "
+                "Provide image data as bytes or a file-like object."
+            )
         if hasattr(image, "read"):
             data = image.read()
             if isinstance(data, str):

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -285,6 +285,13 @@ async def image_edit_api(
     if mask_files:
         data["mask"] = mask_files
 
+    for field in ("image", "mask"):
+        if isinstance(data.get(field), str):
+            raise HTTPException(
+                status_code=422,
+                detail=f"'{field}' must be a file upload. Use multipart/form-data to upload files.",
+            )
+
     # Ensure prompt exists in data (default to None for models that don't require it)
     if "prompt" not in data:
         data["prompt"] = None


### PR DESCRIPTION
## Summary

The image edit endpoint (`/v1/images/edits`) accepted arbitrary strings for the `image` and `mask` parameters when the request was sent as a JSON body rather than multipart form data. Those strings were passed intact to provider-level handlers that treated them as local file paths or HTTP URLs.

This PR adds validation at the proxy layer to reject string values for `image` and `mask` with a 422 error, and aligns the Black Forest Labs and Vertex AI handler internals to match — the BFL handler now uses the existing `safe_get` utility for URL strings and raises for non-URLs, and the Vertex AI handler raises instead of reading from the local filesystem.

## Changes

- `litellm/proxy/image_endpoints/endpoints.py` — after parsing the request body, reject any `image` or `mask` field that is a plain string; both must arrive as multipart file uploads
- `litellm/llms/black_forest_labs/image_edit/transformation.py` — URL strings go through `safe_get()` instead of raw `httpx.get()`; non-URL strings raise `ValueError`
- `litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py` — `str`/`Path` inputs to `_image_to_bytes` now raise `ValueError` instead of reading the path

## Testing

- `uv run pytest tests/test_litellm/llms/black_forest_labs/image_edit/ tests/test_litellm/llms/vertex_ai/image_edit/ tests/test_litellm/images/ tests/test_litellm/proxy/image_endpoints/ -v` — 48 passed
- Live proxy: JSON body with `image="/etc/passwd"`, `mask="/etc/shadow"`, and `image="http://169.254.169.254/..."` all return 422; legitimate multipart upload passes through

## Type

🐛 Bug Fix
✅ Test