### PR TITLE
fix(ci): support CircleCI rerun failed tests for local_testing jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm \
                 --cov-report=xml \
@@ -301,7 +301,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -vv \
                 --cov=litellm \
                 --cov-report=xml \
@@ -466,7 +466,7 @@ jobs:
             echo "$TEST_FILES" | circleci tests run \
               --split-by=timings \
               --verbose \
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
                 -v \
                 -k 'router' \
                 -n 4 \


### PR DESCRIPTION
## Relevant issues

CircleCI's "Rerun failed tests" feature has been broken for `local_testing_part1`, `local_testing_part2`, and `litellm_router_testing` jobs. Reruns collect 0 items and exit with code 123.

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory — N/A, this is a CI config change with no runtime code impact
- [x] My PR passes all unit tests — no runtime code changed
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Before** (rerun output):
```
[DEBU] Received: tests.local_testing.test_router
4 workers [0 items]
============================ no tests ran in 2.74s =============================
Error: exit status 123
```
Debug line from the plugin: `"if all tests are being run instead of only failed tests, ensure your JUnit XML has a file or classname attribute."`

**Root cause**: The `circleci-tests-plugin-cli` plugin, when rerunning failed tests, reads the JUnit XML `classname` attribute (dot notation) and pipes it into `xargs pytest`. pytest receives `tests.local_testing.test_router` instead of `tests/local_testing/test_router.py`, collects zero items, and fails with exit 123.

**Fix verification**:
```
$ printf 'tests/local_testing/test_router.py\ntests.local_testing.test_router\n' \
    | awk '/\.py/ {print; next} {gsub(/\./, "/"); print $0 ".py"}'
tests/local_testing/test_router.py
tests/local_testing/test_router.py
```
Both the normal initial-run input (file paths) and the rerun input (dot notation) are normalized to the same file path.

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

Add an `awk` preprocessor between the `circleci tests run` stdin stream and `xargs pytest` in the three jobs that use this pattern:

- `local_testing_part1`
- `local_testing_part2`
- `litellm_router_testing`

The preprocessor:
- Passes through any line containing `.py` unchanged (normal file-path input)
- For lines without `.py`, replaces `.` with `/` and appends `.py` (converts `tests.local_testing.test_router` → `tests/local_testing/test_router.py`)

Diff:
```diff
-              --command="xargs uv run --no-sync python -m pytest \
+              --command="awk '/\\.py/ {print; next} {gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
```

Applied identically in all three jobs. No change to initial-run behavior; only fixes selective rerun.