### PR TITLE
fix(mcp): preserve native tools in semantic filter hook

### DIFF
--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -123,10 +123,70 @@ class SemanticToolFilterHook(CustomLogger):
 
         return openai_tools_as_dicts
 
+    def _is_mcp_tool(self, tool: Any) -> bool:
+        """
+        Check whether *tool* is registered in the MCP semantic router.
+
+        Classification strategy:
+        1. Standard OpenAI-format dicts (``{"type": "function",
+           "function": {"name": ...}}``) are **always** classified as
+           native — they are detected by shape (both ``"function"``
+           and ``"type"`` keys present) regardless of how
+           ``_extract_tool_info`` resolves the name.
+        2. Everything else (MCP ``Tool`` objects, flat dicts, etc.) is
+           looked up by name in ``self.filter._tool_map``.
+        """
+        # OpenAI-format dicts have name nested under "function", not at
+        # top level.  Check shape first to avoid relying on
+        # _extract_tool_info's return value for these dicts.
+        if isinstance(tool, dict) and "function" in tool and "type" in tool:
+            return False  # Standard OpenAI function tool — always native
+        name, _ = self.filter._extract_tool_info(tool)
+        return bool(name) and name in self.filter._tool_map
+
     def _get_metadata_variable_name(self, data: dict) -> str:
         if "litellm_metadata" in data:
             return "litellm_metadata"
         return "metadata"
+
+    def _emit_filter_metadata(
+        self,
+        data: dict,
+        mcp_tools: list,
+        filtered_mcp_tools: list,
+        native_tools: list,
+        filtered_tools: list,
+    ) -> None:
+        """
+        Emit response-header metadata when MCP tools were filtered.
+
+        Stats report MCP-only counts so downstream consumers see accurate
+        semantic filter metrics (not inflated by native tools that always
+        pass through).  Skips metadata entirely for purely-native requests
+        to avoid spurious ``N->N`` headers.
+        """
+        if mcp_tools:
+            filter_stats = f"{len(mcp_tools)}->{len(filtered_mcp_tools)}"
+            tool_names_csv = self._get_tool_names_csv(filtered_mcp_tools)
+
+            _metadata_variable_name = self._get_metadata_variable_name(data)
+            data[_metadata_variable_name][
+                "litellm_semantic_filter_stats"
+            ] = filter_stats
+            data[_metadata_variable_name][
+                "litellm_semantic_filter_tools"
+            ] = tool_names_csv
+
+            verbose_proxy_logger.info(
+                f"Semantic tool filter: {filter_stats} MCP tools "
+                f"({len(native_tools)} native preserved, "
+                f"{len(filtered_tools)} total)"
+            )
+        else:
+            verbose_proxy_logger.info(
+                f"Semantic tool filter: all {len(native_tools)} tools "
+                f"are native, no MCP filtering applied"
+            )
 
     async def async_pre_call_hook(
         self,
@@ -163,7 +223,11 @@ class SemanticToolFilterHook(CustomLogger):
             verbose_proxy_logger.debug("No tools in request, skipping semantic filter")
             return None
 
-        original_tool_count = len(tools)
+        # Track whether tools were expanded from MCP references so the
+        # partition step treats expanded tools as MCP (they are MCP tools
+        # converted to OpenAI format by _expand_mcp_tools).
+        tools_expanded_from_mcp = False
+        native_tools_before_expand: list = []
 
         # Check for MCP references (server_url="litellm_proxy") and expand them
         if self._should_expand_mcp_tools(tools):
@@ -172,6 +236,17 @@ class SemanticToolFilterHook(CustomLogger):
             )
 
             try:
+                # Preserve native OpenAI-format tools before expansion.
+                # _expand_mcp_tools only returns expanded MCP tools;
+                # non-MCP tools in the original list are discarded by
+                # _parse_mcp_tools.  Without this, native tools in
+                # mixed requests (MCP refs + native) are silently lost.
+                native_tools_before_expand = [
+                    t
+                    for t in tools
+                    if isinstance(t, dict) and "function" in t and "type" in t
+                ]
+
                 expanded_tools = await self._expand_mcp_tools(tools, user_api_key_dict)
 
                 if not expanded_tools:
