### PR TITLE
[Feat] Add "My User" tab to team info page

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -679,6 +679,7 @@ class LiteLLMRoutes(enum.Enum):
         "/team/permissions_list",
         "/team/permissions_update",
         "/team/daily/activity",
+        "/team/{team_id}/members/me",
         "/model/new",
         "/model/update",
         "/model/delete",

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -66,6 +66,7 @@ from litellm.proxy.auth.auth_checks import (
     allowed_route_check_inside_route,
     can_org_access_model,
     get_org_object,
+    get_team_membership,
     get_team_object,
     get_user_object,
 )
@@ -3448,7 +3449,7 @@ async def team_member_me(
     --header 'Authorization: Bearer your_api_key_here'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
     if prisma_client is None:
         raise HTTPException(
@@ -3468,20 +3469,22 @@ async def team_member_me(
             },
         )
 
-    team_row = await prisma_client.db.litellm_teamtable.find_unique(
-        where={"team_id": team_id},
+    team_table = await get_team_object(
+        team_id=team_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
     )
-    if team_row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"error": f"Team not found, passed team_id={team_id}."},
-        )
 
-    team_table = LiteLLM_TeamTable(**team_row.model_dump())
-
+    caller_user_email = user_api_key_dict.user_email
     member_role: Optional[str] = None
     for m in team_table.members_with_roles:
-        if m.user_id == caller_user_id:
+        # Match by user_id when present, else fall back to email — members
+        # added by email may have user_id=None on the stored entry.
+        if (m.user_id is not None and m.user_id == caller_user_id) or (
+            m.user_email is not None
+            and caller_user_email is not None
+            and m.user_email == caller_user_email
+        ):
             member_role = m.role
             break
 
@@ -3496,22 +3499,22 @@ async def team_member_me(
             },
         )
 
-    membership_row = await prisma_client.db.litellm_teammembership.find_unique(
-        where={
-            "user_id_team_id": {
-                "user_id": caller_user_id,
-                "team_id": team_id,
-            }
-        },
-        include={"litellm_budget_table": True},
+    membership = await get_team_membership(
+        user_id=caller_user_id,
+        team_id=team_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
     )
 
-    user_row = await prisma_client.db.litellm_usertable.find_unique(
-        where={"user_id": caller_user_id}
+    user_row = await get_user_object(
+        user_id=caller_user_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        user_id_upsert=False,
     )
     user_email = getattr(user_row, "user_email", None) if user_row is not None else None
 
-    if membership_row is None:
+    if membership is None:
         # Member is in members_with_roles but has no membership row yet
         # (no per-member budget/limits configured). Return defaults.
         return TeamMemberInfoResponse(
@@ -3526,17 +3529,16 @@ async def team_member_me(
             litellm_budget_table=None,
         )
 
-    membership_dict = membership_row.model_dump()
     return TeamMemberInfoResponse(
         user_id=caller_user_id,
         team_id=team_id,
         team_alias=team_table.team_alias,
         role=member_role,
         user_email=user_email,
-        spend=membership_dict.get("spend", 0.0),
-        total_spend=membership_dict.get("total_spend", 0.0),
-        budget_id=membership_dict.get("budget_id"),
-        litellm_budget_table=membership_dict.get("litellm_budget_table"),
+        spend=membership.spend,
+        total_spend=membership.total_spend,
+        budget_id=membership.budget_id,
+        litellm_budget_table=membership.litellm_budget_table,
     )
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -110,6 +110,7 @@ from litellm.types.proxy.management_endpoints.team_endpoints import (
     TeamListItem,
     TeamListResponse,
     TeamMemberAddResult,
+    TeamMemberInfoResponse,
     UpdateTeamMemberPermissionsRequest,
 )
 
@@ -3418,6 +3419,125 @@ async def team_info(
             param=getattr(e, "param", "None"),
             code=status.HTTP_400_BAD_REQUEST,
         )
+
+
+@router.get(
+    "/team/{team_id}/members/me",
+    tags=["team management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=TeamMemberInfoResponse,
+)
+@management_endpoint_wrapper
+async def team_member_me(
+    http_request: Request,
+    team_id: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get the caller's own team-membership row for the given team.
+
+    Used by internal users to view their own spend, budget, budget reset
+    date, rate limits, and role within a team — without exposing other
+    members' data. The caller is resolved from their API key; the path
+    `/members/me` always refers to that caller.
+
+    Returns 404 if the caller is not a member of the team.
+
+    ```
+    curl --location 'http://localhost:4000/team/your_team_id/members/me' \
+    --header 'Authorization: Bearer your_api_key_here'
+    ```
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "Database not connected. Connect a database to your proxy - https://docs.litellm.ai/docs/simple_proxy#managing-auth---virtual-keys"
+            },
+        )
+
+    caller_user_id = user_api_key_dict.user_id
+    if caller_user_id is None:
+        # Team keys / service-account keys without a user_id can't resolve "me".
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "API key has no associated user_id; cannot resolve 'me' for team membership."
+            },
+        )
+
+    team_row = await prisma_client.db.litellm_teamtable.find_unique(
+        where={"team_id": team_id},
+    )
+    if team_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": f"Team not found, passed team_id={team_id}."},
+        )
+
+    team_table = LiteLLM_TeamTable(**team_row.model_dump())
+
+    member_role: Optional[str] = None
+    for m in team_table.members_with_roles:
+        if m.user_id == caller_user_id:
+            member_role = m.role
+            break
+
+    if member_role is None:
+        # Caller is not a member of this team. Even proxy admins get 404 here —
+        # they can use /team/info to view all members; "me" only resolves for
+        # actual members of the team.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": f"User user_id={caller_user_id} is not a member of team_id={team_id}."
+            },
+        )
+
+    membership_row = await prisma_client.db.litellm_teammembership.find_unique(
+        where={
+            "user_id_team_id": {
+                "user_id": caller_user_id,
+                "team_id": team_id,
+            }
+        },
+        include={"litellm_budget_table": True},
+    )
+
+    user_row = await prisma_client.db.litellm_usertable.find_unique(
+        where={"user_id": caller_user_id}
+    )
+    user_email = getattr(user_row, "user_email", None) if user_row is not None else None
+
+    if membership_row is None:
+        # Member is in members_with_roles but has no membership row yet
+        # (no per-member budget/limits configured). Return defaults.
+        return TeamMemberInfoResponse(
+            user_id=caller_user_id,
+            team_id=team_id,
+            team_alias=team_table.team_alias,
+            role=member_role,
+            user_email=user_email,
+            spend=0.0,
+            total_spend=0.0,
+            budget_id=None,
+            litellm_budget_table=None,
+        )
+
+    membership_dict = membership_row.model_dump()
+    return TeamMemberInfoResponse(
+        user_id=caller_user_id,
+        team_id=team_id,
+        team_alias=team_table.team_alias,
+        role=member_role,
+        user_email=user_email,
+        spend=membership_dict.get("spend", 0.0),
+        total_spend=membership_dict.get("total_spend", 0.0),
+        budget_id=membership_dict.get("budget_id"),
+        litellm_budget_table=membership_dict.get("litellm_budget_table"),
+    )
 
 
 @router.post(

--- a/litellm/types/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/team_endpoints.py
@@ -114,3 +114,11 @@ class BulkTeamMemberAddResponse(BaseModel):
     successful_additions: int
     failed_additions: int
     updated_team: Optional[Dict[str, Any]] = None
+
+
+class TeamMemberInfoResponse(LiteLLM_TeamMembership):
+    """Response for GET /team/{team_id}/members/me — caller's own membership row."""
+
+    role: Optional[str] = None
+    user_email: Optional[str] = None
+    team_alias: Optional[str] = None

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -7228,3 +7228,234 @@ async def test_update_team_rejects_unauthorized_caller():
                 user_api_key_dict=caller,
             )
         assert exc_info.value.code == "403"
