### PR TITLE
fix(azure_ai): map max_completion_tokens to max_tokens for Model Inference endpoint

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -46,6 +46,31 @@ class AzureAIStudioConfig(OpenAIConfig):
 
         return supported_params
 
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        # Azure AI Foundry's Model Inference endpoint (/models/chat/completions)
+        # accepts `max_tokens` but not `max_completion_tokens` — requests using
+        # the newer OpenAI name are rejected with 422. Normalize AFTER the parent
+        # mapping so this applies regardless of how the parent dispatched
+        # internally: the default OpenAI-compatible path copies through, but
+        # o-series and gpt-5 configs actively rename `max_tokens` →
+        # `max_completion_tokens`, which would otherwise re-introduce the wrong
+        # name for Foundry-hosted deployments.
+        optional_params = super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
+        if "max_completion_tokens" in optional_params:
+            optional_params["max_tokens"] = optional_params.pop("max_completion_tokens")
+        return optional_params
+
     def _supports_stop_reason(self, model: str) -> bool:
         """
         Check if the model supports stop tokens.

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -197,3 +197,118 @@ def test_azure_model_router_response_shows_actual_model():
         f"Expected model to be 'azure_ai/gpt-5-nano-2025-08-07' (actual model used), "
         f"but got '{result.model}'"
     )
+
+
+def test_azure_ai_map_openai_params_renames_max_completion_tokens():
+    """
+    Azure AI Foundry's Model Inference endpoint only accepts `max_tokens`, so
+    `max_completion_tokens` must be rewritten before the request is sent.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/26322
+    """
+    config = AzureAIStudioConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"max_completion_tokens": 1000},
+        optional_params={},
+        model="mistral-large-3",
+        drop_params=False,
+    )
+    assert optional_params.get("max_tokens") == 1000
+    assert "max_completion_tokens" not in optional_params
+
+
+def test_azure_ai_map_openai_params_preserves_max_tokens():
+    """
+    Plain `max_tokens` must still pass through unchanged.
+    """
+    config = AzureAIStudioConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"max_tokens": 500},
+        optional_params={},
+        model="mistral-large-3",
+        drop_params=False,
+    )
+    assert optional_params.get("max_tokens") == 500
+    assert "max_completion_tokens" not in optional_params
+
+
+def test_azure_ai_map_openai_params_max_completion_tokens_takes_priority():
+    """
+    When both are provided, `max_completion_tokens` should win — matching
+    `MistralConfig.map_openai_params` precedence.
+    """
+    config = AzureAIStudioConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"max_tokens": 500, "max_completion_tokens": 1000},
+        optional_params={},
+        model="mistral-large-3",
+        drop_params=False,
+    )
+    assert optional_params.get("max_tokens") == 1000
+    assert "max_completion_tokens" not in optional_params
+
+
+def test_azure_ai_map_openai_params_does_not_mutate_caller_dict():
+    """
+    The incoming non_default_params dict belongs to the caller — the rename must
+    not mutate it.
+    """
+    config = AzureAIStudioConfig()
+    non_default_params = {"max_completion_tokens": 1000}
+    config.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params={},
+        model="mistral-large-3",
+        drop_params=False,
+    )
+    assert non_default_params == {"max_completion_tokens": 1000}
+
+
+@pytest.mark.parametrize(
+    "model,non_default_params",
+    [
+        # o-series models: parent dispatches to openaiOSeriesConfig which
+        # actively maps max_tokens → max_completion_tokens; our post-super
+        # normalization must still land on max_tokens for the Foundry endpoint.
+        ("o3-mini", {"max_completion_tokens": 1000}),
+        ("o3-mini", {"max_tokens": 1000}),
+        # gpt-5 models: parent dispatches to openAIGPT5Config with the same
+        # max_tokens → max_completion_tokens rename.
+        ("gpt-5-mini", {"max_completion_tokens": 1000}),
+        ("gpt-5-mini", {"max_tokens": 1000}),
+    ],
+)
+def test_azure_ai_map_openai_params_handles_openai_family_models(
+    model, non_default_params
+):
+    """
+    Azure AI Foundry can host OpenAI-family model names (o-series, gpt-5) whose
+    parent configs flip max_tokens ↔ max_completion_tokens internally. The
+    override must normalize to max_tokens regardless of which direction the
+    parent dispatch took.
+    """
+    config = AzureAIStudioConfig()
+    optional_params = config.map_openai_params(
+        non_default_params=dict(non_default_params),
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    assert optional_params.get("max_tokens") == 1000
+    assert "max_completion_tokens" not in optional_params
+
+
+def test_azure_model_router_inherits_max_completion_tokens_rewrite():
+    """
+    `AzureModelRouterConfig` subclasses `AzureAIStudioConfig` and shares the same
+    Model Inference endpoint, so it must also rewrite `max_completion_tokens`.
+    """
+    config = AzureModelRouterConfig()
+    optional_params = config.map_openai_params(
+        non_default_params={"max_completion_tokens": 1000},
+        optional_params={},
+        model="model-router",
+        drop_params=False,
+    )
+    assert optional_params.get("max_tokens") == 1000
+    assert "max_completion_tokens" not in optional_params


### PR DESCRIPTION
## Relevant issues

Fixes #26322

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Backend parameter-mapping fix — no UI surface. Proof is in the unit tests and the before/after trace below.

**Before (upstream `main` at `e9e86ed956`):**

```python
>>> from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig
>>> AzureAIStudioConfig().map_openai_params(
...     {"max_completion_tokens": 1000}, {}, "mistral-large-3", drop_params=False
... )
{'max_completion_tokens': 1000}   # Azure AI Foundry rejects this with 422
```

**After this PR:**

```python
>>> AzureAIStudioConfig().map_openai_params(
...     {"max_completion_tokens": 1000}, {}, "mistral-large-3", drop_params=False
... )
{'max_tokens': 1000}              # accepted by /models/chat/completions
```

Targeted unit tests (9 in total for this override, 5 general + 4 parametrized for OpenAI-family models) all pass:

```
tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
  test_azure_ai_map_openai_params_renames_max_completion_tokens PASSED
  test_azure_ai_map_openai_params_preserves_max_tokens PASSED
  test_azure_ai_map_openai_params_max_completion_tokens_takes_priority PASSED
  test_azure_ai_map_openai_params_does_not_mutate_caller_dict PASSED
  test_azure_ai_map_openai_params_handles_openai_family_models[o3-mini-...] PASSED  (x4)
  test_azure_model_router_inherits_max_completion_tokens_rewrite PASSED
```

Broader `tests/test_litellm/llms/azure_ai/` suite: **105/105 passing** locally. Ruff + MyPy + Black all clean on the touched files.

## Type

Bug Fix

## Changes

**Root cause.** `AzureAIStudioConfig` in `litellm/llms/azure_ai/chat/transformation.py` inherits `map_openai_params` from `OpenAIConfig` unchanged. The parent dispatches by model name — the default path copies `max_completion_tokens` through as-is, and the `o-series` and `gpt-5` sub-configs actively rename `max_tokens` -> `max_completion_tokens`. Either way, the value headed for Azure AI Foundry's Model Inference endpoint (`/models/chat/completions`) ends up as `max_completion_tokens`, which that endpoint's request schema does not accept (see [Microsoft Learn](https://learn.microsoft.com/en-us/rest/api/aifoundry/model-inference/get-chat-completions/get-chat-completions) - the schema lists only `max_tokens`). The endpoint responds with `422 Unprocessable Entity`, which is what the issue reporter hit on `azure_ai/mistral-large-3`.

**Fix.** Override `map_openai_params` in `AzureAIStudioConfig` and normalize AFTER the parent mapping: delegate to `super().map_openai_params(...)` first, then rename `max_completion_tokens` -> `max_tokens` on the resulting dict. Normalizing at the end (rather than before the `super()` call) keeps the fix robust for every parent dispatch path — Mistral/Llama-family (default copy), o-series (`o3-mini`, `o1-*`, ...), and `gpt-5-*` — all end up with `max_tokens` on the wire.

**Precedence.** If a caller passes both `max_tokens` and `max_completion_tokens`, `max_completion_tokens` wins. This matches the existing priority in `MistralConfig.map_openai_params` (`litellm/llms/mistral/chat/transformation.py:154-167`).

**Scope note.** The override lives on `AzureAIStudioConfig`, so it transparently also covers `AzureModelRouterConfig`, which subclasses it and targets the same Model Inference endpoint. Azure OpenAI Service (`azure/...`) is unaffected — `_get_openai_compatible_provider_info` reroutes known OpenAI-catalog models to the `azure` provider, which uses `AzureConfig` with its own separate parameter handling.

**Files changed:**
- `litellm/llms/azure_ai/chat/transformation.py` — new `map_openai_params` override (+25 lines)
- `tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py` — 6 new mocked unit tests, one parametrized across 4 model names (+115 lines)
