### PR TITLE
[Infra] Add standalone create-release-branch workflow

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,65 @@
+name: Create Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v1.83.0-stable) — branch will be named release/<tag>"
+        required: true
+        type: string
+      commit_hash:
+        description: "Full 40-char commit SHA the branch should point to"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag"
+        required: true
+        type: string
+      commit_hash:
+        description: "Full 40-char commit SHA the branch should point to"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  create-branch:
+    name: Create Release Branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate inputs
+        env:
+          TAG: ${{ inputs.tag }}
+          COMMIT_HASH: ${{ inputs.commit_hash }}
+        run: |
+          if ! echo "${COMMIT_HASH}" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::commit_hash must be a full 40-character commit SHA"
+            exit 1
+          fi
+          if ! echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::tag must start with vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Create release branch
+        env:
+          TAG: ${{ inputs.tag }}
+          COMMIT_HASH: ${{ inputs.commit_hash }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const tag = process.env.TAG;
+            const commitHash = process.env.COMMIT_HASH;
+            const branchName = `release/${tag}`;
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/heads/${branchName}`,
+              sha: commitHash,
+            });
+            core.info(`Created branch ${branchName} at ${commitHash}`);

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -102,6 +102,15 @@ jobs:
                 body: updatedBody,
                 draft: false,
               });
+
             } catch (error) {
               core.setFailed(error.message);
             }
+
+  create-branch:
+    name: Create Release Branch
+    needs: release
+    uses: ./.github/workflows/create-release-branch.yml
+    with:
+      tag: ${{ inputs.tag }}
+      commit_hash: ${{ inputs.commit_hash }}


### PR DESCRIPTION
## Summary

Extracts release branch creation out of `create-release.yml` into a new standalone workflow (`create-release-branch.yml`). The new workflow can be triggered independently via `workflow_dispatch` for backfilling release branches, or called by other workflows via `workflow_call`.

`create-release.yml` now calls it as a dependent job (`needs: release`) so the branch is only created after the release publishes successfully.

Branch naming convention used: `release/<tag>` (e.g. `release/v1.83.3-stable`).

## Changes

- Added `.github/workflows/create-release-branch.yml` — reusable workflow with both `workflow_dispatch` and `workflow_call` triggers, input validation, and scoped `contents: write` permission.
- Updated `.github/workflows/create-release.yml` — removed inline branch creation, added `create-branch` job that calls the new workflow.

## Testing

- zizmor reports 0 findings on both files.
- Both workflows validated locally against zizmor v1.23.1.

## Type

🚄 Infrastructure