### PR TITLE
test(ci): add Claude Code ↔ LiteLLM dockerized E2E coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2006,6 +2006,70 @@ jobs:
       - store_test_results:
           path: test-results
 
+  proxy_e2e_claude_code_tests:
+    machine:
+      image: ubuntu-2204:2024.04.1
+    resource_class: large
+    working_directory: ~/project
+    steps:
+      - checkout
+      - setup_google_dns
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Load Docker Database Image
+          command: |
+            zstd -d litellm-docker-database.tar.zst --stdout | docker load
+            docker images | grep litellm-docker-database
+      - run:
+          name: Load Claude Code client image
+          command: |
+            zstd -d claude-code-client.tar.zst --stdout | docker load
+            docker images | grep claude-code-client
+      - run:
+          name: Verify required container images stage
+          command: |
+            docker image inspect litellm-docker-database:ci >/dev/null
+            docker image inspect claude-code-client:ci >/dev/null
+            echo "LiteLLM and Claude Code images are ready"
+      - run:
+          name: Run Dockerized Claude Code E2E Tests
+          command: |
+            mkdir -p test-results
+            : "${LITELLM_MASTER_KEY:?Set LITELLM_MASTER_KEY in CircleCI project env vars.}"
+            : "${ANTHROPIC_API_KEY:?Set ANTHROPIC_API_KEY in CircleCI project env vars.}"
+            set +e
+            LITELLM_IMAGE=litellm-docker-database:ci \
+              CLAUDE_CODE_IMAGE=claude-code-client:ci \
+              LITELLM_SKIP_BUILD=true \
+              CLAUDE_CODE_SKIP_BUILD=true \
+              LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY}" \
+              tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_docker_test.sh
+            status=$?
+            if [ "$status" -eq 0 ]; then
+              printf '%s\n' \
+                '<?xml version="1.0" encoding="UTF-8"?>' \
+                '<testsuite name="proxy_e2e_anthropic_messages_tests" tests="1" failures="0">' \
+                '  <testcase classname="claude_code_docker" name="claude_code_through_litellm"/>' \
+                '</testsuite>' \
+                > test-results/junit.xml
+            else
+              printf '%s\n' \
+                '<?xml version="1.0" encoding="UTF-8"?>' \
+                '<testsuite name="proxy_e2e_anthropic_messages_tests" tests="1" failures="1">' \
+                '  <testcase classname="claude_code_docker" name="claude_code_through_litellm">' \
+                '    <failure message="Dockerized Claude Code E2E test failed">See CircleCI job output for Docker and LiteLLM logs.</failure>' \
+                '  </testcase>' \
+                '</testsuite>' \
+                > test-results/junit.xml
+            fi
+            exit "$status"
+          no_output_timeout: 15m
+
+      # Store test results
+      - store_test_results:
+          path: test-results
+
   upload-coverage:
     docker:
       - *python312_image
@@ -2247,6 +2311,29 @@ jobs:
           paths:
             - litellm-docker-database.tar.zst
 
+  build_claude_code_client_image:
+    machine:
+      image: ubuntu-2204:2024.04.1
+    resource_class: medium
+    working_directory: ~/project
+    steps:
+      - checkout
+      - run:
+          name: Build Claude Code client image
+          command: |
+            docker build \
+              -t claude-code-client:ci \
+              -f tests/proxy_e2e_anthropic_messages_tests/claude_code/Dockerfile.claude-code \
+              tests/proxy_e2e_anthropic_messages_tests/claude_code
+      - run:
+          name: Save Claude Code image to workspace root
+          command: |
+            docker save claude-code-client:ci | zstd -1 -T0 > claude-code-client.tar.zst
+      - persist_to_workspace:
+          root: .
+          paths:
+            - claude-code-client.tar.zst
+
 
   test_bad_database_url:
     machine:
@@ -2320,6 +2407,8 @@ workflows:
           filters: *main_branches
       - build_docker_database_image:
           filters: *main_branches
+      - build_claude_code_client_image:
+          filters: *main_branches
       - e2e_ui_testing:
           filters: *main_branches
       - build_and_test:
@@ -2355,6 +2444,11 @@ workflows:
       - proxy_e2e_anthropic_messages_tests:
           requires:
             - build_docker_database_image
+          filters: *main_branches
+      - proxy_e2e_claude_code_tests:
+          requires:
+            - build_docker_database_image
+            - build_claude_code_client_image
           filters: *main_branches
       - llm_translation_testing:
           filters: *main_branches
@@ -2426,3 +2520,4 @@ workflows:
           requires:
             - build_docker_database_image
           filters: *main_branches
+

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -331,8 +331,17 @@ class CustomGuardrail(CustomLogger):
 
         if "guardrails" in data:
             return data["guardrails"]
-        metadata = data.get("litellm_metadata") or data.get("metadata", {})
-        return metadata.get("guardrails") or []
+        # Check both metadata locations. For regular endpoints move_guardrails_to_metadata
+        # writes to "metadata"; for thread/assistant endpoints it writes to
+        # "litellm_metadata". We check the one that actually contains the "guardrails"
+        # key so that a non-empty litellm_metadata without guardrails does not shadow
+        # the merged list stored in metadata (which would cause team guardrails to be
+        # silently skipped while default_on=True policy guardrails still fire).
+        for meta_key in ("metadata", "litellm_metadata"):
+            meta = data.get(meta_key) or {}
+            if isinstance(meta, dict) and "guardrails" in meta:
+                return meta.get("guardrails") or []
+        return []
 
     def _guardrail_is_in_requested_guardrails(
         self,

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -21,6 +21,7 @@ class SensitiveDataMasker:
             "auth",
             "authorization",
             "credential",
+            "credentials",
             "access",
             "private",
             "certificate",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4645,6 +4645,169 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "azure/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.5-2026-04-23": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
+    "azure/gpt-5.5-pro": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
+        "supports_low_reasoning_effort": false
+    },
+    "azure/gpt-5.5-pro-2026-04-23": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "azure/gpt-5.4-mini": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 7.5e-07,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -679,6 +679,7 @@ class LiteLLMRoutes(enum.Enum):
         "/team/permissions_list",
         "/team/permissions_update",
         "/team/daily/activity",
+        "/team/{team_id}/members/me",
         "/model/new",
         "/model/update",
         "/model/delete",

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1445,6 +1445,10 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             if _team_obj is not None:
                 valid_token.team_object_permission = _team_obj.object_permission
+                # Keep team_metadata in sync with the freshly fetched team so that
+                # guardrails (or any other metadata) added after the key was cached
+                # are picked up on subsequent requests without a cache eviction.
+                valid_token.team_metadata = _team_obj.metadata
             else:
                 valid_token.team_object_permission = None
 

