### PR TITLE
fix(bedrock guardrail): dedupe post-call log entry when only post_call is configured  

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -398,6 +398,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         response: Optional[Union[Any, litellm.ModelResponse]] = None,
         request_data: Optional[dict] = None,
         logging_event_type: Optional[GuardrailEventHooks] = None,
+        skip_logging: bool = False,
     ) -> BedrockGuardrailResponse:
         from datetime import datetime
 
@@ -466,16 +467,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         status_code,
                         detail_message,
                     ) = self._parse_bedrock_guardrail_error_response(response)
-                    self.add_standard_logging_guardrail_information_to_request_data(
-                        guardrail_provider=self.guardrail_provider,
-                        guardrail_json_response={"error": detail_message},
-                        request_data=request_data or {},
-                        guardrail_status="guardrail_failed_to_respond",
-                        start_time=start_time.timestamp(),
-                        end_time=datetime.now().timestamp(),
-                        duration=(datetime.now() - start_time).total_seconds(),
-                        event_type=event_type,
-                    )
+                    if not skip_logging:
+                        self.add_standard_logging_guardrail_information_to_request_data(
+                            guardrail_provider=self.guardrail_provider,
+                            guardrail_json_response={"error": detail_message},
+                            request_data=request_data or {},
+                            guardrail_status="guardrail_failed_to_respond",
+                            start_time=start_time.timestamp(),
+                            end_time=datetime.now().timestamp(),
+                            duration=(datetime.now() - start_time).total_seconds(),
+                            event_type=event_type,
+                        )
                     raise HTTPException(
                         status_code=status_code, detail=detail_message
                     ) from e
@@ -485,16 +487,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             verbose_proxy_logger.error(
                 "Bedrock AI: failed to make guardrail request: %s", str(e)
             )
-            self.add_standard_logging_guardrail_information_to_request_data(
-                guardrail_provider=self.guardrail_provider,
-                guardrail_json_response={"error": str(e)},
-                request_data=request_data or {},
-                guardrail_status="guardrail_failed_to_respond",
-                start_time=start_time.timestamp(),
-                end_time=datetime.now().timestamp(),
-                duration=(datetime.now() - start_time).total_seconds(),
-                event_type=event_type,
-            )
+            if not skip_logging:
+                self.add_standard_logging_guardrail_information_to_request_data(
+                    guardrail_provider=self.guardrail_provider,
+                    guardrail_json_response={"error": str(e)},
+                    request_data=request_data or {},
+                    guardrail_status="guardrail_failed_to_respond",
+                    start_time=start_time.timestamp(),
+                    end_time=datetime.now().timestamp(),
+                    duration=(datetime.now() - start_time).total_seconds(),
+                    event_type=event_type,
+                )
             raise
 
         #########################################################
@@ -503,18 +506,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         _json_response = httpx_response.json()
         # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
-        self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_provider=self.guardrail_provider,
-            guardrail_json_response=_json_response,
-            request_data=request_data or {},
-            guardrail_status=self._get_bedrock_guardrail_response_status(
-                response=httpx_response
-            ),
-            start_time=start_time.timestamp(),
-            end_time=datetime.now().timestamp(),
-            duration=(datetime.now() - start_time).total_seconds(),
-            event_type=event_type,
-        )
+        if not skip_logging:
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response=_json_response,
+                request_data=request_data or {},
+                guardrail_status=self._get_bedrock_guardrail_response_status(
+                    response=httpx_response
+                ),
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
         #########################################################
         if httpx_response.status_code == 200:
             # check if the response was flagged
@@ -1118,12 +1122,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             )
             input_messages = input_filter.payload_messages or new_messages
 
