### PR TITLE
fix(reset_budget_job): use query_raw to filter budget_limits IS NOT NULL

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -634,8 +634,10 @@ class ResetBudgetJob:
 
         # --- Keys ---
         try:
+            # Avoid Prisma JSON null filters here; generated clients handle them
+            # inconsistently for optional Json fields across environments.
             all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
+                select={"token": True, "budget_limits": True}
             )
             for key in all_keys:
                 raw = key.budget_limits  # type: ignore[attr-defined]
@@ -663,8 +665,10 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
+            # Keep the same fetch strategy as keys to avoid Json filter parsing
+            # errors on optional Prisma Json columns.
             all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
+                select={"team_id": True, "budget_limits": True}
             )
             for team in all_teams:
                 raw = team.budget_limits  # type: ignore[attr-defined]

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -634,10 +634,8 @@ class ResetBudgetJob:
 
         # --- Keys ---
         try:
-            # Avoid Prisma JSON null filters here; generated clients handle them
-            # inconsistently for optional Json fields across environments.
             all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                select={"token": True, "budget_limits": True}
+                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
             )
             for key in all_keys:
                 raw = key.budget_limits  # type: ignore[attr-defined]
@@ -665,10 +663,8 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
-            # Keep the same fetch strategy as keys to avoid Json filter parsing
-            # errors on optional Prisma Json columns.
             all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
-                select={"team_id": True, "budget_limits": True}
+                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
             )
             for team in all_teams:
                 raw = team.budget_limits  # type: ignore[attr-defined]

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -632,20 +632,27 @@ class ResetBudgetJob:
 
         now = datetime.utcnow()
 
+        # Use query_raw to push the "budget_limits IS NOT NULL" filter to the DB
+        # and project only the two columns we need. The ORM path is blocked here:
+        # prisma-client-py rejects {"not": None} on Json? fields and has no
+        # select= kwarg, so a plain find_many() would scan both wide tables in
+        # full on every tick. Updates still go through the ORM below.
+
         # --- Keys ---
         try:
-            all_keys = await self.prisma_client.db.litellm_verificationtoken.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
+            key_rows = await self.prisma_client.db.query_raw(
+                'SELECT token, budget_limits FROM "LiteLLM_VerificationToken" '
+                "WHERE budget_limits IS NOT NULL"
             )
