### PR TITLE
Add note that docs live in separate litellm-docs repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,11 +43,13 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 
 <!-- Select the type of Pull Request -->
 <!-- Keep only the necessary ones -->
+<!-- NOTE: Documentation lives in a separate repo: https://github.com/BerriAI/litellm-docs -->
+<!-- For doc changes, please open a PR there instead. -->
 
 🆕 New Feature
 🐛 Bug Fix
 🧹 Refactoring
-📖 Documentation
+📖 Documentation (submit doc PRs to [litellm-docs](https://github.com/BerriAI/litellm-docs))
 🚄 Infrastructure
 ✅ Test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ If `make test-unit` fails:
 - **Write descriptive commit messages**: Help reviewers understand your changes
 - **Keep PRs focused**: One feature/fix per PR
 - **Test edge cases**: Don't just test the happy path
-- **Update documentation**: If you change APIs, update docs
+- **Update documentation**: If you change APIs, update docs in the [litellm-docs](https://github.com/BerriAI/litellm-docs) repo (see [Documentation](#documentation) below)
 
 ## Building and Running Locally
 
@@ -312,6 +312,12 @@ Ensure the UI builds successfully before submitting your PR:
 npm run build
 ```
 
+## Documentation
+
+LiteLLM documentation lives in a **separate repository**: [BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs), served at [docs.litellm.ai](https://docs.litellm.ai).
+
+**Do not create or edit documentation files in this repository.** If your changes require documentation updates, please open a separate PR against the [litellm-docs](https://github.com/BerriAI/litellm-docs) repo.
+
 ## Submitting Your PR
 
 1. **Push your branch**: `git push origin your-feature-branch`
@@ -336,7 +342,7 @@ Looking for ideas? Check out:
 
 - 🐛 [Good first issues](https://github.com/BerriAI/litellm/labels/good%20first%20issue)
 - 🚀 [Feature requests](https://github.com/BerriAI/litellm/labels/enhancement)
-- 📚 Documentation improvements
+- 📚 Documentation improvements (in the [litellm-docs](https://github.com/BerriAI/litellm-docs) repo)
 - 🧪 Test coverage improvements
 - 🔌 New LLM provider integrations
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Addresses contributor confusion about where to submit documentation changes.

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Updates `CONTRIBUTING.md` and `.github/pull_request_template.md` to inform contributors that documentation lives in a **separate repository**: [BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs) (served at [docs.litellm.ai](https://docs.litellm.ai)).

Specifically:
- Added a new **Documentation** section to `CONTRIBUTING.md` explaining that doc PRs should be opened against the `litellm-docs` repo
- Updated the "Common Development Tips" in `CONTRIBUTING.md` to link to the docs repo
- Updated the "What to Contribute" section to note that doc improvements go to the separate repo
- Added a comment and link in the PR template's Type section so contributors selecting "Documentation" see the correct repo
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C09DYGJAVEU/p1777311975210339?thread_ts=1777311975.210339&cid=C09DYGJAVEU)

<div><a href="https://cursor.com/agents/bc-2753758d-e41a-519e-8698-10701b6515f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2753758d-e41a-519e-8698-10701b6515f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

