### PR TITLE
chore(auth): tighten clientside api_base handling

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 
 import litellm
 from litellm.constants import REPLICATE_MODEL_NAME_WITH_ID_LENGTH
@@ -6,6 +7,43 @@ from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.secret_managers.main import get_secret, get_secret_str
 
 from ..types.router import LiteLLM_Params
+
+
+def _endpoint_matches_api_base(endpoint: str, api_base: str) -> bool:
+    """
+    Match a registered openai-compatible endpoint against a caller-supplied
+    ``api_base`` using parsed-URL semantics, not unanchored substring search.
+
+    Both inputs may be a bare hostname (``api.perplexity.ai``), host+path
+    (``api.deepinfra.com/v1/openai``), or a full URL
+    (``https://api.cerebras.ai/v1``). Hostnames must match exactly
+    (case-insensitive); if the registered endpoint has a non-trivial path,
+    the api_base path must start with it on a segment boundary.
+
+    The naive ``endpoint in api_base`` shape lets a caller pass
+    ``https://attacker.com/api.groq.com/openai/v1`` to coerce the proxy
+    into reading the server's GROQ_API_KEY from the environment and
+    forwarding it to the attacker's host as a Bearer credential.
+    """
+
+    def _parse(value: str):
+        # Ensure urlparse sees a scheme so it populates hostname / path.
+        normalized = value if "://" in value else f"https://{value}"
+        return urlparse(normalized)
+
+    parsed_endpoint = _parse(endpoint)
+    parsed_url = _parse(api_base)
+
+    endpoint_host = (parsed_endpoint.hostname or "").lower()
+    url_host = (parsed_url.hostname or "").lower()
+    if not endpoint_host or endpoint_host != url_host:
+        return False
+
+    endpoint_path = parsed_endpoint.path.rstrip("/")
+    if not endpoint_path:
+        return True
+    url_path = parsed_url.path.rstrip("/")
+    return url_path == endpoint_path or url_path.startswith(endpoint_path + "/")
 
 
 def _is_non_openai_azure_model(model: str) -> bool:
@@ -210,7 +248,7 @@ def get_llm_provider(  # noqa: PLR0915
         # check if api base is a known openai compatible endpoint
         if api_base:
             for endpoint in litellm.openai_compatible_endpoints:
-                if endpoint in api_base:
+                if _endpoint_matches_api_base(endpoint, api_base):
                     if endpoint == "api.perplexity.ai":
                         custom_llm_provider = "perplexity"
                         dynamic_api_key = get_secret_str("PERPLEXITYAI_API_KEY")

--- a/litellm/llms/vertex_ai/batches/handler.py
+++ b/litellm/llms/vertex_ai/batches/handler.py
@@ -4,6 +4,7 @@ from typing import Any, Coroutine, Dict, Optional, Union
 import httpx
 
 import litellm
+from litellm.litellm_core_utils.url_utils import safe_get
 from litellm.llms.custom_httpx.http_handler import (
     _get_httpx_client,
     get_async_httpx_client,
@@ -224,8 +225,14 @@ class VertexAIBatchPrediction(VertexLLM):
                     },
                 )
 
-        response = sync_handler.get(
-            url=api_base,
+        # ``api_base`` here can come from caller-supplied request kwargs
+        # (clientside override). Wrap the fetch in ``safe_get`` so DNS
+        # rebind / private / cloud-metadata targets are rejected; the
+        # proxy auth gate already blocks malicious clientside ``api_base``
+        # at the boundary — this is defense-in-depth for SDK callers.
+        response = safe_get(
+            sync_handler,
+            api_base,
             headers=headers,
         )
 

--- a/litellm/llms/vertex_ai/batches/handler.py
+++ b/litellm/llms/vertex_ai/batches/handler.py
@@ -4,7 +4,7 @@ from typing import Any, Coroutine, Dict, Optional, Union
 import httpx
 
 import litellm
-from litellm.litellm_core_utils.url_utils import safe_get
+from litellm.litellm_core_utils.url_utils import async_safe_get, safe_get
 from litellm.llms.custom_httpx.http_handler import (
     _get_httpx_client,
     get_async_httpx_client,
@@ -277,8 +277,13 @@ class VertexAIBatchPrediction(VertexLLM):
                     },
                 )
 