--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -29,6 +29,7 @@ def remove_sensitive_info_from_deployment(
     deployment_dict["litellm_params"].pop("api_key", None)
     deployment_dict["litellm_params"].pop("client_secret", None)
     deployment_dict["litellm_params"].pop("vertex_credentials", None)
+    deployment_dict["litellm_params"].pop("vertex_ai_credentials", None)
     deployment_dict["litellm_params"].pop("aws_access_key_id", None)
     deployment_dict["litellm_params"].pop("aws_secret_access_key", None)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1098,58 +1098,21 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         #########################################################
         ########## 1. Make Bedrock API requests ##########
         #########################################################
-        # Import asyncio for parallel execution
-        import asyncio
-
-        # Determine if INPUT validation is needed in post_call
-        # Skip INPUT validation if pre_call or during_call is already enabled
-        # (to avoid redundant validation - those hooks would have already validated INPUT)
-        should_validate_input = not (
-            self._event_hook_is_event_type(GuardrailEventHooks.pre_call)
-            or self._event_hook_is_event_type(GuardrailEventHooks.during_call)
-        )
-
+        # post_call is the response-validation hook by definition — only scan
+        # OUTPUT. Input scanning belongs to pre_call / during_call hooks, which
+        # users should configure if they want input validation. Running an
+        # extra INPUT scan here produced a duplicate post-call entry in the
+        # trace and made no semantic sense for a "post-call" event.
         output_content_bedrock: Optional[Union[BedrockGuardrailResponse, str]] = None
-
-        if should_validate_input:
-            # Prepare input messages (with optional filtering for latest role message)
-            input_filter = self._prepare_guardrail_messages_for_role(
-                messages=new_messages
-            )
-            input_messages = input_filter.payload_messages or new_messages
-
-            # Create tasks for parallel execution of both INPUT and OUTPUT validation
-            input_task = self.make_bedrock_api_request(
-                source="INPUT",
-                messages=input_messages,
-                request_data=data,
-                logging_event_type=GuardrailEventHooks.post_call,
-            )
-            output_task = self.make_bedrock_api_request(
+        try:
+            output_content_bedrock = await self.make_bedrock_api_request(
                 source="OUTPUT",
                 response=response,
                 request_data=data,
                 logging_event_type=GuardrailEventHooks.post_call,
             )
-
-            # Execute both requests in parallel
-            try:
-                _, output_content_bedrock = await asyncio.gather(
-                    input_task, output_task
-                )
-            except GuardrailInterventionNormalStringError as e:
-                output_content_bedrock = e.message
-        else:
-            # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
-            try:
-                output_content_bedrock = await self.make_bedrock_api_request(
-                    source="OUTPUT",
-                    response=response,
-                    request_data=data,
-                    logging_event_type=GuardrailEventHooks.post_call,
-                )
-            except GuardrailInterventionNormalStringError as e:
-                output_content_bedrock = e.message
+        except GuardrailInterventionNormalStringError as e:
+            output_content_bedrock = e.message
 
         #########################################################
         ########## 2. Apply masking to response with output guardrail response ##########
@@ -1224,11 +1187,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         """
         Process streaming response chunks.
 
-        Collect content from the stream and make parallel bedrock api requests to get the guardrail responses.
+        Collect content from the stream and run the bedrock OUTPUT scan
+        (post_call only validates the response).
         """
         # Import here to avoid circular imports
-        import asyncio
-
         from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
         from litellm.main import stream_chunk_builder
         from litellm.types.utils import TextCompletionResponse
@@ -1245,61 +1207,24 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         )
         if isinstance(assembled_model_response, ModelResponse):
             ####################################################################
-            ########## 1. Make Bedrock Apply Guardrail API requests ##########
-
-            # Bedrock will raise an exception if this violates the guardrail policy
+            ########## 1. Make Bedrock Apply Guardrail API request ##########
+            #
+            # post_call only scans OUTPUT — input scanning belongs to
+            # pre_call / during_call. Bedrock will raise if the response
+            # violates the guardrail policy.
             ###################################################################
-            # Determine if INPUT validation is needed in post_call
-            # Skip INPUT validation if pre_call or during_call is already enabled
-            # (to avoid redundant validation - those hooks would have already validated INPUT)
-            should_validate_input = not (
-                self._event_hook_is_event_type(GuardrailEventHooks.pre_call)
-                or self._event_hook_is_event_type(GuardrailEventHooks.during_call)
-            )
-
             output_guardrail_response: Optional[
                 Union[BedrockGuardrailResponse, str]
             ] = None
-
-            if should_validate_input:
-                # Create tasks for parallel execution
-                input_filter = self._prepare_guardrail_messages_for_role(
-                    messages=request_data.get("messages")
-                )
-                input_messages = input_filter.payload_messages or request_data.get(
-                    "messages"
-                )
-                input_task = self.make_bedrock_api_request(
-                    source="INPUT",
-                    messages=input_messages,
-                    request_data=request_data,
-                    logging_event_type=GuardrailEventHooks.post_call,
-                )  # Only input messages
-                output_task = self.make_bedrock_api_request(
+            try:
+                output_guardrail_response = await self.make_bedrock_api_request(
                     source="OUTPUT",
                     response=assembled_model_response,
                     request_data=request_data,
                     logging_event_type=GuardrailEventHooks.post_call,
-                )  # Only response
-
-                # Execute both requests in parallel
-                try:
-                    _, output_guardrail_response = await asyncio.gather(
-                        input_task, output_task
-                    )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
-            else:
-                # Only run OUTPUT validation (INPUT was already validated in pre_call or during_call)
-                try:
-                    output_guardrail_response = await self.make_bedrock_api_request(
-                        source="OUTPUT",
-                        response=assembled_model_response,
-                        request_data=request_data,
-                        logging_event_type=GuardrailEventHooks.post_call,
-                    )
-                except GuardrailInterventionNormalStringError as e:
-                    output_guardrail_response = e.message
+                )
+            except GuardrailInterventionNormalStringError as e:
+                output_guardrail_response = e.message
 
             #########################################################################
             ########## 2. Apply masking to response with output guardrail response ##########

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1866,83 +1866,122 @@ class ContentFilterGuardrail(CustomGuardrail):
 
         For BLOCK action: Raises HTTPException immediately when blocked content is detected.
         For MASK action: Content is buffered to handle patterns split across chunks.
+
+        At stream end (including when BLOCK raises HTTPException), write a
+        standard_logging_guardrail_information entry into request_data["metadata"]
+        so the post-call log row reaches standard_logging_object.guardrail_information
+        and the UI Request Lifecycle panel. Mirrors apply_guardrail's finally-block
+        contract.
         """
         accumulated_full_text = ""
         yielded_masked_text_len = 0
         buffer_size = 50  # Increased buffer to catch patterns split across many chunks
 
+        start_time = datetime.now()
+        detections: List[ContentFilterDetection] = []
+        masked_entity_count: Dict[str, int] = {}
+        status: GuardrailStatus = "success"
+        exception_str: str = ""
+
         verbose_proxy_logger.info(
             f"ContentFilterGuardrail: Starting robust streaming masking for model {request_data.get('model')}"
         )
 
-        async for item in response:
-            if isinstance(item, ModelResponseStream) and item.choices:
-                delta_content = ""
-                is_final = False
-                for choice in item.choices:
-                    if hasattr(choice, "delta") and choice.delta:
-                        content = getattr(choice.delta, "content", None)
-                        if content and isinstance(content, str):
-                            delta_content += content
-                    if getattr(choice, "finish_reason", None):
-                        is_final = True
+        try:
+            async for item in response:
+                if isinstance(item, ModelResponseStream) and item.choices:
+                    delta_content = ""
+                    is_final = False
+                    for choice in item.choices:
+                        if hasattr(choice, "delta") and choice.delta:
+                            content = getattr(choice.delta, "content", None)
+                            if content and isinstance(content, str):
+                                delta_content += content
+                        if getattr(choice, "finish_reason", None):
+                            is_final = True
 
-                accumulated_full_text += delta_content
+                    accumulated_full_text += delta_content
 
-                # Check for blocking or apply masking
-                # Add a space at the end if it's the final chunk to trigger word boundaries (\b)
-                text_to_check = accumulated_full_text
-                if is_final:
-                    text_to_check += " "
+                    # Check for blocking or apply masking
+                    # Add a space at the end if it's the final chunk to trigger word boundaries (\b)
+                    text_to_check = accumulated_full_text
+                    if is_final:
+                        text_to_check += " "
 
-                try:
-                    masked_text = self._filter_single_text(text_to_check)
-                    if is_final and masked_text.endswith(" "):
-                        masked_text = masked_text[:-1]
-                except HTTPException:
-                    raise
-                except Exception as e:
-                    verbose_proxy_logger.error(
-                        f"ContentFilterGuardrail: Error in masking: {e}"
-                    )
-                    masked_text = text_to_check  # Fallback to current text
+                    try:
+                        # Reset before each scan: _filter_single_text scans the
+                        # whole accumulated buffer every chunk, so previous-chunk
+                        # matches are guaranteed to be re-found. Keeping only the
+                        # latest scan's detections avoids N× duplication in the
+                        # final log row. BLOCK still records correctly because
+                        # handlers append to detections before raising.
+                        detections.clear()
+                        masked_text = self._filter_single_text(
+                            text_to_check, detections=detections
+                        )
+                        if is_final and masked_text.endswith(" "):
+                            masked_text = masked_text[:-1]
+                    except HTTPException:
+                        raise
+                    except Exception as e:
+                        verbose_proxy_logger.error(
+                            f"ContentFilterGuardrail: Error in masking: {e}"
+                        )
+                        masked_text = text_to_check  # Fallback to current text
 
-                # Determine how much can be safely yielded
-                if is_final:
-                    safe_to_yield_len = len(masked_text)
-                else:
-                    safe_to_yield_len = max(0, len(masked_text) - buffer_size)
+                    # Determine how much can be safely yielded
+                    if is_final:
+                        safe_to_yield_len = len(masked_text)
+                    else:
+                        safe_to_yield_len = max(0, len(masked_text) - buffer_size)
 
-                if safe_to_yield_len > yielded_masked_text_len:
-                    new_masked_content = masked_text[
-                        yielded_masked_text_len:safe_to_yield_len
-                    ]
-                    # Modify the chunk to contain only the new masked content
-                    if (
-                        item.choices
-                        and hasattr(item.choices[0], "delta")
-                        and item.choices[0].delta
-                    ):
-                        item.choices[0].delta.content = new_masked_content
-                        yielded_masked_text_len = safe_to_yield_len
+                    if safe_to_yield_len > yielded_masked_text_len:
+                        new_masked_content = masked_text[
+                            yielded_masked_text_len:safe_to_yield_len
+                        ]
+                        # Modify the chunk to contain only the new masked content
+                        if (
+                            item.choices
+                            and hasattr(item.choices[0], "delta")
+                            and item.choices[0].delta
+                        ):
+                            item.choices[0].delta.content = new_masked_content
+                            yielded_masked_text_len = safe_to_yield_len
+                            yield item
+                    else:
+                        # Hold content by yielding empty content chunk (keeps metadata/structure)
+                        if (
+                            item.choices
+                            and hasattr(item.choices[0], "delta")
+                            and item.choices[0].delta
+                        ):
+                            item.choices[0].delta.content = ""
                         yield item
                 else:
-                    # Hold content by yielding empty content chunk (keeps metadata/structure)
-                    if (
-                        item.choices
-                        and hasattr(item.choices[0], "delta")
-                        and item.choices[0].delta
-                    ):
-                        item.choices[0].delta.content = ""
+                    # Not a ModelResponseStream or no choices - yield as is
                     yield item
-            else:
-                # Not a ModelResponseStream or no choices - yield as is
-                yield item
 
-        # Any remaining content (should have been handled by is_final, but just in case)
-        if yielded_masked_text_len < len(accumulated_full_text):
-            # We already reached the end of the generator
-            pass
+            # Any remaining content (should have been handled by is_final, but just in case)
+            if yielded_masked_text_len < len(accumulated_full_text):
+                # We already reached the end of the generator
+                pass
+        except HTTPException:
+            status = "guardrail_intervened"
+            raise
+        except Exception as e:
+            status = "guardrail_failed_to_respond"
+            exception_str = str(e)
+            raise e
+        finally:
+            self._count_masked_entities(detections, masked_entity_count)
+            self._log_guardrail_information(
+                request_data=request_data,
+                detections=detections,
+                status=status,
+                start_time=start_time,
+                masked_entity_count=masked_entity_count,
+                exception_str=exception_str,
+            )
 
     @staticmethod
     def get_config_model():

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3854,6 +3854,8 @@ async def _execute_virtual_key_regeneration(
 
     non_default_values = {}
     if data is not None:
+        # Enforce upperbound key params on regenerate (don't fill defaults)
+        _enforce_upperbound_key_params(data, fill_defaults=False)
         non_default_values = await prepare_key_update_data(
             data=data, existing_key_row=key_in_db
         )

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1448,15 +1448,15 @@ if MCP_AVAILABLE:
         return _redact_mcp_credentials(temp_record)
 
     async def _get_cached_temporary_mcp_server_or_404(
-        server_id: str, request: Optional[Request] = None
+        server_id: str,
+        user_api_key_dict: UserAPIKeyAuth,
+        request: Optional[Request] = None,
     ) -> MCPServer:
         server = await get_cached_temporary_mcp_server(server_id)
+        resolved_from_temp_cache = server is not None
         if server is None:
             # Fall back to real DB/config server (e.g. for the user-side OAuth flow
             # which calls these endpoints with a real server_id, not a temp session id).
-            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-                global_mcp_server_manager,
-            )
             from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 
             client_ip = IPAddressUtils.get_mcp_client_ip(request) if request else None
@@ -1470,6 +1470,28 @@ if MCP_AVAILABLE:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": f"MCP server {server_id} not found"},
             )
+
+        # Per-server access policy mirrors `fetch_mcp_server`: admin-view
+        # callers are unrestricted; non-admins must have the server in their
+        # allowed-servers set. Temporary cached servers come from the
+        # admin-only `/server/oauth/session` setup flow and are not exposed
+        # to non-admins.
+        if not _user_has_admin_view(user_api_key_dict):
+            if resolved_from_temp_cache:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={"error": f"Access denied to MCP server {server_id}"},
+                )
+            allowed_server_ids = (
+                await global_mcp_server_manager.get_allowed_mcp_servers(
+                    user_api_key_dict
+                )
+            )
+            if server.server_id not in allowed_server_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={"error": f"Access denied to MCP server {server_id}"},
+                )
         return server
 
     @router.get(
@@ -1490,7 +1512,7 @@ if MCP_AVAILABLE:
         scope: Optional[str] = None,
     ):
         mcp_server = await _get_cached_temporary_mcp_server_or_404(
-            server_id, request=request
+            server_id, user_api_key_dict, request=request
         )
         # Use the server's stored client_id when the caller doesn't supply one
         resolved_client_id = mcp_server.client_id or client_id or ""
@@ -1536,7 +1558,7 @@ if MCP_AVAILABLE:
         scope: Optional[str] = Form(None),
     ):
         mcp_server = await _get_cached_temporary_mcp_server_or_404(
-            server_id, request=request
+            server_id, user_api_key_dict, request=request
         )
         resolved_client_id = mcp_server.client_id or client_id or ""
         if not resolved_client_id:
@@ -1574,7 +1596,7 @@ if MCP_AVAILABLE:
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ):
         mcp_server = await _get_cached_temporary_mcp_server_or_404(
-            server_id, request=request
+            server_id, user_api_key_dict, request=request
         )
         request_data = await _read_request_body(request=request)
         data: dict = {**request_data}

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -1190,6 +1190,9 @@ async def update_model(
                 data=_data,  # type: ignore
             )
 
+            # Clear cache and reload models (uses config setting or defaults to preserving config models for DB updates)
+            await clear_cache()
+
             ## CREATE AUDIT LOG ##
             asyncio.create_task(
                 create_object_audit_log(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -66,6 +66,7 @@ from litellm.proxy.auth.auth_checks import (
     allowed_route_check_inside_route,
     can_org_access_model,
     get_org_object,
+    get_team_membership,
     get_team_object,
     get_user_object,
 )
@@ -3448,7 +3449,7 @@ async def team_member_me(
     --header 'Authorization: Bearer your_api_key_here'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
     if prisma_client is None:
         raise HTTPException(
@@ -3468,20 +3469,22 @@ async def team_member_me(
             },
         )
 
-    team_row = await prisma_client.db.litellm_teamtable.find_unique(
-        where={"team_id": team_id},
+    team_table = await get_team_object(
+        team_id=team_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
     )
-    if team_row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"error": f"Team not found, passed team_id={team_id}."},
-        )
 
-    team_table = LiteLLM_TeamTable(**team_row.model_dump())
-
+    caller_user_email = user_api_key_dict.user_email
     member_role: Optional[str] = None
     for m in team_table.members_with_roles:
-        if m.user_id == caller_user_id:
+        # Match by user_id when present, else fall back to email — members
+        # added by email may have user_id=None on the stored entry.
+        if (m.user_id is not None and m.user_id == caller_user_id) or (
+            m.user_email is not None
+            and caller_user_email is not None
+            and m.user_email == caller_user_email
+        ):
             member_role = m.role
             break
 
@@ -3496,22 +3499,22 @@ async def team_member_me(
             },
         )
 
-    membership_row = await prisma_client.db.litellm_teammembership.find_unique(
-        where={
-            "user_id_team_id": {
-                "user_id": caller_user_id,
-                "team_id": team_id,
-            }
-        },
-        include={"litellm_budget_table": True},
+    membership = await get_team_membership(
+        user_id=caller_user_id,
+        team_id=team_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
     )
 
-    user_row = await prisma_client.db.litellm_usertable.find_unique(
-        where={"user_id": caller_user_id}
+    user_row = await get_user_object(
+        user_id=caller_user_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        user_id_upsert=False,
     )
     user_email = getattr(user_row, "user_email", None) if user_row is not None else None
 
-    if membership_row is None:
+    if membership is None:
         # Member is in members_with_roles but has no membership row yet
         # (no per-member budget/limits configured). Return defaults.
         return TeamMemberInfoResponse(
@@ -3526,17 +3529,16 @@ async def team_member_me(
             litellm_budget_table=None,
         )
 
-    membership_dict = membership_row.model_dump()
     return TeamMemberInfoResponse(
         user_id=caller_user_id,
         team_id=team_id,
         team_alias=team_table.team_alias,
         role=member_role,
         user_email=user_email,
-        spend=membership_dict.get("spend", 0.0),
-        total_spend=membership_dict.get("total_spend", 0.0),
-        budget_id=membership_dict.get("budget_id"),
-        litellm_budget_table=membership_dict.get("litellm_budget_table"),
+        spend=membership.spend,
+        total_spend=membership.total_spend,
+        budget_id=membership.budget_id,
+        litellm_budget_table=membership.litellm_budget_table,
     )
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -110,6 +110,7 @@ from litellm.types.proxy.management_endpoints.team_endpoints import (
     TeamListItem,
     TeamListResponse,
     TeamMemberAddResult,
+    TeamMemberInfoResponse,
     UpdateTeamMemberPermissionsRequest,
 )
 
@@ -3418,6 +3419,125 @@ async def team_info(
             param=getattr(e, "param", "None"),
             code=status.HTTP_400_BAD_REQUEST,
         )
+
+
+@router.get(
+    "/team/{team_id}/members/me",
+    tags=["team management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=TeamMemberInfoResponse,
+)
+@management_endpoint_wrapper
+async def team_member_me(
+    http_request: Request,
+    team_id: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get the caller's own team-membership row for the given team.
+
+    Used by internal users to view their own spend, budget, budget reset
+    date, rate limits, and role within a team — without exposing other
+    members' data. The caller is resolved from their API key; the path
+    `/members/me` always refers to that caller.
+
+    Returns 404 if the caller is not a member of the team.
+
+    ```
+    curl --location 'http://localhost:4000/team/your_team_id/members/me' \
+    --header 'Authorization: Bearer your_api_key_here'
+    ```
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "error": "Database not connected. Connect a database to your proxy - https://docs.litellm.ai/docs/simple_proxy#managing-auth---virtual-keys"
+            },
+        )
+
+    caller_user_id = user_api_key_dict.user_id
+    if caller_user_id is None:
+        # Team keys / service-account keys without a user_id can't resolve "me".
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "API key has no associated user_id; cannot resolve 'me' for team membership."
+            },
+        )
+
+    team_row = await prisma_client.db.litellm_teamtable.find_unique(
+        where={"team_id": team_id},
+    )
+    if team_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": f"Team not found, passed team_id={team_id}."},
+        )
+
+    team_table = LiteLLM_TeamTable(**team_row.model_dump())
+
+    member_role: Optional[str] = None
+    for m in team_table.members_with_roles:
+        if m.user_id == caller_user_id:
+            member_role = m.role
+            break
+
+    if member_role is None:
+        # Caller is not a member of this team. Even proxy admins get 404 here —
+        # they can use /team/info to view all members; "me" only resolves for
+        # actual members of the team.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": f"User user_id={caller_user_id} is not a member of team_id={team_id}."
+            },
+        )
+
+    membership_row = await prisma_client.db.litellm_teammembership.find_unique(
+        where={
+            "user_id_team_id": {
+                "user_id": caller_user_id,
+                "team_id": team_id,
+            }
+        },
+        include={"litellm_budget_table": True},
+    )
+
+    user_row = await prisma_client.db.litellm_usertable.find_unique(
+        where={"user_id": caller_user_id}
+    )
+    user_email = getattr(user_row, "user_email", None) if user_row is not None else None
+
+    if membership_row is None:
+        # Member is in members_with_roles but has no membership row yet
+        # (no per-member budget/limits configured). Return defaults.
+        return TeamMemberInfoResponse(
+            user_id=caller_user_id,
+            team_id=team_id,
+            team_alias=team_table.team_alias,
+            role=member_role,
+            user_email=user_email,
+            spend=0.0,
+            total_spend=0.0,
+            budget_id=None,
+            litellm_budget_table=None,
+        )
+
+    membership_dict = membership_row.model_dump()
+    return TeamMemberInfoResponse(
+        user_id=caller_user_id,
+        team_id=team_id,
+        team_alias=team_table.team_alias,
+        role=member_role,
+        user_email=user_email,
+        spend=membership_dict.get("spend", 0.0),
+        total_spend=membership_dict.get("total_spend", 0.0),
+        budget_id=membership_dict.get("budget_id"),
+        litellm_budget_table=membership_dict.get("litellm_budget_table"),
+    )
 
 
 @router.post(

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -71,7 +71,10 @@ class BaseRAGIngestion(ABC):
         Load credentials from litellm_credential_name if provided in vector_store config.
 
         This allows users to specify a credential name in the vector_store config
-        which will be resolved from litellm.credential_list.
+        which will be resolved from litellm.credential_list. When a stored
+        credential is used, its values take precedence over caller-supplied
+        equivalents so the api_key / api_base pair stays consistent with the
+        credential definition.
         """
         from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 
@@ -80,10 +83,13 @@ class BaseRAGIngestion(ABC):
             credential_values = CredentialAccessor.get_credential_values(
                 credential_name
             )
-            # Merge credentials into vector_store_config (don't overwrite existing values)
             for key, value in credential_values.items():
-                if key not in self.vector_store_config:
-                    self.vector_store_config[key] = value
+                self.vector_store_config[key] = value
+            if (
+                "api_base" in self.vector_store_config
+                and "api_base" not in credential_values
+            ):
+                del self.vector_store_config["api_base"]
 
     @property
     def custom_llm_provider(self) -> str:

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -83,6 +83,8 @@ class BaseRAGIngestion(ABC):
             credential_values = CredentialAccessor.get_credential_values(
                 credential_name
             )
+            if not credential_values:
+                return
             for key, value in credential_values.items():
                 self.vector_store_config[key] = value
             if (

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -92,10 +92,7 @@ class BaseRAGIngestion(ABC):
                 "aws_sts_endpoint",
                 "aws_web_identity_token",
             ):
-                if (
-                    key in self.vector_store_config
-                    and key not in credential_values
-                ):
+                if key in self.vector_store_config and key not in credential_values:
                     del self.vector_store_config[key]
 
     @property

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -73,7 +73,7 @@ class BaseRAGIngestion(ABC):
         This allows users to specify a credential name in the vector_store config
         which will be resolved from litellm.credential_list. When a stored
         credential is used, its values take precedence over caller-supplied
-        equivalents so the api_key / api_base pair stays consistent with the
+        equivalents so endpoint and identity fields stay consistent with the
         credential definition.
         """
         from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
@@ -87,11 +87,16 @@ class BaseRAGIngestion(ABC):
                 return
             for key, value in credential_values.items():
                 self.vector_store_config[key] = value
-            if (
-                "api_base" in self.vector_store_config
-                and "api_base" not in credential_values
+            for key in (
+                "api_base",
+                "aws_sts_endpoint",
+                "aws_web_identity_token",
             ):
-                del self.vector_store_config["api_base"]
+                if (
+                    key in self.vector_store_config
+                    and key not in credential_values
+                ):
+                    del self.vector_store_config[key]
 
     @property
     def custom_llm_provider(self) -> str:

--- a/litellm/types/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/team_endpoints.py
@@ -114,3 +114,11 @@ class BulkTeamMemberAddResponse(BaseModel):
     successful_additions: int
     failed_additions: int
     updated_team: Optional[Dict[str, Any]] = None
+
+
+class TeamMemberInfoResponse(LiteLLM_TeamMembership):
+    """Response for GET /team/{team_id}/members/me — caller's own membership row."""
+
+    role: Optional[str] = None
+    user_email: Optional[str] = None
+    team_alias: Optional[str] = None

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4659,6 +4659,169 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "azure/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.5-2026-04-23": {
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "cache_read_input_token_cost_priority": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens_priority": 2e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "input_cost_per_token_priority": 1e-05,
+        "input_cost_per_token_above_272k_tokens_priority": 2e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "output_cost_per_token_priority": 6e-05,
+        "output_cost_per_token_above_272k_tokens_priority": 9e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
+    "azure/gpt-5.5-pro": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": false,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
+        "supports_low_reasoning_effort": false
+    },
+    "azure/gpt-5.5-pro-2026-04-23": {
+        "cache_read_input_token_cost": 6e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 1.2e-05,
+        "input_cost_per_token": 6e-05,
+        "input_cost_per_token_above_272k_tokens": 0.00012,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "output_cost_per_token": 0.00036,
+        "output_cost_per_token_above_272k_tokens": 0.00054,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "azure/gpt-5.4-mini": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 7.5e-07,

--- a/tests/proxy_e2e_anthropic_messages_tests/claude_code/Dockerfile.claude-code
+++ b/tests/proxy_e2e_anthropic_messages_tests/claude_code/Dockerfile.claude-code
@@ -1,0 +1,41 @@
+ARG CLAUDE_CODE_BASE_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:f26d42a15d09d9a643b231df929fa3cf609bedc58a728eb445be89a9d8d1da9f
+FROM ${CLAUDE_CODE_BASE_IMAGE}
+
+ARG CLAUDE_CODE_VERSION=latest
+
+USER root
+
+COPY resolve_claude_code_version.js /tmp/resolve_claude_code_version.js
+
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+    curl \
+    nodejs \
+    npm \
+    shadow && \
+    if [ "${CLAUDE_CODE_VERSION}" = "latest" ]; then \
+      CLAUDE_CODE_RESOLVED_VERSION="$(node /tmp/resolve_claude_code_version.js)"; \
+    else \
+      CLAUDE_CODE_RESOLVED_VERSION="${CLAUDE_CODE_VERSION}"; \
+    fi && \
+    echo "Installing @anthropic-ai/claude-code@${CLAUDE_CODE_RESOLVED_VERSION}" && \
+    npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_RESOLVED_VERSION}" && \
+    CLAUDE_CODE_GLOBAL_ROOT="$(npm root -g)" && \
+    node "${CLAUDE_CODE_GLOBAL_ROOT}/@anthropic-ai/claude-code/install.cjs" && \
+    npm cache clean --force && \
+    groupadd --system claude && \
+    useradd --system --create-home --gid claude --shell /bin/bash claude && \
+    mkdir -p /workspace /home/claude/.claude && \
+    chown -R claude:claude /workspace /home/claude
+
+COPY --chown=claude:claude run_claude_code_check.sh /usr/local/bin/run_claude_code_check.sh
+RUN chmod 0755 /usr/local/bin/run_claude_code_check.sh
+
+USER claude
+WORKDIR /workspace
+
+ENV CI=true \
+    HOME=/home/claude
+
+ENTRYPOINT ["/usr/local/bin/run_claude_code_check.sh"]

--- a/tests/proxy_e2e_anthropic_messages_tests/claude_code/README.md
+++ b/tests/proxy_e2e_anthropic_messages_tests/claude_code/README.md
@@ -1,0 +1,62 @@
+# Claude Code LiteLLM E2E Test
+
+This V0 test validates the customer-critical Claude Code -> LiteLLM -> Anthropic path in CircleCI.
+
+## What It Covers
+
+- Builds/runs the LiteLLM proxy container from the current checkout.
+- Starts an isolated Postgres container for proxy database state.
+- Builds a separate Claude Code client container.
+- Runs Claude Code as a non-root user with only the LiteLLM proxy key.
+- Points Claude Code at LiteLLM via `ANTHROPIC_BASE_URL`.
+- Verifies the configured Anthropic model is visible from `/v1/models`.
+- Sends back-to-back Claude Code prompts through LiteLLM and validates both responses.
+- Sends a direct Anthropic Messages API request through LiteLLM and checks proxy response headers:
+  - `x-litellm-call-id`
+  - `x-litellm-response-cost`
+
+The direct `/v1/messages` header check gives a clear proxy-side signal that LiteLLM handled and accounted for the request, instead of only proving the client printed text.
+
+## Claude Code Version Policy
+
+The Claude Code image resolves `@anthropic-ai/claude-code@latest` by querying npm publish times, selecting the newest version older than three days, then installing that exact version.
+
+This intentionally follows the newest Claude Code release that has aged at least three days, which catches customer-facing compatibility issues while avoiding just-published releases that are more likely to be pulled or patched.
+
+Set `CLAUDE_CODE_VERSION=<version>` to test a specific version locally or in a follow-up CI job.
+
+## Running Locally
+
+Set `ANTHROPIC_API_KEY` in the environment or in `tests/proxy_e2e_anthropic_messages_tests/claude_code/.env`, then run:
+
+```bash
+tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_docker_test.sh
+```
+
+Useful overrides:
+
+```bash
+MODEL_NAME=claude-sonnet-4-6
+LITELLM_UPSTREAM_MODEL=anthropic/claude-sonnet-4-6
+CLAUDE_CODE_IMAGE=litellm-claude-code-client:local
+CLAUDE_CODE_VERSION=latest
+KEEP_CONTAINERS=1
+```
+
+In CircleCI, the job sets `LITELLM_IMAGE=litellm-docker-database:ci` and `LITELLM_SKIP_BUILD=true` so the test uses the LiteLLM image already built from the checked-out commit.
+The CircleCI job now has explicit component stages before test execution:
+
+- verify LiteLLM image exists (`litellm-docker-database:ci`)
+- use prebuilt Claude Code client image (`claude-code-client:ci`)
+- run end-to-end test with both image builds skipped (`LITELLM_SKIP_BUILD=true` and `CLAUDE_CODE_SKIP_BUILD=true`)
+
+## Intentionally Left Out Of V0
+
+- Bedrock and other providers. Those belong in V1 after the Anthropic path is stable.
+- Back-to-back session behavior. V0 proves the request path works; V1 can add repeated requests and long-running session checks.
+- Tool-use assertions. Claude Code can invoke tools in richer scenarios, but V0 keeps the signal focused on proxy compatibility and real Anthropic request success.
+- A Claude Code version matrix. The Dockerfile supports `CLAUDE_CODE_VERSION`, but the default CI path tests one recent version to keep cost and flake surface low.
+
+## Failure Output
+
+The runner prints each phase, dumps LiteLLM logs if the proxy fails readiness, and emits a JUnit result in CircleCI. Header-check failures print the response headers and body so regressions are visible without SSHing into the job.

--- a/tests/proxy_e2e_anthropic_messages_tests/claude_code/docker-compose.yaml
+++ b/tests/proxy_e2e_anthropic_messages_tests/claude_code/docker-compose.yaml
@@ -1,0 +1,57 @@
+services:
+  postgres:
+    image: postgres:14@sha256:6a70deda415ec296f977890e11aba04a0db9f632a362e3fce45e845e3db74f26
+    environment:
+      POSTGRES_DB: litellm
+      POSTGRES_USER: litellm
+      POSTGRES_PASSWORD: litellm
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d litellm -U litellm"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  litellm:
+    image: ${LITELLM_IMAGE:-litellm-claude-code-e2e:local}
+    build:
+      context: ../../..
+      dockerfile: Dockerfile
+      target: runtime
+    command: ["--config", "/app/config.yaml", "--port", "4000", "--detailed_debug"]
+    ports:
+      - "${PROXY_PORT:-4000}:4000"
+    environment:
+      DATABASE_URL: postgresql://litellm:litellm@postgres:5432/litellm
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-1234}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY is required}
+      LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS: "True"
+    volumes:
+      - ${CLAUDE_CODE_LITELLM_CONFIG:?CLAUDE_CODE_LITELLM_CONFIG is required}:/app/config.yaml:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness', timeout=5)\"",
+        ]
+      interval: 5s
+      timeout: 10s
+      retries: 60
+
+  claude-code:
+    image: ${CLAUDE_CODE_IMAGE:-litellm-claude-code-client:local}
+    build:
+      context: .
+      dockerfile: Dockerfile.claude-code
+      args:
+        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-latest}
+    environment:
+      ANTHROPIC_BASE_URL: http://litellm:4000
+      ANTHROPIC_AUTH_TOKEN: ${LITELLM_MASTER_KEY:-sk-1234}
+      MODEL_NAME: ${MODEL_NAME:-claude-sonnet-4-6}
+      CLAUDE_CODE_PROMPT: "${CLAUDE_CODE_PROMPT:-Respond with exactly this text and nothing else: Hello from LiteLLM Claude Code.}"
+    depends_on:
+      litellm:
+        condition: service_healthy

