### PR TITLE
fix(aiohttp): sanitize non-ASCII response headers before passing to httpx

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -339,9 +339,23 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                 # Re-raise if it's a different RuntimeError
                 raise
 
+        # Sanitize response headers: aiohttp decodes header values as UTF-8
+        # strings, but httpx.Headers internally calls .encode("ascii") which
+        # raises UnicodeEncodeError on non-ASCII values (e.g. Chinese characters).
+        # Re-encode via latin-1 to preserve the raw bytes for httpx.
+        sanitized_headers = []
+        for key, value in response.headers.items():
+            try:
+                value.encode("ascii")
+                sanitized_headers.append((key, value))
+            except UnicodeEncodeError:
+                sanitized_headers.append(
+                    (key, value.encode("utf-8").decode("latin-1"))
+                )
+
         return httpx.Response(
             status_code=response.status,
-            headers=response.headers,
+            headers=sanitized_headers,
             stream=AiohttpResponseStream(response),
             request=request,
         )


### PR DESCRIPTION
Fixes #26548

### Root Cause

`aiohttp` decodes response header values as UTF-8 strings, preserving non-ASCII characters (e.g. Chinese text in error messages from some providers). When these headers are passed directly to `httpx.Response(headers=response.headers)`, `httpx.Headers` internally calls `.encode("ascii")` on each value, raising `UnicodeEncodeError`.

### Fix

Sanitize response headers before constructing the `httpx.Response`: for any header value that contains non-ASCII characters, re-encode via UTF-8 → latin-1 to preserve the raw bytes in a form that httpx can accept. ASCII-only headers pass through untouched.