### PR TITLE
fix(proxy): avoid blocking event loop by killing engine instead of disconnecting

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -217,16 +217,18 @@ class PrismaWrapper:
     async def recreate_prisma_client(
         self, new_db_url: str, http_client: Optional[Any] = None
     ):
-        """Disconnect and reconnect the Prisma client with a new database URL."""
+        """Disconnect and reconnect the Prisma client with a new database URL.
+
+        Kills the old engine subprocess directly rather than calling
+        disconnect(). prisma-client-py's disconnect ultimately invokes a
+        synchronous `process.wait()` on the query engine that can block
+        the asyncio event loop for 30-120s when the DB is unreachable,
+        freezing liveness probes. See #26191.
+        """
         from prisma import Prisma  # type: ignore
 
         old_engine_pid = self._get_engine_pid()
-
-        try:
-            await self._original_prisma.disconnect()
-        except Exception as e:
-            verbose_proxy_logger.warning(f"Failed to disconnect Prisma client: {e}")
-            await self._kill_engine_process(old_engine_pid)
+        await self._kill_engine_process(old_engine_pid)
 
         if http_client is not None:
             self._original_prisma = Prisma(http=http_client)

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -59,11 +59,12 @@ class PrismaWrapper:
 
     @staticmethod
     async def _kill_engine_process(pid: int) -> None:
-        """Force-kill an orphaned engine subprocess to prevent DB connection pool leaks.
+        """Force-kill the query-engine subprocess during a Prisma client reconnect.
 
