### PR TITLE
fix(responses): normalize bridged object field

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1652,7 +1652,7 @@ class LiteLLMCompletionResponsesConfig:
             id=chat_completion_response.id,
             created_at=chat_completion_response.created,
             model=chat_completion_response.model,
-            object=chat_completion_response.object,
+            object="response",
             error=getattr(chat_completion_response, "error", None),
             incomplete_details=getattr(
                 chat_completion_response, "incomplete_details", None

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -369,6 +369,7 @@ class TestLiteLLMCompletionResponsesConfig:
         ]
         assert len(message_items) == 1, "Should have exactly one message item"
         assert message_items[0].content[0].text == "Just a regular answer."
+        assert responses_api_response.object == "response"
 
     def test_transform_chat_completion_response_multiple_choices_with_reasoning(self):
         """Test that only reasoning from first choice is included when multiple choices exist"""


### PR DESCRIPTION
## Summary
- Force bridged Chat Completions -> Responses conversion to emit `object: \"response\"` instead of forwarding provider chat completion object values.
- Align bridged providers (Bedrock/Anthropic via bridge, etc.) with OpenAI native Responses top-level schema for downstream object-based dispatch.
- Add a regression assertion in the existing responses bridge transformation test.

Fix #26267

## Test plan
- [x] `poetry run pytest tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestLiteLLMCompletionResponsesConfig::test_transform_chat_completion_response_without_reasoning_content -v`

<img width="673" height="771" alt="image" src="https://github.com/user-attachments/assets/0926d22d-02aa-459a-ae74-d5680410dfa9" />