--- a/tests/proxy_e2e_anthropic_messages_tests/claude_code/resolve_claude_code_version.js
+++ b/tests/proxy_e2e_anthropic_messages_tests/claude_code/resolve_claude_code_version.js
@@ -1,0 +1,22 @@
+const { execFileSync } = require("node:child_process");
+
+const packageName = "@anthropic-ai/claude-code";
+const minAgeMs = 3 * 24 * 60 * 60 * 1000;
+const cutoff = Date.now() - minAgeMs;
+const raw = execFileSync("npm", ["view", packageName, "time", "--json"], {
+  encoding: "utf8",
+});
+const time = JSON.parse(raw);
+const versions = Object.keys(time)
+  .filter((version) => /^\d/.test(version))
+  .filter((version) => new Date(time[version]).getTime() <= cutoff)
+  .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+if (versions.length === 0) {
+  console.error(
+    `No ${packageName} version is older than the 3-day exclusion window.`
+  );
+  process.exit(1);
+}
+
+console.log(versions[versions.length - 1]);

--- a/tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_check.sh
+++ b/tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ANTHROPIC_BASE_URL:?ANTHROPIC_BASE_URL is required}"
+: "${ANTHROPIC_AUTH_TOKEN:?ANTHROPIC_AUTH_TOKEN is required}"
+: "${MODEL_NAME:?MODEL_NAME is required}"
+
+OUTPUT_FILE="${CLAUDE_CODE_OUTPUT_FILE:-/tmp/claude-code-output.txt}"
+PROMPT="${CLAUDE_CODE_PROMPT:-Respond with exactly this text and nothing else: Hello from LiteLLM Claude Code.}"
+
+echo "Running Claude Code against ${ANTHROPIC_BASE_URL} with model ${MODEL_NAME}"
+
+claude -p "${PROMPT}" --model "${MODEL_NAME}" >"${OUTPUT_FILE}"
+
+if [[ ! -s "${OUTPUT_FILE}" ]]; then
+  echo "Claude Code produced no output."
+  exit 1
+fi
+
+echo "Claude Code output:"
+sed -n '1,20p' "${OUTPUT_FILE}"

--- a/tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_docker_test.sh
+++ b/tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_docker_test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dockerized Claude Code + LiteLLM integration test.
+#
+# Required:
+#   ANTHROPIC_API_KEY or tests/proxy_e2e_anthropic_messages_tests/claude_code/.env
+#
+# Optional:
+#   MODEL_NAME=claude-sonnet-4-6
+#   LITELLM_UPSTREAM_MODEL=anthropic/${MODEL_NAME}
+#   LITELLM_IMAGE=litellm-claude-code-e2e:local
+#   CLAUDE_CODE_IMAGE=litellm-claude-code-client:local
+#   LITELLM_SKIP_BUILD=true
+#   CLAUDE_CODE_SKIP_BUILD=true
+#   CLAUDE_CODE_VERSION=latest
+#   PROXY_PORT=4000
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yaml"
+ENV_FILE="${SCRIPT_DIR}/.env"
+MODEL_NAME="${MODEL_NAME:-claude-sonnet-4-6}"
+LITELLM_UPSTREAM_MODEL="${LITELLM_UPSTREAM_MODEL:-anthropic/${MODEL_NAME}}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-1234}"
+PROXY_PORT="${PROXY_PORT:-4000}"
+PROXY_URL="http://127.0.0.1:${PROXY_PORT}"
+STARTUP_TIMEOUT_S="${STARTUP_TIMEOUT_S:-300}"
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-litellm-claude-code-e2e}"
+TMP_DIR="$(mktemp -d)"
+CLAUDE_CODE_LITELLM_CONFIG="${TMP_DIR}/config.yaml"
+HEADERS_FILE="${TMP_DIR}/headers.txt"
+BODY_FILE="${TMP_DIR}/body.json"
+
+cleanup() {
+  if [[ "${KEEP_CONTAINERS:-}" == "1" ]]; then
+    echo "KEEP_CONTAINERS=1 set; leaving docker compose project ${COMPOSE_PROJECT_NAME} running."
+    echo "Generated config left at ${CLAUDE_CODE_LITELLM_CONFIG}"
+    return
+  fi
+  docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" down -v >/dev/null 2>&1 || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+fi
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "ANTHROPIC_API_KEY is required in the environment or ${ENV_FILE}"
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required"
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose v2 is required"
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required"
+  exit 1
+fi
+
+is_port_available() {
+  python3 - "$1" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    sock.bind(("127.0.0.1", port))
+    print("yes")
+except OSError:
+    print("no")
+finally:
+    sock.close()
+PY
+}
+
+if [[ "$(is_port_available "${PROXY_PORT}")" != "yes" ]]; then
+  echo "Port ${PROXY_PORT} is in use. Searching for a free port..."
+  FOUND_PORT=""
+  for candidate in $(seq 4001 4050); do
+    if [[ "$(is_port_available "${candidate}")" == "yes" ]]; then
+      FOUND_PORT="${candidate}"
+      break
+    fi
+  done
+  if [[ -z "${FOUND_PORT}" ]]; then
+    echo "No free local port found between 4001-4050."
+    exit 1
+  fi
+  PROXY_PORT="${FOUND_PORT}"
+  PROXY_URL="http://127.0.0.1:${PROXY_PORT}"
+  echo "Using fallback PROXY_PORT=${PROXY_PORT}"
+fi
+
+cat >"${CLAUDE_CODE_LITELLM_CONFIG}" <<EOF
+model_list:
+  - model_name: ${MODEL_NAME}
+    litellm_params:
+      model: ${LITELLM_UPSTREAM_MODEL}
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+general_settings:
+  forward_client_headers_to_llm_api: true
+  master_key: "${LITELLM_MASTER_KEY}"
+
+litellm_settings:
+  drop_params: true
+  modify_params: true
+EOF
+
+export ANTHROPIC_API_KEY
+export CLAUDE_CODE_LITELLM_CONFIG
+export LITELLM_IMAGE="${LITELLM_IMAGE:-litellm-claude-code-e2e:local}"
+export CLAUDE_CODE_IMAGE="${CLAUDE_CODE_IMAGE:-litellm-claude-code-client:local}"
+export LITELLM_MASTER_KEY
+export MODEL_NAME
+export PROXY_PORT
+
+echo "[0/5] Preparing Docker images..."
+if [[ "${LITELLM_SKIP_BUILD:-}" == "true" && "${CLAUDE_CODE_SKIP_BUILD:-}" == "true" ]]; then
+  echo "Skipping image builds (LITELLM_SKIP_BUILD=true and CLAUDE_CODE_SKIP_BUILD=true)."
+elif [[ "${LITELLM_SKIP_BUILD:-}" == "true" ]]; then
+  docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" build claude-code
+elif [[ "${CLAUDE_CODE_SKIP_BUILD:-}" == "true" ]]; then
+  docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" build litellm
+else
+  docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" build litellm claude-code
+fi
+
+echo "[1/5] Starting Postgres and LiteLLM proxy..."
+docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" up -d postgres litellm
+
+echo "[2/5] Waiting for LiteLLM readiness at ${PROXY_URL}..."
+READY=0
+for _ in $(seq 1 "${STARTUP_TIMEOUT_S}"); do
+  if curl -fsS --connect-timeout 5 --max-time 15 \
+      -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" "${PROXY_URL}/v1/models" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${READY}" != "1" ]]; then
+  echo "LiteLLM failed to become ready within ${STARTUP_TIMEOUT_S}s"
+  docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" logs --tail=200 litellm || true
+  exit 1
+fi
+
+echo "[3/5] Checking configured model..."
+curl -fsS --connect-timeout 5 --max-time 20 \
+  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" "${PROXY_URL}/v1/models" | grep -q "\"${MODEL_NAME}\""
+
+echo "[4/5] Running back-to-back Claude Code requests in an isolated non-root container..."
+FIRST_RESPONSE="$(
+docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" run --rm \
+  -e CLAUDE_CODE_PROMPT="Respond with exactly this text and nothing else: Hello from LiteLLM Claude Code request one." \
+  -e CLAUDE_CODE_OUTPUT_FILE="/tmp/claude-output-1.txt" \
+  claude-code
+)"
+
+SECOND_RESPONSE="$(
+docker compose -p "${COMPOSE_PROJECT_NAME}" -f "${COMPOSE_FILE}" run --rm \
+  -e CLAUDE_CODE_PROMPT="Respond with exactly this text and nothing else: Hello from LiteLLM Claude Code request two." \
+  -e CLAUDE_CODE_OUTPUT_FILE="/tmp/claude-output-2.txt" \
+  claude-code
+)"
+
+[[ -n "${FIRST_RESPONSE}" ]] || {
+  echo "First Claude Code request produced no response output."
+  exit 1
+}
+[[ -n "${SECOND_RESPONSE}" ]] || {
+  echo "Second Claude Code request produced no response output."
+  exit 1
+}
+
+printf '%s\n' "${FIRST_RESPONSE}" | grep -qi "request one" || {
+  echo "First Claude Code response did not contain expected content."
+  printf '%s\n' "${FIRST_RESPONSE}" | sed -n '1,40p'
+  exit 1
+}
+printf '%s\n' "${SECOND_RESPONSE}" | grep -qi "request two" || {
+  echo "Second Claude Code response did not contain expected content."
+  printf '%s\n' "${SECOND_RESPONSE}" | sed -n '1,40p'
+  exit 1
+}
+
+echo "[5/5] Verifying LiteLLM request headers on Anthropic messages endpoint..."
+REQUEST_BODY="$(python3 - "${MODEL_NAME}" <<'PY'
+import json
+import sys
+
+print(
+    json.dumps(
+        {
+            "model": sys.argv[1],
+            "max_tokens": 16,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Respond with the word ok.",
+                }
+            ],
+        }
+    )
+)
+PY
+)"
+
+curl -fsS --connect-timeout 5 --max-time 30 -D "${HEADERS_FILE}" -o "${BODY_FILE}" \
+  -X POST "${PROXY_URL}/v1/messages" \
+  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  --data "${REQUEST_BODY}"
+
+grep -qi "^x-litellm-call-id:" "${HEADERS_FILE}" || {
+  echo "Missing x-litellm-call-id header; proxy record signal not found."
+  sed -n '1,80p' "${HEADERS_FILE}"
+  sed -n '1,80p' "${BODY_FILE}"
+  exit 1
+}
+
+if ! grep -qi "^x-litellm-response-cost:" "${HEADERS_FILE}" && \
+   ! grep -qi "^x-litellm-response-cost-original:" "${HEADERS_FILE}"; then
+  echo "Missing LiteLLM response cost headers; proxy usage signal not found."
+  echo "Expected one of: x-litellm-response-cost or x-litellm-response-cost-original"
+  sed -n '1,80p' "${HEADERS_FILE}"
+  sed -n '1,80p' "${BODY_FILE}"
+  exit 1
+fi
+
+echo "Success: Claude Code ran in its own non-root container through LiteLLM, with Postgres-backed proxy headers present."

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -449,6 +449,63 @@ def test_gpt55_dated_variants_match_base_reasoning_effort_capabilities(
         )
 
 