+
+
+# ----- /team/{team_id}/members/me -----
+
+
+def _build_team_row_for_me(team_id, members):
+    row = MagicMock()
+    row.model_dump.return_value = {
+        "team_id": team_id,
+        "team_alias": "team-vec",
+        "members_with_roles": members,
+        "metadata": {},
+        "models": [],
+        "spend": 0.0,
+    }
+    return row
+
+
+def _build_membership_row_for_me(user_id, team_id, *, spend=12.34, max_budget=100.0):
+    row = MagicMock()
+    row.model_dump.return_value = {
+        "user_id": user_id,
+        "team_id": team_id,
+        "budget_id": "b-1",
+        "spend": spend,
+        "total_spend": spend,
+        "litellm_budget_table": {
+            "budget_id": "b-1",
+            "max_budget": max_budget,
+            "soft_budget": None,
+            "tpm_limit": 500,
+            "rpm_limit": 50,
+            "model_max_budget": None,
+            "budget_duration": "30d",
+            "budget_reset_at": "2026-05-01T00:00:00Z",
+            "allowed_models": None,
+        },
+    }
+    return row
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_caller_membership(mock_db_client):
+    """A team member receives their own membership row, not other members'."""
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-1"
+    caller_id = "alice@example.com"
+    other_id = "bob@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
+    )
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [
+                {"user_id": caller_id, "user_email": None, "role": "user"},
+                {"user_id": other_id, "user_email": None, "role": "admin"},
+            ],
+        )
+    )
+    mock_db_client.db.litellm_teammembership = MagicMock()
+    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(
+        return_value=_build_membership_row_for_me(caller_id, team_id, spend=42.0)
+    )
+    mock_user_row = MagicMock()
+    mock_user_row.user_email = caller_id
+    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=mock_user_row
+    )
+
+    response = await team_member_me(
+        http_request=MagicMock(spec=Request),
+        team_id=team_id,
+        user_api_key_dict=caller_auth,
+    )
+
+    assert response.user_id == caller_id
+    assert response.team_id == team_id
+    assert response.role == "user"
+    assert response.spend == 42.0
+    assert response.team_alias == "team-vec"
+    assert response.litellm_budget_table is not None
+    assert response.litellm_budget_table.max_budget == 100.0
+
+    # Membership lookup must scope to caller_id, not just team_id — proves the
+    # endpoint cannot return another member's row.
+    mock_db_client.db.litellm_teammembership.find_unique.assert_awaited_with(
+        where={"user_id_team_id": {"user_id": caller_id, "team_id": team_id}},
+        include={"litellm_budget_table": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_404_for_non_member(mock_db_client):
+    """A user who is not a member of the team gets 404, regardless of role."""
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-2"
+    caller_id = "outsider@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
+    )
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_404_for_proxy_admin_not_in_team(
+    mock_db_client, mock_admin_auth
+):
+    """
+    Proxy admins get 404 if they are not actually a member of the team.
+    `me` only resolves for actual team members; admins use /team/info instead.
+    """
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-3"
+    mock_admin_auth.user_id = "admin_user_999"
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=mock_admin_auth,
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_defaults_when_no_membership_row(mock_db_client):
+    """
+    Caller is in members_with_roles but has no LiteLLM_TeamMembership row yet
+    (no per-member budget configured) — return defaults rather than 404.
+    """
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-4"
+    caller_id = "newmember@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
+    )
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [{"user_id": caller_id, "user_email": None, "role": "user"}],
+        )
+    )
+    mock_db_client.db.litellm_teammembership = MagicMock()
+    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(return_value=None)
+    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+
+    response = await team_member_me(
+        http_request=MagicMock(spec=Request),
+        team_id=team_id,
+        user_api_key_dict=caller_auth,
+    )
+
+    assert response.user_id == caller_id
+    assert response.role == "user"
+    assert response.spend == 0.0
+    assert response.litellm_budget_table is None
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_rejects_team_key_without_user_id(mock_db_client):
+    """A team key with no user_id can't resolve 'me' — must return 400."""
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_key_auth = UserAPIKeyAuth(team_id="team-me-5", user_id=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id="team-me-5",
+            user_api_key_dict=team_key_auth,
+        )
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_404_for_unknown_team(mock_db_client):
+    """Unknown team_id returns 404."""
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="alice@example.com"
+    )
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id="does-not-exist",
+            user_api_key_dict=caller_auth,
+        )
+    assert exc_info.value.status_code == 404

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,10 +17,13 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 from litellm.proxy._types import UserAPIKeyAuth  # Import UserAPIKeyAuth
 from litellm.proxy._types import (
+    LiteLLM_BudgetTableFull,
     LiteLLM_OrganizationMembershipTable,
     LiteLLM_OrganizationTable,
     LiteLLM_OrganizationTableWithMembers,
+    LiteLLM_TeamMembership,
     LiteLLM_TeamTable,
+    LiteLLM_TeamTableCachedObj,
     LiteLLM_UserTable,
     LitellmUserRoles,
     Member,
@@ -7233,40 +7237,57 @@ async def test_update_team_rejects_unauthorized_caller():
 # ----- /team/{team_id}/members/me -----
 
 
-def _build_team_row_for_me(team_id, members):
-    row = MagicMock()
-    row.model_dump.return_value = {
-        "team_id": team_id,
-        "team_alias": "team-vec",
-        "members_with_roles": members,
-        "metadata": {},
-        "models": [],
-        "spend": 0.0,
-    }
-    return row
+def _build_team_for_me(team_id, members):
+    """Real LiteLLM_TeamTableCachedObj as get_team_object would return."""
+    return LiteLLM_TeamTableCachedObj(
+        team_id=team_id,
+        team_alias="team-vec",
+        members_with_roles=[Member(**m) for m in members],
+        metadata={},
+        models=[],
+        spend=0.0,
+    )
 
 
-def _build_membership_row_for_me(user_id, team_id, *, spend=12.34, max_budget=100.0):
-    row = MagicMock()
-    row.model_dump.return_value = {
-        "user_id": user_id,
-        "team_id": team_id,
-        "budget_id": "b-1",
-        "spend": spend,
-        "total_spend": spend,
-        "litellm_budget_table": {
-            "budget_id": "b-1",
-            "max_budget": max_budget,
-            "soft_budget": None,
-            "tpm_limit": 500,
-            "rpm_limit": 50,
-            "model_max_budget": None,
-            "budget_duration": "30d",
-            "budget_reset_at": "2026-05-01T00:00:00Z",
-            "allowed_models": None,
-        },
-    }
-    return row
+def _build_membership_for_me(user_id, team_id, *, spend=12.34, max_budget=100.0):
+    """Real LiteLLM_TeamMembership as get_team_membership would return."""
+    return LiteLLM_TeamMembership(
+        user_id=user_id,
+        team_id=team_id,
+        budget_id="b-1",
+        spend=spend,
+        total_spend=spend,
+        litellm_budget_table=LiteLLM_BudgetTableFull(
+            budget_id="b-1",
+            max_budget=max_budget,
+            soft_budget=None,
+            tpm_limit=500,
+            rpm_limit=50,
+            model_max_budget=None,
+            budget_duration="30d",
+            budget_reset_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            allowed_models=None,
+            created_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+
+def _patch_member_me_helpers(*, team, membership=None, user=None):
+    """Patch the three auth helpers used by team_member_me with AsyncMocks."""
+    return (
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+            AsyncMock(return_value=team),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_team_membership",
+            AsyncMock(return_value=membership),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            AsyncMock(return_value=user),
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -7283,30 +7304,25 @@ async def test_team_member_me_returns_caller_membership(mock_db_client):
         user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
     )
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [
-                {"user_id": caller_id, "user_email": None, "role": "user"},
-                {"user_id": other_id, "user_email": None, "role": "admin"},
-            ],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [
+            {"user_id": caller_id, "user_email": None, "role": "user"},
+            {"user_id": other_id, "user_email": None, "role": "admin"},
+        ],
     )
-    mock_db_client.db.litellm_teammembership = MagicMock()
-    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(
-        return_value=_build_membership_row_for_me(caller_id, team_id, spend=42.0)
-    )
-    mock_user_row = MagicMock()
-    mock_user_row.user_email = caller_id
-    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mock_user_row
-    )
+    membership = _build_membership_for_me(caller_id, team_id, spend=42.0)
+    user = LiteLLM_UserTable(user_id=caller_id, user_email=caller_id, max_budget=None)
 
-    response = await team_member_me(
-        http_request=MagicMock(spec=Request),
-        team_id=team_id,
-        user_api_key_dict=caller_auth,
+    p_team, p_membership, p_user = _patch_member_me_helpers(
+        team=team, membership=membership, user=user
     )
+    with p_team, p_membership as mock_get_membership, p_user:
+        response = await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
 
     assert response.user_id == caller_id
     assert response.team_id == team_id
@@ -7315,13 +7331,63 @@ async def test_team_member_me_returns_caller_membership(mock_db_client):
     assert response.team_alias == "team-vec"
     assert response.litellm_budget_table is not None
     assert response.litellm_budget_table.max_budget == 100.0
+    # budget_reset_at must survive end-to-end — proves the BudgetTableFull
+    # variant of the Union is selected (created_at is present), not the base
+    # LiteLLM_BudgetTable which would silently strip this field.
+    assert response.litellm_budget_table.budget_reset_at == datetime(
+        2026, 5, 1, tzinfo=timezone.utc
+    )
 
     # Membership lookup must scope to caller_id, not just team_id — proves the
     # endpoint cannot return another member's row.
-    mock_db_client.db.litellm_teammembership.find_unique.assert_awaited_with(
-        where={"user_id_team_id": {"user_id": caller_id, "team_id": team_id}},
-        include={"litellm_budget_table": True},
+    call_kwargs = mock_get_membership.call_args.kwargs
+    assert call_kwargs["user_id"] == caller_id
+    assert call_kwargs["team_id"] == team_id
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_matches_email_only_member(mock_db_client):
+    """
+    Members onboarded by email may have user_id=None on the stored entry —
+    the lookup must fall back to email matching against the caller, otherwise
+    a valid team member gets a false 404.
+    """
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-email"
+    caller_id = "u-123"
+    caller_email = "alice@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id=caller_id,
+        user_email=caller_email,
     )
+
+    # Member entry with user_id=None and email matching the caller's email.
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": None, "user_email": caller_email, "role": "user"}],
+    )
+    membership = _build_membership_for_me(caller_id, team_id, spend=7.0)
+    user = LiteLLM_UserTable(
+        user_id=caller_id, user_email=caller_email, max_budget=None
+    )
+
+    p_team, p_membership, p_user = _patch_member_me_helpers(
+        team=team, membership=membership, user=user
+    )
+    with p_team, p_membership, p_user:
+        response = await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
+
+    assert response.user_id == caller_id
+    assert response.role == "user"
+    assert response.spend == 7.0
 
 
 @pytest.mark.asyncio
@@ -7337,19 +7403,19 @@ async def test_team_member_me_returns_404_for_non_member(mock_db_client):
         user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
     )
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": "someone_else", "user_email": None, "role": "user"}],
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await team_member_me(
-            http_request=MagicMock(spec=Request),
-            team_id=team_id,
-            user_api_key_dict=caller_auth,
-        )
+    p_team, p_membership, p_user = _patch_member_me_helpers(team=team)
+    with p_team, p_membership, p_user:
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_me(
+                http_request=MagicMock(spec=Request),
+                team_id=team_id,
+                user_api_key_dict=caller_auth,
+            )
     assert exc_info.value.status_code == 404
 
 
