### PR TITLE
fix(websearch_interception): preserve custom api_base/api_key in agentic follow-up

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -851,6 +851,17 @@ class WebSearchInterceptionLogger(CustomLogger):
                 "agentic_loop_params", {}
             )
             full_model_name = agentic_params.get("model", model)
+            # Preserve deployment-specific credentials in the follow-up
+            # request. Without these, the follow-up call falls back to
+            # provider env vars (e.g. ANTHROPIC_API_KEY) and the default
+            # public api_base, causing 401s and deployment cooldown
+            # cascades for routed deployments (#26389).
+            agentic_api_key = agentic_params.get("api_key")
+            agentic_api_base = agentic_params.get("api_base")
+            if agentic_api_key is not None and "api_key" not in kwargs_for_followup:
+                kwargs_for_followup["api_key"] = agentic_api_key
+            if agentic_api_base is not None and "api_base" not in kwargs_for_followup:
+                kwargs_for_followup["api_base"] = agentic_api_base
         verbose_logger.debug(
             "WebSearchInterception: Built anthropic request patch "
             "[call_id=%s model=%s messages=%d searches=%d]",

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -368,10 +368,21 @@ def anthropic_messages_handler(
     # Store agentic loop params in logging object for agentic hooks
     # This provides original request context needed for follow-up calls
     if litellm_logging_obj is not None:
-        litellm_logging_obj.model_call_details["agentic_loop_params"] = {
+        agentic_loop_params: Dict[str, Any] = {
             "model": original_model,
             "custom_llm_provider": custom_llm_provider,
         }
+        # Preserve the deployment-specific credentials resolved by
+        # get_llm_provider() so agentic follow-up requests (e.g. websearch
+        # interception) target the same api_base / api_key as the initial
+        # call, instead of falling back to provider env vars (#26389).
+        if dynamic_api_key is not None:
+            agentic_loop_params["api_key"] = dynamic_api_key
+        if dynamic_api_base is not None:
+            agentic_loop_params["api_base"] = dynamic_api_base
+        litellm_logging_obj.model_call_details["agentic_loop_params"] = (
+            agentic_loop_params
+        )
 
         # Check if stream was converted for WebSearch interception
         # This is set in the async wrapper above when stream=True is converted to stream=False

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -40,7 +40,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing_extensions import Required, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 from litellm._uuid import uuid
 from litellm.types.llms.base import (
@@ -164,7 +164,7 @@ class AgenticLoopParams(TypedDict, total=False):
     custom_llm_provider: str
     """The LLM provider name (e.g., 'bedrock', 'anthropic')"""
 
-    api_key: str
+    api_key: NotRequired[Optional[str]]
     """Deployment-specific API key resolved by get_llm_provider() (optional).
 
     Stored so agentic follow-up calls (e.g. websearch interception) reuse the
@@ -172,7 +172,7 @@ class AgenticLoopParams(TypedDict, total=False):
     provider env vars.
     """
 
-    api_base: str
+    api_base: NotRequired[Optional[str]]
     """Deployment-specific API base URL resolved by get_llm_provider() (optional)."""
 
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -164,6 +164,17 @@ class AgenticLoopParams(TypedDict, total=False):
     custom_llm_provider: str
     """The LLM provider name (e.g., 'bedrock', 'anthropic')"""
 
+    api_key: str
+    """Deployment-specific API key resolved by get_llm_provider() (optional).
+
+    Stored so agentic follow-up calls (e.g. websearch interception) reuse the
+    same credentials as the initial request instead of falling back to
+    provider env vars.
+    """
+
+    api_base: str
+    """Deployment-specific API base URL resolved by get_llm_provider() (optional)."""
+
 
 class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     key: Required[str]  # the key in litellm.model_cost which is returned

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -380,3 +380,120 @@ async def test_deployment_hook_converts_stream_and_logging_obj_syncs():
         logging_obj.stream = _hook_stream
 
     assert logging_obj.stream is False
+
+
+@pytest.mark.asyncio
+async def test_followup_request_preserves_custom_api_base_and_api_key():
+    """
+    Regression test for #26389.
+
+    When the initial request was routed to a deployment with custom
+    api_base / api_key, the websearch interception follow-up call must
+    preserve those credentials. Without this, the follow-up falls back
+    to provider env vars and the default api_base, causing 401 and
+    deployment cooldown cascade.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["anthropic"])
+    logger._execute_search = AsyncMock(  # type: ignore
+        return_value="Title: LiteLLM\nURL: docs\nSnippet: test"
+    )
+
+    tools_dict = {
+        "tool_calls": [
+            {
+                "id": "toolu_xyz",
+                "type": "tool_use",
+                "name": "litellm_web_search",
+                "input": {"query": "what is litellm"},
+            }
+        ],
+        "response_format": "anthropic",
+    }
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {
+        "agentic_loop_params": {
+            "model": "anthropic/claude-3-5-sonnet",
+            "custom_llm_provider": "anthropic",
+            "api_key": "deployment-specific-key",
+            "api_base": "https://my-proxy.example.com/v1",
+        }
+    }
+
+    plan = await logger.async_build_agentic_loop_plan(
+        tools=tools_dict,
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "search"}],
+        response=None,
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={
+            "max_tokens": 1024,
+            "tools": [{"name": "litellm_web_search"}],
+        },
+        logging_obj=logging_obj,
+        stream=False,
+        kwargs={"temperature": 0.2},
+    )
+
+    assert plan.run_agentic_loop is True
+    assert plan.request_patch is not None
+    followup_kwargs = plan.request_patch.kwargs
+    assert followup_kwargs.get("api_key") == "deployment-specific-key"
+    assert followup_kwargs.get("api_base") == "https://my-proxy.example.com/v1"
+
+
+@pytest.mark.asyncio
+async def test_followup_request_does_not_override_user_provided_api_credentials():
+    """
+    If the caller already explicitly passed api_key / api_base in kwargs,
+    those values should win over the agentic_loop_params copies (caller
+    intent is preserved).
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["anthropic"])
+    logger._execute_search = AsyncMock(  # type: ignore
+        return_value="Title: LiteLLM\nURL: docs\nSnippet: test"
+    )
+
+    tools_dict = {
+        "tool_calls": [
+            {
+                "id": "toolu_abc",
+                "type": "tool_use",
+                "name": "litellm_web_search",
+                "input": {"query": "x"},
+            }
+        ],
+        "response_format": "anthropic",
+    }
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {
+        "agentic_loop_params": {
+            "model": "anthropic/claude-3-5-sonnet",
+            "custom_llm_provider": "anthropic",
+            "api_key": "from-agentic-params",
+            "api_base": "https://from-agentic-params.example.com/v1",
+        }
+    }
+
+    plan = await logger.async_build_agentic_loop_plan(
+        tools=tools_dict,
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "search"}],
+        response=None,
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={
+            "max_tokens": 1024,
+            "tools": [{"name": "litellm_web_search"}],
+        },
+        logging_obj=logging_obj,
+        stream=False,
+        kwargs={
+            "temperature": 0.2,
+            "api_key": "explicit-caller-key",
+            "api_base": "https://explicit-caller.example.com/v1",
+        },
+    )
+
+    assert plan.request_patch is not None
+    followup_kwargs = plan.request_patch.kwargs
+    assert followup_kwargs.get("api_key") == "explicit-caller-key"
+    assert followup_kwargs.get("api_base") == "https://explicit-caller.example.com/v1"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -499,3 +499,91 @@ class TestThinkingSummaryPreservation:
         assert result == {
             "reasoning_effort": {"effort": "medium", "summary": "concise"}
         }
+
+
+def test_agentic_loop_params_preserves_dynamic_api_key_and_api_base():
+    """
+    Regression test for #26389.
+
+    When get_llm_provider() returns deployment-specific dynamic_api_key /
+    dynamic_api_base, those values must be stored in
+    logging_obj.model_call_details["agentic_loop_params"] so agentic
+    follow-up calls (e.g. websearch interception) reuse the same
+    credentials instead of falling back to provider env vars.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+
+    with (
+        patch(
+            "litellm.get_llm_provider",
+            return_value=(
+                "claude-3-5-sonnet",
+                "anthropic",
+                "deployment-specific-key",
+                "https://my-proxy.example.com/v1",
+            ),
+        ),
+        patch("litellm.completion", return_value="test-response"),
+    ):
+        try:
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "hi"}],
+                model="anthropic/claude-3-5-sonnet",
+                custom_llm_provider="anthropic",
+                api_key="deployment-specific-key",
+                api_base="https://my-proxy.example.com/v1",
+                litellm_logging_obj=logging_obj,
+            )
+        except (ValueError, TypeError, AttributeError):
+            pass
+
+    agentic_loop_params = logging_obj.model_call_details.get("agentic_loop_params")
+    assert agentic_loop_params is not None
+    assert agentic_loop_params["model"] == "anthropic/claude-3-5-sonnet"
+    assert agentic_loop_params["custom_llm_provider"] == "anthropic"
+    assert agentic_loop_params["api_key"] == "deployment-specific-key"
+    assert agentic_loop_params["api_base"] == "https://my-proxy.example.com/v1"
+
+
+def test_agentic_loop_params_omits_keys_when_dynamic_values_are_none():
+    """
+    When get_llm_provider() returns no dynamic_api_key / dynamic_api_base
+    (typical for default provider config), the agentic_loop_params dict
+    should NOT contain api_key / api_base keys, so downstream code can
+    fall back to its existing resolution logic.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages_handler,
+    )
+
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+
+    with (
+        patch(
+            "litellm.get_llm_provider",
+            return_value=("claude-3-5-sonnet", "anthropic", None, None),
+        ),
+        patch("litellm.completion", return_value="test-response"),
+    ):
+        try:
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "hi"}],
+                model="anthropic/claude-3-5-sonnet",
+                custom_llm_provider="anthropic",
+                litellm_logging_obj=logging_obj,
+            )
+        except (ValueError, TypeError, AttributeError):
+            pass
+
+    agentic_loop_params = logging_obj.model_call_details.get("agentic_loop_params")
+    assert agentic_loop_params is not None
+    assert "api_key" not in agentic_loop_params
+    assert "api_base" not in agentic_loop_params

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -530,7 +530,7 @@ def test_agentic_loop_params_preserves_dynamic_api_key_and_api_base():
         ),
         patch("litellm.completion", return_value="test-response"),
     ):
