### PR TITLE
fix(vertex_ai/anthropic): stop stripping output_config — restores Claude 4.7 task_budget on Vertex

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
@@ -108,9 +108,6 @@ class VertexAIAnthropicConfig(AnthropicConfig):
         # VertexAI doesn't support output_format parameter, remove it if present
         data.pop("output_format", None)
 
-        # VertexAI doesn't support output_config parameter, remove it if present
-        data.pop("output_config", None)
-
         tools = optional_params.get("tools")
         tool_search_used = self.is_tool_search_used(tools)
         auto_betas = self.get_anthropic_beta_list(


### PR DESCRIPTION
## Problem

`litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py` unconditionally pops `output_config` from the request body before forwarding to Vertex's `streamRawPredict` endpoint:

```python
# VertexAI doesn't support output_config parameter, remove it if present
data.pop("output_config", None)
```

This comment is now incorrect. Vertex AI's Anthropic raw-predict endpoint **accepts and forwards** the `output_config` field, which is how Claude 4.7's `effort` + `task_budget` controls are invoked (`anthropic-beta: task-budgets-2026-03-13`). LiteLLM already correctly forwards the beta header (lines 148–150) but silently drops the body field, so the directive never reaches Vertex.

Fixes #26423

## Fix

Remove the two lines. If a future Vertex endpoint genuinely rejects `output_config`, it will surface as a 400 from Vertex — the same error path used for other unsupported fields — rather than silently succeeding with the feature disabled.

## Test

```python
# Minimal verification: output_config must survive transform_request
import litellm
litellm.set_verbose = True
resp = litellm.completion(
    model="vertex_ai/claude-opus-4-7",
    messages=[{"role": "user", "content": "hi"}],
    output_config={"effort": "high", "task_budget": {"type": "tokens", "total": 8192}},
    extra_headers={"anthropic-beta": "task-budgets-2026-03-13"},
)
```

Before: proxy logs show `output_config` absent from the outgoing Vertex request body.
After: `output_config` is forwarded as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)