@@ -7368,19 +7434,19 @@ async def test_team_member_me_returns_404_for_proxy_admin_not_in_team(
     team_id = "team-me-3"
     mock_admin_auth.user_id = "admin_user_999"
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": "someone_else", "user_email": None, "role": "user"}],
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await team_member_me(
-            http_request=MagicMock(spec=Request),
-            team_id=team_id,
-            user_api_key_dict=mock_admin_auth,
-        )
+    p_team, p_membership, p_user = _patch_member_me_helpers(team=team)
+    with p_team, p_membership, p_user:
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_me(
+                http_request=MagicMock(spec=Request),
+                team_id=team_id,
+                user_api_key_dict=mock_admin_auth,
+            )
     assert exc_info.value.status_code == 404
 
 
@@ -7400,21 +7466,18 @@ async def test_team_member_me_returns_defaults_when_no_membership_row(mock_db_cl
         user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
     )
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [{"user_id": caller_id, "user_email": None, "role": "user"}],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": caller_id, "user_email": None, "role": "user"}],
     )
-    mock_db_client.db.litellm_teammembership = MagicMock()
-    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(return_value=None)
-    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
 
-    response = await team_member_me(
-        http_request=MagicMock(spec=Request),
-        team_id=team_id,
-        user_api_key_dict=caller_auth,
-    )
+    p_team, p_membership, p_user = _patch_member_me_helpers(team=team)
+    with p_team, p_membership, p_user:
+        response = await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
 
     assert response.user_id == caller_id
     assert response.role == "user"