+@pytest.mark.parametrize(
+    "model,expected_mode,expected_input,expected_output,expected_cache_read",
+    [
+        ("azure/gpt-5.5", "chat", 5e-6, 3e-5, 5e-7),
+        ("azure/gpt-5.5-2026-04-23", "chat", 5e-6, 3e-5, 5e-7),
+        ("azure/gpt-5.5-pro", "responses", 6e-5, 3.6e-4, 6e-6),
+        ("azure/gpt-5.5-pro-2026-04-23", "responses", 6e-5, 3.6e-4, 6e-6),
+    ],
+)
+def test_azure_gpt55_entries_present_with_correct_pricing(
+    model, expected_mode, expected_input, expected_output, expected_cache_read
+):
+    """Day-0 Azure entries for GPT-5.5 mirror the OpenAI pricing structure.
+
+    Pricing parity with openai/gpt-5.5* (verified against OpenAI's pricing page
+    on 2026-04-24): $5/$30 input/output per 1M for chat, $60/$360 for pro.
+    Cache discount is 10% of input.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    m = litellm.model_cost[model]
+    assert m["litellm_provider"] == "azure"
+    assert m["mode"] == expected_mode
+    assert m["input_cost_per_token"] == expected_input
+    assert m["output_cost_per_token"] == expected_output
+    assert m["cache_read_input_token_cost"] == expected_cache_read
+    # Long-context window inherited from gpt-5.4 / openai gpt-5.5.
+    assert m["max_input_tokens"] == 1050000
+    assert m["max_output_tokens"] == 128000
+
+
+@pytest.mark.parametrize(
+    "model,expected_none,expected_minimal,expected_xhigh",
+    [
+        # Mirror live OpenAI API contract (verified via openai/gpt-5.5* on
+        # 2026-04-24): chat accepts {none, low, medium, high, xhigh} but NOT
+        # minimal; pro accepts {medium, high, xhigh} only.
+        # NOTE: openai/gpt-5.5* entries currently set supports_minimal=true on
+        # main (pre #26456). Once that PR lands, OpenAI + Azure flags align.
+        ("azure/gpt-5.5", True, False, True),
+        ("azure/gpt-5.5-pro", False, False, True),
+    ],
+)
+def test_azure_gpt55_reasoning_effort_flags_match_live_openai_api(
+    model, expected_none, expected_minimal, expected_xhigh
+):
+    """Azure entries pin reasoning_effort flags to OpenAI's actual API contract."""
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    m = litellm.model_cost[model]
+    assert m.get("supports_none_reasoning_effort") is expected_none
+    assert m.get("supports_minimal_reasoning_effort") is expected_minimal
+    assert m.get("supports_xhigh_reasoning_effort") is expected_xhigh
+
+
 def test_generic_cost_per_token_anthropic_prompt_caching():
     model = "claude-sonnet-4@20250514"
     usage = Usage(

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -65,12 +65,13 @@ def test_excluded_keys_exact_match():
     # Non-sensitive keys should remain unchanged
     assert masked["port"] == 6379
 
-    # Test case sensitivity - excluded_keys should be exact match
+    # Test case sensitivity - excluded_keys should be exact match. Supplying an
+    # uppercase variant must NOT exclude the lowercase key, so the field falls
+    # back to pattern matching ("credentials" is in the sensitive pattern set)
+    # and is masked.
     masked = masker.mask_dict(data, excluded_keys={"LITELLM_CREDENTIALS_NAME"})
-    # Should still be masked because case doesn't match (exact match required)
-    assert (
-        masked["litellm_credentials_name"] == "my-credential-name"
-    )  # Not masked because it doesn't match patterns anyway
+    assert masked["litellm_credentials_name"] != "my-credential-name"
+    assert "*" in masked["litellm_credentials_name"]
 
     # Test with api_key in excluded_keys to verify it works for keys that would be masked
     masked = masker.mask_dict(data, excluded_keys={"api_key"})

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -1737,7 +1737,112 @@ async def test_user_api_key_auth_builder_no_blocking_calls():
             setattr(_proxy_server_mod, k, v)
 
 
+@pytest.mark.asyncio
+async def test_team_metadata_refreshed_from_team_object_during_auth():
+    """
+    Regression test: when a cached API key has stale team_metadata (e.g. a
+    guardrail was added to the team after the key was cached), the auth flow
+    must update valid_token.team_metadata from the freshly fetched team object
+    so that move_guardrails_to_metadata picks up the new guardrail.
+
+    Before the fix: valid_token.team_metadata was never updated from _team_obj
+    at the "Check 6" team-auth step in _user_api_key_auth_builder, so stale
+    team_metadata persisted for the lifetime of the key cache entry.
+    """
+    from starlette.datastructures import URL
+    from starlette.requests import Request
+
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj, LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    api_key = "sk-test-team-metadata-refresh"
+
+    # Simulate a cached key whose team_metadata was captured BEFORE the
+    # guardrail was added — so it has no "guardrails" key.
+    stale_team_metadata: dict = {"some_old_key": "some_old_value"}
+    valid_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=api_key,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        team_id="team-guardrail-test",
+        team_metadata=stale_team_metadata,
+    )
+
+    # The fresh team object returned by get_team_object has the new guardrail.
+    fresh_team_obj = LiteLLM_TeamTableCachedObj(
+        team_id="team-guardrail-test",
+        metadata={"guardrails": ["test-guardrail-333"]},
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=valid_token)
+    mock_cache.async_set_cache = AsyncMock(return_value=None)
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = (
+        AsyncMock()
+    )
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _originals = {k: getattr(_proxy_server_mod, k, None) for k in _attrs}
+
+    try:
+        for k, v in _attrs.items():
+            setattr(_proxy_server_mod, k, v)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_key_object",
+                new_callable=AsyncMock,
+                return_value=valid_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                return_value=fresh_team_obj,
+            ),
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert result.team_metadata == {"guardrails": ["test-guardrail-333"]}, (
+            f"team_metadata was not updated from fresh team object. Got: {result.team_metadata}"
+        )
+
+    finally:
+        for k, v in _originals.items():
+            setattr(_proxy_server_mod, k, v)
+            
 # ---------------------------------------------------------------------------
+            
 # _run_centralized_common_checks — centralized authz gate
 # ---------------------------------------------------------------------------
 

