### PR TITLE
fix(bedrock): preserve cache_control for ARN-based models in /v1/messages adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -299,7 +299,14 @@ class LiteLLMAnthropicMessagesAdapter:
             if isinstance(source, dict)
             else getattr(source, "cache_control", None)
         )
-        if cache_control and model and self.is_anthropic_claude_model(model):
+        if (
+            cache_control
+            and model
+            and (
+                self.is_anthropic_claude_model(model)
+                or ("arn:" in model.lower() and "bedrock" in model.lower())
+            )
+        ):
             # TypedDict objects support dict operations at runtime
             # Use type ignore consistent with codebase pattern (see anthropic/chat/transformation.py:432)
             if isinstance(target, dict):
@@ -667,7 +674,7 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @staticmethod
     def translate_anthropic_thinking_to_reasoning_effort(
-        thinking: Dict[str, Any]
+        thinking: Dict[str, Any],
     ) -> Optional[str]:
         """
         Translate Anthropic's thinking parameter to OpenAI's reasoning_effort.


### PR DESCRIPTION
## Title

Fix: preserve cache_control for Bedrock ARN-based models in /v1/messages adapter

## Relevant issues

Fixes #26625

## Pre-Submission checklist

- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### What this PR does

Scopes the ARN-based Bedrock model detection to `_add_cache_control_if_applicable()` only, so that `cache_control` directives are preserved when translating Anthropic `/v1/messages` requests to OpenAI format for Bedrock Application Inference Profiles.

### Problem being solved

When using Bedrock Application Inference Profiles (ARN format like `arn:aws:bedrock:us-east-1:ACCOUNT:application-inference-profile/ID`) via the `/v1/messages` Anthropic endpoint (used by Claude Code), `cache_control` is silently dropped because `is_anthropic_claude_model()` cannot identify the model as Claude from the ARN string.

This causes prompt caching to never activate, resulting in:
- No `cache_creation_input_tokens` or `cache_read_input_tokens` in responses
- Significantly higher costs (no cache discount)
- Higher latency (no cache hits)

The same model works correctly via `/v1/chat/completions` because that path uses `_bedrock_converse_messages_pt()` directly, which handles `cache_control` → `cachePoint` conversion independently.

### Changes made

**File**: `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`

Scoped fix to `_add_cache_control_if_applicable()` only:

```python
# Before
if cache_control and model and self.is_anthropic_claude_model(model):

# After
if cache_control and model and (
    self.is_anthropic_claude_model(model)
    or ("arn:" in model.lower() and "bedrock" in model.lower())
):
```

### Why this scoping matters

`is_anthropic_claude_model()` is called in three places:
- `_add_cache_control_if_applicable` (line 302) — this PR's target
- `_translate_thinking` (line 1047)
- `translate_thinking_for_model` (line 745)

Modifying the shared helper would also affect `thinking` parameter translation. If a non-Claude Bedrock ARN (e.g., Titan or Llama profile) were to reach this adapter, broadening `is_anthropic_claude_model()` would cause `thinking` to pass through unmodified instead of being translated to `reasoning_effort`, likely causing a provider-side error.

### Why preserving cache_control for non-Claude ARNs is safe

Downstream flow for a request with `cache_control`:

```
OpenAI-format message with cache_control
        │
        ▼
bedrock converse request (cachePoint block added by _bedrock_converse_messages_pt)
        │
        ▼
┌─ Bedrock Converse API ──────────────────────────────┐
│  Claude model     → uses cachePoint, returns cache  │
│                     tokens ✅                       │
│  Titan/Llama etc. → ignores cachePoint, returns     │
│                     normal usage ✅                 │
│  Bedrock does NOT reject requests for cachePoint    │
│  on non-caching models — it silently no-ops         │
└─────────────────────────────────────────────────────┘
```

In contrast, dropping `cache_control` silently is a functional regression (no cache ever created), so erring on preservation is the safer default.

## How to verify it

Verified with Bedrock CloudWatch invocation logs for a Bedrock Application Inference Profile pointing at Claude Opus 4.6:

| State | Endpoint | cacheWriteInputTokens |
|---|---|---|
| Before fix | `/v1/messages` | **0** |
| After fix | `/v1/messages` | **34,004** ✅ |
| Before fix | `/v1/chat/completions` | **34,004** (always worked) |

## Breaking changes

None - purely additive check.
