### PR TITLE
chore(auth): admin-only gate on key_type, allowed_passthrough_routes, and key/regenerate grant fields

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -537,7 +537,18 @@ class RouteChecks:
         """
         Check if route is a passthrough route.
         Supports both exact match and prefix match.
+
+        Defense-in-depth: only authorize routes that are also registered as
+        pass-through endpoints in the admin-defined registry. Without this,
+        any caller with ``metadata.allowed_passthrough_routes`` populated
+        could authorize arbitrary internal routes (e.g. ``/cache/settings``,
+        ``/model/new``) by listing them — even if they happen to no longer
+        be a proxy admin at request time.
         """
+        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+            InitPassThroughEndpointHelpers,
+        )
+
         metadata = user_api_key_dict.metadata
         team_metadata = user_api_key_dict.team_metadata or {}
         if metadata is None and team_metadata is None:
@@ -551,6 +562,12 @@ class RouteChecks:
             metadata.get("allowed_passthrough_routes") is None
             and team_metadata.get("allowed_passthrough_routes") is None
         ):
+            return False
+
+        # The route must actually be registered as a pass-through endpoint.
+        # Routes that aren't in the registry (e.g. internal admin routes)
+        # cannot be authorized by metadata, even if listed there.
+        if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(route):
             return False
 
         allowed_passthrough_routes = (

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -744,6 +744,16 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         allowed_routes=data_json.get("allowed_routes"),
         user_api_key_dict=user_api_key_dict,
     )
