### PR TITLE
fix(content_filter): log guardrail_information on streaming post-call

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1866,83 +1866,115 @@ class ContentFilterGuardrail(CustomGuardrail):
 
         For BLOCK action: Raises HTTPException immediately when blocked content is detected.
         For MASK action: Content is buffered to handle patterns split across chunks.
+
+        At stream end (including when BLOCK raises HTTPException), write a
+        standard_logging_guardrail_information entry into request_data["metadata"]
+        so the post-call log row reaches standard_logging_object.guardrail_information
+        and the UI Request Lifecycle panel. Mirrors apply_guardrail's finally-block
+        contract.
         """
         accumulated_full_text = ""
         yielded_masked_text_len = 0
         buffer_size = 50  # Increased buffer to catch patterns split across many chunks
 
+        start_time = datetime.now()
+        detections: List[ContentFilterDetection] = []
+        masked_entity_count: Dict[str, int] = {}
+        status: GuardrailStatus = "success"
+        exception_str: str = ""
+
         verbose_proxy_logger.info(
             f"ContentFilterGuardrail: Starting robust streaming masking for model {request_data.get('model')}"
         )
 
-        async for item in response:
-            if isinstance(item, ModelResponseStream) and item.choices:
-                delta_content = ""
-                is_final = False
-                for choice in item.choices:
-                    if hasattr(choice, "delta") and choice.delta:
-                        content = getattr(choice.delta, "content", None)
-                        if content and isinstance(content, str):
-                            delta_content += content
-                    if getattr(choice, "finish_reason", None):
-                        is_final = True
+        try:
+            async for item in response:
+                if isinstance(item, ModelResponseStream) and item.choices:
+                    delta_content = ""
+                    is_final = False
+                    for choice in item.choices:
+                        if hasattr(choice, "delta") and choice.delta:
+                            content = getattr(choice.delta, "content", None)
+                            if content and isinstance(content, str):
+                                delta_content += content
+                        if getattr(choice, "finish_reason", None):
+                            is_final = True
 
-                accumulated_full_text += delta_content
+                    accumulated_full_text += delta_content
 
-                # Check for blocking or apply masking
-                # Add a space at the end if it's the final chunk to trigger word boundaries (\b)
-                text_to_check = accumulated_full_text
-                if is_final:
-                    text_to_check += " "
+                    # Check for blocking or apply masking
+                    # Add a space at the end if it's the final chunk to trigger word boundaries (\b)
+                    text_to_check = accumulated_full_text
+                    if is_final:
+                        text_to_check += " "
 
-                try:
-                    masked_text = self._filter_single_text(text_to_check)
-                    if is_final and masked_text.endswith(" "):
-                        masked_text = masked_text[:-1]
-                except HTTPException:
-                    raise
-                except Exception as e:
-                    verbose_proxy_logger.error(
-                        f"ContentFilterGuardrail: Error in masking: {e}"
-                    )
-                    masked_text = text_to_check  # Fallback to current text
+                    try:
+                        masked_text = self._filter_single_text(
+                            text_to_check, detections=detections
+                        )
+                        if is_final and masked_text.endswith(" "):
+                            masked_text = masked_text[:-1]
+                    except HTTPException:
+                        raise
+                    except Exception as e:
+                        verbose_proxy_logger.error(
+                            f"ContentFilterGuardrail: Error in masking: {e}"
+                        )
+                        masked_text = text_to_check  # Fallback to current text
 
-                # Determine how much can be safely yielded
-                if is_final:
-                    safe_to_yield_len = len(masked_text)
-                else:
-                    safe_to_yield_len = max(0, len(masked_text) - buffer_size)
+                    # Determine how much can be safely yielded
+                    if is_final:
+                        safe_to_yield_len = len(masked_text)
+                    else:
+                        safe_to_yield_len = max(0, len(masked_text) - buffer_size)
 
-                if safe_to_yield_len > yielded_masked_text_len:
-                    new_masked_content = masked_text[
-                        yielded_masked_text_len:safe_to_yield_len
-                    ]
-                    # Modify the chunk to contain only the new masked content
-                    if (
-                        item.choices
-                        and hasattr(item.choices[0], "delta")
-                        and item.choices[0].delta
-                    ):
-                        item.choices[0].delta.content = new_masked_content
-                        yielded_masked_text_len = safe_to_yield_len
+                    if safe_to_yield_len > yielded_masked_text_len:
+                        new_masked_content = masked_text[
+                            yielded_masked_text_len:safe_to_yield_len
+                        ]
+                        # Modify the chunk to contain only the new masked content
+                        if (
+                            item.choices
+                            and hasattr(item.choices[0], "delta")
+                            and item.choices[0].delta
+                        ):
+                            item.choices[0].delta.content = new_masked_content
+                            yielded_masked_text_len = safe_to_yield_len
+                            yield item
+                    else:
+                        # Hold content by yielding empty content chunk (keeps metadata/structure)
+                        if (
+                            item.choices
+                            and hasattr(item.choices[0], "delta")
+                            and item.choices[0].delta
+                        ):
+                            item.choices[0].delta.content = ""
                         yield item
                 else:
-                    # Hold content by yielding empty content chunk (keeps metadata/structure)
-                    if (
-                        item.choices
-                        and hasattr(item.choices[0], "delta")
-                        and item.choices[0].delta
-                    ):
-                        item.choices[0].delta.content = ""
+                    # Not a ModelResponseStream or no choices - yield as is
                     yield item
-            else:
-                # Not a ModelResponseStream or no choices - yield as is
-                yield item
 
-        # Any remaining content (should have been handled by is_final, but just in case)
-        if yielded_masked_text_len < len(accumulated_full_text):
-            # We already reached the end of the generator
-            pass
+            # Any remaining content (should have been handled by is_final, but just in case)
+            if yielded_masked_text_len < len(accumulated_full_text):
+                # We already reached the end of the generator
+                pass
+        except HTTPException:
+            status = "guardrail_intervened"
+            raise
+        except Exception as e:
+            status = "guardrail_failed_to_respond"
+            exception_str = str(e)
+            raise e
+        finally:
+            self._count_masked_entities(detections, masked_entity_count)
+            self._log_guardrail_information(
+                request_data=request_data,
+                detections=detections,
+                status=status,
+                start_time=start_time,
+                masked_entity_count=masked_entity_count,
+                exception_str=exception_str,
+            )
 
     @staticmethod
     def get_config_model():

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1909,6 +1909,13 @@ class ContentFilterGuardrail(CustomGuardrail):
                         text_to_check += " "
 
                     try:
+                        # Reset before each scan: _filter_single_text scans the
+                        # whole accumulated buffer every chunk, so previous-chunk
+                        # matches are guaranteed to be re-found. Keeping only the
+                        # latest scan's detections avoids N× duplication in the
+                        # final log row. BLOCK still records correctly because
+                        # handlers append to detections before raising.
+                        detections.clear()
                         masked_text = self._filter_single_text(
                             text_to_check, detections=detections
                         )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -690,6 +690,96 @@ class TestContentFilterGuardrail:
         assert entry["guardrail_name"] == "test-streaming-logging-block"
         assert entry["guardrail_status"] == "guardrail_intervened"
 
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_no_duplicate_detections_across_chunks(self):
+        """
+        Multi-chunk regression: _filter_single_text re-scans the whole accumulated
+        buffer on every chunk, so without per-chunk reset the same detection would
+        be appended once per chunk after it first appears, inflating
+        masked_entity_count and guardrail_response in the log.
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-no-duplicates",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        # The email straddles chunks 1 and 2; chunks 3 and 4 keep streaming after
+        # the match has already been found, exercising the re-scan path.
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="c1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Contact me at test@"), index=0
+                    )
+                ],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="c2",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="example.com please."), index=0
+                    )
+                ],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="c3",
+                choices=[StreamingChoices(delta=Delta(content=" Thanks!"), index=0)],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="c4",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=""), index=0, finish_reason="stop"
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            pass
+
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_status"] == "success"
+
+        detections = entry["guardrail_response"]
+        pattern_detections = [d for d in detections if d.get("type") == "pattern"]
+        # Exactly one email detection — not one per chunk after the match appeared.
+        assert len(pattern_detections) == 1, (
+            f"expected exactly 1 email detection, got {len(pattern_detections)}: "
+            f"{detections}"
+        )
+        assert pattern_detections[0].get("pattern_name") == "email"
+        # masked_entity_count for email is the real count, not N×.
+        assert entry["masked_entity_count"].get("email") == 1
+
     def test_init_with_plain_dicts(self):
         """
         Test initialization with plain dicts (DB format).

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -501,6 +501,195 @@ class TestContentFilterGuardrail:
         assert exc_info.value.status_code == 403
         assert "us_ssn" in str(exc_info.value.detail)
 
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_guardrail_information_clean(self):
+        """
+        Streaming post-call: when no detections fire, still write a success log row
+        into request_data["metadata"]["standard_logging_guardrail_information"].
+
+        Regression test for: UI-created ContentFilterGuardrail in mode=post_call
+        never produced a `standard_logging_object.guardrail_information` entry on
+        streaming responses (Branch 1 dispatcher + iterator hook had no log write).
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-clean",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Hello world, nothing sensitive here."),
+                        index=0,
+                        finish_reason="stop",
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            pass
+
+        assert "standard_logging_guardrail_information" in request_data["metadata"]
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert isinstance(entries, list)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_name"] == "test-streaming-logging-clean"
+        assert entry["guardrail_provider"] == "litellm_content_filter"
+        assert entry["guardrail_status"] == "success"
+        assert entry["guardrail_response"] == []
+
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_guardrail_information_mask(self):
+        """
+        Streaming post-call with a MASK pattern: writes a success row with the
+        detection in guardrail_response and a non-zero masked_entity_count.
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-mask",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Contact me at test@example.com please."),
+                        index=0,
+                        finish_reason="stop",
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        full_content = ""
+        async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            if chunk.choices and chunk.choices[0].delta.content:
+                full_content += chunk.choices[0].delta.content
+
+        # Content was masked, not blocked
+        assert "test@example.com" not in full_content
+        assert "[EMAIL_REDACTED]" in full_content
+
+        # And the log row was written
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_status"] == "success"
+        assert entry["guardrail_provider"] == "litellm_content_filter"
+
+        detections = entry["guardrail_response"]
+        assert isinstance(detections, list)
+        # At least one pattern detection for 'email' should be recorded
+        pattern_detections = [d for d in detections if d.get("type") == "pattern"]
+        assert pattern_detections, f"expected pattern detections, got {detections}"
+        assert any(d.get("pattern_name") == "email" for d in pattern_detections)
+        # And masked_entity_count for email should be >= 1
+        assert entry["masked_entity_count"].get("email", 0) >= 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_guardrail_information_block(self):
+        """
+        Streaming post-call with a BLOCK pattern: the hook raises HTTPException,
+        but the `finally` block still writes a log row with
+        guardrail_status == "guardrail_intervened".
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="us_ssn",
+                action=ContentFilterAction.BLOCK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-block",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(delta=Delta(content="SSN: 123-45-6789"), index=0)
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        with pytest.raises(HTTPException):
+            async for _ in guardrail.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=user_api_key_dict,
+                response=mock_stream(),
+                request_data=request_data,
+            ):
+                pass
+
+        # Even though HTTPException bubbled up, the log row must be written.
+        assert "standard_logging_guardrail_information" in request_data["metadata"]
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_name"] == "test-streaming-logging-block"
+        assert entry["guardrail_status"] == "guardrail_intervened"
+
     def test_init_with_plain_dicts(self):
         """
         Test initialization with plain dicts (DB format).


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

_No linked GitHub issue._

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - \<= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

**Before the fix** — `ContentFilterGuardrail` in `mode=post_call` on a streaming `/chat/completions`:
- `request_data["metadata"]` did not contain `standard_logging_guardrail_information` after stream end.
- Downstream, `LiteLLM_SpendLogs.metadata.guardrail_information` and `standard_logging_object.guardrail_information` had no entry for the guardrail, and the UI Request Lifecycle panel rendered no post-call step.
- Non-streaming requests against the same guardrail wrote the entry correctly (via `apply_guardrail`'s `finally` block).

**After the fix** — same configuration, same request:
- `request_data["metadata"]["standard_logging_guardrail_information"]` contains a post-call entry with `guardrail_provider="litellm_content_filter"`, `guardrail_mode="post_call"`, `guardrail_status="success"`.
- The SpendLogs row's `metadata.guardrail_information` and the SLO's `guardrail_information` are populated. The UI Request Lifecycle panel renders the post-call step.
- Non-streaming behaviour is unchanged.

**Tests** — three new tests in `tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py::TestContentFilterGuardrail` cover the streaming iterator's three exit paths and assert the new log row is written:
- `test_streaming_hook_logs_guardrail_information_clean` — no detections fire, success row written.
- `test_streaming_hook_logs_guardrail_information_mask` — MASK pattern fires, success row with `guardrail_response` populated and `masked_entity_count` incremented.
- `test_streaming_hook_logs_guardrail_information_block` — BLOCK pattern raises `HTTPException`, the `finally` block still writes a row with `guardrail_status="guardrail_intervened"`.

All 51 tests in `test_content_filter.py` pass; the broader `tests/test_litellm/proxy/guardrails` sweep (1209 tests) also passes locally.

## Type

🐛 Bug Fix

## Changes

### Bug

`ContentFilterGuardrail.async_post_call_streaming_iterator_hook` (`litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py`) processed streaming chunks correctly but never called `_log_guardrail_information(...)` at stream end, so on streaming `post_call` runs the guardrail produced no `standard_logging_guardrail_information` entry. The non-streaming path was unaffected because `apply_guardrail` writes the entry from its `finally` block.

The dispatcher routes `ContentFilterGuardrail` through "Branch 1" of `litellm/proxy/utils.py` (it defines `async_post_call_streaming_iterator_hook` in its own `__dict__`), so the deferred-stream closure in `litellm/proxy/common_request_processing.py` skips this class — meaning no other code path was writing the entry on streams either. End result: the SpendLogs row's `metadata.guardrail_information` was empty on streaming, the SLO field was empty, and any UI / custom logger / observability consumer that reads `guardrail_information` saw nothing.

### Fix

In `litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py`:

- Wrap the body of `async_post_call_streaming_iterator_hook` in `try/except/finally`.
- Thread `detections=detections` into the per-chunk `_filter_single_text(...)` call so detections accumulate across chunks (kwarg already existed with a default of `None`).
- In `finally`, count masked entities and call `self._log_guardrail_information(...)`. Status mapping mirrors `apply_guardrail`'s `finally` block: `HTTPException` (raised by `_filter_single_text` on BLOCK) → `"guardrail_intervened"`; any other exception → `"guardrail_failed_to_respond"` with the exception string; normal completion → `"success"`.

Per-chunk masking, buffering, and BLOCK-on-match semantics are preserved unchanged. The only behavioural change is that the log row is now written at stream end on all three exit paths, matching the existing non-streaming contract.

### Out of scope

- The same structural gap likely exists in `AimGuardrail` (`litellm/proxy/guardrails/guardrail_hooks/aim/aim.py`) and `_OPTIONAL_PresidioPIIMasking` (`litellm/proxy/guardrails/guardrail_hooks/presidio.py`) — neither writes a log row from its streaming iterator hook. A shared decorator/helper is the cleaner long-term fix and is intentionally not done here to keep the PR small and focused.
- Branch-1 dispatcher routing in `litellm/proxy/utils.py` and the deferred-stream closure skip in `litellm/proxy/common_request_processing.py` are unchanged — both are intentional and out of scope for this fix.
