### PR TITLE
Fix unsupported thinking_budget=0 for Gemini Pro

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -923,6 +923,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         return thinking_budget is not None and thinking_budget == 0
 
     @staticmethod
+    def _model_supports_thinking_budget_zero(model: Optional[str]) -> bool:
+        """Only Flash-family Gemini 2.x models accept thinkingBudget=0 to disable thinking.
+        Pro models reject it with a 400 INVALID_ARGUMENT error."""
+        if model is None:
+            return False
+        return "flash" in model.lower()
+
+    @staticmethod
     def _validate_thinking_config_conflicts(
         optional_params: Dict,
         param_name: str,
@@ -1005,7 +1013,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             ):
                 params["includeThoughts"] = True
             if thinking_budget is not None and isinstance(thinking_budget, int):
-                params["thinkingBudget"] = thinking_budget
+                if (
+                    thinking_budget > 0
+                    or VertexGeminiConfig._model_supports_thinking_budget_zero(model)
+                ):
+                    params["thinkingBudget"] = thinking_budget
 
         return params
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -91,6 +91,7 @@ from litellm.utils import (
     ModelResponse,
     is_base64_encoded,
     supports_reasoning,
+    supports_thinking_budget_zero,
 )
 
 from ....utils import _remove_additional_properties, _remove_strict_from_schema
@@ -924,11 +925,15 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
     @staticmethod
     def _model_supports_thinking_budget_zero(model: Optional[str]) -> bool:
-        """Only Flash-family Gemini 2.x models accept thinkingBudget=0 to disable thinking.
-        Pro models reject it with a 400 INVALID_ARGUMENT error."""
+        """Returns True if the model accepts thinkingBudget=0 to disable thinking.
+        Reads from model_prices_and_context_window.json via supports_thinking_budget_zero;
+        falls back to False (safe default) when the model is unknown."""
         if model is None:
             return False
-        return "flash" in model.lower()
+        try:
+            return supports_thinking_budget_zero(model)
+        except Exception:
+            return False
 
     @staticmethod
     def _validate_thinking_config_conflicts(

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9431,6 +9431,7 @@
             "us": 1.1,
             "fast": 6.0
         },
+        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-opus-4-7-20260416": {
@@ -9465,6 +9466,7 @@
             "us": 1.1,
             "fast": 6.0
         },
+        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-sonnet-4-20250514": {
@@ -16280,7 +16282,8 @@
             "/v1/audio/speech"
         ],
         "tpm": 4000000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -38785,7 +38788,8 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true
+        "supports_audio_output": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-native-audio-preview-09-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38809,7 +38813,8 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true
+        "supports_audio_output": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-native-audio-preview-12-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38833,7 +38838,8 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true
+        "supports_audio_output": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-3.1-flash-live-preview": {
         "input_cost_per_audio_token": 3e-06,
@@ -38891,7 +38897,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38917,7 +38924,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38943,7 +38951,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-3.1-flash-live-preview": {
         "input_cost_per_audio_token": 3e-06,
@@ -38987,7 +38996,8 @@
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
-        ]
+        ],
+        "supports_thinking_budget_zero": true
     },
     "gemini-flash-latest": {
         "cache_read_input_token_cost": 3e-08,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9431,7 +9431,6 @@
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-opus-4-7-20260416": {
@@ -9466,7 +9465,6 @@
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-sonnet-4-20250514": {
@@ -12006,7 +12004,8 @@
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_thinking_budget_zero": true
     },
     "deepinfra/google/gemini-2.5-pro": {
         "max_tokens": 1000000,
@@ -14289,7 +14288,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -14339,7 +14339,8 @@
         "supports_vision": true,
         "supports_web_search": false,
         "tpm": 8000000,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -14561,7 +14562,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
@@ -14611,7 +14613,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -14661,7 +14664,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -14812,7 +14816,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -15761,7 +15766,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -15817,7 +15823,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -15996,7 +16003,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
@@ -16048,7 +16056,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -16100,7 +16109,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-flash-latest": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -16257,7 +16267,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-preview-tts": {
         "input_cost_per_token": 3e-07,
@@ -25343,7 +25354,8 @@
         "source": "https://www.oracle.com/artificial-intelligence/generative-ai/generative-ai-service/pricing",
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_thinking_budget_zero": true
     },
     "oci/google.gemini-2.5-flash-lite": {
         "input_cost_per_token": 7.5e-08,
@@ -25356,7 +25368,8 @@
         "source": "https://www.oracle.com/artificial-intelligence/generative-ai/generative-ai-service/pricing",
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_thinking_budget_zero": true
     },
     "oci/cohere.embed-english-v3.0": {
         "input_cost_per_token": 1e-07,
@@ -26150,7 +26163,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_thinking_budget_zero": true
     },
     "openrouter/google/gemini-2.5-pro": {
         "input_cost_per_audio_token": 7e-07,
@@ -27893,7 +27907,8 @@
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_thinking_budget_zero": true
     },
     "perplexity/xai/grok-4-1-fast-non-reasoning": {
         "litellm_provider": "perplexity",
@@ -28457,7 +28472,8 @@
         "supports_vision": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_thinking_budget_zero": true
     },
     "replicate/openai/gpt-oss-120b": {
         "input_cost_per_token": 1.8e-07,
@@ -31136,7 +31152,8 @@
         "supports_vision": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_thinking_budget_zero": true
     },
     "vercel_ai_gateway/google/gemini-2.5-pro": {
         "input_cost_per_token": 2.5e-06,
@@ -32645,7 +32662,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": false,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "supports_thinking_budget_zero": true
     },
     "vertex_ai/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -142,6 +142,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_minimal_reasoning_effort: Optional[bool]
     supports_xhigh_reasoning_effort: Optional[bool]
     supports_max_reasoning_effort: Optional[bool]
+    supports_thinking_budget_zero: Optional[bool]
 
 
 class SearchContextCostPerQuery(TypedDict, total=False):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2738,6 +2738,20 @@ def supports_reasoning(model: str, custom_llm_provider: Optional[str] = None) ->
     )
 
 
