### PR TITLE
fix(proxy): set verbose_logger level when LITELLM_LOG=INFO

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5847,10 +5847,15 @@ async def initialize(  # noqa: PLR0915
             if litellm_log_setting.upper() == "INFO":
                 import logging
 
-                from litellm._logging import verbose_proxy_logger, verbose_router_logger
+                from litellm._logging import (
+                    verbose_logger,
+                    verbose_proxy_logger,
+                    verbose_router_logger,
+                )
 
                 # this must ALWAYS remain logging.INFO, DO NOT MODIFY THIS
 
+                verbose_logger.setLevel(level=logging.INFO)  # set package log to info
                 verbose_router_logger.setLevel(
                     level=logging.INFO
                 )  # set router logs to info


### PR DESCRIPTION
Fixes #26396.

The \`LITELLM_LOG=INFO\` branch in \`litellm/proxy/proxy_server.py\` only set \`verbose_router_logger\` and \`verbose_proxy_logger\`. The third logger \`verbose_logger\` (used by e.g. \`token_based_routing.py\` via \`litellm._logging.verbose_logger.info(...)\`) inherited the Python root default (WARNING), so its INFO-level messages were silently filtered.

That's inconsistent with:
- The neighbouring \`LITELLM_LOG=DEBUG\` branch, which configures all three loggers.
- The \`debug=True\` / \`detailed_debug=True\` branches earlier in the same block, which also configure all three.

Include \`verbose_logger\` in the INFO branch so all three loggers behave the same.

## Test plan
- \`LITELLM_LOG=INFO litellm --config ...\` now emits \`verbose_logger.info(...)\` messages (previously suppressed).
- No change to other log levels or branches.
- \`uv run black .\` clean on the touched file.