### PR TITLE
[Fix] Infra: grant contents:write to create-release-branch caller job

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -110,6 +110,8 @@ jobs:
   create-branch:
     name: Create Release Branch
     needs: release
+    permissions:
+      contents: write
     uses: ./.github/workflows/create-release-branch.yml
     with:
       tag: ${{ inputs.tag }}


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

`Create Release` workflow run fails at startup with:

> Error calling workflow `BerriAI/litellm/.github/workflows/create-release-branch.yml@...`. The nested job `create-branch` is requesting `contents: write`, but is only allowed `contents: none`.

Example run: https://github.com/BerriAI/litellm/actions/runs/24861313940

The top-level `permissions: {}` in `create-release.yml` denies all permissions by default. The `release` job overrides to `contents: write`, but the `create-branch` job (which calls the reusable `create-release-branch.yml`) does not, so the nested workflow cannot be granted the `contents: write` it requires.

### Fix

Add `permissions: contents: write` at the `create-branch` job level so the reusable workflow can be granted what it needs.

## Testing

Re-run the `Create Release` workflow on this branch with a valid tag + commit hash and confirm both the release draft and the release branch are created.

## Type

🚄 Infrastructure