### PR TITLE
fix: honor `think: false` to disable reasoning (#26413)

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -79,6 +79,19 @@ class BaseLLMException(Exception):
 
 
 class BaseConfig(ABC):
+    # Per-provider capability flag: ``True`` means this provider's
+    # ``map_openai_params`` / ``_map_reasoning_effort`` (or equivalent)
+    # accepts the literal value ``reasoning_effort="disable"`` and translates
+    # it into a real "no reasoning" signal upstream (e.g. Gemini's
+    # ``thinkingConfig.thinkingBudget = 0``, Ollama's native ``think=False``).
+    # Providers that only accept ``low|medium|high|minimal|none|None`` and
+    # would raise on ``"disable"`` (Anthropic, Bedrock, OpenAI o-series, ...)
+    # must leave this as ``False``. Used by
+    # ``litellm.utils._think_to_reasoning_effort`` to decide whether the
+    # Ollama-style ``"think": false`` request flag should be translated to
+    # ``reasoning_effort="disable"`` for this provider, or silently dropped.
+    supports_reasoning_disable: bool = False
+
     def __init__(self):
         pass
 

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -47,6 +47,9 @@ else:
 
 
 class OllamaChatConfig(BaseConfig):
+    # See OllamaConfig: `reasoning_effort="disable"` is mapped to the native
+    # `think=False` parameter upstream, so it is safe to inject for `think:false`.
+    supports_reasoning_disable: bool = True
     """
     Reference: https://github.com/ollama/ollama/blob/main/docs/api.md#parameters
 

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -40,6 +40,10 @@ else:
 
 
 class OllamaConfig(BaseConfig):
+    # Ollama natively understands `think=False`, and litellm's existing
+    # `reasoning_effort="disable"` -> `think=False` mapping turns the OpenAI-
+    # style flag into the native one upstream. Safe to inject "disable".
+    supports_reasoning_disable: bool = True
     """
     Reference: https://github.com/ollama/ollama/blob/main/docs/api.md#parameters
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -168,6 +168,10 @@ class VertexAIBaseConfig:
 
 
 class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
+    # Gemini's `thinkingConfig.thinkingBudget = 0` translates the OpenAI-style
+    # `reasoning_effort="disable"` into a real "no reasoning" upstream signal,
+    # so it is safe to inject "disable" for `think:false` requests.
+    supports_reasoning_disable: bool = True
     """
     Reference: https://cloud.google.com/vertex-ai/docs/generative-ai/chat/test-chat-prompts
     Reference: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3683,6 +3683,7 @@ def _think_to_reasoning_effort(
     think_value: Any,
     non_default_params: dict,
     supported_params: List[str],
+    custom_llm_provider: Optional[str] = None,
 ) -> None:
     """
     Translate the Ollama-style ``think`` flag (passed directly in a chat
@@ -3698,9 +3699,14 @@ def _think_to_reasoning_effort(
 
     - ``think`` falsy (``False`` / ``"false"`` / ``0`` / ``"no"`` / ``"off"``):
       set ``reasoning_effort = "disable"`` on ``non_default_params`` -- but only
-      when (a) the caller has not already supplied ``reasoning_effort`` and
-      (b) the provider lists ``reasoning_effort`` as a supported param.
-      Otherwise the flag is silently ignored.
+      when (a) the caller has not already supplied ``reasoning_effort``, (b) the
+      provider lists ``reasoning_effort`` as a supported param, and (c) the
+      provider's transformation layer is known to recognise the literal value
+      ``"disable"`` (currently Gemini / Vertex AI / Ollama). Other providers
+      (Anthropic, Bedrock, OpenAI o-series, ...) advertise ``reasoning_effort``
+      but only accept ``low|medium|high|minimal|none|None``; passing
+      ``"disable"`` to them raises ``ValueError`` / ``BadRequestError``. For
+      those providers, ``think`` is silently dropped (with a debug log).
     - ``think`` truthy: ``reasoning_effort`` is left untouched (callers that
       want to enable reasoning should pass ``reasoning_effort`` explicitly).
     - ``think`` is an unrecognized string: ignored.
@@ -3719,12 +3725,38 @@ def _think_to_reasoning_effort(
     else:
         think_bool = bool(think_value)
 
+    # Providers whose `_map_reasoning_effort` (or equivalent) accepts the
+    # literal "disable" value. Adding to this list is safe; omitting a provider
+    # that *does* accept it just means `think:false` is silently ignored there.
+    _PROVIDERS_SUPPORTING_REASONING_DISABLE = {
+        "gemini",
+        "vertex_ai",
+        "vertex_ai_beta",
+        "ollama",
+        "ollama_chat",
+    }
+
     if (
         think_bool is False
-        and not non_default_params.get("reasoning_effort")
+        and "reasoning_effort" not in non_default_params
         and "reasoning_effort" in supported_params
+        and (custom_llm_provider or "") in _PROVIDERS_SUPPORTING_REASONING_DISABLE
     ):
         non_default_params["reasoning_effort"] = "disable"
+    elif think_bool is False:
+        verbose_logger.debug(
+            "litellm: 'think=False' was passed but provider %r does not accept "
+            "reasoning_effort='disable'; dropping silently. Pass "
+            "reasoning_effort explicitly if your provider supports a "
+            "'disable'-equivalent value.",
+            custom_llm_provider,
+        )
+    elif think_bool is True:
+        verbose_logger.debug(
+            "litellm: 'think=True' was passed but is not an OpenAI-compatible "
+            "param; dropping silently. Pass 'reasoning_effort' explicitly to "
+            "enable reasoning."
+        )
 
 
 class PreProcessNonDefaultParams:
@@ -4126,6 +4158,7 @@ def get_optional_params(  # noqa: PLR0915
             think_value=_think_value,
             non_default_params=non_default_params,
             supported_params=supported_params,
+            custom_llm_provider=custom_llm_provider,
         )
 
     _check_valid_arg(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3679,6 +3679,54 @@ def filter_out_litellm_params(kwargs: dict) -> dict:
     }
 
 
+def _think_to_reasoning_effort(
+    think_value: Any,
+    non_default_params: dict,
+    supported_params: List[str],
+) -> None:
+    """
+    Translate the Ollama-style ``think`` flag (passed directly in a chat
+    completion request body) into the OpenAI-style ``reasoning_effort`` param.
+
+    Some clients send ``"think": false`` (or ``"false"``) to disable reasoning.
+    Because ``think`` is not part of the OpenAI-compatible param surface, it is
+    otherwise silently dropped, leaving reasoning enabled on providers that
+    default to it (e.g. some Gemini / reasoning-capable models). See
+    https://github.com/BerriAI/litellm/issues/26413
+
+    Behavior:
+
+    - ``think`` falsy (``False`` / ``"false"`` / ``0`` / ``"no"`` / ``"off"``):
+      set ``reasoning_effort = "disable"`` on ``non_default_params`` -- but only
+      when (a) the caller has not already supplied ``reasoning_effort`` and
+      (b) the provider lists ``reasoning_effort`` as a supported param.
+      Otherwise the flag is silently ignored.
+    - ``think`` truthy: ``reasoning_effort`` is left untouched (callers that
+      want to enable reasoning should pass ``reasoning_effort`` explicitly).
+    - ``think`` is an unrecognized string: ignored.
+    """
+    if think_value is None:
+        return
+
+    if isinstance(think_value, str):
+        normalized = think_value.strip().lower()
+        if normalized in ("false", "0", "no", "off"):
+            think_bool: Optional[bool] = False
+        elif normalized in ("true", "1", "yes", "on"):
+            think_bool = True
+        else:
+            think_bool = None
+    else:
+        think_bool = bool(think_value)
+
+    if (
+        think_bool is False
+        and not non_default_params.get("reasoning_effort")
+        and "reasoning_effort" in supported_params
+    ):
+        non_default_params["reasoning_effort"] = "disable"
+
+
 class PreProcessNonDefaultParams:
     @staticmethod
     def base_pre_process_non_default_params(
@@ -3980,6 +4028,14 @@ def get_optional_params(  # noqa: PLR0915
 ):
     passed_params = locals().copy()
     special_params = passed_params.pop("kwargs")
+
+    # Capture and remove the Ollama-style ``think`` flag from kwargs *before*
+    # pre-processing so it cannot leak into ``passed_params`` / ``optional_params``
+    # for openai-compatible providers. The flag is later translated to
+    # ``reasoning_effort`` once we know the provider's supported params.
+    # See https://github.com/BerriAI/litellm/issues/26413
+    _think_value = special_params.pop("think", None)
+
     provider_config: Optional[BaseConfig] = None
     if custom_llm_provider is not None and custom_llm_provider in [
         provider.value for provider in LlmProviders
@@ -4058,6 +4114,19 @@ def get_optional_params(  # noqa: PLR0915
     supported_params = supported_params or []
     allowed_openai_params = allowed_openai_params or []
     supported_params.extend(allowed_openai_params)
+
+    # Honor Ollama-style `think` flag passed directly in the request body. When
+    # `think: false` is supplied (with no explicit `reasoning_effort`), translate
+    # it to `reasoning_effort="disable"` for providers that support reasoning so
+    # reasoning is actually turned off upstream. Otherwise drop it silently so it
+    # does not raise UnsupportedParamsError. See
+    # https://github.com/BerriAI/litellm/issues/26413
+    if _think_value is not None:
+        _think_to_reasoning_effort(
+            think_value=_think_value,
+            non_default_params=non_default_params,
+            supported_params=supported_params,
+        )
 
     _check_valid_arg(
         supported_params=supported_params or [],

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3683,6 +3683,7 @@ def _think_to_reasoning_effort(
     think_value: Any,
     non_default_params: dict,
     supported_params: List[str],
+    provider_config: Optional[Any] = None,
     custom_llm_provider: Optional[str] = None,
 ) -> None:
     """
@@ -3701,12 +3702,10 @@ def _think_to_reasoning_effort(
       set ``reasoning_effort = "disable"`` on ``non_default_params`` -- but only
       when (a) the caller has not already supplied ``reasoning_effort``, (b) the
       provider lists ``reasoning_effort`` as a supported param, and (c) the
-      provider's transformation layer is known to recognise the literal value
-      ``"disable"`` (currently Gemini / Vertex AI / Ollama). Other providers
-      (Anthropic, Bedrock, OpenAI o-series, ...) advertise ``reasoning_effort``
-      but only accept ``low|medium|high|minimal|none|None``; passing
-      ``"disable"`` to them raises ``ValueError`` / ``BadRequestError``. For
-      those providers, ``think`` is silently dropped (with a debug log).
+      provider's config opts in via the ``supports_reasoning_disable`` class
+      flag (currently Gemini / Vertex AI / Ollama). For other providers (whose
+      ``_map_reasoning_effort`` raises on the literal ``"disable"``),
+      ``think:false`` is silently dropped (with a debug log).
     - ``think`` truthy: ``reasoning_effort`` is left untouched (callers that
       want to enable reasoning should pass ``reasoning_effort`` explicitly).
     - ``think`` is an unrecognized string: ignored.
@@ -3725,30 +3724,23 @@ def _think_to_reasoning_effort(
     else:
         think_bool = bool(think_value)
 
-    # Providers whose `_map_reasoning_effort` (or equivalent) accepts the
-    # literal "disable" value. Adding to this list is safe; omitting a provider
-    # that *does* accept it just means `think:false` is silently ignored there.
-    _PROVIDERS_SUPPORTING_REASONING_DISABLE = {
-        "gemini",
-        "vertex_ai",
-        "vertex_ai_beta",
-        "ollama",
-        "ollama_chat",
-    }
+    provider_supports_disable = bool(
+        getattr(provider_config, "supports_reasoning_disable", False)
+    )
 
     if (
         think_bool is False
         and "reasoning_effort" not in non_default_params
         and "reasoning_effort" in supported_params
-        and (custom_llm_provider or "") in _PROVIDERS_SUPPORTING_REASONING_DISABLE
+        and provider_supports_disable
     ):
         non_default_params["reasoning_effort"] = "disable"
     elif think_bool is False:
         verbose_logger.debug(
-            "litellm: 'think=False' was passed but provider %r does not accept "
-            "reasoning_effort='disable'; dropping silently. Pass "
-            "reasoning_effort explicitly if your provider supports a "
-            "'disable'-equivalent value.",
+            "litellm: 'think=False' was passed but provider %r does not opt "
+            "in to reasoning_effort='disable' (supports_reasoning_disable=False); "
+            "dropping silently. Pass reasoning_effort explicitly if your "
+            "provider supports a 'disable'-equivalent value.",
             custom_llm_provider,
         )
     elif think_bool is True:
@@ -4158,6 +4150,7 @@ def get_optional_params(  # noqa: PLR0915
             think_value=_think_value,
             non_default_params=non_default_params,
             supported_params=supported_params,
+            provider_config=provider_config,
             custom_llm_provider=custom_llm_provider,
         )
 

--- a/tests/test_litellm/test_think_param_normalization.py
+++ b/tests/test_litellm/test_think_param_normalization.py
@@ -1,0 +1,143 @@
+"""
+Tests for the Ollama-style ``think`` -> OpenAI ``reasoning_effort`` normalization
+performed inside ``litellm.utils.get_optional_params``.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/26413.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from litellm.utils import _think_to_reasoning_effort, get_optional_params
+
+
+class TestThinkToReasoningEffortHelper:
+    def test_think_false_bool_sets_reasoning_effort_disable(self):
+        non_default_params: dict = {}
+        supported_params = ["reasoning_effort"]
+
+        _think_to_reasoning_effort(
+            think_value=False,
+            non_default_params=non_default_params,
+            supported_params=supported_params,
+        )
+
+        assert non_default_params["reasoning_effort"] == "disable"
+
+    @pytest.mark.parametrize("falsy", ["false", "FALSE", "0", "no", "off", " False "])
+    def test_think_false_string_variants(self, falsy):
+        non_default_params: dict = {}
+
+        _think_to_reasoning_effort(
+            think_value=falsy,
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+        )
+
+        assert non_default_params["reasoning_effort"] == "disable"
+
+    def test_think_true_does_not_set_reasoning_effort(self):
+        non_default_params: dict = {}
+
+        _think_to_reasoning_effort(
+            think_value=True,
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+        )
+
+        assert "reasoning_effort" not in non_default_params
+
+    def test_think_false_when_provider_does_not_support_reasoning(self):
+        """``think`` should be silently dropped if the provider does not list
+        ``reasoning_effort`` in its supported params, instead of raising."""
+        non_default_params: dict = {}
+
+        _think_to_reasoning_effort(
+            think_value=False,
+            non_default_params=non_default_params,
+            supported_params=["temperature", "top_p"],
+        )
+
+        assert "reasoning_effort" not in non_default_params
+
+    def test_think_false_does_not_override_explicit_reasoning_effort(self):
+        non_default_params = {"reasoning_effort": "high"}
+
+        _think_to_reasoning_effort(
+            think_value=False,
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+        )
+
+        assert non_default_params["reasoning_effort"] == "high"
+
+    def test_think_unrecognized_string_is_ignored(self):
+        non_default_params: dict = {}
+
+        _think_to_reasoning_effort(
+            think_value="maybe",
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+        )
+
+        assert "reasoning_effort" not in non_default_params
+
+
+class TestGetOptionalParamsThinkFalse:
+    """End-to-end tests through ``get_optional_params`` against real provider
+    configs -- no network calls."""
+
+    def test_gemini_think_false_disables_reasoning(self):
+        """For a reasoning-capable Gemini model, ``think=False`` in the request
+        body should cause reasoning to be disabled upstream (mirrors the
+        scenario in issue #26413)."""
+        optional_params = get_optional_params(
+            model="gemini-2.5-flash",
+            custom_llm_provider="gemini",
+            think=False,
+        )
+
+        # Gemini disables thinking by setting thinking_config.thinking_budget=0
+        thinking_config = optional_params.get("thinkingConfig") or optional_params.get(
+            "thinking_config"
+        )
+        assert thinking_config is not None, (
+            f"expected gemini thinkingConfig in optional_params, got: "
+            f"{optional_params}"
+        )
+        assert (
+            thinking_config.get("thinkingBudget") == 0
+            or thinking_config.get("thinking_budget") == 0
+        )
+
+    def test_ollama_chat_think_false_propagates(self):
+        """For Ollama (which natively understands ``think``), the resulting
+        optional params should signal reasoning-off via the existing
+        ``reasoning_effort=disable`` -> ``think=False`` mapping."""
+        optional_params = get_optional_params(
+            model="llama3.1",
+            custom_llm_provider="ollama_chat",
+            think=False,
+        )
+
+        # ollama_chat maps reasoning_effort != {low,medium,high} -> think=False
+        assert optional_params.get("think") is False
+
+    def test_think_false_dropped_silently_for_non_reasoning_provider(self):
+        """A provider that doesn't expose ``reasoning_effort`` should not raise
+        when ``think:false`` is supplied -- ``think`` is silently dropped."""
+        # openai chat completion params do include reasoning_effort, so use a
+        # provider whose supported params do NOT include it. ``cohere`` chat
+        # does not currently advertise ``reasoning_effort``.
+        optional_params = get_optional_params(
+            model="command-r",
+            custom_llm_provider="cohere_chat",
+            think=False,
+        )
+
+        assert "think" not in optional_params
+        assert "reasoning_effort" not in optional_params

--- a/tests/test_litellm/test_think_param_normalization.py
+++ b/tests/test_litellm/test_think_param_normalization.py
@@ -24,6 +24,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=supported_params,
+            custom_llm_provider="gemini",
         )
 
         assert non_default_params["reasoning_effort"] == "disable"
@@ -36,6 +37,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=falsy,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            custom_llm_provider="gemini",
         )
 
         assert non_default_params["reasoning_effort"] == "disable"
@@ -47,6 +49,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=True,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            custom_llm_provider="gemini",
         )
 
         assert "reasoning_effort" not in non_default_params
@@ -60,6 +63,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=["temperature", "top_p"],
+            custom_llm_provider="cohere_chat",
         )
 
         assert "reasoning_effort" not in non_default_params
@@ -71,9 +75,47 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            custom_llm_provider="gemini",
         )
 
         assert non_default_params["reasoning_effort"] == "high"
+
+    def test_think_false_respects_falsy_explicit_reasoning_effort(self):
+        """An explicit ``reasoning_effort=""`` is a present (if empty) value and
+        must NOT be overwritten by ``think=False``. Guards against the falsy
+        membership-vs-presence trap."""
+        non_default_params: dict = {"reasoning_effort": ""}
+
+        _think_to_reasoning_effort(
+            think_value=False,
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+            custom_llm_provider="gemini",
+        )
+
+        assert non_default_params["reasoning_effort"] == ""
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["anthropic", "bedrock", "openai", "azure", "vertex_ai_anthropic"],
+    )
+    def test_think_false_dropped_for_providers_that_reject_disable(self, provider):
+        """Providers whose `_map_reasoning_effort` does not accept the literal
+        ``"disable"`` (Anthropic, Bedrock, OpenAI o-series, ...) would raise a
+        runtime ``ValueError`` / ``BadRequestError`` if we injected
+        ``reasoning_effort="disable"``. For these providers, ``think:false``
+        must be silently dropped instead. Regression test for the P1 review
+        comment on PR #26642."""
+        non_default_params: dict = {}
+
+        _think_to_reasoning_effort(
+            think_value=False,
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+            custom_llm_provider=provider,
+        )
+
+        assert "reasoning_effort" not in non_default_params
 
     def test_think_unrecognized_string_is_ignored(self):
         non_default_params: dict = {}
@@ -82,6 +124,7 @@ class TestThinkToReasoningEffortHelper:
             think_value="maybe",
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            custom_llm_provider="gemini",
         )
 
         assert "reasoning_effort" not in non_default_params

--- a/tests/test_litellm/test_think_param_normalization.py
+++ b/tests/test_litellm/test_think_param_normalization.py
@@ -15,6 +15,23 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 from litellm.utils import _think_to_reasoning_effort, get_optional_params
 
 
+class _FakeConfigSupportsDisable:
+    """Stand-in for a provider config (e.g. ``GeminiConfig`` /
+    ``OllamaConfig``) that opts in to ``reasoning_effort='disable'`` via the
+    ``supports_reasoning_disable`` class flag."""
+
+    supports_reasoning_disable = True
+
+
+class _FakeConfigRejectsDisable:
+    """Stand-in for a provider config (e.g. ``AnthropicConfig`` /
+    ``BedrockConverseConfig``) whose ``_map_reasoning_effort`` would raise on
+    the literal ``'disable'``; default value of the ``BaseConfig`` class flag
+    is ``False``."""
+
+    supports_reasoning_disable = False
+
+
 class TestThinkToReasoningEffortHelper:
     def test_think_false_bool_sets_reasoning_effort_disable(self):
         non_default_params: dict = {}
@@ -24,6 +41,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=supported_params,
+            provider_config=_FakeConfigSupportsDisable(),
             custom_llm_provider="gemini",
         )
 
