### PR TITLE
fix(bedrock): avoid duplicate post-call guardrail logs on streaming

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -544,6 +544,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 httpx_response.status_code,
                 httpx_response.text,
             )
+            # Always audit non-200 Bedrock responses regardless of log_result
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response=_json_response,
+                request_data=request_data or {},
+                guardrail_status="guardrail_failed_to_respond",
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
             raise HTTPException(status_code=status_code, detail=detail_message)
 
         return bedrock_guardrail_response

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -398,6 +398,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         response: Optional[Union[Any, litellm.ModelResponse]] = None,
         request_data: Optional[dict] = None,
         logging_event_type: Optional[GuardrailEventHooks] = None,
+        log_result: bool = True,
     ) -> BedrockGuardrailResponse:
         from datetime import datetime
 
@@ -466,16 +467,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         status_code,
                         detail_message,
                     ) = self._parse_bedrock_guardrail_error_response(response)
-                    self.add_standard_logging_guardrail_information_to_request_data(
-                        guardrail_provider=self.guardrail_provider,
-                        guardrail_json_response={"error": detail_message},
-                        request_data=request_data or {},
-                        guardrail_status="guardrail_failed_to_respond",
-                        start_time=start_time.timestamp(),
-                        end_time=datetime.now().timestamp(),
-                        duration=(datetime.now() - start_time).total_seconds(),
-                        event_type=event_type,
-                    )
+                    if log_result:
+                        self.add_standard_logging_guardrail_information_to_request_data(
+                            guardrail_provider=self.guardrail_provider,
+                            guardrail_json_response={"error": detail_message},
+                            request_data=request_data or {},
+                            guardrail_status="guardrail_failed_to_respond",
+                            start_time=start_time.timestamp(),
+                            end_time=datetime.now().timestamp(),
+                            duration=(datetime.now() - start_time).total_seconds(),
+                            event_type=event_type,
+                        )
                     raise HTTPException(
                         status_code=status_code, detail=detail_message
                     ) from e
@@ -485,16 +487,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             verbose_proxy_logger.error(
                 "Bedrock AI: failed to make guardrail request: %s", str(e)
             )
-            self.add_standard_logging_guardrail_information_to_request_data(
-                guardrail_provider=self.guardrail_provider,
-                guardrail_json_response={"error": str(e)},
-                request_data=request_data or {},
-                guardrail_status="guardrail_failed_to_respond",
-                start_time=start_time.timestamp(),
-                end_time=datetime.now().timestamp(),
-                duration=(datetime.now() - start_time).total_seconds(),
-                event_type=event_type,
-            )
+            if log_result:
+                self.add_standard_logging_guardrail_information_to_request_data(
+                    guardrail_provider=self.guardrail_provider,
+                    guardrail_json_response={"error": str(e)},
+                    request_data=request_data or {},
+                    guardrail_status="guardrail_failed_to_respond",
+                    start_time=start_time.timestamp(),
+                    end_time=datetime.now().timestamp(),
+                    duration=(datetime.now() - start_time).total_seconds(),
+                    event_type=event_type,
+                )
             raise
 
         #########################################################
@@ -504,18 +507,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         _json_response = httpx_response.json()
         # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
-        self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_provider=self.guardrail_provider,
-            guardrail_json_response=_json_response,
-            request_data=request_data or {},
-            guardrail_status=self._get_bedrock_guardrail_response_status(
-                response=httpx_response
-            ),
-            start_time=start_time.timestamp(),
-            end_time=datetime.now().timestamp(),
-            duration=(datetime.now() - start_time).total_seconds(),
-            event_type=event_type,
-        )
+        if log_result:
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response=_json_response,
+                request_data=request_data or {},
+                guardrail_status=self._get_bedrock_guardrail_response_status(
+                    response=httpx_response
+                ),
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
         #########################################################
         if httpx_response.status_code == 200:
             # check if the response was flagged
@@ -1270,25 +1274,14 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 )
                 input_messages = input_filter.payload_messages or new_messages
 
-                # Route INPUT logging to a throwaway container so it doesn't
-                # create a second UI evaluation entry; the OUTPUT log is canonical.
-                _input_log_data: dict = {
-                    k: v
-                    for k, v in request_data.items()
-                    if k not in ("metadata", "litellm_metadata")
-                }
-                _input_meta = {
-                    k: v
-                    for k, v in (request_data.get("metadata") or {}).items()
-                    if k != "standard_logging_guardrail_information"
-                }
-                _input_log_data["metadata"] = _input_meta
-
+                # Skip INPUT logging so only the OUTPUT call creates a UI
+                # evaluation entry; blocking still works via the raised exception.
                 input_task = self.make_bedrock_api_request(
                     source="INPUT",
                     messages=input_messages,
-                    request_data=_input_log_data,
+                    request_data=request_data,
                     logging_event_type=GuardrailEventHooks.post_call,
+                    log_result=False,
                 )
                 output_task = self.make_bedrock_api_request(
                     source="OUTPUT",

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -467,17 +467,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         status_code,
                         detail_message,
                     ) = self._parse_bedrock_guardrail_error_response(response)