+    # Same defense-in-depth for ``allowed_passthrough_routes``: every
+    # endpoint that mutates a key (``/key/generate``, ``/key/update``,
+    # ``/key/regenerate``) gates this field at the request-body layer,
+    # but ``/key/service-account/generate`` reaches this helper directly
+    # without running those gates. Centralizing the check here means any
+    # caller of ``_common_key_generation_helper`` is covered.
+    _check_allowed_passthrough_routes_caller_permission(
+        metadata=data_json.get("metadata"),
+        user_api_key_dict=user_api_key_dict,
+    )
 
     # if we get max_budget passed to /key/generate, then use it as key_max_budget. Since generate_key_helper_fn is used to make new users
     if "max_budget" in data_json:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -485,7 +485,7 @@ def _check_allowed_routes_caller_permission(
 
 
 def _check_management_key_type_caller_permission(
-    key_type: Optional[str],
+    key_type: Optional[LiteLLMKeyType],
     user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     """
@@ -3988,11 +3988,6 @@ async def regenerate_key_fn(  # noqa: PLR0915
                 detail={"error": "DB not connected. prisma_client is None"},
             )
 
-        # Mirror the route-grant gates from /key/generate and /key/update.
-        # Without these, any caller authorized to regenerate a key can also
-        # rewrite its grant fields (allowed_routes, key_type, allowed_passthrough_routes)
-        # at regeneration time, side-stepping the role check those endpoints
-        # already enforce.
         if data is not None:
             _check_allowed_routes_caller_permission(
                 allowed_routes=data.allowed_routes,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -734,6 +734,17 @@ async def _common_key_generation_helper(  # noqa: PLR0915
 
     data_json = handle_key_type(data, data_json)
 
+    # Defense-in-depth: re-run the allowed_routes admin gate on the post-
+    # transform value. ``_check_allowed_routes_caller_permission`` already
+    # ran on the request body in generate_key_fn; running it here again
+    # catches any field (today: ``key_type``; future: anything else)
+    # that injects ``allowed_routes`` via ``handle_key_type``-style
+    # transformation after the request-body check.
+    _check_allowed_routes_caller_permission(
+        allowed_routes=data_json.get("allowed_routes"),
+        user_api_key_dict=user_api_key_dict,
+    )
+
     # if we get max_budget passed to /key/generate, then use it as key_max_budget. Since generate_key_helper_fn is used to make new users
     if "max_budget" in data_json:
         data_json["key_max_budget"] = data_json.pop("max_budget", None)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -484,6 +484,66 @@ def _check_allowed_routes_caller_permission(
     )
 
 
+def _check_management_key_type_caller_permission(
+    key_type: Optional[str],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """
+    Only proxy admins may mint a key with ``key_type='management'``.
+
+    ``key_type='management'`` is expanded into
+    ``allowed_routes=['management_routes']`` by ``handle_key_type`` *after*
+    ``_check_allowed_routes_caller_permission`` has already inspected the
+    raw request body. Without an independent check on ``key_type`` itself,
+    a non-admin can submit ``key_type='management'`` with empty
+    ``allowed_routes`` and end up with full management-route access.
+    """
+    if key_type != LiteLLMKeyType.MANAGEMENT:
+        return
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "error": (
+                "Only proxy admins can set `key_type='management'`. "
+                "Use `key_type='llm_api'` or `key_type='read_only'` instead."
+            )
+        },
+    )
+
+
+def _check_allowed_passthrough_routes_caller_permission(
+    metadata: Optional[dict],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """
+    Only proxy admins may set ``metadata.allowed_passthrough_routes`` on a key.
+
+    ``RouteChecks.check_passthrough_route_access`` runs *before* the standard
+    role-based route gate and matches the request route against
+    ``metadata.allowed_passthrough_routes``. If a non-admin can set this
+    field, they can grant themselves access to any internal endpoint by
+    listing it as a "pass-through" route. Pass-through endpoints must be
+    configured by an admin.
+    """
+    if not metadata:
+        return
+    if not metadata.get("allowed_passthrough_routes"):
+        return
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "error": (
+                "Only proxy admins can set `metadata.allowed_passthrough_routes`. "
+                "An admin must configure pass-through endpoints separately."
+            )
+        },
+    )
+
+
 async def validate_team_id_used_in_service_account_request(
     team_id: Optional[str],
     prisma_client: Optional[PrismaClient],
@@ -1288,6 +1348,14 @@ async def generate_key_fn(
             allowed_routes=data.allowed_routes,
             user_api_key_dict=user_api_key_dict,
         )
+        _check_management_key_type_caller_permission(
+            key_type=data.key_type,
+            user_api_key_dict=user_api_key_dict,
+        )
+        _check_allowed_passthrough_routes_caller_permission(
+            metadata=data.metadata,
+            user_api_key_dict=user_api_key_dict,
+        )
 
         # For non-admin internal users: auto-assign caller's user_id if not provided
         # This prevents creating unbound keys with no user association (LIT-1884)
@@ -1938,6 +2006,10 @@ async def _validate_update_key_data(
 
     _check_allowed_routes_caller_permission(
         allowed_routes=data.allowed_routes,
+        user_api_key_dict=user_api_key_dict,
+    )
+    _check_allowed_passthrough_routes_caller_permission(
+        metadata=data.metadata,
         user_api_key_dict=user_api_key_dict,
     )
 
@@ -3914,6 +3986,25 @@ async def regenerate_key_fn(  # noqa: PLR0915
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail={"error": "DB not connected. prisma_client is None"},
+            )
+
+        # Mirror the route-grant gates from /key/generate and /key/update.
+        # Without these, any caller authorized to regenerate a key can also
+        # rewrite its grant fields (allowed_routes, key_type, allowed_passthrough_routes)
+        # at regeneration time, side-stepping the role check those endpoints
+        # already enforce.
+        if data is not None:
+            _check_allowed_routes_caller_permission(
+                allowed_routes=data.allowed_routes,
+                user_api_key_dict=user_api_key_dict,
+            )
+            _check_management_key_type_caller_permission(
+                key_type=data.key_type,
+                user_api_key_dict=user_api_key_dict,
+            )
+            _check_allowed_passthrough_routes_caller_permission(
+                metadata=data.metadata,
+                user_api_key_dict=user_api_key_dict,
             )
 
         _is_master_key_valid = _is_master_key(api_key=key, _master_key=master_key)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -515,21 +515,29 @@ def _check_management_key_type_caller_permission(
 
 def _check_allowed_passthrough_routes_caller_permission(
     metadata: Optional[dict],
+    top_level_allowed_passthrough_routes: Optional[list],
     user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     """
-    Only proxy admins may set ``metadata.allowed_passthrough_routes`` on a key.
+    Only proxy admins may set ``allowed_passthrough_routes`` on a key.
 
     ``RouteChecks.check_passthrough_route_access`` runs *before* the standard
     role-based route gate and matches the request route against
-    ``metadata.allowed_passthrough_routes``. If a non-admin can set this
-    field, they can grant themselves access to any internal endpoint by
-    listing it as a "pass-through" route. Pass-through endpoints must be
-    configured by an admin.
+    ``allowed_passthrough_routes``. If a non-admin can set this field, they
+    can grant themselves access to any internal endpoint by listing it as
+    a "pass-through" route.
+
+    The field exists in two places on the request schema:
+
+    * ``KeyRequestBase.allowed_passthrough_routes`` (top-level)
+    * ``metadata.allowed_passthrough_routes`` (nested)
+
+    Both end up at the same effective location on the persisted key —
+    ``prepare_key_update_data`` folds the top-level field into metadata via
+    ``_set_object_metadata_field`` — so both paths must be gated.
     """
-    if not metadata:
-        return
-    if not metadata.get("allowed_passthrough_routes"):
+    metadata_field = metadata.get("allowed_passthrough_routes") if metadata else None
+    if not metadata_field and not top_level_allowed_passthrough_routes:
         return
     if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
         return
@@ -537,7 +545,8 @@ def _check_allowed_passthrough_routes_caller_permission(
         status_code=403,
         detail={
             "error": (
-                "Only proxy admins can set `metadata.allowed_passthrough_routes`. "
+                "Only proxy admins can set `allowed_passthrough_routes` on a key "
+                "(top-level field or `metadata.allowed_passthrough_routes`). "
                 "An admin must configure pass-through endpoints separately."
             )
         },
@@ -749,9 +758,14 @@ async def _common_key_generation_helper(  # noqa: PLR0915
     # ``/key/regenerate``) gates this field at the request-body layer,
     # but ``/key/service-account/generate`` reaches this helper directly
     # without running those gates. Centralizing the check here means any
-    # caller of ``_common_key_generation_helper`` is covered.
+    # caller of ``_common_key_generation_helper`` is covered. Both the
+    # top-level ``KeyRequestBase.allowed_passthrough_routes`` field and
+    # the nested ``metadata.allowed_passthrough_routes`` are gated.
     _check_allowed_passthrough_routes_caller_permission(
         metadata=data_json.get("metadata"),
+        top_level_allowed_passthrough_routes=data_json.get(
+            "allowed_passthrough_routes"
+        ),
         user_api_key_dict=user_api_key_dict,
     )
 
@@ -1375,6 +1389,7 @@ async def generate_key_fn(
         )
         _check_allowed_passthrough_routes_caller_permission(
             metadata=data.metadata,
+            top_level_allowed_passthrough_routes=data.allowed_passthrough_routes,
             user_api_key_dict=user_api_key_dict,
         )
 
@@ -2031,6 +2046,7 @@ async def _validate_update_key_data(
     )
     _check_allowed_passthrough_routes_caller_permission(
         metadata=data.metadata,
+        top_level_allowed_passthrough_routes=data.allowed_passthrough_routes,
         user_api_key_dict=user_api_key_dict,
     )
 
@@ -4020,6 +4036,7 @@ async def regenerate_key_fn(  # noqa: PLR0915
             )
             _check_allowed_passthrough_routes_caller_permission(
                 metadata=data.metadata,
+                top_level_allowed_passthrough_routes=data.allowed_passthrough_routes,
                 user_api_key_dict=user_api_key_dict,
             )
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(
@@ -11,6 +12,22 @@ from fastapi import HTTPException, Request
 
 from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.route_checks import RouteChecks
+
+
+@contextmanager
+def _registered_passthrough(is_registered: bool = True):
+    """
+    Patch ``InitPassThroughEndpointHelpers.is_registered_pass_through_route``
+    so tests that exercise the metadata-matching logic in
+    ``check_passthrough_route_access`` don't have to spin up the real
+    pass-through route registry.
+    """
+    with patch(
+        "litellm.proxy.pass_through_endpoints.pass_through_endpoints."
+        "InitPassThroughEndpointHelpers.is_registered_pass_through_route",
+        return_value=is_registered,
+    ):
+        yield
 
 
 def test_non_admin_config_update_route_rejected():
@@ -544,10 +561,11 @@ def test_check_passthrough_route_access_key_metadata_exact_match():
     )
 
     # Test exact match
-    result = RouteChecks.check_passthrough_route_access(
-        route="/custom-endpoint",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result = RouteChecks.check_passthrough_route_access(
+            route="/custom-endpoint",
+            user_api_key_dict=valid_token,
+        )
 
     assert result is True
 
@@ -562,10 +580,11 @@ def test_check_passthrough_route_access_key_metadata_prefix_match():
     )
 
     # Test prefix match
-    result = RouteChecks.check_passthrough_route_access(
-        route="/custom-endpoint/v1/chat/completions",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result = RouteChecks.check_passthrough_route_access(
+            route="/custom-endpoint/v1/chat/completions",
+            user_api_key_dict=valid_token,
+        )
 
     assert result is True
 
@@ -599,10 +618,11 @@ def test_check_passthrough_route_access_team_metadata_exact_match():
     )
 
     # Test exact match
-    result = RouteChecks.check_passthrough_route_access(
-        route="/team-endpoint",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result = RouteChecks.check_passthrough_route_access(
+            route="/team-endpoint",
+            user_api_key_dict=valid_token,
+        )
 
     assert result is True
 
@@ -618,10 +638,11 @@ def test_check_passthrough_route_access_team_metadata_prefix_match():
     )
 
     # Test prefix match
-    result = RouteChecks.check_passthrough_route_access(
-        route="/team-endpoint/v1/messages",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result = RouteChecks.check_passthrough_route_access(
+            route="/team-endpoint/v1/messages",
+            user_api_key_dict=valid_token,
+        )
 
     assert result is True
 
@@ -656,16 +677,17 @@ def test_check_passthrough_route_access_key_metadata_takes_precedence():
     )
 
     # Test that key endpoint is allowed
-    result1 = RouteChecks.check_passthrough_route_access(
-        route="/key-endpoint",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result1 = RouteChecks.check_passthrough_route_access(
+            route="/key-endpoint",
+            user_api_key_dict=valid_token,
+        )
 
-    # Test that team endpoint is NOT allowed (key metadata takes precedence)
-    result2 = RouteChecks.check_passthrough_route_access(
-        route="/team-endpoint",
-        user_api_key_dict=valid_token,
-    )
+        # Test that team endpoint is NOT allowed (key metadata takes precedence)
+        result2 = RouteChecks.check_passthrough_route_access(
+            route="/team-endpoint",
+            user_api_key_dict=valid_token,
+        )
 
     assert result1 is True
     assert result2 is False
@@ -742,24 +764,25 @@ def test_check_passthrough_route_access_multiple_routes():
     )
 
     # Test that all allowed routes work
-    result1 = RouteChecks.check_passthrough_route_access(
-        route="/endpoint-1/v1/chat",
-        user_api_key_dict=valid_token,
-    )
-    result2 = RouteChecks.check_passthrough_route_access(
-        route="/endpoint-2",
-        user_api_key_dict=valid_token,
-    )
-    result3 = RouteChecks.check_passthrough_route_access(
-        route="/endpoint-3/completions",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result1 = RouteChecks.check_passthrough_route_access(
+            route="/endpoint-1/v1/chat",
+            user_api_key_dict=valid_token,
+        )
+        result2 = RouteChecks.check_passthrough_route_access(
+            route="/endpoint-2",
+            user_api_key_dict=valid_token,
+        )
+        result3 = RouteChecks.check_passthrough_route_access(
+            route="/endpoint-3/completions",
+            user_api_key_dict=valid_token,
+        )
 
-    # Test that non-allowed route fails
-    result4 = RouteChecks.check_passthrough_route_access(
-        route="/endpoint-4",
-        user_api_key_dict=valid_token,
-    )
+        # Test that non-allowed route fails
+        result4 = RouteChecks.check_passthrough_route_access(
+            route="/endpoint-4",
+            user_api_key_dict=valid_token,
+        )
 
     assert result1 is True
     assert result2 is True
@@ -777,18 +800,19 @@ def test_check_passthrough_route_access_prevents_false_prefix_match():
     )
 
     # Test that /endpoint-2 is NOT allowed (not a valid prefix match)
-    result = RouteChecks.check_passthrough_route_access(
-        route="/endpoint-2",
-        user_api_key_dict=valid_token,
-    )
+    with _registered_passthrough():
+        result = RouteChecks.check_passthrough_route_access(
+            route="/endpoint-2",
+            user_api_key_dict=valid_token,
+        )
 
-    assert result is False
+        assert result is False
 
-    # Test that /endpoint/something IS allowed (valid prefix match)
-    result2 = RouteChecks.check_passthrough_route_access(
-        route="/endpoint/something",
-        user_api_key_dict=valid_token,
-    )
+        # Test that /endpoint/something IS allowed (valid prefix match)
+        result2 = RouteChecks.check_passthrough_route_access(
+            route="/endpoint/something",
+            user_api_key_dict=valid_token,
+        )
 
     assert result2 is True
 
@@ -807,6 +831,31 @@ def test_check_passthrough_route_access_empty_list():
         route="/any-endpoint",
         user_api_key_dict=valid_token,
     )
+
+    assert result is False
+
+
+def test_check_passthrough_route_access_unregistered_route_denied():
+    """
+    Defense-in-depth: even when ``metadata.allowed_passthrough_routes``
+    matches the request route, access must be denied if the route is not
+    actually registered in the admin-defined pass-through endpoint registry.
+
+    Without this, anyone who could populate ``allowed_passthrough_routes``
+    (e.g. by briefly having admin and then losing it) could authorize
+    arbitrary internal routes — including admin endpoints like
+    ``/cache/settings`` — by listing them in metadata.
+    """
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        metadata={"allowed_passthrough_routes": ["/cache/settings"]},
+    )
+
+    with _registered_passthrough(is_registered=False):
+        result = RouteChecks.check_passthrough_route_access(
+            route="/cache/settings",
+            user_api_key_dict=valid_token,
+        )
 
     assert result is False
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -22,9 +22,11 @@ from litellm.proxy._types import (
     LiteLLM_TeamTableCachedObj,
     LiteLLM_UserTable,
     LiteLLM_VerificationToken,
+    LiteLLMKeyType,
     LitellmUserRoles,
     Member,
     ProxyException,
+    RegenerateKeyRequest,
     ResetSpendRequest,
     UpdateKeyRequest,
 )
@@ -9078,8 +9080,6 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
 
     @pytest.mark.asyncio
     async def test_non_admin_generate_management_key_type_rejected(self):
-        from litellm.proxy._types import LiteLLMKeyType
-
         data = GenerateKeyRequest(
             key_alias="escalate-via-key-type",
             key_type=LiteLLMKeyType.MANAGEMENT,
@@ -9189,6 +9189,7 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
                 {"metadata": {"allowed_passthrough_routes": ["/cache/settings"]}},
                 "allowed_passthrough_routes",
             ),
+            ({"key_type": LiteLLMKeyType.MANAGEMENT}, "key_type"),
         ],
     )
     @pytest.mark.asyncio
@@ -9202,7 +9203,6 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
         ``key_type='management'`` at regeneration time, side-stepping the
         admin gate ``/key/generate`` and ``/key/update`` already enforce.
         """
-        from litellm.proxy._types import RegenerateKeyRequest
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             regenerate_key_fn,
         )
@@ -9231,38 +9231,6 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
                 )
         assert str(exc_info.value.code) == "403"
         assert expected_substring in str(exc_info.value.message)
