### PR TITLE
fix(model_management): refresh router after POST /model/update

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -1190,6 +1190,9 @@ async def update_model(
                 data=_data,  # type: ignore
             )
 
+            # Clear cache and reload models (uses config setting or defaults to preserving config models for DB updates)
+            await clear_cache()
+
             ## CREATE AUDIT LOG ##
             asyncio.create_task(
                 create_object_audit_log(

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -487,6 +487,88 @@ class TestClearCache:
             )
 
 
+class TestUpdateModel:
+    """
+    Tests for the update_model (POST /model/update) handler.
+    """
+
+    @pytest.mark.asyncio
+    async def test_update_model_clears_cache_after_db_write(self):
+        """
+        Regression test for the stale-router bug: POST /model/update must refresh
+        the in-memory router after persisting to LiteLLM_ProxyModelTable, otherwise
+        model-level guardrails (and any other litellm_params change) silently no-op
+        until the APScheduler reload tick fires ~30 s later.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_model,
+        )
+        from litellm.types.router import (
+            ModelInfo,
+            updateDeployment,
+            updateLiteLLMParams,
+        )
+
+        model_id = "db-model-under-test"
+
+        existing_row = MagicMock()
+        existing_row.litellm_params = {
+            "model": "openai/gpt-4o-mini",
+            "api_key": "sk-existing",
+        }
+        existing_row.model_dump.return_value = {
+            "model_name": "gpt-4o-mini",
+            "litellm_params": existing_row.litellm_params,
+            "model_info": {"id": model_id},
+        }
+        existing_row.model_dump_json.return_value = "{}"
+
+        updated_row = MagicMock()
+        updated_row.model_dump_json.return_value = "{}"
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=existing_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.update = AsyncMock(
+            return_value=updated_row
+        )
+
+        mock_router = MagicMock()
+        admin_user = UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.llm_router", mock_router),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
+                side_effect=lambda value: value,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.clear_cache",
+                new=AsyncMock(return_value=None),
+            ) as mock_clear_cache,
+        ):
+            await update_model(
+                model_params=updateDeployment(
+                    litellm_params=updateLiteLLMParams(guardrails=["g1"]),
+                    model_info=ModelInfo(id=model_id),
+                ),
+                user_api_key_dict=admin_user,
+            )
+
+            mock_prisma.db.litellm_proxymodeltable.update.assert_awaited_once()
+            mock_clear_cache.assert_awaited_once_with()
+
+
 class TestUpdatePublicModelGroups:
     """Test that update_public_model_groups correctly sets litellm.public_model_groups
     even when get_config() overwrites it with stale DB values."""


### PR DESCRIPTION
## Relevant issues

N/A (no open issue — surfaced internally)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Minimal sequence that exercises the bug:

1. `POST /model/new` — register a DB-stored model with no guardrails
2. `POST /model/update` — attach `litellm_params.guardrails: ["<guardrail-name>"]` to that model
3. `POST /chat/completions` — call the model with no `guardrails` in the request body

**Before the fix** — `SpendLogs.metadata.guardrail_information` for step 3:

```
null
```

The guardrail's DB row confirms `litellm_params -> 'guardrails'` contains `["<guardrail-name>"]`, so the DB write succeeded. The router was serving the pre-update `Deployment` object, so `_check_and_merge_model_level_guardrails` found nothing to merge and `should_run_guardrail` with `default_on: false` returned `False`.

**After the fix** — same sequence, `SpendLogs.metadata.guardrail_information` for step 3:

```json
[
  {
    "guardrail_mode": "post_call",
    "guardrail_name": "<guardrail-name>",
    "guardrail_status": "success",
    "guardrail_response": { ... },
    "duration": 0.595,
    ...
  }
]
```

The guardrail runs on the first request after the update, matching the behavior of `POST /model/new` with guardrails attached at creation time and of YAML-attached model-level guardrails. No regression on either of those paths was observed.

## Type

🐛 Bug Fix

## Changes

### Bug

`POST /model/update` (handler `update_model` in `litellm/proxy/management_endpoints/model_management_endpoints.py`) persists merged `litellm_params` to `LiteLLM_ProxyModelTable` and returns 200, but never refreshes the in-memory `llm_router`. As a result, subsequent requests are served from the stale `Deployment` object that was loaded at `/model/new` time, so any field updated through this endpoint (e.g. `guardrails`, `api_key`, `tpm`/`rpm`) appears to take effect on the DB row but silently no-ops on request handling until the APScheduler reload tick fires (~30 s later).

The sibling handler `PATCH /model/{model_id}/update` (`patch_model`) already calls `await clear_cache()` immediately after its DB write — that was added in PR #10853. The legacy POST endpoint was missed in that pass.

### Fix

Add a single `await clear_cache()` call in `update_model`, directly after the Prisma `update` and before the fire-and-forget audit-log task. `clear_cache()` is defined in the same module and is already the canonical post-write invariant used by `patch_model`; reusing it aligns the two handlers on identical behavior without introducing a new primitive or import.

`clear_cache()` filters DB-model IDs out of the router and re-reads all DB rows via `proxy_config.add_deployment(...)`, so by the time `update_model` returns, the router has been rebuilt from the same row that was just persisted. Config (YAML) models are preserved (the helper filters on `model_info.db_model`).

### Test

Added `TestUpdateModel::test_update_model_clears_cache_after_db_write` in `tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py`. It patches `clear_cache` at the call site and asserts that `update_model` awaits it exactly once after the Prisma update. The test deliberately does **not** re-test `clear_cache`'s own logic — that is already covered by `TestClearCache::test_clear_cache_success` and `TestClearCache::test_clear_cache_preserve_config_models` in the same file.

### Risk / backwards compatibility

- `clear_cache()` has been exercised on every `PATCH /model/{model_id}/update` since PR #10853 (2025-05-24) and on every 30-second scheduler tick. The new call path exposes `update_model` to the same cost profile, which is known to be sustainable.
- If `clear_cache()` raises (e.g. Prisma flap), the exception is caught by the helper's own `try/except` and logged; it does not propagate into `update_model`. Worst case the fix degrades to the pre-fix behavior (router stays stale until APScheduler heals it).
- No API shape change, no schema change. Revertable by removing the single `await clear_cache()` line.

### Explicitly out of scope

- `PATCH /model/{model_id}/update` — already calls `clear_cache()`, untouched.
- `POST /model/new` — already calls `proxy_config.add_deployment(...)` inline, untouched.
- `_check_and_merge_model_level_guardrails` in `proxy/utils.py` — merge logic is correct; the problem was upstream (stale router).
- The APScheduler 30-second reload — still runs as a safety net.
- A separate pre_call-path gap for model-level guardrails attached via YAML `litellm_params.guardrails` (different call-site pattern — all three current `_check_and_merge_model_level_guardrails` callers are post_call hooks). Will be filed separately.