--- a/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 from litellm.proxy.common_utils.openai_endpoint_utils import (
@@ -86,7 +88,7 @@ def test_remove_sensitive_info_from_deployment_with_excluded_keys():
     """
     Test that excluded_keys prevents masking of specific keys (exact match).
     """
-    model_config = {
+    base_config = {
         "model_name": "test-model",
         "litellm_params": {
             "model": "openai/gpt-4",
@@ -98,13 +100,13 @@ def test_remove_sensitive_info_from_deployment_with_excluded_keys():
     }
 
     # Without excluded_keys, access_token should be masked (contains "token")
-    sanitized_config = remove_sensitive_info_from_deployment(model_config)
+    sanitized_config = remove_sensitive_info_from_deployment(copy.deepcopy(base_config))
     assert sanitized_config["litellm_params"]["access_token"] != "token-12345"
     assert "*" in sanitized_config["litellm_params"]["access_token"]
 
     # With excluded_keys, litellm_credentials_name should NOT be masked (even if it would match patterns)
     sanitized_config = remove_sensitive_info_from_deployment(
-        model_config, excluded_keys={"litellm_credentials_name"}
+        copy.deepcopy(base_config), excluded_keys={"litellm_credentials_name"}
     )
     assert (
         sanitized_config["litellm_params"]["litellm_credentials_name"]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -501,6 +501,285 @@ class TestContentFilterGuardrail:
         assert exc_info.value.status_code == 403
         assert "us_ssn" in str(exc_info.value.detail)
 
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_guardrail_information_clean(self):
+        """
+        Streaming post-call: when no detections fire, still write a success log row
+        into request_data["metadata"]["standard_logging_guardrail_information"].
+
+        Regression test for: UI-created ContentFilterGuardrail in mode=post_call
+        never produced a `standard_logging_object.guardrail_information` entry on
+        streaming responses (Branch 1 dispatcher + iterator hook had no log write).
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-clean",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Hello world, nothing sensitive here."),
+                        index=0,
+                        finish_reason="stop",
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            pass
+
+        assert "standard_logging_guardrail_information" in request_data["metadata"]
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert isinstance(entries, list)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_name"] == "test-streaming-logging-clean"
+        assert entry["guardrail_provider"] == "litellm_content_filter"
+        assert entry["guardrail_status"] == "success"
+        assert entry["guardrail_response"] == []
+
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_guardrail_information_mask(self):
+        """
+        Streaming post-call with a MASK pattern: writes a success row with the
+        detection in guardrail_response and a non-zero masked_entity_count.
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-mask",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Contact me at test@example.com please."),
+                        index=0,
+                        finish_reason="stop",
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        full_content = ""
+        async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            if chunk.choices and chunk.choices[0].delta.content:
+                full_content += chunk.choices[0].delta.content
+
+        # Content was masked, not blocked
+        assert "test@example.com" not in full_content
+        assert "[EMAIL_REDACTED]" in full_content
+
+        # And the log row was written
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_status"] == "success"
+        assert entry["guardrail_provider"] == "litellm_content_filter"
+
+        detections = entry["guardrail_response"]
+        assert isinstance(detections, list)
+        # At least one pattern detection for 'email' should be recorded
+        pattern_detections = [d for d in detections if d.get("type") == "pattern"]
+        assert pattern_detections, f"expected pattern detections, got {detections}"
+        assert any(d.get("pattern_name") == "email" for d in pattern_detections)
+        # And masked_entity_count for email should be >= 1
+        assert entry["masked_entity_count"].get("email", 0) >= 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_guardrail_information_block(self):
+        """
+        Streaming post-call with a BLOCK pattern: the hook raises HTTPException,
+        but the `finally` block still writes a log row with
+        guardrail_status == "guardrail_intervened".
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="us_ssn",
+                action=ContentFilterAction.BLOCK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-block",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="chunk1",
+                choices=[
+                    StreamingChoices(delta=Delta(content="SSN: 123-45-6789"), index=0)
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        with pytest.raises(HTTPException):
+            async for _ in guardrail.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=user_api_key_dict,
+                response=mock_stream(),
+                request_data=request_data,
+            ):
+                pass
+
+        # Even though HTTPException bubbled up, the log row must be written.
+        assert "standard_logging_guardrail_information" in request_data["metadata"]
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_name"] == "test-streaming-logging-block"
+        assert entry["guardrail_status"] == "guardrail_intervened"
+
+    @pytest.mark.asyncio
+    async def test_streaming_hook_logs_no_duplicate_detections_across_chunks(self):
+        """
+        Multi-chunk regression: _filter_single_text re-scans the whole accumulated
+        buffer on every chunk, so without per-chunk reset the same detection would
+        be appended once per chunk after it first appears, inflating
+        masked_entity_count and guardrail_response in the log.
+        """
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-streaming-logging-no-duplicates",
+            patterns=patterns,
+            event_hook=GuardrailEventHooks.post_call,
+        )
+
+        # The email straddles chunks 1 and 2; chunks 3 and 4 keep streaming after
+        # the match has already been found, exercising the re-scan path.
+        async def mock_stream():
+            yield ModelResponseStream(
+                id="c1",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="Contact me at test@"), index=0
+                    )
+                ],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="c2",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content="example.com please."), index=0
+                    )
+                ],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="c3",
+                choices=[StreamingChoices(delta=Delta(content=" Thanks!"), index=0)],
+                model="gpt-4",
+            )
+            yield ModelResponseStream(
+                id="c4",
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(content=""), index=0, finish_reason="stop"
+                    )
+                ],
+                model="gpt-4",
+            )
+
+        user_api_key_dict = MagicMock()
+        request_data = {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "model": "gpt-4o",
+            "metadata": {},
+        }
+
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            pass
+
+        entries = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["guardrail_status"] == "success"
+
+        detections = entry["guardrail_response"]
+        pattern_detections = [d for d in detections if d.get("type") == "pattern"]
+        # Exactly one email detection — not one per chunk after the match appeared.
+        assert len(pattern_detections) == 1, (
+            f"expected exactly 1 email detection, got {len(pattern_detections)}: "
+            f"{detections}"
+        )
+        assert pattern_detections[0].get("pattern_name") == "email"
+        # masked_entity_count for email is the real count, not N×.
+        assert entry["masked_entity_count"].get("email") == 1
+
     def test_init_with_plain_dicts(self):
         """
         Test initialization with plain dicts (DB format).

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -1810,14 +1810,19 @@ async def test_make_bedrock_api_request_logging_event_type_for_spend_logs():
         "messages": [{"role": "user", "content": "hi"}],
     }
 
-    with patch.object(
-        guardrail.async_handler, "post", new_callable=AsyncMock
-    ) as mock_post, patch.object(
-        guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
-    ), patch.object(guardrail, "_prepare_request", return_value=MagicMock()), patch.object(
-        guardrail,
-        "add_standard_logging_guardrail_information_to_request_data",
-    ) as mock_log:
+    with (
+        patch.object(
+            guardrail.async_handler, "post", new_callable=AsyncMock
+        ) as mock_post,
+        patch.object(
+            guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")
+        ),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail,
+            "add_standard_logging_guardrail_information_to_request_data",
+        ) as mock_log,
+    ):
         mock_post.return_value = mock_bedrock_response
 
         await guardrail.make_bedrock_api_request(
@@ -1826,7 +1831,9 @@ async def test_make_bedrock_api_request_logging_event_type_for_spend_logs():
             request_data=request_data,
             logging_event_type=GuardrailEventHooks.during_call,
         )
-        assert mock_log.call_args.kwargs["event_type"] == GuardrailEventHooks.during_call
+        assert (
+            mock_log.call_args.kwargs["event_type"] == GuardrailEventHooks.during_call
+        )
         # Raw Bedrock JSON is forwarded; redaction runs once in
         # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
         assert (
@@ -2035,11 +2042,13 @@ def test_get_http_exception_no_blocked_assessments_omits_field():
 
 
 @pytest.mark.asyncio
-async def test_streaming_post_call_parallel_output_passes_request_data_to_make_bedrock():
+async def test_streaming_post_call_only_runs_output_scan():
     """
     async_post_call_streaming_iterator_hook must pass request_data into OUTPUT
     make_bedrock_api_request so spend/standard_logging attaches to the real request
     (Greptile: previously OUTPUT used request_data=None / ephemeral {}).
+
+    post_call only validates the response — no INPUT scan should run here.
     """
     request_data = {
         "model": "gpt-4o-mini",
@@ -2111,8 +2120,7 @@ async def test_streaming_post_call_parallel_output_passes_request_data_to_make_b
     input_calls = [
         c for c in mock_make.call_args_list if c.kwargs.get("source") == "INPUT"
     ]
-    assert len(input_calls) == 1
-    assert input_calls[0].kwargs.get("request_data") is request_data
+    assert len(input_calls) == 0
 
 
 @pytest.mark.asyncio
@@ -2164,3 +2172,60 @@ async def test_streaming_post_call_output_only_path_passes_request_data_to_make_
     c = mock_make.call_args
     assert c.kwargs.get("source") == "OUTPUT"
     assert c.kwargs.get("request_data") is request_data
+
+
+# ---------------------------------------------------------------------------
+# Regression: post_call only validates OUTPUT.
+# Input scanning belongs to pre_call / during_call. Running an extra INPUT
+# scan here used to produce a duplicate "post-call" trace entry and made no
+# semantic sense for a "post-call" event.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_only_runs_output_scan():
+    """
+    With only `post_call` configured, async_post_call_success_hook must call
+    make_bedrock_api_request exactly once with source="OUTPUT". An INPUT call
+    here would produce a duplicate post-call log entry.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-post-pii",
+        guardrailIdentifier="gid",
+        guardrailVersion="1",
+        event_hook=GuardrailEventHooks.post_call,
+        default_on=True,
+    )
+
+    request_data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {},
+    }
+    response = ModelResponse(
+        choices=[
+            litellm.Choices(
+                message=litellm.Message(role="assistant", content="hello"),
+                index=0,
+                finish_reason="stop",
+            )
+        ],
+        model="gpt-4o-mini",
+    )
+
+    minimal = {"action": "NONE", "assessments": [], "outputs": []}
+    with patch.object(
+        guardrail, "make_bedrock_api_request", AsyncMock(return_value=minimal)
+    ) as mock_make:
+        await guardrail.async_post_call_success_hook(
+            data=request_data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            response=response,
+        )
+
+    sources = [c.kwargs.get("source") for c in mock_make.call_args_list]
+    assert sources == ["OUTPUT"]
+    assert (
+        mock_make.call_args.kwargs.get("logging_event_type")
+        == GuardrailEventHooks.post_call
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -9046,6 +9046,330 @@ def test_enforce_upperbound_no_config_is_noop():
         litellm.upperbound_key_generate_params = original
 
 
+# --- Tests: _execute_virtual_key_regeneration enforces upperbound ---
+
+
+def _make_regenerate_mock_prisma():
+    """Mock prisma client shaped for _execute_virtual_key_regeneration."""
+
+    class DictLikeResult:
+        def __init__(self, data):
+            self._data = data
+
+        def __iter__(self):
+            return iter(self._data.items())
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(
+        return_value=DictLikeResult(
+            {
+                "token": "new-hashed-token",
+                "key_name": "sk-...ab12",
+                "user_id": "user-1",
+            }
+        )
+    )
+    mock_prisma_client.db.litellm_verificationtoken.create = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.jsonify_object = MagicMock(side_effect=lambda data: data)
+    return mock_prisma_client
+
+
+def _make_regenerate_user_api_key_dict():
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-admin",
+        user_id="admin-user",
+    )
+
+
+def _make_regenerate_existing_key():
+    return LiteLLM_VerificationToken(
+        token="abc123",
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_rejects_over_limit_duration():
+    """Regenerate must reject durations exceeding upperbound_key_generate_params.duration."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    original = litellm.upperbound_key_generate_params
+    try:
+        litellm.upperbound_key_generate_params = LiteLLM_UpperboundKeyGenerateParams(
+            duration="1h"
+        )
+        existing_key = _make_regenerate_existing_key()
+        data = RegenerateKeyRequest(duration="2h")
+        user_api_key_dict = _make_regenerate_user_api_key_dict()
+        mock_prisma_client = _make_regenerate_mock_prisma()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+                new_callable=AsyncMock,
+                return_value="sk-newtoken1234ab12",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _execute_virtual_key_regeneration(
+                    prisma_client=mock_prisma_client,
+                    key_in_db=existing_key,
+                    hashed_api_key="abc123",
+                    key="abc123",
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                    user_api_key_cache=MagicMock(),
+                    proxy_logging_obj=MagicMock(),
+                )
+        assert exc_info.value.status_code == 400
+        assert "duration" in str(exc_info.value.detail)
+        # Rejected regenerate must not reach the DB update.
+        assert mock_prisma_client.db.litellm_verificationtoken.update.await_count == 0
+    finally:
+        litellm.upperbound_key_generate_params = original
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_allows_within_limit_duration():
+    """Regenerate must accept durations within upperbound_key_generate_params.duration."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    original = litellm.upperbound_key_generate_params
+    try:
+        litellm.upperbound_key_generate_params = LiteLLM_UpperboundKeyGenerateParams(
+            duration="1h"
+        )
+        existing_key = _make_regenerate_existing_key()
+        data = RegenerateKeyRequest(duration="30m")
+        user_api_key_dict = _make_regenerate_user_api_key_dict()
+        mock_prisma_client = _make_regenerate_mock_prisma()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+                new_callable=AsyncMock,
+                return_value="sk-newtoken1234ab12",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _execute_virtual_key_regeneration(
+                prisma_client=mock_prisma_client,
+                key_in_db=existing_key,
+                hashed_api_key="abc123",
+                key="abc123",
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                litellm_changed_by=None,
+                user_api_key_cache=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+        assert mock_prisma_client.db.litellm_verificationtoken.update.await_count == 1
+    finally:
+        litellm.upperbound_key_generate_params = original
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_rejects_over_limit_max_budget():
+    """Regenerate must reject max_budget exceeding upperbound — proves the fix covers non-duration fields."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    original = litellm.upperbound_key_generate_params
+    try:
+        litellm.upperbound_key_generate_params = LiteLLM_UpperboundKeyGenerateParams(
+            max_budget=10.0
+        )
+        existing_key = _make_regenerate_existing_key()
+        data = RegenerateKeyRequest(max_budget=500.0)
+        user_api_key_dict = _make_regenerate_user_api_key_dict()
+        mock_prisma_client = _make_regenerate_mock_prisma()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+                new_callable=AsyncMock,
+                return_value="sk-newtoken1234ab12",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+                new_callable=AsyncMock,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _execute_virtual_key_regeneration(
+                    prisma_client=mock_prisma_client,
+                    key_in_db=existing_key,
+                    hashed_api_key="abc123",
+                    key="abc123",
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                    user_api_key_cache=MagicMock(),
+                    proxy_logging_obj=MagicMock(),
+                )
+        assert exc_info.value.status_code == 400
+        assert "max_budget" in str(exc_info.value.detail)
+        assert mock_prisma_client.db.litellm_verificationtoken.update.await_count == 0
+    finally:
+        litellm.upperbound_key_generate_params = original
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_skips_none_values():
+    """Regenerate with data.duration=None must not raise, even when upperbound is set
+    (fill_defaults=False semantic — None means 'inherit from existing key')."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+    from litellm.types.proxy.management_endpoints.ui_sso import (
+        LiteLLM_UpperboundKeyGenerateParams,
+    )
+
+    original = litellm.upperbound_key_generate_params
+    try:
+        litellm.upperbound_key_generate_params = LiteLLM_UpperboundKeyGenerateParams(
+            duration="1h"
+        )
+        existing_key = _make_regenerate_existing_key()
+        data = RegenerateKeyRequest()  # all fields None
+        user_api_key_dict = _make_regenerate_user_api_key_dict()
+        mock_prisma_client = _make_regenerate_mock_prisma()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+                new_callable=AsyncMock,
+                return_value="sk-newtoken1234ab12",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _execute_virtual_key_regeneration(
+                prisma_client=mock_prisma_client,
+                key_in_db=existing_key,
+                hashed_api_key="abc123",
+                key="abc123",
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                litellm_changed_by=None,
+                user_api_key_cache=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+        assert mock_prisma_client.db.litellm_verificationtoken.update.await_count == 1
+    finally:
+        litellm.upperbound_key_generate_params = original
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_no_upperbound_config_is_noop():
+    """Regenerate with no upperbound config set must accept any duration."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    original = litellm.upperbound_key_generate_params
+    try:
+        litellm.upperbound_key_generate_params = None
+        existing_key = _make_regenerate_existing_key()
+        data = RegenerateKeyRequest(duration="30d")
+        user_api_key_dict = _make_regenerate_user_api_key_dict()
+        mock_prisma_client = _make_regenerate_mock_prisma()
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+                new_callable=AsyncMock,
+                return_value="sk-newtoken1234ab12",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _execute_virtual_key_regeneration(
+                prisma_client=mock_prisma_client,
+                key_in_db=existing_key,
+                hashed_api_key="abc123",
+                key="abc123",
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                litellm_changed_by=None,
+                user_api_key_cache=MagicMock(),
+                proxy_logging_obj=MagicMock(),
+            )
+        assert mock_prisma_client.db.litellm_verificationtoken.update.await_count == 1
+    finally:
+        litellm.upperbound_key_generate_params = original
+
+
 class TestAllowedRoutesCallerPermission:
     """
     Non-admins must not be able to set `allowed_routes` on a key. The field

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1341,12 +1341,15 @@ class TestTemporaryMCPSessionEndpoints:
         )
 
         server = generate_mock_mcp_server_config_record(server_id="cached")
+        admin_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
 
         with patch(
             "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
             return_value=server,
         ) as get_cached:
-            result = await _get_cached_temporary_mcp_server_or_404("cached")
+            result = await _get_cached_temporary_mcp_server_or_404("cached", admin_auth)
 
         assert result is server
         get_cached.assert_awaited_once_with("cached")
@@ -1356,9 +1359,94 @@ class TestTemporaryMCPSessionEndpoints:
             return_value=None,
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await _get_cached_temporary_mcp_server_or_404("missing")
+                await _get_cached_temporary_mcp_server_or_404("missing", admin_auth)
 
         assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_non_admin_denied(self):
+        """Non-admin without access to the server gets 403, not the server."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+
+        registry_server = generate_mock_mcp_server_config_record(server_id="server-x")
+        non_admin = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_mcp_server_by_id.return_value = registry_server
+        mock_manager.get_mcp_server_by_name.return_value = None
+        mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _get_cached_temporary_mcp_server_or_404("server-x", non_admin)
+
+        assert exc_info.value.status_code == 403
+        mock_manager.get_allowed_mcp_servers.assert_awaited_once_with(non_admin)
+
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_non_admin_allowed(self):
+        """Non-admin with the server in their allowed set gets the server."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+
+        registry_server = generate_mock_mcp_server_config_record(server_id="server-x")
+        non_admin = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_mcp_server_by_id.return_value = registry_server
+        mock_manager.get_mcp_server_by_name.return_value = None
+        mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server-x"])
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            result = await _get_cached_temporary_mcp_server_or_404(
+                "server-x", non_admin
+            )
+
+        assert result is registry_server
+
+    @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_temp_cache_non_admin_denied(self):
+        """Servers resolved from the admin-only temp cache reject non-admins."""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+
+        temp_server = generate_mock_mcp_server_config_record(server_id="temp-cache")
+        non_admin = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+            return_value=temp_server,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _get_cached_temporary_mcp_server_or_404("temp-cache", non_admin)
+
+        assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_add_session_mcp_server_caches_and_redacts_credentials(self):
@@ -1472,6 +1560,9 @@ class TestTemporaryMCPSessionEndpoints:
         request = MagicMock()
         server = generate_mock_mcp_server_config_record(server_id="server-1")
         authorize_response = MagicMock()
+        admin_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
 
         with (
             patch(
@@ -1486,6 +1577,7 @@ class TestTemporaryMCPSessionEndpoints:
             result = await mcp_authorize(
                 request=request,
                 server_id="server-1",
+                user_api_key_dict=admin_auth,
                 client_id="client-id",
                 redirect_uri="https://example.com/callback",
                 state="state123",
@@ -1496,7 +1588,7 @@ class TestTemporaryMCPSessionEndpoints:
             )
 
         assert result is authorize_response
-        get_server.assert_awaited_once_with("server-1", request=request)
+        get_server.assert_awaited_once_with("server-1", admin_auth, request=request)
         authorize_mock.assert_awaited_once_with(
             request=request,
             mcp_server=server,
@@ -1518,6 +1610,9 @@ class TestTemporaryMCPSessionEndpoints:
         request = MagicMock()
         server = generate_mock_mcp_server_config_record(server_id="server-1")
         exchange_response = {"access_token": "token"}
+        admin_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
 
         with (
             patch(
@@ -1532,6 +1627,7 @@ class TestTemporaryMCPSessionEndpoints:
             result = await mcp_token(
                 request=request,
                 server_id="server-1",
+                user_api_key_dict=admin_auth,
                 grant_type="authorization_code",
                 code="code-123",
                 redirect_uri="https://example.com/callback",
@@ -1543,7 +1639,7 @@ class TestTemporaryMCPSessionEndpoints:
             )
 
         assert result is exchange_response
-        get_server.assert_awaited_once_with("server-1", request=request)
+        get_server.assert_awaited_once_with("server-1", admin_auth, request=request)
         exchange_mock.assert_awaited_once_with(
             request=request,
             mcp_server=server,
@@ -1566,6 +1662,9 @@ class TestTemporaryMCPSessionEndpoints:
         request = MagicMock()
         server = generate_mock_mcp_server_config_record(server_id="server-1")
         exchange_response = {"access_token": "new-token", "refresh_token": "new-rt"}
+        admin_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
 
         with (
             patch(
@@ -1580,6 +1679,7 @@ class TestTemporaryMCPSessionEndpoints:
             result = await mcp_token(
                 request=request,
                 server_id="server-1",
+                user_api_key_dict=admin_auth,
                 grant_type="refresh_token",
                 code=None,
                 redirect_uri=None,
@@ -1591,7 +1691,7 @@ class TestTemporaryMCPSessionEndpoints:
             )
 
         assert result is exchange_response
-        get_server.assert_awaited_once_with("server-1", request=request)
+        get_server.assert_awaited_once_with("server-1", admin_auth, request=request)
         exchange_mock.assert_awaited_once_with(
             request=request,
             mcp_server=server,
@@ -1620,6 +1720,9 @@ class TestTemporaryMCPSessionEndpoints:
             "response_types": ["code"],
             "token_endpoint_auth_method": "client_secret_basic",
         }
+        admin_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
 
         with (
             patch(
@@ -1635,10 +1738,14 @@ class TestTemporaryMCPSessionEndpoints:
                 AsyncMock(return_value=register_response),
             ) as register_mock,
         ):
-            result = await mcp_register(request=request, server_id="server-1")
+            result = await mcp_register(
+                request=request,
+                server_id="server-1",
+                user_api_key_dict=admin_auth,
+            )
 
         assert result is register_response
-        get_server.assert_awaited_once_with("server-1", request=request)
+        get_server.assert_awaited_once_with("server-1", admin_auth, request=request)
         read_body.assert_awaited_once_with(request=request)
         register_mock.assert_awaited_once_with(
             request=request,
@@ -1664,12 +1771,15 @@ class TestTemporaryMCPSessionEndpoints:
         original_cache = mgmt_endpoints.litellm.cache
         mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
         try:
-            with patch(
-                "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
-                {},
-            ), patch(
-                "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
-                return_value=serialized,
+            with (
+                patch(
+                    "litellm.proxy.management_endpoints.mcp_management_endpoints._temporary_mcp_servers",
+                    {},
+                ),
+                patch(
+                    "litellm.proxy.management_endpoints.mcp_management_endpoints.decrypt_value_helper",
+                    return_value=serialized,
+                ),
             ):
                 result = await get_cached_temporary_mcp_server("from-redis")
         finally:
@@ -1734,7 +1844,9 @@ class TestTemporaryMCPSessionEndpoints:
             _get_temporary_mcp_server_from_redis,
         )
 
-        server = generate_mock_mcp_server_config_record(server_id="from-redis-encrypted")
+        server = generate_mock_mcp_server_config_record(
+            server_id="from-redis-encrypted"
+        )
         serialized = json.dumps(server.model_dump(mode="json"))
         mock_cache_backend = SimpleNamespace(
             async_get_cache=AsyncMock(return_value="encrypted-payload")
@@ -1808,7 +1920,9 @@ class TestTemporaryMCPSessionEndpoints:
             _get_temporary_mcp_server_from_redis,
         )
 
-        mock_cache_backend = SimpleNamespace(async_get_cache=AsyncMock(return_value="enc"))
+        mock_cache_backend = SimpleNamespace(
+            async_get_cache=AsyncMock(return_value="enc")
+        )
         original_cache = mgmt_endpoints.litellm.cache
         mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
         try:
@@ -1823,12 +1937,16 @@ class TestTemporaryMCPSessionEndpoints:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_get_temporary_mcp_server_from_redis_returns_none_on_decrypt_none(self):
+    async def test_get_temporary_mcp_server_from_redis_returns_none_on_decrypt_none(
+        self,
+    ):
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (
             _get_temporary_mcp_server_from_redis,
         )
 
-        mock_cache_backend = SimpleNamespace(async_get_cache=AsyncMock(return_value="enc"))
+        mock_cache_backend = SimpleNamespace(
+            async_get_cache=AsyncMock(return_value="enc")
+        )
         original_cache = mgmt_endpoints.litellm.cache
         mgmt_endpoints.litellm.cache = SimpleNamespace(cache=mock_cache_backend)
         try:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -487,6 +487,88 @@ class TestClearCache:
             )
 
 
+class TestUpdateModel:
+    """
+    Tests for the update_model (POST /model/update) handler.
+    """
+
+    @pytest.mark.asyncio
+    async def test_update_model_clears_cache_after_db_write(self):
+        """
+        Regression test for the stale-router bug: POST /model/update must refresh
+        the in-memory router after persisting to LiteLLM_ProxyModelTable, otherwise
+        model-level guardrails (and any other litellm_params change) silently no-op
+        until the APScheduler reload tick fires ~30 s later.
+        """
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_model,
+        )
+        from litellm.types.router import (
+            ModelInfo,
+            updateDeployment,
+            updateLiteLLMParams,
+        )
+
+        model_id = "db-model-under-test"
+
+        existing_row = MagicMock()
+        existing_row.litellm_params = {
+            "model": "openai/gpt-4o-mini",
+            "api_key": "sk-existing",
+        }
+        existing_row.model_dump.return_value = {
+            "model_name": "gpt-4o-mini",
+            "litellm_params": existing_row.litellm_params,
+            "model_info": {"id": model_id},
+        }
+        existing_row.model_dump_json.return_value = "{}"
+
+        updated_row = MagicMock()
+        updated_row.model_dump_json.return_value = "{}"
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(
+            return_value=existing_row
+        )
+        mock_prisma.db.litellm_proxymodeltable.update = AsyncMock(
+            return_value=updated_row
+        )
+
+        mock_router = MagicMock()
+        admin_user = UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.llm_router", mock_router),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.encrypt_value_helper",
+                side_effect=lambda value: value,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.clear_cache",
+                new=AsyncMock(return_value=None),
+            ) as mock_clear_cache,
+        ):
+            await update_model(
+                model_params=updateDeployment(
+                    litellm_params=updateLiteLLMParams(guardrails=["g1"]),
+                    model_info=ModelInfo(id=model_id),
+                ),
+                user_api_key_dict=admin_user,
+            )
+
+            mock_prisma.db.litellm_proxymodeltable.update.assert_awaited_once()
+            mock_clear_cache.assert_awaited_once_with()
+
+
 class TestUpdatePublicModelGroups:
     """Test that update_public_model_groups correctly sets litellm.public_model_groups
     even when get_config() overwrites it with stale DB values."""

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -7228,3 +7228,234 @@ async def test_update_team_rejects_unauthorized_caller():
                 user_api_key_dict=caller,
             )
         assert exc_info.value.code == "403"
+
+
+# ----- /team/{team_id}/members/me -----
+
+
+def _build_team_row_for_me(team_id, members):
+    row = MagicMock()
+    row.model_dump.return_value = {
+        "team_id": team_id,
+        "team_alias": "team-vec",
+        "members_with_roles": members,
+        "metadata": {},
+        "models": [],
+        "spend": 0.0,
+    }
+    return row
+
+
+def _build_membership_row_for_me(user_id, team_id, *, spend=12.34, max_budget=100.0):
+    row = MagicMock()
+    row.model_dump.return_value = {
+        "user_id": user_id,
+        "team_id": team_id,
+        "budget_id": "b-1",
+        "spend": spend,
+        "total_spend": spend,
+        "litellm_budget_table": {
+            "budget_id": "b-1",
+            "max_budget": max_budget,
+            "soft_budget": None,
+            "tpm_limit": 500,
+            "rpm_limit": 50,
+            "model_max_budget": None,
+            "budget_duration": "30d",
+            "budget_reset_at": "2026-05-01T00:00:00Z",
+            "allowed_models": None,
+        },
+    }
+    return row
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_caller_membership(mock_db_client):
+    """A team member receives their own membership row, not other members'."""
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-1"
+    caller_id = "alice@example.com"
+    other_id = "bob@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
+    )
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [
+                {"user_id": caller_id, "user_email": None, "role": "user"},
+                {"user_id": other_id, "user_email": None, "role": "admin"},
+            ],
+        )
+    )
+    mock_db_client.db.litellm_teammembership = MagicMock()
+    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(
+        return_value=_build_membership_row_for_me(caller_id, team_id, spend=42.0)
+    )
+    mock_user_row = MagicMock()
+    mock_user_row.user_email = caller_id
+    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=mock_user_row
+    )
+
+    response = await team_member_me(
+        http_request=MagicMock(spec=Request),
+        team_id=team_id,
+        user_api_key_dict=caller_auth,
+    )
+
+    assert response.user_id == caller_id
+    assert response.team_id == team_id
+    assert response.role == "user"
+    assert response.spend == 42.0
+    assert response.team_alias == "team-vec"
+    assert response.litellm_budget_table is not None
+    assert response.litellm_budget_table.max_budget == 100.0
+
+    # Membership lookup must scope to caller_id, not just team_id — proves the
+    # endpoint cannot return another member's row.
+    mock_db_client.db.litellm_teammembership.find_unique.assert_awaited_with(
+        where={"user_id_team_id": {"user_id": caller_id, "team_id": team_id}},
+        include={"litellm_budget_table": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_404_for_non_member(mock_db_client):
+    """A user who is not a member of the team gets 404, regardless of role."""
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-2"
+    caller_id = "outsider@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
+    )
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_404_for_proxy_admin_not_in_team(
+    mock_db_client, mock_admin_auth
+):
+    """
+    Proxy admins get 404 if they are not actually a member of the team.
+    `me` only resolves for actual team members; admins use /team/info instead.
+    """
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-3"
+    mock_admin_auth.user_id = "admin_user_999"
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=mock_admin_auth,
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_defaults_when_no_membership_row(mock_db_client):
+    """
+    Caller is in members_with_roles but has no LiteLLM_TeamMembership row yet
+    (no per-member budget configured) — return defaults rather than 404.
+    """
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-4"
+    caller_id = "newmember@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
+    )
+
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=_build_team_row_for_me(
+            team_id,
+            [{"user_id": caller_id, "user_email": None, "role": "user"}],
+        )
+    )
+    mock_db_client.db.litellm_teammembership = MagicMock()
+    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(return_value=None)
+    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+
+    response = await team_member_me(
+        http_request=MagicMock(spec=Request),
+        team_id=team_id,
+        user_api_key_dict=caller_auth,
+    )
+
+    assert response.user_id == caller_id
+    assert response.role == "user"
+    assert response.spend == 0.0
+    assert response.litellm_budget_table is None
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_rejects_team_key_without_user_id(mock_db_client):
+    """A team key with no user_id can't resolve 'me' — must return 400."""
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_key_auth = UserAPIKeyAuth(team_id="team-me-5", user_id=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id="team-me-5",
+            user_api_key_dict=team_key_auth,
+        )
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_returns_404_for_unknown_team(mock_db_client):
+    """Unknown team_id returns 404."""
+    from fastapi import Request, HTTPException
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="alice@example.com"
+    )
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id="does-not-exist",
+            user_api_key_dict=caller_auth,
+        )
+    assert exc_info.value.status_code == 404

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,10 +17,13 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 from litellm.proxy._types import UserAPIKeyAuth  # Import UserAPIKeyAuth
 from litellm.proxy._types import (
+    LiteLLM_BudgetTableFull,
     LiteLLM_OrganizationMembershipTable,
     LiteLLM_OrganizationTable,
     LiteLLM_OrganizationTableWithMembers,
+    LiteLLM_TeamMembership,
     LiteLLM_TeamTable,
+    LiteLLM_TeamTableCachedObj,
     LiteLLM_UserTable,
     LitellmUserRoles,
     Member,
@@ -7233,40 +7237,57 @@ async def test_update_team_rejects_unauthorized_caller():
 # ----- /team/{team_id}/members/me -----
 
 
-def _build_team_row_for_me(team_id, members):
-    row = MagicMock()
-    row.model_dump.return_value = {
-        "team_id": team_id,
-        "team_alias": "team-vec",
-        "members_with_roles": members,
-        "metadata": {},
-        "models": [],
-        "spend": 0.0,
-    }
-    return row
+def _build_team_for_me(team_id, members):
+    """Real LiteLLM_TeamTableCachedObj as get_team_object would return."""
+    return LiteLLM_TeamTableCachedObj(
+        team_id=team_id,
+        team_alias="team-vec",
+        members_with_roles=[Member(**m) for m in members],
+        metadata={},
+        models=[],
+        spend=0.0,
+    )
 
 
-def _build_membership_row_for_me(user_id, team_id, *, spend=12.34, max_budget=100.0):
-    row = MagicMock()
-    row.model_dump.return_value = {
-        "user_id": user_id,
-        "team_id": team_id,
-        "budget_id": "b-1",
-        "spend": spend,
-        "total_spend": spend,
-        "litellm_budget_table": {
-            "budget_id": "b-1",
-            "max_budget": max_budget,
-            "soft_budget": None,
-            "tpm_limit": 500,
-            "rpm_limit": 50,
-            "model_max_budget": None,
-            "budget_duration": "30d",
-            "budget_reset_at": "2026-05-01T00:00:00Z",
-            "allowed_models": None,
-        },
-    }
-    return row
+def _build_membership_for_me(user_id, team_id, *, spend=12.34, max_budget=100.0):
+    """Real LiteLLM_TeamMembership as get_team_membership would return."""
+    return LiteLLM_TeamMembership(
+        user_id=user_id,
+        team_id=team_id,
+        budget_id="b-1",
+        spend=spend,
+        total_spend=spend,
+        litellm_budget_table=LiteLLM_BudgetTableFull(
+            budget_id="b-1",
+            max_budget=max_budget,
+            soft_budget=None,
+            tpm_limit=500,
+            rpm_limit=50,
+            model_max_budget=None,
+            budget_duration="30d",
+            budget_reset_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            allowed_models=None,
+            created_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+
+def _patch_member_me_helpers(*, team, membership=None, user=None):
+    """Patch the three auth helpers used by team_member_me with AsyncMocks."""
+    return (
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+            AsyncMock(return_value=team),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_team_membership",
+            AsyncMock(return_value=membership),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            AsyncMock(return_value=user),
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -7283,30 +7304,25 @@ async def test_team_member_me_returns_caller_membership(mock_db_client):
         user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
     )
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [
-                {"user_id": caller_id, "user_email": None, "role": "user"},
-                {"user_id": other_id, "user_email": None, "role": "admin"},
-            ],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [
+            {"user_id": caller_id, "user_email": None, "role": "user"},
+            {"user_id": other_id, "user_email": None, "role": "admin"},
+        ],
     )
-    mock_db_client.db.litellm_teammembership = MagicMock()
-    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(
-        return_value=_build_membership_row_for_me(caller_id, team_id, spend=42.0)
-    )
-    mock_user_row = MagicMock()
-    mock_user_row.user_email = caller_id
-    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mock_user_row
-    )
+    membership = _build_membership_for_me(caller_id, team_id, spend=42.0)
+    user = LiteLLM_UserTable(user_id=caller_id, user_email=caller_id, max_budget=None)
 
-    response = await team_member_me(
-        http_request=MagicMock(spec=Request),
-        team_id=team_id,
-        user_api_key_dict=caller_auth,
+    p_team, p_membership, p_user = _patch_member_me_helpers(
+        team=team, membership=membership, user=user
     )
+    with p_team, p_membership as mock_get_membership, p_user:
+        response = await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
 
     assert response.user_id == caller_id
     assert response.team_id == team_id
@@ -7315,13 +7331,63 @@ async def test_team_member_me_returns_caller_membership(mock_db_client):
     assert response.team_alias == "team-vec"
     assert response.litellm_budget_table is not None
     assert response.litellm_budget_table.max_budget == 100.0
+    # budget_reset_at must survive end-to-end — proves the BudgetTableFull
+    # variant of the Union is selected (created_at is present), not the base
+    # LiteLLM_BudgetTable which would silently strip this field.
+    assert response.litellm_budget_table.budget_reset_at == datetime(
+        2026, 5, 1, tzinfo=timezone.utc
+    )
 
     # Membership lookup must scope to caller_id, not just team_id — proves the
     # endpoint cannot return another member's row.
-    mock_db_client.db.litellm_teammembership.find_unique.assert_awaited_with(
-        where={"user_id_team_id": {"user_id": caller_id, "team_id": team_id}},
-        include={"litellm_budget_table": True},
+    call_kwargs = mock_get_membership.call_args.kwargs
+    assert call_kwargs["user_id"] == caller_id
+    assert call_kwargs["team_id"] == team_id
+
+
+@pytest.mark.asyncio
+async def test_team_member_me_matches_email_only_member(mock_db_client):
+    """
+    Members onboarded by email may have user_id=None on the stored entry —
+    the lookup must fall back to email matching against the caller, otherwise
+    a valid team member gets a false 404.
+    """
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_me
+
+    team_id = "team-me-email"
+    caller_id = "u-123"
+    caller_email = "alice@example.com"
+    caller_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id=caller_id,
+        user_email=caller_email,
     )
+
+    # Member entry with user_id=None and email matching the caller's email.
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": None, "user_email": caller_email, "role": "user"}],
+    )
+    membership = _build_membership_for_me(caller_id, team_id, spend=7.0)
+    user = LiteLLM_UserTable(
+        user_id=caller_id, user_email=caller_email, max_budget=None
+    )
+
+    p_team, p_membership, p_user = _patch_member_me_helpers(
+        team=team, membership=membership, user=user
+    )
+    with p_team, p_membership, p_user:
+        response = await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
+
+    assert response.user_id == caller_id
+    assert response.role == "user"
+    assert response.spend == 7.0
 
 
 @pytest.mark.asyncio
@@ -7337,19 +7403,19 @@ async def test_team_member_me_returns_404_for_non_member(mock_db_client):
         user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
     )
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": "someone_else", "user_email": None, "role": "user"}],
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await team_member_me(
-            http_request=MagicMock(spec=Request),
-            team_id=team_id,
-            user_api_key_dict=caller_auth,
-        )
+    p_team, p_membership, p_user = _patch_member_me_helpers(team=team)
+    with p_team, p_membership, p_user:
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_me(
+                http_request=MagicMock(spec=Request),
+                team_id=team_id,
+                user_api_key_dict=caller_auth,
+            )
     assert exc_info.value.status_code == 404
 
 
