### PR TITLE
feat(guardrails): add peyeeye PII redaction & rehydration guardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/__init__.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING
+
+from litellm.types.guardrails import SupportedGuardrailIntegrations
+
+from .peyeeye import PeyeeyeGuardrail
+
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
+    import litellm
+
+    _peyeeye_callback = PeyeeyeGuardrail(
+        guardrail_name=guardrail.get("guardrail_name", ""),
+        api_key=litellm_params.api_key,
+        api_base=litellm_params.api_base,
+        peyeeye_locale=litellm_params.peyeeye_locale,
+        peyeeye_entities=litellm_params.peyeeye_entities,
+        peyeeye_session_mode=litellm_params.peyeeye_session_mode,
+        event_hook=litellm_params.mode,
+        default_on=litellm_params.default_on,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(_peyeeye_callback)
+
+    return _peyeeye_callback
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.PEYEEYE.value: initialize_guardrail,
+}
+
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.PEYEEYE.value: PeyeeyeGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/__init__.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
 
-from .peyeeye import PeyeeyeGuardrail
+from .peyeeye import PEyeEyeGuardrail
 
 if TYPE_CHECKING:
     from litellm.types.guardrails import Guardrail, LitellmParams
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
     import litellm
 
-    _peyeeye_callback = PeyeeyeGuardrail(
+    _peyeeye_callback = PEyeEyeGuardrail(
         guardrail_name=guardrail.get("guardrail_name", ""),
         api_key=litellm_params.api_key,
         api_base=litellm_params.api_base,
@@ -32,5 +32,5 @@ guardrail_initializer_registry = {
 
 
 guardrail_class_registry = {
-    SupportedGuardrailIntegrations.PEYEEYE.value: PeyeeyeGuardrail,
+    SupportedGuardrailIntegrations.PEYEEYE.value: PEyeEyeGuardrail,
 }

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
@@ -50,15 +50,15 @@ DEFAULT_API_BASE = "https://api.peyeeye.ai"
 SESSION_CACHE_TTL_SECONDS = 3600
 
 
-class PeyeeyeGuardrailMissingSecrets(Exception):
+class PEyeEyeGuardrailMissingSecrets(Exception):
     """Raised when the peyeeye API key is missing."""
 
 
-class PeyeeyeGuardrailAPIError(Exception):
+class PEyeEyeGuardrailAPIError(Exception):
     """Raised when the peyeeye API returns an error."""
 
 
-class PeyeeyeGuardrail(CustomGuardrail):
+class PEyeEyeGuardrail(CustomGuardrail):
     """Peyeeye PII redaction + rehydration guardrail.
 
     Pre-call hook redacts PII from each message's ``content`` and stores the
@@ -90,7 +90,7 @@ class PeyeeyeGuardrail(CustomGuardrail):
             peyeeye_api_key or api_key or os.environ.get("PEYEEYE_API_KEY")
         )
         if self.peyeeye_api_key is None:
-            raise PeyeeyeGuardrailMissingSecrets(
+            raise PEyeEyeGuardrailMissingSecrets(
                 "Couldn't get peyeeye api key, either set the `PEYEEYE_API_KEY` "
                 "environment variable or pass it as `api_key` in the guardrail config."
             )
@@ -147,6 +147,12 @@ class PeyeeyeGuardrail(CustomGuardrail):
         redacted_texts, session_id = await self._redact_batch(
             [t for _, _, t in text_parts]
         )
+        if len(redacted_texts) != len(text_parts):
+            raise PEyeEyeGuardrailAPIError(
+                f"peyeeye /v1/redact returned {len(redacted_texts)} texts for "
+                f"{len(text_parts)} inputs; refusing to forward partially-"
+                "redacted data"
+            )
         for (msg_idx, part_path, _), redacted in zip(text_parts, redacted_texts):
             _set_message_text(messages[msg_idx], part_path, redacted)
 
@@ -248,7 +254,7 @@ class PeyeeyeGuardrail(CustomGuardrail):
         elif isinstance(out_text, list):
             redacted = [str(x) for x in out_text]
         else:
-            raise PeyeeyeGuardrailAPIError(
+            raise PEyeEyeGuardrailAPIError(
                 "peyeeye /v1/redact returned unexpected response shape; "
                 "refusing to forward unredacted text"
             )
@@ -296,31 +302,31 @@ class PeyeeyeGuardrail(CustomGuardrail):
     def _reraise_api_error(error: Exception, path: str) -> NoReturn:
         if HTTPX_AVAILABLE and httpx is not None:
             if isinstance(error, httpx.TimeoutException):
-                raise PeyeeyeGuardrailAPIError(f"peyeeye {path} timed out") from error
+                raise PEyeEyeGuardrailAPIError(f"peyeeye {path} timed out") from error
             if isinstance(error, httpx.HTTPStatusError):
                 status = error.response.status_code
                 if status == 401:
-                    raise PeyeeyeGuardrailMissingSecrets(
+                    raise PEyeEyeGuardrailMissingSecrets(
                         "Invalid peyeeye API key"
                     ) from error
                 if status == 429:
-                    raise PeyeeyeGuardrailAPIError(
+                    raise PEyeEyeGuardrailAPIError(
                         "peyeeye rate limit exceeded"
                     ) from error
-                raise PeyeeyeGuardrailAPIError(
+                raise PEyeEyeGuardrailAPIError(
                     f"peyeeye {path} returned {status}"
                 ) from error
-        raise PeyeeyeGuardrailAPIError(
+        raise PEyeEyeGuardrailAPIError(
             f"peyeeye {path} failed: {error}"
         ) from error
 
     @staticmethod
     def get_config_model() -> Optional[Type["GuardrailConfigModel"]]:
         from litellm.types.proxy.guardrails.guardrail_hooks.peyeeye import (
-            PeyeeyeGuardrailConfigModel,
+            PEyeEyeGuardrailConfigModel,
         )
 
-        return PeyeeyeGuardrailConfigModel
+        return PEyeEyeGuardrailConfigModel
 
 
 # ---------------------------------------------------------------- text helpers

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
@@ -1,0 +1,358 @@
+# +-------------------------------------------------------------+
+#
+#           Use Peyeeye PII redaction & rehydration for LLM calls
+#                        https://peyeeye.ai
+#
+# +-------------------------------------------------------------+
+
+import os
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    httpx = None  # type: ignore
+    HTTPX_AVAILABLE = False
+
+from fastapi import HTTPException
+
+import litellm
+from litellm import DualCache
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    log_guardrail_information,
+)
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.guardrails import GuardrailEventHooks
+
+
+if TYPE_CHECKING:
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
+
+
+DEFAULT_API_BASE = "https://api.peyeeye.ai"
+SESSION_CACHE_TTL_SECONDS = 3600
+
+
+class PeyeeyeGuardrailMissingSecrets(Exception):
+    """Raised when the peyeeye API key is missing."""
+
+
+class PeyeeyeGuardrailAPIError(Exception):
+    """Raised when the peyeeye API returns an error."""
+
+
+class PeyeeyeGuardrail(CustomGuardrail):
+    """Peyeeye PII redaction + rehydration guardrail.
+
+    Pre-call hook redacts PII from each message's ``content`` and stores the
+    redaction session id under the request's ``litellm_call_id`` so the
+    post-call hook can rehydrate the model's response with the original
+    values.
+
+    Two session modes:
+      * ``stateful`` (default): peyeeye stores the token→value mapping under
+        a ``ses_…`` id; rehydrate references the id.
+      * ``stateless``: peyeeye returns a sealed ``skey_…`` blob; nothing is
+        retained server-side.
+    """
+
+    def __init__(
+        self,
+        peyeeye_api_key: Optional[str] = None,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        peyeeye_locale: Optional[str] = None,
+        peyeeye_entities: Optional[List[str]] = None,
+        peyeeye_session_mode: Optional[Literal["stateful", "stateless"]] = None,
+        **kwargs,
+    ):
+        self.async_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback
+        )
+        self.peyeeye_api_key = (
+            peyeeye_api_key or api_key or os.environ.get("PEYEEYE_API_KEY")
+        )
+        if self.peyeeye_api_key is None:
+            raise PeyeeyeGuardrailMissingSecrets(
+                "Couldn't get peyeeye api key, either set the `PEYEEYE_API_KEY` "
+                "environment variable or pass it as `api_key` in the guardrail config."
+            )
+
+        self.api_base = (
+            api_base or os.environ.get("PEYEEYE_API_BASE") or DEFAULT_API_BASE
+        ).rstrip("/")
+        self.peyeeye_locale = peyeeye_locale or "auto"
+        self.peyeeye_entities = peyeeye_entities
+        self.peyeeye_session_mode: Literal["stateful", "stateless"] = (
+            peyeeye_session_mode or "stateful"
+        )
+
+        verbose_proxy_logger.debug(
+            "Peyeeye guardrail initialized: name=%s, mode=%s, session_mode=%s",
+            kwargs.get("guardrail_name", "unknown"),
+            kwargs.get("event_hook", "unknown"),
+            self.peyeeye_session_mode,
+        )
+
+        super().__init__(**kwargs)
+
+    # ------------------------------------------------------------------ hooks
+
+    @log_guardrail_information
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: Literal[
+            "completion",
+            "text_completion",
+            "embeddings",
+            "image_generation",
+            "moderation",
+            "audio_transcription",
+            "pass_through_endpoint",
+            "rerank",
+            "mcp_call",
+            "anthropic_messages",
+        ],
+    ) -> Union[Exception, str, dict, None]:
+        """Redact every text message before it reaches the model."""
+        event_type: GuardrailEventHooks = GuardrailEventHooks.pre_call
+        if self.should_run_guardrail(data=data, event_type=event_type) is not True:
+            return data
+
+        messages: List[Dict[str, Any]] = data.get("messages") or []
+        text_parts = list(_iter_message_text(messages))
+        if not text_parts:
+            return data
+
+        redacted_texts, session_id = await self._redact_batch(
+            [t for _, _, t in text_parts]
+        )
+        for (msg_idx, part_path, _), redacted in zip(text_parts, redacted_texts):
+            _set_message_text(messages[msg_idx], part_path, redacted)
+
+        if session_id:
+            cache_key = self._cache_key(data)
+            try:
+                cache.set_cache(
+                    cache_key, session_id, ttl=SESSION_CACHE_TTL_SECONDS
+                )
+            except Exception as e:
+                verbose_proxy_logger.warning(
+                    "peyeeye: failed to cache session id: %s", e
+                )
+
+        return data
+
+    @log_guardrail_information
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        response,
+    ):
+        """Rehydrate model output by swapping placeholders back to original PII."""
+        event_type: GuardrailEventHooks = GuardrailEventHooks.post_call
+        if self.should_run_guardrail(data=data, event_type=event_type) is not True:
+            return response
+
+        cache_key = self._cache_key(data)
+        try:
+            session_id = litellm.cache.get_cache(cache_key) if litellm.cache else None
+        except Exception:
+            session_id = None
+        if not session_id:
+            # No redaction happened (or session expired); nothing to do.
+            return response
+
+        if isinstance(response, litellm.ModelResponse):
+            for choice in response.choices:
+                message = getattr(choice, "message", None)
+                if message is None:
+                    continue
+                content = getattr(message, "content", None)
+                if isinstance(content, str) and content:
+                    new = await self._rehydrate(content, session_id)
+                    message.content = new
+                elif isinstance(content, list):
+                    new_parts: List[Any] = []
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            text = part.get("text", "")
+                            new_parts.append(
+                                {**part, "text": await self._rehydrate(text, session_id)}
+                            )
+                        else:
+                            new_parts.append(part)
+                    message.content = new_parts
+
+        # Clean up: drop the session server-side and from cache.
+        if self.peyeeye_session_mode == "stateful" and session_id.startswith("ses_"):
+            try:
+                await self._delete_session(session_id)
+            except Exception as e:
+                verbose_proxy_logger.debug(
+                    "peyeeye: best-effort session cleanup failed: %s", e
+                )
+        try:
+            if litellm.cache:
+                litellm.cache.delete_cache(cache_key)
+        except Exception:
+            pass
+
+        return response
+
+    # --------------------------------------------------------------- internals
+
+    @staticmethod
+    def _cache_key(data: dict) -> str:
+        return f"peyeeye_session:{data.get('litellm_call_id') or id(data)}"
+
+    async def _redact_batch(self, texts: List[str]) -> tuple[List[str], Optional[str]]:
+        """Redact a batch of texts in a single peyeeye session.
+
+        Returns the redacted strings (in order) and the session id (or sealed
+        ``skey_…`` blob) so the post-call hook can rehydrate.
+        """
+        body: Dict[str, Any] = {
+            "text": texts,
+            "locale": self.peyeeye_locale,
+        }
+        if self.peyeeye_entities:
+            body["entities"] = list(self.peyeeye_entities)
+        if self.peyeeye_session_mode == "stateless":
+            body["session"] = "stateless"
+
+        payload = await self._post("/v1/redact", body)
+        out_text = payload.get("text")
+        if isinstance(out_text, str):
+            redacted = [out_text]
+        elif isinstance(out_text, list):
+            redacted = [str(x) for x in out_text]
+        else:
+            redacted = list(texts)  # fallback
+
+        if self.peyeeye_session_mode == "stateless":
+            session_id = payload.get("rehydration_key")
+        else:
+            session_id = payload.get("session_id") or payload.get("session")
+
+        return redacted, session_id
+
+    async def _rehydrate(self, text: str, session_id: str) -> str:
+        if not text:
+            return text
+        body = {"text": text, "session": session_id}
+        try:
+            payload = await self._post("/v1/rehydrate", body)
+        except Exception as e:
+            verbose_proxy_logger.warning("peyeeye: rehydrate failed: %s", e)
+            return text
+        return payload.get("text", text)
+
+    async def _delete_session(self, session_id: str) -> None:
+        url = f"{self.api_base}/v1/sessions/{session_id}"
+        await self.async_handler.delete(url=url, headers=self._headers(), timeout=10.0)
+
+    async def _post(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.api_base}{path}"
+        try:
+            response = await self.async_handler.post(
+                url=url, headers=self._headers(), json=body, timeout=15.0
+            )
+            response.raise_for_status()
+        except Exception as e:
+            self._reraise_api_error(e, path)
+        return response.json()
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.peyeeye_api_key}",
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _reraise_api_error(error: Exception, path: str) -> None:
+        if isinstance(error, HTTPException):
+            raise error
+        if HTTPX_AVAILABLE and httpx is not None:
+            if isinstance(error, httpx.TimeoutException):
+                raise PeyeeyeGuardrailAPIError(f"peyeeye {path} timed out") from error
+            if isinstance(error, httpx.HTTPStatusError):
+                status = error.response.status_code
+                if status == 401:
+                    raise PeyeeyeGuardrailMissingSecrets(
+                        "Invalid peyeeye API key"
+                    ) from error
+                if status == 429:
+                    raise PeyeeyeGuardrailAPIError(
+                        "peyeeye rate limit exceeded"
+                    ) from error
+                raise PeyeeyeGuardrailAPIError(
+                    f"peyeeye {path} returned {status}"
+                ) from error
+        raise PeyeeyeGuardrailAPIError(
+            f"peyeeye {path} failed: {error}"
+        ) from error
+
+    @staticmethod
+    def get_config_model() -> Optional[Type["GuardrailConfigModel"]]:
+        from litellm.types.proxy.guardrails.guardrail_hooks.peyeeye import (
+            PeyeeyeGuardrailConfigModel,
+        )
+
+        return PeyeeyeGuardrailConfigModel
+
+
+# ---------------------------------------------------------------- text helpers
+
+
+def _iter_message_text(messages: List[Dict[str, Any]]):
+    """Yield (message_index, part_path, text) for every text-bearing chunk.
+
+    ``part_path`` is either ``"content"`` for a plain string message or an
+    int index into the multimodal content list.
+    """
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            if content:
+                yield i, "content", content
+        elif isinstance(content, list):
+            for j, part in enumerate(content):
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text = part.get("text", "")
+                    if text:
+                        yield i, j, text
+
+
+def _set_message_text(message: Dict[str, Any], part_path, value: str) -> None:
+    if part_path == "content":
+        message["content"] = value
+        return
+    parts = message.get("content")
+    if isinstance(parts, list) and isinstance(part_path, int) and part_path < len(parts):
+        part = parts[part_path]
+        if isinstance(part, dict):
+            part["text"] = value

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    NoReturn,
     Optional,
     Type,
     Union,
@@ -25,13 +26,12 @@ except ImportError:
     httpx = None  # type: ignore
     HTTPX_AVAILABLE = False
 
-from fastapi import HTTPException
-
 import litellm
 from litellm import DualCache
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
+    dc as global_cache,
     log_guardrail_information,
 )
 from litellm.llms.custom_httpx.http_handler import (
@@ -153,7 +153,7 @@ class PeyeeyeGuardrail(CustomGuardrail):
         if session_id:
             cache_key = self._cache_key(data)
             try:
-                cache.set_cache(
+                global_cache.set_cache(
                     cache_key, session_id, ttl=SESSION_CACHE_TTL_SECONDS
                 )
             except Exception as e:
@@ -177,7 +177,7 @@ class PeyeeyeGuardrail(CustomGuardrail):
 
         cache_key = self._cache_key(data)
         try:
-            session_id = litellm.cache.get_cache(cache_key) if litellm.cache else None
+            session_id = global_cache.get_cache(cache_key)
         except Exception:
             session_id = None
         if not session_id:
@@ -214,8 +214,7 @@ class PeyeeyeGuardrail(CustomGuardrail):
                     "peyeeye: best-effort session cleanup failed: %s", e
                 )
         try:
-            if litellm.cache:
-                litellm.cache.delete_cache(cache_key)
+            global_cache.delete_cache(cache_key)
         except Exception:
             pass
 
@@ -249,7 +248,10 @@ class PeyeeyeGuardrail(CustomGuardrail):
         elif isinstance(out_text, list):
             redacted = [str(x) for x in out_text]
         else:
-            redacted = list(texts)  # fallback
+            raise PeyeeyeGuardrailAPIError(
+                "peyeeye /v1/redact returned unexpected response shape; "
+                "refusing to forward unredacted text"
+            )
 
         if self.peyeeye_session_mode == "stateless":
             session_id = payload.get("rehydration_key")
@@ -291,9 +293,7 @@ class PeyeeyeGuardrail(CustomGuardrail):
         }
 
     @staticmethod
-    def _reraise_api_error(error: Exception, path: str) -> None:
-        if isinstance(error, HTTPException):
-            raise error
+    def _reraise_api_error(error: Exception, path: str) -> NoReturn:
         if HTTPX_AVAILABLE and httpx is not None:
             if isinstance(error, httpx.TimeoutException):
                 raise PeyeeyeGuardrailAPIError(f"peyeeye {path} timed out") from error

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
@@ -211,8 +211,9 @@ class PEyeEyeGuardrail(CustomGuardrail):
                             new_parts.append(part)
                     message.content = new_parts
 
-        # Clean up: drop the session server-side and from cache.
-        if self.peyeeye_session_mode == "stateful" and session_id.startswith("ses_"):
+        # Clean up: drop the stateful session server-side. Stateless
+        # ``skey_…`` blobs hold no server-side state, so skip the DELETE.
+        if self.peyeeye_session_mode == "stateful":
             try:
                 await self._delete_session(session_id)
             except Exception as e:
@@ -288,9 +289,9 @@ class PEyeEyeGuardrail(CustomGuardrail):
                 url=url, headers=self._headers(), json=body, timeout=15.0
             )
             response.raise_for_status()
+            return response.json()
         except Exception as e:
             self._reraise_api_error(e, path)
-        return response.json()
 
     def _headers(self) -> Dict[str, str]:
         return {

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
@@ -139,13 +139,15 @@ class PEyeEyeGuardrail(CustomGuardrail):
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
             return data
 
-        messages: List[Dict[str, Any]] = data.get("messages") or []
-        text_parts = list(_iter_message_text(messages))
+        # Walk every text-bearing input we know about — chat ``messages``,
+        # tool_call arguments, ``text_completion`` ``prompt``, and embeddings
+        # ``input``. Anything we don't extract here would bypass redaction.
+        text_parts = list(_iter_data_text(data))
         if not text_parts:
             return data
 
         redacted_texts, session_id = await self._redact_batch(
-            [t for _, _, t in text_parts]
+            [t for _, t in text_parts]
         )
         if len(redacted_texts) != len(text_parts):
             raise PEyeEyeGuardrailAPIError(
@@ -153,8 +155,8 @@ class PEyeEyeGuardrail(CustomGuardrail):
                 f"{len(text_parts)} inputs; refusing to forward partially-"
                 "redacted data"
             )
-        for (msg_idx, part_path, _), redacted in zip(text_parts, redacted_texts):
-            _set_message_text(messages[msg_idx], part_path, redacted)
+        for (locator, _), redacted in zip(text_parts, redacted_texts):
+            _set_data_text(data, locator, redacted)
 
         if session_id:
             cache_key = self._cache_key(data, user_api_key_dict)
@@ -230,6 +232,15 @@ class PEyeEyeGuardrail(CustomGuardrail):
                                     fn.arguments = new_args
                                 except Exception:
                                     pass
+        elif isinstance(response, litellm.TextCompletionResponse):
+            # /v1/completions returns choices[].text rather than choices[].message.
+            for choice in response.choices:
+                text = getattr(choice, "text", None)
+                if isinstance(text, str) and text:
+                    try:
+                        choice.text = await self._rehydrate(text, session_id)
+                    except Exception:
+                        pass
 
         # Clean up: drop the stateful session server-side. Stateless
         # ``skey_…`` blobs hold no server-side state, so skip the DELETE.
@@ -361,6 +372,64 @@ class PEyeEyeGuardrail(CustomGuardrail):
 
 
 # ---------------------------------------------------------------- text helpers
+
+
+def _iter_data_text(data: Dict[str, Any]):
+    """Yield ``(locator, text)`` for every text-bearing input in ``data``.
+
+    Covers chat ``messages`` (incl. tool_call arguments), ``text_completion``
+    ``prompt``, and ``embeddings`` ``input``. ``locator`` is opaque to callers
+    and is consumed by ``_set_data_text`` to write the redacted value back.
+    """
+    messages = data.get("messages")
+    if isinstance(messages, list):
+        for msg_idx, sub_path, text in _iter_message_text(messages):
+            yield ("messages", msg_idx, sub_path), text
+
+    prompt = data.get("prompt")
+    if isinstance(prompt, str):
+        if prompt:
+            yield ("prompt",), prompt
+    elif isinstance(prompt, list):
+        for j, p in enumerate(prompt):
+            if isinstance(p, str) and p:
+                yield ("prompt", j), p
+
+    inp = data.get("input")
+    if isinstance(inp, str):
+        if inp:
+            yield ("input",), inp
+    elif isinstance(inp, list):
+        for j, v in enumerate(inp):
+            if isinstance(v, str) and v:
+                yield ("input", j), v
+
+
+def _set_data_text(data: Dict[str, Any], locator, value: str) -> None:
+    head = locator[0]
+    if head == "messages":
+        _, msg_idx, sub_path = locator
+        messages = data.get("messages") or []
+        if isinstance(msg_idx, int) and msg_idx < len(messages):
+            _set_message_text(messages[msg_idx], sub_path, value)
+        return
+    if head == "prompt":
+        if len(locator) == 1:
+            data["prompt"] = value
+            return
+        _, j = locator
+        prompt = data.get("prompt")
+        if isinstance(prompt, list) and isinstance(j, int) and j < len(prompt):
+            prompt[j] = value
+        return
+    if head == "input":
+        if len(locator) == 1:
+            data["input"] = value
+            return
+        _, j = locator
+        inp = data.get("input")
+        if isinstance(inp, list) and isinstance(j, int) and j < len(inp):
+            inp[j] = value
 
 
 def _iter_message_text(messages: List[Dict[str, Any]]):

--- a/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/peyeeye/peyeeye.py
@@ -157,7 +157,7 @@ class PEyeEyeGuardrail(CustomGuardrail):
             _set_message_text(messages[msg_idx], part_path, redacted)
 
         if session_id:
-            cache_key = self._cache_key(data)
+            cache_key = self._cache_key(data, user_api_key_dict)
             try:
                 global_cache.set_cache(
                     cache_key, session_id, ttl=SESSION_CACHE_TTL_SECONDS
@@ -181,7 +181,7 @@ class PEyeEyeGuardrail(CustomGuardrail):
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
             return response
 
-        cache_key = self._cache_key(data)
+        cache_key = self._cache_key(data, user_api_key_dict)
         try:
             session_id = global_cache.get_cache(cache_key)
         except Exception:
@@ -210,6 +210,26 @@ class PEyeEyeGuardrail(CustomGuardrail):
                         else:
                             new_parts.append(part)
                     message.content = new_parts
+                # Mirror the pre-call coverage: if the model echoes placeholders
+                # into tool_call arguments, rehydrate those too.
+                tool_calls = getattr(message, "tool_calls", None)
+                if isinstance(tool_calls, list):
+                    for tc in tool_calls:
+                        fn = getattr(tc, "function", None) or (
+                            tc.get("function") if isinstance(tc, dict) else None
+                        )
+                        if fn is None:
+                            continue
+                        args = getattr(fn, "arguments", None) if not isinstance(fn, dict) else fn.get("arguments")
+                        if isinstance(args, str) and args:
+                            new_args = await self._rehydrate(args, session_id)
+                            if isinstance(fn, dict):
+                                fn["arguments"] = new_args
+                            else:
+                                try:
+                                    fn.arguments = new_args
+                                except Exception:
+                                    pass
 
         # Clean up: drop the stateful session server-side. Stateless
         # ``skey_…`` blobs hold no server-side state, so skip the DELETE.
@@ -230,8 +250,18 @@ class PEyeEyeGuardrail(CustomGuardrail):
     # --------------------------------------------------------------- internals
 
     @staticmethod
-    def _cache_key(data: dict) -> str:
-        return f"peyeeye_session:{data.get('litellm_call_id') or id(data)}"
+    def _cache_key(data: dict, user_api_key_dict: UserAPIKeyAuth) -> str:
+        # ``litellm_call_id`` is sourced from the inbound ``x-litellm-call-id``
+        # header, so it is caller-controlled. Namespace by the authenticated
+        # key (server-controlled) so two callers can't collide on the same key
+        # and rehydrate each other's PII.
+        call_id = data.get("litellm_call_id") or id(data)
+        auth_ns = (
+            getattr(user_api_key_dict, "api_key", None)
+            or getattr(user_api_key_dict, "token", None)
+            or "anon"
+        )
+        return f"peyeeye_session:{auth_ns}:{call_id}"
 
     async def _redact_batch(self, texts: List[str]) -> tuple[List[str], Optional[str]]:
         """Redact a batch of texts in a single peyeeye session.
@@ -336,8 +366,13 @@ class PEyeEyeGuardrail(CustomGuardrail):
 def _iter_message_text(messages: List[Dict[str, Any]]):
     """Yield (message_index, part_path, text) for every text-bearing chunk.
 
-    ``part_path`` is either ``"content"`` for a plain string message or an
-    int index into the multimodal content list.
+    ``part_path`` identifies where the text lives so ``_set_message_text``
+    can write the redacted value back:
+
+      * ``"content"`` — plain string ``content``
+      * ``("content", j)`` — the ``j``-th item of a multimodal content list
+      * ``("tool_call", k)`` — ``tool_calls[k].function.arguments``
+      * ``"function_call"`` — legacy ``function_call.arguments``
     """
     for i, msg in enumerate(messages):
         if not isinstance(msg, dict):
@@ -351,15 +386,49 @@ def _iter_message_text(messages: List[Dict[str, Any]]):
                 if isinstance(part, dict) and part.get("type") == "text":
                     text = part.get("text", "")
                     if text:
-                        yield i, j, text
+                        yield i, ("content", j), text
+        # Tool calls carry model-visible text in ``function.arguments``; if we
+        # leave them alone a caller can put PII there and bypass redaction.
+        tool_calls = msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for k, tc in enumerate(tool_calls):
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function")
+                if isinstance(fn, dict):
+                    args = fn.get("arguments")
+                    if isinstance(args, str) and args:
+                        yield i, ("tool_call", k), args
+        fc = msg.get("function_call")
+        if isinstance(fc, dict):
+            args = fc.get("arguments")
+            if isinstance(args, str) and args:
+                yield i, "function_call", args
 
 
 def _set_message_text(message: Dict[str, Any], part_path, value: str) -> None:
     if part_path == "content":
         message["content"] = value
         return
-    parts = message.get("content")
-    if isinstance(parts, list) and isinstance(part_path, int) and part_path < len(parts):
-        part = parts[part_path]
-        if isinstance(part, dict):
-            part["text"] = value
+    if part_path == "function_call":
+        fc = message.get("function_call")
+        if isinstance(fc, dict):
+            fc["arguments"] = value
+        return
+    if isinstance(part_path, tuple) and len(part_path) == 2:
+        kind, idx = part_path
+        if kind == "content":
+            parts = message.get("content")
+            if isinstance(parts, list) and isinstance(idx, int) and idx < len(parts):
+                part = parts[idx]
+                if isinstance(part, dict):
+                    part["text"] = value
+            return
+        if kind == "tool_call":
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list) and isinstance(idx, int) and idx < len(tool_calls):
+                tc = tool_calls[idx]
+                if isinstance(tc, dict):
+                    fn = tc.get("function")
+                    if isinstance(fn, dict):
+                        fn["arguments"] = value

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -100,6 +100,7 @@ class SupportedGuardrailIntegrations(Enum):
     MCP_JWT_SIGNER = "mcp_jwt_signer"
     LLM_AS_A_JUDGE = "llm_as_a_judge"
     QOSTODIAN_NEXUS = "qostodian_nexus"
+    PEYEEYE = "peyeeye"
 
 
 class Role(Enum):
@@ -446,6 +447,23 @@ class LassoGuardrailConfigModel(BaseModel):
     )
 
 
+class PeyeeyeGuardrailConfigModel(BaseModel):
+    """Configuration parameters for the peyeeye PII redaction & rehydration guardrail"""
+
+    peyeeye_locale: Optional[str] = Field(
+        default="auto",
+        description="BCP-47 language tag for PII detection. 'auto' lets peyeeye detect.",
+    )
+    peyeeye_entities: Optional[List[str]] = Field(
+        default=None,
+        description="Restrict detection to these entity IDs (e.g. ['EMAIL', 'CARD']). Omit to detect all 60+ built-in entities.",
+    )
+    peyeeye_session_mode: Optional[Literal["stateful", "stateless"]] = Field(
+        default="stateful",
+        description="'stateful' uses peyeeye sessions; 'stateless' returns a sealed rehydration key (no PII retained server-side).",
+    )
+
+
 class PillarGuardrailConfigModel(BaseModel):
     """Configuration parameters for the Pillar Security guardrail"""
 
@@ -762,6 +780,7 @@ class LitellmParams(
     BedrockGuardrailConfigModel,
     LakeraV2GuardrailConfigModel,
     LassoGuardrailConfigModel,
+    PeyeeyeGuardrailConfigModel,
     PillarGuardrailConfigModel,
     GraySwanGuardrailConfigModel,
     NomaGuardrailConfigModel,

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -447,7 +447,7 @@ class LassoGuardrailConfigModel(BaseModel):
     )
 
 
-class PeyeeyeGuardrailConfigModel(BaseModel):
+class PEyeEyeGuardrailConfigModel(BaseModel):
     """Configuration parameters for the peyeeye PII redaction & rehydration guardrail"""
 
     peyeeye_locale: Optional[str] = Field(
@@ -780,7 +780,7 @@ class LitellmParams(
     BedrockGuardrailConfigModel,
     LakeraV2GuardrailConfigModel,
     LassoGuardrailConfigModel,
-    PeyeeyeGuardrailConfigModel,
+    PEyeEyeGuardrailConfigModel,
     PillarGuardrailConfigModel,
     GraySwanGuardrailConfigModel,
     NomaGuardrailConfigModel,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/peyeeye.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/peyeeye.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 from .base import GuardrailConfigModel
 
 
-class PeyeeyeGuardrailConfigModelOptionalParams(BaseModel):
+class PEyeEyeGuardrailConfigModelOptionalParams(BaseModel):
     peyeeye_locale: Optional[str] = Field(
         default="auto",
         description="BCP-47 language tag for PII detection. 'auto' lets peyeeye detect.",
@@ -20,8 +20,8 @@ class PeyeeyeGuardrailConfigModelOptionalParams(BaseModel):
     )
 
 
-class PeyeeyeGuardrailConfigModel(
-    GuardrailConfigModel[PeyeeyeGuardrailConfigModelOptionalParams]
+class PEyeEyeGuardrailConfigModel(
+    GuardrailConfigModel[PEyeEyeGuardrailConfigModelOptionalParams]
 ):
     api_key: Optional[str] = Field(
         default=None,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/peyeeye.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/peyeeye.py
@@ -1,0 +1,37 @@
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .base import GuardrailConfigModel
+
+
+class PeyeeyeGuardrailConfigModelOptionalParams(BaseModel):
+    peyeeye_locale: Optional[str] = Field(
+        default="auto",
+        description="BCP-47 language tag for PII detection. 'auto' lets peyeeye detect.",
+    )
+    peyeeye_entities: Optional[List[str]] = Field(
+        default=None,
+        description="Restrict detection to these entity IDs (e.g. ['EMAIL', 'CARD']). Omit to detect all 60+ built-in entities.",
+    )
+    peyeeye_session_mode: Optional[Literal["stateful", "stateless"]] = Field(
+        default="stateful",
+        description="'stateful' stores token→value mappings under a peyeeye session id. 'stateless' returns a sealed rehydration key — no PII retained server-side.",
+    )
+
+
+class PeyeeyeGuardrailConfigModel(
+    GuardrailConfigModel[PeyeeyeGuardrailConfigModelOptionalParams]
+):
+    api_key: Optional[str] = Field(
+        default=None,
+        description="Peyeeye API key. Falls back to the `PEYEEYE_API_KEY` environment variable.",
+    )
+    api_base: Optional[str] = Field(
+        default=None,
+        description="Peyeeye API base URL. Defaults to https://api.peyeeye.ai. Also reads `PEYEEYE_API_BASE`.",
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Peyeeye PII Redaction & Rehydration"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
@@ -237,6 +237,30 @@ async def test_redact_api_error_raises_typed():
 
 
 @pytest.mark.asyncio
+async def test_redact_json_decode_error_raises_typed():
+    """If response.json() blows up, surface a typed PEyeEyeGuardrailAPIError."""
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+
+    bad = MagicMock()
+    bad.raise_for_status = MagicMock()
+    bad.json.side_effect = ValueError("not json")
+    g.async_handler.post = AsyncMock(return_value=bad)
+
+    cache = DualCache()
+    with pytest.raises(PEyeEyeGuardrailAPIError):
+        await g.async_pre_call_hook(
+            UserAPIKeyAuth(api_key="x"),
+            cache,
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "litellm_call_id": "json-err",
+            },
+            "completion",
+        )
+
+
+@pytest.mark.asyncio
 async def test_pre_call_raises_on_length_mismatch():
     """If /v1/redact returns fewer texts than sent, refuse to forward."""
     g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
@@ -97,9 +97,12 @@ async def test_pre_call_redacts_messages_and_caches_session():
     user = UserAPIKeyAuth(api_key="x")
     out = await g.async_pre_call_hook(user, cache, data, "completion")
 
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
     assert out["messages"][0]["content"] == "hi [EMAIL_1]"
-    cached = cache.get_cache("peyeeye_session:call-1")
-    assert cached == "ses_abc"
+    assert global_cache.get_cache("peyeeye_session:call-1") == "ses_abc"
+    global_cache.delete_cache("peyeeye_session:call-1")
 
 
 @pytest.mark.asyncio
@@ -123,9 +126,13 @@ async def test_pre_call_stateless_returns_skey():
     }
     await g.async_pre_call_hook(UserAPIKeyAuth(api_key="x"), cache, data, "completion")
 
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
     sent_body = g.async_handler.post.call_args.kwargs["json"]
     assert sent_body["session"] == "stateless"
-    assert cache.get_cache("peyeeye_session:call-2") == "skey_xyz"
+    assert global_cache.get_cache("peyeeye_session:call-2") == "skey_xyz"
+    global_cache.delete_cache("peyeeye_session:call-2")
 
 
 @pytest.mark.asyncio
@@ -144,18 +151,29 @@ async def test_pre_call_skips_when_no_messages():
 
 
 @pytest.mark.asyncio
-async def test_post_call_rehydrates_response():
+async def test_pre_and_post_call_roundtrip_uses_shared_cache():
+    """End-to-end: pre-call seeds session id, post-call retrieves & rehydrates."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
     g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
     g.async_handler = MagicMock()
     g.async_handler.post = AsyncMock(
-        return_value=_ok({"text": "Reply to alice@acme.com", "replaced": 1})
+        side_effect=[
+            _ok({"text": ["hi [EMAIL_1]"], "session_id": "ses_abc"}),
+            _ok({"text": "Reply to alice@acme.com", "replaced": 1}),
+        ]
     )
     g.async_handler.delete = AsyncMock()
 
-    # Seed the session id into litellm.cache so the post-call hook finds it.
-    litellm.cache = MagicMock()
-    litellm.cache.get_cache = MagicMock(return_value="ses_abc")
-    litellm.cache.delete_cache = MagicMock()
+    cache = DualCache()
+    data = {
+        "messages": [{"role": "user", "content": "hi alice@acme.com"}],
+        "litellm_call_id": "rt-1",
+    }
+    user = UserAPIKeyAuth(api_key="x")
+    await g.async_pre_call_hook(user, cache, data, "completion")
 
     response = litellm.ModelResponse()
     response.choices = [
@@ -167,15 +185,12 @@ async def test_post_call_rehydrates_response():
             ),
         )
     ]
-    data = {"litellm_call_id": "call-1"}
-
     out = await g.async_post_call_success_hook(
-        data, UserAPIKeyAuth(api_key="x"), response
+        {"litellm_call_id": "rt-1"}, user, response
     )
     assert out.choices[0].message.content == "Reply to alice@acme.com"
     g.async_handler.delete.assert_awaited()
-    litellm.cache.delete_cache.assert_called_once_with("peyeeye_session:call-1")
-    litellm.cache = None
+    assert global_cache.get_cache("peyeeye_session:rt-1") is None
 
 
 @pytest.mark.asyncio
@@ -184,7 +199,6 @@ async def test_post_call_noop_without_session():
     g.async_handler = MagicMock()
     g.async_handler.post = AsyncMock()
 
-    litellm.cache = None
     response = litellm.ModelResponse()
     response.choices = [
         litellm.utils.Choices(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
@@ -1,0 +1,222 @@
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+    PeyeeyeGuardrail,
+    PeyeeyeGuardrailAPIError,
+    PeyeeyeGuardrailMissingSecrets,
+)
+from litellm.proxy.guardrails.init_guardrails import init_guardrails_v2
+
+
+def _ok(json_payload: dict):
+    resp = MagicMock()
+    resp.json.return_value = json_payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_peyeeye_init_requires_api_key():
+    for var in ("PEYEEYE_API_KEY", "PEYEEYE_API_BASE"):
+        os.environ.pop(var, None)
+    with pytest.raises(PeyeeyeGuardrailMissingSecrets):
+        PeyeeyeGuardrail(guardrail_name="t")
+
+
+def test_peyeeye_init_reads_env():
+    os.environ["PEYEEYE_API_KEY"] = "pk_test"
+    try:
+        g = PeyeeyeGuardrail(guardrail_name="t")
+        assert g.peyeeye_api_key == "pk_test"
+        assert g.api_base == "https://api.peyeeye.ai"
+        assert g.peyeeye_session_mode == "stateful"
+    finally:
+        del os.environ["PEYEEYE_API_KEY"]
+
+
+def test_peyeeye_init_explicit_args():
+    g = PeyeeyeGuardrail(
+        peyeeye_api_key="pk_x",
+        api_base="https://api.example/",
+        peyeeye_locale="en",
+        peyeeye_entities=["EMAIL"],
+        peyeeye_session_mode="stateless",
+        guardrail_name="t",
+    )
+    assert g.peyeeye_api_key == "pk_x"
+    assert g.api_base == "https://api.example"
+    assert g.peyeeye_locale == "en"
+    assert g.peyeeye_entities == ["EMAIL"]
+    assert g.peyeeye_session_mode == "stateless"
+
+
+def test_peyeeye_guardrail_config_via_init():
+    litellm.guardrail_name_config_map = {}
+    os.environ["PEYEEYE_API_KEY"] = "pk_test"
+    try:
+        init_guardrails_v2(
+            all_guardrails=[
+                {
+                    "guardrail_name": "peyeeye-pre",
+                    "litellm_params": {
+                        "guardrail": "peyeeye",
+                        "mode": "pre_call",
+                        "default_on": True,
+                    },
+                }
+            ],
+            config_file_path="",
+        )
+    finally:
+        del os.environ["PEYEEYE_API_KEY"]
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_messages_and_caches_session():
+    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok(
+            {"text": ["hi [EMAIL_1]"], "session_id": "ses_abc"}
+        )
+    )
+
+    cache = DualCache()
+    data = {
+        "messages": [{"role": "user", "content": "hi alice@acme.com"}],
+        "litellm_call_id": "call-1",
+    }
+    user = UserAPIKeyAuth(api_key="x")
+    out = await g.async_pre_call_hook(user, cache, data, "completion")
+
+    assert out["messages"][0]["content"] == "hi [EMAIL_1]"
+    cached = cache.get_cache("peyeeye_session:call-1")
+    assert cached == "ses_abc"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_stateless_returns_skey():
+    g = PeyeeyeGuardrail(
+        peyeeye_api_key="pk",
+        peyeeye_session_mode="stateless",
+        guardrail_name="t",
+    )
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok(
+            {"text": ["[EMAIL_1]"], "rehydration_key": "skey_xyz"}
+        )
+    )
+
+    cache = DualCache()
+    data = {
+        "messages": [{"role": "user", "content": "alice@acme.com"}],
+        "litellm_call_id": "call-2",
+    }
+    await g.async_pre_call_hook(UserAPIKeyAuth(api_key="x"), cache, data, "completion")
+
+    sent_body = g.async_handler.post.call_args.kwargs["json"]
+    assert sent_body["session"] == "stateless"
+    assert cache.get_cache("peyeeye_session:call-2") == "skey_xyz"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_skips_when_no_messages():
+    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock()
+
+    cache = DualCache()
+    data = {"messages": [], "litellm_call_id": "x"}
+    out = await g.async_pre_call_hook(
+        UserAPIKeyAuth(api_key="x"), cache, data, "completion"
+    )
+    assert out is data
+    g.async_handler.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_call_rehydrates_response():
+    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok({"text": "Reply to alice@acme.com", "replaced": 1})
+    )
+    g.async_handler.delete = AsyncMock()
+
+    # Seed the session id into litellm.cache so the post-call hook finds it.
+    litellm.cache = MagicMock()
+    litellm.cache.get_cache = MagicMock(return_value="ses_abc")
+    litellm.cache.delete_cache = MagicMock()
+
+    response = litellm.ModelResponse()
+    response.choices = [
+        litellm.utils.Choices(
+            finish_reason="stop",
+            index=0,
+            message=litellm.utils.Message(
+                content="Reply to [EMAIL_1]", role="assistant"
+            ),
+        )
+    ]
+    data = {"litellm_call_id": "call-1"}
+
+    out = await g.async_post_call_success_hook(
+        data, UserAPIKeyAuth(api_key="x"), response
+    )
+    assert out.choices[0].message.content == "Reply to alice@acme.com"
+    g.async_handler.delete.assert_awaited()
+    litellm.cache.delete_cache.assert_called_once_with("peyeeye_session:call-1")
+    litellm.cache = None
+
+
+@pytest.mark.asyncio
+async def test_post_call_noop_without_session():
+    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock()
+
+    litellm.cache = None
+    response = litellm.ModelResponse()
+    response.choices = [
+        litellm.utils.Choices(
+            finish_reason="stop",
+            index=0,
+            message=litellm.utils.Message(content="hello", role="assistant"),
+        )
+    ]
+    out = await g.async_post_call_success_hook(
+        {"litellm_call_id": "no-session"}, UserAPIKeyAuth(api_key="x"), response
+    )
+    assert out.choices[0].message.content == "hello"
+    g.async_handler.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_redact_api_error_raises_typed():
+    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+
+    bad = MagicMock()
+    bad.raise_for_status.side_effect = RuntimeError("boom")
+    g.async_handler.post = AsyncMock(return_value=bad)
+
+    cache = DualCache()
+    with pytest.raises(PeyeeyeGuardrailAPIError):
+        await g.async_pre_call_hook(
+            UserAPIKeyAuth(api_key="x"),
+            cache,
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "litellm_call_id": "c",
+            },
+            "completion",
+        )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
@@ -10,9 +10,9 @@ import litellm
 from litellm import DualCache
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
-    PeyeeyeGuardrail,
-    PeyeeyeGuardrailAPIError,
-    PeyeeyeGuardrailMissingSecrets,
+    PEyeEyeGuardrail,
+    PEyeEyeGuardrailAPIError,
+    PEyeEyeGuardrailMissingSecrets,
 )
 from litellm.proxy.guardrails.init_guardrails import init_guardrails_v2
 
@@ -27,14 +27,14 @@ def _ok(json_payload: dict):
 def test_peyeeye_init_requires_api_key():
     for var in ("PEYEEYE_API_KEY", "PEYEEYE_API_BASE"):
         os.environ.pop(var, None)
-    with pytest.raises(PeyeeyeGuardrailMissingSecrets):
-        PeyeeyeGuardrail(guardrail_name="t")
+    with pytest.raises(PEyeEyeGuardrailMissingSecrets):
+        PEyeEyeGuardrail(guardrail_name="t")
 
 
 def test_peyeeye_init_reads_env():
     os.environ["PEYEEYE_API_KEY"] = "pk_test"
     try:
-        g = PeyeeyeGuardrail(guardrail_name="t")
+        g = PEyeEyeGuardrail(guardrail_name="t")
         assert g.peyeeye_api_key == "pk_test"
         assert g.api_base == "https://api.peyeeye.ai"
         assert g.peyeeye_session_mode == "stateful"
@@ -43,7 +43,7 @@ def test_peyeeye_init_reads_env():
 
 
 def test_peyeeye_init_explicit_args():
-    g = PeyeeyeGuardrail(
+    g = PEyeEyeGuardrail(
         peyeeye_api_key="pk_x",
         api_base="https://api.example/",
         peyeeye_locale="en",
@@ -81,7 +81,7 @@ def test_peyeeye_guardrail_config_via_init():
 
 @pytest.mark.asyncio
 async def test_pre_call_redacts_messages_and_caches_session():
-    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
     g.async_handler = MagicMock()
     g.async_handler.post = AsyncMock(
         return_value=_ok(
@@ -107,7 +107,7 @@ async def test_pre_call_redacts_messages_and_caches_session():
 
 @pytest.mark.asyncio
 async def test_pre_call_stateless_returns_skey():
-    g = PeyeeyeGuardrail(
+    g = PEyeEyeGuardrail(
         peyeeye_api_key="pk",
         peyeeye_session_mode="stateless",
         guardrail_name="t",
@@ -137,7 +137,7 @@ async def test_pre_call_stateless_returns_skey():
 
 @pytest.mark.asyncio
 async def test_pre_call_skips_when_no_messages():
-    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
     g.async_handler = MagicMock()
     g.async_handler.post = AsyncMock()
 
@@ -157,7 +157,7 @@ async def test_pre_and_post_call_roundtrip_uses_shared_cache():
         global_cache,
     )
 
-    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
     g.async_handler = MagicMock()
     g.async_handler.post = AsyncMock(
         side_effect=[
@@ -195,7 +195,7 @@ async def test_pre_and_post_call_roundtrip_uses_shared_cache():
 
 @pytest.mark.asyncio
 async def test_post_call_noop_without_session():
-    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
     g.async_handler = MagicMock()
     g.async_handler.post = AsyncMock()
 
@@ -216,7 +216,7 @@ async def test_post_call_noop_without_session():
 
 @pytest.mark.asyncio
 async def test_redact_api_error_raises_typed():
-    g = PeyeeyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
     g.async_handler = MagicMock()
 
     bad = MagicMock()
@@ -224,7 +224,7 @@ async def test_redact_api_error_raises_typed():
     g.async_handler.post = AsyncMock(return_value=bad)
 
     cache = DualCache()
-    with pytest.raises(PeyeeyeGuardrailAPIError):
+    with pytest.raises(PEyeEyeGuardrailAPIError):
         await g.async_pre_call_hook(
             UserAPIKeyAuth(api_key="x"),
             cache,
@@ -233,4 +233,47 @@ async def test_redact_api_error_raises_typed():
                 "litellm_call_id": "c",
             },
             "completion",
+        )
+
+
+@pytest.mark.asyncio
+async def test_pre_call_raises_on_length_mismatch():
+    """If /v1/redact returns fewer texts than sent, refuse to forward."""
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok({"text": ["[EMAIL_1]"], "session_id": "ses_x"})
+    )
+
+    cache = DualCache()
+    data = {
+        "messages": [
+            {"role": "user", "content": "hi alice@acme.com"},
+            {"role": "user", "content": "hi bob@acme.com"},
+        ],
+        "litellm_call_id": "len-1",
+    }
+    with pytest.raises(PEyeEyeGuardrailAPIError, match="partially-redacted"):
+        await g.async_pre_call_hook(
+            UserAPIKeyAuth(api_key="x"), cache, data, "completion"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pre_call_raises_on_unexpected_response_shape():
+    """If /v1/redact returns neither str nor list for `text`, refuse to forward."""
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok({"text": 42, "session_id": "ses_x"})
+    )
+
+    cache = DualCache()
+    data = {
+        "messages": [{"role": "user", "content": "hi alice@acme.com"}],
+        "litellm_call_id": "shape-1",
+    }
+    with pytest.raises(PEyeEyeGuardrailAPIError, match="unexpected response shape"):
+        await g.async_pre_call_hook(
+            UserAPIKeyAuth(api_key="x"), cache, data, "completion"
         )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
@@ -101,8 +101,8 @@ async def test_pre_call_redacts_messages_and_caches_session():
         global_cache,
     )
     assert out["messages"][0]["content"] == "hi [EMAIL_1]"
-    assert global_cache.get_cache("peyeeye_session:call-1") == "ses_abc"
-    global_cache.delete_cache("peyeeye_session:call-1")
+    assert global_cache.get_cache("peyeeye_session:x:call-1") == "ses_abc"
+    global_cache.delete_cache("peyeeye_session:x:call-1")
 
 
 @pytest.mark.asyncio
@@ -131,8 +131,8 @@ async def test_pre_call_stateless_returns_skey():
     )
     sent_body = g.async_handler.post.call_args.kwargs["json"]
     assert sent_body["session"] == "stateless"
-    assert global_cache.get_cache("peyeeye_session:call-2") == "skey_xyz"
-    global_cache.delete_cache("peyeeye_session:call-2")
+    assert global_cache.get_cache("peyeeye_session:x:call-2") == "skey_xyz"
+    global_cache.delete_cache("peyeeye_session:x:call-2")
 
 
 @pytest.mark.asyncio
@@ -190,7 +190,7 @@ async def test_pre_and_post_call_roundtrip_uses_shared_cache():
     )
     assert out.choices[0].message.content == "Reply to alice@acme.com"
     g.async_handler.delete.assert_awaited()
-    assert global_cache.get_cache("peyeeye_session:rt-1") is None
+    assert global_cache.get_cache("peyeeye_session:x:rt-1") is None
 
 
 @pytest.mark.asyncio
@@ -281,6 +281,150 @@ async def test_pre_call_raises_on_length_mismatch():
         await g.async_pre_call_hook(
             UserAPIKeyAuth(api_key="x"), cache, data, "completion"
         )
+
+
+@pytest.mark.asyncio
+async def test_cache_key_isolated_per_authenticated_key():
+    """Two callers sharing a litellm_call_id must not share a session entry."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        side_effect=[
+            _ok({"text": ["[EMAIL_1]"], "session_id": "ses_attacker"}),
+            _ok({"text": ["[EMAIL_1]"], "session_id": "ses_victim"}),
+        ]
+    )
+
+    cache = DualCache()
+    shared_call_id = "shared-call-id"
+    await g.async_pre_call_hook(
+        UserAPIKeyAuth(api_key="attacker"),
+        cache,
+        {"messages": [{"role": "user", "content": "alice@acme.com"}],
+         "litellm_call_id": shared_call_id},
+        "completion",
+    )
+    await g.async_pre_call_hook(
+        UserAPIKeyAuth(api_key="victim"),
+        cache,
+        {"messages": [{"role": "user", "content": "bob@acme.com"}],
+         "litellm_call_id": shared_call_id},
+        "completion",
+    )
+
+    assert global_cache.get_cache(f"peyeeye_session:attacker:{shared_call_id}") == "ses_attacker"
+    assert global_cache.get_cache(f"peyeeye_session:victim:{shared_call_id}") == "ses_victim"
+    global_cache.delete_cache(f"peyeeye_session:attacker:{shared_call_id}")
+    global_cache.delete_cache(f"peyeeye_session:victim:{shared_call_id}")
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_tool_call_arguments():
+    """tool_calls[].function.arguments must not bypass redaction."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok(
+            {
+                "text": [
+                    "hi [EMAIL_1]",
+                    '{"to":"[EMAIL_1]"}',
+                    '{"to":"[EMAIL_2]"}',
+                ],
+                "session_id": "ses_tc",
+            }
+        )
+    )
+
+    cache = DualCache()
+    data = {
+        "messages": [
+            {"role": "user", "content": "hi alice@acme.com"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "send_email",
+                            "arguments": '{"to":"alice@acme.com"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "function_call": {
+                    "name": "send_email",
+                    "arguments": '{"to":"bob@acme.com"}',
+                },
+            },
+        ],
+        "litellm_call_id": "tc-1",
+    }
+    out = await g.async_pre_call_hook(
+        UserAPIKeyAuth(api_key="x"), cache, data, "completion"
+    )
+
+    sent = g.async_handler.post.call_args.kwargs["json"]["text"]
+    assert "alice@acme.com" in sent[0]
+    assert "alice@acme.com" in sent[1]
+    assert "bob@acme.com" in sent[2]
+
+    assert out["messages"][1]["tool_calls"][0]["function"]["arguments"] == '{"to":"[EMAIL_1]"}'
+    assert out["messages"][2]["function_call"]["arguments"] == '{"to":"[EMAIL_2]"}'
+    global_cache.delete_cache("peyeeye_session:x:tc-1")
+
+
+@pytest.mark.asyncio
+async def test_post_call_rehydrates_tool_call_arguments():
+    """If the model echoes placeholders into tool_call args, swap them back."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok(
+            {"text": '{"to":"alice@acme.com"}', "replaced": 1}
+        )
+    )
+    g.async_handler.delete = AsyncMock()
+
+    user = UserAPIKeyAuth(api_key="x")
+    global_cache.set_cache("peyeeye_session:x:tc-out", "ses_tc", ttl=60)
+
+    response = litellm.ModelResponse()
+    msg = litellm.utils.Message(content=None, role="assistant")
+    msg.tool_calls = [
+        litellm.utils.ChatCompletionMessageToolCall(
+            id="call_1",
+            type="function",
+            function=litellm.utils.Function(
+                name="send_email", arguments='{"to":"[EMAIL_1]"}'
+            ),
+        )
+    ]
+    response.choices = [
+        litellm.utils.Choices(finish_reason="stop", index=0, message=msg)
+    ]
+
+    out = await g.async_post_call_success_hook(
+        {"litellm_call_id": "tc-out"}, user, response
+    )
+    assert out.choices[0].message.tool_calls[0].function.arguments == '{"to":"alice@acme.com"}'
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py
@@ -428,6 +428,87 @@ async def test_post_call_rehydrates_tool_call_arguments():
 
 
 @pytest.mark.asyncio
