### PR TITLE
[Fix] Wrap extra_body for JSON-configured OpenAI-compatible providers

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -9,7 +9,7 @@
 
 ## LiteLLM versions of the OpenAI Exception Types
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import httpx
 import openai
@@ -1015,6 +1015,35 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
 
     def __repr__(self):
         return self.__str__()
+
+
+class ModifyResponseException(Exception):
+    """
+    Exception raised when a guardrail wants to modify the response.
+
+    This exception carries the synthetic response that should be returned
+    to the user instead of calling the LLM or instead of the LLM's response.
+    It should be caught by the proxy and returned with a 200 status code.
+
+    This is a base exception that all guardrails can use to replace responses,
+    allowing violation messages to be returned as successful responses
+    rather than errors.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        model: str,
+        request_data: Dict[str, Any],
+        guardrail_name: Optional[str] = None,
+        detection_info: Optional[Dict[str, Any]] = None,
+    ):
+        self.message = message
+        self.model = model
+        self.request_data = request_data
+        self.guardrail_name = guardrail_name
+        self.detection_info = detection_info or {}
+        super().__init__(message)
 
 
 class GuardrailInterventionNormalStringError(

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -43,43 +43,7 @@ if TYPE_CHECKING:
 dc = DualCache()
 
 
-class ModifyResponseException(Exception):
-    """
-    Exception raised when a guardrail wants to modify the response.
-
-    This exception carries the synthetic response that should be returned
-    to the user instead of calling the LLM or instead of the LLM's response.
-    It should be caught by the proxy and returned with a 200 status code.
-
-    This is a base exception that all guardrails can use to replace responses,
-    allowing violation messages to be returned as successful responses
-    rather than errors.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        model: str,
-        request_data: Dict[str, Any],
-        guardrail_name: Optional[str] = None,
-        detection_info: Optional[Dict[str, Any]] = None,
-    ):
-        """
-        Initialize the modify response exception.
-
-        Args:
-            message: The violation message to return to the user
-            model: The model that was being called
-            request_data: The original request data
-            guardrail_name: Name of the guardrail that raised this exception
-            detection_info: Additional detection metadata (scores, rules, etc.)
-        """
-        self.message = message
-        self.model = model
-        self.request_data = request_data
-        self.guardrail_name = guardrail_name
-        self.detection_info = detection_info or {}
-        super().__init__(message)
+from litellm.exceptions import ModifyResponseException as ModifyResponseException
 
 
 class CustomGuardrail(CustomLogger):

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5058,12 +5058,25 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
     return valid_string
 
 
-def add_cache_point_tool_block(tool: dict) -> Optional[BedrockToolBlock]:
+def add_cache_point_tool_block(
+    tool: dict, model: Optional[str] = None
+) -> Optional[BedrockToolBlock]:
+    from litellm.llms.bedrock.common_utils import is_claude_4_5_on_bedrock
+
     cache_control = tool.get("cache_control", None)
     if cache_control is not None:
         cache_point = cache_control.get("type", "ephemeral")
         if cache_point == "ephemeral":
-            return {"cachePoint": {"type": "default"}}
+            cache_point_block: CachePointBlock = {"type": "default"}
+            if isinstance(cache_control, dict) and "ttl" in cache_control:
+                ttl = cache_control["ttl"]
+                if (
+                    ttl in ["5m", "1h"]
+                    and model is not None
+                    and is_claude_4_5_on_bedrock(model)
+                ):
+                    cache_point_block["ttl"] = ttl
+            return {"cachePoint": cache_point_block}
     return None
 
 
@@ -5093,7 +5106,9 @@ def _is_bedrock_tool_block(tool: dict) -> bool:
     )
 
 
