### PR TITLE
fix(custom_httpx): preserve non-ascii response headers

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -341,7 +341,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
 
         return httpx.Response(
             status_code=response.status,
-            headers=response.headers,
+            headers=response.raw_headers,
             stream=AiohttpResponseStream(response),
             request=request,
         )

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -381,11 +381,11 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
         except Exception:
             response_content = b""
 
-        response_headers = {
-            k: v
-            for k, v in original_error.response.headers.items()
-            if k.lower() not in ("content-encoding", "content-length")
-        }
+        response_headers = [
+            (k, v)
+            for k, v in original_error.response.headers.raw
+            if k.lower() not in (b"content-encoding", b"content-length")
+        ]
 
         masked_request = httpx.Request(
             method=original_error.request.method,

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -238,6 +238,7 @@ async def test_handle_async_request_uses_env_proxy(monkeypatch):
             class Resp:
                 status = 200
                 headers = {}
+                raw_headers = ()
 
                 async def __aenter__(self):
                     return self
@@ -260,6 +261,51 @@ async def test_handle_async_request_uses_env_proxy(monkeypatch):
     await transport.handle_async_request(request)
 
     assert captured["proxy"] == proxy_url
+
+
+@pytest.mark.asyncio
+async def test_handle_async_request_preserves_non_ascii_response_headers():
+    """Aiohttp transport should pass raw response header bytes through to httpx."""
+    header_value = "本地化消息"
+
+    class FakeSession:
+        closed = False
+
+        def __init__(self):
+            try:
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = None
+
+        def request(self, *args, **kwargs):
+            class Resp:
+                status = 200
+                headers = {"X-Localized-Message": header_value}
+                raw_headers = ((b"X-Localized-Message", header_value.encode("utf-8")),)
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, exc_type, exc, tb):
+                    pass
+
+                @property
+                def content(self):
+                    class C:
+                        async def iter_chunked(self, size):
+                            yield b"ok"
+
+                    return C()
+
+            return Resp()
+
+    transport = LiteLLMAiohttpTransport(client=lambda: FakeSession())  # type: ignore
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "http://example.com/asset")
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("x-localized-message") == header_value
 
 
 @pytest.mark.asyncio
@@ -295,6 +341,7 @@ async def test_handle_async_request_uses_env_proxy_per_url(monkeypatch):
             class Resp:
                 status = 200
                 headers = {}
+                raw_headers = ()
 
                 async def __aenter__(self):
                     return self
@@ -353,6 +400,7 @@ def _make_mock_response(should_fail=False, fail_count={"count": 0}):
     class MockResp:
         status = 200
         headers = {}
+        raw_headers = ()
 
         async def __aenter__(self):
             if should_fail and fail_count["count"] < 1:

--- a/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
+++ b/tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py
@@ -135,6 +135,24 @@ class TestMaskedHTTPStatusError:
         # Content-Encoding must have been stripped from the rebuilt headers.
         assert "content-encoding" not in {k.lower() for k in masked.response.headers}
 
+    def test_preserves_non_ascii_response_headers(self):
+        header_value = "本地化错误消息"
+        request = httpx.Request("GET", "https://api.example.com?key=SECRET")
+        response = httpx.Response(
+            status_code=400,
+            content=b"bad request",
+            headers=[
+                (b"x-localized-message", header_value.encode("utf-8")),
+            ],
+            request=request,
+        )
+        orig = httpx.HTTPStatusError("400", request=request, response=response)
+
+        masked = MaskedHTTPStatusError(orig)
+
+        assert masked.response.headers.get("x-localized-message") == header_value
+        assert "SECRET" not in str(masked.response.request.url)
+
 
 class TestSafeResponseHelpers:
     def test_safe_get_response_text_normal(self):

--- a/tests/test_litellm/test_streaming_connection_cleanup.py
+++ b/tests/test_litellm/test_streaming_connection_cleanup.py
@@ -40,6 +40,7 @@ async def test_aiohttp_transport_response_uses_stream_not_content():
             class Resp:
                 status = 200
                 headers = {}
+                raw_headers = ()
 
                 async def __aenter__(self):
                     return self
@@ -73,6 +74,7 @@ async def test_aiohttp_response_stream_aclose_releases_connection():
     class MockResponse:
         status = 200
         headers = {}
+        raw_headers = ()
 
         @property
         def content(self):


### PR DESCRIPTION
## PR title

fix(custom_httpx): preserve non-ascii response headers

## PR body

## Relevant issues

Fixes ##26548 
async `AsyncHTTPHandler` aiohttp transport failures when upstream response headers contain non-ASCII values.
Re-submission of #26550 (auto-closed when `litellm_oss_branch` was deleted)
## Pre-Submission checklist

- [x] I have Added testing in the [`[tests/test_litellm/](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [[see details](https://docs.litellm.ai/docs/extras/contributing_code)](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [[Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### Before

When the aiohttp transport received a response header with a non-ASCII value, LiteLLM failed while constructing an `httpx.Response`:

```text
LiteLLM AsyncHTTPHandler aiohttp: ERROR UnicodeEncodeError:
'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)
```

The failure came from passing `aiohttp.ClientResponse.headers`, which is already decoded to `str`, into `httpx.Response(...)`. `httpx.Headers` then attempted to normalize that non-ASCII string using ASCII.

### After

LiteLLM now preserves aiohttp's raw response header bytes when constructing the bridged `httpx.Response`:

```text
LiteLLM AsyncHTTPHandler aiohttp: OK status=200 body=b'ok' header='本地化消息'
```

The masked error path also preserves raw header bytes when rebuilding `httpx.Response` for `MaskedHTTPStatusError`, so non-ASCII response headers do not fail again on HTTP error responses.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Use `response.raw_headers` when converting an aiohttp response into an`httpx.Response` in `LiteLLMAiohttpTransport`.
- Preserve `original_error.response.headers.raw` when rebuilding masked `httpx.Response` objects for `MaskedHTTPStatusError`.
- Keep filtering `content-encoding` and `content-length` in the masked error path to avoid double-decoding already-decoded response bodies.
- Add regression coverage for non-ASCII response headers in the aiohttp transport path.
- Add regression coverage for non-ASCII response headers in the masked HTTP error path.
- Update aiohttp response test doubles to include `raw_headers`, matching real `aiohttp.ClientResponse` objects.

## Test Plan

Ran locally during development:

```text
.venv/bin/python -m pytest tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py -q
16 passed

.venv/bin/python -m pytest tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py -q
28 passed

.venv/bin/python -m pytest tests/test_litellm/test_streaming_connection_cleanup.py -q
8 passed

env BLACK_CACHE_DIR=/tmp/black-cache .venv/bin/python -m black --check \
  litellm/llms/custom_httpx/aiohttp_transport.py \
  litellm/llms/custom_httpx/http_handler.py \
  tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py \
  tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py \
  tests/test_litellm/test_streaming_connection_cleanup.py
5 files would be left unchanged.

git diff --check -- \
  litellm/llms/custom_httpx/aiohttp_transport.py \
  litellm/llms/custom_httpx/http_handler.py \
  tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py \
  tests/test_litellm/llms/custom_httpx/test_credential_leak_prevention.py \
  tests/test_litellm/test_streaming_connection_cleanup.py
exit 0
```

Also validated with the project commands:

```text
make install-dev
make format
make lint
make install-test-deps
make test-unit
```