@@ -7368,19 +7434,19 @@ async def test_team_member_me_returns_404_for_proxy_admin_not_in_team(
     team_id = "team-me-3"
     mock_admin_auth.user_id = "admin_user_999"
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [{"user_id": "someone_else", "user_email": None, "role": "user"}],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": "someone_else", "user_email": None, "role": "user"}],
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await team_member_me(
-            http_request=MagicMock(spec=Request),
-            team_id=team_id,
-            user_api_key_dict=mock_admin_auth,
-        )
+    p_team, p_membership, p_user = _patch_member_me_helpers(team=team)
+    with p_team, p_membership, p_user:
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_me(
+                http_request=MagicMock(spec=Request),
+                team_id=team_id,
+                user_api_key_dict=mock_admin_auth,
+            )
     assert exc_info.value.status_code == 404
 
 
@@ -7400,21 +7466,18 @@ async def test_team_member_me_returns_defaults_when_no_membership_row(mock_db_cl
         user_role=LitellmUserRoles.INTERNAL_USER, user_id=caller_id
     )
 
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=_build_team_row_for_me(
-            team_id,
-            [{"user_id": caller_id, "user_email": None, "role": "user"}],
-        )
+    team = _build_team_for_me(
+        team_id,
+        [{"user_id": caller_id, "user_email": None, "role": "user"}],
     )
-    mock_db_client.db.litellm_teammembership = MagicMock()
-    mock_db_client.db.litellm_teammembership.find_unique = AsyncMock(return_value=None)
-    mock_db_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
 
-    response = await team_member_me(
-        http_request=MagicMock(spec=Request),
-        team_id=team_id,
-        user_api_key_dict=caller_auth,
-    )
+    p_team, p_membership, p_user = _patch_member_me_helpers(team=team)
+    with p_team, p_membership, p_user:
+        response = await team_member_me(
+            http_request=MagicMock(spec=Request),
+            team_id=team_id,
+            user_api_key_dict=caller_auth,
+        )
 
     assert response.user_id == caller_id
     assert response.role == "user"
@@ -7442,7 +7505,7 @@ async def test_team_member_me_rejects_team_key_without_user_id(mock_db_client):
 
 @pytest.mark.asyncio
 async def test_team_member_me_returns_404_for_unknown_team(mock_db_client):
-    """Unknown team_id returns 404."""
+    """Unknown team_id returns 404 — propagated from get_team_object."""
     from fastapi import Request, HTTPException
 
     from litellm.proxy.management_endpoints.team_endpoints import team_member_me
@@ -7450,12 +7513,20 @@ async def test_team_member_me_returns_404_for_unknown_team(mock_db_client):
     caller_auth = UserAPIKeyAuth(
         user_role=LitellmUserRoles.INTERNAL_USER, user_id="alice@example.com"
     )
-    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await team_member_me(
-            http_request=MagicMock(spec=Request),
-            team_id="does-not-exist",
-            user_api_key_dict=caller_auth,
-        )
+    # get_team_object raises 404 directly when the team is missing.
+    with patch(
+        "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+        AsyncMock(
+            side_effect=HTTPException(
+                status_code=404, detail={"error": "Team doesn't exist in db."}
+            )
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await team_member_me(
+                http_request=MagicMock(spec=Request),
+                team_id="does-not-exist",
+                user_api_key_dict=caller_auth,
+            )
     assert exc_info.value.status_code == 404

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -3281,3 +3281,144 @@ def test_clean_headers_strips_x_api_key_when_byok_enabled_but_x_api_key_was_auth
     # Even with BYOK enabled, x-api-key must be stripped when it was used
     # as the LiteLLM auth header (anti-replay guard).
     assert "x-api-key" not in result
+
+
+# ---------------------------------------------------------------------------
+# Team guardrail + global policy regression tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_guardrail_merges_with_global_policy():
+    """
+    Regression: team's direct guardrail must be present alongside guardrails
+    resolved from a global policy (scope='*') configured by the admin.
+
+    The bug: get_guardrail_from_metadata checked litellm_metadata before
+    metadata. When the request contained a non-empty litellm_metadata field
+    (without a 'guardrails' key), the merged list in data["metadata"] was
+    shadowed and non-default guardrails silently received an empty
+    requested_guardrails list.
+    """
+    from litellm.proxy.policy_engine.attachment_registry import get_attachment_registry
+    from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+    from litellm.proxy.litellm_pre_call_utils import move_guardrails_to_metadata
+    from litellm.types.proxy.policy_engine import (
+        Policy,
+        PolicyAttachment,
+        PolicyGuardrails,
+    )
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        # Simulate a request that carries litellm_metadata (without guardrails)
+        # which previously shadowed data["metadata"]["guardrails"].
+        "litellm_metadata": {"some_user_field": "some_value"},
+        "metadata": {},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        team_metadata={"guardrails": ["team-direct-guardrail"]},
+    )
+
+    policy_registry = get_policy_registry()
+    policy_registry._policies = {
+        "global-policy": Policy(
+            guardrails=PolicyGuardrails(add=["policy-guardrail-1", "policy-guardrail-2"]),
+        ),
+    }
+    policy_registry._initialized = True
+
+    attachment_registry = get_attachment_registry()
+    attachment_registry._attachments = [
+        PolicyAttachment(policy="global-policy", scope="*"),
+    ]
+    attachment_registry._initialized = True
+
+    try:
+        with patch("litellm.proxy.utils._premium_user_check"):
+            await move_guardrails_to_metadata(
+                data=data,
+                _metadata_variable_name="metadata",
+                user_api_key_dict=user_api_key_dict,
+            )
+
+        guardrails = data["metadata"].get("guardrails", [])
+
+        assert "team-direct-guardrail" in guardrails, \
+            f"Team guardrail missing from merged list: {guardrails}"
+        assert "policy-guardrail-1" in guardrails, \
+            f"policy-guardrail-1 missing: {guardrails}"
+        assert "policy-guardrail-2" in guardrails, \
+            f"policy-guardrail-2 missing: {guardrails}"
+        assert len(guardrails) == len(set(guardrails)), \
+            f"Duplicates in guardrails list: {guardrails}"
+
+        # Verify get_guardrail_from_metadata returns the merged list even
+        # when litellm_metadata is present (the bug: it returned [] before fix)
+        from litellm.integrations.custom_guardrail import CustomGuardrail
+
+        class _DummyGuardrail(CustomGuardrail):
+            pass
+
+        dummy = _DummyGuardrail(guardrail_name="team-direct-guardrail")
+        returned = dummy.get_guardrail_from_metadata(data)
+        assert "team-direct-guardrail" in returned, (
+            f"get_guardrail_from_metadata shadowed by litellm_metadata; got: {returned}"
+        )
+
+    finally:
+        policy_registry._policies = {}
+        policy_registry._initialized = False
+        attachment_registry._attachments = []
+        attachment_registry._initialized = False
+
+
+@pytest.mark.asyncio
+async def test_get_guardrail_from_metadata_prefers_metadata_over_litellm_metadata():
+    """
+    Unit test: get_guardrail_from_metadata must read from data["metadata"] first.
+    A non-empty data["litellm_metadata"] without a 'guardrails' key must not
+    shadow data["metadata"]["guardrails"].
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    class _DummyGuardrail(CustomGuardrail):
+        pass
+
+    dummy = _DummyGuardrail(guardrail_name="my-guardrail")
+
+    data = {
+        "metadata": {"guardrails": ["my-guardrail", "other-guardrail"]},
+        "litellm_metadata": {"some_field": "some_value"},  # no 'guardrails' key
+    }
+
+    result = dummy.get_guardrail_from_metadata(data)
+    assert result == ["my-guardrail", "other-guardrail"], (
+        f"Expected guardrails from metadata, got: {result}"
+    )
+
+
+def test_get_guardrail_from_metadata_reads_litellm_metadata_when_no_metadata():
+    """
+    get_guardrail_from_metadata must still read from litellm_metadata when
+    data["metadata"] has no 'guardrails' key (thread/assistant endpoint path).
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    class _DummyGuardrail(CustomGuardrail):
+        pass
+
+    dummy = _DummyGuardrail(guardrail_name="my-guardrail")
+
+    data = {
+        "metadata": {"requester_metadata": {"user": "alice"}},  # no guardrails key
+        "litellm_metadata": {"guardrails": ["my-guardrail"]},
+    }
+
+    result = dummy.get_guardrail_from_metadata(data)
+    assert result == ["my-guardrail"], (
+        f"Expected guardrails from litellm_metadata fallback, got: {result}"
+    )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -769,6 +769,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "uses_embed_content": {"type": "boolean"},
                 "supports_reasoning": {"type": "boolean"},
                 "supports_minimal_reasoning_effort": {"type": "boolean"},
+                "supports_low_reasoning_effort": {"type": "boolean"},
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},
                 "supports_max_reasoning_effort": {"type": "boolean"},

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1414,59 +1414,6 @@ export const teamInfoCall = async (accessToken: string, teamID: string | null) =
   }
 };
 