+async def test_pre_call_redacts_text_completion_prompt():
+    """text_completion `prompt` (str or list[str]) must be redacted."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok(
+            {
+                "text": ["hi [EMAIL_1]", "ping [EMAIL_2]"],
+                "session_id": "ses_p",
+            }
+        )
+    )
+
+    cache = DualCache()
+    data = {
+        "prompt": ["hi alice@acme.com", "ping bob@acme.com"],
+        "litellm_call_id": "p-1",
+    }
+    out = await g.async_pre_call_hook(
+        UserAPIKeyAuth(api_key="x"), cache, data, "text_completion"
+    )
+    assert out["prompt"] == ["hi [EMAIL_1]", "ping [EMAIL_2]"]
+    global_cache.delete_cache("peyeeye_session:x:p-1")
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_embeddings_input():
+    """embeddings `input` (str or list[str]) must be redacted."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok({"text": ["[EMAIL_1]"], "session_id": "ses_e"})
+    )
+
+    cache = DualCache()
+    data = {"input": "alice@acme.com", "litellm_call_id": "e-1"}
+    out = await g.async_pre_call_hook(
+        UserAPIKeyAuth(api_key="x"), cache, data, "embeddings"
+    )
+    assert out["input"] == "[EMAIL_1]"
+    global_cache.delete_cache("peyeeye_session:x:e-1")
+
+
+@pytest.mark.asyncio
+async def test_post_call_rehydrates_text_completion_response():
+    """TextCompletionResponse.choices[].text must be rehydrated."""
+    from litellm.proxy.guardrails.guardrail_hooks.peyeeye.peyeeye import (
+        global_cache,
+    )
+
+    g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")
+    g.async_handler = MagicMock()
+    g.async_handler.post = AsyncMock(
+        return_value=_ok({"text": "Reply to alice@acme.com", "replaced": 1})
+    )
+    g.async_handler.delete = AsyncMock()
+
+    user = UserAPIKeyAuth(api_key="x")
+    global_cache.set_cache("peyeeye_session:x:tc-2", "ses_tc", ttl=60)
+
+    response = litellm.TextCompletionResponse()
+    response.choices = [
+        litellm.utils.TextChoices(
+            finish_reason="stop", index=0, text="Reply to [EMAIL_1]"
+        )
+    ]
+    out = await g.async_post_call_success_hook(
+        {"litellm_call_id": "tc-2"}, user, response
+    )
+    assert out.choices[0].text == "Reply to alice@acme.com"
+
+
+@pytest.mark.asyncio
 async def test_pre_call_raises_on_unexpected_response_shape():
     """If /v1/redact returns neither str nor list for `text`, refuse to forward."""
     g = PEyeEyeGuardrail(peyeeye_api_key="pk", guardrail_name="t")


