### PR TITLE
fix(bedrock): preserve cache_control for ARN-based models in /v1/messages adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -717,7 +717,9 @@ class LiteLLMAnthropicMessagesAdapter:
         - vertex_ai/*claude* models
         """
         model_lower = model.lower()
-        return "anthropic" in model_lower or "claude" in model_lower
+        return "anthropic" in model_lower or "claude" in model_lower or (
+            "arn:" in model_lower and "bedrock" in model_lower
+        )
 
     @staticmethod
     def translate_thinking_for_model(


### PR DESCRIPTION
## Title

Fix: preserve cache_control for Bedrock ARN-based models in /v1/messages adapter

## Relevant issues

Fixes #26625

## Pre-Submission checklist

- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### What this PR does

Adds Bedrock ARN detection to `is_anthropic_claude_model()` so that `cache_control` directives are preserved when translating Anthropic `/v1/messages` requests to OpenAI format for Bedrock Application Inference Profiles.

### Problem being solved

When using Bedrock Application Inference Profiles (ARN format like `arn:aws:bedrock:us-east-1:ACCOUNT:application-inference-profile/ID`) via the `/v1/messages` Anthropic endpoint (used by Claude Code), `cache_control` is silently dropped because `is_anthropic_claude_model()` cannot identify the model as Claude from the ARN string.

This causes prompt caching to never activate, resulting in:
- No `cache_creation_input_tokens` or `cache_read_input_tokens` in responses
- Significantly higher costs (no cache discount)
- Higher latency (no cache hits)

The same model works correctly via `/v1/chat/completions` because that path uses `_bedrock_converse_messages_pt()` directly, which handles `cache_control` → `cachePoint` conversion independently.

### Changes made

**File**: `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`

One-line change to `is_anthropic_claude_model()`:

```python
# Before
return "anthropic" in model_lower or "claude" in model_lower

# After  
return "anthropic" in model_lower or "claude" in model_lower or (
    "arn:" in model_lower and "bedrock" in model_lower
)
```

This is safe because the only code path reaching this function with a Bedrock ARN is through the `/v1/messages` Anthropic endpoint → `LiteLLMMessagesToCompletionTransformationHandler` adapter, which is exclusively used for Claude models on Bedrock.

## How to verify it

Verified with Bedrock CloudWatch invocation logs:

| State | Endpoint | cacheWriteInputTokens |
|---|---|---|
| Before fix | `/v1/messages` | **0** |
| After fix | `/v1/messages` | **34,004** ✅ |
| Before fix | `/v1/chat/completions` | **34,004** (always worked) |

## Breaking changes

None - purely additive check.
