### PR TITLE
fix(anthropic-messages): apply top-level additional_drop_params on /v1/messages

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1966,7 +1966,9 @@ class BaseLLMHTTPHandler:
             custom_llm_provider=custom_llm_provider,
         )
 
-        # Apply additional_drop_params for nested field removal
+        # Apply additional_drop_params — top-level and nested fields.
+        # Unlike /v1/chat/completions, this path has no prior top-level drop
+        # step, so we must handle both here. See issue #25931.
         additional_drop_params = litellm_params.get("additional_drop_params")
         if additional_drop_params:
             from litellm.litellm_core_utils.dot_notation_indexing import (
@@ -1974,11 +1976,13 @@ class BaseLLMHTTPHandler:
                 is_nested_path,
             )
 
-            nested_paths = [p for p in additional_drop_params if is_nested_path(p)]
-            for path in nested_paths:
-                anthropic_messages_optional_request_params = delete_nested_value(
-                    anthropic_messages_optional_request_params, path
-                )
+            for path in additional_drop_params:
+                if is_nested_path(path):
+                    anthropic_messages_optional_request_params = delete_nested_value(
+                        anthropic_messages_optional_request_params, path
+                    )
+                else:
+                    anthropic_messages_optional_request_params.pop(path, None)
 
         # Prepare request body
         request_body = anthropic_messages_provider_config.transform_anthropic_messages_request(

--- a/tests/test_litellm/llms/custom_httpx/test_anthropic_messages_drop_params.py
+++ b/tests/test_litellm/llms/custom_httpx/test_anthropic_messages_drop_params.py
@@ -1,0 +1,156 @@
+"""
+Regression tests for issue #25931.
+
+`async_anthropic_messages_handler` (the /v1/messages Bedrock/Anthropic path)
+must honor `additional_drop_params` for both top-level and nested field names.
+
+Before the fix, only nested paths (containing `.` or `[`) were dropped, so
+top-level fields like `context_management` — injected automatically by
+Claude Code v2.1+ via the `context-management-2025-06-27` Anthropic beta —
+leaked through to Bedrock and produced:
+
+    {"message": "context_management: Extra inputs are not permitted"}
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+
+class _StopAfterDrop(Exception):
+    """Sentinel raised by the mocked transform to halt the handler after drop."""
+
+
+def _build_provider_config_mock(captured: dict) -> MagicMock:
+    provider_config = MagicMock()
+    provider_config.validate_anthropic_messages_environment.return_value = (
+        {},
+        "http://test-base",
+    )
+
+    def _capture_transform(**kwargs):
+        captured["optional_params"] = kwargs[
+            "anthropic_messages_optional_request_params"
+        ]
+        raise _StopAfterDrop
+
+    provider_config.transform_anthropic_messages_request.side_effect = (
+        _capture_transform
+    )
+    return provider_config
+
+
+def _build_logging_obj_mock() -> MagicMock:
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+    return logging_obj
+
+
+@pytest.mark.asyncio
+async def test_top_level_additional_drop_params_applied_on_messages_path():
+    """Top-level keys (e.g. `context_management`) must be dropped from
+    the params forwarded to the provider transform.
+
+    Regression for https://github.com/BerriAI/litellm/issues/25931."""
+    handler = BaseLLMHTTPHandler()
+    captured: dict = {}
+
+    params = {
+        "context_management": {
+            "edits": [{"type": "clear_thinking_20251015"}],
+        },
+        "max_tokens": 1024,
+    }
+    litellm_params = {"additional_drop_params": ["context_management"]}
+
+    with pytest.raises(_StopAfterDrop):
+        await handler.async_anthropic_messages_handler(
+            model="us.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            anthropic_messages_provider_config=_build_provider_config_mock(captured),
+            anthropic_messages_optional_request_params=params,
+            custom_llm_provider="bedrock",
+            litellm_params=litellm_params,
+            logging_obj=_build_logging_obj_mock(),
+        )
+
+    forwarded = captured["optional_params"]
+    assert "context_management" not in forwarded, (
+        "top-level `context_management` should be stripped from params before "
+        "transform_anthropic_messages_request — otherwise Bedrock returns 400"
+    )
+    assert forwarded["max_tokens"] == 1024, "unrelated fields must be preserved"
+
+
+@pytest.mark.asyncio
+async def test_nested_additional_drop_params_still_work():
+    """Nested JSONPath entries must continue to work alongside top-level drops."""
+    handler = BaseLLMHTTPHandler()
+    captured: dict = {}
+
+    params = {
+        "tools": [
+            {"name": "t0", "input_examples": ["ex0"]},
+            {"name": "t1", "input_examples": ["ex1"]},
+        ],
+        "max_tokens": 1024,
+    }
+    litellm_params = {"additional_drop_params": ["tools[*].input_examples"]}
+
+    with pytest.raises(_StopAfterDrop):
+        await handler.async_anthropic_messages_handler(
+            model="us.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            anthropic_messages_provider_config=_build_provider_config_mock(captured),
+            anthropic_messages_optional_request_params=params,
+            custom_llm_provider="bedrock",
+            litellm_params=litellm_params,
+            logging_obj=_build_logging_obj_mock(),
+        )
+
+    forwarded = captured["optional_params"]
+    assert forwarded["max_tokens"] == 1024
+    assert [t["name"] for t in forwarded["tools"]] == ["t0", "t1"]
+    for tool in forwarded["tools"]:
+        assert "input_examples" not in tool
+
+
+@pytest.mark.asyncio
+async def test_mixed_top_level_and_nested_drop_params():
+    """Top-level and nested drops specified in the same list should both apply."""
+    handler = BaseLLMHTTPHandler()
+    captured: dict = {}
+
+    params = {
+        "context_management": {"edits": []},
+        "tools": [{"name": "t", "input_examples": ["ex"]}],
+        "max_tokens": 1024,
+    }
+    litellm_params = {
+        "additional_drop_params": [
+            "context_management",
+            "tools[*].input_examples",
+        ],
+    }
+
+    with pytest.raises(_StopAfterDrop):
+        await handler.async_anthropic_messages_handler(
+            model="us.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            anthropic_messages_provider_config=_build_provider_config_mock(captured),
+            anthropic_messages_optional_request_params=params,
+            custom_llm_provider="bedrock",
+            litellm_params=litellm_params,
+            logging_obj=_build_logging_obj_mock(),
+        )
+
+    forwarded = captured["optional_params"]
+    assert "context_management" not in forwarded
+    assert "input_examples" not in forwarded["tools"][0]
+    assert forwarded["max_tokens"] == 1024


### PR DESCRIPTION
## Relevant issues

Fixes #25931

## Summary

`async_anthropic_messages_handler` in `litellm/llms/custom_httpx/llm_http_handler.py` only honored **nested** (JSONPath) entries in `additional_drop_params` — top-level keys were silently filtered out and leaked into the signed request body forwarded to the provider (Bedrock / Anthropic).

This breaks Claude Code v2.1+ against Bedrock. The client automatically enables the `context-management-2025-06-27` Anthropic beta, which adds a top-level `context_management` field to every request. Bedrock rejects it:

```
{"message": "context_management: Extra inputs are not permitted"}
```

Setting `additional_drop_params: [\"context_management\"]` in `litellm_settings` or a model's `litellm_params` had **no effect** on the `/v1/messages` path, even though it works as expected on `/v1/chat/completions`.

## Root cause

Introduced in commit `da2aa2ba8d` (`feat: Add nested field removal support to additional_drop_params using JSONPath`). The new block prefiltered the list with `is_nested_path`, which returns `False` for bare keys like `context_management`:

```python
nested_paths = [p for p in additional_drop_params if is_nested_path(p)]
for path in nested_paths:
    anthropic_messages_optional_request_params = delete_nested_value(...)
```

Unlike the `/v1/chat/completions` path, `async_anthropic_messages_handler` has **no prior top-level drop step** (no call to `add_provider_specific_params_to_optional_params`), so top-level fields were never dropped anywhere in this path.

`litellm/utils.py` is intentionally left unchanged — its nested-only filter is correct because top-level drop already happens earlier there.

## Fix

Dispatch by path type: nested paths go through `delete_nested_value`, top-level paths through `dict.pop`.

```python
for path in additional_drop_params:
    if is_nested_path(path):
        anthropic_messages_optional_request_params = delete_nested_value(
            anthropic_messages_optional_request_params, path
        )
    else:
        anthropic_messages_optional_request_params.pop(path, None)
```

## Tests

Added `tests/test_litellm/llms/custom_httpx/test_anthropic_messages_drop_params.py` with three async cases that drive `BaseLLMHTTPHandler.async_anthropic_messages_handler` through a mocked `provider_config` and assert on the params forwarded to `transform_anthropic_messages_request`:

1. `test_top_level_additional_drop_params_applied_on_messages_path` — regression for #25931, verifies `context_management` is stripped.
2. `test_nested_additional_drop_params_still_work` — protects the existing JSONPath behavior.
3. `test_mixed_top_level_and_nested_drop_params` — both entry kinds in the same list.

Verified that tests 1 and 3 fail without the fix and pass with it. Existing `tests/test_litellm/test_nested_drop_params.py` continues to pass.

```
$ uv run pytest tests/test_litellm/llms/custom_httpx/test_anthropic_messages_drop_params.py \
                tests/test_litellm/test_nested_drop_params.py -v
... 13 passed in 1.75s
```

## Relation to #25963

PR #25963 targets a different code path (`litellm/proxy/pass_through_endpoints/pass_through_endpoints.py`, the proxy pass-through endpoints). As noted in #25931 by @mchtech, the real failing path for Claude Code → Bedrock flows through `llm_http_handler.py`, which this PR addresses. The two PRs are independent and both needed.

## Type

🐛 Bug Fix