-        Called when disconnect() fails and the old engine process may still be
-        holding open connections. Sends SIGTERM for graceful shutdown, waits
-        briefly, then SIGKILL as a backstop.
+        Used by the reconnect paths in place of `disconnect()`, whose
+        synchronous `process.wait()` blocks the asyncio event loop for
+        30-120s on DB outages (#26191). Sends SIGTERM for graceful shutdown,
+        waits briefly, then SIGKILL as a backstop.
         """
         if pid <= 0:
             return
@@ -72,7 +73,7 @@ class PrismaWrapper:
         except (ProcessLookupError, PermissionError, OSError):
             return  # Already dead or inaccessible
         verbose_proxy_logger.warning(
-            "Sent SIGTERM to orphaned prisma-query-engine PID %s after failed disconnect.",
+            "Sent SIGTERM to prisma-query-engine PID %s during client reconnect.",
             pid,
         )
         # Brief wait for graceful shutdown, then force-kill

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4134,15 +4134,13 @@ class PrismaClient:
             )
 
             async def _do_direct_reconnect() -> None:
+                # Kill the old engine subprocess directly rather than calling
+                # disconnect(). prisma-client-py's disconnect ultimately invokes
+                # a synchronous `process.wait()` on the query engine that can
+                # block the asyncio event loop for 30-120s when the DB is
+                # unreachable, freezing liveness probes. See #26191.
                 old_pid = self._get_engine_pid()
-                try:
-                    await self.db.disconnect()
-                except Exception as disconnect_err:
-                    verbose_proxy_logger.warning(
-                        "Prisma DB disconnect before reconnect failed: %s",
-                        disconnect_err,
-                    )
-                    await PrismaWrapper._kill_engine_process(old_pid)
+                await PrismaWrapper._kill_engine_process(old_pid)
 
                 await self.db.connect()
                 await self.db.query_raw("SELECT 1")

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -2,7 +2,7 @@ import json
 import os
 import signal
 import sys
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -46,52 +46,21 @@ def test_should_update_prisma_schema(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_recreate_prisma_client_successful_disconnect():
-    """
-    Test that recreate_prisma_client works normally when disconnect succeeds.
-    """
-    # Mock the original prisma client
-    mock_prisma = AsyncMock()
-
-    # Create a mock PrismaWrapper instance
-    wrapper = Mock()
-    wrapper._original_prisma = mock_prisma
-
-    # Configure disconnect to succeed
-    mock_prisma.disconnect.return_value = None
-
-    # Mock the entire recreate_prisma_client method to avoid import issues
-    async def mock_recreate_prisma_client(new_db_url: str, http_client=None):
-        try:
-            await mock_prisma.disconnect()
-        except Exception:
-            pass
-
-        mock_new_prisma = AsyncMock()
-        wrapper._original_prisma = mock_new_prisma
-        await mock_new_prisma.connect()
-
-    # Assign the mock method to the wrapper
-    wrapper.recreate_prisma_client = mock_recreate_prisma_client
-
-    # Call the method
-    await wrapper.recreate_prisma_client("postgresql://new:new@localhost:5432/new")
-
-    # Verify that disconnect was called
-    mock_prisma.disconnect.assert_called_once()
-
-    # Verify that the new client replaced the original
-    assert wrapper._original_prisma != mock_prisma
-    assert hasattr(wrapper._original_prisma, "connect")
-
-
-@pytest.mark.asyncio
-async def test_recreate_prisma_client_kills_old_engine_on_disconnect_failure(
+async def test_recreate_prisma_client_kills_old_engine_without_disconnect(
     mock_prisma_binary,
 ):
-    """When disconnect() fails, recreate_prisma_client must SIGTERM/SIGKILL the old engine PID."""
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/26191.
+
+    recreate_prisma_client must kill the old engine subprocess directly
+    and must NOT call disconnect() on the underlying Prisma client, which
+    blocks the asyncio event loop via a synchronous `process.wait()`.
+    """
     mock_prisma = AsyncMock()
-    mock_prisma.disconnect.side_effect = Exception("engine hung")
+    # disconnect is never expected to be called — fail loudly if it is.
+    mock_prisma.disconnect.side_effect = AssertionError(
+        "disconnect would block the event loop"
+    )
 
     # Simulate engine subprocess with a known PID
     mock_engine = MagicMock()
@@ -100,7 +69,6 @@ async def test_recreate_prisma_client_kills_old_engine_on_disconnect_failure(
 
     wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
 
-    # Configure the mock Prisma constructor
     mock_new_prisma = AsyncMock()
     mock_prisma_binary.Prisma.return_value = mock_new_prisma
 
@@ -110,29 +78,8 @@ async def test_recreate_prisma_client_kills_old_engine_on_disconnect_failure(
     ):
         await wrapper.recreate_prisma_client("postgresql://new")
 
-    # Verify old engine was killed
     mock_kill.assert_any_call(12345, signal.SIGTERM)
-    # Verify new client was created and connected
-    mock_new_prisma.connect.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_recreate_prisma_client_skips_kill_on_successful_disconnect(
-    mock_prisma_binary,
-):
-    """When disconnect() succeeds, no kill should be attempted."""
-    mock_prisma = AsyncMock()
-    mock_prisma.disconnect.return_value = None
-
-    wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
-
-    mock_new_prisma = AsyncMock()
-    mock_prisma_binary.Prisma.return_value = mock_new_prisma
-
-    with patch("os.kill") as mock_kill:
-        await wrapper.recreate_prisma_client("postgresql://new")
-
-    mock_kill.assert_not_called()
+    mock_prisma.disconnect.assert_not_called()
     mock_new_prisma.connect.assert_awaited_once()
 
 
@@ -142,7 +89,6 @@ async def test_recreate_prisma_client_handles_missing_engine_pid(
 ):
     """When engine PID is unavailable (no _engine attr), kill is skipped gracefully."""
     mock_prisma = AsyncMock()
-    mock_prisma.disconnect.side_effect = Exception("engine hung")
     mock_prisma._engine = None  # No engine subprocess
 
     wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -34,17 +34,20 @@ async def test_attempt_db_reconnect_should_succeed(mock_proxy_logging):
     client = PrismaClient(
         database_url="mock://test", proxy_logging_obj=mock_proxy_logging
     )
-    client.db.disconnect = AsyncMock(return_value=None)
     client.db.connect = AsyncMock(return_value=None)
     client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
 
-    result = await client.attempt_db_reconnect(
-        reason="unit_test_reconnect_success",
-        force=True,
-    )
+    with (
+        patch.object(client, "_get_engine_pid", return_value=0),
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await client.attempt_db_reconnect(
+            reason="unit_test_reconnect_success",
+            force=True,
+        )
 
     assert result is True
-    client.db.disconnect.assert_awaited_once()
     client.db.connect.assert_awaited_once()
     client.db.query_raw.assert_awaited_once_with("SELECT 1")
 
@@ -140,15 +143,20 @@ async def test_attempt_db_reconnect_should_set_cooldown_after_attempt(
     )
     client._db_last_reconnect_attempt_ts = 0.0
     client._db_reconnect_cooldown_seconds = 10
-    client.db.disconnect = AsyncMock(return_value=None)
     client.db.connect = AsyncMock(return_value=None)
     client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
 
     # Use a counter-based mock to avoid StopIteration when time.time() is called
     # more times than expected (varies by Python version / internal code paths).
     fake_clock = iter(range(100, 10000))
-    with patch(
-        "litellm.proxy.utils.time.time", side_effect=lambda: float(next(fake_clock))
+    with (
+        patch(
+            "litellm.proxy.utils.time.time",
+            side_effect=lambda: float(next(fake_clock)),
+        ),
+        patch.object(client, "_get_engine_pid", return_value=0),
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         result = await client.attempt_db_reconnect(
             reason="unit_test_cooldown_timestamp_after_attempt",
@@ -170,13 +178,16 @@ async def test_run_reconnect_cycle_watchdog_should_use_direct_db_ops(
     )
     client.disconnect = AsyncMock(side_effect=AssertionError("wrapper disconnect used"))
     client.connect = AsyncMock(side_effect=AssertionError("wrapper connect used"))
-    client.db.disconnect = AsyncMock(return_value=None)
     client.db.connect = AsyncMock(return_value=None)
     client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
 
-    await client._run_reconnect_cycle(timeout_seconds=None)
+    with (
+        patch.object(client, "_get_engine_pid", return_value=0),
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await client._run_reconnect_cycle(timeout_seconds=None)
 
-    client.db.disconnect.assert_awaited_once()
     client.db.connect.assert_awaited_once()
     client.db.query_raw.assert_awaited_once_with("SELECT 1")
 
@@ -189,7 +200,6 @@ async def test_run_reconnect_cycle_watchdog_should_use_default_timeout_budget(
         database_url="mock://test", proxy_logging_obj=mock_proxy_logging
     )
     client._db_watchdog_reconnect_timeout_seconds = 0.1
-    client.db.disconnect = AsyncMock(return_value=None)
 
     async def _slow_connect():
         await asyncio.sleep(0.08)
@@ -201,7 +211,10 @@ async def test_run_reconnect_cycle_watchdog_should_use_default_timeout_budget(
     client.db.connect = AsyncMock(side_effect=_slow_connect)
     client.db.query_raw = AsyncMock(side_effect=_slow_query)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with (
+        patch.object(client, "_get_engine_pid", return_value=0),
+        pytest.raises(asyncio.TimeoutError),
+    ):
         await client._run_reconnect_cycle(timeout_seconds=None)
 
 
@@ -212,7 +225,6 @@ async def test_run_reconnect_cycle_timeout_should_use_single_overall_budget(
     client = PrismaClient(
         database_url="mock://test", proxy_logging_obj=mock_proxy_logging
     )
-    client.db.disconnect = AsyncMock(return_value=None)
 
     async def _slow_connect():
         await asyncio.sleep(0.08)
@@ -224,7 +236,10 @@ async def test_run_reconnect_cycle_timeout_should_use_single_overall_budget(
     client.db.connect = AsyncMock(side_effect=_slow_connect)
     client.db.query_raw = AsyncMock(side_effect=_slow_query)
 
-    with pytest.raises(asyncio.TimeoutError):
+    with (
+        patch.object(client, "_get_engine_pid", return_value=0),
+        pytest.raises(asyncio.TimeoutError),
+    ):
         await client._run_reconnect_cycle(timeout_seconds=0.1)
 
 
@@ -319,14 +334,23 @@ async def test_db_health_watchdog_start_stop_lifecycle(mock_proxy_logging):
 
 
 @pytest.mark.asyncio
-async def test_lightweight_reconnect_kills_engine_on_disconnect_failure(
+async def test_lightweight_reconnect_kills_old_engine_without_disconnect(
     mock_proxy_logging,
 ):
-    """Lightweight reconnect must kill the old engine PID when disconnect() fails."""
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/26191.
+
+    The lightweight reconnect path must kill the old engine subprocess
+    directly and must NOT call the Prisma client's disconnect(), which
+    blocks the asyncio event loop via a synchronous `process.wait()`.
+    """
     client = PrismaClient(
         database_url="mock://test", proxy_logging_obj=mock_proxy_logging
     )
-    client.db.disconnect = AsyncMock(side_effect=Exception("disconnect failed"))
+    # disconnect is never expected to be called — fail loudly if it is.
+    client.db.disconnect = AsyncMock(
+        side_effect=AssertionError("disconnect would block the event loop")
+    )
     client.db.connect = AsyncMock(return_value=None)
     client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
 
@@ -338,23 +362,6 @@ async def test_lightweight_reconnect_kills_engine_on_disconnect_failure(
         await client._run_reconnect_cycle(timeout_seconds=5.0)
 
     mock_kill.assert_any_call(9999, signal.SIGTERM)
+    client.db.disconnect.assert_not_called()
     client.db.connect.assert_awaited_once()
     client.db.query_raw.assert_awaited_once_with("SELECT 1")
-
-
-@pytest.mark.asyncio
-async def test_lightweight_reconnect_skips_kill_on_successful_disconnect(
-    mock_proxy_logging,
-):
-    """Lightweight reconnect must NOT kill when disconnect() succeeds."""
-    client = PrismaClient(
-        database_url="mock://test", proxy_logging_obj=mock_proxy_logging
-    )
-    client.db.disconnect = AsyncMock(return_value=None)
-    client.db.connect = AsyncMock(return_value=None)
-    client.db.query_raw = AsyncMock(return_value=[{"result": 1}])
-
-    with patch("os.kill") as mock_kill:
-        await client._run_reconnect_cycle(timeout_seconds=5.0)
-
-    mock_kill.assert_not_called()


### PR DESCRIPTION
Re-opening previously closed PR #26329 against the new OSS staging branch (the original target \`litellm_oss_branch\` was deleted on 2026-04-27 as part of the maintainer branch rotation).

## Relevant issues
Fixes #26191

## Type
Bug Fix

## Problem
The Prisma DB reconnect paths called \`await self.db.disconnect()\` / \`await self._original_prisma.disconnect()\`, which ultimately invoke prisma-client-py's synchronous \`process.wait()\` on the query engine subprocess. When the database is unreachable this blocks the asyncio event loop for 30-120 seconds — long enough for the \`/health/liveliness\` endpoint to time out and Kubernetes to SIGKILL the pod (exit code 137).

Both reconnect paths already had a fallback that used \`_kill_engine_process\` (SIGTERM → 0.5s grace → SIGKILL) when disconnect raised. This PR promotes that fallback to the primary path — the old Prisma client is being discarded anyway.

## Fix
- \`PrismaClient._do_direct_reconnect\` (\`utils.py\` ~L4136): removed the \`disconnect()\` call, kill engine + reconnect directly
- \`PrismaWrapper.recreate_prisma_client\` (\`db/prisma_client.py\` ~L217): same change

Also updated the \`_kill_engine_process\` docstring + SIGTERM log to reflect its new primary-path role (was: \"after failed disconnect\" → now: \"during client reconnect\"). Greptile previously flagged this as P2; addressed in follow-up commit.

## Tests
Two regression tests assert \`disconnect.assert_not_called()\` — the exact invariant that triggers the event-loop block:
- \`test_recreate_prisma_client_kills_old_engine_without_disconnect\` in \`test_prisma_client.py\`
- \`test_lightweight_reconnect_kills_old_engine_without_disconnect\` in \`test_prisma_self_heal.py\`

Other affected tests updated to patch \`_get_engine_pid\` / \`os.kill\` for the new unconditional kill path. Two tests encoding the old "skip kill when disconnect succeeds" invariant were removed — that invariant is the bug.

\`pytest tests/test_litellm/proxy/db/\` → 154 passed, no regressions.

## Scope notes
- The graceful-shutdown \`PrismaClient.disconnect()\` wrapper also calls the blocking disconnect path. Out of scope here — does not cause liveness-probe failures during DB outages. Can address as a follow-up via \`loop.run_in_executor\`.
- No new API surface, no new config flags.

## Pre-Submission checklist
- [x] Added testing in \`tests/test_litellm/\`
- [x] PR passes \`pytest tests/test_litellm/proxy/db/\` (154/154)
- [x] Scope isolated to a single bug