### PR TITLE
fix(responses): hardcode "response" object literal in Chat Completions bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1652,7 +1652,7 @@ class LiteLLMCompletionResponsesConfig:
             id=chat_completion_response.id,
             created_at=chat_completion_response.created,
             model=chat_completion_response.model,
-            object=chat_completion_response.object,
+            object="response",
             error=getattr(chat_completion_response, "error", None),
             incomplete_details=getattr(
                 chat_completion_response, "incomplete_details", None

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -605,6 +605,39 @@ class TestLiteLLMCompletionResponsesConfig:
         assert hasattr(responses_api_response, "_hidden_params")
         assert responses_api_response._hidden_params == {}
 
+    def test_transform_chat_completion_response_sets_object_to_response(self):
+        """The bridged Responses API payload must emit ``object="response"``, not
+        forward the upstream Chat Completion's ``"chat.completion"`` literal.
+
+        Regression for https://github.com/BerriAI/litellm/issues/26267.
+        Also aligns the non-streaming bridge with the streaming sibling in
+        ``streaming_iterator.py``, which already hardcodes ``"object": "response"``.
+        """
+        chat_completion_response = ModelResponse(
+            id="chatcmpl-abc123",
+            created=1234567890,
+            model="anthropic.claude-sonnet-4-6",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(
+                        content="Test response",
+                        role="assistant",
+                    ),
+                )
+            ],
+        )
+
+        responses_api_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="Test",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        assert responses_api_response.object == "response"
+
 
 class TestFunctionCallTransformation:
     """Test cases for function_call input transformation"""


### PR DESCRIPTION
## Relevant issues

Fixes #26267. Confirmed the fix direction in [issue comments](https://github.com/BerriAI/litellm/issues/26267#issuecomment-4300724610) and @krrish-berri-2's [follow-up](https://github.com/BerriAI/litellm/issues/26267#issuecomment-4305174864) ("not intentional - we should just map the response api.object").

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(Local: 21/21 pass on `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestLiteLLMCompletionResponsesConfig`, including the new regression test. CI will confirm the full suite.)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

### Problem

`LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response` forwarded the upstream Chat Completion's `object` field verbatim. Because this transformation runs only when bridging Chat Completions to the Responses API, the forwarded value was always `"chat.completion"`:

```python
resp = await litellm.aresponses(
    model="bedrock/anthropic.claude-sonnet-4-...",
    input="Tell me a joke",
)
resp.model_dump()["object"]
# Before this PR: "chat.completion"   <- violates the OpenAI Responses spec
# After this PR:  "response"
```

The OpenAI native Responses path returns the correct value, so the shape silently differed across providers for anything dispatching on `object`.

### Fix

One-line change in [`transformation.py:1655`](https://github.com/BerriAI/litellm/blob/fb39683521702145833a502c90127b0600886a9e/litellm/responses/litellm_completion_transformation/transformation.py#L1655): replace `object=chat_completion_response.object` with `object="response"`.

This aligns the non-streaming bridge with the streaming sibling at [`streaming_iterator.py:370`](https://github.com/BerriAI/litellm/blob/fb39683521702145833a502c90127b0600886a9e/litellm/responses/litellm_completion_transformation/streaming_iterator.py#L370), which already emits `"object": "response"` in `response_created_event_data`. The two bridging paths previously disagreed on this one field.

### Regression evidence

Stash-bisect against the new test on the current branch HEAD:

- Without the fix: `AssertionError: assert 'chat.completion' == 'response'`
- With the fix: `1 passed in 0.48s`

Full `TestLiteLLMCompletionResponsesConfig` class: 21/21 pass (20 pre-existing + 1 new).

## Changes

### Files

- `litellm/responses/litellm_completion_transformation/transformation.py` (1 line)
- `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` (+33 lines)

### Tests

- `TestLiteLLMCompletionResponsesConfig::test_transform_chat_completion_response_sets_object_to_response`: feeds a `ModelResponse` with `object="chat.completion"` (the shape the bridge receives from any Chat Completion upstream) through the transform, asserts the returned `ResponsesAPIResponse.object == "response"`.