### PR TITLE
feat: add azure/gpt-5.5 to model cost map (mirror openai gpt-5.5 pricing)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4467,6 +4467,42 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "azure/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
+    },
     "azure/gpt-5.4": {
         "cache_read_input_token_cost": 2.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4481,6 +4481,42 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "azure/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": true
+    },
     "azure/gpt-5.4": {
         "cache_read_input_token_cost": 2.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 5e-07,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -365,6 +365,87 @@ def test_generic_cost_per_token_gpt55():
     )
 
 
+def test_generic_cost_per_token_azure_gpt55():
+    """azure/gpt-5.5: pricing identical to openai gpt-5.5 ($5/$0.50/$30 per 1M)."""
+    model = "azure/gpt-5.5"
+    custom_llm_provider = "azure"
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_cost_map = litellm.model_cost[model]
+
+    assert model_cost_map["input_cost_per_token"] == 5e-6
+    assert model_cost_map["output_cost_per_token"] == 3e-5
+    assert model_cost_map["cache_read_input_token_cost"] == 5e-7
+    assert model_cost_map["litellm_provider"] == "azure"
+    assert model_cost_map["mode"] == "chat"
+    assert model_cost_map["max_input_tokens"] == 272000
+
+    prompt_tokens = 1000
+    completion_tokens = 500
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model=model,
+        usage=usage,
+        custom_llm_provider=custom_llm_provider,
+    )
+    assert round(prompt_cost, 10) == round(
+        model_cost_map["input_cost_per_token"] * prompt_tokens, 10
+    )
+    assert round(completion_cost, 10) == round(
+        model_cost_map["output_cost_per_token"] * completion_tokens, 10
+    )
+
+
+def test_azure_gpt55_pricing_matches_openai_gpt55():
+    """azure/gpt-5.5 cost fields must mirror gpt-5.5 exactly (excluding provider)."""
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    openai_entry = litellm.model_cost["gpt-5.5"]
+    azure_entry = litellm.model_cost["azure/gpt-5.5"]
+
+    # Provider differs by design; everything else should match.
+    assert openai_entry["litellm_provider"] == "openai"
+    assert azure_entry["litellm_provider"] == "azure"
+
+    parity_fields = [
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "cache_read_input_token_cost",
+        "max_input_tokens",
+        "max_output_tokens",
+        "max_tokens",
+        "mode",
+        "supported_endpoints",
+        "supported_modalities",
+        "supported_output_modalities",
+        "supports_function_calling",
+        "supports_native_streaming",
+        "supports_parallel_function_calling",
+        "supports_pdf_input",
+        "supports_prompt_caching",
+        "supports_reasoning",
+        "supports_response_schema",
+        "supports_system_messages",
+        "supports_tool_choice",
+        "supports_service_tier",
+        "supports_vision",
+        "supports_none_reasoning_effort",
+        "supports_xhigh_reasoning_effort",
+        "supports_minimal_reasoning_effort",
+    ]
+    for field in parity_fields:
+        assert azure_entry.get(field) == openai_entry.get(field), (
+            f"azure/gpt-5.5.{field} ({azure_entry.get(field)!r}) "
+            f"does not match gpt-5.5.{field} ({openai_entry.get(field)!r})"
+        )
+
+
 def test_generic_cost_per_token_anthropic_prompt_caching():
     model = "claude-sonnet-4@20250514"
     usage = Usage(


### PR DESCRIPTION
## Relevant issues

Follow-up to #26345 — adds the Azure-side entry for gpt-5.5, which was requested in PR review to ship alongside the OpenAI entry.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

```
$ LITELLM_LOCAL_MODEL_COST_MAP=true python -c "
import litellm
print(litellm.get_model_info('azure/gpt-5.5'))
"
{'input_cost_per_token': 5e-06,
 'output_cost_per_token': 3e-05,
 'cache_read_input_token_cost': 5e-07,
 'max_input_tokens': 272000,
 'max_output_tokens': 128000,
 'litellm_provider': 'azure',
 'mode': 'chat', ...}

$ uv run pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_generic_cost_per_token_azure_gpt55 \
                tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_azure_gpt55_pricing_matches_openai_gpt55 \
                tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py::test_generic_cost_per_token_gpt55 -x -vv
... 3 passed in 0.22s
```

## Type

🆕 New Feature

## Changes

### Model cost map

Added `azure/gpt-5.5` to both `model_prices_and_context_window.json` and the bundled `litellm/model_prices_and_context_window_backup.json`. The entry mirrors the existing `gpt-5.5` (OpenAI) entry exactly — only `litellm_provider` differs.

| Field | Value |
|---|---|
| `input_cost_per_token` | `5e-6` ($5.00 / 1M) |
| `cache_read_input_token_cost` | `5e-7` ($0.50 / 1M) |
| `output_cost_per_token` | `3e-5` ($30.00 / 1M) |
| `max_input_tokens` | 272000 |
| `max_output_tokens` | 128000 |
| `mode` | `chat` |
| `litellm_provider` | `azure` |

Endpoints: `/v1/chat/completions`, `/v1/responses`, `/v1/batch`.

**Why identical pricing?** Azure has historically mirrored OpenAI list pricing at launch for the GPT-5 series. Once Azure publishes different rates (or adds tier-specific flex/priority/long-context fields as it does for `azure/gpt-5.4`), this entry can be updated in a follow-up.

### Tests (`tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py`)

- `test_generic_cost_per_token_azure_gpt55`: loads the cost map, asserts the `azure/gpt-5.5` fields match the published values, and verifies `generic_cost_per_token(model='azure/gpt-5.5', custom_llm_provider='azure', ...)` returns the expected prompt/completion costs.
- `test_azure_gpt55_pricing_matches_openai_gpt55`: parity guard — iterates across pricing and capability fields and fails if `azure/gpt-5.5` drifts from `gpt-5.5` (provider aside). Catches accidental divergence during future edits.