### PR TITLE
fix(proxy): set verbose_logger level in init_verbose_loggers when LITELLM_LOG=INFO/DEBUG

### DIFF
--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -808,12 +808,16 @@ def init_verbose_loggers():
                     import logging
 
                     from litellm._logging import (
+                        verbose_logger,
                         verbose_proxy_logger,
                         verbose_router_logger,
                     )
 
                     # this must ALWAYS remain logging.INFO, DO NOT MODIFY THIS
 
+                    verbose_logger.setLevel(
+                        level=logging.INFO
+                    )  # set package logs to info
                     verbose_router_logger.setLevel(
                         level=logging.INFO
                     )  # set router logs to info
@@ -824,10 +828,14 @@ def init_verbose_loggers():
                     import logging
 
                     from litellm._logging import (
+                        verbose_logger,
                         verbose_proxy_logger,
                         verbose_router_logger,
                     )
 
+                    verbose_logger.setLevel(
+                        level=logging.DEBUG
+                    )  # set package logs to debug
                     verbose_router_logger.setLevel(
                         level=logging.DEBUG
                     )  # set router logs to info


### PR DESCRIPTION
Closes #26396 (the remaining half).

## Status update

When this PR was first opened it touched two files (`proxy_server.py` and `common_utils/debug_utils.py`). The `proxy_server.py` half has since landed independently on `litellm_oss_staging_04_25_2026` (the `LITELLM_LOG=INFO` branch there now imports and sets `verbose_logger` correctly).

`common_utils/debug_utils.py::init_verbose_loggers` is **still missing** the same fix — that path is taken when the proxy reads `WORKER_CONFIG` and the JSON does not set `debug`/`detailed_debug`, so users running with `LITELLM_LOG=INFO` via that startup path still get `verbose_logger` records suppressed.

PR is now scoped to that single remaining file (8 lines added).

## Root cause (recap)

`init_verbose_loggers` has four branches:

1. `debug=True` → imports & sets `verbose_logger`, `verbose_router_logger`, `verbose_proxy_logger`
2. `detailed_debug=True` → same three
3. `LITELLM_LOG=INFO` → only `verbose_router_logger` + `verbose_proxy_logger` (bug)
4. `LITELLM_LOG=DEBUG` → only `verbose_router_logger` + `verbose_proxy_logger` (bug)

Because `verbose_logger` is left unconfigured in branches 3/4, it inherits the root logger's WARNING level — so \`litellm._logging.verbose_logger.info(...)\` records (e.g. those emitted by \`token_based_routing\`) are silently filtered out.

## Fix

Add \`verbose_logger\` to the import + setLevel calls in both LITELLM_LOG sub-branches, matching what \`debug=True\` / \`detailed_debug=True\` and \`proxy_server.py\` already do.

## Test plan
- [x] Module parses cleanly.
- [ ] With a WORKER_CONFIG JSON that does not set debug/detailed_debug, set LITELLM_LOG=INFO, restart, confirm verbose_logger.info records appear.
- [ ] Same with LITELLM_LOG=DEBUG.
- [ ] With LITELLM_LOG unset, confirm verbose_logger is unaffected.

Type of change: Bug Fix