### PR TITLE
fix(jwt-auth): apply team TPM/RPM + attribution for admins using x-litellm-team-id

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -1427,14 +1427,27 @@ class JWTAuthManager:
         )
         if not header_team_id or not RouteChecks.is_llm_api_route(route=route):
             return
-        team_object = await get_team_object(
-            team_id=header_team_id,
-            prisma_client=prisma_client,
-            user_api_key_cache=user_api_key_cache,
-            parent_otel_span=parent_otel_span,
-            proxy_logging_obj=proxy_logging_obj,
-            team_id_upsert=jwt_handler.litellm_jwtauth.team_id_upsert,
-        )
+        try:
+            team_object = await get_team_object(
+                team_id=header_team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+                team_id_upsert=jwt_handler.litellm_jwtauth.team_id_upsert,
+            )
+        except Exception as e:
+            # Fall back to pre-PR admin behavior: honor the admin's
+            # authorization but skip team attribution/limits for this
+            # request. Log so operators can find the misconfigured caller.
+            verbose_proxy_logger.warning(
+                "admin x-litellm-team-id=%r on route=%s could not be resolved (%s); "
+                "proceeding with admin access, team context NOT attached.",
+                header_team_id,
+                route,
+                e,
+            )
+            return
         admin_result["team_id"] = header_team_id
         admin_result["team_object"] = team_object
 

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -1406,6 +1406,39 @@ class JWTAuthManager:
         return None
 
     @staticmethod
+    async def _attach_team_from_header_for_admin(
+        admin_result: JWTAuthBuilderResult,
+        route: str,
+        request_headers: Optional[dict],
+        jwt_handler: JWTHandler,
+        prisma_client: Optional[PrismaClient],
+        user_api_key_cache: DualCache,
+        parent_otel_span: Optional[Span],
+        proxy_logging_obj: ProxyLogging,
+    ) -> None:
+        """Attach team context from x-litellm-team-id to an admin result.
+
+        Only applies on LLM API routes so team TPM/RPM limits and attribution
+        are enforced when admins act on behalf of a team. Admin management
+        routes ignore the header to preserve pre-existing bypass behavior.
+        """
+        header_team_id = (
+            request_headers.get("x-litellm-team-id") if request_headers else None
+        )
+        if not header_team_id or not RouteChecks.is_llm_api_route(route=route):
+            return
+        team_object = await get_team_object(
+            team_id=header_team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+            team_id_upsert=jwt_handler.litellm_jwtauth.team_id_upsert,
+        )
+        admin_result["team_id"] = header_team_id
+        admin_result["team_object"] = team_object
+
+    @staticmethod
     async def auth_builder(
         api_key: str,
         jwt_handler: JWTHandler,
@@ -1494,25 +1527,16 @@ class JWTAuthManager:
             jwt_handler, scopes, route, user_id, org_id, api_key, jwt_valid_token
         )
         if admin_result:
-            # When an admin explicitly acts on behalf of a team via
-            # x-litellm-team-id on an LLM API route, fetch the team so
-            # team TPM/RPM limits and attribution apply. For admin
-            # management routes we intentionally ignore the header to
-            # preserve the pre-existing bypass behavior.
-            header_team_id = (
-                request_headers.get("x-litellm-team-id") if request_headers else None
+            await JWTAuthManager._attach_team_from_header_for_admin(
+                admin_result=admin_result,
+                route=route,
+                request_headers=request_headers,
+                jwt_handler=jwt_handler,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
             )
-            if header_team_id and RouteChecks.is_llm_api_route(route=route):
-                team_object = await get_team_object(
-                    team_id=header_team_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    parent_otel_span=parent_otel_span,
-                    proxy_logging_obj=proxy_logging_obj,
-                    team_id_upsert=jwt_handler.litellm_jwtauth.team_id_upsert,
-                )
-                admin_result["team_id"] = header_team_id
-                admin_result["team_object"] = team_object
             return admin_result
 
         # Get team with model access

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -45,6 +45,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.auth_checks import can_team_access_model
+from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.utils import PrismaClient, ProxyLogging
 
 from .auth_checks import (
@@ -1493,6 +1494,25 @@ class JWTAuthManager:
             jwt_handler, scopes, route, user_id, org_id, api_key, jwt_valid_token
         )
         if admin_result:
+            # When an admin explicitly acts on behalf of a team via
+            # x-litellm-team-id on an LLM API route, fetch the team so
+            # team TPM/RPM limits and attribution apply. For admin
+            # management routes we intentionally ignore the header to
+            # preserve the pre-existing bypass behavior.
+            header_team_id = (
+                request_headers.get("x-litellm-team-id") if request_headers else None
+            )
+            if header_team_id and RouteChecks.is_llm_api_route(route=route):
+                team_object = await get_team_object(
+                    team_id=header_team_id,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    parent_otel_span=parent_otel_span,
+                    proxy_logging_obj=proxy_logging_obj,
+                    team_id_upsert=jwt_handler.litellm_jwtauth.team_id_upsert,
+                )
+                admin_result["team_id"] = header_team_id
+                admin_result["team_object"] = team_object
             return admin_result
 
         # Get team with model access

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -810,6 +810,21 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                                 if team_object is not None
                                 else None
                             ),
+                            team_tpm_limit=(
+                                team_object.tpm_limit
+                                if team_object is not None
+                                else None
+                            ),
+                            team_rpm_limit=(
+                                team_object.rpm_limit
+                                if team_object is not None
+                                else None
+                            ),
+                            team_models=(
+                                team_object.models
+                                if team_object is not None
+                                else []
+                            ),
                             team_metadata=(
                                 team_object.metadata
                                 if team_object is not None

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -821,9 +821,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                                 else None
                             ),
                             team_models=(
-                                team_object.models
-                                if team_object is not None
-                                else []
+                                team_object.models if team_object is not None else []
                             ),
                             team_metadata=(
                                 team_object.metadata

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1521,9 +1521,7 @@ async def test_auth_builder_admin_on_llm_route_honors_team_header():
         ),
     )
 