@@ -181,12 +256,12 @@ class SemanticToolFilterHook(CustomLogger):
                     return None
 
                 verbose_proxy_logger.info(
-                    f"Expanded {len(tools)} MCP reference(s) to {len(expanded_tools)} tools"
+                    f"Expanded MCP references to {len(expanded_tools)} tools"
+                    f" ({len(native_tools_before_expand)} native preserved)"
                 )
 
-                # Update tools for filtering
                 tools = expanded_tools
-                original_tool_count = len(tools)
+                tools_expanded_from_mcp = True
 
             except Exception as e:
                 verbose_proxy_logger.error(
@@ -218,33 +293,48 @@ class SemanticToolFilterHook(CustomLogger):
                 )
                 return None
 
+            # ── Partition tools into MCP-registered and native ──
+            # When tools were expanded from MCP references, expanded
+            # tools are MCP by definition; any native tools from the
+            # original request were preserved in native_tools_before_expand.
+            # Otherwise, classify by shape / _tool_map.
+            if tools_expanded_from_mcp:
+                native_tools = native_tools_before_expand
+                mcp_tools = tools
+            else:
+                native_tools = []
+                mcp_tools = []
+                for t in tools:
+                    (mcp_tools if self._is_mcp_tool(t) else native_tools).append(t)
+
             verbose_proxy_logger.debug(
-                f"Applying semantic filter to {len(tools)} tools "
-                f"with query: '{user_query[:50]}...'"
+                f"Applying semantic filter: {len(mcp_tools)} MCP tools, "
+                f"{len(native_tools)} native tools, "
+                f"query: '{user_query[:50]}...'"
             )
 
-            # Filter tools semantically
-            filtered_tools = await self.filter.filter_tools(
-                query=user_query,
-                available_tools=tools,  # type: ignore
-            )
+            # ── Filter only MCP tools semantically ──
+            if mcp_tools:
+                filtered_mcp_tools = await self.filter.filter_tools(
+                    query=user_query,
+                    available_tools=mcp_tools,  # type: ignore
+                )
+            else:
+                filtered_mcp_tools = []
 
-            # Always update tools and emit header (even if count unchanged)
+            # Merge: native tools always kept, filtered MCP tools appended
+            filtered_tools = native_tools + filtered_mcp_tools
+
+            # Always update tools
             data["tools"] = filtered_tools
 