-export interface TeamMemberInfo {
-  user_id: string;
-  team_id: string;
-  team_alias?: string | null;
-  role?: string | null;
-  user_email?: string | null;
-  budget_id?: string | null;
-  spend?: number | null;
-  total_spend?: number | null;
-  litellm_budget_table?: {
-    budget_id?: string;
-    soft_budget?: number | null;
-    max_budget?: number | null;
-    max_parallel_requests?: number | null;
-    tpm_limit?: number | null;
-    rpm_limit?: number | null;
-    model_max_budget?: Record<string, number> | null;
-    budget_duration?: string | null;
-    budget_reset_at?: string | null;
-    allowed_models?: string[] | null;
-  } | null;
-}
-
-export const teamMemberMeCall = async (
-  accessToken: string,
-  teamID: string,
-): Promise<TeamMemberInfo> => {
-  try {
-    const url = proxyBaseUrl
-      ? `${proxyBaseUrl}/team/${encodeURIComponent(teamID)}/members/me`
-      : `/team/${encodeURIComponent(teamID)}/members/me`;
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-    });
-
-    if (!response.ok) {
-      const errorData = await response.json();
-      const errorMessage = deriveErrorMessage(errorData);
-      handleError(errorMessage);
-      throw new Error(errorMessage);
-    }
-
-    return (await response.json()) as TeamMemberInfo;
-  } catch (error) {
-    console.error("Failed to fetch team member 'me' info:", error);
-    throw error;
-  }
-};
-
 type TeamListResponse = {
   teams: Team[];
   total: number;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1414,6 +1414,59 @@ export const teamInfoCall = async (accessToken: string, teamID: string | null) =
   }
 };
 
+export interface TeamMemberInfo {
+  user_id: string;
+  team_id: string;
+  team_alias?: string | null;
+  role?: string | null;
+  user_email?: string | null;
+  budget_id?: string | null;
+  spend?: number | null;
+  total_spend?: number | null;
+  litellm_budget_table?: {
+    budget_id?: string;
+    soft_budget?: number | null;
+    max_budget?: number | null;
+    max_parallel_requests?: number | null;
+    tpm_limit?: number | null;
+    rpm_limit?: number | null;
+    model_max_budget?: Record<string, number> | null;
+    budget_duration?: string | null;
+    budget_reset_at?: string | null;
+    allowed_models?: string[] | null;
+  } | null;
+}
+
+export const teamMemberMeCall = async (
+  accessToken: string,
+  teamID: string,
+): Promise<TeamMemberInfo> => {
+  try {
+    const url = proxyBaseUrl
+      ? `${proxyBaseUrl}/team/${encodeURIComponent(teamID)}/members/me`
+      : `/team/${encodeURIComponent(teamID)}/members/me`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return (await response.json()) as TeamMemberInfo;
+  } catch (error) {
+    console.error("Failed to fetch team member 'me' info:", error);
+    throw error;
+  }
+};
+
 type TeamListResponse = {
   teams: Team[];
   total: number;

--- a/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
@@ -1,14 +1,12 @@
-import { TeamMemberInfo } from "@/components/networking";
 import { formatBudgetReset } from "@/utils/budgetUtils";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Card, Col, Row, Space, Tag, Tooltip, Typography } from "antd";
 import React from "react";