-            # Create tasks for parallel execution of both INPUT and OUTPUT validation
+            # Create tasks for parallel execution of both INPUT and OUTPUT validation.
+            # The OUTPUT scan is the canonical post_call log entry; suppress the
+            # INPUT scan's log to avoid two duplicate post-call entries for the
+            # same guardrail. INPUT exceptions still propagate so blocking works.
             input_task = self.make_bedrock_api_request(
                 source="INPUT",
                 messages=input_messages,
                 request_data=data,
                 logging_event_type=GuardrailEventHooks.post_call,
+                skip_logging=True,
             )
             output_task = self.make_bedrock_api_request(
                 source="OUTPUT",
@@ -1269,11 +1277,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 input_messages = input_filter.payload_messages or request_data.get(
                     "messages"
                 )
+                # OUTPUT scan is the canonical post_call log entry; suppress the
+                # INPUT scan's log to avoid two duplicate post-call entries for
+                # the same guardrail. INPUT exceptions still propagate so
+                # blocking works.
                 input_task = self.make_bedrock_api_request(
                     source="INPUT",
                     messages=input_messages,
                     request_data=request_data,
                     logging_event_type=GuardrailEventHooks.post_call,
+                    skip_logging=True,
                 )  # Only input messages
                 output_task = self.make_bedrock_api_request(
                     source="OUTPUT",

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -398,7 +398,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         response: Optional[Union[Any, litellm.ModelResponse]] = None,
         request_data: Optional[dict] = None,
         logging_event_type: Optional[GuardrailEventHooks] = None,
-        skip_logging: bool = False,
     ) -> BedrockGuardrailResponse:
         from datetime import datetime
 
@@ -467,17 +466,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         status_code,
                         detail_message,
                     ) = self._parse_bedrock_guardrail_error_response(response)
-                    if not skip_logging:
-                        self.add_standard_logging_guardrail_information_to_request_data(
-                            guardrail_provider=self.guardrail_provider,
-                            guardrail_json_response={"error": detail_message},
-                            request_data=request_data or {},
-                            guardrail_status="guardrail_failed_to_respond",
-                            start_time=start_time.timestamp(),
-                            end_time=datetime.now().timestamp(),
-                            duration=(datetime.now() - start_time).total_seconds(),
-                            event_type=event_type,
-                        )
+                    self.add_standard_logging_guardrail_information_to_request_data(
+                        guardrail_provider=self.guardrail_provider,
+                        guardrail_json_response={"error": detail_message},
+                        request_data=request_data or {},
+                        guardrail_status="guardrail_failed_to_respond",
+                        start_time=start_time.timestamp(),
+                        end_time=datetime.now().timestamp(),
+                        duration=(datetime.now() - start_time).total_seconds(),
+                        event_type=event_type,
+                    )
                     raise HTTPException(
                         status_code=status_code, detail=detail_message
                     ) from e
@@ -487,17 +485,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             verbose_proxy_logger.error(
                 "Bedrock AI: failed to make guardrail request: %s", str(e)
             )
-            if not skip_logging:
-                self.add_standard_logging_guardrail_information_to_request_data(
-                    guardrail_provider=self.guardrail_provider,
-                    guardrail_json_response={"error": str(e)},
-                    request_data=request_data or {},
-                    guardrail_status="guardrail_failed_to_respond",
-                    start_time=start_time.timestamp(),
-                    end_time=datetime.now().timestamp(),
-                    duration=(datetime.now() - start_time).total_seconds(),
-                    event_type=event_type,
-                )
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_provider=self.guardrail_provider,
+                guardrail_json_response={"error": str(e)},
+                request_data=request_data or {},
+                guardrail_status="guardrail_failed_to_respond",
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
+                duration=(datetime.now() - start_time).total_seconds(),
+                event_type=event_type,
+            )
             raise
 
         #########################################################
@@ -506,19 +503,18 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         _json_response = httpx_response.json()
         # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
-        if not skip_logging:
-            self.add_standard_logging_guardrail_information_to_request_data(
-                guardrail_provider=self.guardrail_provider,
-                guardrail_json_response=_json_response,
-                request_data=request_data or {},
-                guardrail_status=self._get_bedrock_guardrail_response_status(
-                    response=httpx_response
-                ),
-                start_time=start_time.timestamp(),
-                end_time=datetime.now().timestamp(),
-                duration=(datetime.now() - start_time).total_seconds(),
-                event_type=event_type,
-            )
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_provider=self.guardrail_provider,
+            guardrail_json_response=_json_response,
+            request_data=request_data or {},
+            guardrail_status=self._get_bedrock_guardrail_response_status(
+                response=httpx_response
+            ),
+            start_time=start_time.timestamp(),
+            end_time=datetime.now().timestamp(),
+            duration=(datetime.now() - start_time).total_seconds(),
+            event_type=event_type,
+        )
         #########################################################
         if httpx_response.status_code == 200:
             # check if the response was flagged
