### PR TITLE
[Infra] Declare proprietary license in litellm-enterprise metadata

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.38"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
+license = "LicenseRef-Proprietary"
 license-files = ["LICENSE.md"]
 authors = [
     { name = "BerriAI" },


### PR DESCRIPTION
## Relevant issues

## Summary

### Problem

The `litellm-enterprise` package has no `license` field in its `pyproject.toml`. Metadata-reading tools (PyPI classifiers, Nexus IQ, pip-licenses) report License-None against every published version, mirroring the issue that #26369 fixed for `litellm-proxy-extras`.

Unlike `litellm-proxy-extras`, the enterprise package is governed by the BerriAI Enterprise License in `enterprise/LICENSE.md`, which is not on the SPDX license list and cannot be declared as `MIT`.

### Fix

Add `license = "LicenseRef-Proprietary"` to `enterprise/pyproject.toml`. This is the PEP 639-sanctioned SPDX expression for licenses not in the SPDX list. The existing `license-files = ["LICENSE.md"]` entry continues to ship the full terms inside the wheel.

## Changes

`enterprise/pyproject.toml`: add `license = "LicenseRef-Proprietary"`. No behavior change; surfaces the declaration in package metadata so PEP 639-aware tools resolve it.

## Testing

No code change. Verified the field is accepted by the build backend: `uv build` on the enterprise package succeeds and the resulting wheel's `METADATA` contains `License-Expression: LicenseRef-Proprietary`.

## Type

🚄 Infrastructure

## Screenshots