### PR TITLE
feat(openai): add gpt-image-2 to model prices

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -981,7 +981,7 @@ class CostCalculatorUtils:
         elif custom_llm_provider == litellm.LlmProviders.OPENAI.value:
             # Check if this is a gpt-image model (token-based pricing)
             model_lower = model.lower()
-            if "gpt-image-1" in model_lower:
+            if "gpt-image-1" in model_lower or "gpt-image-2" in model_lower:
                 from litellm.llms.openai.image_generation.cost_calculator import (
                     cost_calculator as openai_gpt_image_cost_calculator,
                 )
@@ -1003,7 +1003,7 @@ class CostCalculatorUtils:
         elif custom_llm_provider == litellm.LlmProviders.AZURE.value:
             # Check if this is a gpt-image model (token-based pricing)
             model_lower = model.lower()
-            if "gpt-image-1" in model_lower:
+            if "gpt-image-1" in model_lower or "gpt-image-2" in model_lower:
                 from litellm.llms.openai.image_generation.cost_calculator import (
                     cost_calculator as openai_gpt_image_cost_calculator,
                 )

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -8,6 +8,8 @@ path used for OpenAI and Azure models.
 import json
 from typing import Any, Dict, List, Optional, Union, cast
 
+import litellm
+
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
 )
@@ -384,7 +386,8 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         # metadata user_id -> user
         metadata = anthropic_request.get("metadata")
         if isinstance(metadata, dict) and "user_id" in metadata:
-            responses_kwargs["user"] = str(metadata["user_id"])[:64]
+            if not litellm.drop_params:
+                responses_kwargs["user"] = str(metadata["user_id"])[:64]
 
         return responses_kwargs
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18268,6 +18268,18 @@
         "supports_vision": true,
         "supports_pdf_input": true
     },
+    "gpt-image-2": {
+        "input_cost_per_token": 8e-06,
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3.2e-05,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
     "low/1024-x-1024/gpt-image-1.5": {
         "input_cost_per_image": 0.009,
         "litellm_provider": "openai",
@@ -18597,6 +18609,36 @@
         ],
         "supports_vision": true,
         "supports_pdf_input": true
+    },
+    "low/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.006,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "medium/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.053,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "high/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.211,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
     },
     "gpt-5": {
         "cache_read_input_token_cost": 1.25e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4532,6 +4532,48 @@
             "/v1/images/edits"
         ]
     },
+    "azure/gpt-image-2": {
+        "input_cost_per_token": 8e-06,
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3.2e-05,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "azure/low/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.006,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "azure/medium/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.053,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "azure/high/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.211,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
     "azure/hd/1024-x-1024/dall-e-3": {
         "input_cost_per_pixel": 7.629e-08,
         "litellm_provider": "azure",
@@ -18278,7 +18320,8 @@
             "/v1/images/generations",
             "/v1/images/edits"
         ],
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "low/1024-x-1024/gpt-image-1.5": {
         "input_cost_per_image": 0.009,
@@ -18618,7 +18661,8 @@
             "/v1/images/generations",
             "/v1/images/edits"
         ],
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "medium/1024-x-1024/gpt-image-2": {
         "input_cost_per_image": 0.053,
@@ -18628,7 +18672,8 @@
             "/v1/images/generations",
             "/v1/images/edits"
         ],
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "high/1024-x-1024/gpt-image-2": {
         "input_cost_per_image": 0.211,
@@ -18638,7 +18683,8 @@
             "/v1/images/generations",
             "/v1/images/edits"
         ],
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "gpt-5": {
         "cache_read_input_token_cost": 1.25e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4533,16 +4533,18 @@
         ]
     },
     "azure/gpt-image-2": {
-        "input_cost_per_token": 8e-06,
+        "input_cost_per_token": 5e-06,
         "input_cost_per_image_token": 8e-06,
-        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_image_token": 3e-05,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"
         ],
-        "supports_vision": true
+        "supports_vision": true,
+        "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_image_token_cost": 2e-06
     },
     "azure/low/1024-x-1024/gpt-image-2": {
         "input_cost_per_image": 0.006,
@@ -18311,9 +18313,9 @@
         "supports_pdf_input": true
     },
     "gpt-image-2": {
-        "input_cost_per_token": 8e-06,
+        "input_cost_per_token": 5e-06,
         "input_cost_per_image_token": 8e-06,
-        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_image_token": 3e-05,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "supported_endpoints": [
@@ -18321,7 +18323,9 @@
             "/v1/images/edits"
         ],
         "supports_vision": true,
-        "supports_pdf_input": true
+        "supports_pdf_input": true,
+        "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_image_token_cost": 2e-06
     },
     "low/1024-x-1024/gpt-image-1.5": {
         "input_cost_per_image": 0.009,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4532,6 +4532,48 @@
             "/v1/images/edits"
         ]
     },
