### PR TITLE
[Fix] Harden team metadata handling in /team/new and /team/update

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -159,6 +159,18 @@ async def _verify_team_access(
 class TeamMemberBudgetHandler:
     """Helper class to handle team member budget, RPM, and TPM limit operations"""
 
+    # Metadata keys that are owned and set by the server. Callers must not be
+    # able to inject or overwrite these via request payloads.
+    SYSTEM_MANAGED_METADATA_KEYS = ("team_member_budget_id",)
+
+    @staticmethod
+    def strip_system_managed_metadata_keys(metadata: Optional[dict]) -> None:
+        """Remove server-owned metadata keys from a caller-supplied dict."""
+        if not isinstance(metadata, dict):
+            return
+        for key in TeamMemberBudgetHandler.SYSTEM_MANAGED_METADATA_KEYS:
+            metadata.pop(key, None)
+
     @staticmethod
     def should_create_budget(
         team_member_budget: Optional[float] = None,
@@ -1040,6 +1052,8 @@ async def new_team(  # noqa: PLR0915
             _model_id = model_dict.id
 
         ## Create Team Member Budget Table
+        if isinstance(data.metadata, dict):
+            TeamMemberBudgetHandler.strip_system_managed_metadata_keys(data.metadata)
         data_json = data.json()
 
         ## Handle Object Permission - MCP, Vector Stores etc.
@@ -1729,6 +1743,13 @@ async def update_team(  # noqa: PLR0915
                 )
 
         updated_kv = data.json(exclude_unset=True)
+
+        # Drop server-owned metadata keys from caller input so they can only
+        # be written by the same code path that creates the underlying rows.
+        if isinstance(updated_kv.get("metadata"), dict):
+            TeamMemberBudgetHandler.strip_system_managed_metadata_keys(
+                updated_kv["metadata"]
+            )
 
         # Check budget_duration and budget_reset_at
         _set_budget_reset_at(data, updated_kv)


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)
Callers of `/team/new` and `/team/update` could set arbitrary keys inside the team `metadata` payload, including keys that the server uses as pointers to related rows. Subsequent budget update logic read those keys back from team metadata and used them directly.

### Fix
`/team/new` and `/team/update` now strip server-owned keys from caller-supplied `metadata` before persisting. Only the code paths that create the underlying rows can write these keys.

- `team_endpoints.py` — added `SYSTEM_MANAGED_METADATA_KEYS` + `strip_system_managed_metadata_keys` helper on `TeamMemberBudgetHandler`.
- `team_endpoints.py` — `new_team` and `update_team` call the helper before building the DB write payload.

## Testing
- Verified against live proxy: caller-supplied `team_member_budget_id` in `metadata` no longer reaches the DB through either endpoint; legitimate `team_member_budget` updates and user-provided metadata (`extra_info`, etc.) still round-trip correctly.
- `poetry run pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py` — 120 passed.

## Type
🐛 Bug Fix

## Screenshots