### PR TITLE
[Fix] Harden /model/info redaction for plural credential field names

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -21,6 +21,7 @@ class SensitiveDataMasker:
             "auth",
             "authorization",
             "credential",
+            "credentials",
             "access",
             "private",
             "certificate",

--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -29,6 +29,7 @@ def remove_sensitive_info_from_deployment(
     deployment_dict["litellm_params"].pop("api_key", None)
     deployment_dict["litellm_params"].pop("client_secret", None)
     deployment_dict["litellm_params"].pop("vertex_credentials", None)
+    deployment_dict["litellm_params"].pop("vertex_ai_credentials", None)
     deployment_dict["litellm_params"].pop("aws_access_key_id", None)
     deployment_dict["litellm_params"].pop("aws_secret_access_key", None)
 

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -65,12 +65,13 @@ def test_excluded_keys_exact_match():
     # Non-sensitive keys should remain unchanged
     assert masked["port"] == 6379
 
-    # Test case sensitivity - excluded_keys should be exact match
+    # Test case sensitivity - excluded_keys should be exact match. Supplying an
+    # uppercase variant must NOT exclude the lowercase key, so the field falls
+    # back to pattern matching ("credentials" is in the sensitive pattern set)
+    # and is masked.
     masked = masker.mask_dict(data, excluded_keys={"LITELLM_CREDENTIALS_NAME"})
-    # Should still be masked because case doesn't match (exact match required)
-    assert (
-        masked["litellm_credentials_name"] == "my-credential-name"
-    )  # Not masked because it doesn't match patterns anyway
+    assert masked["litellm_credentials_name"] != "my-credential-name"
+    assert "*" in masked["litellm_credentials_name"]
 
     # Test with api_key in excluded_keys to verify it works for keys that would be masked
     masked = masker.mask_dict(data, excluded_keys={"api_key"})

--- a/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 from litellm.proxy.common_utils.openai_endpoint_utils import (
@@ -86,7 +88,7 @@ def test_remove_sensitive_info_from_deployment_with_excluded_keys():
     """
     Test that excluded_keys prevents masking of specific keys (exact match).
     """
-    model_config = {
+    base_config = {
         "model_name": "test-model",
         "litellm_params": {
             "model": "openai/gpt-4",
@@ -98,13 +100,13 @@ def test_remove_sensitive_info_from_deployment_with_excluded_keys():
     }
 
     # Without excluded_keys, access_token should be masked (contains "token")
-    sanitized_config = remove_sensitive_info_from_deployment(model_config)
+    sanitized_config = remove_sensitive_info_from_deployment(copy.deepcopy(base_config))
     assert sanitized_config["litellm_params"]["access_token"] != "token-12345"
     assert "*" in sanitized_config["litellm_params"]["access_token"]
 
     # With excluded_keys, litellm_credentials_name should NOT be masked (even if it would match patterns)
     sanitized_config = remove_sensitive_info_from_deployment(
-        model_config, excluded_keys={"litellm_credentials_name"}
+        copy.deepcopy(base_config), excluded_keys={"litellm_credentials_name"}
     )
     assert (
         sanitized_config["litellm_params"]["litellm_credentials_name"]


### PR DESCRIPTION
## Relevant issues

## Summary

### Failure Path (Before Fix)

`/model/info` returns deployment configuration with sensitive fields stripped via two layers: an explicit pop list in `remove_sensitive_info_from_deployment` and a dynamic `SensitiveDataMasker` for anything not popped. The newer `vertex_ai_credentials` deployment field passes through both layers untouched — it isn't on the pop list (only the legacy `vertex_credentials` name is), and the masker's pattern set lists `"credential"` (singular) while the field's segments split to `["vertex","ai","credentials"]` (plural), so neither matches.

### Fix

- Pop `vertex_ai_credentials` alongside the existing `vertex_credentials` pop in `remove_sensitive_info_from_deployment`.
- Add `"credentials"` (plural) to the masker's sensitive-pattern set so other plural-named credential fields are also covered going forward.
- Update two unit tests that depended on the old behavior:
  - `test_excluded_keys_exact_match` — case-mismatched `excluded_keys` now correctly falls through to pattern matching, which masks the field.
  - `test_remove_sensitive_info_from_deployment_with_excluded_keys` — deepcopy the input dict between back-to-back helper calls so the second call doesn't see the first call's mutated state.

## Testing

- `uv run pytest tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py -v` — 10 passed.
- Manual `/model/info` checks against a local proxy with a vertex_ai deployment carrying a `vertex_ai_credentials` payload: pre-fix the credentials dict was returned in the response (with only the inner `private_key` partially masked); post-fix the entire `vertex_ai_credentials` field is absent.

## Type

🐛 Bug Fix
✅ Test