### PR TITLE
feat: bedrock guardrail input roles filter

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -217,8 +217,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         """
         bedrock_request: BedrockRequest = BedrockRequest(source=source)
         if source == "INPUT":
-            if messages is not None and self.experimental_guardrail_input_roles is not None:
-                messages = [m for m in messages if m.get("role") in self.experimental_guardrail_input_roles]
+            if (
+                messages is not None
+                and self.experimental_guardrail_input_roles is not None
+            ):
+                messages = [
+                    m
+                    for m in messages
+                    if m.get("role") in self.experimental_guardrail_input_roles
+                ]
             bedrock_request = self._create_bedrock_input_content_request(
                 messages=messages
             )

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -425,6 +425,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         bedrock_guardrail_response: BedrockGuardrailResponse = (
             BedrockGuardrailResponse()
         )
+        if not bedrock_request_data.get("content"):
+            return bedrock_guardrail_response
         api_key: Optional[str] = None
         if request_data:
             bedrock_request_data.update(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -123,6 +123,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         self.experimental_use_latest_role_message_only = bool(
             kwargs.get("experimental_use_latest_role_message_only")
         )
+        self.experimental_guardrail_input_roles: Optional[List[str]] = kwargs.get(
+            "experimental_guardrail_input_roles"
+        )
 
         # store kwargs as optional_params
         self.optional_params = kwargs
@@ -214,6 +217,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         """
         bedrock_request: BedrockRequest = BedrockRequest(source=source)
         if source == "INPUT":
+            if messages is not None and self.experimental_guardrail_input_roles is not None:
+                messages = [m for m in messages if m.get("role") in self.experimental_guardrail_input_roles]
             bedrock_request = self._create_bedrock_input_content_request(
                 messages=messages
             )

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -226,6 +226,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     for m in messages
                     if m.get("role") in self.experimental_guardrail_input_roles
                 ]
+                if not messages:
+                    return bedrock_request
             bedrock_request = self._create_bedrock_input_content_request(
                 messages=messages
             )

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -31,6 +31,7 @@ def initialize_bedrock(litellm_params: LitellmParams, guardrail: Guardrail):
         aws_sts_endpoint=litellm_params.aws_sts_endpoint,
         aws_bedrock_runtime_endpoint=litellm_params.aws_bedrock_runtime_endpoint,
         experimental_use_latest_role_message_only=litellm_params.experimental_use_latest_role_message_only,
+        experimental_guardrail_input_roles=litellm_params.experimental_guardrail_input_roles,
     )
     litellm.logging_callback_manager.add_litellm_callback(_bedrock_callback)
     return _bedrock_callback

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -616,7 +616,7 @@ class BaseLitellmParams(
 
     experimental_guardrail_input_roles: Optional[List[str]] = Field(
         default=None,
-        description="When set, only messages with the specified roles are sent to Bedrock for INPUT validation (e.g. [\"user\"] to exclude system prompts).",
+        description='When set, only messages with the specified roles are sent to Bedrock for INPUT validation (e.g. ["user"] to exclude system prompts).',
     )
 
     skip_system_message_in_guardrail: Optional[bool] = Field(

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -614,6 +614,11 @@ class BaseLitellmParams(
         description="When True, guardrails only receive the latest message for the relevant role (e.g., newest user input pre-call, newest assistant output post-call)",
     )
 
+    experimental_guardrail_input_roles: Optional[List[str]] = Field(
+        default=None,
+        description="When set, only messages with the specified roles are sent to Bedrock for INPUT validation (e.g. [\"user\"] to exclude system prompts).",
+    )
+
     skip_system_message_in_guardrail: Optional[bool] = Field(
         default=None,
         description=(

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -616,7 +616,11 @@ class BaseLitellmParams(
 
     experimental_guardrail_input_roles: Optional[List[str]] = Field(
         default=None,
-        description='When set, only messages with the specified roles are sent to Bedrock for INPUT validation (e.g. ["user"] to exclude system prompts).',
+        description=(
+            "When set, only messages whose role appears in this list are forwarded "
+            'for INPUT validation (e.g. ["user"] to exclude system prompts). '
+            "Currently wired for Bedrock guardrails; silently ignored by other providers."
+        ),
     )
 
     skip_system_message_in_guardrail: Optional[bool] = Field(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -21,6 +21,9 @@ from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
 )
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
+    BedrockGuardrailResponse,
+)
 from litellm.types.utils import ModelResponse
 
 
@@ -2252,3 +2255,24 @@ def test_convert_to_bedrock_format_returns_empty_bedrock_request_when_all_messag
     assert "guardrailIdentifier" not in result, (
         "Should return empty BedrockRequest, not a populated one"
     )
+
+
+@pytest.mark.asyncio
+async def test_make_bedrock_api_request_skips_http_call_when_all_messages_filtered():
+    """make_bedrock_api_request must not POST to Bedrock when role filtering removes all
+    messages — the empty BedrockRequest from convert_to_bedrock_format should trigger an
+    early return before _prepare_request is reached."""
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-id",
+        guardrailVersion="DRAFT",
+        experimental_guardrail_input_roles=["user"],
+    )
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+    ]
+    with patch.object(guardrail, "_prepare_request") as mock_prepare:
+        response = await guardrail.make_bedrock_api_request(
+            source="INPUT", messages=messages
+        )
+    mock_prepare.assert_not_called()
+    assert isinstance(response, BedrockGuardrailResponse)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2232,3 +2232,23 @@ def test_convert_to_bedrock_format_input_roles_does_not_affect_output():
     result = guardrail.convert_to_bedrock_format(source="OUTPUT", response=response)
     texts = [item["text"]["text"] for item in result.get("content", [])]
     assert texts == ["response text"], f"Expected assistant response, got: {texts}"
+
+
+def test_convert_to_bedrock_format_returns_empty_bedrock_request_when_all_messages_filtered():
+    """When role filtering removes all messages, return an empty BedrockRequest rather
+    than forwarding an empty content list to Bedrock (which would cause an API error)."""
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-id",
+        guardrailVersion="DRAFT",
+        experimental_guardrail_input_roles=["user"],
+    )
+    # Only system messages — all will be filtered out
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+    ]
+    result = guardrail.convert_to_bedrock_format(source="INPUT", messages=messages)
+    # Should return the empty BedrockRequest rather than content: []
+    assert result.get("content", []) == [], f"Expected no content, got: {result}"
+    assert "guardrailIdentifier" not in result, (
+        "Should return empty BedrockRequest, not a populated one"
+    )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -21,9 +21,6 @@ from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
 )
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
-from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
-    BedrockGuardrailResponse,
-)
 from litellm.types.utils import ModelResponse
 
 