@@ -7442,7 +7505,7 @@ async def test_team_member_me_rejects_team_key_without_user_id(mock_db_client):
 
 @pytest.mark.asyncio
 async def test_team_member_me_returns_404_for_unknown_team(mock_db_client):
-    """Unknown team_id returns 404."""
+    """Unknown team_id returns 404 — propagated from get_team_object."""
     from fastapi import Request, HTTPException
 
     from litellm.proxy.management_endpoints.team_endpoints import team_member_me
@@ -7450,12 +7513,20 @@ async def test_team_member_me_returns_404_for_unknown_team(mock_db_client):
     caller_auth = UserAPIKeyAuth(
         user_role=LitellmUserRoles.INTERNAL_USER, user_id="alice@example.com"
     )
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await team_member_me(
-            http_request=MagicMock(spec=Request),
-            team_id="does-not-exist",
-            user_api_key_dict=caller_auth,
-        )
+    # get_team_object raises 404 directly when the team is missing.
+    with patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        AsyncMock(
+            side_effect=HTTPException(
+                status_code=404, detail={"error": "Team doesn't exist in db."}
+            )
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_me(
+                http_request=MagicMock(spec=Request),
+                team_id="does-not-exist",
+                user_api_key_dict=caller_auth,
+            )
     assert exc_info.value.status_code == 404

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1414,59 +1414,6 @@ export const teamInfoCall = async (accessToken: string, teamID: string | null) =
   }
 };
 
