### PR TITLE
fix(health-check): skip max_tokens for non-chat modes (image, embedding, rerank, etc.)

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -366,10 +366,22 @@ def _update_litellm_params_for_health_check(
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
     """
+    _NON_CHAT_MODES = {
+        "image_generation",
+        "video_generation",
+        "embedding",
+        "rerank",
+        "transcription",
+        "audio_speech",
+    }
+    _mode = model_info.get("mode", None)
     litellm_params["messages"] = _get_random_llm_message()
-    _resolved_max_tokens = _resolve_health_check_max_tokens(model_info, litellm_params)
-    if _resolved_max_tokens is not None:
-        litellm_params["max_tokens"] = _resolved_max_tokens
+    if _mode not in _NON_CHAT_MODES:
+        _resolved_max_tokens = _resolve_health_check_max_tokens(
+            model_info, litellm_params
+        )
+        if _resolved_max_tokens is not None:
+            litellm_params["max_tokens"] = _resolved_max_tokens
 
     _health_check_model = model_info.get("health_check_model", None)
     if _health_check_model is not None:

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -368,11 +368,15 @@ def _update_litellm_params_for_health_check(
     """
     _NON_CHAT_MODES = {
         "image_generation",
+        "image_edit",
         "video_generation",
         "embedding",
         "rerank",
-        "transcription",
+        "audio_transcription",
         "audio_speech",
+        "ocr",
+        "search",
+        "moderation",
     }
     _mode = model_info.get("mode", None)
     litellm_params["messages"] = _get_random_llm_message()

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -32,6 +32,19 @@ ILLEGAL_DISPLAY_PARAMS = [
 
 MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
 
+_NON_CHAT_MODES = {
+    "image_generation",
+    "image_edit",
+    "video_generation",
+    "embedding",
+    "rerank",
+    "audio_transcription",
+    "audio_speech",
+    "ocr",
+    "search",
+    "moderation",
+}
+
 
 def _get_process_rss_mb() -> Optional[float]:
     """
@@ -366,18 +379,6 @@ def _update_litellm_params_for_health_check(
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
     """
-    _NON_CHAT_MODES = {
-        "image_generation",
-        "image_edit",
-        "video_generation",
-        "embedding",
-        "rerank",
-        "audio_transcription",
-        "audio_speech",
-        "ocr",
-        "search",
-        "moderation",
-    }
     _mode = model_info.get("mode", None)
     litellm_params["messages"] = _get_random_llm_message()
     if _mode not in _NON_CHAT_MODES:

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -86,6 +86,37 @@ async def test_ahealth_check_wildcard_models_respects_max_tokens():
         assert model_params["max_tokens"] == 3
 
 
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "image_generation",
+        "video_generation",
+        "embedding",
+        "rerank",
+        "transcription",
+        "audio_speech",
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_litellm_params_no_max_tokens_for_non_chat_modes(
+    monkeypatch, mode
+):
+    """
+    Non-chat modes (image_generation, embedding, etc.) must not receive max_tokens
+    because those endpoints reject it with a 400 error.
+    """
+    monkeypatch.setattr(hc_module, "BACKGROUND_HEALTH_CHECK_MAX_TOKENS", None)
+    monkeypatch.setattr(hc_module, "BACKGROUND_HEALTH_CHECK_MAX_TOKENS_REASONING", None)
+    model_info = {"mode": mode}
+    litellm_params = {"model": "openai/dall-e-3"}
+
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert (
+        "max_tokens" not in updated_params
+    ), f"max_tokens should not be set for mode={mode!r}, got {updated_params.get('max_tokens')}"
+
+
 @pytest.mark.asyncio
 async def test_background_health_check_max_tokens_env_var(monkeypatch):
     """

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -90,11 +90,15 @@ async def test_ahealth_check_wildcard_models_respects_max_tokens():
     "mode",
     [
         "image_generation",
+        "image_edit",
         "video_generation",
         "embedding",
         "rerank",
-        "transcription",
+        "audio_transcription",
         "audio_speech",
+        "ocr",
+        "search",
+        "moderation",
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Health check was unconditionally injecting `max_tokens` into every deployment request. OpenAI image endpoints (`dall-e-2`, `dall-e-3`, `gpt-image-1`) and other non-chat handlers reject `max_tokens` with a 400 error, causing them to appear permanently unhealthy in the UI even though the models work fine.

Root cause in `litellm/proxy/health_check.py:370-372` — `_resolve_health_check_max_tokens` runs unconditionally for all modes. The fix guards the injection behind a mode check, skipping it for `image_generation`, `video_generation`, `embedding`, `rerank`, `transcription`, and `audio_speech`.

## Relevant issues

Fixes #26406

## Type

Bug Fix

## Changes

- `litellm/proxy/health_check.py`: skip `max_tokens` injection when `model_info.mode` is a non-chat mode
- `tests/test_litellm/proxy/test_health_check_max_tokens.py`: parametrized test covering all 6 non-chat modes — verifies `max_tokens` is absent from health check params for each

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review