-        try:
+        with pytest.raises(Exception):
             anthropic_messages_handler(
                 max_tokens=100,
                 messages=[{"role": "user", "content": "hi"}],
@@ -540,8 +540,6 @@ def test_agentic_loop_params_preserves_dynamic_api_key_and_api_base():
                 api_base="https://my-proxy.example.com/v1",
                 litellm_logging_obj=logging_obj,
             )
-        except (ValueError, TypeError, AttributeError):
-            pass
 
     agentic_loop_params = logging_obj.model_call_details.get("agentic_loop_params")
     assert agentic_loop_params is not None
@@ -572,7 +570,7 @@ def test_agentic_loop_params_omits_keys_when_dynamic_values_are_none():
         ),
         patch("litellm.completion", return_value="test-response"),
     ):
-        try:
+        with pytest.raises(Exception):
             anthropic_messages_handler(
                 max_tokens=100,
                 messages=[{"role": "user", "content": "hi"}],
@@ -580,8 +578,6 @@ def test_agentic_loop_params_omits_keys_when_dynamic_values_are_none():
                 custom_llm_provider="anthropic",
                 litellm_logging_obj=logging_obj,
             )
-        except (ValueError, TypeError, AttributeError):
-            pass
 
     agentic_loop_params = logging_obj.model_call_details.get("agentic_loop_params")
     assert agentic_loop_params is not None