-export interface TeamMemberInfo {
-  user_id: string;
-  team_id: string;
-  team_alias?: string | null;
-  role?: string | null;
-  user_email?: string | null;
-  budget_id?: string | null;
-  spend?: number | null;
-  total_spend?: number | null;
-  litellm_budget_table?: {
-    budget_id?: string;
-    soft_budget?: number | null;
-    max_budget?: number | null;
-    max_parallel_requests?: number | null;
-    tpm_limit?: number | null;
-    rpm_limit?: number | null;
-    model_max_budget?: Record<string, number> | null;
-    budget_duration?: string | null;
-    budget_reset_at?: string | null;
-    allowed_models?: string[] | null;
-  } | null;
-}
-
-export const teamMemberMeCall = async (
-  accessToken: string,
-  teamID: string,
-): Promise<TeamMemberInfo> => {
-  try {
-    const url = proxyBaseUrl
-      ? `${proxyBaseUrl}/team/${encodeURIComponent(teamID)}/members/me`
-      : `/team/${encodeURIComponent(teamID)}/members/me`;
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-    });
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
-      throw new Error(errorMessage);
-    }
-
-    return (await response.json()) as TeamMemberInfo;
-  } catch (error) {
-    console.error("Failed to fetch team member 'me' info:", error);
-    throw error;
-  }
-};
-
 type TeamListResponse = {
   teams: Team[];
   total: number;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1414,6 +1414,59 @@ export const teamInfoCall = async (accessToken: string, teamID: string | null) =
   }
 };
 
+export interface TeamMemberInfo {
+  user_id: string;
+  team_id: string;
+  team_alias?: string | null;
+  role?: string | null;
+  user_email?: string | null;
+  budget_id?: string | null;
+  spend?: number | null;
+  total_spend?: number | null;
+  litellm_budget_table?: {
+    budget_id?: string;
+    soft_budget?: number | null;
+    max_budget?: number | null;
+    max_parallel_requests?: number | null;
+    tpm_limit?: number | null;
+    rpm_limit?: number | null;
+    model_max_budget?: Record<string, number> | null;
+    budget_duration?: string | null;
+    budget_reset_at?: string | null;
+    allowed_models?: string[] | null;
+  } | null;
+}
+
+export const teamMemberMeCall = async (
+  accessToken: string,
+  teamID: string,
+): Promise<TeamMemberInfo> => {
+  try {
+    const url = proxyBaseUrl
+      ? `${proxyBaseUrl}/team/${encodeURIComponent(teamID)}/members/me`
+      : `/team/${encodeURIComponent(teamID)}/members/me`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return (await response.json()) as TeamMemberInfo;
+  } catch (error) {
+    console.error("Failed to fetch team member 'me' info:", error);
+    throw error;
+  }
+};
+
 type TeamListResponse = {
   teams: Team[];
   total: number;

--- a/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
@@ -1,14 +1,12 @@
-import { TeamMemberInfo } from "@/components/networking";
 import { formatBudgetReset } from "@/utils/budgetUtils";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Card, Col, Row, Space, Tag, Tooltip, Typography } from "antd";
 import React from "react";
