### PR TITLE
fix(guardrails): re-emit chunks in tool_permission streaming hook when no tool_calls found

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -799,6 +799,11 @@ class ToolPermissionGuardrail(CustomGuardrail):
                 verbose_proxy_logger.debug(
                     "Tool Permission Guardrail: No tool uses found"
                 )
+                mock_response = MockResponseIterator(
+                    model_response=assembled_model_response
+                )
+                async for chunk in mock_response:
+                    yield chunk
                 return
 
             verbose_proxy_logger.debug(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -28,6 +28,7 @@ from litellm.types.utils import (
     ChatCompletionMessageToolCall,
     Choices,
     ModelResponse,
+    ModelResponseStream,
 )
 
 
@@ -675,6 +676,45 @@ class TestToolPermissionGuardrail:
         assert [function["name"] for function in new_data["functions"]] == ["Bash"]
         assert new_data["function_call"] == "none"
         assert new_data["tool_choice"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_streaming_iterator_hook_plain_text_yields_chunks(
+        self,
+    ):
+        """Regression test: hook must re-emit chunks when LLM replies with plain text.
+
+        Before the fix, the `if not tool_calls:` branch did a bare `return` inside
+        the async generator, which yielded nothing.  Clients received only
+        `data: [DONE]` with no content.
+        """
+        text_chunk = ModelResponseStream(
+            id="chatcmpl-plain-text",
+            created=1700000000,
+            model="gpt-4",
+            object="chat.completion.chunk",
+            choices=[],
+        )
+
+        async def _fake_stream():
+            yield text_chunk
+
+        assembled = ModelResponse(
+            choices=[Choices(message={"content": "Hello, world!"})]
+        )
+
+        with patch("litellm.main.stream_chunk_builder", return_value=assembled):
+            chunks = []
+            async for chunk in self.guardrail.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=_fake_stream(),
+                request_data={},
+            ):
+                chunks.append(chunk)
+
+        assert len(chunks) >= 1, (
+            "Hook must yield at least one chunk for plain-text responses; "
+            "got none — bare return bug"
+        )
 
     def test_modify_response_with_permission_errors(self):
         # Setup a response with one tool_call

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -715,6 +715,10 @@ class TestToolPermissionGuardrail:
             "Hook must yield at least one chunk for plain-text responses; "
             "got none — bare return bug"
         )
+        assert chunks[0].choices[0].delta.content == "Hello, world!", (
+            "Hook must preserve the original response content; "
+            f"got: {chunks[0].choices[0].delta.content!r}"
+        )
 
     def test_modify_response_with_permission_errors(self):
         # Setup a response with one tool_call


### PR DESCRIPTION
## Relevant issues

Fixes #26547
Re-submission of #26551 (auto-closed when `litellm_oss_branch` was deleted)

## Pre-Submission checklist

- [x] Added test in `tests/test_litellm/` — `test_async_post_call_streaming_iterator_hook_plain_text_yields_chunks`
- [x] `make test-unit` passes locally; all CI checks pass on this PR
- [x] PR scope isolated to **1 specific problem**, **2 files** changed
- [x] `@greptileai` review requested — **Confidence Score: 5/5 — "Safe to merge"**
- [x] CLA signed

## Type

🐛 Bug Fix

## Root cause

`ToolPermissionGuardrail.async_post_call_streaming_iterator_hook` is an **async generator** (it contains `yield` statements). In the `if not tool_calls:` branch — the path taken when the LLM replies with plain text — the original code did a bare `return`.

In an async generator, `return` is equivalent to `raise StopAsyncIteration`. Nothing is yielded. The client receives only `data: [DONE]` with **empty content**. The entire plain-text response is silently dropped whenever the `tool_permission` guardrail is active with `mode: post_call` on a streaming request.

**User-visible impact:** Any chat client using LiteLLM proxy with `tool_permission` guardrail enabled gets a blank reply whenever the LLM decides not to call a tool (a very common case for conversational queries).

## Fix

Before returning, re-emit the assembled response through `MockResponseIterator` — the same pattern already used in the allowed-tool path a few lines below in the same function:

```python
# BEFORE
if not tool_calls:
    verbose_proxy_logger.debug("Tool Permission Guardrail: No tool uses found")
    return

# AFTER
if not tool_calls:
    verbose_proxy_logger.debug("Tool Permission Guardrail: No tool uses found")
    mock_response = MockResponseIterator(model_response=assembled_model_response)
    async for chunk in mock_response:
        yield chunk
    return
```

Five lines, scoped to the exact location of the bug. Mirrors an existing, well-tested pattern in the same method, so risk of behavioural surprise is minimal.

## Screenshots / Proof of Fix

Reproduced against a local LiteLLM proxy (Docker) with the `tool_permission` guardrail configured in `mode: post_call`. The **same byte-identical streaming request** was sent in both runs — the only variable is whether the 5-line fix is present in `tool_permission.py`.

**Reproduction command:**

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "gemini-2.5-flash-lite",
    "stream": true,
    "messages": [{"role":"user","content":"Reply with exactly the word: FOUR. Do not use any tools."}]
  }'
```

### 1. Wire-level — Before fix (BUG)

Client receives only `data: [DONE]`. No content chunk is ever emitted, so the user sees a blank response.

<img width="1024" height="618" alt="1-curl-bug-empty-stream" src="https://github.com/user-attachments/assets/27bae2ff-fbe6-4bc3-b3c3-70de26d7422e" />


### 2. Wire-level — After fix (FIX)

Same request, fix applied. A `chat.completion.chunk` carrying `delta.content: "FOUR"` is now delivered before `[DONE]`.

<img width="1024" height="618" alt="2-curl-fix-content-delivered" src="https://github.com/user-attachments/assets/745081b2-a6c3-485a-a87c-e268a6d65a3a" />

### 3. Server-side control (LiteLLM Logs, from the BUG run)

Even in the bug case, the LLM returned content (`ASSISTANT: "FOUR."`) and both guardrails passed — the proxy logged the request as **Success**. This pinpoints the drop: it happens *strictly inside* `async_post_call_streaming_iterator_hook`'s `if not tool_calls:` branch, between guardrail evaluation and the SSE response written to the client. That is exactly where this PR's 5 lines live.

<img width="1829" height="927" alt="3-litellm-logs-bug-run" src="https://github.com/user-attachments/assets/de0ea02c-55d2-4a1b-a5e5-56380fc485e6" />

## Changes

| File | Change |
|---|---|
| `litellm/proxy/guardrails/guardrail_hooks/tool_permission.py` | **+5 lines** — the fix |
| `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py` | **+40 lines** — regression test (`test_async_post_call_streaming_iterator_hook_plain_text_yields_chunks`) asserts both that ≥1 chunk is yielded *and* that `chunk.delta.content` matches the assembled response, guarding against silent drops and content-mangling regressions |



### PR raised by [Someswar](someswara@incubyte.co) at [Incubyte](https://incubyte.co/)
