### PR TITLE
fix(docker): exclude docker/build_from_pip/ from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ tests
 *.tgz
 log.txt
 docker/Dockerfile.*
+docker/build_from_pip/
 
 # Claude Flow generated files (must be excluded from Docker build)
 .claude/


### PR DESCRIPTION
## Fixes following issue

**Exclude `build_from_pip` CI Fixtures from runtime image**

- `docker/build_from_pip/` is a CI smoke-test fixture and a copy-paste reference for security-strict downstream users who want to build from PyPI. Nothing inside it is loaded, imported, or executed by the running proxy

- But having this in runtime image causes issues with CVE policy gates on downstream builds because a non-runtime CI fixture inside the published image declares a vulnerable litellm pin, even though the correct version is patched. Excluding the fixture from the runtime image fixes the false positive at the source


## Changes (🐛 Bug Fix)

Adds `docker/build_from_pip/` to `.dockerignore` so the directory no longer ships inside the published runtime image.