### PR TITLE
[Fix] Tests - drain logging worker in test_router_caching_ttl to fix flakiness

### DIFF
--- a/litellm/litellm_core_utils/logging_worker.py
+++ b/litellm/litellm_core_utils/logging_worker.py
@@ -370,11 +370,17 @@ class LoggingWorker:
         self._running_tasks.clear()
 
     async def flush(self) -> None:
-        """Flush the logging queue."""
+        """Flush the logging queue.
+
+        Waits until every enqueued task has completed. ``queue.join()`` blocks
+        on the queue's unfinished-task counter (decremented by ``task_done()``),
+        so it correctly handles items that have been dequeued but whose
+        callback hasn't finished yet — ``queue.empty()`` would return True in
+        that window and cause us to skip the wait.
+        """
         if self._queue is None:
             return
-        while not self._queue.empty():
-            await self._queue.join()
+        await self._queue.join()
 
     async def clear_queue(self):
         """

--- a/tests/local_testing/test_tpm_rpm_routing_v2.py
+++ b/tests/local_testing/test_tpm_rpm_routing_v2.py
@@ -547,6 +547,8 @@ async def test_router_caching_ttl():
 
     assert router.cache.redis_cache is not None
 
+    from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
     increment_cache_kwargs = {}
     with patch.object(
         router.cache,
@@ -554,6 +556,10 @@ async def test_router_caching_ttl():
         new=AsyncMock(),
     ) as mock_client:
         await router.acompletion(model=model, messages=messages)
+
+        # Async success callbacks are dispatched to GLOBAL_LOGGING_WORKER's
+        # background queue; drain it before asserting the mock was invoked.
+        await GLOBAL_LOGGING_WORKER.flush()
 
         # mock_client.assert_called_once()
         print(f"mock_client.call_args.kwargs: {mock_client.call_args.kwargs}")


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)
`test_router_caching_ttl` intermittently fails with `AttributeError: 'NoneType' object has no attribute 'kwargs'` when reading `mock_client.call_args`. The mocked `async_increment_cache_pipeline` is invoked from `Router.deployment_callback_on_success`, registered as an async success callback. Those callbacks are enqueued to `GLOBAL_LOGGING_WORKER` and processed on a background task, so they may not have executed when the test asserts on the mock.

`LoggingWorker.flush()` also had a latent race: `while not self._queue.empty(): await self._queue.join()` skipped the wait entirely when the worker had already dequeued a task but not yet called `task_done()`.

### Fix
- Drain `GLOBAL_LOGGING_WORKER` in the test after `router.acompletion(...)` before asserting on the mock.
- Fix `LoggingWorker.flush()` to unconditionally `await self._queue.join()`. `asyncio.Queue.join()` tracks `_unfinished_tasks` (incremented by `put`, decremented by `task_done`), so it already handles the in-flight case — the `empty()` guard was wrong.

## Testing
- Ran `test_router_caching_ttl` 5x locally — passes consistently.

## Type
🐛 Bug Fix
✅ Test