### PR TITLE
chore(vector-stores): redact credentials in list/info/update responses; gate update by per-store access

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -21,6 +21,8 @@ class SensitiveDataMasker:
             "auth",
             "authorization",
             "credential",
+            # Plural form: Vertex uses ``vertex_credentials``; segment-exact
+            # matching otherwise misses it because "credential" != "credentials".
             "credentials",
             "access",
             "private",

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -40,12 +40,7 @@ from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
 
 router = APIRouter()
 
-# Inherit the default sensitive-key heuristics and add the plural
-# ``credentials`` so segment-exact matching catches Vertex's
-# ``vertex_credentials`` (the singular ``credential`` pattern misses it).
-_LITELLM_PARAMS_MASKER = SensitiveDataMasker(
-    sensitive_patterns={*SensitiveDataMasker().sensitive_patterns, "credentials"},
-)
+_LITELLM_PARAMS_MASKER = SensitiveDataMasker()
 
 
 def _redact_sensitive_litellm_params(
@@ -812,6 +807,25 @@ async def update_vector_store(
         update_data = data.model_dump(exclude_unset=True)
         vector_store_id = update_data.pop("vector_store_id")
 
+        # Per-store access control: anyone authenticated who passes the
+        # premium-feature gate could otherwise update *any* vector store —
+        # including stores belonging to other teams. Mirror the check
+        # ``/vector_store/info`` already performs.
+        existing = await prisma_client.db.litellm_managedvectorstorestable.find_unique(
+            where={"vector_store_id": vector_store_id}
+        )
+        if existing is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Vector store with ID {vector_store_id} not found",
+            )
+        existing_typed = LiteLLM_ManagedVectorStore(**existing.model_dump())
+        if not await _check_vector_store_access(existing_typed, user_api_key_dict):
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied: You do not have permission to update this vector store",
+            )
+
         # Handle metadata serialization
         if update_data.get("vector_store_metadata") is not None:
             update_data["vector_store_metadata"] = safe_dumps(
@@ -859,11 +873,24 @@ async def update_vector_store(
                 f"Updated vector store {vector_store_id} in both database and in-memory registry"
             )
 
+        # The DB row is returned in full, so the response would otherwise
+        # echo the persisted ``litellm_params`` (including provider
+        # credentials) back to the caller — even when the caller only
+        # changed unrelated fields like ``vector_store_description``.
+        response_vs = LiteLLM_ManagedVectorStore(**updated_vs)
+        response_vs["litellm_params"] = _redact_sensitive_litellm_params(
+            updated_vs.get("litellm_params")
+        )
         return {
             "status": "success",
             "message": f"Vector store {vector_store_id} updated successfully",
-            "vector_store": updated_vs,
+            "vector_store": response_vs,
         }
+    except HTTPException:
+        # Preserve 403/404 responses from the access-control / not-found
+        # checks above; the catch-all below would otherwise rewrite them
+        # as 500 with the original status code embedded in the detail.
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error updating vector store: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -43,7 +43,10 @@ router = APIRouter()
 _LITELLM_PARAMS_MASKER = SensitiveDataMasker()
 
 
-def _redact_sensitive_litellm_params(litellm_params: Any) -> Any:
+_REDACT_LITELLM_PARAMS_MAX_DEPTH = 10
+
+
+def _redact_sensitive_litellm_params(litellm_params: Any, _depth: int = 0) -> Any:
     """
     Replace credential-bearing values in ``litellm_params`` with
     ``REDACTED_BY_LITELM`` while preserving non-secret keys (``api_base``,
@@ -58,7 +61,13 @@ def _redact_sensitive_litellm_params(litellm_params: Any) -> Any:
       fails, return the redaction sentinel rather than echo the value
       back verbatim.
     * Anything else, or ``None`` — passed through.
+
+    Recursion depth is bounded by ``_REDACT_LITELLM_PARAMS_MAX_DEPTH`` —
+    matching the convention of other allowlisted recursive helpers in the
+    repo (see ``tests/code_coverage_tests/recursive_detector.py``).
     """
+    if _depth >= _REDACT_LITELLM_PARAMS_MAX_DEPTH:
+        return REDACTED_BY_LITELM_STRING
     if litellm_params is None:
         return None
     if isinstance(litellm_params, str):
@@ -66,7 +75,7 @@ def _redact_sensitive_litellm_params(litellm_params: Any) -> Any:
             parsed = json.loads(litellm_params)
         except (TypeError, ValueError):
             return REDACTED_BY_LITELM_STRING
-        return json.dumps(_redact_sensitive_litellm_params(parsed))
+        return json.dumps(_redact_sensitive_litellm_params(parsed, _depth + 1))
     if not isinstance(litellm_params, dict):
         return litellm_params
     out: Dict[str, Any] = {}
@@ -74,7 +83,7 @@ def _redact_sensitive_litellm_params(litellm_params: Any) -> Any:
         if _LITELLM_PARAMS_MASKER.is_sensitive_key(k):
             out[k] = REDACTED_BY_LITELM_STRING
         elif isinstance(v, dict):
-            out[k] = _redact_sensitive_litellm_params(v)
+            out[k] = _redact_sensitive_litellm_params(v, _depth + 1)
         else:
             out[k] = v
     return out
@@ -807,6 +816,10 @@ async def get_vector_store_info(
                 vector_store_dict["litellm_params"]
             )
         return {"vector_store": vector_store_dict}
+    except HTTPException:
+        # Preserve 403/404 from the access-control / not-found checks above;
+        # the catch-all below would otherwise rewrite them as 500.
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error getting vector store info: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -40,25 +40,11 @@ from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
 
 router = APIRouter()
 
-# Module-level masker — extends the default sensitive-key heuristics with
-# plural forms used by some providers (e.g. Vertex's ``vertex_credentials``,
-# which would otherwise slip past the singular "credential" pattern).
+# Inherit the default sensitive-key heuristics and add the plural
+# ``credentials`` so segment-exact matching catches Vertex's
+# ``vertex_credentials`` (the singular ``credential`` pattern misses it).
 _LITELLM_PARAMS_MASKER = SensitiveDataMasker(
-    sensitive_patterns={
-        "password",
-        "secret",
-        "key",
-        "token",
-        "auth",
-        "authorization",
-        "credential",
-        "credentials",
-        "access",
-        "private",
-        "certificate",
-        "fingerprint",
-        "tenancy",
-    },
+    sensitive_patterns={*SensitiveDataMasker().sensitive_patterns, "credentials"},
 )
 
 
@@ -66,41 +52,20 @@ def _redact_sensitive_litellm_params(
     litellm_params: Optional[Dict[str, Any]],
 ) -> Optional[Dict[str, Any]]:
     """
-    Replace credential-bearing values inside ``litellm_params`` with the
-    ``REDACTED_BY_LITELM`` sentinel while preserving non-secret keys
-    (``api_base``, ``region``, ``model``, etc.) so callers can still see
-    *which* upstream is configured.
-
-    Without this, ``/vector_store/list`` and ``/vector_store/info`` return
-    the raw provider credentials (OpenAI ``api_key``, AWS
-    ``aws_secret_access_key``, GCP ``vertex_credentials``, ...) to any
-    authenticated principal, including read-only users and narrowly-scoped
-    keys.
+    Replace credential-bearing values in ``litellm_params`` with
+    ``REDACTED_BY_LITELM`` while preserving non-secret keys (``api_base``,
+    ``region``, ``model``, ``api_version``).
     """
     if not litellm_params or not isinstance(litellm_params, dict):
         return litellm_params
-
-    redacted: Dict[str, Any] = {}
-    for k, v in litellm_params.items():
-        if _LITELLM_PARAMS_MASKER.is_sensitive_key(k):
-            redacted[k] = REDACTED_BY_LITELM_STRING
-        else:
-            redacted[k] = v
-    return redacted
-
-
-def _redact_vector_store(
-    vector_store: LiteLLM_ManagedVectorStore,
-) -> LiteLLM_ManagedVectorStore:
-    """
-    Return a copy of ``vector_store`` with credential-bearing fields
-    inside ``litellm_params`` replaced by the redaction sentinel.
-    """
-    redacted = LiteLLM_ManagedVectorStore(**vector_store)
-    redacted["litellm_params"] = _redact_sensitive_litellm_params(
-        vector_store.get("litellm_params")
-    )
-    return redacted
+    return {
+        k: (
+            REDACTED_BY_LITELM_STRING
+            if _LITELLM_PARAMS_MASKER.is_sensitive_key(k)
+            else v
+        )
+        for k, v in litellm_params.items()
+    }
 
 
 def _resolve_embedding_config_from_router(
@@ -619,7 +584,11 @@ async def list_vector_stores(
         accessible_vector_stores = []
         for vs in vector_store_map.values():
             if await _check_vector_store_access(vs, user_api_key_dict):
-                accessible_vector_stores.append(_redact_vector_store(vs))
+                redacted = LiteLLM_ManagedVectorStore(**vs)
+                redacted["litellm_params"] = _redact_sensitive_litellm_params(
+                    vs.get("litellm_params")
+                )
+                accessible_vector_stores.append(redacted)
 
         total_count = len(accessible_vector_stores)
         total_pages = (total_count + page_size - 1) // page_size

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -63,6 +63,33 @@ def _redact_sensitive_litellm_params(
     }
 
 
+async def _fetch_and_authorize_vector_store(
+    vector_store_id: str,
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: Any,
+) -> "LiteLLM_ManagedVectorStore":
+    """
+    Look up a vector store by id and confirm the caller can access it.
+    Raises HTTPException(404) on miss and HTTPException(403) on access
+    denial.
+    """
+    row = await prisma_client.db.litellm_managedvectorstorestable.find_unique(
+        where={"vector_store_id": vector_store_id}
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Vector store with ID {vector_store_id} not found",
+        )
+    typed = LiteLLM_ManagedVectorStore(**row.model_dump())
+    if not await _check_vector_store_access(typed, user_api_key_dict):
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: You do not have permission to access this vector store",
+        )
+    return typed
+
+
 def _resolve_embedding_config_from_router(
     embedding_model: str, llm_router
 ) -> Optional[Dict[str, Any]]:
@@ -752,26 +779,12 @@ async def get_vector_store_info(
                 )
                 return {"vector_store": vector_store_pydantic_obj}
 
-        vector_store = (
-            await prisma_client.db.litellm_managedvectorstorestable.find_unique(
-                where={"vector_store_id": data.vector_store_id}
-            )
+        vector_store_typed = await _fetch_and_authorize_vector_store(
+            vector_store_id=data.vector_store_id,
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
         )
-        if vector_store is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Vector store with ID {data.vector_store_id} not found",
-            )
-
-        # Check access control for DB vector store
-        vector_store_dict = vector_store.model_dump()  # type: ignore[attr-defined]
-        vector_store_typed = LiteLLM_ManagedVectorStore(**vector_store_dict)
-        if not await _check_vector_store_access(vector_store_typed, user_api_key_dict):
-            raise HTTPException(
-                status_code=403,
-                detail="Access denied: You do not have permission to access this vector store",
-            )
-
+        vector_store_dict = dict(vector_store_typed)
         if "litellm_params" in vector_store_dict:
             vector_store_dict["litellm_params"] = _redact_sensitive_litellm_params(
                 vector_store_dict["litellm_params"]
@@ -809,22 +822,12 @@ async def update_vector_store(
 
         # Per-store access control: anyone authenticated who passes the
         # premium-feature gate could otherwise update *any* vector store —
-        # including stores belonging to other teams. Mirror the check
-        # ``/vector_store/info`` already performs.
-        existing = await prisma_client.db.litellm_managedvectorstorestable.find_unique(
-            where={"vector_store_id": vector_store_id}
+        # including stores belonging to other teams.
+        await _fetch_and_authorize_vector_store(
+            vector_store_id=vector_store_id,
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
         )
-        if existing is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Vector store with ID {vector_store_id} not found",
-            )
-        existing_typed = LiteLLM_ManagedVectorStore(**existing.model_dump())
-        if not await _check_vector_store_access(existing_typed, user_api_key_dict):
-            raise HTTPException(
-                status_code=403,
-                detail="Access denied: You do not have permission to update this vector store",
-            )
 
         # Handle metadata serialization
         if update_data.get("vector_store_metadata") is not None:

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -16,7 +16,9 @@ from fastapi import APIRouter, Depends, HTTPException
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import REDACTED_BY_LITELM_STRING
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.proxy._types import (
     LiteLLM_ManagedVectorStoresTable,
     ResponseLiteLLM_ManagedVectorStore,
@@ -37,6 +39,68 @@ from litellm.types.vector_stores import (
 from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
 
 router = APIRouter()
+
+# Module-level masker — extends the default sensitive-key heuristics with
+# plural forms used by some providers (e.g. Vertex's ``vertex_credentials``,
+# which would otherwise slip past the singular "credential" pattern).
+_LITELLM_PARAMS_MASKER = SensitiveDataMasker(
+    sensitive_patterns={
+        "password",
+        "secret",
+        "key",
+        "token",
+        "auth",
+        "authorization",
+        "credential",
+        "credentials",
+        "access",
+        "private",
+        "certificate",
+        "fingerprint",
+        "tenancy",
+    },
+)
+
+
+def _redact_sensitive_litellm_params(
+    litellm_params: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """
+    Replace credential-bearing values inside ``litellm_params`` with the
+    ``REDACTED_BY_LITELM`` sentinel while preserving non-secret keys
+    (``api_base``, ``region``, ``model``, etc.) so callers can still see
+    *which* upstream is configured.
+
+    Without this, ``/vector_store/list`` and ``/vector_store/info`` return
+    the raw provider credentials (OpenAI ``api_key``, AWS
+    ``aws_secret_access_key``, GCP ``vertex_credentials``, ...) to any
+    authenticated principal, including read-only users and narrowly-scoped
+    keys.
+    """
+    if not litellm_params or not isinstance(litellm_params, dict):
+        return litellm_params
+
+    redacted: Dict[str, Any] = {}
+    for k, v in litellm_params.items():
+        if _LITELLM_PARAMS_MASKER.is_sensitive_key(k):
+            redacted[k] = REDACTED_BY_LITELM_STRING
+        else:
+            redacted[k] = v
+    return redacted
+
+
+def _redact_vector_store(
+    vector_store: LiteLLM_ManagedVectorStore,
+) -> LiteLLM_ManagedVectorStore:
+    """
+    Return a copy of ``vector_store`` with credential-bearing fields
+    inside ``litellm_params`` replaced by the redaction sentinel.
+    """
+    redacted = LiteLLM_ManagedVectorStore(**vector_store)
+    redacted["litellm_params"] = _redact_sensitive_litellm_params(
+        vector_store.get("litellm_params")
+    )
+    return redacted
 
 
 def _resolve_embedding_config_from_router(
@@ -555,7 +619,7 @@ async def list_vector_stores(
         accessible_vector_stores = []
         for vs in vector_store_map.values():
             if await _check_vector_store_access(vs, user_api_key_dict):
-                accessible_vector_stores.append(vs)
+                accessible_vector_stores.append(_redact_vector_store(vs))
 
         total_count = len(accessible_vector_stores)
         total_pages = (total_count + page_size - 1) // page_size
@@ -716,7 +780,9 @@ async def get_vector_store_info(
                     created_at=vector_store.get("created_at") or None,
                     updated_at=vector_store.get("updated_at") or None,
                     litellm_credential_name=vector_store.get("litellm_credential_name"),
-                    litellm_params=vector_store.get("litellm_params") or None,
+                    litellm_params=_redact_sensitive_litellm_params(
+                        vector_store.get("litellm_params")
+                    ),
                     team_id=vector_store.get("team_id") or None,
                     user_id=vector_store.get("user_id") or None,
                 )
@@ -742,6 +808,10 @@ async def get_vector_store_info(
                 detail="Access denied: You do not have permission to access this vector store",
             )
 
+        if "litellm_params" in vector_store_dict:
+            vector_store_dict["litellm_params"] = _redact_sensitive_litellm_params(
+                vector_store_dict["litellm_params"]
+            )
         return {"vector_store": vector_store_dict}
     except Exception as e:
         verbose_proxy_logger.exception(f"Error getting vector store info: {str(e)}")

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -43,24 +43,41 @@ router = APIRouter()
 _LITELLM_PARAMS_MASKER = SensitiveDataMasker()
 
 
-def _redact_sensitive_litellm_params(
-    litellm_params: Optional[Dict[str, Any]],
-) -> Optional[Dict[str, Any]]:
+def _redact_sensitive_litellm_params(litellm_params: Any) -> Any:
     """
     Replace credential-bearing values in ``litellm_params`` with
     ``REDACTED_BY_LITELM`` while preserving non-secret keys (``api_base``,
     ``region``, ``model``, ``api_version``).
+
+    Handles three input shapes:
+
+    * ``dict`` — recurse into nested dicts (e.g. ``litellm_embedding_config``
+      which itself carries ``api_key`` / ``aws_*`` / ``vertex_credentials``).
+    * ``str`` — the in-memory registry occasionally holds the params as a
+      JSON-serialized string. Parse, redact, re-serialize. If parsing
+      fails, return the redaction sentinel rather than echo the value
+      back verbatim.
+    * Anything else, or ``None`` — passed through.
     """
-    if not litellm_params or not isinstance(litellm_params, dict):
+    if litellm_params is None:
+        return None
+    if isinstance(litellm_params, str):
+        try:
+            parsed = json.loads(litellm_params)
+        except (TypeError, ValueError):
+            return REDACTED_BY_LITELM_STRING
+        return json.dumps(_redact_sensitive_litellm_params(parsed))
+    if not isinstance(litellm_params, dict):
         return litellm_params
-    return {
-        k: (
-            REDACTED_BY_LITELM_STRING
-            if _LITELLM_PARAMS_MASKER.is_sensitive_key(k)
-            else v
-        )
-        for k, v in litellm_params.items()
-    }
+    out: Dict[str, Any] = {}
+    for k, v in litellm_params.items():
+        if _LITELLM_PARAMS_MASKER.is_sensitive_key(k):
+            out[k] = REDACTED_BY_LITELM_STRING
+        elif isinstance(v, dict):
+            out[k] = _redact_sensitive_litellm_params(v)
+        else:
+            out[k] = v
+    return out
 
 
 async def _fetch_and_authorize_vector_store(

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -46,6 +46,7 @@ IGNORE_FUNCTIONS = [
     "dict",  # max depth set. _LiteLLMParamsDictView.dict() calls builtin dict(), not itself.
     "_read_image_bytes",  # max depth set.
     "_get_masked_values",  # max depth set (default 20) to prevent infinite recursion while masking nested sensitive config dicts.
+    "_redact_sensitive_litellm_params",  # max depth set (default 10).
 ]
 
 

--- a/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
@@ -104,7 +104,9 @@ def test_remove_sensitive_info_from_deployment_with_excluded_keys():
     assert sanitized_config["litellm_params"]["access_token"] != "token-12345"
     assert "*" in sanitized_config["litellm_params"]["access_token"]
 
-    # With excluded_keys, litellm_credentials_name should NOT be masked (even if it would match patterns)
+    # With excluded_keys, litellm_credentials_name should NOT be masked.
+    # ``remove_sensitive_info_from_deployment`` mutates its input, so feed it
+    # a fresh copy rather than the already-sanitized one.
     sanitized_config = remove_sensitive_info_from_deployment(
         copy.deepcopy(base_config), excluded_keys={"litellm_credentials_name"}
     )

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -1951,6 +1951,78 @@ class TestRedactSensitiveLitellmParams:
         _redact_sensitive_litellm_params(original)
         assert original == snapshot, "input dict must not be mutated"
 
+    def test_redacts_nested_credentials_in_embedding_config(self):
+        """
+        ``/vector_store/new`` and ``/vector_store/update`` auto-resolve
+        ``litellm_embedding_config`` from the model registry and store it
+        as a nested dict inside ``litellm_params``. The nested dict carries
+        its own ``api_key`` / ``aws_*`` / ``vertex_credentials``, and a
+        non-recursive redactor would leak them.
+        """
+        from litellm.constants import REDACTED_BY_LITELM_STRING
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_sensitive_litellm_params,
+        )
+
+        params = {
+            "model": "openai/text-embedding-3-large",
+            "api_base": "https://api.openai.com/v1",
+            "litellm_embedding_config": {
+                "api_key": "sk-nested-secret",
+                "api_base": "https://nested.example.com",
+                "vertex_credentials": '{"private_key":"-----BEGIN..."}',
+            },
+        }
+        out = _redact_sensitive_litellm_params(params)
+        nested = out["litellm_embedding_config"]
+        assert nested["api_key"] == REDACTED_BY_LITELM_STRING
+        assert nested["vertex_credentials"] == REDACTED_BY_LITELM_STRING
+        assert nested["api_base"] == "https://nested.example.com"
+        # Top-level non-secrets preserved
+        assert out["api_base"] == "https://api.openai.com/v1"
+        assert out["model"] == "openai/text-embedding-3-large"
+
+    def test_redacts_json_string_litellm_params(self):
+        """
+        The in-memory registry occasionally holds ``litellm_params`` as a
+        JSON-serialized string rather than a dict. The redactor must parse,
+        redact, and re-serialize so callers don't get the raw string back.
+        """
+        import json as _json
+
+        from litellm.constants import REDACTED_BY_LITELM_STRING
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_sensitive_litellm_params,
+        )
+
+        params_json = _json.dumps(
+            {
+                "api_key": "sk-secret-from-json-string",
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+        out = _redact_sensitive_litellm_params(params_json)
+        assert isinstance(out, str)
+        parsed = _json.loads(out)
+        assert parsed["api_key"] == REDACTED_BY_LITELM_STRING
+        assert parsed["api_base"] == "https://api.openai.com/v1"
+
+    def test_redacts_unparseable_string_litellm_params(self):
+        """
+        If ``litellm_params`` is a string that isn't valid JSON, the
+        redactor must NOT echo the value back verbatim — it could contain
+        opaque credential material.
+        """
+        from litellm.constants import REDACTED_BY_LITELM_STRING
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_sensitive_litellm_params,
+        )
+
+        out = _redact_sensitive_litellm_params(
+            "this is not json but might contain a secret"
+        )
+        assert out == REDACTED_BY_LITELM_STRING
+
 
 class TestUpdateVectorStoreAccessControlAndRedaction:
     """

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -1938,23 +1938,15 @@ class TestRedactSensitiveLitellmParams:
         assert _redact_sensitive_litellm_params(None) is None
         assert _redact_sensitive_litellm_params({}) == {}
 
-    def test_redact_vector_store_does_not_mutate_input(self):
+    def test_redaction_does_not_mutate_input_litellm_params(self):
         from litellm.proxy.vector_store_endpoints.management_endpoints import (
-            _redact_vector_store,
+            _redact_sensitive_litellm_params,
         )
 
         original = {
-            "vector_store_id": "vs_abc123",
-            "vector_store_name": "prod-embeddings",
-            "litellm_params": {
-                "api_key": "sk-real-openai-key-12345",
-                "api_base": "https://api.openai.com/v1",
-            },
+            "api_key": "sk-real-openai-key-12345",
+            "api_base": "https://api.openai.com/v1",
         }
-        snapshot = {
-            "vector_store_id": original["vector_store_id"],
-            "vector_store_name": original["vector_store_name"],
-            "litellm_params": dict(original["litellm_params"]),
-        }
-        _redact_vector_store(original)
-        assert original == snapshot, "input vector store dict must not be mutated"
+        snapshot = dict(original)
+        _redact_sensitive_litellm_params(original)
+        assert original == snapshot, "input dict must not be mutated"

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -1950,3 +1950,134 @@ class TestRedactSensitiveLitellmParams:
         snapshot = dict(original)
         _redact_sensitive_litellm_params(original)
         assert original == snapshot, "input dict must not be mutated"
+
+
+class TestUpdateVectorStoreAccessControlAndRedaction:
+    """
+    ``/vector_store/update`` previously skipped per-store access control
+    (only the premium-feature gate ran), letting any authenticated
+    premium principal mutate *any* vector store. It also returned the
+    full DB row including ``litellm_params``, leaking provider
+    credentials to the caller. Both are fixed at the endpoint level.
+    """
+
+    @pytest.mark.asyncio
+    async def test_update_denied_when_caller_cannot_access_store(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            update_vector_store,
+        )
+        from litellm.types.vector_stores import VectorStoreUpdateRequest
+
+        existing_row = MagicMock()
+        existing_row.model_dump = MagicMock(
+            return_value={
+                "vector_store_id": "vs_other_team",
+                "team_id": "team-A",
+                "litellm_params": {"api_key": "sk-team-A-secret"},
+            }
+        )
+
+        mock_prisma_client = MagicMock()
+        mock_prisma_client.db.litellm_managedvectorstorestable.find_unique = AsyncMock(
+            return_value=existing_row
+        )
+
+        with (
+            patch(
+                "litellm.proxy.vector_store_endpoints.management_endpoints.check_feature_access_for_user",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.vector_store_endpoints.management_endpoints._check_vector_store_access",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_vector_store(
+                    data=VectorStoreUpdateRequest(
+                        vector_store_id="vs_other_team",
+                        vector_store_description="hijacked",
+                    ),
+                    user_api_key_dict=UserAPIKeyAuth(
+                        user_id="attacker", team_id="team-B"
+                    ),
+                )
+        assert exc_info.value.status_code == 403
+        # The attacker must NOT see the existing credential in the
+        # error message either.
+        assert "sk-team-A-secret" not in str(exc_info.value.detail)
+        # And the DB update must not have been called.
+        mock_prisma_client.db.litellm_managedvectorstorestable.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_response_redacts_litellm_params(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from litellm.constants import REDACTED_BY_LITELM_STRING
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            update_vector_store,
+        )
+        from litellm.types.vector_stores import VectorStoreUpdateRequest
+
+        existing_row = MagicMock()
+        existing_row.model_dump = MagicMock(
+            return_value={
+                "vector_store_id": "vs_owned",
+                "team_id": "team-A",
+                "litellm_params": {
+                    "api_key": "sk-real-openai-key-123",
+                    "api_base": "https://api.openai.com/v1",
+                },
+            }
+        )
+        updated_row = MagicMock()
+        updated_row.model_dump = MagicMock(
+            return_value={
+                "vector_store_id": "vs_owned",
+                "team_id": "team-A",
+                "vector_store_description": "new desc",
+                "litellm_params": {
+                    "api_key": "sk-real-openai-key-123",
+                    "api_base": "https://api.openai.com/v1",
+                },
+            }
+        )
+
+        mock_prisma_client = MagicMock()
+        mock_prisma_client.db.litellm_managedvectorstorestable.find_unique = AsyncMock(
+            return_value=existing_row
+        )
+        mock_prisma_client.db.litellm_managedvectorstorestable.update = AsyncMock(
+            return_value=updated_row
+        )
+
+        with (
+            patch(
+                "litellm.proxy.vector_store_endpoints.management_endpoints.check_feature_access_for_user",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.vector_store_endpoints.management_endpoints._check_vector_store_access",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.vector_store_registry", None),
+        ):
+            response = await update_vector_store(
+                data=VectorStoreUpdateRequest(
+                    vector_store_id="vs_owned",
+                    vector_store_description="new desc",
+                ),
+                user_api_key_dict=UserAPIKeyAuth(user_id="owner", team_id="team-A"),
+            )
+
+        params = response["vector_store"]["litellm_params"]
+        assert params["api_key"] == REDACTED_BY_LITELM_STRING
+        assert params["api_base"] == "https://api.openai.com/v1"

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -1882,3 +1882,79 @@ async def test_create_vector_store_in_db_raises_when_no_db():
 
     assert exc_info.value.status_code == 500
     assert "database not connected" in exc_info.value.detail.lower()
+
+
+class TestRedactSensitiveLitellmParams:
+    """
+    ``litellm_params`` on a managed vector store carries the upstream
+    provider credential (OpenAI ``api_key``, AWS ``aws_secret_access_key``,
+    GCP ``vertex_credentials``, etc.). The list/info endpoints must redact
+    those values before returning them to any caller — including read-only
+    users and narrowly-scoped keys.
+    """
+
+    def test_redacts_well_known_credential_keys(self):
+        from litellm.constants import REDACTED_BY_LITELM_STRING
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_sensitive_litellm_params,
+        )
+
+        params = {
+            "api_key": "sk-real-openai-key-12345",
+            "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+            "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "vertex_credentials": (
+                '{"type":"service_account","private_key":"-----BEGIN PRIVATE KEY-----..."}'
+            ),
+            "azure_authorization_token": "Bearer eyJhbGciOi...",
+        }
+        out = _redact_sensitive_litellm_params(params)
+        for k in params:
+            assert (
+                out[k] == REDACTED_BY_LITELM_STRING
+            ), f"{k} should be redacted, got {out[k]!r}"
+
+    def test_preserves_non_sensitive_keys(self):
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_sensitive_litellm_params,
+        )
+
+        params = {
+            "api_base": "https://api.openai.com/v1",
+            "model": "text-embedding-3-large",
+            "region": "us-east-1",
+            "vector_store_id": "vs_abc123",
+            "api_version": "2023-05-15",
+        }
+        out = _redact_sensitive_litellm_params(params)
+        for k, v in params.items():
+            assert out[k] == v, f"{k} should be preserved verbatim"
+
+    def test_handles_none_and_empty(self):
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_sensitive_litellm_params,
+        )
+
+        assert _redact_sensitive_litellm_params(None) is None
+        assert _redact_sensitive_litellm_params({}) == {}
+
+    def test_redact_vector_store_does_not_mutate_input(self):
+        from litellm.proxy.vector_store_endpoints.management_endpoints import (
+            _redact_vector_store,
+        )
+
+        original = {
+            "vector_store_id": "vs_abc123",
+            "vector_store_name": "prod-embeddings",
+            "litellm_params": {
+                "api_key": "sk-real-openai-key-12345",
+                "api_base": "https://api.openai.com/v1",
+            },
+        }
+        snapshot = {
+            "vector_store_id": original["vector_store_id"],
+            "vector_store_name": original["vector_store_name"],
+            "litellm_params": dict(original["litellm_params"]),
+        }
+        _redact_vector_store(original)
+        assert original == snapshot, "input vector store dict must not be mutated"


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory.
- [x] My PR passes all unit tests on `make test-unit`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

The vector-store management endpoints (\`/vector_store/list\`, \`/vector_store/info\`, \`/vector_store/update\`) returned the persisted \`litellm_params\` field verbatim — including admin-configured upstream credentials (Vertex / AWS / Azure keys). \`/vector_store/update\` had no per-store access check, so any authenticated caller could mutate any vector store's config.

This PR:

- Adds a recursive \`_redact_sensitive_litellm_params\` helper that replaces credential-bearing values in the persisted \`litellm_params\` with a redaction sentinel before returning them. Handles dicts, top-level JSON-string-serialized params, and nested-dict shapes (e.g. \`litellm_embedding_config\`).
- Gates \`/vector_store/update\` with \`_fetch_and_authorize_vector_store\` — the same per-store access check already present on \`/vector_store/info\`.
- Adds \`except HTTPException: raise\` guards in both \`get_vector_store_info\` and \`update_vector_store\` so 403 / 404 responses are no longer silently downgraded to 500 by the catch-all.
- Adds the plural \`"credentials"\` to \`SensitiveDataMasker\`'s default sensitive-pattern set so segment-exact matching catches \`vertex_credentials\`, \`aws_credentials\`, etc. (was a latent leak for every default-instantiated masker, not just the vector-store one).

**Files**

- Modified: \`litellm/proxy/vector_store_endpoints/management_endpoints.py\`, \`litellm/litellm_core_utils/sensitive_data_masker.py\`
- Tests: extensive regression coverage in \`tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py\` (redaction shapes, per-store access denial, nested credential bags); updates \`tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py\` and \`tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py\` for the broader masker change.