### PR TITLE
chore(packaging): declare MIT license in litellm-proxy-extras metadata

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.4.67"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
+license = "MIT"
 license-files = ["LICENSE"]
 authors = [
     { name = "BerriAI" },


### PR DESCRIPTION
## Relevant issues

Closes License-None findings reported against every published version of `litellm-proxy-extras` by metadata-reading tools (PyPI classifiers, Nexus IQ, pip-licenses).

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🚄 Infrastructure

## Changes

`litellm-proxy-extras/pyproject.toml`: add an explicit `license = "MIT"` SPDX expression. The existing `LICENSE` file already contains MIT terms verbatim; this only surfaces the declaration in the package metadata so PEP 639-aware tools resolve it instead of reporting License-None.