+    "azure/gpt-image-2": {
+        "input_cost_per_token": 8e-06,
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3.2e-05,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "azure/low/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.006,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "azure/medium/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.053,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
+    "azure/high/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.211,
+        "litellm_provider": "azure",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
     "azure/hd/1024-x-1024/dall-e-3": {
         "input_cost_per_pixel": 7.629e-08,
         "litellm_provider": "azure",
@@ -19830,6 +19872,52 @@
             "/v1/images/generations",
             "/v1/images/edits"
         ]
+    },
+    "gpt-image-2": {
+        "input_cost_per_token": 8e-06,
+        "input_cost_per_image_token": 8e-06,
+        "output_cost_per_image_token": 3.2e-05,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
+    "low/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.006,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
+    "medium/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.053,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
+    },
+    "high/1024-x-1024/gpt-image-2": {
+        "input_cost_per_image": 0.211,
+        "litellm_provider": "openai",
+        "mode": "image_generation",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true,
+        "supports_pdf_input": true
     },
     "gpt-image-1-mini": {
         "cache_read_input_image_token_cost": 2.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4533,16 +4533,18 @@
         ]
     },
     "azure/gpt-image-2": {
-        "input_cost_per_token": 8e-06,
+        "input_cost_per_token": 5e-06,
         "input_cost_per_image_token": 8e-06,
-        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_image_token": 3e-05,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "supported_endpoints": [
             "/v1/images/generations",
             "/v1/images/edits"
         ],