+import { useMyTeamMember } from "./useMyTeamMember";
 
 interface MyUserTabProps {
-  data: TeamMemberInfo | null;
-  loading: boolean;
-  error: string | null;
+  teamId: string;
 }
 
 const labelWithTooltip = (label: string, tooltip: string) => (
@@ -30,8 +28,10 @@ const formatRateLimit = (value: number | null | undefined): string => {
   return formatNumberWithCommas(value, 0);
 };
 
-export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
-  if (loading) {
+export default function MyUserTab({ teamId }: MyUserTabProps) {
+  const { data, isLoading, error } = useMyTeamMember(teamId);
+
+  if (isLoading) {
     return (
       <Card>
         <Typography.Text type="secondary">Loading your membership info…</Typography.Text>
@@ -42,7 +42,11 @@ export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
   if (error) {
     return (
       <Card>
-        <Typography.Text type="danger">{error}</Typography.Text>
+        <Typography.Text type="danger">
+          {error instanceof Error
+            ? error.message
+            : "Failed to load your membership info for this team."}
+        </Typography.Text>
       </Card>
     );
   }
@@ -145,7 +149,7 @@ export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
           <Card>
             {labelWithTooltip(
               "Model Scope",
-              "Models you can access within this team. Empty means you inherit all team models.",
+              "Models you can access within this team.",
             )}
             <div style={{ marginTop: 8 }}>
               {allowedModels && allowedModels.length > 0 ? (
@@ -155,7 +159,7 @@ export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
                   ))}
                 </Space>
               ) : (
-                <Typography.Text type="secondary">(all team models)</Typography.Text>
+                <Typography.Text>All Team Models</Typography.Text>
               )}
             </div>
           </Card>

--- a/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/MyUserTab.tsx
@@ -1,0 +1,166 @@
+import { TeamMemberInfo } from "@/components/networking";
+import { formatBudgetReset } from "@/utils/budgetUtils";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import { Card, Col, Row, Space, Tag, Tooltip, Typography } from "antd";
+import React from "react";
+
+interface MyUserTabProps {
+  data: TeamMemberInfo | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const labelWithTooltip = (label: string, tooltip: string) => (
+  <Space size={4}>
+    <Typography.Text type="secondary">{label}</Typography.Text>
+    <Tooltip title={tooltip}>
+      <InfoCircleOutlined style={{ color: "#8c8c8c" }} />
+    </Tooltip>
+  </Space>
+);
+
+const formatNumber = (value: number | null | undefined, digits = 4): string => {
+  if (value === null || value === undefined) return "0";
+  return formatNumberWithCommas(value, digits);
+};
+
+const formatRateLimit = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) return "Unlimited";
+  return formatNumberWithCommas(value, 0);
+};
+
+export default function MyUserTab({ data, loading, error }: MyUserTabProps) {
+  if (loading) {
+    return (
+      <Card>
+        <Typography.Text type="secondary">Loading your membership info…</Typography.Text>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <Typography.Text type="danger">{error}</Typography.Text>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card>
+        <Typography.Text type="secondary">
+          No membership info available for the current user in this team.
+        </Typography.Text>
+      </Card>
+    );
+  }
+
+  const budgetTable = data.litellm_budget_table ?? null;
+  const maxBudget = budgetTable?.max_budget ?? null;
+  const spend = data.spend ?? 0;
+  const totalSpend = data.total_spend ?? 0;
+  const tpmLimit = budgetTable?.tpm_limit ?? null;
+  const rpmLimit = budgetTable?.rpm_limit ?? null;
+  const budgetReset = formatBudgetReset(budgetTable?.budget_reset_at);
+  const allowedModels = budgetTable?.allowed_models ?? null;
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Card>
+        <Row gutter={[24, 16]}>
+          <Col xs={24} sm={12} md={8}>
+            <Typography.Text type="secondary">User</Typography.Text>
+            <div style={{ marginTop: 4 }}>
+              <Typography.Text strong>{data.user_email || data.user_id}</Typography.Text>
+            </div>
+            <Typography.Text type="secondary" style={{ fontSize: 12, fontFamily: "monospace" }}>
+              {data.user_id}
+            </Typography.Text>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Typography.Text type="secondary">Team Role</Typography.Text>
+            <div style={{ marginTop: 4 }}>
+              <Tag color={data.role === "admin" ? "blue" : "default"}>
+                {data.role || "user"}
+              </Tag>
+            </div>
+          </Col>
+        </Row>
+      </Card>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Current Cycle Spend (USD)",
+              "Spend for the current budget cycle. Resets to $0 when the budget window rolls over.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Typography.Title level={3} style={{ margin: 0 }}>
+                ${formatNumber(spend, 4)}
+              </Typography.Title>
+              <Typography.Text type="secondary">
+                of {maxBudget === null ? "Unlimited" : `$${formatNumber(maxBudget, 4)}`}
+              </Typography.Text>
+            </div>
+            {budgetReset && (
+              <div style={{ marginTop: 4 }}>
+                <Typography.Text type="secondary">Resets {budgetReset}</Typography.Text>
+              </div>
+            )}
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Rate Limits",
+              "Your per-member rate limits within this team.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Typography.Text>TPM: {formatRateLimit(tpmLimit)}</Typography.Text>
+              <br />
+              <Typography.Text>RPM: {formatRateLimit(rpmLimit)}</Typography.Text>
+            </div>
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Total Spend (USD)",
+              "Cumulative spend across all budget cycles within this team.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              <Typography.Title level={4} style={{ margin: 0 }}>
+                ${formatNumber(totalSpend, 4)}
+              </Typography.Title>
+            </div>
+          </Card>
+        </Col>
+
+        <Col xs={24} md={12}>
+          <Card>
+            {labelWithTooltip(
+              "Model Scope",
+              "Models you can access within this team. Empty means you inherit all team models.",
+            )}
+            <div style={{ marginTop: 8 }}>
+              {allowedModels && allowedModels.length > 0 ? (
+                <Space wrap>
+                  {allowedModels.map((m) => (
+                    <Tag key={m}>{m}</Tag>
+                  ))}
+                </Space>
+              ) : (
+                <Typography.Text type="secondary">(all team models)</Typography.Text>
+              )}
+            </div>
+          </Card>
+        </Col>
+      </Row>
+    </Space>
+  );
+}

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -11,8 +11,6 @@ import {
   teamInfoCall,
   teamMemberAddCall,
   teamMemberDeleteCall,
-  teamMemberMeCall,
-  TeamMemberInfo,
   teamMemberUpdateCall,
   teamUpdateCall,
 } from "@/components/networking";
@@ -248,35 +246,6 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
   useEffect(() => {
     fetchTeamInfo();
-  }, [teamId, accessToken]);
-
-  const [myUserData, setMyUserData] = useState<TeamMemberInfo | null>(null);
-  const [myUserLoading, setMyUserLoading] = useState(false);
-  const [myUserError, setMyUserError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const fetchMyUser = async () => {
-      if (!accessToken || !teamId) return;
-      try {
-        setMyUserLoading(true);
-        setMyUserError(null);
-        const response = await teamMemberMeCall(accessToken, teamId);
-        if (!cancelled) setMyUserData(response);
-      } catch (error: any) {
-        if (!cancelled) {
-          const message =
-            error?.message || "Failed to load your membership info for this team.";
-          setMyUserError(message);
-        }
-      } finally {
-        if (!cancelled) setMyUserLoading(false);
-      }
-    };
-    fetchMyUser();
-    return () => {
-      cancelled = true;
-    };
   }, [teamId, accessToken]);
 
   // Fetch organization data when team has organization_id
@@ -888,13 +857,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           {
             key: TEAM_INFO_TAB_KEYS.MY_USER,
             label: TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MY_USER],
-            children: (
-              <MyUserTab
-                data={myUserData}
-                loading={myUserLoading}
-                error={myUserError}
-              />
-            ),
+            children: <MyUserTab teamId={teamId} />,
           },
           {
             key: TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -11,6 +11,8 @@ import {
   teamInfoCall,
   teamMemberAddCall,
   teamMemberDeleteCall,
+  teamMemberMeCall,
+  TeamMemberInfo,
   teamMemberUpdateCall,
   teamUpdateCall,
 } from "@/components/networking";
@@ -46,6 +48,7 @@ import EditLoggingSettings from "./EditLoggingSettings";
 import RouterSettingsAccordion, { RouterSettingsAccordionRef } from "../common_components/RouterSettingsAccordion";
 import MemberModal from "./EditMembership";
 import MemberPermissions from "./member_permissions";
+import MyUserTab from "./MyUserTab";
 import {
   getTeamInfoDefaultTab,
   getTeamInfoVisibleTabs,
@@ -245,6 +248,35 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
   useEffect(() => {
     fetchTeamInfo();
+  }, [teamId, accessToken]);
+
+  const [myUserData, setMyUserData] = useState<TeamMemberInfo | null>(null);
+  const [myUserLoading, setMyUserLoading] = useState(false);
+  const [myUserError, setMyUserError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchMyUser = async () => {
+      if (!accessToken || !teamId) return;
+      try {
+        setMyUserLoading(true);
+        setMyUserError(null);
+        const response = await teamMemberMeCall(accessToken, teamId);
+        if (!cancelled) setMyUserData(response);
+      } catch (error: any) {
+        if (!cancelled) {
+          const message =
+            error?.message || "Failed to load your membership info for this team.";
+          setMyUserError(message);
+        }
+      } finally {
+        if (!cancelled) setMyUserLoading(false);
+      }
+    };
+    fetchMyUser();
+    return () => {
+      cancelled = true;
+    };
   }, [teamId, accessToken]);
 
   // Fetch organization data when team has organization_id
@@ -851,6 +883,17 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   variant="card"
                 />
               </Grid>
+            ),
+          },
+          {
+            key: TEAM_INFO_TAB_KEYS.MY_USER,
+            label: TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MY_USER],
+            children: (
+              <MyUserTab
+                data={myUserData}
+                loading={myUserLoading}
+                error={myUserError}
+              />
             ),
           },
           {

--- a/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.test.ts
+++ b/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.test.ts
@@ -11,6 +11,7 @@ describe("team_info_tabs", () => {
   describe("TEAM_INFO_TAB_LABELS", () => {
     it("should have label for every tab key", () => {
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.OVERVIEW]).toBe("Overview");
+      expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MY_USER]).toBe("My User");
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS]).toBe("Virtual Keys");
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MEMBERS]).toBe("Members");
       expect(TEAM_INFO_TAB_LABELS[TEAM_INFO_TAB_KEYS.MEMBER_PERMISSIONS]).toBe("Member Permissions");
@@ -19,15 +20,20 @@ describe("team_info_tabs", () => {
   });
 
   describe("getTeamInfoVisibleTabs", () => {
-    it("returns overview and virtual keys when user cannot edit team", () => {
+    it("returns overview, my user, and virtual keys when user cannot edit team", () => {
       const tabs = getTeamInfoVisibleTabs(false);
-      expect(tabs).toEqual([TEAM_INFO_TAB_KEYS.OVERVIEW, TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS]);
+      expect(tabs).toEqual([
+        TEAM_INFO_TAB_KEYS.OVERVIEW,
+        TEAM_INFO_TAB_KEYS.MY_USER,
+        TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,
+      ]);
     });
 
     it("returns all tabs when user can edit team", () => {
       const tabs = getTeamInfoVisibleTabs(true);
       expect(tabs).toEqual([
         TEAM_INFO_TAB_KEYS.OVERVIEW,
+        TEAM_INFO_TAB_KEYS.MY_USER,
         TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,
         TEAM_INFO_TAB_KEYS.MEMBERS,
         TEAM_INFO_TAB_KEYS.MEMBER_PERMISSIONS,
@@ -60,6 +66,11 @@ describe("team_info_tabs", () => {
     it("always returns true for virtual keys tab regardless of edit permission", () => {
       expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS, false)).toBe(true);
       expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS, true)).toBe(true);
+    });
+
+    it("always returns true for my user tab regardless of edit permission", () => {
+      expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.MY_USER, false)).toBe(true);
+      expect(isTeamInfoTabVisible(TEAM_INFO_TAB_KEYS.MY_USER, true)).toBe(true);
     });
 
     it("returns false for member permissions tab when user cannot edit", () => {

--- a/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.ts
+++ b/ui/litellm-dashboard/src/components/team/tabVisibilityUtils.ts
@@ -5,6 +5,7 @@
 
 export const TEAM_INFO_TAB_KEYS = {
   OVERVIEW: "overview",
+  MY_USER: "my-user",
   VIRTUAL_KEYS: "virtual-keys",
   MEMBERS: "members",
   MEMBER_PERMISSIONS: "member-permissions",
@@ -13,6 +14,7 @@ export const TEAM_INFO_TAB_KEYS = {
 
 export const TEAM_INFO_TAB_LABELS: Record<string, string> = {
   [TEAM_INFO_TAB_KEYS.OVERVIEW]: "Overview",
+  [TEAM_INFO_TAB_KEYS.MY_USER]: "My User",
   [TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS]: "Virtual Keys",
   [TEAM_INFO_TAB_KEYS.MEMBERS]: "Members",
   [TEAM_INFO_TAB_KEYS.MEMBER_PERMISSIONS]: "Member Permissions",
@@ -21,11 +23,15 @@ export const TEAM_INFO_TAB_LABELS: Record<string, string> = {
 
 /**
  * Returns the list of tab keys that should be visible based on permissions.
- * - Overview, Virtual Keys: always visible
+ * - Overview, My User, Virtual Keys: always visible
  * - Members, Member Permissions, Settings: only when canEditTeam is true
  */
 export function getTeamInfoVisibleTabs(canEditTeam: boolean): readonly string[] {
-  const baseTabs = [TEAM_INFO_TAB_KEYS.OVERVIEW, TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS];
+  const baseTabs = [
+    TEAM_INFO_TAB_KEYS.OVERVIEW,
+    TEAM_INFO_TAB_KEYS.MY_USER,
+    TEAM_INFO_TAB_KEYS.VIRTUAL_KEYS,
+  ];
   if (canEditTeam) {
     return [
       ...baseTabs,

--- a/ui/litellm-dashboard/src/components/team/useMyTeamMember.ts
+++ b/ui/litellm-dashboard/src/components/team/useMyTeamMember.ts
@@ -1,0 +1,74 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import {
+  deriveErrorMessage,
+  getGlobalLitellmHeaderName,
+  getProxyBaseUrl,
+} from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+
+export interface TeamMemberInfo {
+  user_id: string;
+  team_id: string;
+  team_alias?: string | null;
+  role?: string | null;
+  user_email?: string | null;
+  budget_id?: string | null;
+  spend?: number | null;
+  total_spend?: number | null;
+  litellm_budget_table?: {
+    budget_id?: string;
+    soft_budget?: number | null;
+    max_budget?: number | null;
+    max_parallel_requests?: number | null;
+    tpm_limit?: number | null;
+    rpm_limit?: number | null;
+    model_max_budget?: Record<string, number> | null;
+    budget_duration?: string | null;
+    budget_reset_at?: string | null;
+    allowed_models?: string[] | null;
+  } | null;
+}
+
+const fetchMyTeamMember = async (
+  accessToken: string,
+  teamId: string,
+): Promise<TeamMemberInfo | null> => {
+  const proxyBaseUrl = getProxyBaseUrl();
+  const url = proxyBaseUrl
+    ? `${proxyBaseUrl}/team/${encodeURIComponent(teamId)}/members/me`
+    : `/team/${encodeURIComponent(teamId)}/members/me`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  // 404 means the caller is not a team member (e.g. proxy admin viewing
+  // a team they don't belong to). The "My User" tab is always visible so
+  // the fetch fires regardless — return null and let the UI render the
+  // empty state instead of a noisy error.
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(deriveErrorMessage(errorData));
+  }
+
+  return (await response.json()) as TeamMemberInfo;
+};
+
+export const useMyTeamMember = (
+  teamId: string | null | undefined,
+): UseQueryResult<TeamMemberInfo | null> => {
+  const { accessToken } = useAuthorized();
+  return useQuery<TeamMemberInfo | null>({
+    queryKey: ["team", teamId, "members", "me"],
+    queryFn: () => fetchMyTeamMember(accessToken!, teamId!),
+    enabled: Boolean(accessToken && teamId),
+  });
+};


### PR DESCRIPTION
## Summary
- add a dedicated Claude Code E2E harness under `tests/proxy_e2e_anthropic_messages_tests/claude_code/` with isolated `postgres`, `litellm`, and non-root `claude-code` containers
- add CircleCI jobs to build LiteLLM and Claude client images separately, then run the Claude Code integration job using prebuilt images from workspace artifacts
- verify proxy-path behavior end-to-end by asserting model availability, two sequential Claude Code requests through LiteLLM, and LiteLLM response headers (`x-litellm-call-id` plus response-cost header compatibility)
- harden failure behavior with required env var checks, bounded curl timeouts, and schema-correct `master_key` placement under `general_settings`

## Test plan
- [x] `circleci config validate .circleci/config.yml`
- [x] local Docker E2E run:
  - build Claude client image
  - run `tests/proxy_e2e_anthropic_messages_tests/claude_code/run_claude_code_docker_test.sh`
- [x] CircleCI run (`build_docker_database_image` + `build_claude_code_client_image` + `proxy_e2e_claude_code_tests`) succeeded on this branch

## Intentional V0 scope limits
- Anthropic route first (no Bedrock/provider matrix yet)
- no long-session/tool-use matrix yet
- no multi-version Claude matrix yet