-
-    @pytest.mark.asyncio
-    async def test_non_admin_regenerate_key_management_type_rejected(self):
-        from litellm.proxy._types import LiteLLMKeyType, RegenerateKeyRequest
-        from litellm.proxy.management_endpoints.key_management_endpoints import (
-            regenerate_key_fn,
-        )
-
-        data = RegenerateKeyRequest(key="sk-victim", key_type=LiteLLMKeyType.MANAGEMENT)
-        user_api_key_dict = UserAPIKeyAuth(
-            user_id="internal-user-123",
-            user_role=LitellmUserRoles.INTERNAL_USER,
-        )
-        mock_prisma_client = AsyncMock()
-
-        with (
-            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
-            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
-            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
-            patch("litellm.proxy.proxy_server.master_key", "sk-master"),
-            patch("litellm.proxy.proxy_server.premium_user", True),
-            patch("litellm.proxy.proxy_server.hash_token", lambda x: f"hash::{x}"),
-        ):
-            with pytest.raises(ProxyException) as exc_info:
-                await regenerate_key_fn(
-                    key="sk-victim",
-                    data=data,
-                    user_api_key_dict=user_api_key_dict,
-                    litellm_changed_by=None,
-                )
-        assert str(exc_info.value.code) == "403"
-        assert "key_type" in str(exc_info.value.message)
 
 
 def test_jinja_prompt_manager_is_sandboxed():

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -8089,9 +8089,7 @@ async def test_update_key_non_budget_rejects_cross_user_modification(monkeypatch
     )
 
     mock_prisma_client = AsyncMock()