+def supports_thinking_budget_zero(
+    model: str, custom_llm_provider: Optional[str] = None
+) -> bool:
+    """
+    Check if the model accepts thinkingBudget=0 to disable thinking.
+    Flash-family Gemini 2.x models support this; Pro models reject it with 400.
+    """
+    return _supports_factory(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        key="supports_thinking_budget_zero",
+    )
+
+
 def supports_native_structured_output(
     model: str, custom_llm_provider: Optional[str] = None
 ) -> bool:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5916,6 +5916,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 supports_max_reasoning_effort=_model_info.get(
                     "supports_max_reasoning_effort", None
                 ),
+                supports_thinking_budget_zero=_model_info.get(
+                    "supports_thinking_budget_zero", None
+                ),
                 supports_computer_use=_model_info.get("supports_computer_use", None),
                 search_context_cost_per_query=_model_info.get(
                     "search_context_cost_per_query", None

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8046,17 +8046,16 @@
     },
     "bedrock/us-east-1/minimax.minimax-m2.5": {
         "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "source": "https://aws.amazon.com/bedrock/pricing/",
         "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "output_cost_per_token": 1.2e-06
+        "source": "https://aws.amazon.com/bedrock/pricing/"
     },
     "bedrock/us-east-1/moonshotai.kimi-k2-thinking": {
         "input_cost_per_token": 6e-07,
@@ -8664,17 +8663,16 @@
     },
     "bedrock/us-west-2/minimax.minimax-m2.5": {
         "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "source": "https://aws.amazon.com/bedrock/pricing/",
         "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "output_cost_per_token": 1.2e-06
+        "source": "https://aws.amazon.com/bedrock/pricing/"
     },
     "bedrock/us-west-2/moonshotai.kimi-k2-thinking": {
         "input_cost_per_token": 6e-07,
@@ -9445,7 +9443,6 @@
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-opus-4-7-20260416": {
@@ -9480,7 +9477,6 @@
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-sonnet-4-20250514": {
@@ -12020,7 +12016,8 @@
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_thinking_budget_zero": true
     },
     "deepinfra/google/gemini-2.5-pro": {
         "max_tokens": 1000000,
@@ -14303,7 +14300,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -14353,7 +14351,8 @@
         "supports_vision": true,
         "supports_web_search": false,
         "tpm": 8000000,
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -14575,7 +14574,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
@@ -14625,7 +14625,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -14675,7 +14676,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -14826,7 +14828,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -15775,7 +15778,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-image": {
         "cache_read_input_token_cost": 3e-08,
@@ -15831,7 +15835,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -16010,7 +16015,8 @@
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
         },
-        "supports_service_tier": true
+        "supports_service_tier": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
         "cache_read_input_token_cost": 1e-08,
@@ -16062,7 +16068,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -16114,7 +16121,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-flash-latest": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -16271,7 +16279,8 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        }
+        },
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-preview-tts": {
         "input_cost_per_token": 3e-07,