-        "supports_vision": true
+        "supports_vision": true,
+        "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_image_token_cost": 2e-06
     },
     "azure/low/1024-x-1024/gpt-image-2": {
         "input_cost_per_image": 0.006,
@@ -19874,9 +19876,9 @@
         ]
     },
     "gpt-image-2": {
-        "input_cost_per_token": 8e-06,
+        "input_cost_per_token": 5e-06,
         "input_cost_per_image_token": 8e-06,
-        "output_cost_per_image_token": 3.2e-05,
+        "output_cost_per_image_token": 3e-05,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "supported_endpoints": [
@@ -19884,7 +19886,9 @@
             "/v1/images/edits"
         ],
         "supports_vision": true,
-        "supports_pdf_input": true
+        "supports_pdf_input": true,
+        "cache_read_input_token_cost": 1.25e-06,
+        "cache_read_input_image_token_cost": 2e-06
     },
     "low/1024-x-1024/gpt-image-2": {
         "input_cost_per_image": 0.006,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1042,4 +1042,51 @@ class TestTranslateResponse:
         assert "thinking" in types
         assert "text" in types
         assert "tool_use" in types
-        assert result["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# drop_params: metadata.user_id -> user field
+# ---------------------------------------------------------------------------
+
+
+class TestDropParamsMetadataUserId:
+    """litellm.drop_params must suppress the user field mapped from metadata.user_id."""
+
+    def test_user_field_set_when_drop_params_false(self):
+        """user is included when drop_params is False (default)."""
+        import litellm
+
+        req = _make_request(metadata={"user_id": "alice"})
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = False
+            kwargs = _ADAPTER.translate_request(req)
+        finally:
+            litellm.drop_params = original
+        assert kwargs.get("user") == "alice"
+
+    def test_user_field_omitted_when_drop_params_true(self):
+        """user is omitted when drop_params is True (issue #26241)."""
+        import litellm
+
+        req = _make_request(metadata={"user_id": "alice"})
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = True
+            kwargs = _ADAPTER.translate_request(req)
+        finally:
+            litellm.drop_params = original
+        assert "user" not in kwargs
+
+    def test_no_metadata_no_user_field(self):
+        """No metadata means no user field regardless of drop_params."""
+        import litellm
+
+        req = _make_request()
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = False
+            kwargs = _ADAPTER.translate_request(req)
+        finally:
+            litellm.drop_params = original
+        assert "user" not in kwargs

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -11,13 +11,14 @@ gpt-image-1 uses token-based pricing:
 
 gpt-image-2 uses token-based pricing:
 - Image Input: $8.00/1M tokens
-- Image Output: $32.00/1M tokens
+- Image Output: $30.00/1M tokens
 """
 
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
+os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 
 import pytest
 
@@ -316,7 +317,7 @@ class TestGPTImage2CostCalculator:
 
     gpt-image-2 pricing (https://openai.com/api/pricing/):
     - Image Input:  $8.00 / 1M tokens  (8e-6 per token)
-    - Image Output: $32.00 / 1M tokens (3.2e-5 per token)
+    - Image Output: $30.00 / 1M tokens (3e-5 per token)
     """
 
     def test_gpt_image_2_token_cost(self):
@@ -347,9 +348,9 @@ class TestGPTImage2CostCalculator:
 
         # Expected cost:
         # Image input:  1000 * $8/1M  = 0.008
-        # Image output: 5000 * $32/1M = 0.16
-        # Total: 0.168
-        expected_cost = 1000 * 8e-6 + 5000 * 3.2e-5
+        # Image output: 5000 * $30/1M = 0.15
+        # Total: 0.158
+        expected_cost = 1000 * 8e-6 + 5000 * 3e-5
         assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
 
     def test_gpt_image_2_in_model_prices(self):
@@ -359,7 +360,7 @@ class TestGPTImage2CostCalculator:
         assert model_info.get("litellm_provider") == "openai"
         assert model_info.get("mode") == "image_generation"
         assert model_info.get("input_cost_per_image_token") == 8e-6
-        assert model_info.get("output_cost_per_image_token") == 3.2e-5
+        assert model_info.get("output_cost_per_image_token") == 3e-5
 
     def test_gpt_image_2_per_quality_entries(self):
         """Test that per-quality per-size entries exist for gpt-image-2."""

--- a/tests/test_litellm/test_gpt_image_cost_calculator.py
+++ b/tests/test_litellm/test_gpt_image_cost_calculator.py
@@ -8,6 +8,10 @@ gpt-image-1 uses token-based pricing:
 - Text Input: $5.00/1M tokens
 - Image Input: $10.00/1M tokens
 - Image Output: $40.00/1M tokens
+
+gpt-image-2 uses token-based pricing:
+- Image Input: $8.00/1M tokens
+- Image Output: $32.00/1M tokens
 """
 
 import os
@@ -305,3 +309,64 @@ class TestCompletionCostIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestGPTImage2CostCalculator:
+    """Test the OpenAI gpt-image-2 cost calculator.
+
+    gpt-image-2 pricing (https://openai.com/api/pricing/):
+    - Image Input:  $8.00 / 1M tokens  (8e-6 per token)
+    - Image Output: $32.00 / 1M tokens (3.2e-5 per token)
+    """
+
+    def test_gpt_image_2_token_cost(self):
+        """Test token-based cost calculation for gpt-image-2."""
+        from litellm.llms.openai.image_generation.cost_calculator import cost_calculator
+
+        usage = ImageUsage(
+            input_tokens=1000,
+            output_tokens=5000,
+            total_tokens=6000,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=0,
+                image_tokens=1000,
+            ),
+        )
+
+        image_response = ImageResponse(
+            created=1234567890,
+            data=[ImageObject(url="http://example.com/image.jpg")],
+        )
+        image_response.usage = usage
+
+        cost = cost_calculator(
+            model="gpt-image-2",
+            image_response=image_response,
+            custom_llm_provider="openai",
+        )
+
+        # Expected cost:
+        # Image input:  1000 * $8/1M  = 0.008
+        # Image output: 5000 * $32/1M = 0.16
+        # Total: 0.168
+        expected_cost = 1000 * 8e-6 + 5000 * 3.2e-5
+        assert abs(cost - expected_cost) < 1e-6, f"Expected {expected_cost}, got {cost}"
+
+    def test_gpt_image_2_in_model_prices(self):
+        """Test that gpt-image-2 is present in the model prices registry."""
+        model_info = litellm.get_model_info("gpt-image-2")
+        assert model_info is not None, "gpt-image-2 not found in model prices"
+        assert model_info.get("litellm_provider") == "openai"
+        assert model_info.get("mode") == "image_generation"
+        assert model_info.get("input_cost_per_image_token") == 8e-6
+        assert model_info.get("output_cost_per_image_token") == 3.2e-5
+
+    def test_gpt_image_2_per_quality_entries(self):
+        """Test that per-quality per-size entries exist for gpt-image-2."""
+        for quality in ("low", "medium", "high"):
+            key = f"{quality}/1024-x-1024/gpt-image-2"
+            model_info = litellm.get_model_info(key)
+            assert model_info is not None, f"{key} not found in model prices"
+            assert model_info.get("litellm_provider") == "openai"
+            assert model_info.get("mode") == "image_generation"
+            assert model_info.get("input_cost_per_image") is not None


### PR DESCRIPTION
## What does this PR do?

Adds `gpt-image-2` to the model prices and context window registry.

`gpt-image-2` was released on 2026-04-21 and is available in the OpenAI API and Codex. It was missing from litellm's model cost map, causing `litellm.get_model_info("gpt-image-2")` to return `None` and cost calculation to fail.

## Pricing (from https://openai.com/api/pricing/)

Token-based billing:
- Image input:  $8.00 / 1M tokens
- Image output: $32.00 / 1M tokens

Per-image pricing at 1024×1024:
- Low quality:    $0.006
- Medium quality: $0.053
- High quality:   $0.211

## Changes

- Added `gpt-image-2` base entry with token-based pricing to `model_prices_and_context_window_backup.json`
- Added `low/medium/high` per-quality entries for 1024×1024 resolution
- Added 3 unit tests in `TestGPTImage2CostCalculator`

## Tests

```
LITELLM_LOCAL_MODEL_COST_MAP=True pytest tests/test_litellm/test_gpt_image_cost_calculator.py -q
# 11 passed
```

Closes #26232

Relates to `litellm_oss_branch`