-    test_hashed_token = (
-        "cafebabe" * 8
-    )
+    test_hashed_token = "cafebabe" * 8
 
     mock_existing_key = MagicMock()
     mock_existing_key.token = test_hashed_token
@@ -9059,6 +9057,212 @@ class TestAllowedRoutesCallerPermission:
                 )
         assert str(exc_info.value.code) == "403"
         assert "allowed_routes" in str(exc_info.value.message)
+
+
+class TestKeyTypeAndPassthroughRoutesCallerPermission:
+    """
+    Sibling gates to ``_check_allowed_routes_caller_permission``:
+
+    * ``key_type='management'`` is expanded into
+      ``allowed_routes=['management_routes']`` after the explicit-input check
+      runs, so a non-admin who can submit it bypasses the
+      ``allowed_routes`` admin gate.
+    * ``metadata.allowed_passthrough_routes`` is consumed by
+      ``RouteChecks.check_passthrough_route_access`` *before* the standard
+      role-based route gate, so a non-admin who can populate it grants
+      themselves admin-route access.
+
+    Both must be admin-only on every key-mutating endpoint
+    (/key/generate, /key/update, /key/regenerate).
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_admin_generate_management_key_type_rejected(self):
+        from litellm.proxy._types import LiteLLMKeyType
+
+        data = GenerateKeyRequest(
+            key_alias="escalate-via-key-type",
+            key_type=LiteLLMKeyType.MANAGEMENT,
+        )
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_generate", None),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._common_key_generation_helper",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await generate_key_fn(
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "key_type" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_generate_key_with_allowed_passthrough_routes_rejected(
+        self,
+    ):
+        data = GenerateKeyRequest(
+            key_alias="escalate-via-passthrough",
+            metadata={"allowed_passthrough_routes": ["/cache/settings"]},
+        )
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_generate", None),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._common_key_generation_helper",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await generate_key_fn(
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_passthrough_routes" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_update_key_with_allowed_passthrough_routes_rejected(self):
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            update_key_fn,
+        )
+
+        data = UpdateKeyRequest(
+            key="sk-test",
+            metadata={"allowed_passthrough_routes": ["/cache/settings"]},
+        )
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_update", None),
+            patch("litellm.proxy.proxy_server.llm_router", None),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._get_and_validate_existing_key",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await update_key_fn(
+                    request=MagicMock(),
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_passthrough_routes" in str(exc_info.value.message)
+
+    @pytest.mark.parametrize(
+        "field_kwargs,expected_substring",
+        [
+            ({"allowed_routes": ["/*"]}, "allowed_routes"),
+            (
+                {"metadata": {"allowed_passthrough_routes": ["/cache/settings"]}},
+                "allowed_passthrough_routes",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_non_admin_regenerate_key_grant_fields_rejected(
+        self, field_kwargs, expected_substring
+    ):
+        """
+        ``/key/regenerate`` previously called none of the grant-field gates,
+        so any caller authorized to regenerate a key (e.g. its owner) could
+        rewrite ``allowed_routes`` / ``allowed_passthrough_routes`` /
+        ``key_type='management'`` at regeneration time, side-stepping the
+        admin gate ``/key/generate`` and ``/key/update`` already enforce.
+        """
+        from litellm.proxy._types import RegenerateKeyRequest
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            regenerate_key_fn,
+        )
+
+        data = RegenerateKeyRequest(key="sk-victim", **field_kwargs)
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+            patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.hash_token", lambda x: f"hash::{x}"),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await regenerate_key_fn(
+                    key="sk-victim",
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert expected_substring in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_regenerate_key_management_type_rejected(self):
+        from litellm.proxy._types import LiteLLMKeyType, RegenerateKeyRequest
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            regenerate_key_fn,
+        )
+
+        data = RegenerateKeyRequest(key="sk-victim", key_type=LiteLLMKeyType.MANAGEMENT)
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+            patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.hash_token", lambda x: f"hash::{x}"),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await regenerate_key_fn(
+                    key="sk-victim",
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "key_type" in str(exc_info.value.message)
 
 
 def test_jinja_prompt_manager_is_sandboxed():

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -9232,6 +9232,66 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
         assert str(exc_info.value.code) == "403"
         assert expected_substring in str(exc_info.value.message)
 
+    @pytest.mark.asyncio
+    async def test_non_admin_service_account_generate_with_passthrough_metadata_rejected(
+        self,
+    ):
+        """
+        ``/key/service-account/generate`` calls ``_common_key_generation_helper``
+        directly without going through ``generate_key_fn``'s per-field gate
+        stack. The gate must therefore live inside the helper as well, so
+        non-admin team admins cannot mint a service-account key with
+        ``metadata.allowed_passthrough_routes`` populated.
+        """
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            generate_service_account_key_fn,
+        )
+
+        data = GenerateKeyRequest(
+            key_alias="sa-escalate",
+            team_id="team-A",
+            metadata={"allowed_passthrough_routes": ["/cache/settings"]},
+        )
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="team-admin-not-proxy-admin",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+
+        mock_prisma_client = AsyncMock()
+        # Make the team lookup resolve so we reach the helper.
+        mock_team_table = MagicMock()
+        mock_team_table.team_id = "team-A"
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_generate", None),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.validate_team_id_used_in_service_account_request",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_team_object",
+                new_callable=AsyncMock,
+                return_value=mock_team_table,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._check_team_key_limits",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.key_generation_check"
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await generate_service_account_key_fn(
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert exc_info.value.status_code == 403
+        assert "allowed_passthrough_routes" in str(exc_info.value.detail)
+
 
 def test_jinja_prompt_manager_is_sandboxed():
     """

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -9109,14 +9109,18 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
         assert str(exc_info.value.code) == "403"
         assert "key_type" in str(exc_info.value.message)
 
