### PR TITLE
[Fix] bind RAG ingestion config to stored credential values

### DIFF
--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -71,7 +71,10 @@ class BaseRAGIngestion(ABC):
         Load credentials from litellm_credential_name if provided in vector_store config.
 
         This allows users to specify a credential name in the vector_store config
-        which will be resolved from litellm.credential_list.
+        which will be resolved from litellm.credential_list. When a stored
+        credential is used, its values take precedence over caller-supplied
+        equivalents so the api_key / api_base pair stays consistent with the
+        credential definition.
         """
         from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 
@@ -80,10 +83,13 @@ class BaseRAGIngestion(ABC):
             credential_values = CredentialAccessor.get_credential_values(
                 credential_name
             )
-            # Merge credentials into vector_store_config (don't overwrite existing values)
             for key, value in credential_values.items():
-                if key not in self.vector_store_config:
-                    self.vector_store_config[key] = value
+                self.vector_store_config[key] = value
+            if (
+                "api_base" in self.vector_store_config
+                and "api_base" not in credential_values
+            ):
+                del self.vector_store_config["api_base"]
 
     @property
     def custom_llm_provider(self) -> str:

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -83,6 +83,8 @@ class BaseRAGIngestion(ABC):
             credential_values = CredentialAccessor.get_credential_values(
                 credential_name
             )
+            if not credential_values:
+                return
             for key, value in credential_values.items():
                 self.vector_store_config[key] = value
             if (


### PR DESCRIPTION
## Relevant issues

## Summary

When `ingest_options.vector_store` references a stored credential by name
via `litellm_credential_name`, the resolved config now binds `api_key` and
`api_base` to the credential definition rather than allowing per-call
overrides on those fields.

### Before

`_load_credentials_from_config()` only filled keys that were missing from
the caller's `vector_store_config`. A caller could set `api_base` in the
request alongside `litellm_credential_name`, and the credential's `api_key`
would then be paired with the caller-chosen `api_base` for the outbound
request.

### Fix

Credential values now overwrite caller-supplied entries on the same keys,
and `api_base` is removed from the resolved config when the credential
does not define one. After this change, the routing target for a stored
credential is the credential's own `api_base` (or the provider default if
the credential leaves it unset).

## Testing

- `uv run pytest tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py -v` — 3 passed
- `uv run pytest tests/test_litellm/vector_stores/test_vector_store_registry.py tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py -v` — 48 passed
- Manual API verification against the proxy (three scenarios):
  1. Stored credential without `api_base` + caller-supplied `api_base` — request no longer routes to the caller-supplied URL.
  2. Stored credential that includes its own `api_base` — request routes to the credential's `api_base` (unchanged).
  3. No stored credential, caller supplies `api_key` + `api_base` directly — request routes to the caller's URL with the caller's key (unchanged).

## Type

🐛 Bug Fix

## Screenshots