@@ -22697,14 +22706,13 @@
     },
     "minimax.minimax-m2.5": {
         "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 1.2e-06,
         "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
@@ -25349,7 +25357,8 @@
         "source": "https://www.oracle.com/artificial-intelligence/generative-ai/generative-ai-service/pricing",
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_thinking_budget_zero": true
     },
     "oci/google.gemini-2.5-flash-lite": {
         "input_cost_per_token": 7.5e-08,
@@ -25362,7 +25371,8 @@
         "source": "https://www.oracle.com/artificial-intelligence/generative-ai/generative-ai-service/pricing",
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_thinking_budget_zero": true
     },
     "oci/cohere.embed-english-v3.0": {
         "input_cost_per_token": 1e-07,
@@ -26180,7 +26190,8 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_thinking_budget_zero": true
     },
     "openrouter/google/gemini-2.5-pro": {
         "input_cost_per_audio_token": 7e-07,
@@ -27945,7 +27956,8 @@
         "mode": "responses",
         "supports_web_search": true,
         "supports_reasoning": false,
-        "supports_function_calling": true
+        "supports_function_calling": true,
+        "supports_thinking_budget_zero": true
     },
     "perplexity/xai/grok-4-1-fast-non-reasoning": {
         "litellm_provider": "perplexity",
@@ -28509,7 +28521,8 @@
         "supports_vision": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_thinking_budget_zero": true
     },
     "replicate/openai/gpt-oss-120b": {
         "input_cost_per_token": 1.8e-07,
@@ -31190,7 +31203,8 @@
         "supports_vision": true,
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_thinking_budget_zero": true
     },
     "vercel_ai_gateway/google/gemini-2.5-pro": {
         "input_cost_per_token": 2.5e-06,
@@ -32699,7 +32713,8 @@
         "supports_url_context": true,
         "supports_vision": true,
         "supports_web_search": false,
-        "tpm": 8000000
+        "tpm": 8000000,
+        "supports_thinking_budget_zero": true
     },
     "vertex_ai/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -34758,17 +34773,17 @@
     },
     "zai.glm-5": {
         "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "output_cost_per_token": 3.2e-06,
-        "source": "https://aws.amazon.com/bedrock/pricing/",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
     },
     "zai/glm-5": {
         "cache_creation_input_token_cost": 0,
@@ -39551,20 +39566,6 @@
             }
         ]
     },
-    "zai.glm-5": {
-        "input_cost_per_token": 1e-06,
-        "output_cost_per_token": 3.2e-06,
-        "litellm_provider": "bedrock_converse",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
-    },
     "bedrock/us-east-1/zai.glm-5": {
         "input_cost_per_token": 1e-06,
         "output_cost_per_token": 3.2e-06,
@@ -39589,45 +39590,6 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
-    },
-    "minimax.minimax-m2.5": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "litellm_provider": "bedrock_converse",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
-    },
-    "bedrock/us-east-1/minimax.minimax-m2.5": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
-    },
-    "bedrock/us-west-2/minimax.minimax-m2.5": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "supports_function_calling": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8046,16 +8046,17 @@
     },
     "bedrock/us-east-1/minimax.minimax-m2.5": {
         "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "source": "https://aws.amazon.com/bedrock/pricing/",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
+        "output_cost_per_token": 1.2e-06
     },
     "bedrock/us-east-1/moonshotai.kimi-k2-thinking": {
         "input_cost_per_token": 6e-07,
@@ -8663,16 +8664,17 @@
     },
     "bedrock/us-west-2/minimax.minimax-m2.5": {
         "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "source": "https://aws.amazon.com/bedrock/pricing/",
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
+        "output_cost_per_token": 1.2e-06
     },
     "bedrock/us-west-2/moonshotai.kimi-k2-thinking": {
         "input_cost_per_token": 6e-07,
@@ -9443,6 +9445,7 @@
             "us": 1.1,
             "fast": 6.0
         },
+        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-opus-4-7-20260416": {
@@ -9477,6 +9480,7 @@
             "us": 1.1,
             "fast": 6.0
         },
+        "supports_max_reasoning_effort": true,
         "supports_minimal_reasoning_effort": true
     },
     "claude-sonnet-4-20250514": {
@@ -16292,7 +16296,8 @@
             "/v1/audio/speech"
         ],
         "tpm": 4000000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -22706,13 +22711,14 @@
     },
     "minimax.minimax-m2.5": {
         "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
@@ -34773,17 +34779,17 @@
     },
     "zai.glm-5": {
         "input_cost_per_token": 1e-06,
-        "output_cost_per_token": 3.2e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "output_cost_per_token": 3.2e-06,
+        "source": "https://aws.amazon.com/bedrock/pricing/",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "source": "https://aws.amazon.com/bedrock/pricing/"
+        "supports_tool_choice": true
     },
     "zai/glm-5": {
         "cache_creation_input_token_cost": 0,
@@ -38863,7 +38869,8 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true
+        "supports_audio_output": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-native-audio-preview-09-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38887,7 +38894,8 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true
+        "supports_audio_output": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-2.5-flash-native-audio-preview-12-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38911,7 +38919,8 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true
+        "supports_audio_output": true,
+        "supports_thinking_budget_zero": true
     },
     "gemini-3.1-flash-live-preview": {
         "input_cost_per_audio_token": 3e-06,
@@ -38969,7 +38978,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -38995,7 +39005,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -39021,7 +39032,8 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10
+        "rpm": 10,
+        "supports_thinking_budget_zero": true
     },
     "gemini/gemini-3.1-flash-live-preview": {
         "input_cost_per_audio_token": 3e-06,
@@ -39065,7 +39077,8 @@
         "source": "https://ai.google.dev/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
-        ]
+        ],
+        "supports_thinking_budget_zero": true
     },
     "gemini-flash-latest": {
         "cache_read_input_token_cost": 3e-08,
@@ -39566,6 +39579,20 @@
             }
         ]
     },
