### PR TITLE
[Fix] broaden RAG ingestion credential cleanup to AWS endpoint/identity fields

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4645,6 +4645,169 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "azure/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.5-2026-04-23": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
+    "azure/gpt-5.5-pro": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
+        "supports_low_reasoning_effort": false
+    },
+    "azure/gpt-5.5-pro-2026-04-23": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "azure/gpt-5.4-mini": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 7.5e-07,

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -92,10 +92,7 @@ class BaseRAGIngestion(ABC):
                 "aws_sts_endpoint",
                 "aws_web_identity_token",
             ):
-                if (
-                    key in self.vector_store_config
-                    and key not in credential_values
-                ):
+                if key in self.vector_store_config and key not in credential_values:
                     del self.vector_store_config[key]
 
     @property

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -73,7 +73,7 @@ class BaseRAGIngestion(ABC):
         This allows users to specify a credential name in the vector_store config
         which will be resolved from litellm.credential_list. When a stored
         credential is used, its values take precedence over caller-supplied
-        equivalents so the api_key / api_base pair stays consistent with the
+        equivalents so endpoint and identity fields stay consistent with the
         credential definition.
         """
         from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
@@ -87,11 +87,16 @@ class BaseRAGIngestion(ABC):
                 return
             for key, value in credential_values.items():
                 self.vector_store_config[key] = value
-            if (
-                "api_base" in self.vector_store_config
-                and "api_base" not in credential_values
+            for key in (
+                "api_base",
+                "aws_sts_endpoint",
+                "aws_web_identity_token",
             ):
-                del self.vector_store_config["api_base"]
+                if (
+                    key in self.vector_store_config
+                    and key not in credential_values
+                ):
+                    del self.vector_store_config[key]
 
     @property
     def custom_llm_provider(self) -> str:

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4659,6 +4659,169 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "azure/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.5-2026-04-23": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
+    "azure/gpt-5.5-pro": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
+        "supports_low_reasoning_effort": false
+    },
+    "azure/gpt-5.5-pro-2026-04-23": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "azure/gpt-5.4-mini": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 7.5e-07,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -449,6 +449,63 @@ def test_gpt55_dated_variants_match_base_reasoning_effort_capabilities(
         )
 
 
+@pytest.mark.parametrize(
+    "model,expected_mode,expected_input,expected_output,expected_cache_read",
+    [
+        ("azure/gpt-5.5", "chat", 5e-6, 3e-5, 5e-7),
+        ("azure/gpt-5.5-2026-04-23", "chat", 5e-6, 3e-5, 5e-7),
+        ("azure/gpt-5.5-pro", "responses", 6e-5, 3.6e-4, 6e-6),
+        ("azure/gpt-5.5-pro-2026-04-23", "responses", 6e-5, 3.6e-4, 6e-6),
+    ],
+)
+def test_azure_gpt55_entries_present_with_correct_pricing(
+    model, expected_mode, expected_input, expected_output, expected_cache_read
+):
+    """Day-0 Azure entries for GPT-5.5 mirror the OpenAI pricing structure.
+
+    Pricing parity with openai/gpt-5.5* (verified against OpenAI's pricing page
+    on 2026-04-24): $5/$30 input/output per 1M for chat, $60/$360 for pro.
+    Cache discount is 10% of input.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    m = litellm.model_cost[model]
+    assert m["litellm_provider"] == "azure"
+    assert m["mode"] == expected_mode
+    assert m["input_cost_per_token"] == expected_input
+    assert m["output_cost_per_token"] == expected_output
+    assert m["cache_read_input_token_cost"] == expected_cache_read
+    # Long-context window inherited from gpt-5.4 / openai gpt-5.5.
+    assert m["max_input_tokens"] == 1050000
+    assert m["max_output_tokens"] == 128000
+
+
+@pytest.mark.parametrize(
+    "model,expected_none,expected_minimal,expected_xhigh",
+    [
+        # Mirror live OpenAI API contract (verified via openai/gpt-5.5* on
+        # 2026-04-24): chat accepts {none, low, medium, high, xhigh} but NOT
+        # minimal; pro accepts {medium, high, xhigh} only.
+        # NOTE: openai/gpt-5.5* entries currently set supports_minimal=true on
+        # main (pre #26456). Once that PR lands, OpenAI + Azure flags align.
+        ("azure/gpt-5.5", True, False, True),
+        ("azure/gpt-5.5-pro", False, False, True),
+    ],
+)
+def test_azure_gpt55_reasoning_effort_flags_match_live_openai_api(
+    model, expected_none, expected_minimal, expected_xhigh
+):
+    """Azure entries pin reasoning_effort flags to OpenAI's actual API contract."""
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    m = litellm.model_cost[model]
+    assert m.get("supports_none_reasoning_effort") is expected_none
+    assert m.get("supports_minimal_reasoning_effort") is expected_minimal
+    assert m.get("supports_xhigh_reasoning_effort") is expected_xhigh
+
+
 def test_generic_cost_per_token_anthropic_prompt_caching():
     model = "claude-sonnet-4@20250514"
     usage = Usage(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -769,6 +769,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "uses_embed_content": {"type": "boolean"},
                 "supports_reasoning": {"type": "boolean"},
                 "supports_minimal_reasoning_effort": {"type": "boolean"},
+                "supports_low_reasoning_effort": {"type": "boolean"},
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},
                 "supports_max_reasoning_effort": {"type": "boolean"},


### PR DESCRIPTION
## Relevant issues

## Summary

Extends the cleanup logic in `BaseRAGIngestion._load_credentials_from_config()`
so caller-supplied `aws_sts_endpoint` and `aws_web_identity_token` are
removed when a `litellm_credential_name` is referenced and the stored
credential does not itself define those fields. Mirrors the existing
`api_base` handling.

### Fix

The credential-overwrite loop already replaces caller-supplied entries on
keys that the stored credential defines, but the post-loop strip covered
only `api_base`. Generalize the strip to a tuple of three keys
(`api_base`, `aws_sts_endpoint`, `aws_web_identity_token`) so the resolved
`vector_store_config` cannot pair the credential's keys with caller-chosen
endpoint or identity values when the stored credential omits them.

## Testing

- `uv run pytest tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py tests/test_litellm/vector_stores/test_vector_store_registry.py tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py -v` — 51 passed.
- Manual API verification against the proxy with three scenarios:
  1. Stored credential + caller-supplied `aws_sts_endpoint` to a localhost listener → after the fix, the listener receives no traffic and the call routes to the real AWS STS.
  2. Stored credential, no malicious overrides → unchanged before/after.
  3. Caller-direct keys (no stored credential) + caller-supplied `aws_sts_endpoint` → unchanged before/after; caller remains in control of their own endpoint.

## Type

🐛 Bug Fix

## Screenshots