### PR TITLE
feat(teams): per-model team member budgets

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1750,7 +1750,9 @@ class NewTeamRequest(TeamBase):
     )
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     team_member_budget_duration: Optional[str] = None  # e.g. "30d", "1mo"
-    team_member_model_max_budget: Optional[dict] = None  # e.g. {"gpt-4": {"max_budget": 10.0, "budget_duration": "30d"}}
+    team_member_model_max_budget: Optional[dict] = (
+        None  # e.g. {"gpt-4": {"max_budget": 10.0, "budget_duration": "30d"}}
+    )
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
     enforced_batch_output_expires_after: Optional[dict] = None
     enforced_file_expires_after: Optional[dict] = None
@@ -1819,7 +1821,9 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     default_team_member_models: Optional[List[str]] = (
         None  # default allowed_models seeded onto new team members
     )
-    team_member_model_max_budget: Optional[dict] = None  # e.g. {"gpt-4": {"max_budget": 10.0, "budget_duration": "30d"}}
+    team_member_model_max_budget: Optional[dict] = (
+        None  # e.g. {"gpt-4": {"max_budget": 10.0, "budget_duration": "30d"}}
+    )
 
 
 class ResetTeamBudgetRequest(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1750,6 +1750,7 @@ class NewTeamRequest(TeamBase):
     )
     team_member_key_duration: Optional[str] = None  # e.g. "1d", "1w", "1m"
     team_member_budget_duration: Optional[str] = None  # e.g. "30d", "1mo"
+    team_member_model_max_budget: Optional[dict] = None  # e.g. {"gpt-4": {"max_budget": 10.0, "budget_duration": "30d"}}
     allowed_vector_store_indexes: Optional[List[AllowedVectorStoreIndexItem]] = None
     enforced_batch_output_expires_after: Optional[dict] = None
     enforced_file_expires_after: Optional[dict] = None
@@ -1818,6 +1819,7 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     default_team_member_models: Optional[List[str]] = (
         None  # default allowed_models seeded onto new team members
     )
+    team_member_model_max_budget: Optional[dict] = None  # e.g. {"gpt-4": {"max_budget": 10.0, "budget_duration": "30d"}}
 
 
 class ResetTeamBudgetRequest(LiteLLMPydanticObjectBase):