-    team_object = LiteLLM_TeamTable(
-        team_id="team-low", tpm_limit=100, rpm_limit=2
-    )
+    team_object = LiteLLM_TeamTable(team_id="team-low", tpm_limit=100, rpm_limit=2)
 
     with (
         patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1499,6 +1499,176 @@ async def test_auth_builder_uses_team_from_header_e2e():
 
 
 @pytest.mark.asyncio
+async def test_auth_builder_admin_on_llm_route_honors_team_header():
+    """JWT proxy_admin + x-litellm-team-id on an LLM API route -> team context is
+    attached to the admin result so team TPM/RPM limits and attribution apply."""
+    from litellm.caching import DualCache
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_ids_jwt_field="groups",
+            user_id_jwt_field="sub",
+            admin_allowed_routes=[
+                "management_routes",
+                "info_routes",
+                "openai_routes",
+            ],
+        ),
+    )
+
+    team_object = LiteLLM_TeamTable(
+        team_id="team-low", tpm_limit=100, rpm_limit=2
+    )
+
+    with (
+        patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
+        patch.object(JWTAuthManager, "check_rbac_role", new_callable=AsyncMock),
+        patch.object(jwt_handler, "is_admin", return_value=True),
+        patch(
+            "litellm.proxy.auth.handle_jwt.get_team_object", new_callable=AsyncMock
+        ) as mock_get_team,
+    ):
+        mock_auth_jwt.return_value = {
+            "sub": "admin-user",
+            "scope": "",
+            "groups": [],
+        }
+        mock_get_team.return_value = team_object
+
+        result = await JWTAuthManager.auth_builder(
+            api_key="jwt-token",
+            jwt_handler=jwt_handler,
+            request_data={"model": "gpt-4"},
+            general_settings={},
+            route="/chat/completions",
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=ProxyLogging(user_api_key_cache=user_api_key_cache),
+            request_headers={"x-litellm-team-id": "team-low"},
+        )
+
+        assert result["is_proxy_admin"] is True
+        assert result["team_id"] == "team-low"
+        assert result["team_object"] == team_object
+        mock_get_team.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_auth_builder_admin_on_mgmt_route_ignores_team_header():
+    """JWT proxy_admin + x-litellm-team-id on an admin management route -> header
+    is ignored; no team fetch. Preserves pre-existing bypass behavior and avoids
+    phantom team creation when team_id_upsert is enabled."""
+    from litellm.caching import DualCache
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_ids_jwt_field="groups",
+            user_id_jwt_field="sub",
+            team_id_upsert=True,
+        ),
+    )
+
+    with (
+        patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
+        patch.object(JWTAuthManager, "check_rbac_role", new_callable=AsyncMock),
+        patch.object(jwt_handler, "is_admin", return_value=True),
+        patch(
+            "litellm.proxy.auth.handle_jwt.get_team_object", new_callable=AsyncMock
+        ) as mock_get_team,
+    ):
+        mock_auth_jwt.return_value = {
+            "sub": "admin-user",
+            "scope": "",
+            "groups": [],
+        }
+
+        result = await JWTAuthManager.auth_builder(
+            api_key="jwt-token",
+            jwt_handler=jwt_handler,
+            request_data={},
+            general_settings={},
+            route="/user/info",
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=ProxyLogging(user_api_key_cache=user_api_key_cache),
+            request_headers={"x-litellm-team-id": "totally-made-up-team"},
+        )
+
+        assert result["is_proxy_admin"] is True
+        assert result["team_id"] is None
+        assert result["team_object"] is None
+        mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_builder_admin_on_llm_route_without_header_unchanged():
+    """JWT proxy_admin on an LLM API route without x-litellm-team-id -> no team
+    context (team limits not applied, admin keeps unrestricted access)."""
+    from litellm.caching import DualCache
+    from litellm.proxy.utils import ProxyLogging
+
+    jwt_handler = JWTHandler()
+    user_api_key_cache = DualCache()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(
+            team_ids_jwt_field="groups",
+            user_id_jwt_field="sub",
+            admin_allowed_routes=[
+                "management_routes",
+                "info_routes",
+                "openai_routes",
+            ],
+        ),
+    )
+
+    with (
+        patch.object(jwt_handler, "auth_jwt", new_callable=AsyncMock) as mock_auth_jwt,
+        patch.object(JWTAuthManager, "check_rbac_role", new_callable=AsyncMock),
+        patch.object(jwt_handler, "is_admin", return_value=True),
+        patch(
+            "litellm.proxy.auth.handle_jwt.get_team_object", new_callable=AsyncMock
+        ) as mock_get_team,
+    ):
+        mock_auth_jwt.return_value = {
+            "sub": "admin-user",
+            "scope": "",
+            "groups": [],
+        }
+
+        result = await JWTAuthManager.auth_builder(
+            api_key="jwt-token",
+            jwt_handler=jwt_handler,
+            request_data={"model": "gpt-4"},
+            general_settings={},
+            route="/chat/completions",
+            prisma_client=None,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=ProxyLogging(user_api_key_cache=user_api_key_cache),
+            request_headers={},
+        )
+
+        assert result["is_proxy_admin"] is True
+        assert result["team_id"] is None
+        assert result["team_object"] is None
+        mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_team_alias_with_nested_fields():
     """
     Test get_team_alias() method with nested JWT fields


### PR DESCRIPTION
## Summary

When a JWT-authenticated user resolved to `proxy_admin` passed an `x-litellm-team-id` header, the team's TPM/RPM limits were silently dropped and the request wasn't attributed to that team. This PR gives admins the team's rate limits **and** proper attribution (spend logs, metadata) when they act on behalf of a team, while preserving the pre-existing admin-bypass behavior for management routes.

## screenshots 

before 

<img width="798" height="337" alt="Screenshot 2026-04-24 at 2 58 17 PM" src="https://github.com/user-attachments/assets/fdeb2924-4f74-4f07-839c-6f53ba53bbb4" />


after 

<img width="829" height="831" alt="Screenshot 2026-04-24 at 2 58 42 PM" src="https://github.com/user-attachments/assets/18e5fa94-aeb3-4ffb-894d-2dc3716c2374" />
<img width="807" height="835" alt="Screenshot 2026-04-24 at 2 58 47 PM" src="https://github.com/user-attachments/assets/6d73936a-15c9-4d5a-b0cf-5f833b9f01a6" />
<img width="809" height="837" alt="Screenshot 2026-04-24 at 2 58 52 PM" src="https://github.com/user-attachments/assets/e96ddf42-6695-46ef-95a4-2cbad4b8a24c" />

## Root cause

The admin branch of `_user_api_key_auth_builder` (in `litellm/proxy/auth/user_api_key_auth.py`) constructed a `UserAPIKeyAuth` with `team_id` but without `team_tpm_limit` / `team_rpm_limit` / `team_models`, even though `team_object` was available. The rate limiter saw `None` for the team limits and skipped enforcement.

A second gap also existed: for admins detected via `admin_jwt_scope` (rather than `jwt_litellm_role_map`), `check_admin_access` ran before the `x-litellm-team-id` header was resolved and returned `team_id=None`, so team context never reached the admin result at all.

## Approach

Scope the header-driven team fetch to **LLM API routes** (`RouteChecks.is_llm_api_route(route)`). This is where team TPM/RPM limits and attribution matter; admin management routes (`/user/*`, `/team/*`, etc.) intentionally ignore the header to preserve their existing behavior.

The fetch is added inside the `if admin_result:` branch in `auth_builder`, so:

- On LLM API routes (`/chat/completions`, `/embeddings`, etc.): header is read, `get_team_object` runs, team context is attached to the admin result, rate limits enforce, attribution flows through.
- On admin management routes: header is ignored (same as before the fix), no team fetch happens, no phantom teams via `team_id_upsert`, no spurious 404s.

An earlier draft of this PR reordered `auth_builder` to resolve the header unconditionally before the admin check, introduced a `bypass_allowed_check` flag on `get_team_id_from_header`, and extended `check_admin_access`'s signature. That version regressed admin-mgmt routes: with `team_id_upsert=true` a stray header caused phantom team creation; with `team_id_upsert=false` it caused 404s on routes that previously worked. The scoped approach in this PR avoids both regressions and is smaller (+205 / -0).

## Changes

- `litellm/proxy/auth/user_api_key_auth.py` — in the `is_proxy_admin` branch, populate `team_tpm_limit`, `team_rpm_limit`, `team_models` from `team_object` (matching the non-admin branch directly below).
- `litellm/proxy/auth/handle_jwt.py` — inside the `if admin_result:` block, if the request carries `x-litellm-team-id` **and** the route is an LLM API route, fetch the team and attach `team_id` / `team_object` to the admin result. No signature changes to `check_admin_access`, no reorder, no bypass flag.
- `tests/test_litellm/proxy/auth/test_handle_jwt.py` — 3 new tests:
  - `test_auth_builder_admin_on_llm_route_honors_team_header` — admin + header on `/chat/completions` → team context attached
  - `test_auth_builder_admin_on_mgmt_route_ignores_team_header` — admin + bogus header on `/user/info` → header ignored, `get_team_object` not called
  - `test_auth_builder_admin_on_llm_route_without_header_unchanged` — admin on LLM route without header → no team context

## Test plan

- [x] 3 new unit tests pass; full `test_handle_jwt.py` (44 tests) passes
- [x] E2E verified with a local proxy + JWKS + admin JWT: 6 `/chat/completions` requests against a team with `rpm_limit=2` now return `200, 200, 429, 429, 429, 429` (was `200` x6 pre-fix)
- [x] E2E verified no regression on admin mgmt routes: admin + `/user/info` with a bogus `x-litellm-team-id` returns the same "user not found" as without the header, and does **not** create a phantom team under `team_id_upsert=true`
- [x] Verified team attribution: spend log rows for admin+header requests have `team_id=team-low-rpm` populated