@@ -37,6 +55,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=falsy,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            provider_config=_FakeConfigSupportsDisable(),
             custom_llm_provider="gemini",
         )
 
@@ -49,6 +68,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=True,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            provider_config=_FakeConfigSupportsDisable(),
             custom_llm_provider="gemini",
         )
 
@@ -63,6 +83,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=["temperature", "top_p"],
+            provider_config=_FakeConfigRejectsDisable(),
             custom_llm_provider="cohere_chat",
         )
 
@@ -75,6 +96,7 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            provider_config=_FakeConfigSupportsDisable(),
             custom_llm_provider="gemini",
         )
 
@@ -90,29 +112,40 @@ class TestThinkToReasoningEffortHelper:
             think_value=False,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            provider_config=_FakeConfigSupportsDisable(),
             custom_llm_provider="gemini",
         )
 
         assert non_default_params["reasoning_effort"] == ""
 
-    @pytest.mark.parametrize(
-        "provider",
-        ["anthropic", "bedrock", "openai", "azure", "vertex_ai_anthropic"],
-    )
-    def test_think_false_dropped_for_providers_that_reject_disable(self, provider):
-        """Providers whose `_map_reasoning_effort` does not accept the literal
-        ``"disable"`` (Anthropic, Bedrock, OpenAI o-series, ...) would raise a
-        runtime ``ValueError`` / ``BadRequestError`` if we injected
-        ``reasoning_effort="disable"``. For these providers, ``think:false``
-        must be silently dropped instead. Regression test for the P1 review
-        comment on PR #26642."""
+    def test_think_false_dropped_when_provider_config_rejects_disable(self):
+        """Providers whose config has ``supports_reasoning_disable=False`` (the
+        ``BaseConfig`` default — Anthropic, Bedrock, OpenAI o-series, ...)
+        would raise on ``reasoning_effort='disable'``. ``think:false`` must be
+        silently dropped instead. Regression for the P1 review on PR #26642."""
         non_default_params: dict = {}
 
         _think_to_reasoning_effort(
             think_value=False,
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
-            custom_llm_provider=provider,
+            provider_config=_FakeConfigRejectsDisable(),
+            custom_llm_provider="anthropic",
+        )
+
+        assert "reasoning_effort" not in non_default_params
+
+    def test_think_false_dropped_when_no_provider_config_passed(self):
+        """If we cannot determine the provider's capability (no config), be
+        conservative and drop rather than risk a runtime ValueError."""
+        non_default_params: dict = {}
+
+        _think_to_reasoning_effort(
+            think_value=False,
+            non_default_params=non_default_params,
+            supported_params=["reasoning_effort"],
+            provider_config=None,
+            custom_llm_provider="some_unknown_provider",
         )
 
         assert "reasoning_effort" not in non_default_params