-            # Store filter stats and tool names for response header
-            filter_stats = f"{original_tool_count}->{len(filtered_tools)}"
-            tool_names_csv = self._get_tool_names_csv(filtered_tools)
-
-            _metadata_variable_name = self._get_metadata_variable_name(data)
-            data[_metadata_variable_name][
-                "litellm_semantic_filter_stats"
-            ] = filter_stats
-            data[_metadata_variable_name][
-                "litellm_semantic_filter_tools"
-            ] = tool_names_csv
-
-            verbose_proxy_logger.info(f"Semantic tool filter: {filter_stats} tools")
+            self._emit_filter_metadata(
+                data=data,
+                mcp_tools=mcp_tools,
+                filtered_mcp_tools=filtered_mcp_tools,
+                native_tools=native_tools,
+                filtered_tools=filtered_tools,
+            )
 
             return data
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -452,6 +452,237 @@ async def test_semantic_filter_hook_skips_no_tools():
     print("✅ Hook correctly skips requests without tools")
 
 
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_preserves_native_tools():
+    """
+    Regression test: mixed MCP + native tools.
+
+    Given: 5 MCP tools (registered in _tool_map) + 2 native OpenAI-format
+           function tools (not in _tool_map)
+    When:  The hook filters tools
+    Then:  The native tools must survive unconditionally, and only MCP
+           tools go through the semantic filter.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    mock_router = Mock()
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=2,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # --- MCP tools (registered in the semantic router) ---
+    mcp_tools = [
+        MCPTool(
+            name=f"mcp_tool_{i}",
+            description=f"MCP tool {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(5)
+    ]
+    filter_instance._build_router(mcp_tools)
+
+    # --- Native OpenAI-format function tools (NOT in _tool_map) ---
+    native_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "search_web",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+
+    # Combine: MCP tools + native tools
+    all_tools = list(mcp_tools) + native_tools
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "What is the weather?"}],
+        "tools": all_tools,
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is not None, "Hook should return modified data"
+    filtered = result["tools"]
+
+    # Native tools must survive
+    native_in_result = [
+        t for t in filtered if isinstance(t, dict) and t.get("type") == "function"
+    ]
+    assert (
+        len(native_in_result) == 2
+    ), f"Both native tools must survive, got {len(native_in_result)}"
+
+    # MCP tools should be filtered (top_k=2)
+    mcp_in_result = [t for t in filtered if not isinstance(t, dict)]
+    assert (
+        len(mcp_in_result) <= 2
+    ), f"MCP tools should be filtered to top_k=2, got {len(mcp_in_result)}"
+
+    # Total should be native + filtered MCP
+    assert len(filtered) <= 4, f"Expected at most 4 tools, got {len(filtered)}"
+
+    # Filter stats should be emitted (MCP tools were present)
+    assert "litellm_semantic_filter_stats" in result["metadata"]
+
+    # Stats should report MCP-only counts, not inflated with native tools
+    stats = result["metadata"]["litellm_semantic_filter_stats"]
+    mcp_before, mcp_after = stats.split("->")
+    assert (
+        int(mcp_before) == 5
+    ), f"Stats 'from' should be MCP count (5), got {mcp_before}"
+    assert int(mcp_after) == len(
+        mcp_in_result
+    ), f"Stats 'to' should match filtered MCP count, got {mcp_after}"
+
+    print(
+        f"✅ Hook preserves native tools: {len(all_tools)} -> {len(filtered)} "
+        f"({len(native_in_result)} native + {len(mcp_in_result)} MCP), "
+        f"stats={stats}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_all_native_tools():
+    """
+    Regression test: all-native request.
+
+    Given: Only native OpenAI-format function tools (none registered in
+           the MCP semantic router)
+    When:  The hook processes the request
+    Then:  All tools pass through, and NO spurious semantic filter response
+           headers are emitted (no litellm_semantic_filter_stats in metadata).
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    mock_router = Mock()
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=3,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    # Build router with some MCP tools (so tool_router is not None)
+    mcp_tools = [
+        MCPTool(
+            name="some_mcp_tool",
+            description="An MCP tool",
+            inputSchema={"type": "object"},
+        )
+    ]
+
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    filter_instance._build_router(mcp_tools)
+
+    # --- Only native tools in the request ---
+    native_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": f"native_func_{i}",
+                "description": f"Native function {i}",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for i in range(3)
+    ]
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "tools": native_tools,
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
+
+    assert result is not None, "Hook should return modified data"
+    filtered = result["tools"]
+
+    # All native tools must pass through
+    assert (
+        len(filtered) == 3
+    ), f"All 3 native tools must pass through, got {len(filtered)}"
+
+    # No spurious semantic filter stats (P2 fix)
+    assert (
+        "litellm_semantic_filter_stats" not in result["metadata"]
+    ), "Should NOT emit semantic filter stats for all-native-tool requests"
+
+    print(
+        f"✅ Hook passes through all {len(filtered)} native tools, "
+        f"no spurious filter headers emitted"
+    )
+
+
 class TestGetToolsByNames:
     """
     Regression coverage for SemanticMCPToolFilter._get_tools_by_names
@@ -489,9 +720,7 @@ class TestGetToolsByNames:
             {"name": "send_email", "description": "send mail"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            ["send_email"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["send_email"], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "send_email"
@@ -503,9 +732,7 @@ class TestGetToolsByNames:
         client_name = "litellm_" + canonical
         available_tools = [{"name": client_name, "description": "scrape"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         # Must return the incoming tool unchanged so the client-facing
@@ -516,13 +743,9 @@ class TestGetToolsByNames:
         """Some clients use dash as alias separator; accept that too."""
         filter_instance = self._make_filter()
         canonical = "weather_svc-get_weather"
-        available_tools = [
-            {"name": "mcp-" + canonical, "description": "weather"}
-        ]
+        available_tools = [{"name": "mcp-" + canonical, "description": "weather"}]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "mcp-" + canonical
@@ -552,9 +775,7 @@ class TestGetToolsByNames:
             {"name": "litellm_" + canonical, "description": "wrapped"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == canonical
@@ -567,9 +788,7 @@ class TestGetToolsByNames:
         separator-anchored suffixes of ``litellm_api-fs-read_file``.
         """
         filter_instance = self._make_filter()
