### PR TITLE
fix: add 1h cache pricing for vertex claude sonnet 4.6

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -31564,6 +31564,7 @@
     },
     "vertex_ai/claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
@@ -38432,6 +38433,7 @@
     },
     "vertex_ai/claude-sonnet-4-6@default": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -735,6 +735,34 @@ def test_cache_writing_cost_with_zero_creation_tokens_and_ephemeral_details():
     assert round(result, 6) == round(expected, 6)
 
 
+def test_vertex_ai_claude_sonnet_4_6_1h_cache_writes_are_priced():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    usage = Usage(
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=0,
+            cache_creation_tokens=0,
+            cache_creation_token_details=CacheCreationTokenDetails(
+                ephemeral_5m_input_tokens=0,
+                ephemeral_1h_input_tokens=1_000_000,
+            ),
+        ),
+    )
+
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model="claude-sonnet-4-6",
+        usage=usage,
+        custom_llm_provider="vertex_ai",
+    )
+
+    assert prompt_cost == 6.0
+    assert completion_cost == 0.0
+
+
 def test_service_tier_flex_pricing():
     """Test that flex service tier uses correct pricing (approximately 50% of standard)."""
     # Set up environment for local model cost map


### PR DESCRIPTION
## Summary
- add `cache_creation_input_token_cost_above_1hr` for `vertex_ai/claude-sonnet-4-6`
- add the same 1h cache write rate for `vertex_ai/claude-sonnet-4-6@default`
- add a regression test covering Vertex Claude Sonnet 4.6 1h cache write pricing through `generic_cost_per_token`

## Validation
- verified locally with `LITELLM_LOCAL_MODEL_COST_MAP=True` that `generic_cost_per_token(..., custom_llm_provider="vertex_ai")` returns `(6.0, 0.0)` for `ephemeral_1h_input_tokens=1_000_000`
- added a regression test for the same scenario