@@ -124,10 +157,48 @@ class TestThinkToReasoningEffortHelper:
             think_value="maybe",
             non_default_params=non_default_params,
             supported_params=["reasoning_effort"],
+            provider_config=_FakeConfigSupportsDisable(),
             custom_llm_provider="gemini",
         )
 
         assert "reasoning_effort" not in non_default_params
+
+
+class TestProviderConfigsOptInToReasoningDisable:
+    """Verifies the per-provider opt-in flags wired up on the actual config
+    classes — these are what the real ``get_optional_params`` flow consults."""
+
+    def test_gemini_configs_opt_in(self):
+        from litellm.llms.gemini.chat.transformation import GoogleAIStudioGeminiConfig
+        from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+            VertexGeminiConfig,
+        )
+
+        assert VertexGeminiConfig.supports_reasoning_disable is True
+        assert GoogleAIStudioGeminiConfig.supports_reasoning_disable is True
+
+    def test_ollama_configs_opt_in(self):
+        from litellm.llms.ollama.chat.transformation import OllamaChatConfig
+        from litellm.llms.ollama.completion.transformation import OllamaConfig
+
+        assert OllamaConfig.supports_reasoning_disable is True
+        assert OllamaChatConfig.supports_reasoning_disable is True
+
+    def test_anthropic_config_does_not_opt_in(self):
+        """Anthropic's ``_map_reasoning_effort`` raises on ``'disable'``, so it
+        must keep the ``BaseConfig`` default of ``False``."""
+        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+        assert AnthropicConfig.supports_reasoning_disable is False
+
+    def test_bedrock_config_does_not_opt_in(self):
+        """Bedrock Converse rejects any ``reasoning_effort`` value outside
+        ``low|medium|high``, so it must not opt in."""
+        from litellm.llms.bedrock.chat.converse_transformation import (
+            AmazonConverseConfig,
+        )
+
+        assert AmazonConverseConfig.supports_reasoning_disable is False
 
 
 class TestGetOptionalParamsThinkFalse:


### PR DESCRIPTION
# Title

Fix: honor `think: false` to disable reasoning (#26413)

## Relevant issues

Fixes #26413

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Root cause

When a client sends `"think": false` (Ollama-native flag) directly in a chat
completion request body — as the Ollama JSON API supports — LiteLLM silently
drops it. `think` is not part of `DEFAULT_CHAT_COMPLETION_PARAM_VALUES`, so
`pre_process_non_default_params` filters it out before any provider sees it.
For reasoning-capable models (e.g. some Gemini models, the model in the
reproduction in the issue) this leaves reasoning enabled, and the response
still contains `reasoning_content`, `thinking_blocks`, and non-zero
`usage.completion_tokens_details.reasoning_tokens` — exactly the bug reported
in #26413.

### Fix

In `litellm.utils.get_optional_params`, capture `think` from kwargs early
(before pre-processing so it cannot leak into `optional_params` for openai-
compatible providers) and translate it once we know the provider's supported
params:

- `think` falsy (`False` / `"false"` / `"0"` / `"no"` / `"off"`) — set
  `reasoning_effort = "disable"`, but only when the caller has not already
  supplied `reasoning_effort` and the provider lists `reasoning_effort` in its
  supported params. Otherwise the flag is silently ignored (no
  `UnsupportedParamsError` regression for non-reasoning providers).
- `think` truthy — left untouched. Callers that want to enable reasoning
  should pass `reasoning_effort` explicitly; we don't auto-enable.
- `think` unrecognized string — ignored.

This routes `think: false` through the existing per-provider
`reasoning_effort = "disable"` plumbing (Gemini → `thinkingConfig.thinkingBudget = 0`,
Ollama → native `think=False`, etc.), so reasoning is actually turned off
upstream rather than the response being post-processed.

### Files changed

- `litellm/utils.py` — new `_think_to_reasoning_effort` helper + early
  capture/late-translate hook in `get_optional_params`.
- `tests/test_litellm/test_think_param_normalization.py` — new mocked unit
  tests (no network).

## Test plan

New mocked unit tests in `tests/test_litellm/test_think_param_normalization.py`:

- Helper-level tests cover the truth-table: `False`/`"false"`/`"0"`/`"no"`/
  `"off"`/` False ` → `reasoning_effort="disable"`; `True` → no change;
  unrecognized string → no change; explicit `reasoning_effort` not
  overridden; provider without `reasoning_effort` → silently dropped.
- End-to-end through `get_optional_params`:
  - `gemini/gemini-2.5-flash` + `think=False` → `thinkingConfig.thinkingBudget == 0`.
  - `ollama_chat/llama3.1` + `think=False` → `optional_params["think"] is False`
    (uses the existing `reasoning_effort` mapping).
  - `cohere_chat/command-r` + `think=False` → silently dropped, no error.

```
$ python -m pytest tests/test_litellm/test_think_param_normalization.py -q
14 passed
```

Existing `tests/test_litellm/test_utils.py` reasoning/optional_params tests
also still pass:

```
$ python -m pytest tests/test_litellm/test_utils.py -k "optional_params or reasoning" -q
6 passed
```

`black` formatting clean on all changed files.

---

> Authored with assistance from GitHub Copilot CLI (Claude Opus 4.7).
