### PR TITLE
fix(semantic-filter): only filter MCP tools, pass non-MCP through

### DIFF
--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -128,6 +128,36 @@ class SemanticToolFilterHook(CustomLogger):
             return "litellm_metadata"
         return "metadata"
 
+    @staticmethod
+    def _recombine_preserving_order(
+        original_count: int,
+        filtered_mcp_tools: List[Any],
+        passthrough_with_positions: List[Any],
+    ) -> List[Any]:
+        """
+        Rebuild the tool list so that:
+
+        - non-MCP tools keep their original relative ordering, and
+        - the filtered MCP block is anchored at the position of the first
+          MCP tool in the input (subsequent MCP slots are absorbed into the
+          filtered block).
+
+        ``passthrough_with_positions`` is a list of ``(original_index, tool)``
+        pairs sorted by original_index.
+        """
+        recombined: List[Any] = []
+        mcp_inserted = False
+        pt_iter = iter(passthrough_with_positions)
+        next_pt = next(pt_iter, None)
+        for idx in range(original_count):
+            if next_pt is not None and next_pt[0] == idx:
+                recombined.append(next_pt[1])
+                next_pt = next(pt_iter, None)
+            elif not mcp_inserted:
+                recombined.extend(filtered_mcp_tools)
+                mcp_inserted = True
+        return recombined
+
     async def async_pre_call_hook(
         self,
         user_api_key_dict: "UserAPIKeyAuth",
@@ -163,8 +193,6 @@ class SemanticToolFilterHook(CustomLogger):
             verbose_proxy_logger.debug("No tools in request, skipping semantic filter")
             return None
 
-        original_tool_count = len(tools)
-
         # Check for MCP references (server_url="litellm_proxy") and expand them
         if self._should_expand_mcp_tools(tools):
             verbose_proxy_logger.debug(
@@ -186,7 +214,6 @@ class SemanticToolFilterHook(CustomLogger):
 
                 # Update tools for filtering
                 tools = expanded_tools
-                original_tool_count = len(tools)
 
             except Exception as e:
                 verbose_proxy_logger.error(
@@ -218,22 +245,52 @@ class SemanticToolFilterHook(CustomLogger):
                 )
                 return None
 
+            # Only semantically filter MCP gateway tools — identified by the
+            # "mcp__" name prefix assigned by the LiteLLM proxy. Non-MCP tools
+            # (user-defined function tools, model-specific tool schemas) are
+            # passed through untouched so they are never inadvertently dropped.
+            # Track original positions so the recombined list preserves the
+            # caller's tool ordering for any model that is order-sensitive.
+            mcp_tools = []
+            passthrough_with_positions = []
+            for idx, t in enumerate(tools):
+                name = (
+                    t.get("function", {}).get("name", "") or t.get("name", "")
+                    if isinstance(t, dict)
+                    else getattr(t, "name", "")
+                )
+                if name.startswith("mcp__"):
+                    mcp_tools.append(t)
+                else:
+                    passthrough_with_positions.append((idx, t))
+
+            if not mcp_tools:
+                verbose_proxy_logger.debug(
+                    "No MCP tools to filter, skipping semantic filter"
+                )
+                return None
+
             verbose_proxy_logger.debug(
-                f"Applying semantic filter to {len(tools)} tools "
+                f"Applying semantic filter to {len(mcp_tools)} MCP tools "
+                f"({len(passthrough_with_positions)} non-MCP tools passed through) "
                 f"with query: '{user_query[:50]}...'"
             )
 
-            # Filter tools semantically
+            # Filter MCP tools semantically
             filtered_tools = await self.filter.filter_tools(
                 query=user_query,
-                available_tools=tools,  # type: ignore
+                available_tools=mcp_tools,  # type: ignore
             )
 
-            # Always update tools and emit header (even if count unchanged)
-            data["tools"] = filtered_tools
+            # Recombine while preserving the caller's original ordering.
+            data["tools"] = self._recombine_preserving_order(
+                original_count=len(tools),
+                filtered_mcp_tools=filtered_tools,
+                passthrough_with_positions=passthrough_with_positions,
+            )
 
-            # Store filter stats and tool names for response header
-            filter_stats = f"{original_tool_count}->{len(filtered_tools)}"
+            # Store filter stats and tool names for response header (MCP tools only)
+            filter_stats = f"{len(mcp_tools)}->{len(filtered_tools)}"
             tool_names_csv = self._get_tool_names_csv(filtered_tools)
 
             _metadata_variable_name = self._get_metadata_variable_name(data)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -363,10 +363,16 @@ async def test_semantic_filter_hook_triggers_on_completion():
         enabled=True,
     )
 
-    # Prepare data - completion request with tools
+    # Prepare data — completion request with MCP gateway tools.
+    # Note: tools served via the LiteLLM MCP gateway are name-prefixed
+    # with `mcp__`. Only tools with that prefix are semantically filtered;
+    # non-MCP tools (user-defined function tools, model-specific schemas)
+    # are passed through untouched. See SemanticToolFilterHook.
     tools = [
         MCPTool(
-            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
+            name=f"mcp__tool_{i}",
+            description=f"Tool {i}",
+            inputSchema={"type": "object"},
         )
         for i in range(10)
     ]
@@ -489,9 +495,7 @@ class TestGetToolsByNames:
             {"name": "send_email", "description": "send mail"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            ["send_email"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["send_email"], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "send_email"
@@ -503,9 +507,7 @@ class TestGetToolsByNames:
         client_name = "litellm_" + canonical
         available_tools = [{"name": client_name, "description": "scrape"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         # Must return the incoming tool unchanged so the client-facing
@@ -516,13 +518,9 @@ class TestGetToolsByNames:
         """Some clients use dash as alias separator; accept that too."""
         filter_instance = self._make_filter()
         canonical = "weather_svc-get_weather"
-        available_tools = [
-            {"name": "mcp-" + canonical, "description": "weather"}
-        ]
+        available_tools = [{"name": "mcp-" + canonical, "description": "weather"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "mcp-" + canonical
@@ -552,9 +550,7 @@ class TestGetToolsByNames:
             {"name": "litellm_" + canonical, "description": "wrapped"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == canonical
@@ -567,9 +563,7 @@ class TestGetToolsByNames:
         separator-anchored suffixes of ``litellm_api-fs-read_file``.
         """
         filter_instance = self._make_filter()
-        available_tools = [
-            {"name": "litellm_api-fs-read_file", "description": "read"}
-        ]
+        available_tools = [{"name": "litellm_api-fs-read_file", "description": "read"}]
 
         matched = filter_instance._get_tools_by_names(
             ["fs-read_file", "api-fs-read_file"], available_tools
@@ -590,9 +584,7 @@ class TestGetToolsByNames:
             {"name": "my_" + canonical, "description": "plain search"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "my_" + canonical
@@ -640,3 +632,171 @@ class TestGetToolsByNames:
         )
 
         assert matched == []
+
+
+# ---------------------------------------------------------------------------
+# SemanticToolFilterHook — MCP/non-MCP split + ordering preservation
+# ---------------------------------------------------------------------------
+class _MockSemanticFilter:
+    """
+    Lightweight stub of SemanticMCPToolFilter for hook tests.
+
+    Avoids the embedding-model setup needed by the real filter and lets tests
+    assert directly on the inputs received by ``filter_tools``.
+    """
+
+    def __init__(self, top_k: int = 2):
+        self.enabled = True
+        self.top_k = top_k
+        self.received_tools = None
+        self.received_query = None
+
+    def extract_user_query(self, messages):
+        for m in reversed(messages):
+            if m.get("role") == "user":
+                content = m.get("content", "")
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            return block.get("text", "")
+                    return ""
+                return content
+        return ""
+
+    async def filter_tools(self, query, available_tools):
+        self.received_tools = available_tools
+        self.received_query = query
+        return list(available_tools)[: self.top_k]
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_filters_only_mcp_tools():
+    """
+    Only tools whose name starts with ``mcp__`` are semantically filtered.
+    Non-MCP tools (user-defined function tools, model-specific schemas)
+    are passed through untouched and must still be present in the output.
+    """
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_filter = _MockSemanticFilter(top_k=1)
+    hook = SemanticToolFilterHook(mock_filter)
+
+    user_tool = {"type": "function", "function": {"name": "user_lookup"}}
+    mcp_tool_1 = {"type": "function", "function": {"name": "mcp__email_send"}}
+    mcp_tool_2 = {"type": "function", "function": {"name": "mcp__calendar_create"}}
+    builtin_tool = {"type": "function", "function": {"name": "submit_form"}}
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "send email"}],
+        "tools": [user_tool, mcp_tool_1, mcp_tool_2, builtin_tool],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is not None
+    out_names = [t["function"]["name"] for t in result["tools"]]
+
+    # filter_tools was called with only MCP tools
+    received_names = [
+        t["function"]["name"] for t in mock_filter.received_tools  # type: ignore
+    ]
+    assert received_names == ["mcp__email_send", "mcp__calendar_create"]
+
+    # Non-MCP tools survive the filter pass
+    assert "user_lookup" in out_names
+    assert "submit_form" in out_names
+
+    # Filtered MCP tool count is bounded by top_k
+    mcp_in_output = [n for n in out_names if n.startswith("mcp__")]
+    assert len(mcp_in_output) == 1
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_preserves_original_tool_order():
+    """
+    The recombined tool list must preserve the caller's relative ordering of
+    non-MCP tools and place the filtered MCP block where the first MCP tool
+    originally sat. This guards against the naive
+    ``filtered_tools + passthrough_tools`` recombination that re-orders the
+    list and may break order-sensitive clients.
+    """
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_filter = _MockSemanticFilter(top_k=2)
+    hook = SemanticToolFilterHook(mock_filter)
+
+    # Original layout: user, mcp_a, user2, mcp_b, builtin, mcp_c
+    # Expected: user, [filtered MCP block], user2, builtin
+    tools = [
+        {"type": "function", "function": {"name": "user_lookup"}},
+        {"type": "function", "function": {"name": "mcp__email_send"}},
+        {"type": "function", "function": {"name": "user_audit"}},
+        {"type": "function", "function": {"name": "mcp__calendar_create"}},
+        {"type": "function", "function": {"name": "submit_form"}},
+        {"type": "function", "function": {"name": "mcp__calendar_update"}},
+    ]
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "send email"}],
+        "tools": tools,
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is not None
+    out_names = [t["function"]["name"] for t in result["tools"]]
+
+    # Non-MCP tools must appear in the same relative order as the input
+    non_mcp_positions = [
+        out_names.index(n) for n in ("user_lookup", "user_audit", "submit_form")
+    ]
+    assert non_mcp_positions == sorted(
+        non_mcp_positions
+    ), f"non-MCP tool order must be preserved, got {out_names}"
+
+    # The filtered MCP block must appear at position 1 (after user_lookup,
+    # before user_audit), matching the position of the first MCP tool in
+    # the original list.
+    assert out_names[0] == "user_lookup"
+    assert out_names[1].startswith("mcp__")
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_skips_when_no_mcp_tools():
+    """
+    If the request only contains non-MCP tools, the hook must return None
+    rather than mutate the tool list. Non-MCP tools are out of scope for
+    semantic filtering.
+    """
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    hook = SemanticToolFilterHook(_MockSemanticFilter())
+
+    data = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {"type": "function", "function": {"name": "user_lookup"}},
+            {"type": "function", "function": {"name": "submit_form"}},
+        ],
+        "metadata": {},
+    }
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+    assert result is None


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement**
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (verified locally with `pytest -v` on the changed test file: 19 passed)
- [x] My PR scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

[Bug Fix]

## Changes

`SemanticToolFilterHook` was running its semantic filter on **all** tools in the request, regardless of whether they came from the LiteLLM MCP gateway or from elsewhere (user-defined function tools, model-specific tool schemas). When the user query was unrelated to one of those non-MCP tools, the filter would drop it from the request even though semantic filtering was never intended to apply to that class of tool.

This PR scopes the filter to MCP gateway tools only:

- Tools whose name starts with `mcp__` (the prefix the LiteLLM proxy assigns) are semantically filtered.
- Every other tool is passed through untouched.
- The recombined tool list preserves the caller's original ordering: the filtered MCP block is anchored at the position of the first MCP tool in the input, and non-MCP tools keep their relative ordering.

This was previously combined with a separate fix in #26567 (now closed); split into two single-issue PRs as per the contributing guideline. The companion PR for the `anthropic_messages` call type allowlist will be opened separately.

### Tests

Three new hook tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py`:

- `test_semantic_filter_hook_filters_only_mcp_tools`
- `test_semantic_filter_hook_preserves_original_tool_order`
- `test_semantic_filter_hook_skips_when_no_mcp_tools`

The existing `test_semantic_filter_hook_triggers_on_completion` is updated to use `mcp__` prefixed names that real MCP gateway tools always carry.

All 19 tests in the file pass locally.