@@ -1102,62 +1098,21 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         #########################################################
         ########## 1. Make Bedrock API requests ##########
         #########################################################
-        # Import asyncio for parallel execution
-        import asyncio
-
-        # Determine if INPUT validation is needed in post_call
-        # Skip INPUT validation if pre_call or during_call is already enabled
-        # (to avoid redundant validation - those hooks would have already validated INPUT)
-        should_validate_input = not (
-            self._event_hook_is_event_type(GuardrailEventHooks.pre_call)
-            or self._event_hook_is_event_type(GuardrailEventHooks.during_call)
-        )
-
+        # post_call is the response-validation hook by definition — only scan
+        # OUTPUT. Input scanning belongs to pre_call / during_call hooks, which
+        # users should configure if they want input validation. Running an
+        # extra INPUT scan here produced a duplicate post-call entry in the
+        # trace and made no semantic sense for a "post-call" event.
         output_content_bedrock: Optional[Union[BedrockGuardrailResponse, str]] = None
-
-        if should_validate_input:
-            # Prepare input messages (with optional filtering for latest role message)
-            input_filter = self._prepare_guardrail_messages_for_role(
-                messages=new_messages
-            )
-            input_messages = input_filter.payload_messages or new_messages
-
-            # Create tasks for parallel execution of both INPUT and OUTPUT validation.
-            # The OUTPUT scan is the canonical post_call log entry; suppress the
-            # INPUT scan's log to avoid two duplicate post-call entries for the
-            # same guardrail. INPUT exceptions still propagate so blocking works.
-            input_task = self.make_bedrock_api_request(
-                source="INPUT",
-                messages=input_messages,
-                request_data=data,
-                logging_event_type=GuardrailEventHooks.post_call,
-                skip_logging=True,
-            )
-            output_task = self.make_bedrock_api_request(
+        try:
+            output_content_bedrock = await self.make_bedrock_api_request(
                 source="OUTPUT",
                 response=response,
                 request_data=data,
                 logging_event_type=GuardrailEventHooks.post_call,
             )
-
-            # Execute both requests in parallel
-            try:
-                _, output_content_bedrock = await asyncio.gather(
-                    input_task, output_task
-                )
-            except GuardrailInterventionNormalStringError as e:
-                output_content_bedrock = e.message
-        else:
-            # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
-            try:
-                output_content_bedrock = await self.make_bedrock_api_request(
-                    source="OUTPUT",
-                    response=response,
-                    request_data=data,
-                    logging_event_type=GuardrailEventHooks.post_call,
-                )
-            except GuardrailInterventionNormalStringError as e:
-                output_content_bedrock = e.message
+        except GuardrailInterventionNormalStringError as e:
+            output_content_bedrock = e.message
 
         #########################################################
         ########## 2. Apply masking to response with output guardrail response ##########
@@ -1232,11 +1187,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         """
         Process streaming response chunks.
 
-        Collect content from the stream and make parallel bedrock api requests to get the guardrail responses.
+        Collect content from the stream and run the bedrock OUTPUT scan
+        (post_call only validates the response).
         """
         # Import here to avoid circular imports
-        import asyncio
-
         from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
         from litellm.main import stream_chunk_builder
         from litellm.types.utils import TextCompletionResponse
@@ -1253,66 +1207,24 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         )
         if isinstance(assembled_model_response, ModelResponse):
             ####################################################################
-            ########## 1. Make Bedrock Apply Guardrail API requests ##########
-
-            # Bedrock will raise an exception if this violates the guardrail policy
+            ########## 1. Make Bedrock Apply Guardrail API request ##########
+            #
+            # post_call only scans OUTPUT — input scanning belongs to
+            # pre_call / during_call. Bedrock will raise if the response
+            # violates the guardrail policy.
             ###################################################################