+import { useMyTeamMember } from "./useMyTeamMember";
 
 interface MyUserTabProps {
-  data: TeamMemberInfo | null;
-  loading: boolean;
-  error: string | null;
+  teamId: string;
 }
 
 const labelWithTooltip = (label: string, tooltip: string) => (
@@ -30,8 +28,10 @@ const formatRateLimit = (value: number | null | undefined): string => {
   return formatNumberWithCommas(value, 0);
 };
 
-export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
-  if (loading) {
+export default function MyUserTab({ teamId }: MyUserTabProps) {
+  const { data, isLoading, error } = useMyTeamMember(teamId);
+
+  if (isLoading) {
     return (
       <Card>
         <Typography.Text type="secondary">Loading your membership info…</Typography.Text>
@@ -42,7 +42,11 @@ export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
   if (error) {
     return (
       <Card>
-        <Typography.Text type="danger">{error}</Typography.Text>
+        <Typography.Text type="danger">
+          {error instanceof Error
+            ? error.message
+            : "Failed to load your membership info for this team."}
+        </Typography.Text>
       </Card>
     );
   }
@@ -145,7 +149,7 @@ export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
           <Card>
             {labelWithTooltip(
               "Model Scope",
-              "Models you can access within this team. Empty means you inherit all team models.",
+              "Models you can access within this team.",
             )}
             <div style={{ marginTop: 8 }}>
               {allowedModels && allowedModels.length > 0 ? (
@@ -155,7 +159,7 @@ export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
                   ))}
                 </Space>
               ) : (
-                <Typography.Text type="secondary">(all team models)</Typography.Text>
+                <Typography.Text>All Team Models</Typography.Text>
               )}
             </div>
           </Card>

--- a/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
@@ -1,0 +1,166 @@
+import { TeamMemberInfo } from "@/components/networking";
+import { formatBudgetReset } from "@/utils/budgetUtils";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import { Card, Col, Row, Space, Tag, Tooltip, Typography } from "antd";
+import React from "react";
+
+interface MyUserTabProps {
+  data: TeamMemberInfo | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const labelWithTooltip = (label: string, tooltip: string) => (
+  <Space size={4}>
+    <Typography.Text type="secondary">{label}</Typography.Text>
+    <Tooltip title={tooltip}>
+      <InfoCircleOutlined style={{ color: "#8c8c8c" }} />
+    </Tooltip>
+  </Space>
+);
+
+const formatNumber = (value: number | null | undefined, digits = 4): string => {
+  if (value === null || value === undefined) return "0";
+  return formatNumberWithCommas(value, digits);
+};
+
+const formatRateLimit = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return "Unlimited";
+  return formatNumberWithCommas(value, 0);
+};
+
+export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
+  if (loading) {
+    return (
+      <Card>
+        <Typography.Text type="secondary">Loading your membership info…</Typography.Text>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <Typography.Text type="danger">{error}</Typography.Text>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card>
+        <Typography.Text type="secondary">
+          No membership info available for the current user in this team.
+        </Typography.Text>
+      </Card>
+    );
+  }
+
+  const budgetTable = data.litellm_budget_table ?? null;
+  const maxBudget = budgetTable?.max_budget ?? null;
+  const spend = data.spend ?? 0;
+  const totalSpend = data.total_spend ?? 0;
+  const tpmLimit = budgetTable?.tpm_limit ?? null;
+  const rpmLimit = budgetTable?.rpm_limit ?? null;
+  const budgetReset = formatBudgetReset(budgetTable?.budget_reset_at);
+  const allowedModels = budgetTable?.allowed_models ?? null;
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Card>
+        <Row gutter={[24, 16]}>
+          <Col xs={24} sm={12} md={8}>
+            <Typography.Text type="secondary">User</Typography.Text>
+            <div style={{ marginTop: 4 }}>
+              <Typography.Text strong>{data.user_email || data.user_id}</Typography.Text>
+            </div>
+            <Typography.Text type="secondary" style={{ fontSize: 12, fontFamily: "monospace" }}>
+              {data.user_id}
+            </Typography.Text>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Typography.Text type="secondary">Team Role</Typography.Text>
+            <div style={{ marginTop: 4 }}>
+              <Tag color={data.role === "admin" ? "blue" : "default"}>
+                {data.role || "user"}
+              </Tag>
+            </div>
+          </Col>
+        </Row>
+      </Card>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Current Cycle Spend (USD)",
+              "Spend for the current budget cycle. Resets to $0 when the budget window rolls over.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Typography.Title level={3} style={{ margin: 0 }}>
+                ${formatNumber(spend, 4)}
+              </Typography.Title>
+              <Typography.Text type="secondary">
+                of {maxBudget === null ? "Unlimited" : `$${formatNumber(maxBudget, 4)}`}
+              </Typography.Text>
+            </div>
+            {budgetReset && (
+              <div style={{ marginTop: 4 }}>
+                <Typography.Text type="secondary">Resets {budgetReset}</Typography.Text>
+              </div>
+            )}
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Rate Limits",
+              "Your per-member rate limits within this team.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Typography.Text>TPM: {formatRateLimit(tpmLimit)}</Typography.Text>
+              <br />
+              <Typography.Text>RPM: {formatRateLimit(rpmLimit)}</Typography.Text>
+            </div>
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Total Spend (USD)",
+              "Cumulative spend across all budget cycles within this team.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Typography.Title level={4} style={{ margin: 0 }}>
+                ${formatNumber(totalSpend, 4)}
+              </Typography.Title>
+            </div>
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Model Scope",
+              "Models you can access within this team. Empty means you inherit all team models.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              {allowedModels && allowedModels.length > 0 ? (
+                <Space wrap>
+                  {allowedModels.map((m) => (
+                    <Tag key={m}>{m}</Tag>
+                  ))}
+                </Space>
+              ) : (
+                <Typography.Text type="secondary">(all team models)</Typography.Text>
+              )}
+            </div>
+          </Card>
+        </Col>
+      </Row>
+    </Space>
+  );
+}

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -11,8 +11,6 @@ import {
   teamInfoCall,
   teamMemberAddCall,
   teamMemberDeleteCall,
-  teamMemberMeCall,
-  TeamMemberInfo,
   teamMemberUpdateCall,
   teamUpdateCall,
 } from "@/components/networking";