### PR DESCRIPTION
## Relevant issues

Fixes #26389

## Type

🐛 Bug Fix

## Root cause

When the `websearch_interception` callback runs the agentic loop for a model whose deployment uses a custom `api_base` / `api_key`, the follow-up request after the web-search results was being sent to the provider's default endpoint (e.g. `https://api.anthropic.com`) authenticated with the env-var key (e.g. `ANTHROPIC_API_KEY`). The deployment-specific credentials were silently dropped, producing `401 Unauthorized` and triggering a deployment cooldown cascade.

Two places contributed:

1. **`litellm/llms/anthropic/experimental_pass_through/messages/handler.py`** — after calling `litellm.get_llm_provider(...)`, the handler stored only `model` and `custom_llm_provider` in `logging_obj.model_call_details["agentic_loop_params"]`, discarding the `dynamic_api_key` and `dynamic_api_base` returned alongside.

2. **`litellm/integrations/websearch_interception/handler.py`** — `_build_anthropic_request_patch` built `kwargs_for_followup` without re-injecting `api_key` / `api_base`, so the follow-up `anthropic_messages.acreate(...)` had no way to recover the deployment credentials.

## Changes

### `litellm/llms/anthropic/experimental_pass_through/messages/handler.py`

Persist the dynamic credentials returned by `get_llm_provider()` into `agentic_loop_params` (only when not `None`, so the default provider-config path is unaffected):