-            for key in all_keys:
-                raw = key.budget_limits  # type: ignore[attr-defined]
+            for key in key_rows or []:
+                raw = key["budget_limits"]
                 if not raw:
                     continue
                 windows: list = raw if isinstance(raw, list) else json.loads(raw)
                 changed = False
                 for window in windows:
                     counter_key = (
-                        f"spend:key:{key.token}:window:{window['budget_duration']}"
+                        f"spend:key:{key['token']}:window:{window['budget_duration']}"
                     )
                     if await ResetBudgetJob._reset_expired_window(
                         window, counter_key, spend_counter_cache, now
@@ -653,7 +660,7 @@ class ResetBudgetJob:
                         changed = True
                 if changed:
                     await self.prisma_client.db.litellm_verificationtoken.update(
-                        where={"token": key.token},
+                        where={"token": key["token"]},
                         data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
                     )
         except Exception as e:
@@ -663,18 +670,19 @@ class ResetBudgetJob:
 
         # --- Teams ---
         try:
-            all_teams = await self.prisma_client.db.litellm_teamtable.find_many(
-                where={"budget_limits": {"not": None}}  # type: ignore[arg-type]
+            team_rows = await self.prisma_client.db.query_raw(
+                'SELECT team_id, budget_limits FROM "LiteLLM_TeamTable" '
+                "WHERE budget_limits IS NOT NULL"
             )
-            for team in all_teams:
-                raw = team.budget_limits  # type: ignore[attr-defined]
+            for team in team_rows or []:
+                raw = team["budget_limits"]
                 if not raw:
                     continue
                 windows = raw if isinstance(raw, list) else json.loads(raw)
                 changed = False
                 for window in windows:
                     counter_key = (
-                        f"spend:team:{team.team_id}:window:{window['budget_duration']}"
+                        f"spend:team:{team['team_id']}:window:{window['budget_duration']}"
                     )
                     if await ResetBudgetJob._reset_expired_window(
                         window, counter_key, spend_counter_cache, now
@@ -682,7 +690,7 @@ class ResetBudgetJob:
                         changed = True
                 if changed:
                     await self.prisma_client.db.litellm_teamtable.update(
-                        where={"team_id": team.team_id},
+                        where={"team_id": team["team_id"]},
                         data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
                     )
         except Exception as e:

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -824,7 +824,7 @@ def test_reset_budget_for_team_members_preserves_total_spend():
 
 
 @pytest.mark.asyncio
-async def test_reset_budget_windows_uses_plain_find_many_and_resets_key_and_team(
+async def test_reset_budget_windows_uses_query_raw_and_resets_key_and_team(
     monkeypatch,
 ):
     class _InMemoryCache:
@@ -847,29 +847,30 @@ async def test_reset_budget_windows_uses_plain_find_many_and_resets_key_and_team
     expired_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
     future_at = (datetime.utcnow() + timedelta(minutes=5)).isoformat()
 
-    key_row = SimpleNamespace(
-        token="key-1",
-        budget_limits=[
+    key_row = {
+        "token": "key-1",
+        "budget_limits": [
             {"budget_duration": "1d", "reset_at": expired_at},
             {"budget_duration": "7d", "reset_at": future_at},
         ],
-    )
-    key_without_limits = SimpleNamespace(token="key-2", budget_limits=None)
+    }
+    team_row = {
+        "team_id": "team-1",
+        "budget_limits": json.dumps(
+            [{"budget_duration": "1d", "reset_at": expired_at}]
+        ),
+    }
 
-    team_row = SimpleNamespace(
-        team_id="team-1",
-        budget_limits=json.dumps([{"budget_duration": "1d", "reset_at": expired_at}]),
-    )
-    team_without_limits = SimpleNamespace(team_id="team-2", budget_limits=None)
+    async def fake_query_raw(sql: str, *args):
+        if "LiteLLM_VerificationToken" in sql:
+            return [key_row]
+        if "LiteLLM_TeamTable" in sql:
+            return [team_row]
+        raise AssertionError(f"unexpected query_raw call: {sql!r}")
 
     mock_prisma_client = MagicMock()
-    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
-        return_value=[key_row, key_without_limits]
-    )
+    mock_prisma_client.db.query_raw = AsyncMock(side_effect=fake_query_raw)
     mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock()
-    mock_prisma_client.db.litellm_teamtable.find_many = AsyncMock(
-        return_value=[team_row, team_without_limits]
-    )
     mock_prisma_client.db.litellm_teamtable.update = AsyncMock()
 
     job = ResetBudgetJob(
@@ -878,11 +879,15 @@ async def test_reset_budget_windows_uses_plain_find_many_and_resets_key_and_team
 
     await job.reset_budget_windows()
 
-    mock_prisma_client.db.litellm_verificationtoken.find_many.assert_called_once_with(
-        where={"budget_limits": {"not": None}}
+    assert mock_prisma_client.db.query_raw.call_count == 2
+    queries = [call.args[0] for call in mock_prisma_client.db.query_raw.call_args_list]
+    assert any(
+        'FROM "LiteLLM_VerificationToken"' in q and "budget_limits IS NOT NULL" in q
+        for q in queries
     )
-    mock_prisma_client.db.litellm_teamtable.find_many.assert_called_once_with(
-        where={"budget_limits": {"not": None}}
+    assert any(
+        'FROM "LiteLLM_TeamTable"' in q and "budget_limits IS NOT NULL" in q
+        for q in queries
     )
 
     mock_prisma_client.db.litellm_verificationtoken.update.assert_called_once()

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 import os
 import sys
 import time
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock
 
@@ -696,9 +698,9 @@ def test_reset_budget_resets_endusers_with_null_budget_id(
 
     # Both end users should have been reset
     updated = mock_prisma_client.updated_data["enduser"]
-    assert len(updated) == 2, (
-        f"Expected 2 endusers reset (1 explicit + 1 implicit), got {len(updated)}"
-    )
+    assert (
+        len(updated) == 2
+    ), f"Expected 2 endusers reset (1 explicit + 1 implicit), got {len(updated)}"
 
     user_ids = {u.user_id for u in updated}
     assert "enduser-explicit" in user_ids
@@ -819,3 +821,86 @@ def test_reset_budget_for_team_members_preserves_total_spend():
     assert call_kwargs["where"]["budget_id"]["in"] == ["budget-1"]
     assert call_kwargs["data"] == {"spend": 0}
     assert "total_spend" not in call_kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_reset_budget_windows_uses_plain_find_many_and_resets_key_and_team(
+    monkeypatch,
+):
+    class _InMemoryCache:
+        def __init__(self):
+            self.calls = []
+
+        def set_cache(self, key: str, value: float) -> None:
+            self.calls.append((key, value))
+
+    spend_counter_cache = SimpleNamespace(
+        in_memory_cache=_InMemoryCache(),
+        redis_cache=None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm.proxy.proxy_server",
+        SimpleNamespace(spend_counter_cache=spend_counter_cache),
+    )
+
+    expired_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    future_at = (datetime.utcnow() + timedelta(minutes=5)).isoformat()
+
+    key_row = SimpleNamespace(
+        token="key-1",
+        budget_limits=[
+            {"budget_duration": "1d", "reset_at": expired_at},
+            {"budget_duration": "7d", "reset_at": future_at},
+        ],
+    )
+    key_without_limits = SimpleNamespace(token="key-2", budget_limits=None)
+
+    team_row = SimpleNamespace(
+        team_id="team-1",
+        budget_limits=json.dumps([{"budget_duration": "1d", "reset_at": expired_at}]),
+    )
+    team_without_limits = SimpleNamespace(team_id="team-2", budget_limits=None)
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[key_row, key_without_limits]
+    )
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock()
+    mock_prisma_client.db.litellm_teamtable.find_many = AsyncMock(
+        return_value=[team_row, team_without_limits]
+    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock()
+
+    job = ResetBudgetJob(
+        proxy_logging_obj=MagicMock(), prisma_client=mock_prisma_client
+    )
+
+    await job.reset_budget_windows()
+
+    mock_prisma_client.db.litellm_verificationtoken.find_many.assert_called_once_with(
+        where={"budget_limits": {"not": None}}
+    )
+    mock_prisma_client.db.litellm_teamtable.find_many.assert_called_once_with(
+        where={"budget_limits": {"not": None}}
+    )
+
+    mock_prisma_client.db.litellm_verificationtoken.update.assert_called_once()
+    key_update_kwargs = (
+        mock_prisma_client.db.litellm_verificationtoken.update.call_args.kwargs
+    )
+    assert key_update_kwargs["where"] == {"token": "key-1"}
+    updated_key_windows = json.loads(key_update_kwargs["data"]["budget_limits"])
+    assert updated_key_windows[0]["reset_at"] != expired_at
+    assert updated_key_windows[1]["reset_at"] == future_at
+
+    mock_prisma_client.db.litellm_teamtable.update.assert_called_once()
+    team_update_kwargs = mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs
+    assert team_update_kwargs["where"] == {"team_id": "team-1"}
+    updated_team_windows = json.loads(team_update_kwargs["data"]["budget_limits"])
+    assert updated_team_windows[0]["reset_at"] != expired_at
+
+    assert spend_counter_cache.in_memory_cache.calls == [
+        ("spend:key:key-1:window:1d", 0.0),
+        ("spend:team:team-1:window:1d", 0.0),
+    ]


### PR DESCRIPTION
## Summary

Fix `reset_budget_windows` in `ResetBudgetJob` so it no longer errors out at runtime, and avoid scanning two wide tables in full every 10 minutes.

## Why the previous attempts failed

This PR went through three iterations. The real reasons each earlier approach broke are captured below so they don't get re-tried:

| Attempt | Call site | Failure | Layer |
|---|---|---|---|
| `where={"budget_limits": {"not": None}}` | Prisma ORM | `MissingRequiredValueError: where.budget_limits.not: A value is required but not set` | Prisma engine |
| `select={"token": True, "budget_limits": True}` | Prisma ORM | `TypeError: find_many() got an unexpected keyword argument 'select'` | Python client |
| `find_many()` (no filter) + Python filter | Prisma ORM | Runs, but full-scans both tables | N/A |

**Root causes**

1. **Json? null filter is broken in `prisma-client-py`.** The generated `JsonFilter` is:
   ```python
   JsonFilter = TypedDict('JsonFilter', {'equals': 'fields.Json', 'not': 'fields.Json'}, total=False)
   ```
   Both `equals` and `not` require a JSON value, not Python `None`. Passing `{"not": None}` reaches the engine with an empty operand, which the engine rejects. Unlike the JS client, the Python client never ships the `DbNull` / `JsonNull` sentinels that would express "IS NOT NULL" on a nullable JSON column.
2. **`select=` is not supported at all in `prisma-client-py==0.11.0`.** The generated `find_many()`, `find_first()`, and `find_unique()` signatures have no `select` parameter — it's a long-standing gap relative to the JS client. Passing `select=` raises `TypeError` before anything touches the engine.
3. **Plain `find_many()` works but is expensive.** Both tables are wide (~45 columns for `LiteLLM_VerificationToken`, with multiple `Json` columns that grow per active key: `model_spend`, `model_max_budget`, etc.). `budget_limits` is an opt-in multi-window budget feature that ~0–5% of rows use. Scanning the full table every scheduler tick (~10 min, per pod) is disproportionate.

## What this PR does

Switch the **read** path to `query_raw` with explicit `WHERE budget_limits IS NOT NULL` and column projection:

```python
key_rows = await prisma_client.db.query_raw(
    'SELECT token, budget_limits FROM "LiteLLM_VerificationToken" '
    'WHERE budget_limits IS NOT NULL'
)
```

The **update** path keeps using the ORM (`prisma_client.db.litellm_verificationtoken.update(...)`) so type safety and transactional semantics are unchanged. `LiteLLM_TeamTable` is handled the same way.

This bypasses both `prisma-client-py` limitations at once:
- No `JsonFilter` involvement → no `MissingRequiredValueError`
- No `select=` needed → no `TypeError`
- DB-side filter + column projection → no full-table scan, no 45-column payload

CLAUDE.md generally discourages `query_raw`; this is a deliberate, narrow exception because the ORM has no way to express "filter a nullable JSON column for `IS NOT NULL`" on the current client version. The inline comment in `reset_budget_windows()` records the reasoning so future readers know not to revert to `where=` or `select=`.

## Test plan

- [x] Updated unit test `test_reset_budget_windows_uses_query_raw_and_resets_key_and_team` mocks `query_raw`, verifies SQL contains both table names and `budget_limits IS NOT NULL`, and verifies updates go through the ORM with the correct `where` / `data`.
- [ ] `make test-unit` passes locally
- [ ] Reset-budget job runs without `MissingRequiredValueError` or `TypeError` against Postgres
- [ ] Keys/teams with `budget_limits = NULL` are excluded by the SQL filter (no Python-side skip needed)
- [ ] Keys/teams with non-null `budget_limits` have expired windows reset and future windows untouched

## Follow-ups (not in this PR)

- A partial index `CREATE INDEX ... ON "LiteLLM_VerificationToken" (token) WHERE budget_limits IS NOT NULL` (and the same on `LiteLLM_TeamTable`) would take the filtered query from a seq-scan on the large table down to near-zero cost. Worth adding if the `budget_limits` feature sees wider adoption.
- If `prisma-client-py` is ever upgraded to a version that exposes JSON null sentinels and/or `select=`, this can be rewritten back to pure ORM. Not recommended as a blocker for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