+    @pytest.mark.parametrize(
+        "field_kwargs",
+        [
+            {"metadata": {"allowed_passthrough_routes": ["/cache/settings"]}},
+            {"allowed_passthrough_routes": ["/cache/settings"]},
+        ],
+    )
     @pytest.mark.asyncio
     async def test_non_admin_generate_key_with_allowed_passthrough_routes_rejected(
-        self,
+        self, field_kwargs
     ):
-        data = GenerateKeyRequest(
-            key_alias="escalate-via-passthrough",
-            metadata={"allowed_passthrough_routes": ["/cache/settings"]},
-        )
+        data = GenerateKeyRequest(key_alias="escalate-via-passthrough", **field_kwargs)
         user_api_key_dict = UserAPIKeyAuth(
             user_id="internal-user-123",
             user_role=LitellmUserRoles.INTERNAL_USER,
@@ -9142,16 +9146,27 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
         assert str(exc_info.value.code) == "403"
         assert "allowed_passthrough_routes" in str(exc_info.value.message)
 
+    @pytest.mark.parametrize(
+        "field_kwargs",
+        [
+            # Nested metadata path — historical
+            {"metadata": {"allowed_passthrough_routes": ["/cache/settings"]}},
+            # Top-level field — ``KeyRequestBase.allowed_passthrough_routes``
+            # is folded into metadata downstream by ``prepare_key_update_data``
+            # via ``_set_object_metadata_field``, so a non-admin who can set
+            # it bypasses any gate that only inspects ``data.metadata``.
+            {"allowed_passthrough_routes": ["/cache/settings"]},
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_non_admin_update_key_with_allowed_passthrough_routes_rejected(self):
+    async def test_non_admin_update_key_with_allowed_passthrough_routes_rejected(
+        self, field_kwargs
+    ):
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             update_key_fn,
         )
 
-        data = UpdateKeyRequest(
-            key="sk-test",
-            metadata={"allowed_passthrough_routes": ["/cache/settings"]},
-        )
+        data = UpdateKeyRequest(key="sk-test", **field_kwargs)
         user_api_key_dict = UserAPIKeyAuth(
             user_id="internal-user-123",
             user_role=LitellmUserRoles.INTERNAL_USER,
@@ -9187,6 +9202,13 @@ class TestKeyTypeAndPassthroughRoutesCallerPermission:
             ({"allowed_routes": ["/*"]}, "allowed_routes"),
             (
                 {"metadata": {"allowed_passthrough_routes": ["/cache/settings"]}},
+                "allowed_passthrough_routes",
+            ),
+            # Top-level ``allowed_passthrough_routes`` on KeyRequestBase —
+            # ``prepare_key_update_data`` later folds it into metadata via
+            # ``_set_object_metadata_field``, so it must be gated too.
+            (
+                {"allowed_passthrough_routes": ["/cache/settings"]},
                 "allowed_passthrough_routes",
             ),
             ({"key_type": LiteLLMKeyType.MANAGEMENT}, "key_type"),


### PR DESCRIPTION
## Relevant issues

Three sibling fields on the key-mutation request schema grant access to routes outside the standard role-based gate, but only one (``allowed_routes``) was previously admin-gated, and only on ``/key/generate`` and ``/key/update``:

- **``key_type='management'``** is expanded into ``allowed_routes=['management_routes']`` by ``handle_key_type`` *after* ``_check_allowed_routes_caller_permission`` has inspected the raw request body. A non-admin can leave ``allowed_routes`` empty, send ``key_type='management'``, and end up with full management-route access.
- **``metadata.allowed_passthrough_routes``** is consumed by ``RouteChecks.check_passthrough_route_access`` *before* the standard role-based route gate. A non-admin who can populate this field grants themselves access to any route they list — including admin endpoints like ``/cache/settings`` or ``/model/new``.
- **``/key/regenerate``** runs none of the grant-field gates that ``/key/generate`` and ``/key/update`` enforce. Any caller authorized to regenerate a key (its owner, a team admin) can rewrite ``allowed_routes`` / ``key_type`` / ``metadata.allowed_passthrough_routes`` at regeneration time and side-step the admin gate the other endpoints already enforce.

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🔧 Hardening

## Changes

### Source-side admin gates (`litellm/proxy/management_endpoints/key_management_endpoints.py`)

- New ``_check_management_key_type_caller_permission(key_type, user_api_key_dict)`` — only ``PROXY_ADMIN`` may submit ``key_type='management'``.
- New ``_check_allowed_passthrough_routes_caller_permission(metadata, user_api_key_dict)`` — only ``PROXY_ADMIN`` may set ``metadata.allowed_passthrough_routes``.
- ``/key/generate`` (``_common_key_generation_helper``) now runs all three grant-field gates (``allowed_routes``, ``key_type``, ``metadata.allowed_passthrough_routes``) instead of only the ``allowed_routes`` one.
- ``/key/update`` (``_validate_update_key_data``) adds the ``allowed_passthrough_routes`` gate. (``key_type`` is not on ``UpdateKeyRequest``.)
- ``/key/regenerate`` (``regenerate_key_fn``) previously had none of these gates. It now mirrors ``/key/generate``.

### Root-cause tightening

- **Post-transform check:** ``_check_allowed_routes_caller_permission`` is also re-run inside ``_common_key_generation_helper`` *after* ``handle_key_type`` transforms ``data_json``. The earlier per-field check on ``key_type`` blocks the only known derivation today, but any future field that injects ``allowed_routes`` via ``handle_key_type``-style transformation is now caught for free.
- **Route-registry guard** (`litellm/proxy/auth/route_checks.py`): ``RouteChecks.check_passthrough_route_access`` now requires the request route to be present in the admin-defined registry (``InitPassThroughEndpointHelpers.is_registered_pass_through_route``) before authorizing it via ``metadata.allowed_passthrough_routes``. A stale or malicious metadata entry can no longer authorize anything outside the admin-configured pass-through set, even if ``allowed_passthrough_routes`` somehow contains an internal route.

### Tests

- New ``TestKeyTypeAndPassthroughRoutesCallerPermission`` covers all three vectors on ``/key/generate``, ``/key/update``, and ``/key/regenerate``. ``/key/regenerate`` is parametrized over the three grant fields (``allowed_routes``, ``allowed_passthrough_routes``, ``key_type``).
- New ``test_check_passthrough_route_access_unregistered_route_denied`` verifies the route-registry guard.
- The seven existing positive ``check_passthrough_route_access`` tests are wrapped in a small ``_registered_passthrough()`` context manager that patches the registry to ``True`` so they continue to exercise the metadata-matching logic they were written for.

## Risk note for operators

Operators who relied on a non-admin caller setting ``key_type='management'``, ``metadata.allowed_passthrough_routes``, or ``allowed_routes`` on ``/key/regenerate`` will now get a 403. The intended path remains: an admin-issued key, or an admin-configured pass-through endpoint plus an admin-set ``allowed_passthrough_routes`` field.