```python
if litellm_logging_obj is not None:
    agentic_loop_params: Dict[str, Any] = {
        "model": original_model,
        "custom_llm_provider": custom_llm_provider,
    }
    if dynamic_api_key is not None:
        agentic_loop_params["api_key"] = dynamic_api_key
    if dynamic_api_base is not None:
        agentic_loop_params["api_base"] = dynamic_api_base
    litellm_logging_obj.model_call_details["agentic_loop_params"] = agentic_loop_params
```

### `litellm/integrations/websearch_interception/handler.py`

In `_build_anthropic_request_patch`, propagate the credentials into the follow-up kwargs (without overriding values explicitly supplied by the caller):

```python
agentic_api_key = agentic_params.get("api_key")
agentic_api_base = agentic_params.get("api_base")
if agentic_api_key is not None and "api_key" not in kwargs_for_followup:
    kwargs_for_followup["api_key"] = agentic_api_key
if agentic_api_base is not None and "api_base" not in kwargs_for_followup:
    kwargs_for_followup["api_base"] = agentic_api_base
```

### `litellm/types/utils.py`

Extend `AgenticLoopParams` TypedDict with optional `api_key` / `api_base` fields and docstrings.

## Test plan

Four new mocked unit tests added; all four pass locally along with the entire existing test suites for both modules (`131 passed, 2 skipped`).

**`tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py`:**

- `test_agentic_loop_params_preserves_dynamic_api_key_and_api_base` — patches `litellm.get_llm_provider` to return `("…", "…", "deployment-specific-key", "https://my-proxy.example.com/v1")`, invokes `anthropic_messages_handler`, and asserts the resulting `logging_obj.model_call_details["agentic_loop_params"]` contains both `api_key` and `api_base`.
- `test_agentic_loop_params_omits_keys_when_dynamic_values_are_none` — when `get_llm_provider` returns `(…, …, None, None)`, asserts `api_key` / `api_base` are **not** present in `agentic_loop_params` (so existing fallback resolution is untouched).

**`tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py`:**

- `test_followup_request_preserves_custom_api_base_and_api_key` — seeds `agentic_loop_params` with custom credentials, runs `async_build_agentic_loop_plan`, and asserts `plan.request_patch.kwargs` carries the custom `api_key` / `api_base`.
- `test_followup_request_does_not_override_user_provided_api_credentials` — when the caller already provides `api_key` / `api_base` in kwargs, the explicit values must win over the `agentic_loop_params` copies.

Test command:

```bash
python -m pytest tests/test_litellm/llms/anthropic/experimental_pass_through/messages/ tests/test_litellm/integrations/websearch_interception/ -q
# 131 passed, 2 skipped, 2 warnings in 22.74s
```

## Pre-Submission checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the type definitions where required (`AgenticLoopParams`)
- [x] My changes do not introduce any new warnings
- [x] Scope is isolated to the bug — no unrelated changes
- [x] Black formatting applied to all modified files
- [x] Existing tests for affected modules continue to pass

---

_This contribution was prepared with the assistance of GitHub Copilot CLI (Claude Opus 4.7)._