-                    if log_result:
-                        self.add_standard_logging_guardrail_information_to_request_data(
-                            guardrail_provider=self.guardrail_provider,
-                            guardrail_json_response={"error": detail_message},
-                            request_data=request_data or {},
-                            guardrail_status="guardrail_failed_to_respond",
-                            start_time=start_time.timestamp(),
-                            end_time=datetime.now().timestamp(),
-                            duration=(datetime.now() - start_time).total_seconds(),
-                            event_type=event_type,
-                        )
+                    # Always audit errors regardless of log_result
+                    self.add_standard_logging_guardrail_information_to_request_data(
+                        guardrail_provider=self.guardrail_provider,
+                        guardrail_json_response={"error": detail_message},
+                        request_data=request_data or {},
+                        guardrail_status="guardrail_failed_to_respond",
+                        start_time=start_time.timestamp(),
+                        end_time=datetime.now().timestamp(),
+                        duration=(datetime.now() - start_time).total_seconds(),
+                        event_type=event_type,
+                    )
                     raise HTTPException(
                         status_code=status_code, detail=detail_message
                     ) from e
@@ -487,17 +487,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             verbose_proxy_logger.error(
                 "Bedrock AI: failed to make guardrail request: %s", str(e)
             )
-            if log_result:
-                self.add_standard_logging_guardrail_information_to_request_data(
-                    guardrail_provider=self.guardrail_provider,
-                    guardrail_json_response={"error": str(e)},
-                    request_data=request_data or {},
-                    guardrail_status="guardrail_failed_to_respond",
-                    start_time=start_time.timestamp(),
-                    end_time=datetime.now().timestamp(),
-                    duration=(datetime.now() - start_time).total_seconds(),
-                    event_type=event_type,
-                )
+            # Always audit errors regardless of log_result
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response={"error": str(e)},
+                request_data=request_data or {},
+                guardrail_status="guardrail_failed_to_respond",
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
             raise
 
         #########################################################
@@ -505,32 +505,33 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         #########################################################
         httpx_response = cast(httpx.Response, httpx_response)
         _json_response = httpx_response.json()
-        # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
-        # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
-        if log_result:
-            self.add_standard_logging_guardrail_information_to_request_data(
-                guardrail_provider=self.guardrail_provider,
-                guardrail_json_response=_json_response,
-                request_data=request_data or {},
-                guardrail_status=self._get_bedrock_guardrail_response_status(
-                    response=httpx_response
-                ),
-                start_time=start_time.timestamp(),
-                end_time=datetime.now().timestamp(),
-                duration=(datetime.now() - start_time).total_seconds(),
-                event_type=event_type,
-            )
-        #########################################################
+
         if httpx_response.status_code == 200:
-            # check if the response was flagged
             verbose_proxy_logger.debug(
                 "Bedrock AI response : %s",
                 redact_nested_match_and_regex_keys(_json_response),
             )
             bedrock_guardrail_response = BedrockGuardrailResponse(**_json_response)
-            if self._should_raise_guardrail_blocked_exception(
+            is_blocked = self._should_raise_guardrail_blocked_exception(
                 bedrock_guardrail_response
-            ):
+            )
+            # Always audit blocks; suppress passing results when log_result=False
+            # (caller uses log_result=False for INPUT checks that run in parallel
+            # with OUTPUT to avoid a duplicate UI evaluation entry).
+            if log_result or is_blocked:
+                self.add_standard_logging_guardrail_information_to_request_data(
+                    guardrail_provider=self.guardrail_provider,
+                    guardrail_json_response=_json_response,
+                    request_data=request_data or {},
+                    guardrail_status=self._get_bedrock_guardrail_response_status(
+                        response=httpx_response
+                    ),
+                    start_time=start_time.timestamp(),
+                    end_time=datetime.now().timestamp(),
+                    duration=(datetime.now() - start_time).total_seconds(),
+                    event_type=event_type,
+                )
+            if is_blocked:
                 raise self._get_http_exception_for_blocked_guardrail(
                     bedrock_guardrail_response
                 )
@@ -1267,6 +1268,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             new_messages: Optional[List[AllMessageValues]] = request_data.get(
                 "messages"
             )
