### PR TITLE
fix(vector_stores): restrict vector store and index deletion to proxy…

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -47,6 +47,7 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
 )
 from litellm.proxy.utils import is_known_model
 from litellm.proxy.vector_store_endpoints.utils import (
+    _is_proxy_admin,
     is_allowed_to_call_vector_store_endpoint,
 )
 from litellm.secret_managers.main import get_secret_str
@@ -1369,6 +1370,14 @@ async def azure_proxy_route(
                     ),
                 )
             elif is_vector_store_index:
+                if request.method == "DELETE" and not _is_proxy_admin(
+                    user_api_key_dict
+                ):
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Only proxy admins can delete vector store indexes.",
+                    )
+
                 # get the api key from the provider config
                 provider_config = (
                     ProviderConfigManager.get_provider_vector_stores_config(
@@ -1427,6 +1436,14 @@ async def azure_proxy_route(
                     custom_llm_provider=litellm.LlmProviders.AZURE_AI,
                     extra_headers=cast(dict, extra_headers),
                 )
+
+    if request.method == "DELETE" and "indexes" in endpoint and not _is_proxy_admin(
+        user_api_key_dict
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Only proxy admins can delete vector store indexes.",
+        )
 
     base_target_url = get_secret_str(secret_name="AZURE_API_BASE")
     if base_target_url is None:

--- a/litellm/proxy/vector_store_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/endpoints.py
@@ -10,7 +10,10 @@ from litellm.proxy._types import CommonProxyErrors, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.utils import jsonify_object
-from litellm.proxy.vector_store_endpoints.utils import can_user_access_vector_store
+from litellm.proxy.vector_store_endpoints.utils import (
+    _is_proxy_admin,
+    can_user_access_vector_store,
+)
 from litellm.types.vector_stores import IndexCreateRequest
 
 router = APIRouter()
@@ -498,6 +501,12 @@ async def vector_store_delete(
     API Reference:
     https://platform.openai.com/docs/api-reference/vector-stores/delete
     """
+    if not _is_proxy_admin(user_api_key_dict):
+        raise HTTPException(
+            status_code=403,
+            detail="Only proxy admins can delete vector stores.",
+        )
+
     from litellm.proxy.proxy_server import (
         general_settings,
         llm_router,


### PR DESCRIPTION
Description:

Vector store and Azure AI Search index deletion was not restricted to admin users, allowing any valid API key to perform destructive operations.

Cause:

DELETE /v1/vector_stores/{id} only validated that the caller had any valid key (user_api_key_auth) with no role check.
DELETE /azure_ai/indexes/{name} passed through to Azure with only a metadata-based permission check (allowed_vector_store_indexes) — no admin guard. If the index wasn't in the in-memory registry, it fell through to a generic Azure pass-through with zero access control.
Fix:

Added _is_proxy_admin check at the top of vector_store_delete in vector_store_endpoints/endpoints.py — non-admins receive HTTP 403 immediately.
In azure_proxy_route (llm_passthrough_endpoints.py):
When a registered index is matched and method is DELETE, block non-admins before any Azure call.
Added a fallthrough guard: if method is DELETE and the path contains "indexes", block non-admins — covers indexes created via POST /v1/indexes that are DB-only and not in the in-memory registry.