@@ -2270,9 +2267,16 @@ async def test_make_bedrock_api_request_skips_http_call_when_all_messages_filter
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
     ]
-    with patch.object(guardrail, "_prepare_request") as mock_prepare:
+    with (
+        patch.object(
+            guardrail,
+            "_load_credentials",
+            return_value=(MagicMock(), "us-east-1"),
+        ),
+        patch.object(guardrail, "_prepare_request") as mock_prepare,
+    ):
         response = await guardrail.make_bedrock_api_request(
             source="INPUT", messages=messages
         )
     mock_prepare.assert_not_called()
-    assert isinstance(response, BedrockGuardrailResponse)
+    assert isinstance(response, dict)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2164,3 +2164,71 @@ async def test_streaming_post_call_output_only_path_passes_request_data_to_make_
     c = mock_make.call_args
     assert c.kwargs.get("source") == "OUTPUT"
     assert c.kwargs.get("request_data") is request_data
+
+
+# ---------------------------------------------------------------------------
+# experimental_guardrail_input_roles: role-based message filtering
+# ---------------------------------------------------------------------------
+
+
+def test_convert_to_bedrock_format_filters_by_input_roles():
+    """When experimental_guardrail_input_roles is set, only messages with matching
+    roles are sent to Bedrock for INPUT validation."""
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-id",
+        guardrailVersion="DRAFT",
+        experimental_guardrail_input_roles=["user"],
+    )
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+    ]
+    result = guardrail.convert_to_bedrock_format(source="INPUT", messages=messages)
+    texts = [item["text"]["text"] for item in result.get("content", [])]
+    assert texts == ["Hello"], f"Expected only user message, got: {texts}"
+
+
+def test_convert_to_bedrock_format_no_filter_when_roles_not_set():
+    """When experimental_guardrail_input_roles is not set, all messages pass through."""
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-id",
+        guardrailVersion="DRAFT",
+    )
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+    ]
+    result = guardrail.convert_to_bedrock_format(source="INPUT", messages=messages)
+    texts = [item["text"]["text"] for item in result.get("content", [])]
+    assert texts == [
+        "You are a helpful assistant.",
+        "Hello",
+        "Hi there",
+    ], f"Expected all messages, got: {texts}"
+
+
+def test_convert_to_bedrock_format_input_roles_does_not_affect_output():
+    """experimental_guardrail_input_roles must not filter OUTPUT source requests."""
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-id",
+        guardrailVersion="DRAFT",
+        experimental_guardrail_input_roles=["user"],
+    )
+    response = ModelResponse(
+        id="r1",
+        choices=[
+            litellm.Choices(
+                message=litellm.Message(role="assistant", content="response text"),
+                finish_reason="stop",
+                index=0,
+            )
+        ],
+        created=1,
+        model="gpt-4o-mini",
+        object="chat.completion",
+    )
+    result = guardrail.convert_to_bedrock_format(source="OUTPUT", response=response)
+    texts = [item["text"]["text"] for item in result.get("content", [])]
+    assert texts == ["response text"], f"Expected assistant response, got: {texts}"

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -634,7 +634,7 @@ async def test_bedrock_guardrail_make_api_request_passes_api_key():
     ):
 
         mock_load_creds.return_value = (Mock(), "us-east-1")
-        mock_convert.return_value = {"source": "INPUT", "content": []}
+        mock_convert.return_value = {"source": "INPUT", "content": [{"text": {"text": "test"}}]}
         mock_get_params.return_value = {}
 
         mock_request_instance = Mock()


### PR DESCRIPTION
## Relevant issues

Fixes #26392

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

🆕 New Feature

## Changes

  - litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py — stores experimental_guardrail_input_roles from kwargs; filters messages by role in convert_to_bedrock_format before INPUT validation
  - litellm/proxy/guardrails/guardrail_initializers.py — passes experimental_guardrail_input_roles through from LitellmParams to BedrockGuardrail
  - litellm/types/guardrails.py — declares experimental_guardrail_input_roles: Optional[List[str]] on BaseLitellmParams so it is accepted via YAML config and the /guardrail API


<img width="471" height="129" alt="image" src="https://github.com/user-attachments/assets/32f995a3-70f3-4313-9ed1-968c6b8ca043" />