### PR DESCRIPTION
## Summary

Adds a built-in `peyeeye` guardrail to LiteLLM that handles the full **redact → LLM → rehydrate** roundtrip for PII in prompts:

- **Pre-call**: redacts PII from `messages[].content` via the [peyeeye](https://peyeeye.ai) API. The redaction session id is cached against `litellm_call_id` so the post-call hook can rehydrate without a second client call.
- **Post-call**: swaps placeholders in `response.choices[].message.content` back to the original values, then cleans up the session.

Detects 60+ built-in entity types out of the box (emails, payment data, secrets, government IDs, medical IDs, travel data, etc.) plus first-class custom entities defined by the user. Two session modes:

- **Stateful** (default) — peyeeye holds the token → value mapping under a `ses_…` id.
- **Stateless** — peyeeye returns a sealed `skey_…` rehydration key; nothing is retained server-side.

This complements the existing Presidio guardrail by adding a hosted option that ships with broader entity coverage and built-in rehydration (Presidio is detection-only out of the box).

## Files

- `litellm/proxy/guardrails/guardrail_hooks/peyeeye/__init__.py` + `peyeeye.py` — `PeyeeyeGuardrail(CustomGuardrail)` with pre/post hooks. Auto-discovered by `guardrail_registry.get_guardrail_initializer_from_hooks`.
- `litellm/types/proxy/guardrails/guardrail_hooks/peyeeye.py` — `PeyeeyeGuardrailConfigModel` for the UI schema.
- `litellm/types/guardrails.py` — `SupportedGuardrailIntegrations.PEYEEYE` enum entry + `PeyeeyeGuardrailConfigModel` mixin appended to `LitellmParams`.
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_peyeeye.py` — init, pre-call, post-call, stateless, error-path tests.

No new dependencies — uses the existing `httpx` async handler.

## Example `config.yaml`

```yaml
guardrails:
  - guardrail_name: "peyeeye-redact"
    litellm_params:
      guardrail: peyeeye
      mode: "pre_call"
      api_key: os.environ/PEYEEYE_API_KEY
  - guardrail_name: "peyeeye-rehydrate"
    litellm_params:
      guardrail: peyeeye
      mode: "post_call"
      api_key: os.environ/PEYEEYE_API_KEY
```

## Docs PR

Companion docs PR: BerriAI/litellm-docs adding `docs/proxy/guardrails/peyeeye.md` and the sidebar entry.

## Test plan

- [x] `test_peyeeye_init_requires_api_key` — raises when no key
- [x] `test_peyeeye_init_reads_env` — picks up `PEYEEYE_API_KEY`
- [x] `test_peyeeye_init_explicit_args` — explicit args take priority
- [x] `test_peyeeye_guardrail_config_via_init` — `init_guardrails_v2` accepts the new `guardrail: peyeeye` value
- [x] `test_pre_call_redacts_messages_and_caches_session` — replaces user message content, caches session id under `litellm_call_id`
- [x] `test_pre_call_stateless_returns_skey` — stateless mode caches the `skey_…` rehydration key
- [x] `test_pre_call_skips_when_no_messages` — no API call when there's nothing to redact
- [x] `test_post_call_rehydrates_response` — swaps placeholders back to originals, deletes session, clears cache
- [x] `test_post_call_noop_without_session` — gracefully no-ops when no session was cached (e.g. only `post_call` configured)
- [x] `test_redact_api_error_raises_typed` — surfaces typed `PeyeeyeGuardrailAPIError`