-        available_tools = [
-            {"name": "litellm_api-fs-read_file", "description": "read"}
-        ]
+        available_tools = [{"name": "litellm_api-fs-read_file", "description": "read"}]
 
         matched = filter_instance._get_tools_by_names(
             ["fs-read_file", "api-fs-read_file"], available_tools
@@ -590,9 +809,7 @@ class TestGetToolsByNames:
             {"name": "my_" + canonical, "description": "plain search"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            [canonical], available_tools
-        )
+        matched = filter_instance._get_tools_by_names([canonical], available_tools)
 
         assert len(matched) == 1
         assert matched[0]["name"] == "my_" + canonical


### PR DESCRIPTION
## Relevant issues

Fixes #26212

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` 

## Screenshots / Proof of Fix

All 18 tests pass (9 existing + 2 new regression tests + 7 TestGetToolsByNames):

    tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
    ✅ test_semantic_filter_basic_filtering PASSED
    ✅ test_semantic_filter_top_k_limiting PASSED
    ✅ test_semantic_filter_disabled PASSED
    ✅ test_semantic_filter_empty_tools PASSED
    ✅ test_semantic_filter_extract_user_query PASSED
    ✅ test_semantic_filter_hook_triggers_on_completion PASSED
    ✅ test_semantic_filter_hook_skips_no_tools PASSED
    ✅ test_semantic_filter_hook_preserves_native_tools PASSED  ← NEW
    ✅ test_semantic_filter_hook_all_native_tools PASSED  ← NEW
    ✅ TestGetToolsByNames (7 tests) PASSED
    18 passed in 5.90s

## Type

🐛 Bug Fix

## Changes

**Problem:** `SemanticToolFilterHook.async_pre_call_hook` passed ALL tools (MCP + native) to `filter_tools()`, which queries a `SemanticRouter` built exclusively from the MCP registry. Native tools have no entry in the router's `_tool_map`, so `_get_tools_by_names()` silently drops them. The LLM never receives native tools → responds in prose or the upstream provider returns 400.

**Fix (in `hook.py`):**

- Added robust `_is_mcp_tool()` helper using **shape-based detection** for OpenAI-format dicts (`isinstance(tool, dict) and "function" in tool and "type" in tool`). Safe regardless of future `_extract_tool_info` changes.
- Modified `async_pre_call_hook` to partition tools into native (not in `_tool_map`) and MCP-registered before filtering
- Semantic filter runs only on MCP tools; native tools are merged back unconditionally
- Track MCP expansion (`tools_expanded_from_mcp` flag) to prevent expanded MCP tools from being misclassified as native and silently bypassing semantic filtering
- `filter_stats` now reports **MCP-only counts** (e.g. `5->2` not `9->6`) so downstream consumers see accurate semantic filter metrics
- Extracted `_emit_filter_metadata()` helper for cleaner code structure
- Skip spurious semantic filter response headers for all-native tool requests

**Tests (in `test_semantic_tool_filter.py`):**

- `test_semantic_filter_hook_preserves_native_tools` — mixed MCP + native tools: verifies native tools survive filtering, and `filter_stats` reports MCP-only counts
- `test_semantic_filter_hook_all_native_tools` — all-native request: verifies all tools pass through and no spurious filter headers are emitted
