### PR TITLE
fix(proxy): add verbose_logger to LITELLM_LOG=INFO branch

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5847,10 +5847,15 @@ async def initialize(  # noqa: PLR0915
             if litellm_log_setting.upper() == "INFO":
                 import logging
 
-                from litellm._logging import verbose_proxy_logger, verbose_router_logger
+                from litellm._logging import (
+                    verbose_logger,
+                    verbose_proxy_logger,
+                    verbose_router_logger,
+                )
 
                 # this must ALWAYS remain logging.INFO, DO NOT MODIFY THIS
 
+                verbose_logger.setLevel(level=logging.INFO)  # set package log to info
                 verbose_router_logger.setLevel(
                     level=logging.INFO
                 )  # set router logs to info


### PR DESCRIPTION
## Summary

Fixes #26396

The `INFO` branch in `initialize()` only set `verbose_router_logger` and `verbose_proxy_logger`, omitting `verbose_logger`. Because `verbose_logger` inherits the root logger level (default: WARNING), all `verbose_logger.info(...)` calls in the core package — e.g. `token_based_routing.py` — were silently suppressed when `LITELLM_LOG=INFO`.

## Change

Aligns the `INFO` branch with the `DEBUG` branch: imports and sets all three loggers to `logging.INFO`.

**Before:**
```python
from litellm._logging import verbose_proxy_logger, verbose_router_logger
verbose_router_logger.setLevel(level=logging.INFO)
verbose_proxy_logger.setLevel(level=logging.INFO)
```

**After:**
```python
from litellm._logging import verbose_logger, verbose_proxy_logger, verbose_router_logger
verbose_logger.setLevel(level=logging.INFO)   # ← was missing
verbose_router_logger.setLevel(level=logging.INFO)
verbose_proxy_logger.setLevel(level=logging.INFO)
```

## Test plan

- [ ] `LITELLM_LOG=INFO` → `verbose_logger.info(...)` messages now appear
- [ ] `LITELLM_LOG=DEBUG` → unchanged behaviour
- [ ] `LITELLM_LOG=WARNING/ERROR/CRITICAL` → unchanged behaviour (handled by separate PR #24921)

🤖 Generated with [Claude Code](https://claude.com/claude-code)