+    "zai.glm-5": {
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/us-east-1/zai.glm-5": {
         "input_cost_per_token": 1e-06,
         "output_cost_per_token": 3.2e-06,
@@ -39590,6 +39617,45 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "minimax.minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/us-east-1/minimax.minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "bedrock/us-west-2/minimax.minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "supports_function_calling": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -454,36 +454,27 @@ def test_gemini_thinking():
 
 def test_gemini_thinking_budget_0():
     litellm._turn_on_debug()
-    from unittest.mock import patch
-    from litellm.types.utils import Message, CallTypes
+    import os
+    from litellm.types.utils import CallTypes
     from litellm.utils import return_raw_request
     import json
 
-    # Inject supports_thinking_budget_zero so the translation layer emits
-    # thinkingBudget=0 for Flash regardless of whether the remote JSON has the
-    # flag yet (CI fetches GitHub main which lags behind this PR).
-    # _map_thinking_param receives the stripped model name ("gemini-2.5-flash"),
-    # which resolves to key "gemini-2.5-flash" in model_cost (vertex_ai provider).
-    flash_cost_patch = {
-        "gemini-2.5-flash": {
-            **litellm.model_cost.get("gemini-2.5-flash", {}),
-            "supports_thinking_budget_zero": True,
-        }
-    }
-    with patch.dict(litellm.model_cost, flash_cost_patch):
-        raw_request = return_raw_request(
-            endpoint=CallTypes.completion,
-            kwargs={
-                "model": "gemini/gemini-2.5-flash",
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": "Explain the concept of Occam's Razor and provide a simple, everyday example",
-                    }
-                ],
-                "thinking": {"type": "enabled", "budget_tokens": 0},
-            },
-        )
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    raw_request = return_raw_request(
+        endpoint=CallTypes.completion,
+        kwargs={
+            "model": "gemini/gemini-2.5-flash",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Explain the concept of Occam's Razor and provide a simple, everyday example",
+                }
+            ],
+            "thinking": {"type": "enabled", "budget_tokens": 0},
+        },
+    )
     print(json.dumps(raw_request, indent=4, default=str))
     assert "0" in json.dumps(raw_request["raw_request_body"])
 