-            # Determine if INPUT validation is needed in post_call
-            # Skip INPUT validation if pre_call or during_call is already enabled
-            # (to avoid redundant validation - those hooks would have already validated INPUT)
-            should_validate_input = not (
-                self._event_hook_is_event_type(GuardrailEventHooks.pre_call)
-                or self._event_hook_is_event_type(GuardrailEventHooks.during_call)
-            )
-
             output_guardrail_response: Optional[
                 Union[BedrockGuardrailResponse, str]
             ] = None
-
-            if should_validate_input:
-                # Create tasks for parallel execution
-                input_filter = self._prepare_guardrail_messages_for_role(
-                    messages=request_data.get("messages")
-                )
-                input_messages = input_filter.payload_messages or request_data.get(
-                    "messages"
-                )
-                # OUTPUT scan is the canonical post_call log entry; suppress the
-                # INPUT scan's log to avoid two duplicate post-call entries for
-                # the same guardrail. INPUT exceptions still propagate so
-                # blocking works.
-                input_task = self.make_bedrock_api_request(
-                    source="INPUT",
-                    messages=input_messages,
-                    request_data=request_data,
-                    logging_event_type=GuardrailEventHooks.post_call,
-                    skip_logging=True,
-                )  # Only input messages
-                output_task = self.make_bedrock_api_request(
+            try:
+                output_guardrail_response = await self.make_bedrock_api_request(
                     source="OUTPUT",
                     response=assembled_model_response,
                     request_data=request_data,
                     logging_event_type=GuardrailEventHooks.post_call,
-                )  # Only response
-
-                # Execute both requests in parallel
-                try:
-                    _, output_guardrail_response = await asyncio.gather(
-                        input_task, output_task
-                    )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
-            else:
-                # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
-                try:
-                    output_guardrail_response = await self.make_bedrock_api_request(
-                        source="OUTPUT",
-                        response=assembled_model_response,
-                        request_data=request_data,
-                        logging_event_type=GuardrailEventHooks.post_call,
-                    )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
+                )
+            except GuardrailInterventionNormalStringError as e:
+                output_guardrail_response = e.message
 
             #########################################################################
             ########## 2. Apply masking to response with output guardrail response ##########

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -1810,14 +1810,19 @@ async def test_make_bedrock_api_request_logging_event_type_for_spend_logs():
         "messages": [{"role": "user", "content": "hi"}],
     }
 
-    with patch.object(
-        guardrail.async_handler, "post", new_callable=AsyncMock
-    ) as mock_post, patch.object(
-        guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
-    ), patch.object(guardrail, "_prepare_request", return_value=MagicMock()), patch.object(
-        guardrail,
-        "add_standard_logging_guardrail_information_to_request_data",
-    ) as mock_log:
+    with (
+        patch.object(
+            guardrail.async_handler, "post", new_callable=AsyncMock
+        ) as mock_post,
+        patch.object(
+            guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+        ),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail,
+            "add_standard_logging_guardrail_information_to_request_data",
+        ) as mock_log,
+    ):
         mock_post.return_value = mock_bedrock_response
 
         await guardrail.make_bedrock_api_request(
@@ -1826,7 +1831,9 @@ async def test_make_bedrock_api_request_logging_event_type_for_spend_logs():
             request_data=request_data,
             logging_event_type=GuardrailEventHooks.during_call,
         )
