### PR TITLE
[WIP] test: regression test for completion_tokens_details on Responses API usage (#15377)

### DIFF
--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -348,6 +348,38 @@ class TestResponseAPILoggingUtils:
         assert result.completion_tokens_details.image_tokens == 100
         assert result.completion_tokens_details.text_tokens == 70
 
+    def test_transform_response_api_usage_populates_reasoning_tokens_regression_15377(
+        self,
+    ):
+        """Regression test for issue #15377.
+
+        Azure OpenAI Responses API returns ``usage.output_tokens_details`` with
+        ``reasoning_tokens``. LiteLLM must transform this into
+        ``completion_tokens_details.reasoning_tokens`` on the returned ``Usage``
+        object so downstream callbacks (e.g. ``async_log_success_event``) see
+        the reasoning tokens rather than ``completion_tokens_details=None``.
+        """
+        # Raw usage shape as returned by Azure Responses API for a reasoning model.
+        usage = {
+            "input_tokens": 12,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 204,
+            "output_tokens_details": {"reasoning_tokens": 64},
+            "total_tokens": 216,
+        }
+
+        result = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+            usage
+        )
+
+        assert isinstance(result, Usage)
+        # Core fix: completion_tokens_details must be populated, not None.
+        assert result.completion_tokens_details is not None
+        assert result.completion_tokens_details.reasoning_tokens == 64
+        # Sanity check: prompt_tokens_details still behaves as before.
+        assert result.prompt_tokens_details is not None
+        assert result.prompt_tokens_details.cached_tokens == 0
+
 
 class TestResponsesAPIProviderSpecificParams:
     """


### PR DESCRIPTION
## Summary

Fixes #15377

Issue #15377 reported that Azure OpenAI Responses API calls produced `Usage` objects with `completion_tokens_details=None` in `async_log_success_event`, even though the raw Azure response includes `output_tokens_details.reasoning_tokens`.

The underlying fix (map `output_tokens_details` -> `CompletionTokensDetailsWrapper`) is already present in the shared OpenAI Responses transformation used by Azure (`litellm/responses/utils.py::ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage`). Since Azure inherits this behaviour, the bug is already resolved on `main`.

This PR adds a focused regression test that explicitly locks in the behaviour from issue #15377:

- Feeds the transformer a raw Azure Responses API usage dict with `output_tokens_details.reasoning_tokens = 64`.
- Asserts the returned `Usage.completion_tokens_details.reasoning_tokens == 64` (and that `completion_tokens_details` is not `None`).

This prevents future regressions that could reintroduce the `completion_tokens_details=None` symptom reporters saw in v1.77.7.

## Changes

- `tests/test_litellm/responses/test_responses_utils.py`: add `test_transform_response_api_usage_populates_reasoning_tokens_regression_15377`.

## Notes

- No production code changes required — the mapping is already in the shared OpenAI Responses base path (`litellm/responses/utils.py`), which Azure reuses since `AzureOpenAIResponsesAPIConfig` does not override usage transformation.
- The existing test file has 3 pre-existing ruff warnings (unused imports) that I intentionally left untouched to keep the diff surgical.

## Test Plan

```
uv run pytest tests/test_litellm/responses/test_responses_utils.py -xvs
```

All 20 tests pass (19 existing + 1 new).