### PR TITLE
fix(ui): add missing 'zai' (Z.AI / Zhipu AI) provider to Add-Model dropdown

### DIFF
--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -68,6 +68,16 @@ describe("provider_info_helpers", () => {
       expect(result.logo).toBe(providerLogoMap[Providers.OpenAI]);
     });
 
+    it("should resolve the zai (Z.AI) provider value to the Z.AI display name", () => {
+      // Regression test for https://github.com/BerriAI/litellm/issues/25482 —
+      // the backend already returns `zai` from /public/providers and the docs
+      // have a dedicated page, but the UI dropdown was missing an entry, so
+      // `getProviderLogoAndName("zai")` previously returned the raw value as
+      // the display name (no mapping).
+      const result = getProviderLogoAndName("zai");
+      expect(result.displayName).toBe(Providers.ZAI);
+    });
+
     it("should return provider value as display name when no mapping exists", () => {
       const unknownProvider = "unknown_provider";
       const result = getProviderLogoAndName(unknownProvider);
@@ -154,6 +164,10 @@ describe("provider_info_helpers", () => {
 
     it("should return watsonx placeholder for Watsonx provider", () => {
       expect(getPlaceholder(Providers.WATSONX)).toBe("watsonx/ibm/granite-3-3-8b-instruct");
+    });
+
+    it("should return zai/glm-4.5 placeholder for Z.AI provider", () => {
+      expect(getPlaceholder(Providers.ZAI)).toBe("zai/glm-4.5");
     });
 
     it("should return default gpt-3.5-turbo placeholder for unknown provider", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -103,6 +103,7 @@ export enum Providers {
   WATSONX_TEXT = "Watsonx Text",
   xAI = "xAI",
   XINFERENCE = "Xinference",
+  ZAI = "Z.AI (Zhipu AI)",
 }
 
 export const provider_map: Record<string, string> = {
@@ -210,6 +211,7 @@ export const provider_map: Record<string, string> = {
   WATSONX_TEXT: "watsonx_text",
   xAI: "xai",
   XINFERENCE: "xinference",
+  ZAI: "zai",
 };
 
 const asset_logos_folder = "../ui/assets/logos/";
@@ -366,6 +368,8 @@ export const getPlaceholder = (selectedProvider: string): string => {
     return "watsonx/ibm/granite-3-3-8b-instruct";
   } else if (selectedProvider === Providers.Cursor) {
     return "cursor/claude-4-sonnet";
+  } else if (selectedProvider === Providers.ZAI) {
+    return "zai/glm-4.5";
   } else {
     return "gpt-3.5-turbo";
   }


### PR DESCRIPTION
## What

Closes #25482.

The Z.AI (Zhipu AI) provider is available in the LiteLLM backend but is missing from the "Add Model" provider dropdown in the admin UI, so users cannot select it when adding a model through the web interface.

This PR adds the missing dropdown entry and a regression test.

## Why

The rest of the stack already supports `zai`:

- `/public/providers` returns `zai` in the provider list.
- `provider_endpoints_support.json` includes a complete `zai` entry (display name "Z.AI (Zhipu AI)", endpoints, docs URL [docs.litellm.ai/docs/providers/zai](https://docs.litellm.ai/docs/providers/zai)).
- `litellm/__init__.py` defines `zai_models` and registers `"zai"` in `models_by_provider`.
- `model_prices_and_context_window.json` contains many `zai/*` entries (e.g. `zai/glm-5`, `zai/glm-5-code`, `zai/glm-4.5`, `zai/glm-4.5-air`, `zai/glm-4.6`, `zai/glm-4.7`).
- `litellm/llms/zai/chat/transformation.py` (`ZAIChatConfig`) exists.

The Add-Model UI dropdown, however, is driven by the hard-coded `Providers` enum and `provider_map` in `ui/litellm-dashboard/src/components/provider_info_helpers.tsx`, which did not list `zai`. As a result:

1. Opening Models → Add Model → "Select a provider" does not include Z.AI.
2. Searching for "zai" or "z" returns nothing.

## Changes

`ui/litellm-dashboard/src/components/provider_info_helpers.tsx`:

- Add `Providers.ZAI = "Z.AI (Zhipu AI)"` to the enum.
- Add `ZAI: "zai"` to `provider_map` so the UI round-trips the existing backend provider key exactly.
- Add a `zai/glm-4.5` branch to `getPlaceholder` — `glm-4.5` is a well-established `zai/*` entry in the pricing catalog.

`ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx`:

- Add a regression test that `getProviderLogoAndName("zai")` resolves to `Providers.ZAI` (tied to #25482).
- Add a test that `getPlaceholder(Providers.ZAI)` returns `zai/glm-4.5`.

No logo asset is added in this PR. `getProviderLogoAndName` already handles providers missing from `providerLogoMap` by returning an empty logo string (same pattern used by several existing providers). A follow-up PR can add a dedicated Z.AI logo.

Net diff: **2 files, +18 / −0**.

## Verification

1. Run the UI unit tests:

```
cd ui/litellm-dashboard
npm install
npm test -- src/components/provider_info_helpers.test.tsx
```

On this branch: **47 tests passing** (45 existing + 2 new).

2. The existing test `should map provider_map values to valid display names` also covers the new entry automatically — every value in `provider_map` must resolve to a valid (non-"-") display name.

3. Manual: start the dashboard, open Models → Add Model, confirm "Z.AI (Zhipu AI)" appears in the provider dropdown and that the form pre-fills the placeholder `zai/glm-4.5` when it is selected.

## Risk

- Pure additive change in a UI registry; no backend, routing, or auth touched.
- No breaking changes to existing providers; the new enum value is the last entry and does not re-order or rename anything.
- No new dependency, no new logo asset.

## References

- Issue: #25482
- Backend registration: `litellm/__init__.py:544,559,765,1040`, `litellm/llms/zai/chat/transformation.py`
- Provider endpoints: `provider_endpoints_support.json` (`"zai"` entry)
- Pricing entries: `model_prices_and_context_window.json` (grep `"litellm_provider": "zai"`)
- Docs page: https://docs.litellm.ai/docs/providers/zai