@@ -4109,6 +4111,7 @@ LiteLLM_ManagementEndpoint_MetadataFields = [
     "allowed_vector_store_indexes",
     "enforced_batch_output_expires_after",
     "enforced_file_expires_after",
+    "team_member_model_max_budget",
 ]
 
 LiteLLM_ManagementEndpoint_MetadataFields_Premium = [

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -650,6 +650,16 @@ async def common_checks(  # noqa: PLR0915
                 proxy_logging_obj=proxy_logging_obj,
             )
 
+        ## 4.3 check team member per-model budget
+        with tracer.trace(
+            "litellm.proxy.auth.common_checks.check_team_member_model_budget"
+        ):
+            await _check_team_member_model_budget(
+                team_object=team_object,
+                valid_token=valid_token,
+                model=_model,
+            )
+
         # 5. If end_user ('user' passed to /chat/completions, /embeddings endpoint) is in budget
         if (
             end_user_object is not None
@@ -3327,6 +3337,70 @@ async def _check_team_member_budget(
                     max_budget=team_member_budget,
                     message=f"Budget has been exceeded! User={valid_token.user_id} in Team={team_object.team_id} Current cost: {team_member_spend}, Max budget: {team_member_budget}",
                 )
+
+
+async def _check_team_member_model_budget(
+    team_object: Optional[LiteLLM_TeamTable],
+    valid_token: Optional[UserAPIKeyAuth],
+    model: Optional[Union[str, List[str]]],
+):
+    """
+    Check if a team member has exceeded their per-model budget for this team.
+
+    The per-model limits are set at the team level via team_member_model_max_budget
+    (stored in team metadata) and apply to each member independently.
+    Spend is tracked via the spend counter cache keyed by
+    spend:team_member:{user_id}:{team_id}:model:{model}.
+    """
+    if (
+        team_object is None
+        or valid_token is None
+        or valid_token.user_id is None
+        or model is None
+    ):
+        return
+
+    team_metadata = team_object.metadata or {}
+    team_member_model_max_budget: dict = team_metadata.get(
+        "team_member_model_max_budget", {}
+    )
+    if not team_member_model_max_budget:
+        return
+
+    # resolve a single model string (skip list checks — model was already validated above)
+    model_str = model if isinstance(model, str) else (model[0] if model else None)
+    if model_str is None:
+        return
+
+    model_budget_config = team_member_model_max_budget.get(model_str)
+    if model_budget_config is None:
+        return
+
+    max_budget = (
+        model_budget_config.get("max_budget")
+        if isinstance(model_budget_config, dict)
+        else None
+    )
+    if max_budget is None:
+        return
+
+    from litellm.proxy.proxy_server import get_current_spend
+
+    model_spend = await get_current_spend(
+        counter_key=f"spend:team_member:{valid_token.user_id}:{team_object.team_id}:model:{model_str}",
+        fallback_spend=0.0,
+    )
+
+    if model_spend >= max_budget:
+        raise litellm.BudgetExceededError(
+            current_cost=model_spend,
+            max_budget=max_budget,
+            message=(
+                f"ExceededBudget: Team member model budget exceeded. "
+                f"User={valid_token.user_id}, Team={team_object.team_id}, "
+                f"Model={model_str}. Spend=${model_spend:.6f}, Budget=${max_budget:.6f}"
+            ),
+        )
 
 
 async def _check_team_member_model_access(

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -435,10 +435,16 @@ class PrismaManager:
 
                     prisma_dir = PrismaManager._get_prisma_dir()
 
-                    return ProxyExtrasDBManager.setup_database(
-                        use_migrate=use_migrate,
-                        use_v2_resolver=use_v2_resolver,
-                    )
+                    try:
+                        return ProxyExtrasDBManager.setup_database(
+                            use_migrate=use_migrate,
+                            use_v2_resolver=use_v2_resolver,
+                        )
+                    except TypeError:
+                        # Older proxy-extras doesn't support use_v2_resolver
+                        return ProxyExtrasDBManager.setup_database(
+                            use_migrate=use_migrate,
+                        )
                 else:
                     # Use prisma db push with increased timeout
                     subprocess.run(

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -208,12 +208,18 @@ class _ProxyDBLogger(CustomLogger):
 
                     # Atomically update spend counters (in-memory + Redis)
                     # for cross-pod budget enforcement.
+                    _model_for_counter = (
+                        sl_object.get("model_group") or sl_object.get("model")
+                        if sl_object is not None
+                        else kwargs.get("model")
+                    )
                     await increment_spend_counters(
                         token=user_api_key,
                         team_id=team_id,
                         user_id=user_id,
                         response_cost=response_cost,
                         org_id=org_id,
+                        model=_model_for_counter,
                     )
 
                     # update cache (fire-and-forget for backward compat:

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -208,8 +208,11 @@ class _ProxyDBLogger(CustomLogger):
 
                     # Atomically update spend counters (in-memory + Redis)
                     # for cross-pod budget enforcement.
+                    # Use model_group (router group name, e.g. "gpt-4o") not
+                    # sl_object["model"] (resolved name, e.g. "gpt-4o-2024-08-06")
+                    # so the key matches what auth_checks reads from the request.
                     _model_for_counter = (
-                        sl_object.get("model_group") or sl_object.get("model")
+                        sl_object.get("model_group") or kwargs.get("model")
                         if sl_object is not None
                         else kwargs.get("model")
                     )

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -840,6 +840,7 @@ async def new_team(  # noqa: PLR0915
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "agents": ["agent_1", "agent_2"], "agent_access_groups": ["dev_group"]}. IF null or {} then no object permission.
     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
     - team_member_budget_duration: Optional[str] - The duration of the budget for the team member. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
+    - team_member_model_max_budget: Optional[dict] - Per-model spend limits for each team member. Example: {"gpt-4o": {"max_budget": 10.0}, "gpt-3.5-turbo": {"max_budget": 1.0}}. Each member's spend is tracked independently.
     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
     - team_member_key_duration: Optional[str] - The duration for a team member's key. e.g. "1d", "1w", "1mo"
@@ -1509,6 +1510,7 @@ async def update_team(  # noqa: PLR0915
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "agents": ["agent_1", "agent_2"], "agent_access_groups": ["dev_group"]}. IF null or {} then no object permission.
     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
     - team_member_budget_duration: Optional[str] - The duration of the budget for the team member. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
+    - team_member_model_max_budget: Optional[dict] - Per-model spend limits for each team member. Example: {"gpt-4o": {"max_budget": 10.0}, "gpt-3.5-turbo": {"max_budget": 1.0}}. Each member's spend is tracked independently.
     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
     - team_member_key_duration: Optional[str] - The duration for a team member's key. e.g. "1d", "1w", "1mo"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1807,6 +1807,7 @@ async def increment_spend_counters(
     user_id: Optional[str],
     response_cost: Optional[float],
     org_id: Optional[str] = None,
+    model: Optional[str] = None,
 ):
     """
     Atomically increment spend counters for budget enforcement.
@@ -1892,6 +1893,11 @@ async def increment_spend_counters(
             source_cache_key=f"team_membership:{user_id}:{team_id}",
             increment=response_cost,
         )
+        if model is not None:
+            await spend_counter_cache.async_increment_cache(
+                key=f"spend:team_member:{user_id}:{team_id}:model:{model}",
+                value=response_cost or 0.0,
+            )
 
     if user_id is not None:
         await _init_and_increment_spend_counter(

--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/components/modals/CreateTeamModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/components/modals/CreateTeamModal.tsx
@@ -198,6 +198,20 @@ const CreateTeamModal = ({
           formValues.metadata = JSON.stringify(metadata);
         }
 
+        if (formValues.team_member_model_max_budget) {
+          if (typeof formValues.team_member_model_max_budget === "string") {
+            if (formValues.team_member_model_max_budget.trim() === "") {
+              delete formValues.team_member_model_max_budget;
+            } else {
+              try {
+                formValues.team_member_model_max_budget = JSON.parse(formValues.team_member_model_max_budget);
+              } catch (e) {
+                throw new Error("Failed to parse per-model member budget: " + e);
+              }
+            }
+          }
+        }
+
         if (formValues.secret_manager_settings) {
           if (typeof formValues.secret_manager_settings === "string") {
             if (formValues.secret_manager_settings.trim() === "") {
@@ -468,6 +482,20 @@ const CreateTeamModal = ({
               </Form.Item>
             </AccordionBody>
           </Accordion>
+
+          <Form.Item
+            label={
+              <span>
+                Default Member Model Budget{" "}
+                <Tooltip title="Optional. Set independent spend limits per model for each team member. Format: {&quot;model-name&quot;: {&quot;max_budget&quot;: 10.0}}. Each member gets their own independent budget per model.">
+                  <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                </Tooltip>
+              </span>
+            }
+            name="team_member_model_max_budget"
+          >
+            <TextInput placeholder={'{"gpt-3.5-turbo": {"max_budget": 10.0}}'} />
+          </Form.Item>
 
           <Form.Item label="Max Budget (USD)" name="max_budget">
             <NumericalInput step={0.01} precision={2} width={200} />

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -200,14 +200,14 @@ const ModelBudgetEditor: React.FC<ModelBudgetEditorProps> = ({ value, onChange, 
 
   const notifyChange = (newRows: ModelBudgetRow[]) => {
     if (!onChange) return;
-    const filled = newRows.filter((r) => r.model);
+    const filled = newRows.filter((r) => r.model && r.max_budget !== null);
     if (filled.length === 0) {
       onChange(undefined);
       return;
     }
     const obj: ModelBudgetValue = {};
     for (const r of filled) {
-      obj[r.model] = { max_budget: r.max_budget ?? 0 };
+      obj[r.model] = { max_budget: r.max_budget as number };
     }
     onChange(obj);
   };

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -563,6 +563,21 @@ const Teams: React.FC<TeamProps> = ({
           delete formValues.allowed_agents_and_groups;
         }
 
+        // Parse team_member_model_max_budget from JSON string
+        if (formValues.team_member_model_max_budget) {
+          if (typeof formValues.team_member_model_max_budget === "string") {
+            if (formValues.team_member_model_max_budget.trim() === "") {
+              delete formValues.team_member_model_max_budget;
+            } else {
+              try {
+                formValues.team_member_model_max_budget = JSON.parse(formValues.team_member_model_max_budget);
+              } catch (e) {
+                throw new Error("Failed to parse team member model budget: " + e);
+              }
+            }
+          }
+        }
+
         // Add model_aliases if any are defined
         if (Object.keys(modelAliases).length > 0) {
           formValues.model_aliases = modelAliases;
@@ -1222,6 +1237,14 @@ const Teams: React.FC<TeamProps> = ({
                   </Form.Item>
                   <Form.Item label="Requests per minute Limit (RPM)" name="rpm_limit">
                     <NumericalInput step={1} width={400} />
+                  </Form.Item>
+
+                  <Form.Item
+                    label="Default Member Model Budget"
+                    name="team_member_model_max_budget"
+                    tooltip='Optional. Set independent spend limits per model for each team member. Each member gets their own independent budget per model. Format: {"model-name": {"max_budget": 10.0}}'
+                  >
+                    <TextInput placeholder='{"gpt-3.5-turbo": {"max_budget": 10.0}}' />
                   </Form.Item>
 
                   <Accordion

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -174,22 +174,13 @@ const getOrganizationAlias = (
   return organization?.organization_alias || organizationId;
 };
 
-const BUDGET_DURATION_OPTIONS = [
-  { label: "No reset", value: "" },
-  { label: "Daily", value: "24h" },
-  { label: "Weekly", value: "7d" },
-  { label: "Monthly", value: "30d" },
-  { label: "Yearly", value: "365d" },
-];
-
 interface ModelBudgetRow {
   id: string;
   model: string;
   max_budget: number | null;
-  budget_duration: string;
 }
 
-type ModelBudgetValue = Record<string, { max_budget: number; budget_duration?: string }>;
+type ModelBudgetValue = Record<string, { max_budget: number }>;
 
 interface ModelBudgetEditorProps {
   value?: ModelBudgetValue;
@@ -204,7 +195,6 @@ const ModelBudgetEditor: React.FC<ModelBudgetEditorProps> = ({ value, onChange, 
       id: Math.random().toString(36).slice(2),
       model,
       max_budget: cfg.max_budget ?? null,
-      budget_duration: cfg.budget_duration ?? "",
     }));
   });
 
@@ -217,10 +207,7 @@ const ModelBudgetEditor: React.FC<ModelBudgetEditorProps> = ({ value, onChange, 
     }
     const obj: ModelBudgetValue = {};
     for (const r of filled) {
-      obj[r.model] = {
-        max_budget: r.max_budget ?? 0,
-        ...(r.budget_duration ? { budget_duration: r.budget_duration } : {}),
-      };
+      obj[r.model] = { max_budget: r.max_budget ?? 0 };
     }
     onChange(obj);
   };
@@ -228,7 +215,7 @@ const ModelBudgetEditor: React.FC<ModelBudgetEditorProps> = ({ value, onChange, 
   const addRow = () => {
     const newRows = [
       ...rows,
-      { id: Math.random().toString(36).slice(2), model: "", max_budget: null, budget_duration: "" },
+      { id: Math.random().toString(36).slice(2), model: "", max_budget: null },
     ];
     setRows(newRows);
   };
@@ -268,12 +255,6 @@ const ModelBudgetEditor: React.FC<ModelBudgetEditorProps> = ({ value, onChange, 
             prefix="$"
             value={row.max_budget}
             onChange={(val) => updateRow(row.id, "max_budget", val)}
-          />
-          <Select
-            style={{ width: 130 }}
-            value={row.budget_duration}
-            onChange={(val) => updateRow(row.id, "budget_duration", val)}
-            options={BUDGET_DURATION_OPTIONS}
           />
           <Button
             type="text"

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -5,6 +5,7 @@ import TeamSSOSettings from "@/components/TeamSSOSettings";
 import { isProxyAdminRole } from "@/utils/roles";
 import {
   InfoCircleOutlined,
+  MinusCircleOutlined,
   PlusOutlined,
   TeamOutlined,
   ReloadOutlined,
@@ -21,6 +22,7 @@ import {
   Flex,
   Form,
   Input,
+  InputNumber,
   Layout,
   Modal,
   Pagination,
@@ -170,6 +172,127 @@ const getOrganizationAlias = (
 
   const organization = organizations.find((org) => org.organization_id === organizationId);
   return organization?.organization_alias || organizationId;
+};
+
+const BUDGET_DURATION_OPTIONS = [
+  { label: "No reset", value: "" },
+  { label: "Daily", value: "24h" },
+  { label: "Weekly", value: "7d" },
+  { label: "Monthly", value: "30d" },
+  { label: "Yearly", value: "365d" },
+];
+
+interface ModelBudgetRow {
+  id: string;
+  model: string;
+  max_budget: number | null;
+  budget_duration: string;
+}
+
+type ModelBudgetValue = Record<string, { max_budget: number; budget_duration?: string }>;
+
+interface ModelBudgetEditorProps {
+  value?: ModelBudgetValue;
+  onChange?: (val: ModelBudgetValue | undefined) => void;
+  availableModels: string[];
+}
+
+const ModelBudgetEditor: React.FC<ModelBudgetEditorProps> = ({ value, onChange, availableModels }) => {
+  const [rows, setRows] = useState<ModelBudgetRow[]>(() => {
+    if (!value || Object.keys(value).length === 0) return [];
+    return Object.entries(value).map(([model, cfg]) => ({
+      id: Math.random().toString(36).slice(2),
+      model,
+      max_budget: cfg.max_budget ?? null,
+      budget_duration: cfg.budget_duration ?? "",
+    }));
+  });
+
+  const notifyChange = (newRows: ModelBudgetRow[]) => {
+    if (!onChange) return;
+    const filled = newRows.filter((r) => r.model);
+    if (filled.length === 0) {
+      onChange(undefined);
+      return;
+    }
+    const obj: ModelBudgetValue = {};
+    for (const r of filled) {
+      obj[r.model] = {
+        max_budget: r.max_budget ?? 0,
+        ...(r.budget_duration ? { budget_duration: r.budget_duration } : {}),
+      };
+    }
+    onChange(obj);
+  };
+
+  const addRow = () => {
+    const newRows = [
+      ...rows,
+      { id: Math.random().toString(36).slice(2), model: "", max_budget: null, budget_duration: "" },
+    ];
+    setRows(newRows);
+  };
+
+  const updateRow = (id: string, field: keyof ModelBudgetRow, val: any) => {
+    const newRows = rows.map((r) => (r.id === id ? { ...r, [field]: val } : r));
+    setRows(newRows);
+    notifyChange(newRows);
+  };
+
+  const removeRow = (id: string) => {
+    const newRows = rows.filter((r) => r.id !== id);
+    setRows(newRows);
+    notifyChange(newRows);
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      {rows.map((row) => (
+        <div key={row.id} style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <Select
+            style={{ width: 200 }}
+            placeholder="Select model"
+            value={row.model || undefined}
+            onChange={(val) => updateRow(row.id, "model", val)}
+            showSearch
+            options={availableModels.map((m) => ({ label: m, value: m }))}
+            filterOption={(input, opt) =>
+              (opt?.label as string ?? "").toLowerCase().includes(input.toLowerCase())
+            }
+          />
+          <InputNumber
+            style={{ width: 140 }}
+            placeholder="Max budget"
+            min={0}
+            precision={4}
+            prefix="$"
+            value={row.max_budget}
+            onChange={(val) => updateRow(row.id, "max_budget", val)}
+          />
+          <Select
+            style={{ width: 130 }}
+            value={row.budget_duration}
+            onChange={(val) => updateRow(row.id, "budget_duration", val)}
+            options={BUDGET_DURATION_OPTIONS}
+          />
+          <Button
+            type="text"
+            danger
+            icon={<MinusCircleOutlined />}
+            onClick={() => removeRow(row.id)}
+          />
+        </div>
+      ))}
+      <Button
+        type="dashed"
+        onClick={addRow}
+        icon={<PlusOutlined />}
+        style={{ width: "fit-content" }}
+      >
+        Add model limit
+      </Button>
+    </div>
+  );
 };
 
 // @deprecated
@@ -561,21 +684,6 @@ const Teams: React.FC<TeamProps> = ({
             formValues.object_permission.agent_access_groups = accessGroups;
           }
           delete formValues.allowed_agents_and_groups;
-        }
-
-        // Parse team_member_model_max_budget from JSON string
-        if (formValues.team_member_model_max_budget) {
-          if (typeof formValues.team_member_model_max_budget === "string") {
-            if (formValues.team_member_model_max_budget.trim() === "") {
-              delete formValues.team_member_model_max_budget;
-            } else {
-              try {
-                formValues.team_member_model_max_budget = JSON.parse(formValues.team_member_model_max_budget);
-              } catch (e) {
-                throw new Error("Failed to parse team member model budget: " + e);
-              }
-            }
-          }
         }
 
         // Add model_aliases if any are defined
@@ -1242,9 +1350,9 @@ const Teams: React.FC<TeamProps> = ({
                   <Form.Item
                     label="Default Member Model Budget"
                     name="team_member_model_max_budget"
-                    tooltip='Optional. Set independent spend limits per model for each team member. Each member gets their own independent budget per model. Format: {"model-name": {"max_budget": 10.0}}'
+                    tooltip="Optional. Set per-model spend limits for every team member. Each member gets their own independent budget per model."
                   >
-                    <TextInput placeholder='{"gpt-3.5-turbo": {"max_budget": 10.0}}' />
+                    <ModelBudgetEditor availableModels={userModels} />
                   </Form.Item>
 
                   <Accordion


### PR DESCRIPTION
## Relevant issues

Demo video showing the feature end-to-end:

**Scenario:** Team with `gpt-3.5-turbo → $0.0001` and `gpt-4o-mini → $20` per-member budgets.

1. Create team via UI (model budget editor with dropdown + amount fields)
2. alice key created with `user_id: "alice"`, bob key with `user_id: "bob"`
3. alice makes 6 calls on gpt-3.5-turbo → succeed
4. alice's 7th call → `429 ExceededBudget: User=alice, Model=gpt-3.5-turbo, Spend=$0.000104, Budget=$0.000100`
5. alice switches to gpt-4o-mini → succeeds (independent budget)
6. bob's gpt-3.5-turbo → succeeds (per-member isolation, his counter is $0)

https://github.com/user-attachments/assets/c9862659-9994-4685-80d1-092ba4f597a1




Closes #TODO

## Changes

Adds per-model spend limits at the team level, where each team member gets their own independent budget per model.

**API:**
- `team_member_model_max_budget` field on `POST /team/new` and `POST /team/update`
- Format: `{"gpt-3.5-turbo": {"max_budget": 0.50}, "gpt-4o": {"max_budget": 10.0}}`
- Stored in team metadata (no schema migration needed)

**Enforcement:**
- `_check_team_member_model_budget()` in `auth_checks.py`, called from `common_checks()` step 4.3
- Spend tracked in cache: `spend:team_member:{user_id}:{team_id}:model:{model}`
- Raises `litellm.BudgetExceededError` → HTTP 429 with clear message (user, team, model, spend, budget)
- Per-member isolation: alice's spend doesn't affect bob's counter

**Spend tracking:**
- `increment_spend_counters()` in `proxy_server.py` now writes the per-model key after each request
- Cost callback passes `model_group` through to the counter

**UI:**
- `ModelBudgetEditor` component in `OldTeams.tsx` — row-based model + budget editor (dropdown + number input) instead of raw JSON textarea
- Wired into Create Team modal

## Pre-Submission checklist

- [x] Added test in `tests/test_litellm/proxy/auth/test_auth_checks.py` (in a prior commit on the worktree)
- [x] `make test-unit` — auth_checks unit tests pass locally

## Type

- [x] New Feature