### PR TITLE
docs: fix duplicate prisma generate step and typo in backend dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,15 +407,14 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
 ### Run in Developer Mode
 #### Services
 1. Setup .env file in root
-2. Run dependant services `docker-compose up db prometheus`
+2. Run dependent services `docker-compose up db prometheus`
 
 #### Backend
 1. (In root) create virtual environment `python -m venv .venv`
 2. Activate virtual environment `source .venv/bin/activate`
 3. Install dependencies `uv sync --all-extras --group proxy-dev`
-4. `uv run prisma generate`
-5. `prisma generate`
-6. Start proxy backend `python litellm/proxy/proxy_cli.py`
+4. `uv run prisma generate --schema litellm/proxy/schema.prisma`
+5. Start proxy backend `python litellm/proxy/proxy_cli.py`
 
 #### Frontend
 1. Navigate to `ui/litellm-dashboard`


### PR DESCRIPTION
## Summary

Two small fixes to the "Run in Developer Mode" section of the root README:

- **Removed duplicate `prisma generate` step.** Steps 4 and 5 were both `prisma generate` — step 5 was a duplicate of step 4. Additionally, both were missing the `--schema litellm/proxy/schema.prisma` flag that the Makefile uses (line 66), so following the README from the repo root may not resolve the schema correctly. Merged into a single step with the correct `--schema` path.
- **Fixed typo:** `dependant` → `dependent` in the Services section.

## How to reproduce

1. Follow README "Run in Developer Mode → Backend" steps verbatim from the repo root
2. Step 5 (`prisma generate`) is a no-op duplicate of step 4 and may also fail to locate the schema file without the `--schema` flag

## Test plan

- [ ] Run the updated step 4 (`uv run prisma generate --schema litellm/proxy/schema.prisma`) from repo root — matches the Makefile's `prisma-generate` target
- [ ] Confirm no other README sections reference the removed duplicate step