-        response = await client.get(
-            url=api_base,
+        # Mirror the sync path: ``api_base`` may come from caller-supplied
+        # request kwargs, so wrap the fetch in ``async_safe_get`` to reject
+        # DNS-rebind / private / cloud-metadata targets. Defense-in-depth
+        # behind the proxy auth gate's clientside ``api_base`` check.
+        response = await async_safe_get(
+            client,
+            api_base,
             headers=headers,
         )
         if response.status_code != 200:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -53,6 +53,12 @@ def _check_valid_ip(
 def check_complete_credentials(request_body: dict) -> bool:
     """
     if 'api_base' in request body. Check if complete credentials given. Prevent malicious attacks.
+
+    Supplying an ``api_key`` is necessary but not sufficient: even with
+    credentials supplied, an ``api_base`` / ``base_url`` that resolves to a
+    private/internal/cloud-metadata address would still allow the proxy to
+    be used as an SSRF pivot. Validate any URL fields here so the gate
+    can't be bypassed with ``api_key=anything`` plus a malicious target.
     """
     given_model: Optional[str] = None
 
@@ -70,10 +76,24 @@ def check_complete_credentials(request_body: dict) -> bool:
         return False
 
     api_key_value = request_body.get("api_key")
-    if api_key_value and isinstance(api_key_value, str) and api_key_value.strip():
-        return True
+    if not (api_key_value and isinstance(api_key_value, str) and api_key_value.strip()):
+        return False
 
-    return False
+    from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
+
+    for url_field in ("api_base", "base_url"):
+        url_value = request_body.get(url_field)
+        if not url_value or not isinstance(url_value, str):
+            continue
+        try:
+            validate_url(url_value)
+        except SSRFError as e:
+            raise ValueError(
+                f"Rejected request: client-side {url_field}={url_value!r} "
+                f"is rejected by the SSRF guard ({e})."
+            )
+
+    return True
 
 
 def check_regex_or_str_match(request_body_value: Any, regex_str: str) -> bool:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -184,6 +184,15 @@ def is_request_body_safe(
         "aws_web_identity_token",
         "aws_role_name",
         "vertex_credentials",
+        # Endpoint-targeting fields that must not flow through clientside.
+        # ``aws_bedrock_runtime_endpoint`` redirects Bedrock traffic to an
+        # arbitrary host; ``langsmith_base_url`` / ``langfuse_host`` are
+        # callback hostnames that, if attacker-controlled, exfiltrate the
+        # request payload (incl. message content + admin-configured
+        # observability keys) to the attacker's server.
+        "aws_bedrock_runtime_endpoint",
+        "langsmith_base_url",
+        "langfuse_host",
     ]
 
     for param in banned_params:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -184,24 +184,34 @@ def is_request_body_safe(
         "aws_web_identity_token",
         "aws_role_name",
         "vertex_credentials",
-        # Endpoint-targeting fields that must not flow through clientside.
-        # ``aws_bedrock_runtime_endpoint`` redirects Bedrock traffic to an
-        # arbitrary host; ``langsmith_base_url`` / ``langfuse_host`` are
-        # callback hostnames that, if attacker-controlled, exfiltrate the
-        # request payload (incl. message content + admin-configured
-        # observability keys) to the attacker's server.
+        # Endpoint-targeting fields that retarget the outbound request or
+        # an observability callback. An attacker-controlled value either
+        # exfiltrates the request payload (incl. messages + admin-set
+        # tokens) to the attacker's host, or coerces the proxy into
+        # authenticating against the attacker's host with admin secrets.
         "aws_bedrock_runtime_endpoint",
         "langsmith_base_url",
         "langfuse_host",
+        "posthog_host",
+        "braintrust_host",
+        "slack_webhook_url",
     ]
 
+    # The blocklist is enforced unconditionally. Legitimate clientside
+    # credential / endpoint passthrough goes through one of the two
+    # explicit admin opt-ins (``general_settings.allow_client_side_credentials``
+    # proxy-wide or ``configurable_clientside_auth_params`` per deployment).
+    # Historically there was a third, *implicit*, *caller-controlled* path:
+    # ``check_complete_credentials`` returned True when the caller supplied
+    # any non-empty ``api_key``, which made the entire blocklist a no-op.
+    # That bypass turned every missing entry on the blocklist into an
+    # exploitable SSRF / credential-exfil hole — see GHSA-jh89-88fc-qrfp,
+    # GHSA-3frq-6r6h-7j64, and the chain of veria-admin findings (Dv_m860l,
+    # b_yRJeQ5, stN90yjP, LBlyOAc8, U2TD78kg). Removed: the blocklist now
+    # has a single, predictable failure mode for missing entries (a 400),
+    # not a credential leak.
     for param in banned_params:
-        if (
-            param in request_body
-            and not check_complete_credentials(  # allow client-credentials to be passed to proxy
-                request_body=request_body
-            )
-        ):
+        if param in request_body:
             if general_settings.get("allow_client_side_credentials") is True:
                 return True
             elif (
@@ -216,7 +226,10 @@ def is_request_body_safe(
                 return True
             raise ValueError(
                 f"Rejected Request: {param} is not allowed in request body. "
-                "Enable with `general_settings::allow_client_side_credentials` on proxy config.yaml. "
+                "Clientside passthrough requires explicit admin opt-in via "
+                "either `general_settings.allow_client_side_credentials = true` "
+                "(proxy-wide) or `configurable_clientside_auth_params` on the "
+                "deployment in your proxy config.yaml. "
                 "Relevant Issue: https://huntr.com/bounties/4001e1a2-7b7a-4776-a3ae-e6692ec3d997",
             )
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -195,6 +195,14 @@ def is_request_body_safe(
         "posthog_host",
         "braintrust_host",
         "slack_webhook_url",
+        # Provider-specific endpoint overrides that flow into the outbound
+        # request via ``optional_params``. Same threat as ``api_base``:
+        # ``s3_endpoint_url`` redirects Bedrock file uploads to attacker
+        # S3; ``sagemaker_base_url`` redirects all SageMaker traffic;
+        # ``deployment_url`` redirects SAP deployments.
+        "s3_endpoint_url",
+        "sagemaker_base_url",
+        "deployment_url",
     ]
 
     # The blocklist is enforced unconditionally. Legitimate clientside

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, Request, status
 from litellm import Router, provider_list
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import STANDARD_CUSTOMER_ID_HEADERS
+from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
 from litellm.proxy._types import *
 from litellm.types.router import CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS
 
@@ -78,8 +79,6 @@ def check_complete_credentials(request_body: dict) -> bool:
     api_key_value = request_body.get("api_key")
     if not (api_key_value and isinstance(api_key_value, str) and api_key_value.strip()):
         return False
-
-    from litellm.litellm_core_utils.url_utils import SSRFError, validate_url
 
     for url_field in ("api_base", "base_url"):
         url_value = request_body.get(url_field)

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Tuple
 
 from fastapi import HTTPException, Request, status
 
+import litellm
 from litellm import Router, provider_list
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import STANDARD_CUSTOMER_ID_HEADERS
@@ -80,17 +81,22 @@ def check_complete_credentials(request_body: dict) -> bool:
     if not (api_key_value and isinstance(api_key_value, str) and api_key_value.strip()):
         return False
 
-    for url_field in ("api_base", "base_url"):
-        url_value = request_body.get(url_field)
-        if not url_value or not isinstance(url_value, str):
-            continue
-        try:
-            validate_url(url_value)
-        except SSRFError as e:
-            raise ValueError(
-                f"Rejected request: client-side {url_field}={url_value!r} "
-                f"is rejected by the SSRF guard ({e})."
-            )
+    # ``validate_url`` itself doesn't consult the toggle; ``safe_get`` /
+    # ``async_safe_get`` do. Mirror that here so admins who explicitly
+    # disabled URL validation (e.g. for an internal Ollama endpoint they
+    # accept the SSRF risk for) aren't blocked at the proxy boundary.
+    if getattr(litellm, "user_url_validation", False):
+        for url_field in ("api_base", "base_url"):
+            url_value = request_body.get(url_field)
+            if not url_value or not isinstance(url_value, str):
+                continue
+            try:
+                validate_url(url_value)
+            except SSRFError as e:
+                raise ValueError(
+                    f"Rejected request: client-side {url_field}={url_value!r} "
+                    f"is rejected by the SSRF guard ({e})."
+                )
 
     return True
 

--- a/litellm/router_utils/clientside_credential_handler.py
+++ b/litellm/router_utils/clientside_credential_handler.py
@@ -11,34 +11,48 @@ If given, generate a unique model_id for the deployment.
 Ensures cooldowns are applied correctly.
 """
 
+from typing import List
+
 clientside_credential_keys = ["api_key", "api_base", "base_url"]
 
-# Admin-configured fields that carry secrets or environment-specific config
-# meant for the *original* upstream. When the caller redirects ``api_base`` /
-# ``base_url`` to their own server, these MUST NOT flow through unchanged or
-# the admin's ``OpenAI-Organization`` header, ``extra_body`` payloads, AWS /
-# Vertex / Azure credentials, etc. would be sent to the attacker. Only carry
-# them through when the caller explicitly re-supplies the field.
-_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE = [
-    "organization",
-    "extra_body",
-    "extra_headers",
-    "default_headers",
-    "api_version",
-    "api_type",
-    "azure_ad_token",
-    "azure_ad_token_provider",
-    "aws_access_key_id",
-    "aws_secret_access_key",
-    "aws_session_token",
-    "aws_region_name",
-    "aws_sts_endpoint",
-    "aws_web_identity_token",
-    "aws_role_name",
-    "vertex_credentials",
-    "vertex_project",
-    "vertex_location",
-]
+
+def _admin_config_fields_to_clear_on_base_override() -> List[str]:
+    """
+    Provider-specific credential / endpoint-targeting fields that must NOT
+    flow through to a client-redirected upstream.
+
+    Built dynamically from ``CredentialLiteLLMParams.model_fields`` so any
+    new provider field added there (Bedrock endpoint, Watsonx region, etc.)
+    is gated automatically — plus a fixed list of kwargs-only fields that
+    aren't declared on the typed model.
+    """
+    from litellm.types.router import CredentialLiteLLMParams
+
+    typed_fields = [
+        f
+        for f in CredentialLiteLLMParams.model_fields
+        if f not in clientside_credential_keys
+    ]
+    kwargs_only_fields = [
+        # Caller-supplied via **kwargs, not declared on CredentialLiteLLMParams.
+        "organization",
+        "extra_body",
+        "extra_headers",
+        "default_headers",
+        "api_type",
+        "azure_ad_token",
+        "azure_ad_token_provider",
+        "aws_session_token",
+        "aws_sts_endpoint",
+        "aws_web_identity_token",
+        "aws_role_name",
+    ]
+    return typed_fields + kwargs_only_fields
+
+
+_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE = (
+    _admin_config_fields_to_clear_on_base_override()
+)
 
 
 def is_clientside_credential(request_kwargs: dict) -> bool:

--- a/litellm/router_utils/clientside_credential_handler.py
+++ b/litellm/router_utils/clientside_credential_handler.py
@@ -46,6 +46,16 @@ def _admin_config_fields_to_clear_on_base_override() -> List[str]:
         "aws_sts_endpoint",
         "aws_web_identity_token",
         "aws_role_name",
+        # OCI provider — consumed by litellm/llms/oci/* via optional_params
+        # and not declared on CredentialLiteLLMParams. Without these here,
+        # an admin's OCI signing key / tenancy / fingerprint would flow
+        # through to an attacker-redirected upstream.
+        "oci_signer",
+        "oci_user",
+        "oci_fingerprint",
+        "oci_tenancy",
+        "oci_key",
+        "oci_key_file",
     ]
     return typed_fields + kwargs_only_fields
 

--- a/litellm/router_utils/clientside_credential_handler.py
+++ b/litellm/router_utils/clientside_credential_handler.py
@@ -79,9 +79,16 @@ def get_dynamic_litellm_params(litellm_params: dict, request_kwargs: dict) -> di
     # If the caller redirected api_base/base_url to a client-controlled value,
     # don't forward the admin's organization / extra_body / region / token /
     # vertex / aws fields — those were meant for the original upstream.
+    # Always drop the admin's value first, then write the caller's value back
+    # if they resupplied the field. The naive
+    # ``if field not in request_kwargs: pop`` shape lets a caller *echo* a
+    # field name (with any value, including an empty string) to keep the
+    # admin's value in ``litellm_params`` and have it forwarded to the
+    # redirected upstream.
     if "api_base" in request_kwargs or "base_url" in request_kwargs:
         for field in _ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE:
-            if field not in request_kwargs:
-                litellm_params.pop(field, None)
+            litellm_params.pop(field, None)
+            if field in request_kwargs:
+                litellm_params[field] = request_kwargs[field]
 
     return litellm_params

--- a/litellm/router_utils/clientside_credential_handler.py
+++ b/litellm/router_utils/clientside_credential_handler.py
@@ -13,6 +13,33 @@ Ensures cooldowns are applied correctly.
 
 clientside_credential_keys = ["api_key", "api_base", "base_url"]
 
+# Admin-configured fields that carry secrets or environment-specific config
+# meant for the *original* upstream. When the caller redirects ``api_base`` /
+# ``base_url`` to their own server, these MUST NOT flow through unchanged or
+# the admin's ``OpenAI-Organization`` header, ``extra_body`` payloads, AWS /
+# Vertex / Azure credentials, etc. would be sent to the attacker. Only carry
+# them through when the caller explicitly re-supplies the field.
+_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE = [
+    "organization",
+    "extra_body",
+    "extra_headers",
+    "default_headers",
+    "api_version",
+    "api_type",
+    "azure_ad_token",
+    "azure_ad_token_provider",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "aws_region_name",
+    "aws_sts_endpoint",
+    "aws_web_identity_token",
+    "aws_role_name",
+    "vertex_credentials",
+    "vertex_project",
+    "vertex_location",
+]
+
 
 def is_clientside_credential(request_kwargs: dict) -> bool:
     """
@@ -34,4 +61,13 @@ def get_dynamic_litellm_params(litellm_params: dict, request_kwargs: dict) -> di
     for key in clientside_credential_keys:
         if key in request_kwargs:
             litellm_params[key] = request_kwargs[key]
+
+    # If the caller redirected api_base/base_url to a client-controlled value,
+    # don't forward the admin's organization / extra_body / region / token /
+    # vertex / aws fields — those were meant for the original upstream.
+    if "api_base" in request_kwargs or "base_url" in request_kwargs:
+        for field in _ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE:
+            if field not in request_kwargs:
+                litellm_params.pop(field, None)
+
     return litellm_params

--- a/tests/test_litellm/litellm_core_utils/test_get_llm_provider_endpoint_match.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_llm_provider_endpoint_match.py
@@ -1,0 +1,138 @@
+"""
+Regression tests for the parsed-URL hostname match used to identify a
+caller-supplied ``api_base`` as a known openai-compatible provider.
+
+The previous shape (``if endpoint in api_base:``) used unanchored
+substring search, which let a caller pass
+``https://attacker.com/api.groq.com/openai/v1`` and have the proxy
+return ``GROQ_API_KEY`` as the dynamic credential — exfiltrating the
+server's real provider key to an attacker-controlled host on the
+outbound request.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.get_llm_provider_logic import (
+    _endpoint_matches_api_base,
+    get_llm_provider,
+)
+
+
+class TestEndpointMatchesApiBase:
+    """Direct unit tests on the parsed-URL matcher."""
+
+    @pytest.mark.parametrize(
+        "endpoint, api_base",
+        [
+            # Bare hostname endpoint, exact host match.
+            ("api.perplexity.ai", "https://api.perplexity.ai/v1"),
+            # Endpoint includes a path; api_base path starts with it.
+            ("api.groq.com/openai/v1", "https://api.groq.com/openai/v1"),
+            # Endpoint with full URL scheme.
+            ("https://api.cerebras.ai/v1", "https://api.cerebras.ai/v1/chat"),
+            # Trailing-slash on registered endpoint must not break match.
+            ("https://llm.chutes.ai/v1/", "https://llm.chutes.ai/v1/chat"),
+            # Case-insensitive on hostname.
+            ("api.groq.com/openai/v1", "https://API.GROQ.COM/openai/v1"),
+        ],
+    )
+    def test_legitimate_provider_urls_match(self, endpoint, api_base):
+        assert _endpoint_matches_api_base(endpoint, api_base) is True
+
+    @pytest.mark.parametrize(
+        "endpoint, api_base",
+        [
+            # Attacker host, registered endpoint smuggled into path.
+            (
+                "api.groq.com/openai/v1",
+                "https://attacker.com/api.groq.com/openai/v1",
+            ),
+            # Attacker host, registered endpoint smuggled into a path segment.
+            (
+                "api.groq.com/openai/v1",
+                "https://attacker.com/foo/api.groq.com/openai/v1",
+            ),
+            # Lookalike host that contains the registered host as a suffix label.
+            (
+                "api.groq.com/openai/v1",
+                "https://api.groq.com.attacker.com/openai/v1",
+            ),
+            # Lookalike host with the registered host as a prefix.
+            (
+                "api.groq.com/openai/v1",
+                "https://api.groq.com.evil.example/openai/v1",
+            ),
+            # Right host, wrong path — endpoint requires ``/openai/v1`` prefix.
+            ("api.groq.com/openai/v1", "https://api.groq.com/v1"),
+            # Path-segment lookalike: ``/openai/v10`` must not match ``/openai/v1``.
+            ("api.groq.com/openai/v1", "https://api.groq.com/openai/v10"),
+            # Userinfo / @-injection trick — the ``hostname`` after ``@`` is
+            # what httpx connects to.
+            (
+                "api.groq.com/openai/v1",
+                "https://api.groq.com@attacker.com/openai/v1",
+            ),
+        ],
+    )
+    def test_attacker_smuggling_does_not_match(self, endpoint, api_base):
+        assert _endpoint_matches_api_base(endpoint, api_base) is False
+
+
+class TestGetLlmProviderRejectsAttackerSmuggledApiBase:
+    """
+    End-to-end: ``get_llm_provider`` must NOT return the server's stored
+    secret (e.g. ``GROQ_API_KEY``) for an api_base whose hostname is
+    attacker-controlled, even when the registered endpoint string appears
+    elsewhere in the URL.
+    """
+
+    def test_attacker_host_does_not_yield_groq_secret(self):
+        # The function may either fall through (different provider) or
+        # raise BadRequestError because the model can't be identified.
+        # The invariant under test is that ``GROQ_API_KEY`` is never
+        # looked up against an attacker-controlled hostname.
+        import litellm
+
+        with patch(
+            "litellm.litellm_core_utils.get_llm_provider_logic.get_secret_str",
+            return_value="server-real-groq-key",
+        ) as mocked_secret:
+            try:
+                _, _, dynamic_api_key, _ = get_llm_provider(
+                    model="some-model",
+                    api_base="https://attacker.com/api.groq.com/openai/v1",
+                )
+                # If it returned, the dynamic key must not be the secret.
+                assert dynamic_api_key != "server-real-groq-key"
+            except litellm.exceptions.BadRequestError:
+                # Acceptable outcome: provider unidentifiable, no secret
+                # was returned.
+                pass
+
+        # Regardless of return / raise, the secret must never have been
+        # read against this attacker-controlled api_base.
+        groq_lookups = [
+            call
+            for call in mocked_secret.call_args_list
+            if call.args and call.args[0] == "GROQ_API_KEY"
+        ]
+        assert groq_lookups == []
+
+    def test_legitimate_groq_api_base_still_resolves(self):
+        with patch(
+            "litellm.litellm_core_utils.get_llm_provider_logic.get_secret_str",
+            return_value="server-real-groq-key",
+        ):
+            _, provider, dynamic_api_key, _ = get_llm_provider(
+                model="some-model",
+                api_base="https://api.groq.com/openai/v1",
+            )
+
+        assert provider == "groq"
+        assert dynamic_api_key == "server-real-groq-key"

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -17,6 +17,7 @@ from litellm.proxy.auth.auth_utils import (
     get_key_model_tpm_limit,
     get_project_model_rpm_limit,
     get_project_model_tpm_limit,
+    is_request_body_safe,
 )
 
 
@@ -876,3 +877,47 @@ class TestGetDynamicLitellmParamsClearsAdminConfigOnBaseOverride:
         assert out["organization"] == "org-admin"
         assert out["api_version"] == "2026-04-01"
         assert out["api_base"] == "https://admin.upstream/v1"
+
+
+class TestIsRequestBodySafeBlocksEndpointTargetingFields:
+    """
+    ``is_request_body_safe`` rejects request-body fields that retarget the
+    outbound request to a caller-controlled host. Beyond the original
+    ``api_base`` / ``base_url``, the same protection must apply to:
+
+    * ``aws_bedrock_runtime_endpoint`` — Bedrock endpoint redirect; an
+      attacker-controlled value coerces the proxy to authenticate against
+      their host with the admin's AWS creds.
+    * ``langsmith_base_url`` — Langsmith callback host; attacker-controlled
+      values exfiltrate the entire request payload (incl. message content)
+      via the observability hook.
+    * ``langfuse_host`` — same exfil vector via the Langfuse hook.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _disable_url_validation(self, monkeypatch):
+        # The new banned-params entries should be rejected even when
+        # ``user_url_validation`` is off — the gate isn't the URL guard,
+        # it's the banned-params list.
+        import litellm
+
+        monkeypatch.setattr(litellm, "user_url_validation", False, raising=False)
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "aws_bedrock_runtime_endpoint",
+            "langsmith_base_url",
+            "langfuse_host",
+        ],
+    )
+    def test_endpoint_targeting_field_in_request_body_is_rejected(self, field):
+        with pytest.raises(ValueError) as exc:
+            is_request_body_safe(
+                request_body={"model": "gpt-4", field: "https://attacker.example"},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+        # The function lists the offending param name in the error.
+        assert field in str(exc.value)

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -670,7 +670,17 @@ class TestCheckCompleteCredentialsBlocksSSRF:
     point at private / internal / cloud-metadata addresses. Without this
     the gate accepts ``api_key=anything`` plus a malicious target and the
     proxy is used as an SSRF pivot.
+
+    The check only runs when ``litellm.user_url_validation`` is True, so
+    every test in this class flips the toggle. Tests stay mock-only — no
+    real DNS is performed.
     """
+
+    @pytest.fixture(autouse=True)
+    def _enable_url_validation(self, monkeypatch):
+        import litellm
+
+        monkeypatch.setattr(litellm, "user_url_validation", True, raising=False)
 
     @pytest.mark.parametrize(
         "url_field",
@@ -687,27 +697,57 @@ class TestCheckCompleteCredentialsBlocksSSRF:
         ],
     )
     def test_rejects_private_or_metadata_targets(self, url_field, blocked_url):
-        with pytest.raises(ValueError) as exc_info:
-            check_complete_credentials(
-                {
-                    "model": "gpt-4",
-                    "api_key": "sk-some-clientside-key",
-                    url_field: blocked_url,
-                }
-            )
+        from litellm.litellm_core_utils.url_utils import SSRFError
+
+        with patch(
+            "litellm.proxy.auth.auth_utils.validate_url",
+            side_effect=SSRFError(f"blocked: {blocked_url}"),
+        ):
+            with pytest.raises(ValueError) as exc_info:
+                check_complete_credentials(
+                    {
+                        "model": "gpt-4",
+                        "api_key": "sk-some-clientside-key",
+                        url_field: blocked_url,
+                    }
+                )
         assert url_field in str(exc_info.value)
         assert "SSRF" in str(exc_info.value)
 
-    def test_allows_public_https_target(self):
-        # No DNS / SSRF guard objection on a normal public host.
-        result = check_complete_credentials(
-            {
-                "model": "gpt-4",
-                "api_key": "sk-some-clientside-key",
-                "api_base": "https://api.openai.com/v1",
-            }
-        )
+    def test_allows_public_target_when_validate_url_passes(self):
+        # ``validate_url`` is mocked so no real DNS is performed.
+        with patch(
+            "litellm.proxy.auth.auth_utils.validate_url",
+            return_value=("https://api.openai.com/v1", "api.openai.com"),
+        ):
+            result = check_complete_credentials(
+                {
+                    "model": "gpt-4",
+                    "api_key": "sk-some-clientside-key",
+                    "api_base": "https://api.openai.com/v1",
+                }
+            )
         assert result is True
+
+    def test_skips_url_validation_when_toggle_is_off(self, monkeypatch):
+        # Admins who disable ``user_url_validation`` (default) should not
+        # have requests rejected at the proxy boundary even if the URL
+        # would fail the SSRF guard.
+        import litellm
+
+        monkeypatch.setattr(litellm, "user_url_validation", False, raising=False)
+        with patch(
+            "litellm.proxy.auth.auth_utils.validate_url",
+        ) as mocked:
+            result = check_complete_credentials(
+                {
+                    "model": "gpt-4",
+                    "api_key": "sk-some-clientside-key",
+                    "api_base": "http://127.0.0.1:8080/admin",
+                }
+            )
+        assert result is True
+        mocked.assert_not_called()
 
 
 class TestGetDynamicLitellmParamsClearsAdminConfigOnBaseOverride:
@@ -767,7 +807,14 @@ class TestGetDynamicLitellmParamsClearsAdminConfigOnBaseOverride:
         assert "vertex_credentials" not in out
         assert "vertex_project" not in out
 
-    def test_preserves_admin_config_when_caller_resupplies(self):
+    def test_caller_resupplied_value_overrides_admin_value_on_base_override(self):
+        # When the caller redirects ``api_base`` and *also* supplies their
+        # own value for one of the admin fields (e.g. ``organization``),
+        # the caller's value must win — never the admin's. The naive
+        # ``if field not in request_kwargs: pop`` shape lets a caller echo
+        # the field name with any value (or empty string) to keep the
+        # admin's value forwarded, which is the exfiltration vector this
+        # test guards against.
         from litellm.router_utils.clientside_credential_handler import (
             get_dynamic_litellm_params,
         )
@@ -784,8 +831,32 @@ class TestGetDynamicLitellmParamsClearsAdminConfigOnBaseOverride:
                 "extra_body": {"attacker": "value"},
             },
         )
-        assert out["organization"] == "org-admin"
-        assert out["extra_body"] == {"admin": "value"}
+        assert out["organization"] == "org-attacker"
+        assert out["extra_body"] == {"attacker": "value"}
+
+    def test_field_echo_does_not_preserve_admin_value(self):
+        # Regression: a caller that echoes an admin-config field name with
+        # an *empty* value (or any value) must not be able to keep the
+        # admin's value in ``litellm_params``.
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        out = get_dynamic_litellm_params(
+            litellm_params={
+                "api_base": "https://admin.upstream/v1",
+                "organization": "org-admin-secret",
+                "extra_body": {"x-admin-only": "secret"},
+            },
+            request_kwargs={
+                "api_base": "https://attacker.example",
+                "organization": "",
+                "extra_body": "",
+            },
+        )
+        assert out["organization"] == ""
+        assert out["extra_body"] == ""
+        assert "org-admin-secret" not in str(out)
 
     def test_no_clearing_when_only_api_key_overridden(self):
         from litellm.router_utils.clientside_credential_handler import (

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -909,6 +909,9 @@ class TestIsRequestBodySafeBlocksEndpointTargetingFields:
             "aws_bedrock_runtime_endpoint",
             "langsmith_base_url",
             "langfuse_host",
+            "posthog_host",
+            "braintrust_host",
+            "slack_webhook_url",
         ],
     )
     def test_endpoint_targeting_field_in_request_body_is_rejected(self, field):
@@ -921,3 +924,40 @@ class TestIsRequestBodySafeBlocksEndpointTargetingFields:
             )
         # The function lists the offending param name in the error.
         assert field in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "field",
+        ["api_base", "base_url", "user_config", "langfuse_host", "slack_webhook_url"],
+    )
+    def test_api_key_does_not_bypass_blocklist(self, field):
+        # Regression: the historical ``check_complete_credentials`` clause
+        # made the entire blocklist a no-op for any caller that supplied
+        # a non-empty ``api_key``. That bypass turned every missing entry
+        # on the blocklist into an SSRF / credential-exfil hole. Verify
+        # that supplying an api_key (alongside the banned param) does NOT
+        # bypass the gate — it can only be opened by an admin opt-in.
+        with pytest.raises(ValueError) as exc:
+            is_request_body_safe(
+                request_body={
+                    "model": "gpt-4",
+                    "api_key": "sk-anything",
+                    field: "https://attacker.example",
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+        assert field in str(exc.value)
+
+    def test_admin_opt_in_proxy_wide_still_allows(self):
+        # ``general_settings.allow_client_side_credentials = True`` remains
+        # the documented proxy-wide BYOK opt-in.
+        assert (
+            is_request_body_safe(
+                request_body={"model": "gpt-4", "api_base": "https://my-byok.example"},
+                general_settings={"allow_client_side_credentials": True},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -5,6 +5,8 @@ Unit tests for auth_utils functions related to rate limiting and customer ID ext
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.auth_utils import (
     _get_customer_id_from_standard_headers,
@@ -660,3 +662,146 @@ class TestCheckCompleteCredentials:
     def test_returns_true_when_api_key_is_valid(self):
         result = check_complete_credentials({"model": "gpt-4", "api_key": "sk-valid"})
         assert result is True
+
+
+class TestCheckCompleteCredentialsBlocksSSRF:
+    """
+    Even with credentials supplied, ``api_base`` / ``base_url`` must not
+    point at private / internal / cloud-metadata addresses. Without this
+    the gate accepts ``api_key=anything`` plus a malicious target and the
+    proxy is used as an SSRF pivot.
+    """
+
+    @pytest.mark.parametrize(
+        "url_field",
+        ["api_base", "base_url"],
+    )
+    @pytest.mark.parametrize(
+        "blocked_url",
+        [
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+            "http://metadata.google.internal/computeMetadata/v1/",
+            "http://127.0.0.1:8080/admin",
+            "http://10.0.0.1/",
+            "http://192.168.1.1/",
+        ],
+    )
+    def test_rejects_private_or_metadata_targets(self, url_field, blocked_url):
+        with pytest.raises(ValueError) as exc_info:
+            check_complete_credentials(
+                {
+                    "model": "gpt-4",
+                    "api_key": "sk-some-clientside-key",
+                    url_field: blocked_url,
+                }
+            )
+        assert url_field in str(exc_info.value)
+        assert "SSRF" in str(exc_info.value)
+
+    def test_allows_public_https_target(self):
+        # No DNS / SSRF guard objection on a normal public host.
+        result = check_complete_credentials(
+            {
+                "model": "gpt-4",
+                "api_key": "sk-some-clientside-key",
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+        assert result is True
+
+
+class TestGetDynamicLitellmParamsClearsAdminConfigOnBaseOverride:
+    """
+    When the caller redirects ``api_base`` / ``base_url`` to their own
+    server, admin-set fields like ``OpenAI-Organization``, ``extra_body``,
+    AWS / Vertex / Azure tokens, and per-deployment ``api_version`` must
+    NOT flow through to that destination.
+    """
+
+    def test_clears_admin_organization_and_extra_body_on_base_override(self):
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        admin_params = {
+            "model": "gpt-4",
+            "api_key": "sk-admin-key",
+            "api_base": "https://admin.upstream/v1",
+            "organization": "org-admin-corp",
+            "extra_body": {"x-admin-secret": "super-secret"},
+            "api_version": "2026-04-01",
+        }
+        out = get_dynamic_litellm_params(
+            litellm_params=dict(admin_params),
+            request_kwargs={
+                "api_key": "sk-attacker",
+                "api_base": "https://attacker.example",
+            },
+        )
+        assert out["api_base"] == "https://attacker.example"
+        assert out["api_key"] == "sk-attacker"
+        assert "organization" not in out
+        assert "extra_body" not in out
+        assert "api_version" not in out
+
+    def test_clears_aws_and_vertex_secrets_on_base_override(self):
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        admin_params = {
+            "model": "bedrock/claude-3",
+            "aws_access_key_id": "AKIA-EXAMPLE",
+            "aws_secret_access_key": "secret-example",
+            "aws_session_token": "session-example",
+            "vertex_credentials": '{"private_key":"-----BEGIN..."}',
+            "vertex_project": "admin-gcp-project",
+        }
+        out = get_dynamic_litellm_params(
+            litellm_params=dict(admin_params),
+            request_kwargs={"base_url": "https://attacker.example"},
+        )
+        assert "aws_access_key_id" not in out
+        assert "aws_secret_access_key" not in out
+        assert "aws_session_token" not in out
+        assert "vertex_credentials" not in out
+        assert "vertex_project" not in out
+
+    def test_preserves_admin_config_when_caller_resupplies(self):
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        out = get_dynamic_litellm_params(
+            litellm_params={
+                "api_base": "https://admin.upstream/v1",
+                "organization": "org-admin",
+                "extra_body": {"admin": "value"},
+            },
+            request_kwargs={
+                "api_base": "https://attacker.example",
+                "organization": "org-attacker",
+                "extra_body": {"attacker": "value"},
+            },
+        )
+        assert out["organization"] == "org-admin"
+        assert out["extra_body"] == {"admin": "value"}
+
+    def test_no_clearing_when_only_api_key_overridden(self):
+        from litellm.router_utils.clientside_credential_handler import (
+            get_dynamic_litellm_params,
+        )
+
+        # Caller only overrides api_key (BYOK pattern); admin's organization /
+        # extra_body / region still apply because the destination is unchanged.
+        out = get_dynamic_litellm_params(
+            litellm_params={
+                "api_base": "https://admin.upstream/v1",
+                "organization": "org-admin",
+                "api_version": "2026-04-01",
+            },
+            request_kwargs={"api_key": "sk-byok"},
+        )
+        assert out["organization"] == "org-admin"
+        assert out["api_version"] == "2026-04-01"
+        assert out["api_base"] == "https://admin.upstream/v1"

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -912,6 +912,9 @@ class TestIsRequestBodySafeBlocksEndpointTargetingFields:
             "posthog_host",
             "braintrust_host",
             "slack_webhook_url",
+            "s3_endpoint_url",
+            "sagemaker_base_url",
+            "deployment_url",
         ],
     )
     def test_endpoint_targeting_field_in_request_body_is_rejected(self, field):


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory.
- [x] My PR passes all unit tests on `make test-unit`.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

A cluster of hardenings around how the proxy accepts and forwards a clientside \`api_base\` / \`base_url\`.

**1. Entry-point URL gate** (\`litellm/proxy/auth/auth_utils.py\`). \`check_complete_credentials\` now runs any clientside \`api_base\` / \`base_url\` through \`validate_url\` (the existing SSRF guard) when \`litellm.user_url_validation\` is on. Requests pointing at private / internal / cloud-metadata hosts are rejected with a clear error naming the offending field.

**2. Field clearing on base override** (\`litellm/router_utils/clientside_credential_handler.py\`). When a request redirects \`api_base\` / \`base_url\`, drop admin-configured provider credentials and per-deployment metadata before they are forwarded to the new upstream. The list of fields to clear is derived from \`CredentialLiteLLMParams.model_fields\` (so any field added there is gated automatically), plus a fixed list of kwargs-only fields covering OCI signing keys, AWS / Azure / Vertex tokens, and observability vars. The naive \`if field not in request_kwargs: pop\` shape that lets a caller *echo* a field name to keep the admin's value is fixed: always pop, then write the caller's value back if they resupplied the field.

**3. Provider-confusion fix** (\`litellm/litellm_core_utils/get_llm_provider_logic.py\`). The previous matcher was an unanchored substring match (\`if endpoint in api_base:\`). A caller could pass \`api_base="https://attacker.com/api.groq.com/openai/v1"\` and have the proxy hand them the server's \`GROQ_API_KEY\` (and equivalents for ~30 other providers). Replaced with a parsed-URL hostname-equality + segment-bounded path-prefix match.

**4. Banned-params expansion + bypass removal** (\`litellm/proxy/auth/auth_utils.py\`). Added \`aws_bedrock_runtime_endpoint\`, \`langsmith_base_url\`, \`langfuse_host\`, \`posthog_host\`, \`braintrust_host\`, \`slack_webhook_url\`, \`s3_endpoint_url\`, \`sagemaker_base_url\`, \`deployment_url\` to the blocklist. Removed the historical \`check_complete_credentials\` clause that turned the blocklist into a no-op for any request with a non-empty \`api_key\` — the documented BYOK paths (\`general_settings.allow_client_side_credentials\` proxy-wide, or \`configurable_clientside_auth_params\` per deployment) remain the supported way to opt in.

**5. Async vertex batch wrap** (\`litellm/llms/vertex_ai/batches/handler.py\`). Both sync \`_retrieve_batch\` and async \`_async_retrieve_batch\` now use \`safe_get\` / \`async_safe_get\` for SDK callers.

**Files**

- Modified: \`litellm/proxy/auth/auth_utils.py\`, \`litellm/router_utils/clientside_credential_handler.py\`, \`litellm/litellm_core_utils/get_llm_provider_logic.py\`, \`litellm/llms/vertex_ai/batches/handler.py\`
- Tests: extends \`tests/test_litellm/proxy/auth/test_auth_utils.py\`; new \`tests/test_litellm/litellm_core_utils/test_get_llm_provider_endpoint_match.py\`

**Behaviour notes for operators**

- BYOK that previously worked on the implicit \`api_key=anything\` bypass will now return \`400\` with a message pointing to either \`general_settings.allow_client_side_credentials = true\` or \`configurable_clientside_auth_params: [...]\` per deployment. The error spells out the remediation.
- \`litellm.user_url_validation\` is honoured at the proxy boundary now (consistent with \`safe_get\`); admins running with it disabled are unaffected by the new URL gate.