### PR TITLE
feat: add FuturMix as named OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -101,5 +101,13 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "futurmix": {
+    "base_url": "https://futurmix.ai/v1",
+    "api_key_env": "FUTURMIX_API_KEY",
+    "api_base_env": "FUTURMIX_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds [FuturMix.ai](https://futurmix.ai) as a named OpenAI-compatible provider in `providers.json`.

FuturMix is a enterprise AI agent platform that provides OpenAI-compatible access to 22+ models (Claude, GPT, Gemini) . Adding it as a named provider allows users to use `futurmix/` prefix for model routing.

## Changes

- Added `futurmix` entry to `litellm/llms/openai_like/providers.json`

## Usage

Once merged, users can call FuturMix models with:

```python
import litellm

response = litellm.completion(
 model="futurmix/claude-sonnet-4-20250514",
 messages=[{"role": "user", "content": "Hello"}],
 api_key="your-futurmix-key"
)
```

Environment variable: `FUTURMIX_API_KEY`

## Testing

```python
import os
os.environ["FUTURMIX_API_KEY"] = "sk-..."

# Chat completion
response = litellm.completion(
 model="futurmix/gpt-4o",
 messages=[{"role": "user", "content": "test"}]
)

# Streaming
for chunk in litellm.completion(
 model="futurmix/claude-sonnet-4-20250514",
 messages=[{"role": "user", "content": "test"}],
 stream=True
):
 print(chunk.choices[0].delta.content or "", end="")
```