-        assert mock_log.call_args.kwargs["event_type"] == GuardrailEventHooks.during_call
+        assert (
+            mock_log.call_args.kwargs["event_type"] == GuardrailEventHooks.during_call
+        )
         # Raw Bedrock JSON is forwarded; redaction runs once in
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
         assert (
@@ -2164,3 +2171,172 @@ async def test_streaming_post_call_output_only_path_passes_request_data_to_make_
     c = mock_make.call_args
     assert c.kwargs.get("source") == "OUTPUT"
     assert c.kwargs.get("request_data") is request_data
+
+
+# ---------------------------------------------------------------------------
+# Regression: post_call must emit one log entry per guardrail (not two).
+# When only post_call is configured, the hook scans both INPUT and OUTPUT in
+# parallel — the INPUT scan must skip logging so the trace shows a single
+# post-call entry instead of duplicates.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_call_combined_input_output_emits_single_log_entry():
+    """
+    With only `post_call` configured, async_post_call_success_hook validates
+    both INPUT and OUTPUT. Only the OUTPUT scan should append a log entry; the
+    INPUT scan must pass skip_logging=True so the post-call section in the
+    trace shows the guardrail once, not twice.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-post-pii",
+        guardrailIdentifier="gid",
+        guardrailVersion="1",
+        event_hook=GuardrailEventHooks.post_call,
+        default_on=True,
+    )
+
+    request_data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {},
+    }
+    response = ModelResponse(
+        choices=[
+            litellm.Choices(
+                message=litellm.Message(role="assistant", content="hello"),
+                index=0,
+                finish_reason="stop",
+            )
+        ],
+        model="gpt-4o-mini",
+    )
+
+    minimal = {"action": "NONE", "assessments": [], "outputs": []}
+    with patch.object(
+        guardrail, "make_bedrock_api_request", AsyncMock(return_value=minimal)
+    ) as mock_make:
+        await guardrail.async_post_call_success_hook(
+            data=request_data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            response=response,
+        )
+
+    sources = [c.kwargs.get("source") for c in mock_make.call_args_list]
+    assert sources.count("INPUT") == 1
+    assert sources.count("OUTPUT") == 1
+
+    input_call = next(
+        c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
+    )
+    output_call = next(
+        c for c in mock_make.call_args_list if c.kwargs.get("source") == "OUTPUT"
+    )
+    assert input_call.kwargs.get("skip_logging") is True
+    assert output_call.kwargs.get("skip_logging", False) is False
+
+
+@pytest.mark.asyncio
+async def test_post_call_combined_streaming_input_skips_logging():
+    """
+    Same dedupe applies to the streaming post_call path: INPUT scan suppresses
+    its log entry, OUTPUT remains the canonical post_call log.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-post-pii-stream",
+        guardrailIdentifier="gid",
+        guardrailVersion="1",
+        event_hook=GuardrailEventHooks.post_call,
+        default_on=True,
+    )
+
+    request_data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    chunks = [
+        litellm.ModelResponseStream(
+            id="tid",
+            choices=[
+                litellm.types.utils.StreamingChoices(
+                    delta=litellm.types.utils.Delta(content="hi", role="assistant"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            created=1,
+            model="gpt-4o-mini",
+            object="chat.completion.chunk",
+        )
+    ]
+
+    async def stream():
+        for c in chunks:
+            yield c
+
+    minimal = {"action": "NONE", "assessments": [], "outputs": []}
+    with patch.object(
+        guardrail, "make_bedrock_api_request", AsyncMock(return_value=minimal)
+    ) as mock_make:
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=UserAPIKeyAuth(),
+            response=stream(),
+            request_data=request_data,
+        ):
+            pass
+
+    input_call = next(
+        c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
+    )
+    output_call = next(
+        c for c in mock_make.call_args_list if c.kwargs.get("source") == "OUTPUT"
+    )
+    assert input_call.kwargs.get("skip_logging") is True
+    assert output_call.kwargs.get("skip_logging", False) is False
+
+
+@pytest.mark.asyncio
+async def test_make_bedrock_api_request_skip_logging_suppresses_standard_log():
+    """
+    skip_logging=True must suppress the call into
+    add_standard_logging_guardrail_information_to_request_data even on the
+    success path so the post_call combined run produces one log entry, not two.
+    """
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT"
+    )
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"action": "NONE", "assessments": []}
+
+    request_data = {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+
+    with (
+        patch.object(
+            guardrail.async_handler,
+            "post",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        patch.object(
+            guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+        ),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail, "add_standard_logging_guardrail_information_to_request_data"
+        ) as mock_log,
+    ):
+        await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=request_data["messages"],
+            request_data=request_data,
+            logging_event_type=GuardrailEventHooks.post_call,
+            skip_logging=True,
+        )
+        assert mock_log.call_count == 0

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2042,11 +2042,13 @@ def test_get_http_exception_no_blocked_assessments_omits_field():
 
 
 @pytest.mark.asyncio