@@ -1636,40 +1627,31 @@ async def test_gemini_flash_to_pro_fallback_thinking_budget_zero():
     Fix: _map_thinking_param skips thinkingBudget=0 for non-Flash models.
     Flash-family models support disabling thinking via thinkingBudget=0; Pro does not.
     """
+    import os
     from unittest.mock import patch
     from litellm import Router
     from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
         VertexGeminiConfig,
     )
 
-    # Patch model_cost to declare Flash support for thinkingBudget=0.
-    # In CI, litellm fetches the remote JSON from GitHub main which won't have
-    # this flag until after the PR merges, so we inject it here explicitly.
-    # _map_thinking_param receives the stripped model name ("gemini-2.5-flash"),
-    # which resolves to key "gemini-2.5-flash" in model_cost (vertex_ai provider).
-    flash_cost_patch = {
-        "gemini-2.5-flash": {
-            **litellm.model_cost.get("gemini-2.5-flash", {}),
-            "supports_thinking_budget_zero": True,
-        }
-    }
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
 
-    with patch.dict(litellm.model_cost, flash_cost_patch):
-        # Translation-layer check: Pro must not receive thinkingBudget=0
-        pro_config = VertexGeminiConfig._map_thinking_param(
-            thinking_param={"type": "enabled", "budget_tokens": 0},
-            model="gemini-2.5-pro",
-        )
-        assert "thinkingBudget" not in pro_config, (
-            "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
-        )
+    # Translation-layer check: Pro must not receive thinkingBudget=0
+    pro_config = VertexGeminiConfig._map_thinking_param(
+        thinking_param={"type": "enabled", "budget_tokens": 0},
+        model="gemini-2.5-pro",
+    )
+    assert "thinkingBudget" not in pro_config, (
+        "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
+    )
 
-        # Flash must still receive thinkingBudget=0 (it supports disabling thinking)
-        flash_config = VertexGeminiConfig._map_thinking_param(
-            thinking_param={"type": "enabled", "budget_tokens": 0},
-            model="gemini-2.5-flash",
-        )
-        assert flash_config.get("thinkingBudget") == 0
+    # Flash must still receive thinkingBudget=0 (it supports disabling thinking)
+    flash_config = VertexGeminiConfig._map_thinking_param(
+        thinking_param={"type": "enabled", "budget_tokens": 0},
+        model="gemini-2.5-flash",
+    )
+    assert flash_config.get("thinkingBudget") == 0
 
     # Router-layer check: fallback from flash (429) to pro succeeds without 400
     router = Router(

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1610,3 +1610,97 @@ async def test_gemini_openai_web_search_tool_to_google_search():
     print("response: ", response.model_dump_json(indent=4))
     assert hasattr(response, "vertex_ai_grounding_metadata")
     assert getattr(response, "vertex_ai_grounding_metadata") is not None
+
+
+@pytest.mark.asyncio
+async def test_gemini_flash_to_pro_fallback_thinking_budget_zero():
+    """
+    Regression test: when gemini-2.5-flash is rate-limited and falls back to
+    gemini-2.5-pro, thinking={"type": "enabled", "budget_tokens": 0} must NOT
+    produce thinkingBudget=0 in the Pro request body. Pro rejects that with a
+    400 INVALID_ARGUMENT ("The model does not support setting thinking_budget to 0").
+
+    Fix: _map_thinking_param skips thinkingBudget=0 for non-Flash models.
+    Flash-family models support disabling thinking via thinkingBudget=0; Pro does not.
+    """
+    from unittest.mock import patch
+    from litellm import Router
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    # Translation-layer check: Pro must not receive thinkingBudget=0
+    pro_config = VertexGeminiConfig._map_thinking_param(
+        thinking_param={"type": "enabled", "budget_tokens": 0},
+        model="gemini-2.5-pro",
+    )
+    assert "thinkingBudget" not in pro_config, (
+        "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
+    )
+
+    # Flash must still receive thinkingBudget=0 (it supports disabling thinking)
+    flash_config = VertexGeminiConfig._map_thinking_param(
+        thinking_param={"type": "enabled", "budget_tokens": 0},
+        model="gemini-2.5-flash",
+    )
+    assert flash_config.get("thinkingBudget") == 0
+
+    # Router-layer check: fallback from flash (429) to pro succeeds without 400
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gemini-2.5-flash",
+                "litellm_params": {
+                    "model": "gemini/gemini-2.5-flash",
+                    "api_key": "fake-key",
+                },
+            },
+            {
+                "model_name": "gemini-2.5-pro",
+                "litellm_params": {
+                    "model": "gemini/gemini-2.5-pro",
+                    "api_key": "fake-key",
+                },
+            },
+        ],
+        fallbacks=[{"gemini-2.5-flash": ["gemini-2.5-pro"]}],
+        num_retries=0,
+    )
+
+    call_count = 0
+    pro_call_kwargs: dict = {}
+
+    async def mock_acompletion(**kwargs):
+        nonlocal call_count, pro_call_kwargs
+        call_count += 1
+        model = kwargs.get("model", "")
+        if "flash" in model:
+            raise litellm.RateLimitError(
+                message='vertex_aiException - {"error": {"code": 429, "message": "Resource exhausted.", "status": "RESOURCE_EXHAUSTED"}}',
+                llm_provider="vertex_ai",
+                model="gemini/gemini-2.5-flash",
+            )
+        pro_call_kwargs = kwargs.copy()
+        return litellm.ModelResponse(
+            id="chatcmpl-pro-mock",
+            choices=[
+                litellm.Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=litellm.Message(role="assistant", content="Hello!"),
+                )
+            ],
+            model="gemini-2.5-pro",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        response = await router.acompletion(
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "enabled", "budget_tokens": 0},
+        )
+
+    assert call_count == 2, f"Expected 2 calls (flash then pro fallback), got {call_count}"
+    assert response.choices[0].message.content == "Hello!"
+    # The thinking param reaches pro but thinkingBudget=0 is not in the translated body
+    assert pro_call_kwargs.get("thinking") == {"type": "enabled", "budget_tokens": 0}

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1642,9 +1642,9 @@ async def test_gemini_flash_to_pro_fallback_thinking_budget_zero():
         thinking_param={"type": "enabled", "budget_tokens": 0},
         model="gemini-2.5-pro",
     )
-    assert "thinkingBudget" not in pro_config, (
-        "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
-    )
+    assert (
+        "thinkingBudget" not in pro_config
+    ), "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
 
     # Flash must still receive thinkingBudget=0 (it supports disabling thinking)
     flash_config = VertexGeminiConfig._map_thinking_param(
@@ -1708,7 +1708,9 @@ async def test_gemini_flash_to_pro_fallback_thinking_budget_zero():
             thinking={"type": "enabled", "budget_tokens": 0},
         )
 
-    assert call_count == 2, f"Expected 2 calls (flash then pro fallback), got {call_count}"
+    assert (
+        call_count == 2
+    ), f"Expected 2 calls (flash then pro fallback), got {call_count}"
     assert response.choices[0].message.content == "Hello!"
     # The thinking param reaches pro but thinkingBudget=0 is not in the translated body
     assert pro_call_kwargs.get("thinking") == {"type": "enabled", "budget_tokens": 0}

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -454,23 +454,36 @@ def test_gemini_thinking():
 
 def test_gemini_thinking_budget_0():
     litellm._turn_on_debug()
+    from unittest.mock import patch
     from litellm.types.utils import Message, CallTypes
     from litellm.utils import return_raw_request
     import json
 
-    raw_request = return_raw_request(
-        endpoint=CallTypes.completion,
-        kwargs={
-            "model": "gemini/gemini-2.5-flash",
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Explain the concept of Occam's Razor and provide a simple, everyday example",
-                }
-            ],
-            "thinking": {"type": "enabled", "budget_tokens": 0},
-        },
-    )
+    # Inject supports_thinking_budget_zero so the translation layer emits
+    # thinkingBudget=0 for Flash regardless of whether the remote JSON has the
+    # flag yet (CI fetches GitHub main which lags behind this PR).
+    # _map_thinking_param receives the stripped model name ("gemini-2.5-flash"),
+    # which resolves to key "gemini-2.5-flash" in model_cost (vertex_ai provider).
+    flash_cost_patch = {
+        "gemini-2.5-flash": {
+            **litellm.model_cost.get("gemini-2.5-flash", {}),
+            "supports_thinking_budget_zero": True,
+        }
+    }
+    with patch.dict(litellm.model_cost, flash_cost_patch):
+        raw_request = return_raw_request(
+            endpoint=CallTypes.completion,
+            kwargs={
+                "model": "gemini/gemini-2.5-flash",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Explain the concept of Occam's Razor and provide a simple, everyday example",
+                    }
+                ],
+                "thinking": {"type": "enabled", "budget_tokens": 0},
+            },
+        )
     print(json.dumps(raw_request, indent=4, default=str))
     assert "0" in json.dumps(raw_request["raw_request_body"])
 
@@ -1629,21 +1642,34 @@ async def test_gemini_flash_to_pro_fallback_thinking_budget_zero():
         VertexGeminiConfig,
     )
 
-    # Translation-layer check: Pro must not receive thinkingBudget=0
-    pro_config = VertexGeminiConfig._map_thinking_param(
-        thinking_param={"type": "enabled", "budget_tokens": 0},
-        model="gemini-2.5-pro",
-    )
-    assert "thinkingBudget" not in pro_config, (
-        "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
-    )
+    # Patch model_cost to declare Flash support for thinkingBudget=0.
+    # In CI, litellm fetches the remote JSON from GitHub main which won't have
+    # this flag until after the PR merges, so we inject it here explicitly.
+    # _map_thinking_param receives the stripped model name ("gemini-2.5-flash"),
+    # which resolves to key "gemini-2.5-flash" in model_cost (vertex_ai provider).
+    flash_cost_patch = {
+        "gemini-2.5-flash": {
+            **litellm.model_cost.get("gemini-2.5-flash", {}),
+            "supports_thinking_budget_zero": True,
+        }
+    }
 
-    # Flash must still receive thinkingBudget=0 (it supports disabling thinking)
-    flash_config = VertexGeminiConfig._map_thinking_param(
-        thinking_param={"type": "enabled", "budget_tokens": 0},
-        model="gemini-2.5-flash",
-    )
-    assert flash_config.get("thinkingBudget") == 0
+    with patch.dict(litellm.model_cost, flash_cost_patch):
+        # Translation-layer check: Pro must not receive thinkingBudget=0
+        pro_config = VertexGeminiConfig._map_thinking_param(
+            thinking_param={"type": "enabled", "budget_tokens": 0},
+            model="gemini-2.5-pro",
+        )
+        assert "thinkingBudget" not in pro_config, (
+            "thinkingBudget=0 must not be sent to Pro — it causes a 400 INVALID_ARGUMENT"
+        )
+
+        # Flash must still receive thinkingBudget=0 (it supports disabling thinking)
+        flash_config = VertexGeminiConfig._map_thinking_param(
+            thinking_param={"type": "enabled", "budget_tokens": 0},
+            model="gemini-2.5-flash",
+        )
+        assert flash_config.get("thinkingBudget") == 0
 
     # Router-layer check: fallback from flash (429) to pro succeeds without 400
     router = Router(

--- a/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
@@ -57,13 +57,34 @@ class TestMapThinkingParamBudgetZero:
         assert result.get("includeThoughts") is True
 
     def test_model_supports_thinking_budget_zero_flash(self, local_model_cost_map):
-        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash") is True
-        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini/gemini-2.5-flash") is True
-        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash-lite") is True
+        assert (
+            VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash")
+            is True
+        )
+        assert (
+            VertexGeminiConfig._model_supports_thinking_budget_zero(
+                "gemini/gemini-2.5-flash"
+            )
+            is True
+        )
+        assert (
+            VertexGeminiConfig._model_supports_thinking_budget_zero(
+                "gemini-2.5-flash-lite"
+            )
+            is True
+        )
 
     def test_model_supports_thinking_budget_zero_pro(self):
-        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-pro") is False
-        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini/gemini-2.5-pro") is False
+        assert (
+            VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-pro")
+            is False
+        )
+        assert (
+            VertexGeminiConfig._model_supports_thinking_budget_zero(
+                "gemini/gemini-2.5-pro"
+            )
+            is False
+        )
 
     def test_model_supports_thinking_budget_zero_none(self):
         assert VertexGeminiConfig._model_supports_thinking_budget_zero(None) is False

--- a/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+import os
 
 import pytest
 
@@ -7,30 +7,13 @@ from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     VertexGeminiConfig,
 )
 
-# Keys that _get_model_info_helper resolves to for Flash models when the remote
-# model_cost JSON is used (which won't have the flag until after this PR merges).
-_FLASH_MODEL_COST_KEYS = [
-    "gemini-2.5-flash",
-    "gemini/gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
-    "gemini/gemini-2.5-flash-lite",
-]
-
 
 @pytest.fixture()
-def flash_model_cost_flags():
-    """Inject supports_thinking_budget_zero=True into model_cost for Flash models.
-
-    In CI, litellm fetches the remote model_cost JSON from GitHub main, which
-    won't have this flag until after the PR merges. Patching model_cost here
-    makes tests independent of the remote file state.
-    """
-    patch_entries = {
-        key: {**litellm.model_cost.get(key, {}), "supports_thinking_budget_zero": True}
-        for key in _FLASH_MODEL_COST_KEYS
-    }
-    with patch.dict(litellm.model_cost, patch_entries):
-        yield
+def local_model_cost_map():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    yield
+    del os.environ["LITELLM_LOCAL_MODEL_COST_MAP"]
 
 
 class TestMapThinkingParamBudgetZero:
@@ -50,7 +33,7 @@ class TestMapThinkingParamBudgetZero:
         )
         assert "thinkingBudget" not in result
 
-    def test_flash_budget_zero_emits_thinking_budget(self, flash_model_cost_flags):
+    def test_flash_budget_zero_emits_thinking_budget(self, local_model_cost_map):
         result = VertexGeminiConfig._map_thinking_param(
             thinking_param={"type": "enabled", "budget_tokens": 0},
             model="gemini-2.5-flash",
@@ -73,7 +56,7 @@ class TestMapThinkingParamBudgetZero:
         assert result.get("thinkingBudget") == 1024
         assert result.get("includeThoughts") is True
 
-    def test_model_supports_thinking_budget_zero_flash(self, flash_model_cost_flags):
+    def test_model_supports_thinking_budget_zero_flash(self, local_model_cost_map):
         assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash") is True
         assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini/gemini-2.5-flash") is True
         assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash-lite") is True

--- a/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
@@ -1,8 +1,36 @@
+from unittest.mock import patch
+
 import pytest
 
+import litellm
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     VertexGeminiConfig,
 )
+
+# Keys that _get_model_info_helper resolves to for Flash models when the remote
+# model_cost JSON is used (which won't have the flag until after this PR merges).
+_FLASH_MODEL_COST_KEYS = [
+    "gemini-2.5-flash",
+    "gemini/gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "gemini/gemini-2.5-flash-lite",
+]
+
+
+@pytest.fixture()
+def flash_model_cost_flags():
+    """Inject supports_thinking_budget_zero=True into model_cost for Flash models.
+
+    In CI, litellm fetches the remote model_cost JSON from GitHub main, which
+    won't have this flag until after the PR merges. Patching model_cost here
+    makes tests independent of the remote file state.
+    """
+    patch_entries = {
+        key: {**litellm.model_cost.get(key, {}), "supports_thinking_budget_zero": True}
+        for key in _FLASH_MODEL_COST_KEYS
+    }
+    with patch.dict(litellm.model_cost, patch_entries):
+        yield
 
 
 class TestMapThinkingParamBudgetZero:
@@ -22,7 +50,7 @@ class TestMapThinkingParamBudgetZero:
         )
         assert "thinkingBudget" not in result
 
-    def test_flash_budget_zero_emits_thinking_budget(self):
+    def test_flash_budget_zero_emits_thinking_budget(self, flash_model_cost_flags):
         result = VertexGeminiConfig._map_thinking_param(
             thinking_param={"type": "enabled", "budget_tokens": 0},
             model="gemini-2.5-flash",
@@ -45,7 +73,7 @@ class TestMapThinkingParamBudgetZero:
         assert result.get("thinkingBudget") == 1024
         assert result.get("includeThoughts") is True
 
-    def test_model_supports_thinking_budget_zero_flash(self):
+    def test_model_supports_thinking_budget_zero_flash(self, flash_model_cost_flags):
         assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash") is True
         assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini/gemini-2.5-flash") is True
         assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash-lite") is True

--- a/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_thinking_param.py
@@ -1,0 +1,58 @@
+import pytest
+
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+    VertexGeminiConfig,
+)
+
+
+class TestMapThinkingParamBudgetZero:
+    """
+    Tests for the thinkingBudget=0 handling in _map_thinking_param.
+
+    Gemini 2.5 Flash accepts thinkingBudget=0 to disable thinking.
+    Gemini 2.5 Pro rejects it with 400 INVALID_ARGUMENT.
+    When a router falls back from Flash (rate-limited) to Pro, the same
+    thinking param must not produce thinkingBudget=0 in the Pro request body.
+    """
+
+    def test_pro_budget_zero_omits_thinking_budget(self):
+        result = VertexGeminiConfig._map_thinking_param(
+            thinking_param={"type": "enabled", "budget_tokens": 0},
+            model="gemini-2.5-pro",
+        )
+        assert "thinkingBudget" not in result
+
+    def test_flash_budget_zero_emits_thinking_budget(self):
+        result = VertexGeminiConfig._map_thinking_param(
+            thinking_param={"type": "enabled", "budget_tokens": 0},
+            model="gemini-2.5-flash",
+        )
+        assert result.get("thinkingBudget") == 0
+
+    def test_flash_nonzero_budget_emits_thinking_budget(self):
+        result = VertexGeminiConfig._map_thinking_param(
+            thinking_param={"type": "enabled", "budget_tokens": 1024},
+            model="gemini-2.5-flash",
+        )
+        assert result.get("thinkingBudget") == 1024
+        assert result.get("includeThoughts") is True
+
+    def test_pro_nonzero_budget_emits_thinking_budget(self):
+        result = VertexGeminiConfig._map_thinking_param(
+            thinking_param={"type": "enabled", "budget_tokens": 1024},
+            model="gemini-2.5-pro",
+        )
+        assert result.get("thinkingBudget") == 1024
+        assert result.get("includeThoughts") is True
+
+    def test_model_supports_thinking_budget_zero_flash(self):
+        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash") is True
+        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini/gemini-2.5-flash") is True
+        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-flash-lite") is True
+
+    def test_model_supports_thinking_budget_zero_pro(self):
+        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini-2.5-pro") is False
+        assert VertexGeminiConfig._model_supports_thinking_budget_zero("gemini/gemini-2.5-pro") is False
+
+    def test_model_supports_thinking_budget_zero_none(self):
+        assert VertexGeminiConfig._model_supports_thinking_budget_zero(None) is False

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -773,6 +773,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},
                 "supports_max_reasoning_effort": {"type": "boolean"},
+                "supports_thinking_budget_zero": {"type": "boolean"},
                 "supports_service_tier": {"type": "boolean"},
                 "supports_preset": {"type": "boolean"},
                 "tool_use_system_prompt_tokens": {"type": "number"},

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -2826,9 +2826,9 @@ def test_gemini_embedding_2_ga_in_cost_map():
         assert info.get("input_cost_per_audio_per_second") == 0.00016
         assert info.get("input_cost_per_video_per_second") == 0.00079
         if provider in ("vertex_ai-embedding-models", "vertex_ai"):
-            assert info.get("uses_embed_content") is True, (
-                f"{key} must have uses_embed_content=true for correct Vertex AI routing"
-            )
+            assert (
+                info.get("uses_embed_content") is True
+            ), f"{key} must have uses_embed_content=true for correct Vertex AI routing"
 
 
 def test_gemini_lyria_3_preview_models_in_cost_map():


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before:

```
Message: LLM API call failed: `litellm.RateLimitError: litellm.RateLimitError: vertex_aiException - {
  "error": {
    "code": 429,
    "message": "Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.",
    "status": "RESOURCE_EXHAUSTED"
  }
}
. Received Model Group=gemini-2.5-flash
Available Model Group Fallbacks=['gemini-2.5-pro']
Error doing the fallback: litellm.BadRequestError: Vertex_aiException BadRequestError - {
  "error": {
    "code": 400,
    "message": "Unable to submit request because The model does not support setting thinking_budget to 0.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini",
    "status": "INVALID_ARGUMENT"
  }
}
```

Now: no error log

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

When a router falls back from gemini-2.5-flash (429) to gemini-2.5-pro, LiteLLM was forwarding thinkingBudget: 0 to Pro. Pro rejects that with 400 INVALID_ARGUMENT: The model does not support setting thinking_budget to 0.

This PR fixes the issue; _map_thinking_param now skips emitting thinkingBudget: 0 for non-Flash models. Flash-family models support disabling thinking this way; Pro does not. Non-zero budgets are unaffected.