### PR TITLE
fix(proxy): handle OAuth error in SSO callback

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1308,6 +1308,15 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     """Verify login"""
     verbose_proxy_logger.info(f"Starting SSO callback with state: {state}")
 
+    oauth_error = request.query_params.get("error")
+    oauth_error_description = request.query_params.get("error_description")
+
+    if oauth_error:
+        raise HTTPException(
+            status_code=401,
+            detail=f"OAuth error: {oauth_error}, error_description: {oauth_error_description}",
+        )
+
     # Check if this is a CLI login (state starts with our CLI prefix)
     from litellm.constants import LITELLM_CLI_SESSION_TOKEN_PREFIX
     from litellm.proxy._types import LiteLLM_JWTAuth

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1312,9 +1312,18 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     oauth_error_description = request.query_params.get("error_description")
 
     if oauth_error:
+        verbose_proxy_logger.warning(
+            f"SSO callback received OAuth error: {oauth_error!r}, "
+            f"description: {oauth_error_description!r}"
+        )
         raise HTTPException(
             status_code=401,
-            detail=f"OAuth error: {oauth_error}, error_description: {oauth_error_description}",
+            detail=f"OAuth error: {oauth_error}"
+            + (
+                f", error_description: {oauth_error_description}"
+                if oauth_error_description
+                else ""
+            ),
         )
 
     # Check if this is a CLI login (state starts with our CLI prefix)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1311,19 +1311,20 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     oauth_error = request.query_params.get("error")
     oauth_error_description = request.query_params.get("error_description")
 
-    if oauth_error:
+    if isinstance(oauth_error, str) and oauth_error:
+        _err_desc = (
+            oauth_error_description
+            if isinstance(oauth_error_description, str)
+            else None
+        )
         verbose_proxy_logger.warning(
             f"SSO callback received OAuth error: {oauth_error!r}, "
-            f"description: {oauth_error_description!r}"
+            f"description: {_err_desc!r}"
         )
         raise HTTPException(
             status_code=401,
             detail=f"OAuth error: {oauth_error}"
-            + (
-                f", error_description: {oauth_error_description}"
-                if oauth_error_description
-                else ""
-            ),
+            + (f", error_description: {_err_desc}" if _err_desc else ""),
         )
 
     # Check if this is a CLI login (state starts with our CLI prefix)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -5512,3 +5512,61 @@ class TestSyncUserRoleFromJwtRoleMap:
         )
 
         prisma.db.litellm_usertable.update.assert_not_called()
+
+
+class TestAuthCallbackOAuthError:
+    """Tests for OAuth error handling in /sso/callback (issue #26403)."""
+
+    @pytest.mark.asyncio
+    async def test_auth_callback_raises_on_oauth_error(self):
+        """When the IdP redirects back with ?error=access_denied, auth_callback
+        should raise HTTPException(401) instead of crashing on missing 'code'."""
+        from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {
+            "error": "access_denied",
+            "error_description": "The user denied the request",
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_callback(request=mock_request, state=None)
+
+        assert exc_info.value.status_code == 401
+        assert "access_denied" in str(exc_info.value.detail)
+        assert "The user denied the request" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_auth_callback_does_not_raise_when_no_oauth_error(self):
+        """Sanity: when no `error` query param is present, the new OAuth-error
+        guard does not fire and the function proceeds into the normal flow."""
+        from litellm.constants import LITELLM_CLI_SESSION_TOKEN_PREFIX
+        from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"code": "some-auth-code"}
+
+        cli_state = f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:sk-new-key:sk-existing-key"
+        mock_result = {"user_id": "test-user", "email": "test@example.com"}
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.cli_sso_callback"
+            ) as mock_cli_callback,
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.master_key", "test-master-key"),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+            patch("litellm.proxy.proxy_server.jwt_handler", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch.dict(os.environ, {"GOOGLE_CLIENT_ID": "test-google-id"}, clear=True),
+            patch(
+                "litellm.proxy.management_endpoints.ui_sso.GoogleSSOHandler.get_google_callback_response",
+                return_value=mock_result,
+            ),
+        ):
+            mock_cli_callback.return_value = MagicMock()
+
+            # Should NOT raise the new 401 HTTPException; downstream is mocked.
+            await auth_callback(request=mock_request, state=cli_state)
+
+            mock_cli_callback.assert_called_once()

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -5537,6 +5537,23 @@ class TestAuthCallbackOAuthError:
         assert "The user denied the request" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
+    async def test_auth_callback_omits_error_description_when_absent(self):
+        """When the IdP redirects with `?error=...` but no `error_description`,
+        the detail string should not contain the literal substring 'None'."""
+        from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"error": "access_denied"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_callback(request=mock_request, state=None)
+
+        assert exc_info.value.status_code == 401
+        assert "access_denied" in str(exc_info.value.detail)
+        assert "None" not in str(exc_info.value.detail)
+        assert "error_description" not in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
     async def test_auth_callback_does_not_raise_when_no_oauth_error(self):
         """Sanity: when no `error` query param is present, the new OAuth-error
         guard does not fire and the function proceeds into the normal flow."""


### PR DESCRIPTION
## Relevant issues

Fixes #26403

## Type

🐛 Bug Fix

## Root cause

When an IdP (e.g. Okta) denies SSO access, it redirects the user back to LiteLLM's `/sso/callback` URL with `?error=access_denied&error_description=...` query params and **no** `code` parameter. The existing `auth_callback` handler in `litellm/proxy/management_endpoints/ui_sso.py` assumed `code` was always present and produced an unhelpful error/crash for the user instead of surfacing the actual reason access was denied.

## Changes

- `litellm/proxy/management_endpoints/ui_sso.py` — In `auth_callback`, immediately after the existing `Starting SSO callback with state: ...` log line, inspect `request.query_params` for an `error` (and `error_description`). If present, raise `HTTPException(status_code=401, detail="OAuth error: <error>, error_description: <description>")` so the caller sees a clean, actionable 401.
- `tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` — Added `TestAuthCallbackOAuthError` with two mocked unit tests:
  1. `test_auth_callback_raises_on_oauth_error` — verifies `HTTPException(401)` is raised and the detail mentions the IdP error code and description when `error=access_denied` is present.
  2. `test_auth_callback_does_not_raise_when_no_oauth_error` — sanity check: when `error` is absent and `code` is supplied, the new guard does not fire and the function proceeds to the normal flow (downstream is mocked).

The fix is minimal and isolated to the callback handler — no other behavior is changed.

## Test plan

```
python -m pytest tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::TestAuthCallbackOAuthError -v
```

Result locally: **2 passed**.

No real network calls are made; everything is mocked via `unittest.mock`.

## Pre-Submission checklist

- [x] Bug fix scope is isolated to the failing path (no unrelated refactoring)
- [x] New unit tests added covering both the error and non-error branches
- [x] All new tests pass locally
- [x] Code formatted with `black`
- [x] No secrets or credentials introduced
- [x] No real HTTP calls in tests

---

_This PR was prepared with assistance from GitHub Copilot CLI (Claude Opus 4.7)._