-async def test_streaming_post_call_parallel_output_passes_request_data_to_make_bedrock():
+async def test_streaming_post_call_only_runs_output_scan():
     """
     async_post_call_streaming_iterator_hook must pass request_data into OUTPUT
     make_bedrock_api_request so spend/standard_logging attaches to the real request
     (Greptile: previously OUTPUT used request_data=None / ephemeral {}).
+
+    post_call only validates the response — no INPUT scan should run here.
     """
     request_data = {
         "model": "gpt-4o-mini",
@@ -2118,8 +2120,7 @@ async def test_streaming_post_call_parallel_output_passes_request_data_to_make_b
     input_calls = [
         c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
     ]
-    assert len(input_calls) == 1
-    assert input_calls[0].kwargs.get("request_data") is request_data
+    assert len(input_calls) == 0
 
 
 @pytest.mark.asyncio
@@ -2174,20 +2175,19 @@ async def test_streaming_post_call_output_only_path_passes_request_data_to_make_
 
 
 # ---------------------------------------------------------------------------
-# Regression: post_call must emit one log entry per guardrail (not two).
-# When only post_call is configured, the hook scans both INPUT and OUTPUT in
-# parallel — the INPUT scan must skip logging so the trace shows a single
-# post-call entry instead of duplicates.
+# Regression: post_call only validates OUTPUT.
+# Input scanning belongs to pre_call / during_call. Running an extra INPUT
+# scan here used to produce a duplicate "post-call" trace entry and made no
+# semantic sense for a "post-call" event.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_post_call_combined_input_output_emits_single_log_entry():
+async def test_post_call_success_hook_only_runs_output_scan():
     """
-    With only `post_call` configured, async_post_call_success_hook validates
-    both INPUT and OUTPUT. Only the OUTPUT scan should append a log entry; the
-    INPUT scan must pass skip_logging=True so the post-call section in the
-    trace shows the guardrail once, not twice.
+    With only `post_call` configured, async_post_call_success_hook must call
+    make_bedrock_api_request exactly once with source="OUTPUT". An INPUT call
+    here would produce a duplicate post-call log entry.
     """
     guardrail = BedrockGuardrail(
         guardrail_name="bedrock-post-pii",
@@ -2224,119 +2224,8 @@ async def test_post_call_combined_input_output_emits_single_log_entry():
         )
 
     sources = [c.kwargs.get("source") for c in mock_make.call_args_list]
-    assert sources.count("INPUT") == 1
-    assert sources.count("OUTPUT") == 1
-
-    input_call = next(
-        c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
+    assert sources == ["OUTPUT"]
+    assert (
+        mock_make.call_args.kwargs.get("logging_event_type")
+        == GuardrailEventHooks.post_call
     )
-    output_call = next(
-        c for c in mock_make.call_args_list if c.kwargs.get("source") == "OUTPUT"
-    )
-    assert input_call.kwargs.get("skip_logging") is True
-    assert output_call.kwargs.get("skip_logging", False) is False
-
-
-@pytest.mark.asyncio
-async def test_post_call_combined_streaming_input_skips_logging():
-    """
-    Same dedupe applies to the streaming post_call path: INPUT scan suppresses
-    its log entry, OUTPUT remains the canonical post_call log.
-    """
-    guardrail = BedrockGuardrail(
-        guardrail_name="bedrock-post-pii-stream",
-        guardrailIdentifier="gid",
-        guardrailVersion="1",
-        event_hook=GuardrailEventHooks.post_call,
-        default_on=True,
-    )
-
-    request_data = {
-        "model": "gpt-4o-mini",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    chunks = [
-        litellm.ModelResponseStream(
-            id="tid",
-            choices=[
-                litellm.types.utils.StreamingChoices(
-                    delta=litellm.types.utils.Delta(content="hi", role="assistant"),
-                    finish_reason="stop",
-                    index=0,
-                )
-            ],
-            created=1,
-            model="gpt-4o-mini",
-            object="chat.completion.chunk",
-        )
-    ]
-
-    async def stream():
-        for c in chunks:
-            yield c
-
-    minimal = {"action": "NONE", "assessments": [], "outputs": []}
-    with patch.object(
-        guardrail, "make_bedrock_api_request", AsyncMock(return_value=minimal)
-    ) as mock_make:
-        async for _ in guardrail.async_post_call_streaming_iterator_hook(
-            user_api_key_dict=UserAPIKeyAuth(),
-            response=stream(),
-            request_data=request_data,
-        ):
-            pass
-
-    input_call = next(
-        c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
-    )
-    output_call = next(
-        c for c in mock_make.call_args_list if c.kwargs.get("source") == "OUTPUT"
-    )
-    assert input_call.kwargs.get("skip_logging") is True
-    assert output_call.kwargs.get("skip_logging", False) is False
-
-
-@pytest.mark.asyncio
-async def test_make_bedrock_api_request_skip_logging_suppresses_standard_log():
-    """
-    skip_logging=True must suppress the call into
-    add_standard_logging_guardrail_information_to_request_data even on the
-    success path so the post_call combined run produces one log entry, not two.
-    """
-    guardrail = BedrockGuardrail(
-        guardrailIdentifier="test-guardrail", guardrailVersion="DRAFT"
-    )
-    mock_credentials = MagicMock()
-    mock_credentials.access_key = "k"
-    mock_credentials.secret_key = "s"
-    mock_credentials.token = None
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"action": "NONE", "assessments": []}
-
-    request_data = {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
-
-    with (
-        patch.object(
-            guardrail.async_handler,
-            "post",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ),
-        patch.object(
-            guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
-        ),
-        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
-        patch.object(
-            guardrail, "add_standard_logging_guardrail_information_to_request_data"
-        ) as mock_log,
-    ):
-        await guardrail.make_bedrock_api_request(
-            source="INPUT",
-            messages=request_data["messages"],
-            request_data=request_data,
-            logging_event_type=GuardrailEventHooks.post_call,
-            skip_logging=True,
-        )
-        assert mock_log.call_count == 0


### PR DESCRIPTION
 Description                                                                                            
   
  When a Bedrock guardrail was configured with only post_call, the post-call section of the trace showed 
  the same guardrail twice (e.g. post-pii at T+353ms and again at T+370ms). This PR makes post_call do
  exactly what its name says — validate the response only — which removes the duplicate at its source and
   aligns the hook with its semantic contract.

  Net diff is −268 / +69. The previous commit on this branch introduced a skip_logging workaround; this  
  commit drops that workaround in favor of just not running the redundant scan.
                                                                                                         
  Cause                       

  async_post_call_success_hook (and its streaming sibling) had a should_validate_input branch: when      
  neither pre_call nor during_call was configured, the hook fan-out two make_bedrock_api_request calls in
   parallel via asyncio.gather — one with source="INPUT" and one with source="OUTPUT" — both logged under
   event_type=post_call. Each call appended its own entry to standard_logging_guardrail_information, so
  the trace and spend logs showed the guardrail twice for one logical post_call evaluation. Beyond the
  duplicate log, scanning request input inside a "post-call" hook is semantically wrong — input
  validation belongs to pre_call / during_call.

  Fix

  - Removed the should_validate_input / asyncio.gather branch from both async_post_call_success_hook and 
  async_post_call_streaming_iterator_hook. Each hook now performs a single
  make_bedrock_api_request(source="OUTPUT", ...). Users who want input validation should configure       
  pre_call or during_call.    
  - Reverted the skip_logging parameter on make_bedrock_api_request introduced in the prior commit on
  this branch — no longer needed since there is no second scan to suppress.                              
  - Cleaned up the now-unused import asyncio in both hooks.
                                                                                                         
  Tests (tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py):                
  - Updated test_streaming_post_call_only_runs_output_scan to assert len(input_calls) == 0 (was == 1).
  - Replaced the three skip_logging-era regression tests with one focused test,                          
  test_post_call_success_hook_only_runs_output_scan, which asserts sources == ["OUTPUT"] and
  logging_event_type == post_call.  
  
  Before:

<img width="692" height="284" alt="Screenshot 2026-04-25 at 2 26 26 PM" src="https://github.com/user-attachments/assets/af885d5d-1d35-4219-a80b-da624b448044" />

After:
<img width="709" height="444" alt="Screenshot 2026-04-25 at 2 25 53 PM" src="https://github.com/user-attachments/assets/3fee950d-6566-41dd-b29f-fa5bd14203bb" />