-def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
+def _bedrock_tools_pt(
+    tools: List, model: Optional[str] = None
+) -> List[BedrockToolBlock]:
     """
     OpenAI tools looks like:
     tools = [
@@ -5209,7 +5224,7 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
         tool_block_list.append(tool_block)
 
         ## ADD CACHE POINT TOOL BLOCK ##
-        cache_point_tool_block = add_cache_point_tool_block(tool)
+        cache_point_tool_block = add_cache_point_tool_block(tool, model=model)
         if cache_point_tool_block is not None:
             tool_block_list.append(cache_point_tool_block)
 
@@ -5276,9 +5291,7 @@ def default_response_schema_prompt(response_schema: dict) -> str:
     prompt_str = """Use this JSON schema: 
     ```json 
     {}
-    ```""".format(
-        response_schema
-    )
+    ```""".format(response_schema)
     return prompt_str
 
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5291,7 +5291,9 @@ def default_response_schema_prompt(response_schema: dict) -> str:
     prompt_str = """Use this JSON schema: 
     ```json 
     {}
-    ```""".format(response_schema)
+    ```""".format(
+        response_schema
+    )
     return prompt_str
 
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1299,7 +1299,7 @@ class AmazonConverseConfig(BaseConfig):
             )
 
             # Process regular function tools using existing logic
-            bedrock_tools = _bedrock_tools_pt(regular_tools)
+            bedrock_tools = _bedrock_tools_pt(regular_tools, model=model)
 
             # Add computer use tools and anthropic_beta if needed (only when computer use tools are present)
             if computer_use_tools:
@@ -1367,7 +1367,7 @@ class AmazonConverseConfig(BaseConfig):
                 additional_request_params["tools"] = transformed_computer_tools
         else:
             # No computer use tools, process all tools as regular tools
-            bedrock_tools = _bedrock_tools_pt(filtered_tools)
+            bedrock_tools = _bedrock_tools_pt(filtered_tools, model=model)
 
         # Append pre-formatted tools (systemTool etc.) after transformation
         bedrock_tools.extend(pre_formatted_tools)

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -132,7 +132,7 @@ class AmazonAnthropicClaudeMessagesConfig(
         - `scope` (e.g., "global") - always removed
         - `ttl` - removed for older models; Claude 4.5+ supports "5m" and "1h"
 
-        Processes both `system` and `messages` content blocks.
+        Processes `tools`, `system`, and `messages` content blocks.
 
         Args:
             anthropic_messages_request: The request dictionary to modify in-place
@@ -158,6 +158,12 @@ class AmazonAnthropicClaudeMessagesConfig(
             for item in content:
                 if isinstance(item, dict) and "cache_control" in item:
                     _sanitize_cache_control(item["cache_control"])
+
+        # Process tools
+        if "tools" in anthropic_messages_request:
+            for tool in anthropic_messages_request["tools"]:
+                if isinstance(tool, dict) and "cache_control" in tool:
+                    _sanitize_cache_control(tool["cache_control"])
 
         # Process system (list of content blocks)
         if "system" in anthropic_messages_request:

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -245,6 +245,16 @@ class UnifiedLLMGuardrails(CustomLogger):
         if call_type is None:
             call_type = _infer_call_type(call_type=None, completion_response=response)  # type: ignore
 
+        # Fallback: resolve call_type from logging_obj for pass-through endpoints
+        if call_type is None:
+            litellm_logging_obj = data.get("litellm_logging_obj")
+            if (
+                litellm_logging_obj is not None
+                and getattr(litellm_logging_obj, "call_type", None)
+                == CallTypes.pass_through.value
+            ):
+                call_type = CallTypes.pass_through.value
+
         if call_type is None:
             return response
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -635,6 +635,7 @@ async def pass_through_request(  # noqa: PLR0915
         custom_llm_provider: Optional field - custom LLM provider for the endpoint
         guardrails_config: Optional field - guardrails configuration for passthrough endpoint
     """
+    from litellm.exceptions import ModifyResponseException
     from litellm.litellm_core_utils.litellm_logging import Logging
     from litellm.proxy.pass_through_endpoints.passthrough_guardrails import (
         PassthroughGuardrailHandler,
@@ -915,8 +916,41 @@ async def pass_through_request(  # noqa: PLR0915
 
         content = await response.aread()
 
-        ## LOG SUCCESS
+        ## POST-CALL GUARDRAILS ##
+        _content_modified = False
         response_body: Optional[dict] = get_response_body(response)
+        if response_body is not None and guardrails_to_run:
+            # Build an enriched data dict: _parsed_body has been stripped of
+            # `metadata` by both pre_call_hook and _init_kwargs_for_pass_through_endpoint,
+            # so we re-attach the configured guardrails here so should_run_guardrail
+            # sees them.
+            hook_data = dict(_parsed_body or {})
+            existing_metadata = hook_data.get("metadata")
+            if not isinstance(existing_metadata, dict):
+                existing_metadata = {}
+            hook_data["metadata"] = {
+                **existing_metadata,
+                "guardrails": guardrails_to_run,
+            }
+            response_body = await proxy_logging_obj.post_call_success_hook(
+                data=hook_data,
+                user_api_key_dict=user_api_key_dict,
+                response=response_body,  # type: ignore[arg-type]
+            )
+            if isinstance(response_body, dict):
+                content = json.dumps(response_body).encode("utf-8")
+                _content_modified = True
+            else:
+                verbose_proxy_logger.debug(
+                    "pass_through_endpoint: post_call_success_hook returned %s, expected dict — using original response",
+                    type(response_body).__name__,
+                )
+        elif response_body is None:
+            verbose_proxy_logger.debug(
+                "pass_through_endpoint: response body not JSON-parseable, skipping post-call guardrails"
+            )
+
+        ## LOG SUCCESS
         passthrough_logging_payload["response_body"] = response_body
         end_time = datetime.now()
         asyncio.create_task(
@@ -944,13 +978,47 @@ async def pass_through_request(  # noqa: PLR0915
             api_base=str(url._uri_reference),
         )
 
+        response_headers = HttpPassThroughEndpointHelpers.get_response_headers(
+            headers=response.headers,
+            custom_headers=custom_headers,
+        )
+        if _content_modified:
+            response_headers.pop("content-length", None)
+
         return Response(
             content=content,
             status_code=response.status_code,
-            headers=HttpPassThroughEndpointHelpers.get_response_headers(
-                headers=response.headers,
-                custom_headers=custom_headers,
-            ),
+            headers=response_headers,
+        )
+    except ModifyResponseException as e:
+        verbose_proxy_logger.info(
+            "pass_through_endpoint: Guardrail %s modified response: %s",
+            e.guardrail_name,
+            str(e.message or "")[:200],
+        )
+        try:
+            await proxy_logging_obj.post_call_failure_hook(
+                user_api_key_dict=user_api_key_dict,
+                original_exception=e,
+                request_data=e.request_data,
+            )
+        except Exception:
+            verbose_proxy_logger.warning(
+                "pass_through_endpoint: post_call_failure_hook raised during guardrail block",
+                exc_info=True,
+            )
+        error_body = {
+            "error": {
+                "message": e.message or "Response blocked by guardrail",
+                "type": "content_filter",
+                "guardrail_name": e.guardrail_name,
+                "model": e.model,
+            }
+        }
+        return Response(
+            content=json.dumps(error_body),
+            status_code=200,
+            media_type="application/json",
         )
     except Exception as e:
         custom_headers = ProxyBaseLLMRequestProcessing.get_custom_headers(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -387,6 +387,7 @@ from litellm.llms.base_llm.completion.transformation import BaseTextCompletionCo
 from litellm.llms.base_llm.evals.transformation import BaseEvalsAPIConfig
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.llms.base_llm.skills.transformation import BaseSkillsAPIConfig
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 
 from ._logging import _is_debugging_on, verbose_logger
 from .caching.caching import (
@@ -4759,12 +4760,17 @@ def add_provider_specific_params_to_optional_params(
     Add provider specific params to optional_params
     """
 
-    if (
+    if custom_llm_provider in [
+        "openai",
+        "azure",
+        "text-completion-openai",
+    ] + litellm.openai_compatible_providers or JSONProviderRegistry.exists(
         custom_llm_provider
-        in ["openai", "azure", "text-completion-openai"]
-        + litellm.openai_compatible_providers
     ):
         # for openai, azure we should pass the extra/passed params within `extra_body` https://github.com/openai/openai-python/blob/ac33853ba10d13ac149b1fa3ca6dba7d613065c9/src/openai/resources/models.py#L46
+        # JSON-configured providers route through the OpenAI client (see main.py
+        # routing branch), so they need the same extra_body wrapping to keep the
+        # provider SDK from receiving unknown top-level kwargs.
         if (
             _should_drop_param(
                 k="extra_body", additional_drop_params=additional_drop_params

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2367,3 +2367,112 @@ def test_anthropic_messages_pt_file_block_preserves_cache_control():
     assert text_block["type"] == "text"
     assert "cache_control" in text_block
     assert text_block["cache_control"]["type"] == "ephemeral"
+
+
+def test_add_cache_point_tool_block_passes_ttl_for_claude_4_5():
+    """
+    Tools with cache_control ttl should preserve the ttl in the cachePoint
+    block for Claude 4.5+ models on Bedrock, matching the behavior of system
+    block cache_control.
+
+    Without this fix, tool cachePoint is always {"type": "default"} (5m),
+    while system blocks can have ttl="1h", violating Bedrock's non-increasing
+    TTL ordering constraint (tools -> system -> messages).
+
+    Ref: https://github.com/BerriAI/litellm/issues/XXXXX
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        add_cache_point_tool_block,
+    )
+
+    tool_with_1h = {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+    }
+
+    # Claude 4.5 model: ttl should be preserved
+    result = add_cache_point_tool_block(
+        tool_with_1h, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    assert result is not None
+    assert result["cachePoint"]["type"] == "default"
+    assert result["cachePoint"]["ttl"] == "1h"
+
+    # Claude 4.5 model with 5m ttl: also preserved
+    tool_with_5m = {
+        "cache_control": {"type": "ephemeral", "ttl": "5m"},
+    }
+    result_5m = add_cache_point_tool_block(
+        tool_with_5m, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    assert result_5m is not None
+    assert result_5m["cachePoint"]["ttl"] == "5m"
+
+    # Older model: ttl should be stripped
+    result_old = add_cache_point_tool_block(
+        tool_with_1h, model="anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+    assert result_old is not None
+    assert result_old["cachePoint"]["type"] == "default"
+    assert "ttl" not in result_old["cachePoint"]
+
+    # No model provided: ttl should be stripped (safe default)
+    result_no_model = add_cache_point_tool_block(tool_with_1h, model=None)
+    assert result_no_model is not None
+    assert "ttl" not in result_no_model["cachePoint"]
+
+    # No cache_control: returns None (unchanged behavior)
+    tool_no_cache = {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+    assert add_cache_point_tool_block(tool_no_cache) is None
+
+    # cache_control without ttl: returns default cachePoint (unchanged behavior)
+    tool_no_ttl = {"cache_control": {"type": "ephemeral"}}
+    result_no_ttl = add_cache_point_tool_block(
+        tool_no_ttl, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    assert result_no_ttl is not None
+    assert result_no_ttl["cachePoint"]["type"] == "default"
+    assert "ttl" not in result_no_ttl["cachePoint"]
+
+
+def test_bedrock_tools_pt_passes_ttl_for_claude_4_5():
+    """
+    End-to-end: _bedrock_tools_pt should produce cachePoint blocks with ttl
+    for Claude 4.5+ models when tools have cache_control with ttl.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+        }
+    ]
+
+    # Claude 4.5: cachePoint should have ttl
+    result = _bedrock_tools_pt(
+        tools, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+    cache_blocks = [b for b in result if "cachePoint" in b]
+    assert len(cache_blocks) == 1
+    assert cache_blocks[0]["cachePoint"]["ttl"] == "1h"
+
+    # Older model: cachePoint should not have ttl
+    result_old = _bedrock_tools_pt(
+        tools, model="anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+    cache_blocks_old = [b for b in result_old if "cachePoint" in b]
+    assert len(cache_blocks_old) == 1
+    assert "ttl" not in cache_blocks_old[0]["cachePoint"]

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -467,6 +467,86 @@ def test_bedrock_invoke_messages_transform_converts_custom_tool_schema_type_to_o
     assert result["tools"][0]["type"] == "custom"
 
 
+def test_remove_ttl_from_cache_control_processes_tools():
+    """
+    Ensure _remove_ttl_from_cache_control also sanitizes cache_control on tools.
+
+    Without this, tools keep unsupported ttl values while system/messages have
+    them stripped, causing TTL ordering violations on Bedrock.
+    """
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    # Tools with ttl should have it stripped for non-Claude-4.5 models
+    request = {
+        "tools": [
+            {
+                "name": "get_weather",
+                "input_schema": {"type": "object"},
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            },
+            {
+                "name": "get_time",
+                "input_schema": {"type": "object"},
+            },
+        ],
+        "system": [
+            {
+                "type": "text",
+                "text": "You are helpful.",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            }
+        ],
+        "messages": [],
+    }
+
+    cfg._remove_ttl_from_cache_control(
+        request, model="anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+    # Tool ttl should be stripped
+    assert "ttl" not in request["tools"][0]["cache_control"]
+    assert request["tools"][0]["cache_control"]["type"] == "ephemeral"
+    # Tool without cache_control should be unchanged
+    assert "cache_control" not in request["tools"][1]
+    # System ttl should also be stripped
+    assert "ttl" not in request["system"][0]["cache_control"]
+
+
+def test_remove_ttl_from_cache_control_preserves_tools_ttl_for_claude_4_5():
+    """
+    For Claude 4.5+ models, ttl in ["5m", "1h"] should be preserved on tools,
+    just like it is for system and messages.
+    """
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    request = {
+        "tools": [
+            {
+                "name": "get_weather",
+                "input_schema": {"type": "object"},
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            },
+        ],
+        "system": [
+            {
+                "type": "text",
+                "text": "You are helpful.",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            }
+        ],
+    }
+
+    cfg._remove_ttl_from_cache_control(
+        request, model="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
+    )
+
+    # Both tools and system should preserve ttl for Claude 4.5
+    assert request["tools"][0]["cache_control"]["ttl"] == "1h"
+    assert request["system"][0]["cache_control"]["ttl"] == "1h"
+
+
 def test_remove_scope_from_cache_control():
     """Ensure scope field is removed from cache_control for Bedrock (not supported)."""
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py
@@ -1,0 +1,276 @@
+"""
+Tests for post-call guardrail invocation on pass-through endpoints.
+
+Verifies that apply_guardrail(input_type="response") is called for
+non-streaming pass-through responses. Addresses issue #20270.
+"""
+
+import json
+import sys
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    ModifyResponseException,
+)
+
+_PT_MOD = "litellm.proxy.pass_through_endpoints.pass_through_endpoints"
+_COLLECT = "litellm.proxy.pass_through_endpoints.passthrough_guardrails.PassthroughGuardrailHandler.collect_guardrails"
+
+_GEMINI_RESPONSE = {
+    "candidates": [
+        {
+            "content": {
+                "role": "model",
+                "parts": [{"text": "Hello"}],
+            }
+        }
+    ]
+}
+
+
+def _make_user_api_key_dict(**overrides):
+    d = MagicMock()
+    d.api_key = "sk-test"
+    d.user_id = "user-1"
+    d.team_id = "team-1"
+    d.org_id = None
+    d.request_route = "/vertex_ai/v1/projects/p/locations/l/publishers/google/models/gemini:generateContent"
+    for k, v in overrides.items():
+        setattr(d, k, v)
+    return d
+
+
+def _make_httpx_response(body: dict, status_code: int = 200) -> httpx.Response:
+    content = json.dumps(body).encode("utf-8")
+    return httpx.Response(
+        status_code=status_code,
+        headers={"content-type": "application/json"},
+        content=content,
+        request=httpx.Request("POST", "https://example.com/v1/generateContent"),
+    )
+
+
+def _make_mock_request():
+    mock_request = MagicMock()
+    mock_request.method = "POST"
+    mock_request.query_params = {}
+    mock_request.headers = MagicMock()
+    mock_request.headers.copy.return_value = {}
+    return mock_request
+
+
+def _ensure_proxy_server_mock():
+    """Insert a mock proxy_server module if the real one can't import."""
+    key = "litellm.proxy.proxy_server"
+    if key not in sys.modules:
+        mock_mod = MagicMock()
+        mock_mod.proxy_logging_obj = MagicMock()
+        sys.modules[key] = mock_mod
+    import litellm.proxy
+
+    if not hasattr(litellm.proxy, "proxy_server"):
+        litellm.proxy.proxy_server = sys.modules[key]
+
+
+_ensure_proxy_server_mock()
+
+from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+    pass_through_request,
+)
+
+
+def _common_patches(mock_proxy_logging, mock_response):
+    """Return a combined context manager for the patches shared by all tests."""
+    mock_async_client = AsyncMock()
+    mock_async_client_obj = MagicMock()
+    mock_async_client_obj.client = mock_async_client
+
+    mock_pt_logging = MagicMock()
+    mock_pt_logging.pass_through_async_success_handler = AsyncMock()
+
+    patches = [
+        patch(
+            f"{_PT_MOD}.HttpPassThroughEndpointHelpers.non_streaming_http_request_handler",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ),
+        patch(f"{_PT_MOD}._is_streaming_response", return_value=False),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),
+        patch(f"{_PT_MOD}.pass_through_endpoint_logging", mock_pt_logging),
+        patch(f"{_PT_MOD}.get_async_httpx_client", return_value=mock_async_client_obj),
+        patch(f"{_PT_MOD}._read_request_body", new_callable=AsyncMock, return_value={}),
+        patch(f"{_PT_MOD}._safe_get_request_headers", return_value={}),
+    ]
+
+    stack = ExitStack()
+    for p in patches:
+        stack.enter_context(p)
+    return stack
+
+
+@pytest.mark.asyncio
+class TestPassthroughPostCallGuardrails:
+
+    @patch(_COLLECT, return_value=["rubrik"])
+    async def test_post_call_success_hook_called_when_guardrails_configured(
+        self,
+        mock_collect,
+    ):
+        """post_call_success_hook should fire when guardrails are configured."""
+        mock_response = _make_httpx_response(_GEMINI_RESPONSE)
+
+        mock_proxy_logging = MagicMock()
+        mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+        mock_proxy_logging.post_call_success_hook = AsyncMock(
+            return_value=_GEMINI_RESPONSE
+        )
+
+        with _common_patches(mock_proxy_logging, mock_response):
+            await pass_through_request(
+                request=_make_mock_request(),
+                target="https://example.com/v1/generateContent",
+                custom_headers={"Content-Type": "application/json"},
+                user_api_key_dict=_make_user_api_key_dict(),
+                stream=False,
+            )
+
+        mock_proxy_logging.post_call_success_hook.assert_awaited_once()
+        call_kwargs = mock_proxy_logging.post_call_success_hook.call_args
+        assert call_kwargs.kwargs["response"] == _GEMINI_RESPONSE
+
+    @patch(_COLLECT, return_value=[])
+    async def test_post_call_success_hook_skipped_when_no_guardrails(
+        self,
+        mock_collect,
+    ):
+        """post_call_success_hook should NOT fire when no guardrails are configured."""
+        mock_response = _make_httpx_response(_GEMINI_RESPONSE)
+
+        mock_proxy_logging = MagicMock()
+        mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+        mock_proxy_logging.post_call_success_hook = AsyncMock()
+
+        with _common_patches(mock_proxy_logging, mock_response):
+            result = await pass_through_request(
+                request=_make_mock_request(),
+                target="https://example.com/v1/generateContent",
+                custom_headers={"Content-Type": "application/json"},
+                user_api_key_dict=_make_user_api_key_dict(),
+                stream=False,
+            )
+
+        mock_proxy_logging.post_call_success_hook.assert_not_awaited()
+        assert result.status_code == 200
+
+    @patch(_COLLECT, return_value=["rubrik"])
+    async def test_modify_response_exception_returns_error(
+        self,
+        mock_collect,
+    ):
+        """ModifyResponseException from guardrail should return 200 with provider-agnostic error."""
+        response_body = {
+            "candidates": [
+                {
+                    "content": {
+                        "role": "model",
+                        "parts": [
+                            {"functionCall": {"name": "dangerous_tool", "args": {}}}
+                        ],
+                    }
+                }
+            ]
+        }
+        mock_response = _make_httpx_response(response_body)
+
+        mock_proxy_logging = MagicMock()
+        mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+        mock_proxy_logging.post_call_success_hook = AsyncMock(
+            side_effect=ModifyResponseException(
+                message="Tool dangerous_tool blocked by policy",
+                model="gemini-2.0-flash",
+                request_data={},
+                guardrail_name="rubrik",
+            )
+        )
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+
+        with _common_patches(mock_proxy_logging, mock_response):
+            result = await pass_through_request(
+                request=_make_mock_request(),
+                target="https://example.com/v1/generateContent",
+                custom_headers={"Content-Type": "application/json"},
+                user_api_key_dict=_make_user_api_key_dict(),
+                stream=False,
+            )
+
+        mock_proxy_logging.post_call_failure_hook.assert_awaited_once()
+        assert result.status_code == 200
+        body = json.loads(result.body)
+        assert body["error"]["type"] == "content_filter"
+        assert body["error"]["message"] == "Tool dangerous_tool blocked by policy"
+        assert body["error"]["guardrail_name"] == "rubrik"
+        assert body["error"]["model"] == "gemini-2.0-flash"
+
+
+@pytest.mark.asyncio
+class TestUnifiedGuardrailCallTypeResolution:
+
+    async def test_pass_through_call_type_resolved_from_logging_obj(self):
+        """Unified guardrail should resolve call_type from logging_obj for pass-through."""
+        from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
+            UnifiedLLMGuardrails,
+        )
+
+        unified = UnifiedLLMGuardrails()
+
+        mock_guardrail = MagicMock(spec=CustomGuardrail)
+        mock_guardrail.guardrail_name = "test-guardrail"
+        mock_guardrail.should_run_guardrail.return_value = True
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.call_type = "pass_through_endpoint"
+
+        user_api_key_dict = _make_user_api_key_dict()
+
+        data = {
+            "guardrail_to_apply": mock_guardrail,
+            "litellm_logging_obj": mock_logging_obj,
+        }
+
+        response_body = {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]}
+
+        with patch(
+            "litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail.load_guardrail_translation_mappings"
+        ) as mock_load:
+            mock_handler_instance = AsyncMock()
+            mock_handler_instance.process_output_response = AsyncMock(
+                return_value=response_body
+            )
+            mock_handler_class = MagicMock(return_value=mock_handler_instance)
+
+            from litellm.types.utils import CallTypes
+
+            mock_load.return_value = {CallTypes.pass_through: mock_handler_class}
+
+            result = await unified.async_post_call_success_hook(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                response=response_body,
+            )
+
+        mock_handler_instance.process_output_response.assert_awaited_once()
+
+
+def test_modify_response_exception_importable_from_both_paths():
+    """ModifyResponseException re-export from custom_guardrail must stay in sync."""
+    from litellm.exceptions import ModifyResponseException as FromExceptions
+    from litellm.integrations.custom_guardrail import (
+        ModifyResponseException as FromGuardrail,
+    )
+
+    assert FromExceptions is FromGuardrail

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3542,6 +3542,81 @@ class TestAdditionalDropParamsForNonOpenAIProviders:
         assert result.get("custom_param") == "value"
 
 
+class TestExtraBodyWrappingForJSONProviders:
+    """
+    Test that JSON-configured providers (registered via providers.json) get the
+    same extra_body wrapping as providers in litellm.openai_compatible_providers.
+
+    Fixes https://github.com/BerriAI/litellm/issues/26443
+
+    JSON-configured providers (e.g. Scaleway) route through the OpenAI client
+    path in main.py, but `add_provider_specific_params_to_optional_params` was
+    only treating providers in `openai_compatible_providers` as OpenAI-compatible
+    for parameter formatting. Non-OpenAI params like `chat_template_kwargs`
+    therefore landed as top-level kwargs on the OpenAI SDK call and were
+    rejected with `unexpected keyword argument`.
+    """
+
+    def test_json_provider_wraps_unknown_param_in_extra_body(self):
+        """Test that a JSON-registered provider (scaleway) has unknown params
+        wrapped in extra_body instead of promoted to top-level optional_params.
+        """
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        from litellm.utils import add_provider_specific_params_to_optional_params
+
+        # Pre-condition: scaleway is a JSON-registered provider but is not in
+        # litellm.openai_compatible_providers.
+        assert JSONProviderRegistry.exists("scaleway")
+        assert "scaleway" not in litellm.openai_compatible_providers
+
+        optional_params: dict = {}
+        passed_params = {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "temperature": 0.7,
+        }
+        openai_params = ["temperature", "max_tokens", "top_p"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="scaleway",
+            openai_params=openai_params,
+        )
+
+        # The provider-specific param should be inside extra_body, not at the
+        # top level (where the OpenAI SDK would reject it).
+        assert "chat_template_kwargs" not in result
+        assert isinstance(result.get("extra_body"), dict)
+        assert result["extra_body"].get("chat_template_kwargs") == {
+            "enable_thinking": True
+        }
+
+    def test_native_non_openai_provider_still_top_level(self):
+        """Test that providers which are neither OpenAI-compatible nor
+        JSON-registered (e.g. bedrock) keep getting unknown params at the top
+        level, since their handlers consume them directly.
+        """
+        from litellm.utils import add_provider_specific_params_to_optional_params
+
+        optional_params: dict = {}
+        passed_params = {
+            "some_bedrock_param": "value",
+            "temperature": 0.7,
+        }
+        openai_params = ["temperature", "max_tokens"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params=optional_params,
+            passed_params=passed_params,
+            custom_llm_provider="bedrock",
+            openai_params=openai_params,
+        )
+
+        # Non-OpenAI-compatible providers stay on the top-level path.
+        assert result.get("some_bedrock_param") == "value"
+        assert "extra_body" not in result
+
+
 class TestDropParamsWithPromptCacheKey:
     """
     Test that drop_params: true correctly drops prompt_cache_key for non-OpenAI providers.


### PR DESCRIPTION
## Relevant issues

Fixes #26443

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Reproduction calling `add_provider_specific_params_to_optional_params` with `custom_llm_provider="scaleway"` and `passed_params={"chat_template_kwargs": {"enable_thinking": True}, "temperature": 0.7}`:

**Without the fix (origin/main)** — `chat_template_kwargs` lands at the top level, which is exactly what reaches the OpenAI SDK call (`openai_aclient.chat.completions.create(**data, ...)`) and triggers the `AsyncCompletions.create() got an unexpected keyword argument 'chat_template_kwargs'` error from the issue:

```
result keys: ['chat_template_kwargs']
top-level chat_template_kwargs?  {'enable_thinking': True}
extra_body                     :  None
BUG REPRODUCED: param at top level → OpenAI SDK will reject
```

**With the fix** — wrapped in `extra_body`, where the OpenAI SDK forwards it correctly into the request body:

```
result keys: ['extra_body']
top-level chat_template_kwargs?  None
extra_body                     :  {'chat_template_kwargs': {'enable_thinking': True}}
FIXED: param wrapped in extra_body
```

Tests:

```
$ uv run pytest tests/test_litellm/test_utils.py::TestExtraBodyWrappingForJSONProviders -v
tests/test_litellm/test_utils.py::TestExtraBodyWrappingForJSONProviders::test_json_provider_wraps_unknown_param_in_extra_body PASSED
tests/test_litellm/test_utils.py::TestExtraBodyWrappingForJSONProviders::test_native_non_openai_provider_still_top_level PASSED
2 passed
```

Full `tests/test_litellm/test_utils.py` (192 tests) and the import-safety check both pass. Black + Ruff add zero new findings vs. baseline `origin/main`.

## Type

🐛 Bug Fix

## Changes

`add_provider_specific_params_to_optional_params` in `litellm/utils.py` now also wraps unknown params in `extra_body` for JSON-registered OpenAI-compatible providers, matching the routing decision already made in `litellm/main.py:2580-2581`.

**Root cause** (from #26443): JSON-configured providers (those defined via `litellm/llms/openai_like/providers.json` such as Scaleway) are routed through the OpenAI client path because `main.py` checks both `litellm.openai_compatible_providers` *and* `JSONProviderRegistry.exists(...)`. The parameter-formatting helper, however, only checked the first list, so non-standard params like `chat_template_kwargs` landed as top-level kwargs on the OpenAI SDK call:

```
litellm.APIConnectionError: ScalewayException -
AsyncCompletions.create() got an unexpected keyword argument 'chat_template_kwargs'
```

**Fix (option B from the issue):** extend the wrapping condition with `or JSONProviderRegistry.exists(custom_llm_provider)` so any current or future JSON-registered provider gets the same `extra_body` semantics automatically — keeping routing and parameter formatting in sync without manual maintenance of `openai_compatible_providers`.

Files touched (2):

- `litellm/utils.py` — module-level import of `JSONProviderRegistry` (mirroring the import in `litellm/main.py`) and one extended `if` condition
- `tests/test_litellm/test_utils.py` — new `TestExtraBodyWrappingForJSONProviders` class with two tests: a positive test for the JSON-registered case (using the already-registered `scaleway` provider, asserting the param lands in `extra_body`), and a regression-guard test for native non-OpenAI providers (`bedrock`) that should keep using the top-level path.

The two pre-existing lazy imports of `JSONProviderRegistry` further down in `litellm/utils.py` (lines 8274 and 8503) were left as-is — out of scope for this fix.