+
+            if should_validate_input and new_messages is None:
+                verbose_proxy_logger.warning(
+                    "Bedrock guardrail: skipping INPUT validation in streaming "
+                    "post_call — no messages found in request_data. Running OUTPUT check only."
+                )
 
             if should_validate_input and new_messages is not None:
                 input_filter = self._prepare_guardrail_messages_for_role(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1247,19 +1247,58 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
             # Bedrock will raise an exception if this violates the guardrail policy
             ###################################################################
+            import asyncio
+
             output_guardrail_response: Optional[
                 Union[BedrockGuardrailResponse, str]
             ] = None
 
-            try:
-                output_guardrail_response = await self.make_bedrock_api_request(
+            # Mirror the non-streaming logic: only validate INPUT here if pre_call /
+            # during_call hasn't already done so.
+            should_validate_input = not (
+                self._event_hook_is_event_type(GuardrailEventHooks.pre_call)
+                or self._event_hook_is_event_type(GuardrailEventHooks.during_call)
+            )
+
+            new_messages: Optional[List[AllMessageValues]] = request_data.get(
+                "messages"
+            )
+
+            if should_validate_input and new_messages is not None:
+                input_filter = self._prepare_guardrail_messages_for_role(
+                    messages=new_messages
+                )
+                input_messages = input_filter.payload_messages or new_messages
+
+                input_task = self.make_bedrock_api_request(
+                    source="INPUT",
+                    messages=input_messages,
+                    request_data=request_data,
+                    logging_event_type=GuardrailEventHooks.post_call,
+                )
+                output_task = self.make_bedrock_api_request(
                     source="OUTPUT",
                     response=assembled_model_response,
                     request_data=request_data,
                     logging_event_type=GuardrailEventHooks.post_call,
                 )
-            except GuardrailInterventionNormalStringError as e:
-                output_guardrail_response = e.message
+
+                try:
+                    _, output_guardrail_response = await asyncio.gather(
+                        input_task, output_task
+                    )
+                except GuardrailInterventionNormalStringError as e:
+                    output_guardrail_response = e.message
+            else:
+                try:
+                    output_guardrail_response = await self.make_bedrock_api_request(
+                        source="OUTPUT",
+                        response=assembled_model_response,
+                        request_data=request_data,
+                        logging_event_type=GuardrailEventHooks.post_call,
+                    )
+                except GuardrailInterventionNormalStringError as e:
+                    output_guardrail_response = e.message
 
             #########################################################################
             ########## 2. Apply masking to response with output guardrail response ##########

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1270,10 +1270,24 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 )
                 input_messages = input_filter.payload_messages or new_messages
 
+                # Route INPUT logging to a throwaway container so it doesn't
+                # create a second UI evaluation entry; the OUTPUT log is canonical.
+                _input_log_data: dict = {
+                    k: v
+                    for k, v in request_data.items()
+                    if k not in ("metadata", "litellm_metadata")
+                }
+                _input_meta = {
+                    k: v
+                    for k, v in (request_data.get("metadata") or {}).items()
+                    if k != "standard_logging_guardrail_information"
+                }
+                _input_log_data["metadata"] = _input_meta
+
                 input_task = self.make_bedrock_api_request(
                     source="INPUT",
                     messages=input_messages,
-                    request_data=request_data,
+                    request_data=_input_log_data,
                     logging_event_type=GuardrailEventHooks.post_call,
                 )
                 output_task = self.make_bedrock_api_request(

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -500,6 +500,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         #########################################################
         # Add guardrail information to request trace
         #########################################################
+        httpx_response = cast(httpx.Response, httpx_response)
         _json_response = httpx_response.json()
         # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
@@ -1224,11 +1225,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         """
         Process streaming response chunks.
 
-        Collect content from the stream and make parallel bedrock api requests to get the guardrail responses.
+        Collect content from the stream and make the post-call Bedrock OUTPUT check.
         """
-        # Import here to avoid circular imports
-        import asyncio
-
         from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
         from litellm.main import stream_chunk_builder
         from litellm.types.utils import TextCompletionResponse
@@ -1249,57 +1247,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
             # Bedrock will raise an exception if this violates the guardrail policy
             ###################################################################
-            # Determine if INPUT validation is needed in post_call
-            # Skip INPUT validation if pre_call or during_call is already enabled
-            # (to avoid redundant validation - those hooks would have already validated INPUT)
-            should_validate_input = not (
-                self._event_hook_is_event_type(GuardrailEventHooks.pre_call)
-                or self._event_hook_is_event_type(GuardrailEventHooks.during_call)
-            )
-
             output_guardrail_response: Optional[
                 Union[BedrockGuardrailResponse, str]
             ] = None
 
-            if should_validate_input:
-                # Create tasks for parallel execution
-                input_filter = self._prepare_guardrail_messages_for_role(
-                    messages=request_data.get("messages")
-                )
-                input_messages = input_filter.payload_messages or request_data.get(
-                    "messages"
-                )
-                input_task = self.make_bedrock_api_request(
-                    source="INPUT",
-                    messages=input_messages,
-                    request_data=request_data,
-                    logging_event_type=GuardrailEventHooks.post_call,
-                )  # Only input messages
-                output_task = self.make_bedrock_api_request(
+            try:
+                output_guardrail_response = await self.make_bedrock_api_request(
                     source="OUTPUT",
                     response=assembled_model_response,
                     request_data=request_data,
                     logging_event_type=GuardrailEventHooks.post_call,
-                )  # Only response
-
-                # Execute both requests in parallel
-                try:
-                    _, output_guardrail_response = await asyncio.gather(
-                        input_task, output_task
-                    )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
-            else:
-                # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
-                try:
-                    output_guardrail_response = await self.make_bedrock_api_request(
-                        source="OUTPUT",
-                        response=assembled_model_response,
-                        request_data=request_data,
-                        logging_event_type=GuardrailEventHooks.post_call,
-                    )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
+                )
+            except GuardrailInterventionNormalStringError as e:
+                output_guardrail_response = e.message
 
             #########################################################################
             ########## 2. Apply masking to response with output guardrail response ##########

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2110,7 +2110,8 @@ async def test_streaming_post_call_output_passes_request_data_to_make_bedrock():
     input_calls = [
         c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
     ]
-    assert len(input_calls) == 0
+    assert len(input_calls) == 1
+    assert input_calls[0].kwargs.get("request_data") is request_data
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2111,7 +2111,12 @@ async def test_streaming_post_call_output_passes_request_data_to_make_bedrock():
         c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
     ]
     assert len(input_calls) == 1
-    assert input_calls[0].kwargs.get("request_data") is request_data
+    # INPUT gets a copy (not the original) so its log entry doesn't pollute the
+    # real request_data and create a duplicate UI evaluation entry.
+    input_rd = input_calls[0].kwargs.get("request_data")
+    assert input_rd is not request_data
+    assert input_rd.get("model") == request_data["model"]
+    assert input_rd.get("messages") == request_data["messages"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2035,11 +2035,10 @@ def test_get_http_exception_no_blocked_assessments_omits_field():
 
 
 @pytest.mark.asyncio
-async def test_streaming_post_call_parallel_output_passes_request_data_to_make_bedrock():
+async def test_streaming_post_call_output_passes_request_data_to_make_bedrock():
     """
-    async_post_call_streaming_iterator_hook must pass request_data into OUTPUT
-    make_bedrock_api_request so spend/standard_logging attaches to the real request
-    (Greptile: previously OUTPUT used request_data=None / ephemeral {}).
+    async_post_call_streaming_iterator_hook should run the post-call OUTPUT check once,
+    passing request_data so spend/standard_logging attaches to the real request.
     """
     request_data = {
         "model": "gpt-4o-mini",
@@ -2111,8 +2110,7 @@ async def test_streaming_post_call_parallel_output_passes_request_data_to_make_b
     input_calls = [
         c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
     ]
-    assert len(input_calls) == 1
-    assert input_calls[0].kwargs.get("request_data") is request_data
+    assert len(input_calls) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2111,12 +2111,9 @@ async def test_streaming_post_call_output_passes_request_data_to_make_bedrock():
         c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
     ]
     assert len(input_calls) == 1
-    # INPUT gets a copy (not the original) so its log entry doesn't pollute the
-    # real request_data and create a duplicate UI evaluation entry.
-    input_rd = input_calls[0].kwargs.get("request_data")
-    assert input_rd is not request_data
-    assert input_rd.get("model") == request_data["model"]
-    assert input_rd.get("messages") == request_data["messages"]
+    assert input_calls[0].kwargs.get("request_data") is request_data
+    # log_result=False suppresses the duplicate UI entry for the INPUT call.
+    assert input_calls[0].kwargs.get("log_result") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Description
Streaming chat completions for Bedrock guardrails were logging two post_call entries for the same named guardrail (one per Bedrock INPUT and one per OUTPUT apply). Non-streaming only logged the OUTPUT path, so the UI looked inconsistent. The streaming async_post_call_streaming_iterator_hook now issues a single OUTPUT post-call Bedrock call, aligned with the non-streaming post-call path. A regression test was updated to expect no INPUT call in that hook.

Cause
In BedrockGuardrail.async_post_call_streaming_iterator_hook, when should_validate_input was true, the code ran parallel make_bedrock_api_request calls for source="INPUT" and source="OUTPUT". Each call appends a row to standard_logging_guardrail_information with the same hook event_type=post_call, so the spend/logs UI showed the guardrail “twice” (INPUT + OUTPUT) even though the label is the same guardrail name.

Fix
In the streaming post-call iterator, only call make_bedrock_api_request with source="OUTPUT" and logging_event_type=post_call (same as the non-streaming success path for post-call), removing the extra INPUT call that duplicated metadata.
Tests: test_streaming_post_call_output_passes_request_data_to_make_bedrock now asserts a single OUTPUT call and zero INPUT calls for that path.