@@ -248,35 +246,6 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
   useEffect(() => {
     fetchTeamInfo();
-  }, [teamId, accessToken]);
-
-  const [myUserData, setMyUserData] = useState<TeamMemberInfo | null>(null);
-  const [myUserLoading, setMyUserLoading] = useState(false);
-  const [myUserError, setMyUserError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const fetchMyUser = async () => {
-      if (!accessToken || !teamId) return;
-      try {
-        setMyUserLoading(true);
-        setMyUserError(null);
-        const response = await teamMemberMeCall(accessToken, teamId);
-        if (!cancelled) setMyUserData(response);
-      } catch (error: any) {
-        if (!cancelled) {
-          const message =
-            error?.message || "Failed to load your membership info for this team.";
-          setMyUserError(message);
-        }
-      } finally {
-        if (!cancelled) setMyUserLoading(false);
-      }
-    };
-    fetchMyUser();
-    return () => {
-      cancelled = true;
-    };
   }, [teamId, accessToken]);
 
   // Fetch organization data when team has organization_id
@@ -888,13 +857,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           {
             key: TEAM_INFO_TAB_KEYS.MY_USER,
             label: TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MY_USER],
-            children: (
-              <MyUserTab
-                data={myUserData}
-                loading={myUserLoading}
-                error={myUserError}
-              />
-            ),
+            children: <MyUserTab teamId={teamId} />,
           },
           {
             key: TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -11,6 +11,8 @@ import {
   teamInfoCall,
   teamMemberAddCall,
   teamMemberDeleteCall,
+  teamMemberMeCall,
+  TeamMemberInfo,
   teamMemberUpdateCall,
   teamUpdateCall,
 } from "@/components/networking";
@@ -46,6 +48,7 @@ import EditLoggingSettings from "./EditLoggingSettings";
 import RouterSettingsAccordion, { RouterSettingsAccordionRef } from "../common_components/RouterSettingsAccordion";
 import MemberModal from "./EditMembership";
 import MemberPermissions from "./member_permissions";
+import MyUserTab from "./MyUserTab";
 import {
   getTeamInfoDefaultTab,
   getTeamInfoVisibleTabs,
@@ -245,6 +248,35 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
   useEffect(() => {
     fetchTeamInfo();
+  }, [teamId, accessToken]);
+
+  const [myUserData, setMyUserData] = useState<TeamMemberInfo | null>(null);
+  const [myUserLoading, setMyUserLoading] = useState(false);
+  const [myUserError, setMyUserError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchMyUser = async () => {
+      if (!accessToken || !teamId) return;
+      try {
+        setMyUserLoading(true);
+        setMyUserError(null);
+        const response = await teamMemberMeCall(accessToken, teamId);
+        if (!cancelled) setMyUserData(response);
+      } catch (error: any) {
+        if (!cancelled) {
+          const message =
+            error?.message || "Failed to load your membership info for this team.";
+          setMyUserError(message);
+        }
+      } finally {
+        if (!cancelled) setMyUserLoading(false);
+      }
+    };
+    fetchMyUser();
+    return () => {
+      cancelled = true;
+    };
   }, [teamId, accessToken]);
 
   // Fetch organization data when team has organization_id
@@ -851,6 +883,17 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   variant="card"
                 />
               </Grid>
+            ),
+          },
+          {
+            key: TEAM_INFO_TAB_KEYS.MY_USER,
+            label: TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MY_USER],
+            children: (
+              <MyUserTab
+                data={myUserData}
+                loading={myUserLoading}
+                error={myUserError}
+              />
             ),
           },
           {

--- a/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.test.ts
+++ b/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.test.ts
@@ -11,6 +11,7 @@ describe("team_info_tabs", () => {
   describe("TEAM_INFO_TAB_LABELS", () => {
     it("should have label for every tab key", () => {
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.OVERVIEW]).toBe("Overview");
+      expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MY_USER]).toBe("My User");
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS]).toBe("Virtual Keys");
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MEMBERS]).toBe("Members");
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MEMBER_PERMISSIONS]).toBe("Member Permissions");
@@ -19,15 +20,20 @@ describe("team_info_tabs", () => {
   });
 
   describe("getTeamInfoVisibleTabs", () => {
-    it("returns overview and virtual keys when user cannot edit team", () => {
+    it("returns overview, my user, and virtual keys when user cannot edit team", () => {
       const tabs = getTeamInfoVisibleTabs(false);
-      expect(tabs).toEqual([TEAM_INFO_TAB_KEYS.OVERVIEW, TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS]);
+      expect(tabs).toEqual([
+        TEAM_INFO_TAB_KEYS.OVERVIEW,
+        TEAM_INFO_TAB_KEYS.MY_USER,
+        TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,
+      ]);
     });
 
     it("returns all tabs when user can edit team", () => {
       const tabs = getTeamInfoVisibleTabs(true);
       expect(tabs).toEqual([
         TEAM_INFO_TAB_KEYS.OVERVIEW,
+        TEAM_INFO_TAB_KEYS.MY_USER,
         TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,
         TEAM_INFO_TAB_KEYS.MEMBERS,
         TEAM_INFO_TAB_KEYS.MEMBER_PERMISSIONS,
@@ -60,6 +66,11 @@ describe("team_info_tabs", () => {
     it("always returns true for virtual keys tab regardless of edit permission", () => {
       expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS, false)).toBe(true);
       expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS, true)).toBe(true);
+    });
+
+    it("always returns true for my user tab regardless of edit permission", () => {
+      expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.MY_USER, false)).toBe(true);
+      expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.MY_USER, true)).toBe(true);
     });
 
     it("returns false for member permissions tab when user cannot edit", () => {

--- a/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.ts
+++ b/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.ts
@@ -5,6 +5,7 @@
 
 export const TEAM_INFO_TAB_KEYS = {
   OVERVIEW: "overview",
+  MY_USER: "my-user",
   VIRTUAL_KEYS: "virtual-keys",
   MEMBERS: "members",
   MEMBER_PERMISSIONS: "member-permissions",
@@ -13,6 +14,7 @@ export const TEAM_INFO_TAB_KEYS = {
 
 export const TEAM_INFO_TAB_LABELS: Record<string, string> = {
   [TEAM_INFO_TAB_KEYS.OVERVIEW]: "Overview",
+  [TEAM_INFO_TAB_KEYS.MY_USER]: "My User",
   [TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS]: "Virtual Keys",
   [TEAM_INFO_TAB_KEYS.MEMBERS]: "Members",
   [TEAM_INFO_TAB_KEYS.MEMBER_PERMISSIONS]: "Member Permissions",
@@ -21,11 +23,15 @@ export const TEAM_INFO_TAB_LABELS: Record<string, string> = {
 
 /**
  * Returns the list of tab keys that should be visible based on permissions.
- * - Overview, Virtual Keys: always visible
+ * - Overview, My User, Virtual Keys: always visible
  * - Members, Member Permissions, Settings: only when canEditTeam is true
  */
 export function getTeamInfoVisibleTabs(canEditTeam: boolean): readonly string[] {
-  const baseTabs = [TEAM_INFO_TAB_KEYS.OVERVIEW, TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS];
+  const baseTabs = [
+    TEAM_INFO_TAB_KEYS.OVERVIEW,
+    TEAM_INFO_TAB_KEYS.MY_USER,
+    TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,
+  ];
   if (canEditTeam) {
     return [
       ...baseTabs,

--- a/ui/litellm-dashboard/src/components/team/useMyTeamMember.ts
+++ b/ui/litellm-dashboard/src/components/team/useMyTeamMember.ts
@@ -1,0 +1,74 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import {
+  deriveErrorMessage,
+  getGlobalLitellmHeaderName,
+  getProxyBaseUrl,
+} from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export interface TeamMemberInfo {
+  user_id: string;
+  team_id: string;
+  team_alias?: string | null;
+  role?: string | null;
+  user_email?: string | null;
+  budget_id?: string | null;
+  spend?: number | null;
+  total_spend?: number | null;
+  litellm_budget_table?: {
+    budget_id?: string;
+    soft_budget?: number | null;
+    max_budget?: number | null;
+    max_parallel_requests?: number | null;
+    tpm_limit?: number | null;
+    rpm_limit?: number | null;
+    model_max_budget?: Record<string, number> | null;
+    budget_duration?: string | null;
+    budget_reset_at?: string | null;
+    allowed_models?: string[] | null;
+  } | null;
+}
+
+const fetchMyTeamMember = async (
+  accessToken: string,
+  teamId: string,
+): Promise<TeamMemberInfo | null> => {
+  const proxyBaseUrl = getProxyBaseUrl();
+  const url = proxyBaseUrl
+    ? `${proxyBaseUrl}/team/${encodeURIComponent(teamId)}/members/me`
+    : `/team/${encodeURIComponent(teamId)}/members/me`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  // 404 means the caller is not a team member (e.g. proxy admin viewing
+  // a team they don't belong to). The "My User" tab is always visible so
+  // the fetch fires regardless — return null and let the UI render the
+  // empty state instead of a noisy error.
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(deriveErrorMessage(errorData));
+  }
+
+  return (await response.json()) as TeamMemberInfo;
+};
+
+export const useMyTeamMember = (
+  teamId: string | null | undefined,
+): UseQueryResult<TeamMemberInfo | null> => {
+  const { accessToken } = useAuthorized();
+  return useQuery<TeamMemberInfo | null>({
+    queryKey: ["team", teamId, "members", "me"],
+    queryFn: () => fetchMyTeamMember(accessToken!, teamId!),
+    enabled: Boolean(accessToken && teamId),
+  });
+};


### PR DESCRIPTION
## Summary

- Adds a new **My User** tab on the team detail page (between Overview and Virtual Keys) so non-admin team members can see *their own* spend, budget, budget reset date, rate limits, model scope, and team role within that team.
- New backend endpoint `GET /team/{team_id}/members/me` — server resolves the caller from their API key and returns only their `LiteLLM_TeamMembership` row plus minimal team context. **No client-side filtering**, so other members' data is never sent over the wire.
- Tab is visible to all team members (admins and non-admins).

## screenshots 

<img width="1208" height="544" alt="Screenshot 2026-04-25 at 2 17 18 PM" src="https://github.com/user-attachments/assets/83b57cf8-b216-49a3-b38b-05bf8b6a742f" />


## Test plan

- [x] `pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py -k team_member_me` — 6 new tests pass:
  - returns caller's row (verifies membership lookup is scoped to caller's user_id)
  - 404 for non-member
  - 404 for proxy admin who isn't an actual team member (`me` only resolves for real members)
  - returns defaults when caller is in `members_with_roles` but has no membership row yet
  - 400 for team key without a `user_id`
  - 404 for unknown `team_id`
- [x] `vitest src/components/team/tabVisibilityUtils.test.ts` — 15 tests pass (existing + new "My User always visible" coverage).
- [x] `tsc --noEmit` — no new type errors in modified files.
- [x] Manual UI smoke test on the dashboard: log in as a non-admin team member, open the team detail page, verify the **My User** tab is visible between Overview and Virtual Keys and renders the caller's spend/budget/limits.